### PR TITLE
error out hostport usage when the network plugin is cni or kubenet

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -553,6 +553,9 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 
 	// Set port mappings.
 	exposedPorts, portBindings := makePortsAndBindings(c.GetPortMappings())
+	if hc.NetworkMode == "none" && len(portBindings) != 0 {
+		return nil, fmt.Errorf("does not support hostport mapping when using cni or kubenet as network plugins")
+	}
 	createConfig.Config.ExposedPorts = exposedPorts
 	hc.PortBindings = portBindings
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When the network plugin is `cni` or `kubenet`, `HostConfig.NetworkMode` will be set to `none`, which does not apply to `hostPort`.

Should error out this to warn the users to stop using `hostPort` when using `cni`/`kubenet` as network plugins. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @tallclair @yujuhong 
/cc @CaoShuFeng @kubernetes/sig-node-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
error out hostport usage when the network plugin is cni or kubenet
```
