### PR TITLE
Update local-volume e2e test for new provisioner config format

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**: 

The local-volume bootstrapper/provisioner configuration format changed in
https://github.com/kubernetes-incubator/external-storage/pull/352

This PR updates the provisioner config, so that the existing e2e test continues to function.

**Which issue(s) this PR fixes** : 
Fixes https://github.com/kubernetes/kubernetes/issues/57664

**Special notes for your reviewer**:
The image tag for the provisioner and bootstrapper have been changed to v2.0.0.

**Release note**:
```NONE

```
