### PR TITLE
Remove duplicate error output

### DIFF
--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"k8s.io/kubernetes/cmd/kubectl/app"
@@ -25,7 +24,7 @@ import (
 
 func main() {
 	if err := app.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		// err already printed to stderr by cobra
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Cobra already printed `err` to stderr. `fmt.Fprintf` prints `err` again, as shown below:

```
# kubectl expo
Error: unknown command "expo" for "kubectl"

Did you mean this?
        expose
        exec

Run 'kubectl --help' for usage.
error: unknown command "expo" for "kubectl"

Did you mean this?
        expose
        exec

```

Duplicate `err` is printed for all CLI commands errors case.

```
# kubectl --no-such-command               
Error: unknown flag: --no-such-command               
                                                     
.. skipped ...

error: unknown flag: --no-such-command                                                  
```
```
# kubectl nosuchcommand
Error: unknown command "nosuchcommand" for "kubectl"
Run 'kubectl --help' for usage.
error: unknown command "nosuchcommand" for "kubectl"
```
