### PR TITLE
kubeadm/phases: small grammar improvements

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/addons.go
@@ -139,7 +139,7 @@ func getAddonsSubCommands() []*cobra.Command {
 
 		// Add flags to the command
 		cmd.Flags().StringVar(&kubeConfigFile, "kubeconfig", "/etc/kubernetes/admin.conf", "The KubeConfig file to use when talking to the cluster")
-		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental!")
+		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental")
 		cmd.Flags().StringVar(&cfg.KubernetesVersion, "kubernetes-version", cfg.KubernetesVersion, `Choose a specific Kubernetes version for the control plane`)
 		cmd.Flags().StringVar(&cfg.ImageRepository, "image-repository", cfg.ImageRepository, `Choose a container registry to pull control plane images from`)
 

--- a/cmd/kubeadm/app/cmd/phases/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/bootstraptoken.go
@@ -284,7 +284,7 @@ func NewSubCmdNodeBootstrapTokenAutoApprove(kubeConfigFile *string) *cobra.Comma
 func addBootstrapTokenFlags(flagSet *pflag.FlagSet, cfg *kubeadmapiext.MasterConfiguration, cfgPath, description *string, usages, extraGroups *[]string, skipTokenPrint *bool) {
 	flagSet.StringVar(
 		cfgPath, "config", *cfgPath,
-		"Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)",
+		"Path to kubeadm config file. WARNING: Usage of a configuration file is experimental",
 	)
 	flagSet.StringVar(
 		&cfg.Token, "token", cfg.Token,

--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -188,12 +188,12 @@ func getCertsSubCommands(defaultKubernetesVersion string) []*cobra.Command {
 		}
 
 		// Add flags to the command
-		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental")
 		cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, "The path where to save the certificates")
 		if properties.use == "all" || properties.use == "apiserver" {
 			cmd.Flags().StringVar(&cfg.Networking.DNSDomain, "service-dns-domain", cfg.Networking.DNSDomain, "Alternative domain for services, to use for the API server serving cert")
 			cmd.Flags().StringVar(&cfg.Networking.ServiceSubnet, "service-cidr", cfg.Networking.ServiceSubnet, "Alternative range of IP address for service VIPs, from which derives the internal API server VIP that will be added to the API Server serving cert")
-			cmd.Flags().StringSliceVar(&cfg.APIServerCertSANs, "apiserver-cert-extra-sans", []string{}, "Optional extra altnames to use for the API server serving cert. Can be both IP addresses and dns names")
+			cmd.Flags().StringSliceVar(&cfg.APIServerCertSANs, "apiserver-cert-extra-sans", []string{}, "Optional extra altnames to use for the API server serving cert. Can be both IP addresses and DNS names")
 			cmd.Flags().StringVar(&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress, "The IP address the API server is accessible on, to use for the API server serving cert")
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -110,19 +110,19 @@ func getControlPlaneSubCommands(outDir, defaultKubernetesVersion string) []*cobr
 		},
 		{
 			use:     "apiserver",
-			short:   "Generates the API server static Pod manifest.",
+			short:   "Generates the API server static Pod manifest",
 			long:    apiServerControlplaneLongDesc,
 			cmdFunc: controlplanephase.CreateAPIServerStaticPodManifestFile,
 		},
 		{
 			use:     "controller-manager",
-			short:   "Generates the controller-manager static Pod manifest.",
+			short:   "Generates the controller-manager static Pod manifest",
 			long:    controllerManagerControlplaneLongDesc,
 			cmdFunc: controlplanephase.CreateControllerManagerStaticPodManifestFile,
 		},
 		{
 			use:     "scheduler",
-			short:   "Generates the scheduler static Pod manifest.",
+			short:   "Generates the scheduler static Pod manifest",
 			long:    schedulerControlplaneLongDesc,
 			cmdFunc: controlplanephase.CreateSchedulerStaticPodManifestFile,
 		},
@@ -160,7 +160,7 @@ func getControlPlaneSubCommands(outDir, defaultKubernetesVersion string) []*cobr
 			cmd.Flags().Var(utilflag.NewMapStringString(&cfg.SchedulerExtraArgs), "scheduler-extra-args", "A set of extra flags to pass to the Scheduler or override default ones in form of <flagname>=<value>")
 		}
 
-		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+		cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental")
 
 		subCmds = append(subCmds, cmd)
 	}

--- a/cmd/kubeadm/app/cmd/phases/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/etcd.go
@@ -101,7 +101,7 @@ func getEtcdSubCommands(outDir, defaultKubernetesVersion string) []*cobra.Comman
 
 	// Add flags to the command
 	cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, `The path where certificates are stored`)
