### PR TITLE
Automated cherry pick of #57434: node_e2e: do not return error if Docker's check-config.sh

### DIFF
--- a/test/e2e_node/gke_environment_test.go
+++ b/test/e2e_node/gke_environment_test.go
@@ -139,10 +139,10 @@ func checkDockerConfig() error {
 		if _, err := os.Stat(bin); os.IsNotExist(err) {
 			continue
 		}
-		output, err := runCommand(bin)
-		if err != nil {
-			return err
-		}
+		// We don't check the return code because it's OK if the script returns
+		// a non-zero exit code just because the configs in the whitelist are
+		// missing.
+		output, _ := runCommand(bin)
 		for _, line := range strings.Split(output, "\n") {
 			if !strings.Contains(line, "missing") {
 				continue


### PR DESCRIPTION
Cherry pick of #57434 on release-1.9.

#57434: node_e2e: do not return error if Docker's check-config.sh