### PR TITLE
Bump pause container used by kubelet and tests to 3.1

### DIFF
--- a/build/pause/CHANGELOG.md
+++ b/build/pause/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 3.1
+
+* The pause container gains a signal handler to clean up orphaned zombie processes. ([#36853](https://prs.k8s.io/36853), [@verb](https://github.com/verb))
+* `pause -v` will return build information for the pause binary. ([#56762](https://prs.k8s.io/56762), [@verb](https://github.com/verb))
+
+# 3.0
+
+* The pause container was rewritten entirely in C. ([#23009](https://prs.k8s.io/23009), [@uluyol](https://github.com/uluyol))

--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	validTmpl    = "image: {{ .ImageRepository }}/pause-{{ .Arch }}:3.0"
-	validTmplOut = "image: gcr.io/google_containers/pause-amd64:3.0"
-	doNothing    = "image: gcr.io/google_containers/pause-amd64:3.0"
+	validTmpl    = "image: {{ .ImageRepository }}/pause-{{ .Arch }}:3.1"
+	validTmplOut = "image: gcr.io/google_containers/pause-amd64:3.1"
+	doNothing    = "image: gcr.io/google_containers/pause-amd64:3.1"
 	invalidTmpl1 = "{{ .baz }/d}"
 	invalidTmpl2 = "{{ !foobar }}"
 )

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -26,9 +26,9 @@ import (
 )
 
 const (
-	// When these values are updated, also update test/e2e/framework/util.go
+	// When these values are updated, also update test/utils/image/manifest.go
 	defaultPodSandboxImageName    = "gcr.io/google_containers/pause"
-	defaultPodSandboxImageVersion = "3.0"
+	defaultPodSandboxImageVersion = "3.1"
 	// From pkg/kubelet/rkt/rkt.go to avoid circular import
 	defaultRktAPIServiceEndpoint = "localhost:15441"
 )

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -719,9 +719,9 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
-  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "gcr.io/google_containers/pause-amd64:3.0"}]}}'
-  # Post-condition: valid-pod POD has image gcr.io/google_containers/pause-amd64:3.0
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'gcr.io/google_containers/pause-amd64:3.0:'
+  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "gcr.io/google_containers/pause-amd64:3.1"}]}}'
+  # Post-condition: valid-pod POD has image gcr.io/google_containers/pause-amd64:3.1
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'gcr.io/google_containers/pause-amd64:3.1:'
 
   ## If resourceVersion is specified in the patch, it will be treated as a precondition, i.e., if the resourceVersion is different from that is stored in the server, the Patch should be rejected
   ERROR_FILE="${KUBE_TEMP}/conflict-error"

--- a/hack/testdata/pod-with-precision.json
+++ b/hack/testdata/pod-with-precision.json
@@ -9,7 +9,7 @@
       "containers": [
         {
           "name": "kubernetes-pause",
-          "image": "gcr.io/google_containers/pause-amd64:3.0"
+          "image": "gcr.io/google_containers/pause-amd64:3.1"
         }
       ],
       "restartPolicy": "Never",

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "gcr.io/google_containers/pause-amd64:3.0"
+	defaultSandboxImage = "gcr.io/google_containers/pause-amd64:3.1"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2

--- a/test/integration/benchmark-controller.json
+++ b/test/integration/benchmark-controller.json
@@ -17,7 +17,7 @@
        "spec": {
            "containers": [{
              "name": "test-container",
-             "image": "gcr.io/google_containers/pause-amd64:3.0"
+             "image": "gcr.io/google_containers/pause-amd64:3.1"
            }]
        }
     }

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	// When these values are updated, also update cmd/kubelet/app/options/options.go
-	// A copy of these values exist in e2e/framework/util.go.
+	// When these values are updated, also update cmd/kubelet/app/options/container_runtime.go
+	// A copy of these values exist in test/utils/image/manifest.go
 	currentPodInfraContainerImageName    = "gcr.io/google_containers/pause"
-	currentPodInfraContainerImageVersion = "3.0"
+	currentPodInfraContainerImageVersion = "3.1"
 )
 
 // GetServerArchitecture fetches the architecture of the cluster's apiserver.

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -82,8 +82,8 @@ var (
 	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0", true}
 	NoSnatTestProxy          = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0", true}
 	NWayHTTP                 = ImageConfig{e2eRegistry, "n-way-http", "1.0", true}
-	// When these values are updated, also update cmd/kubelet/app/options/options.go
-	Pause               = ImageConfig{gcRegistry, "pause", "3.0", true}
+	// When these values are updated, also update cmd/kubelet/app/options/container_runtime.go
+	Pause               = ImageConfig{gcRegistry, "pause", "3.1", true}
 	Porter              = ImageConfig{e2eRegistry, "porter", "1.0", true}
 	PortForwardTester   = ImageConfig{e2eRegistry, "port-forward-tester", "1.0", true}
 	Redis               = ImageConfig{e2eRegistry, "redis", "1.0", true}


### PR DESCRIPTION
This updates the version of the pause container used by the kubelet and
various test utilities to 3.1.

**What this PR does / why we need it**: The pause container hasn't been rebuilt in quite a while and needs an update to reap zombies (#50865) and for schema2 manifest (#56253).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #50865, Fixes #56253

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The kubelet uses a new release 3.1 of the pause container with the Docker runtime. This version will clean up orphaned zombie processes that it inherits.
```

  