### PR TITLE
Fix incorrect hairpin-mode value and validate it

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -591,6 +591,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			ReadOnlyPort:                utilpointer.Int32Ptr(0),
 			RegistryBurst:               10,
 			RegistryPullQPS:             utilpointer.Int32Ptr(5),
+			HairpinMode:                 "promiscuous-bridge",
 		},
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase, nil); len(allErrors) != 0 {

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -192,7 +192,7 @@ type KubeletConfiguration struct {
 	//   "promiscuous-bridge": make the container bridge promiscuous.
 	//   "hairpin-veth":       set the hairpin flag on container veth interfaces.
 	//   "none":               do nothing.
-	// Generally, one must set --hairpin-mode=veth-flag to achieve hairpin NAT,
+	// Generally, one must set --hairpin-mode=hairpin-veth to achieve hairpin NAT,
 	// because promiscous-bridge assumes the existence of a container bridge named cbr0.
 	HairpinMode string
 	// maxPods is the number of pods that can run on this Kubelet.

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
@@ -189,7 +189,7 @@ type KubeletConfiguration struct {
 	//   "promiscuous-bridge": make the container bridge promiscuous.
 	//   "hairpin-veth":       set the hairpin flag on container veth interfaces.
 	//   "none":               do nothing.
-	// Generally, one must set --hairpin-mode=veth-flag to achieve hairpin NAT,
+	// Generally, one must set --hairpin-mode=hairpin-veth to achieve hairpin NAT,
 	// because promiscous-bridge assumes the existence of a container bridge named cbr0.
 	HairpinMode string `json:"hairpinMode"`
 	// maxPods is the number of pods that can run on this Kubelet.

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation.go
@@ -100,5 +100,13 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 				val, kubetypes.NodeAllocatableEnforcementKey, kubetypes.SystemReservedEnforcementKey, kubetypes.KubeReservedEnforcementKey))
 		}
 	}
+	switch kc.HairpinMode {
+	case kubeletconfig.HairpinNone:
+	case kubeletconfig.HairpinVeth:
+	case kubeletconfig.PromiscuousBridge:
+	default:
+		allErrors = append(allErrors, fmt.Errorf("Invalid option %q specified for HairpinMode (--hairpin-mode) setting. Valid options are %q, %q or %q",
+			kc.HairpinMode, kubeletconfig.HairpinNone, kubeletconfig.HairpinVeth, kubeletconfig.PromiscuousBridge))
+	}
 	return utilerrors.NewAggregate(allErrors)
 }

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation_test.go
@@ -47,6 +47,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		ReadOnlyPort:                0,
 		RegistryBurst:               10,
 		RegistryPullQPS:             5,
+		HairpinMode:                 kubeletconfig.PromiscuousBridge,
 	}
 	if allErrors := ValidateKubeletConfiguration(successCase); allErrors != nil {
 		t.Errorf("expect no errors got %v", allErrors)
@@ -75,8 +76,9 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		ReadOnlyPort:                -10,
 		RegistryBurst:               -10,
 		RegistryPullQPS:             -10,
+		HairpinMode:                 "foo",
 	}
-	if allErrors := ValidateKubeletConfiguration(errorCase); len(allErrors.(utilerrors.Aggregate).Errors()) != 21 {
-		t.Errorf("expect 21 errors got %v", len(allErrors.(utilerrors.Aggregate).Errors()))
+	if allErrors := ValidateKubeletConfiguration(errorCase); len(allErrors.(utilerrors.Aggregate).Errors()) != 22 {
+		t.Errorf("expect 22 errors got %v", len(allErrors.(utilerrors.Aggregate).Errors()))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* Fix incorrect hairpin-mode value 

* Add validation

**Which issue(s) this PR fixes**:
Fixes #57609

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
