### PR TITLE
code-generator: add boilerplate header

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -72,7 +72,7 @@ INTERNAL_DIRS_CSV=$(IFS=',';echo "${INTERNAL_DIRS[*]// /,}";IFS=$)
 # This can be called with one flag, --verify-only, so it works for both the
 # update- and verify- scripts.
 ${clientgen} --input-base="k8s.io/kubernetes/pkg/apis" --input="${INTERNAL_DIRS_CSV}" "$@"
-${clientgen} --output-base "${KUBE_ROOT}/vendor" --output-package="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" "$@"
+${clientgen} --output-base "${KUBE_ROOT}/vendor" --output-package="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" --go-header-file ${KUBE_ROOT}/hack/boilerplate/boilerplate.go.txt "$@"
 
 listergen_internal_apis=(
 $(
@@ -91,7 +91,7 @@ $(
 )
 )
 listergen_external_apis_csv=$(IFS=,; echo "${listergen_external_apis[*]}")
-${listergen} --output-base "${KUBE_ROOT}/vendor" --output-package "k8s.io/client-go/listers" --input-dirs "${listergen_external_apis_csv}" "$@"
+${listergen} --output-base "${KUBE_ROOT}/vendor" --output-package "k8s.io/client-go/listers" --input-dirs "${listergen_external_apis_csv}" --go-header-file ${KUBE_ROOT}/hack/boilerplate/boilerplate.go.txt "$@"
 
 informergen_internal_apis=(
 $(
@@ -105,6 +105,7 @@ ${informergen} \
   --input-dirs "${informergen_internal_apis_csv}" \
   --internal-clientset-package k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset \
   --listers-package k8s.io/kubernetes/pkg/client/listers \
+  --go-header-file ${KUBE_ROOT}/hack/boilerplate/boilerplate.go.txt \
   "$@"
 
 informergen_external_apis=(
@@ -124,6 +125,7 @@ ${informergen} \
   --input-dirs "${informergen_external_apis_csv}" \
   --versioned-clientset-package k8s.io/client-go/kubernetes \
   --listers-package k8s.io/client-go/listers \
+  --go-header-file ${KUBE_ROOT}/hack/boilerplate/boilerplate.go.txt \
   "$@"
 
 # You may add additional calls of code generators like set-gen above.

--- a/hack/update-generated-protobuf-dockerized.sh
+++ b/hack/update-generated-protobuf-dockerized.sh
@@ -92,5 +92,6 @@ PATH="${KUBE_ROOT}/_output/bin:${PATH}" \
   "${gotoprotobuf}" \
   --proto-import="${KUBE_ROOT}/vendor" \
   --proto-import="${KUBE_ROOT}/third_party/protobuf" \
-  --packages=$(IFS=, ; echo "${PACKAGES[*]}")
+  --packages=$(IFS=, ; echo "${PACKAGES[*]}") \
+  --go-header-file ${KUBE_ROOT}/hack/boilerplate/boilerplate.go.txt \
   "$@"

--- a/staging/BUILD
+++ b/staging/BUILD
@@ -212,6 +212,7 @@ filegroup(
         "//staging/src/k8s.io/code-generator/cmd/lister-gen:all-srcs",
         "//staging/src/k8s.io/code-generator/cmd/openapi-gen:all-srcs",
         "//staging/src/k8s.io/code-generator/cmd/set-gen:all-srcs",
+        "//staging/src/k8s.io/code-generator/hack:all-srcs",
         "//staging/src/k8s.io/code-generator/pkg/util:all-srcs",
         "//staging/src/k8s.io/code-generator/third_party/forked/golang/reflect:all-srcs",
         "//staging/src/k8s.io/kube-aggregator:all-srcs",

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/generators:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -27,6 +27,7 @@ import (
 
 	generatorargs "k8s.io/code-generator/cmd/client-gen/args"
 	"k8s.io/code-generator/cmd/client-gen/generators"
+	"k8s.io/code-generator/pkg/util"
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of client-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 	genericArgs.OutputPackagePath = "k8s.io/kubernetes/pkg/client/clientset_generated/"
 
 	genericArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/conversion-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/conversion-gen/generators:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
@@ -44,6 +44,7 @@ import (
 
 	generatorargs "k8s.io/code-generator/cmd/conversion-gen/args"
 	"k8s.io/code-generator/cmd/conversion-gen/generators"
+	"k8s.io/code-generator/pkg/util"
 )
 
 func main() {
@@ -51,7 +52,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of conversion-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/deepcopy-gen/args:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/examples/deepcopy-gen/generators:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/main.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/gengo/examples/deepcopy-gen/generators"
 
 	generatorargs "k8s.io/code-generator/cmd/deepcopy-gen/args"
+	"k8s.io/code-generator/pkg/util"
 )
 
 func main() {
@@ -59,7 +60,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of deepcopy-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/defaulter-gen/args:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/examples/defaulter-gen/generators:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/main.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/gengo/examples/defaulter-gen/generators"
 
 	generatorargs "k8s.io/code-generator/cmd/defaulter-gen/args"
+	"k8s.io/code-generator/pkg/util"
 )
 
 func main() {
@@ -58,7 +59,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of defaulter-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/BUILD
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/code-generator/third_party/forked/golang/reflect:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -55,7 +56,7 @@ func New() *Generator {
 	sourceTree := args.DefaultSourceTree()
 	common := args.GeneratorArgs{
 		OutputBase:       sourceTree,
-		GoHeaderFilePath: filepath.Join(sourceTree, "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt"),
+		GoHeaderFilePath: filepath.Join(sourceTree, util.BoilerplatePath()),
 	}
 	defaultProtoImport := filepath.Join(sourceTree, "k8s.io", "kubernetes", "vendor", "github.com", "gogo", "protobuf", "protobuf")
 	cwd, err := os.Getwd()

--- a/staging/src/k8s.io/code-generator/cmd/import-boss/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/import-boss/BUILD
@@ -18,6 +18,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/import-boss",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/examples/import-boss/generators:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/import-boss/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/import-boss/main.go
@@ -59,6 +59,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/examples/import-boss/generators"
 
@@ -69,7 +70,7 @@ func main() {
 	arguments := args.Default()
 
 	// Override defaults.
-	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 	arguments.InputDirs = []string{
 		"k8s.io/kubernetes/pkg/...",
 		"k8s.io/kubernetes/cmd/...",

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/informer-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/informer-gen/generators:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"k8s.io/code-generator/cmd/informer-gen/generators"
+	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 
 	generatorargs "k8s.io/code-generator/cmd/informer-gen/args"
@@ -33,7 +34,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move out of informer-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 	genericArgs.OutputPackagePath = "k8s.io/kubernetes/pkg/client/informers/informers_generated"
 	customArgs.VersionedClientSetPackage = "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	customArgs.InternalClientSetPackage = "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/lister-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/lister-gen/generators:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"k8s.io/code-generator/cmd/lister-gen/generators"
+	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 
 	generatorargs "k8s.io/code-generator/cmd/lister-gen/args"
@@ -33,7 +34,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of lister-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 	genericArgs.OutputPackagePath = "k8s.io/kubernetes/pkg/client/listers"
 
 	genericArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/openapi-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/openapi-gen/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/openapi-gen/args:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/generators:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/openapi-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/openapi-gen/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kube-openapi/pkg/generators"
 
 	generatorargs "k8s.io/code-generator/cmd/openapi-gen/args"
+	"k8s.io/code-generator/pkg/util"
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 
 	// Override defaults.
 	// TODO: move this out of openapi-gen
-	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)

--- a/staging/src/k8s.io/code-generator/cmd/set-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/set-gen/BUILD
@@ -22,6 +22,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/set-gen",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/examples/set-gen/generators:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/set-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/set-gen/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/examples/set-gen/generators"
 
@@ -38,7 +39,7 @@ func main() {
 	arguments := args.Default()
 
 	// Override defaults.
-	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), util.BoilerplatePath())
 	arguments.InputDirs = []string{"k8s.io/kubernetes/pkg/util/sets/types"}
 	arguments.OutputPackagePath = "k8s.io/apimachinery/pkg/util/sets"
 

--- a/staging/src/k8s.io/code-generator/hack/BUILD
+++ b/staging/src/k8s.io/code-generator/hack/BUILD
@@ -1,0 +1,18 @@
+exports_files(
+    glob(["*.txt"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/code-generator/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/code-generator/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/code-generator/pkg/util/build.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/build.go
@@ -18,9 +18,13 @@ package util
 
 import (
 	gobuild "go/build"
+	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 )
+
+type empty struct{}
 
 // CurrentPackage returns the go package of the current directory, or "" if it cannot
 // be derived from the GOPATH.
@@ -49,4 +53,9 @@ func hasSubdir(root, dir string) (rel string, ok bool) {
 
 	// cut off root
 	return filepath.ToSlash(dir[len(root):]), true
+}
+
+// BoilerplatePath uses the boilerplate in code-generator by calculating the relative path to it.
+func BoilerplatePath() string {
+	return path.Join(reflect.TypeOf(empty{}).PkgPath(), "/../../hack/boilerplate.go.txt")
 }


### PR DESCRIPTION
Currently, the boilerplate header from k8s.io/kubernetes is used. If k8s.io/kubernetes is not in the GOPATH, a
panic will occur.

Making this a part of k8s.io/code-generator will prevent this panic.

Fixes kubernetes/code-generator#6


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts 