### PR TITLE
add dynamic config metrics

### DIFF
--- a/pkg/kubelet/kubeletconfig/status/BUILD
+++ b/pkg/kubelet/kubeletconfig/status/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/status",
     deps = [
         "//pkg/kubelet/kubeletconfig/util/log:go_default_library",
+        "//pkg/kubelet/metrics:go_default_library",
         "//pkg/util/node:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/kubelet/kubeletconfig/status/status.go
+++ b/pkg/kubelet/kubeletconfig/status/status.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	utillog "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -174,6 +175,24 @@ func (s *nodeConfigStatus) Sync(client clientset.Interface, nodeName string) {
 		// with the override
 		status = status.DeepCopy()
 		status.Error = s.errorOverride
+	}
+
+	// update metrics based on the status we will sync
+	metrics.SetConfigError(len(status.Error) > 0)
+	err = metrics.SetAssignedConfig(status.Assigned)
+	if err != nil {
+		err = fmt.Errorf("failed to update Assigned config metric, error: %v", err)
+		return
+	}
+	err = metrics.SetActiveConfig(status.Active)
+	if err != nil {
+		err = fmt.Errorf("failed to update Active config metric, error: %v", err)
+		return
+	}
+	err = metrics.SetLastKnownGoodConfig(status.LastKnownGood)
+	if err != nil {
+		err = fmt.Errorf("failed to update LastKnownGood config metric, error: %v", err)
+		return
 	}
 
 	// apply the status to a copy of the node so we don't modify the object in the informer's store

--- a/pkg/kubelet/metrics/BUILD
+++ b/pkg/kubelet/metrics/BUILD
@@ -10,9 +10,12 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "k8s.io/kubernetes/pkg/kubelet/metrics",
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -17,11 +17,15 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
@@ -47,6 +51,17 @@ const (
 	// Metrics keys of device plugin operations
 	DevicePluginRegistrationCountKey = "device_plugin_registration_count"
 	DevicePluginAllocationLatencyKey = "device_plugin_alloc_latency_microseconds"
+
+	// Metric keys for node config
+	AssignedConfigKey             = "node_config_assigned"
+	ActiveConfigKey               = "node_config_active"
+	LastKnownGoodConfigKey        = "node_config_last_known_good"
+	ConfigErrorKey                = "node_config_error"
+	ConfigSourceLabelKey          = "node_config_source"
+	ConfigSourceLabelValueLocal   = "local"
+	ConfigUIDLabelKey             = "node_config_uid"
+	ConfigResourceVersionLabelKey = "node_config_resource_version"
+	KubeletConfigKeyLabelKey      = "node_config_kubelet_key"
 )
 
 var (
@@ -150,6 +165,40 @@ var (
 		},
 		[]string{"resource_name"},
 	)
+
+	// Metrics for node config
+
+	AssignedConfig = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      AssignedConfigKey,
+			Help:      "The node's understanding of intended config. The count is always 1.",
+		},
+		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
+	)
+	ActiveConfig = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      ActiveConfigKey,
+			Help:      "The config source the node is actively using. The count is always 1.",
+		},
+		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
+	)
+	LastKnownGoodConfig = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      LastKnownGoodConfigKey,
+			Help:      "The config source the node will fall back to when it encounters certain errors. The count is always 1.",
+		},
+		[]string{ConfigSourceLabelKey, ConfigUIDLabelKey, ConfigResourceVersionLabelKey, KubeletConfigKeyLabelKey},
+	)
+	ConfigError = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      ConfigErrorKey,
+			Help:      "This metric is true (1) if the node is experiencing a configuration-related error, false (0) otherwise.",
+		},
+	)
 )
 
 var registerMetrics sync.Once
@@ -172,6 +221,12 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...prometheu
 		prometheus.MustRegister(EvictionStatsAge)
 		prometheus.MustRegister(DevicePluginRegistrationCount)
 		prometheus.MustRegister(DevicePluginAllocationLatency)
+		if utilfeature.DefaultFeatureGate.Enabled(features.DynamicKubeletConfig) {
+			prometheus.MustRegister(AssignedConfig)
+			prometheus.MustRegister(ActiveConfig)
+			prometheus.MustRegister(LastKnownGoodConfig)
+			prometheus.MustRegister(ConfigError)
+		}
 		for _, collector := range collectors {
 			prometheus.MustRegister(collector)
 		}
@@ -231,4 +286,89 @@ func (pc *podAndContainerCollector) Collect(ch chan<- prometheus.Metric) {
 		runningContainerCountDesc,
 		prometheus.GaugeValue,
 		float64(runningContainers))