-	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental")
 
 	subCmds = append(subCmds, cmd)
 

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig.go
@@ -51,7 +51,7 @@ var (
 		`+cmdutil.AlphaDisclaimer), kubeadmconstants.AdminKubeConfigFileName)
 
 	kubeletKubeconfigLongDesc = fmt.Sprintf(normalizer.LongDesc(`
-		Generates the kubeconfig file for the kubelet to use and saves it to %s file. 
+		Generates the kubeconfig file for the kubelet to use and saves it to %s file.
 
 		Please note that this should *only* be used for bootstrapping purposes. After your control plane is up, 
 		you should request all kubelet credentials from the CSR API.
@@ -127,7 +127,7 @@ func getKubeConfigSubCommands(out io.Writer, outDir, defaultKubernetesVersion st
 		},
 		{
 			use:     "kubelet",
-			short:   "Generates a kubeconfig file for the kubelet to use. Please note that this should be used *only* for bootstrapping purposes.",
+			short:   "Generates a kubeconfig file for the kubelet to use. Please note that this should be used *only* for bootstrapping purposes",
 			long:    kubeletKubeconfigLongDesc,
 			cmdFunc: kubeconfigphase.CreateKubeletKubeConfigFile,
 		},
@@ -176,7 +176,7 @@ func getKubeConfigSubCommands(out io.Writer, outDir, defaultKubernetesVersion st
 
 		// Add flags to the command
 		if properties.use != "user" {
-			cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+			cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental")
 		}
 		cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, "The path where certificates are stored")
 		cmd.Flags().StringVar(&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress, "The IP address the API server is accessible on")
@@ -186,7 +186,7 @@ func getKubeConfigSubCommands(out io.Writer, outDir, defaultKubernetesVersion st
 			cmd.Flags().StringVar(&cfg.NodeName, "node-name", cfg.NodeName, `The node name that should be used for the kubelet client certificate`)
 		}
 		if properties.use == "user" {
-			cmd.Flags().StringVar(&token, "token", token, "The token that should be used as the authentication mechanism for this kubeconfig (instead of client certificates)")
+			cmd.Flags().StringVar(&token, "token", token, "The token that should be used as the authentication mechanism for this kubeconfig, instead of client certificates")
 			cmd.Flags().StringVar(&clientName, "client-name", clientName, "The name of user. It will be used as the CN if client certificates are created")
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
@@ -196,7 +196,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithFlags(t *testing.T) {
 			// reads generated files
 			config, err := clientcmd.LoadFromFile(filepath.Join(tmpdir, file))
 			if err != nil {
-				t.Errorf("Couldn't load generated kubeconfig file: %v", err)
+				t.Errorf("couldn't load generated kubeconfig file: %v", err)
 			}
 
 			// checks that CLI flags are properly propagated and kubeconfig properties are correct
@@ -302,7 +302,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithConfigFile(t *testing.T) {
 			// reads generated files
 			config, err := clientcmd.LoadFromFile(filepath.Join(tmpdir, file))
 			if err != nil {
-				t.Errorf("Couldn't load generated kubeconfig file: %v", err)
+				t.Errorf("couldn't load generated kubeconfig file: %v", err)
 			}
 
 			// checks that config file properties are properly propagated and kubeconfig properties are correct
@@ -371,7 +371,7 @@ func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 		// reads kubeconfig written to stdout
 		config, err := clientcmd.Load(buf.Bytes())
 		if err != nil {
-			t.Errorf("Couldn't read kubeconfig file from buffer: %v", err)
+			t.Errorf("couldn't read kubeconfig file from buffer: %v", err)
 			continue
 		}
 

--- a/cmd/kubeadm/app/cmd/phases/markmaster.go
+++ b/cmd/kubeadm/app/cmd/phases/markmaster.go
@@ -81,7 +81,7 @@ func NewCmdMarkMaster() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&kubeConfigFile, "kubeconfig", "/etc/kubernetes/admin.conf", "The KubeConfig file to use when talking to the cluster")
-	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental")
 	cmd.Flags().StringVar(&cfg.NodeName, "node-name", cfg.NodeName, `The node name to which label and taints should apply`)
 
 	return cmd

--- a/cmd/kubeadm/app/cmd/phases/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/phases/selfhosting.go
@@ -111,7 +111,7 @@ func getSelfhostingSubCommand() *cobra.Command {
 	// Add flags to the command
 	// flags bound to the configuration object
 	cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, `The path where certificates are stored`)
-	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental!")
+	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental")
 	cmd.Flags().StringVar(&featureGatesString, "feature-gates", featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 

--- a/cmd/kubeadm/app/cmd/phases/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/uploadconfig.go
@@ -57,7 +57,7 @@ func NewCmdUploadConfig() *cobra.Command {
 		Aliases: []string{"uploadconfig"},
 		Run: func(_ *cobra.Command, args []string) {
 			if len(cfgPath) == 0 {
-				kubeadmutil.CheckErr(fmt.Errorf("The --config flag is mandatory"))
+				kubeadmutil.CheckErr(fmt.Errorf("the --config flag is mandatory"))
 			}
 			client, err := kubeconfigutil.ClientSetFromFile(kubeConfigFile)
 			kubeadmutil.CheckErr(err)
@@ -72,7 +72,7 @@ func NewCmdUploadConfig() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&kubeConfigFile, "kubeconfig", "/etc/kubernetes/admin.conf", "The KubeConfig file to use when talking to the cluster")
-	cmd.Flags().StringVar(&cfgPath, "config", "", "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental!")
+	cmd.Flags().StringVar(&cfgPath, "config", "", "Path to a kubeadm config file. WARNING: Usage of a configuration file is experimental")
 
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
small grammar fixes and cleanup in `kubeadm/phases`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Lubomir (VMware)