### PR TITLE
kubectl: auto correction for typos in resource name

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -16,6 +16,7 @@ go_library(
         "helpers.go",
         "printing.go",
         "shortcut_restmapper.go",
+        "suggestion_restmapper.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/util",
     visibility = [
@@ -94,6 +95,7 @@ go_test(
         "factory_test.go",
         "helpers_test.go",
         "shortcut_restmapper_test.go",
+        "suggestion_restmapper_test.go",
     ],
     data = [
         "//api/swagger-spec",

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -100,8 +100,14 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.VersionInterfacesFunc(interfaces))
 	// TODO: should this also indicate it recognizes typed objects?
 	typer := discovery.NewUnstructuredObjectTyper(groupResources, legacyscheme.Scheme)
+
 	expander := NewShortcutExpander(mapper, discoveryClient)
-	return expander, typer, err
+	suggestionMapper := &suggestionRESTMapper{
+		resourceDiscover: expander.resourceDiscover,
+		delegate:         expander,
+	}
+
+	return suggestionMapper, typer, err
 }
 
 func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {

--- a/pkg/kubectl/cmd/util/shortcut_restmapper.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper.go
@@ -19,97 +19,65 @@ package util
 import (
 	"strings"
 
-	"github.com/golang/glog"
-
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/kubernetes/pkg/kubectl"
 )
 
-// shortcutExpander is a RESTMapper that can be used for Kubernetes resources.   It expands the resource first, then invokes the wrapped
+// shortcutExpander is a RESTMapper that can be used for Kubernetes resources.
+// It expands the resource first, then invokes the wrapped
 type shortcutExpander struct {
-	RESTMapper meta.RESTMapper
+	*resourceDiscover
 
-	discoveryClient discovery.DiscoveryInterface
+	RESTMapper meta.RESTMapper
 }
 
 var _ meta.RESTMapper = &shortcutExpander{}
 
-func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) shortcutExpander {
-	return shortcutExpander{RESTMapper: delegate, discoveryClient: client}
+func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) *shortcutExpander {
+	return &shortcutExpander{
+		RESTMapper: delegate,
+		resourceDiscover: &resourceDiscover{
+			discoveryClient: client,
+		},
+	}
 }
 
-func (e shortcutExpander) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+func (e *shortcutExpander) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	return e.RESTMapper.KindFor(e.expandResourceShortcut(resource))
 }
 
-func (e shortcutExpander) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+func (e *shortcutExpander) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	return e.RESTMapper.KindsFor(e.expandResourceShortcut(resource))
 }
 
-func (e shortcutExpander) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+func (e *shortcutExpander) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	return e.RESTMapper.ResourcesFor(e.expandResourceShortcut(resource))
 }
 
-func (e shortcutExpander) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+func (e *shortcutExpander) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	return e.RESTMapper.ResourceFor(e.expandResourceShortcut(resource))
 }
 
-func (e shortcutExpander) ResourceSingularizer(resource string) (string, error) {
+func (e *shortcutExpander) ResourceSingularizer(resource string) (string, error) {
 	return e.RESTMapper.ResourceSingularizer(e.expandResourceShortcut(schema.GroupVersionResource{Resource: resource}).Resource)
 }
 
-func (e shortcutExpander) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+func (e *shortcutExpander) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	return e.RESTMapper.RESTMapping(gk, versions...)
 }
 
