### PR TITLE
Bugfix/logf newline

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -56,7 +56,7 @@ func setupProviderConfig() error {
 		glog.Info("The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.")
 
 	case "gce", "gke":
-		framework.Logf("Fetching cloud provider for %q\r\n", framework.TestContext.Provider)
+		framework.Logf("Fetching cloud provider for %q\r", framework.TestContext.Provider)
 		zone := framework.TestContext.CloudConfig.Zone
 		region := framework.TestContext.CloudConfig.Region
 
@@ -295,7 +295,7 @@ func gatherTestSuiteMetrics() error {
 			return fmt.Errorf("error writing to %q: %v", filePath, err)
 		}
 	} else {
-		framework.Logf("\n\nTest Suite Metrics:\n%s\n\n", metricsJSON)
+		framework.Logf("\n\nTest Suite Metrics:\n%s\n", metricsJSON)
 	}
 
 	return nil

--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -103,7 +103,7 @@ func testStackdriverAcceleratorMonitoring(f *framework.Framework) {
 	pollingFunction := checkForAcceleratorMetrics(projectId, gcmService, time.Now(), metricsMap)
 	err = wait.Poll(pollFrequency, pollTimeout, pollingFunction)
 	if err != nil {
-		framework.Logf("Missing metrics: %+v\n", metricsMap)
+		framework.Logf("Missing metrics: %+v", metricsMap)
 	}
 	framework.ExpectNoError(err)
 }

--- a/test/e2e/scheduling/ubernetes_lite_volumes.go
+++ b/test/e2e/scheduling/ubernetes_lite_volumes.go
@@ -65,7 +65,7 @@ func OnlyAllowNodeZones(f *framework.Framework, zoneCount int, image string) {
 	// Get all the zones that the nodes are in
 	expectedZones, err := gceCloud.GetAllZonesFromCloudProvider()
 	Expect(err).NotTo(HaveOccurred())
-	framework.Logf("Expected zones: %v\n", expectedZones)
+	framework.Logf("Expected zones: %v", expectedZones)
 
 	// Get all the zones in this current region
 	region := gceCloud.Region()

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -161,9 +161,9 @@ var _ = framework.KubeDescribe("Container Manager Misc [Serial]", func() {
 							},
 						})
 						Expect(err).NotTo(HaveOccurred())
-						framework.Logf("Running containers:\n")
+						framework.Logf("Running containers:")
 						for _, c := range containers {
-							framework.Logf("%+v\n", c)
+							framework.Logf("%+v", c)
 						}
 					}
 				})

--- a/test/e2e_node/density_test.go
+++ b/test/e2e_node/density_test.go
@@ -198,7 +198,7 @@ var _ = framework.KubeDescribe("Density [Serial] [Slow]", func() {
 				// Here we set API QPS limit from default 5 to 60 in order to test real Kubelet performance.
 				// Note that it will cause higher resource usage.
 				tempSetCurrentKubeletConfig(f, func(cfg *kubeletconfig.KubeletConfiguration) {
-					framework.Logf("Old QPS limit is: %d\n", cfg.KubeAPIQPS)
+					framework.Logf("Old QPS limit is: %d", cfg.KubeAPIQPS)
 					// Set new API QPS limit
 					cfg.KubeAPIQPS = int32(itArg.APIQPSLimit)
 				})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Removes all redundant new lines being passed into the `Logf()` function. This involved going through code in both `test/e2e` and `test/e2e_node`, finding the newline redundancies in calls to `Logf()` and removing them.

**Which issue(s) this PR fixes**:
Fixes [#57102](https://github.com/kubernetes/kubernetes/issues/57102)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
  