### PR TITLE
add eventratelimit config to scheme

### DIFF
--- a/plugin/pkg/admission/eventratelimit/admission.go
+++ b/plugin/pkg/admission/eventratelimit/admission.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	eventratelimitapi "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit"
+	eventratelimitapiv1alpha1 "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1"
 	"k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/validation"
 )
 
@@ -43,6 +44,10 @@ func Register(plugins *admission.Plugins) {
 			}
 			return newEventRateLimit(configuration, realClock{})
 		})
+
+	// add our config types
+	eventratelimitapi.AddToScheme(plugins.ConfigScheme)
+	eventratelimitapiv1alpha1.AddToScheme(plugins.ConfigScheme)
 }
 
 // Plugin implements an admission controller that can enforce event rate limits


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/57030

Because the config types are decoded, their types have to be registered in the scheme used for admission config decoding.  Looks like we missed one.

@kubernetes/sig-api-machinery-bugs 
/assign jennybuckley 