+}
+
+const configMapAPIPathFmt = "/api/v1/namespaces/%s/configmaps/%s"
+
+func configLabels(source *corev1.NodeConfigSource) (map[string]string, error) {
+	if source == nil {
+		return map[string]string{
+			// prometheus requires all of the labels that can be set on the metric
+			ConfigSourceLabelKey:          "local",
+			ConfigUIDLabelKey:             "",
+			ConfigResourceVersionLabelKey: "",
+			KubeletConfigKeyLabelKey:      "",
+		}, nil
+	}
+	if source.ConfigMap != nil {
+		return map[string]string{
+			ConfigSourceLabelKey:          fmt.Sprintf(configMapAPIPathFmt, source.ConfigMap.Namespace, source.ConfigMap.Name),
+			ConfigUIDLabelKey:             string(source.ConfigMap.UID),
+			ConfigResourceVersionLabelKey: source.ConfigMap.ResourceVersion,
+			KubeletConfigKeyLabelKey:      source.ConfigMap.KubeletConfigKey,
+		}, nil
+	}
+	return nil, fmt.Errorf("unrecognized config source type, all source subfields were nil")
+}
+
+// track labels across metric updates, so we can delete old label sets and prevent leaks
+var assignedConfigLabels map[string]string = map[string]string{}
+
+func SetAssignedConfig(source *corev1.NodeConfigSource) error {
+	// compute the timeseries labels from the source
+	labels, err := configLabels(source)
+	if err != nil {
+		return err
+	}
+	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
+	AssignedConfig.Delete(assignedConfigLabels)
+	// record the new timeseries
+	assignedConfigLabels = labels
+	// expose the new timeseries with a constant count of 1
+	AssignedConfig.With(assignedConfigLabels).Set(1)
+	return nil
+}
+
+// track labels across metric updates, so we can delete old label sets and prevent leaks
+var activeConfigLabels map[string]string = map[string]string{}
+
+func SetActiveConfig(source *corev1.NodeConfigSource) error {
+	// compute the timeseries labels from the source
+	labels, err := configLabels(source)
+	if err != nil {
+		return err
+	}
+	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
+	ActiveConfig.Delete(activeConfigLabels)
+	// record the new timeseries
+	activeConfigLabels = labels
+	// expose the new timeseries with a constant count of 1
+	ActiveConfig.With(activeConfigLabels).Set(1)
+	return nil
+}
+
+// track labels across metric updates, so we can delete old label sets and prevent leaks
+var lastKnownGoodConfigLabels map[string]string = map[string]string{}
+
+func SetLastKnownGoodConfig(source *corev1.NodeConfigSource) error {
+	// compute the timeseries labels from the source
+	labels, err := configLabels(source)
+	if err != nil {
+		return err
+	}
+	// clean up the old timeseries (WithLabelValues creates a new one for each distinct label set)
+	LastKnownGoodConfig.Delete(lastKnownGoodConfigLabels)
+	// record the new timeseries
+	lastKnownGoodConfigLabels = labels
+	// expose the new timeseries with a constant count of 1
+	LastKnownGoodConfig.With(lastKnownGoodConfigLabels).Set(1)
+	return nil
+}
+
+func SetConfigError(err bool) {
+	if err {
+		ConfigError.Set(1)
+	} else {
+		ConfigError.Set(0)
+	}
 }

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -137,6 +137,7 @@ go_test(
         "//pkg/kubelet/types:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e_node/services:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
@@ -147,6 +148,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
+        "//vendor/github.com/prometheus/common/model:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -164,7 +166,6 @@ go_test(
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//test/e2e/common:go_default_library",
-            "//test/e2e/framework/metrics:go_default_library",
             "//test/e2e_node/system:go_default_library",
             "//test/utils:go_default_library",
             "//vendor/github.com/kardianos/osext:go_default_library",

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/remote"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
+	frameworkmetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -332,6 +333,24 @@ func logKubeletMetrics(metricKeys ...string) {
 	} else {
 		framework.Logf("Kubelet Metrics: %+v", framework.GetKubeletMetrics(metric, metricSet))
 	}
+}
+
+// returns config related metrics from the local kubelet, filtered to the filterMetricNames passed in
+func getKubeletMetrics(filterMetricNames sets.String) (frameworkmetrics.KubeletMetrics, error) {
+	// grab Kubelet metrics
+	ms, err := metrics.GrabKubeletMetricsWithoutProxy(framework.TestContext.NodeName + ":10255")
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := metrics.NewKubeletMetrics()
+	for name := range ms {
+		if !filterMetricNames.Has(name) {
+			continue
+		}
+		filtered[name] = ms[name]
+	}
+	return filtered, nil
 }
 
 // runCommand runs the cmd and returns the combined stdout and stderr, or an


### PR DESCRIPTION
This PR exports config-releated metrics from the Kubelet.
The Guages for active, assigned, and last-known-good config can be used
to identify config versions and produce aggregate counts across several
nodes. The error-reporting Gauge can be used to determine whether a node
is experiencing a config-related error, and to prodouce an aggregate
count of nodes in an error state.

https://github.com/kubernetes/features/issues/281

```release-note
The Kubelet now exports metrics that report the assigned (node_config_assigned), last-known-good (node_config_last_known_good), and active (node_config_active) config sources, and a metric indicating whether the node is experiencing a config-related error (node_config_error). The config source metrics always report the value 1, and carry the node_config_name, node_config_uid, node_config_resource_version, and node_config_kubelet_key labels, which identify the config version. The error metric reports 1 if there is an error, 0 otherwise.
```
