### PR TITLE
keep oom events watch cgroup root sync with kubelet

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/certificate:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
+        "//pkg/kubelet/cm/util:go_default_library",
         "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/configmap:go_default_library",
         "//pkg/kubelet/container:go_default_library",

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/deviceplugin"
+	"k8s.io/kubernetes/pkg/kubelet/cm/util"
 	cmutil "k8s.io/kubernetes/pkg/kubelet/cm/util"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -242,7 +243,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		glog.Infof("container manager verified user specified cgroup-root exists: %v", cgroupRoot)
 		// Include the top level cgroup for enforcing node allocatable into cgroup-root.
 		// This way, all sub modules can avoid having to understand the concept of node allocatable.
-		cgroupRoot = path.Join(cgroupRoot, defaultNodeAllocatableCgroupName)
+		cgroupRoot = util.GetCgroupRootUnderCgroupsPerQOS(cgroupRoot)
 	}
 	glog.Infof("Creating Container Manager object based on Node Config: %+v", nodeConfig)
 

--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -35,10 +35,6 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
-const (
-	defaultNodeAllocatableCgroupName = "kubepods"
-)
-
 func (cm *containerManagerImpl) createNodeAllocatableCgroups() error {
 	cgroupConfig := &CgroupConfig{
 		Name: CgroupName(cm.cgroupRoot),

--- a/pkg/kubelet/cm/util/BUILD
+++ b/pkg/kubelet/cm/util/BUILD
@@ -7,7 +7,9 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = select({
+    srcs = [
+        "util.go",
+    ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "cgroups_unsupported.go",
         ],

--- a/pkg/kubelet/cm/util/util.go
+++ b/pkg/kubelet/cm/util/util.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"path"
+)
+
+const (
+	defaultNodeAllocatableCgroupName = "kubepods"
+)
+
+// GetCgroupRootUnderCgroupsPerQOS returns adjusted CgroupRoot when CgroupsPerQOS is enabled.
+func GetCgroupRootUnderCgroupsPerQOS(cgroupRoot string) string {
+	return path.Join(cgroupRoot, defaultNodeAllocatableCgroupName)
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -465,7 +465,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	containerRefManager := kubecontainer.NewRefManager()
 
-	oomWatcher := NewOOMWatcher(kubeDeps.CAdvisorInterface, kubeDeps.Recorder)
+	oomWatcher := NewOOMWatcher(kubeDeps.CAdvisorInterface, kubeDeps.Recorder, kubeDeps.ContainerManager)
 
 	clusterDNS := make([]net.IP, 0, len(kubeCfg.ClusterDNS))
 	for _, ipEntry := range kubeCfg.ClusterDNS {

--- a/pkg/kubelet/oom_watcher_test.go
+++ b/pkg/kubelet/oom_watcher_test.go
@@ -24,13 +24,15 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 )
 
 func TestBasic(t *testing.T) {
 	fakeRecorder := &record.FakeRecorder{}
 	mockCadvisor := &cadvisortest.Fake{}
 	node := &v1.ObjectReference{}
-	oomWatcher := NewOOMWatcher(mockCadvisor, fakeRecorder)
+	containerManager := cm.NewStubContainerManager()
+	oomWatcher := NewOOMWatcher(mockCadvisor, fakeRecorder, containerManager)
 	assert.NoError(t, oomWatcher.Start(node))
 
 	// TODO: Improve this test once cadvisor exports events.EventChannel as an interface


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently kubelet will adjust cgroup root based on `--cgroup-root` and `--cgroups-per-qos` kubelet command line argument. OOM events watch cgroup name does not change according to different composition of `--cgroup-root` and `--cgroups-per-qos`.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Keep oom events watch cgroup root sync with kubelet
```
