### PR TITLE
dynamic config test: use a hyphen between the config name and the unique suffix

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -302,7 +302,7 @@ func newKubeletConfigMap(name string, internalKC *kubeletconfig.KubeletConfigura
 	framework.ExpectNoError(err)
 
 	cmap := &apiv1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{GenerateName: name},
+		ObjectMeta: metav1.ObjectMeta{GenerateName: name + "-"},
 		Data: map[string]string{
 			"kubelet": string(data),
 		},


### PR DESCRIPTION
These are painful to read right now due to the lack of hyphen.

```release-note
NONE
```
