### PR TITLE
Add localhost to valid bind IPs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -378,10 +378,10 @@ func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer) (net.IP,
 }
 
 // If bind-address is usable, return it directly
-// If bind-address is not usable (unset, 0.0.0.0, or loopback), we will use the host's default
+// If bind-address is not usable (unset, 0.0.0.0), we will use the host's default
 // interface.
 func ChooseBindAddress(bindAddress net.IP) (net.IP, error) {
-	if bindAddress == nil || bindAddress.IsUnspecified() || bindAddress.IsLoopback() {
+	if bindAddress == nil || bindAddress.IsUnspecified() {
 		hostIP, err := ChooseHostInterface()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously in case IP was set to 127.0.0.1, IP was rediscovered from available interfaces instead of configured one. This blocks use-cases like localhost proxies on client side

**Which issue(s) this PR fixes** 
kubernetes/kubeadm#487

**Special notes for your reviewer**:
I've created PR: https://github.com/kubernetes/apimachinery/pull/26 but @nikhita asked to reopen it to main repo. So here it is. 

**Release note**:
```
NONE
```