### PR TITLE
Add custom volume name based on SC parameter.

### DIFF
--- a/pkg/volume/glusterfs/BUILD
+++ b/pkg/volume/glusterfs/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )


### PR DESCRIPTION
    At present glusterfs dynamic PVs are created with
    random names. However an admin would like to have some
    handle on the volume names created dynamically for
    various purposes. One example would be having a filter
    for sorting out PVs created for a particular storage class.
    
    This patch enables the functionality by having a custom
    volume name as a prefix to dynamic PVs. This is an optional
    parameter in SC and if set, the dynamic volumes are created
    in below format where `_` is the field seperator/delimiter:
    
    customvolumeprefix_PVCname_randomUUID

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

