### PR TITLE
Disable the DNS autoscaler test in large clusters.

### DIFF
--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -157,7 +157,8 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 		Expect(waitForDNSReplicasSatisfied(c, getExpectReplicasLinear, DNSdefaultTimeout)).NotTo(HaveOccurred())
 	})
 
-	It("kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios", func() {
+	// TODO: Get rid of [DisabledForLargeClusters] tag when issue #55779 is fixed.
+	It("[DisabledForLargeClusters] kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios", func() {
 
 		By("Replace the dns autoscaling parameters with testing parameters")
 		err := updateDNSScalingConfigMap(c, packDNSScalingConfigMap(packLinearParams(&DNSParams_1)))


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to prevent colateral damage while details are being
investigated.

See details in https://github.com/kubernetes/kubernetes/issues/55779#issuecomment-353560287

**Release note**:
```release-note
NONE
```