### PR TITLE
Ensure virtual nodes aren't stranded in GC graph

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly"
 	_ "k8s.io/kubernetes/pkg/util/reflector/prometheus" // for reflector metric registration
 	// install the prometheus plugin
 	_ "k8s.io/kubernetes/pkg/util/workqueue/prometheus"
@@ -259,22 +258,14 @@ func (gc *GarbageCollector) attemptToDeleteWorker() bool {
 		}
 		// retry if garbage collection of an object failed.
 		gc.attemptToDelete.AddRateLimited(item)
+	} else if !n.isObserved() {
+		// requeue if item hasn't been observed via an informer event yet.
+		// otherwise a virtual node for an item added AND removed during watch reestablishment can get stuck in the graph and never removed.
+		// see https://issue.k8s.io/56121
+		glog.V(5).Infof("item %s hasn't been observed via informer yet", n.identity)
+		gc.attemptToDelete.AddRateLimited(item)
 	}
 	return true
-}
-
-func objectReferenceToMetadataOnlyObject(ref objectReference) *metaonly.MetadataOnlyObject {
-	return &metaonly.MetadataOnlyObject{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ref.APIVersion,
-			Kind:       ref.Kind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ref.Namespace,
-			UID:       ref.UID,
-			Name:      ref.Name,
-		},
-	}
 }
 
 // isDangling check if a reference is pointing to an object that doesn't exist.
@@ -353,15 +344,6 @@ func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []me
 	return solid, dangling, waitingForDependentsDeletion, nil
 }
 
-func (gc *GarbageCollector) generateVirtualDeleteEvent(identity objectReference) {
-	event := &event{
-		eventType: deleteEvent,
-		obj:       objectReferenceToMetadataOnlyObject(identity),
-	}
-	glog.V(5).Infof("generating virtual delete event for %s\n\n", event.obj)
-	gc.dependencyGraphBuilder.enqueueChanges(event)
-}
-
 func ownerRefsToUIDs(refs []metav1.OwnerReference) []types.UID {
 	var ret []types.UID
 	for _, ref := range refs {
@@ -387,7 +369,10 @@ func (gc *GarbageCollector) attemptToDeleteItem(item *node) error {
 		// exist yet, so we need to enqueue a virtual Delete event to remove
 		// the virtual node from GraphBuilder.uidToNode.
 		glog.V(5).Infof("item %v not found, generating a virtual delete event", item.identity)
-		gc.generateVirtualDeleteEvent(item.identity)
+		gc.dependencyGraphBuilder.enqueueVirtualDeleteEvent(item.identity)
+		// since we're manually inserting a delete event to remove this node,
+		// we don't need to keep tracking it as a virtual node and requeueing in attemptToDelete
+		item.markObserved()
 		return nil
 	case err != nil:
 		return err
@@ -395,7 +380,10 @@ func (gc *GarbageCollector) attemptToDeleteItem(item *node) error {
 
 	if latest.GetUID() != item.identity.UID {
 		glog.V(5).Infof("UID doesn't match, item %v not found, generating a virtual delete event", item.identity)
-		gc.generateVirtualDeleteEvent(item.identity)
+		gc.dependencyGraphBuilder.enqueueVirtualDeleteEvent(item.identity)
+		// since we're manually inserting a delete event to remove this node,
+		// we don't need to keep tracking it as a virtual node and requeueing in attemptToDelete
+		item.markObserved()
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #56121

See https://github.com/kubernetes/kubernetes/issues/56121#issuecomment-353265160 for details on the sequence of events that can lead to virtual nodes getting stranded in the graph

```release-note
Fixed garbage collection hang
```

(a branch with a commit that reliably triggers the cascading deletion test failure is at https://github.com/liggitt/kubernetes/commits/gc-debug-cascading... it's not easily made into a permanent test case because it only works when that test is run in isolation, and requires plumbing test hooks deep into the watch cache layer)