### PR TITLE
validate pdb name when created and updated

### DIFF
--- a/pkg/apis/policy/validation/validation.go
+++ b/pkg/apis/policy/validation/validation.go
@@ -27,13 +27,14 @@ import (
 )
 
 func ValidatePodDisruptionBudget(pdb *policy.PodDisruptionBudget) field.ErrorList {
-	allErrs := ValidatePodDisruptionBudgetSpec(pdb.Spec, field.NewPath("spec"))
+	allErrs := apivalidation.ValidateObjectMeta(&pdb.ObjectMeta, true, ValidatePodDisruptionBudgetName, field.NewPath("metadata"))
+	allErrs = ValidatePodDisruptionBudgetSpec(pdb.Spec, field.NewPath("spec"))
 	allErrs = append(allErrs, ValidatePodDisruptionBudgetStatus(pdb.Status, field.NewPath("status"))...)
 	return allErrs
 }
 
 func ValidatePodDisruptionBudgetUpdate(pdb, oldPdb *policy.PodDisruptionBudget) field.ErrorList {
-	allErrs := field.ErrorList{}
+	allErrs := apivalidation.ValidateObjectMetaUpdate(&pdb.ObjectMeta, &oldPdb.ObjectMeta, field.NewPath("metadata"))
 
 	restoreGeneration := pdb.Generation
 	pdb.Generation = oldPdb.Generation
@@ -77,3 +78,6 @@ func ValidatePodDisruptionBudgetStatus(status policy.PodDisruptionBudgetStatus, 
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.ExpectedPods), fldPath.Child("expectedPods"))...)
 	return allErrs
 }
+
+// Validates that the given name can be used as a poddisruptionbudget name.
+var ValidatePodDisruptionBudgetName = apivalidation.NameIsDNSSubdomain


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
```
➜  docker-opentsdb git:(play) ✗ kubectl get pdb
NAME      MIN-AVAILABLE   ALLOWED-DISRUPTIONS   AGE
-pdb      0               0                     4d
➜  docker-opentsdb git:(play) ✗ kubectl delete pdb -pdb
Error: unknown shorthand flag: 'p' in -pdb

apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
 creationTimestamp: 2017-12-17T15:03:40Z
 generation: 1
 name: -pdb
 namespace: default
 resourceVersion: "1951208"
 selfLink: /apis/policy/v1beta1/namespaces/default/poddisruptionbudgets/-pdb
 uid: 77478ed4-e33b-11e7-ab2e-5254005aadf2
```

/cc @liggitt do not have experience in apiserver, i want add a validation when create pbd.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
