### PR TITLE
Automated cherry pick of #57296: Update CoreDNS version and Corefile.

### DIFF
--- a/cluster/addons/dns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns.yaml.base
@@ -57,9 +57,11 @@ data:
   Corefile: |
     .:53 {
         errors
-        log stdout
+        log
         health
-        kubernetes __PILLAR__DNS__DOMAIN__ __PILLAR__CLUSTER_CIDR__
+        kubernetes __PILLAR__DNS__DOMAIN__ __PILLAR__CLUSTER_CIDR__ {
+            pods insecure
+        }
         prometheus
         proxy . /etc/resolv.conf
         cache 30
@@ -93,7 +95,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:0.9.10
+        image: coredns/coredns:1.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns.yaml.in
@@ -57,9 +57,11 @@ data:
   Corefile: |
     .:53 {
         errors
-        log stdout
+        log
         health
-        kubernetes {{ pillar['dns_domain'] }} {{ pillar['service_cluster_ip_range'] }}
+        kubernetes {{ pillar['dns_domain'] }} {{ pillar['service_cluster_ip_range'] }} {
+            pods insecure
+        }
         prometheus
         proxy . /etc/resolv.conf
         cache 30
@@ -93,7 +95,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:0.9.10
+        image: coredns/coredns:1.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns.yaml.sed
@@ -57,9 +57,11 @@ data:
   Corefile: |
     .:53 {
         errors
-        log stdout
+        log
         health
-        kubernetes $DNS_DOMAIN $SERVICE_CLUSTER_IP_RANGE
+        kubernetes $DNS_DOMAIN $SERVICE_CLUSTER_IP_RANGE {
+            pods insecure
+        }
         prometheus
         proxy . /etc/resolv.conf
         cache 30
@@ -93,7 +95,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:0.9.10
+        image: coredns/coredns:1.0.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -293,7 +293,7 @@ data:
   Corefile: |
     .:53 {
         errors
-        log stdout
+        log
         health
         kubernetes {{ .DNSDomain }} {{ .ServiceCIDR }} {
            pods insecure

--- a/cmd/kubeadm/app/phases/addons/dns/versions.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions.go
@@ -27,14 +27,14 @@ const (
 
 	kubeDNSProbeSRV = "SRV"
 	kubeDNSProbeA   = "A"
-	coreDNSVersion  = "1.0.0"
+	coreDNSVersion  = "1.0.1"
 )
 
 // GetDNSVersion returns the right kube-dns version for a specific k8s version
 func GetDNSVersion(kubeVersion *version.Version, dns string) string {
 	// v1.8.0+ uses kube-dns 1.14.5
 	// v1.9.0+ uses kube-dns 1.14.7
-	// v1.9.0+ uses CoreDNS  1.0.0
+	// v1.9.0+ uses CoreDNS  1.0.1
 
 	// In the future when the version is bumped at HEAD; add conditional logic to return the right versions
 	// Also, the version might be bumped for different k8s releases on the same branch


### PR DESCRIPTION
Cherry pick of #57296 on release-1.9.

#57296: Update CoreDNS version and Corefile.

```release-note
Fix CoreDNS not having logs when it's deployed by default using feature-gates of kubeadm. Add `pods insecure` option of CoreDNS in kubeadm manifest to be on parity with kube-dns behavior.
```