### PR TITLE
Handle gazelle moving to a new repo

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -475,10 +475,15 @@ kube::util::go_install_from_commit() {
 
   kube::util::ensure-temp-dir
   mkdir -p "${KUBE_TEMP}/go/src"
-  GOPATH="${KUBE_TEMP}/go" go get -d -u "${pkg}"
+  # TODO(spiffxp): remove this brittle workaround for go getting a package that doesn't exist at HEAD
+  repo=$(echo ${pkg} | cut -d/ -f1-3)
+  git clone "https://${repo}" "${KUBE_TEMP}/go/src/${repo}"
+  # GOPATH="${KUBE_TEMP}/go" go get -d -u "${pkg}"
   (
-    cd "${KUBE_TEMP}/go/src/${pkg}"
+    cd "${KUBE_TEMP}/go/src/${repo}"
+    git fetch # TODO(spiffxp): workaround
     git checkout -q "${commit}"
+    GOPATH="${KUBE_TEMP}/go" go get -d "${pkg}" #TODO(spiffxp): workaround
     GOPATH="${KUBE_TEMP}/go" go install "${pkg}"
   )
   PATH="${KUBE_TEMP}/go/bin:${PATH}"


### PR DESCRIPTION
Gazelle moved to a new repo, and out of bazebuild/rules_go.  At first I tried the same approach I used for kubernetes/test-infra and just bumped to the new repo.  Turns out that version was later than what is used here in kubernetes/kubernetes.  Now I'm trying to use a rewritten version of `go_install_from_commit` to support installing packages that aren't available at HEAD

ref kubernetes/test-infra#6075

/priority critical-urgent
https://k8s-testgrid.appspot.com/presubmits-kubernetes-blocking#pull-kubernetes-verify is blocked until this is addressed