### PR TITLE
[quota controller] remove extra queue.Add()

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -308,7 +308,6 @@ func (rq *ResourceQuotaController) syncResourceQuotaFromKey(key string) (err err
 	}
 	if err != nil {
 		glog.Infof("Unable to retrieve resource quota %v from store: %v", key, err)
-		rq.queue.Add(key)
 		return err
 	}
 	return rq.syncResourceQuota(quota)


### PR DESCRIPTION
requeue immediately after an error may end-up with hot-loop


**Release note**:

```release-note
NONE
```
