### PR TITLE
Automated cherry pick of #57192: Reduce CPU request of Dasboard addon

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Cherry pick of #57192 on release-1.9.

#57192: Reduce CPU request of Dasboard addon

**Release note**:
```release-note
Free up CPU requested but unused by Kubernetes Dashboard.
```