-func (e shortcutExpander) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+func (e *shortcutExpander) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	return e.RESTMapper.RESTMappings(gk, versions...)
-}
-
-// getShortcutMappings returns a set of tuples which holds short names for resources.
-// First the list of potential resources will be taken from the API server.
-// Next we will append the hardcoded list of resources - to be backward compatible with old servers.
-// NOTE that the list is ordered by group priority.
-func (e shortcutExpander) getShortcutMappings() ([]*metav1.APIResourceList, []kubectl.ResourceShortcuts, error) {
-	res := []kubectl.ResourceShortcuts{}
-	// get server resources
-	// This can return an error *and* the results it was able to find.  We don't need to fail on the error.
-	apiResList, err := e.discoveryClient.ServerResources()
-	if err != nil {
-		glog.V(1).Infof("Error loading discovery information: %v", err)
-	}
-	for _, apiResources := range apiResList {
-		gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)
-		if err != nil {
-			glog.V(1).Infof("Unable to parse groupversion = %s due to = %s", apiResources.GroupVersion, err.Error())
-			continue
-		}
-		for _, apiRes := range apiResources.APIResources {
-			for _, shortName := range apiRes.ShortNames {
-				rs := kubectl.ResourceShortcuts{
-					ShortForm: schema.GroupResource{Group: gv.Group, Resource: shortName},
-					LongForm:  schema.GroupResource{Group: gv.Group, Resource: apiRes.Name},
-				}
-				res = append(res, rs)
-			}
-		}
-	}
-
-	// append hardcoded short forms at the end of the list
-	res = append(res, kubectl.ResourcesShortcutStatic...)
-	return apiResList, res, nil
 }
 
 // expandResourceShortcut will return the expanded version of resource
 // (something that a pkg/api/meta.RESTMapper can understand), if it is
 // indeed a shortcut. If no match has been found, we will match on group prefixing.
 // Lastly we will return resource unmodified.
