### PR TITLE
Support multiple scale sets in Azure cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -58,23 +58,6 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 	return machine, exists, err
 }
 
-// GetScaleSetsVMWithRetry invokes ss.getScaleSetVM with exponential backoff retry
-func (ss *scaleSet) GetScaleSetsVMWithRetry(name types.NodeName, scaleSetName string) (compute.VirtualMachineScaleSetVM, bool, error) {
-	var machine compute.VirtualMachineScaleSetVM
-	var exists bool
-	err := wait.ExponentialBackoff(ss.resourceRequestBackoff, func() (bool, error) {
-		var retryErr error
-		machine, exists, retryErr = ss.getScaleSetVM(string(name), scaleSetName)
-		if retryErr != nil {
-			glog.Errorf("GetScaleSetsVMWithRetry backoff: failure, will retry,err=%v", retryErr)
-			return false, nil
-		}
-		glog.V(10).Infof("GetScaleSetsVMWithRetry backoff: success")
-		return true, nil
-	})
-	return machine, exists, err
-}
-
 // VirtualMachineClientGetWithRetry invokes az.VirtualMachinesClient.Get with exponential backoff retry
 func (az *Cloud) VirtualMachineClientGetWithRetry(resourceGroup, vmName string, types compute.InstanceViewTypes) (compute.VirtualMachine, error) {
 	var machine compute.VirtualMachine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds multiple scale sets support in Azure cloud provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Continue of #43287.

**Special notes for your reviewer**:

- Adds a local cache of basic scale sets information
- Update the cache when new nodes are not found or periodically
- Since azure doesn't support getting the scale set which contains the node, the cache is updated via listing all scale sets and their virtual machines

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support multiple scale sets in Azure cloud provider.
```

/assign @brendandburns @andyzhangx