-func (e shortcutExpander) expandResourceShortcut(resource schema.GroupVersionResource) schema.GroupVersionResource {
+func (e *shortcutExpander) expandResourceShortcut(resource schema.GroupVersionResource) schema.GroupVersionResource {
 	// get the shortcut mappings and return on first match.
-	if allResources, shortcutResources, err := e.getShortcutMappings(); err == nil {
+	if allResources, shortcutResources, err := e.getResources(); err == nil {
 		// avoid expanding if there's an exact match to a full resource name
 		for _, apiResources := range allResources {
 			gv, err := schema.ParseGroupVersion(apiResources.GroupVersion)

--- a/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
@@ -125,10 +125,9 @@ func TestReplaceAliases(t *testing.T) {
 		},
 	}
 
-	ds := &fakeDiscoveryClient{}
-	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
-
 	for _, test := range tests {
+		ds := &fakeDiscoveryClient{}
+		mapper := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
 		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
 			return test.srvRes, nil
 		}

--- a/pkg/kubectl/cmd/util/suggestion_restmapper.go
+++ b/pkg/kubectl/cmd/util/suggestion_restmapper.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/kubectl"
+)
+
+type NoResourceWithSuggestionError struct {
+	*meta.NoResourceMatchError
+
+	Suggestions []string
+}
+
+var _ error = &NoResourceWithSuggestionError{}
+
+// suggestionRESTMapper is a decorator of meta.RESTMapper. If the KindFor,
+// KindsFor, ResourcesFor, ResourceFor returns NoResourceMatchError, it will try
+// to guess resource names based on shorted edit distance.
+type suggestionRESTMapper struct {
+	*resourceDiscover
+
+	delegate     meta.RESTMapper
+	excludeShort bool // exclude short form if set as true
+}
+
+var _ meta.RESTMapper = &suggestionRESTMapper{}
+
+func (m *suggestionRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	result, err := m.delegate.KindFor(resource)
+	return result, m.wrapError(err, resource)
+}
+
+func (m *suggestionRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	result, err := m.delegate.KindsFor(resource)
+	return result, m.wrapError(err, resource)
+}
+
+func (m *suggestionRESTMapper) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	result, err := m.delegate.ResourcesFor(resource)
+	return result, m.wrapError(err, resource)
+}
+
+func (m *suggestionRESTMapper) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	result, err := m.delegate.ResourceFor(resource)
+	return result, m.wrapError(err, resource)
+}
+
+func (m *suggestionRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	return m.delegate.ResourceSingularizer(schema.GroupVersionResource{Resource: resource}.Resource)
+}
+
+func (m *suggestionRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return m.delegate.RESTMapping(gk, versions...)
+}
+
+func (m *suggestionRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return m.delegate.RESTMappings(gk, versions...)
+}
+
+func (m *suggestionRESTMapper) similarResources(resource schema.GroupVersionResource) []string {
+	var shortcuts []kubectl.ResourceShortcuts
+	var resources []*metav1.APIResourceList
+	var err error
+
+	if resources, shortcuts, err = m.getResources(); err != nil || len(shortcuts) == 0 {
+		return []string{}
+	}
+
+	allNames := map[string]bool{}
+	for _, resourceList := range resources {
+		for _, resource := range resourceList.APIResources {
+			allNames[resource.Name] = true
+			allNames[resource.SingularName] = true
+		}
+	}
+	for _, shortcut := range shortcuts {
+		allNames[shortcut.LongForm.String()] = true
+		allNames[shortcut.LongForm.Resource] = true
+		if !m.excludeShort {
+			allNames[shortcut.ShortForm.String()] = true
+			allNames[shortcut.ShortForm.Resource] = true
+		}
+	}
+
+	results := map[int][]string{}
+	gr := resource.GroupResource()
+	res := (&gr).String()
+	max := len(res) / 2
+
+	for name := range allNames {
+		// TODO: parallel it
+		dist := editDistance(res, name)
+		if dist <= max {
+			results[dist] = append(results[dist], name)
+		}
+	}
+
+	for i := 1; i <= max; i++ {
+		if result, ok := results[i]; ok {
+			return result
+		}
+	}
+
+	return []string{}
+}
+
+func (m *suggestionRESTMapper) wrapError(err error, resource schema.GroupVersionResource) error {
+	switch er := err.(type) {
+	case *meta.NoResourceMatchError:
+		return &NoResourceWithSuggestionError{
+			NoResourceMatchError: er,
+			Suggestions:          m.similarResources(resource),
+		}
+	}
+
+	return err
+}

--- a/pkg/kubectl/cmd/util/suggestion_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/suggestion_restmapper_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+func TestKindForSuggestion(t *testing.T) {
+	tests := []struct {
+		in          schema.GroupVersionResource
+		srvRes      []*metav1.APIResourceList
+		suggestions []string
+	}{
+		{
+			in:          schema.GroupVersionResource{Group: "storage.k8s.io", Version: "", Resource: "ss"},
+			suggestions: []string{"sc.storage.k8s.io"},
+			srvRes: []*metav1.APIResourceList{
+				{
+					GroupVersion: "storage.k8s.io/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "storageclasses",
+							ShortNames: []string{"sc"},
+						},
+					},
+				},
+			},
+		},
+		{
+			in:          schema.GroupVersionResource{Group: "", Version: "", Resource: "deploym"},
+			suggestions: []string{"deploy"},
+			srvRes:      []*metav1.APIResourceList{},
+		},
+		{
+			in:          schema.GroupVersionResource{Group: "", Version: "", Resource: "ns1"},
+			suggestions: []string{"ns"},
+			srvRes:      []*metav1.APIResourceList{},
+		},
+		{
+			in:          schema.GroupVersionResource{Group: "", Version: "", Resource: "deploymenst"},
+			suggestions: []string{"deployments"},
+			srvRes:      []*metav1.APIResourceList{},
+		},
+	}
+
+	ds := &fakeDiscoveryClient{}
+	expander := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
+	mapper := &suggestionRESTMapper{
+		resourceDiscover: expander.resourceDiscover,
+		delegate:         expander,
+	}
+
+	for i, test := range tests {
+		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
+			return test.srvRes, nil
+		}
+		_, err := mapper.KindFor(test.in)
+		if err == nil {
+			t.Errorf("%d: expected error; got nil", i)
+		}
+
+		switch err := err.(type) {
+		case *NoResourceWithSuggestionError:
+			if !reflect.DeepEqual(err.Suggestions, test.suggestions) {
+				t.Errorf("%d: unexpected recommends %s", i, err.Suggestions)
+			}
+		default:
+			t.Errorf("%d: unexpected error %s", i, err.Error())
+		}
+	}
+}


### PR DESCRIPTION
When typing the wrong resource type name, make kubectl smart enough to
recommend the true resource name based on the shorted edit distance.
Inspired by `git`.

$ ./kubectl get nodex
the server doesn't have a resource type "nodex"

Did you mean one of these?

	nodes

$ ./kubectl get deplyo.extensions
the server doesn't have a resource type "deplyo" in group "extensions"

Did you mean one of these?

	deploy.extensions

**What this PR does / why we need it**: more user-friendly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl: auto correction for typos in subcommand and resource name
```
