### PR TITLE
Implement verbosity feature for kubeadm

### DIFF
--- a/cmd/kubeadm/app/BUILD
+++ b/cmd/kubeadm/app/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm/install:go_default_library",
         "//cmd/kubeadm/app/cmd:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//pkg/util/node:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 
@@ -133,6 +134,7 @@ func RunCompletion(out io.Writer, boilerPlate string, cmd *cobra.Command, args [
 }
 
 func runCompletionBash(out io.Writer, kubeadm *cobra.Command) error {
+	glog.V(1).Infoln("[completion] writing completion code for Bash")
 	return kubeadm.GenBashCompletion(out)
 }
 
@@ -278,10 +280,12 @@ __kubeadm_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__kubeadm_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
+	glog.V(1).Infoln("[completion] writing completion code for Zsh")
 	out.Write([]byte(zshInitialization))
 
 	buf := new(bytes.Buffer)
 	kubeadm.GenBashCompletion(buf)
+	glog.V(1).Infoln("[completion] writing completion code for Bash")
 	out.Write(buf.Bytes())
 
 	zshTail := `

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -200,27 +201,33 @@ type Join struct {
 func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, ignorePreflightErrors sets.String) (*Join, error) {
 
 	if cfg.NodeName == "" {
+		glog.V(1).Infoln("[join] found NodeName empty")
+		glog.V(1).Infoln("[join] considered OS hostname as NodeName")
 		cfg.NodeName = nodeutil.GetHostname("")
 	}
 
 	if cfgPath != "" {
+		glog.V(1).Infoln("[join] reading configuration from", cfgPath)
 		b, err := ioutil.ReadFile(cfgPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read config from %q [%v]", cfgPath, err)
 		}
+		glog.V(1).Infoln("[join] decoding configuration information")
 		if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), b, cfg); err != nil {
 			return nil, fmt.Errorf("unable to decode config from %q [%v]", cfgPath, err)
 		}
 	}
 
-	fmt.Println("[preflight] Running pre-flight checks.")
+	glog.Infoln("[preflight] running pre-flight checks")
 
 	// Then continue with the others...
+	glog.V(1).Infoln("[preflight] running various checks on all nodes")
 	if err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, ignorePreflightErrors); err != nil {
 		return nil, err
 	}
 
 	// Try to start the kubelet service in case it's inactive
+	glog.V(1).Infoln("[preflight] starting kubelet service if it's inactive")
 	preflight.TryStartKubelet(ignorePreflightErrors)
 
 	return &Join{cfg: cfg}, nil
@@ -236,6 +243,7 @@ func (j *Join) Validate(cmd *cobra.Command) error {
 
 // Run executes worker node provisioning and tries to join an existing cluster.
 func (j *Join) Run(out io.Writer) error {
+	glog.V(1).Infoln("[join] retrieving KubeConfig objects")
 	cfg, err := discovery.For(j.cfg)
 	if err != nil {
 		return err
@@ -244,6 +252,7 @@ func (j *Join) Run(out io.Writer) error {
 	kubeconfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.KubeletBootstrapKubeConfigFileName)
 
 	// Write the bootstrap kubelet config file or the TLS-Boostrapped kubelet config file down to disk
+	glog.V(1).Infoln("[join] writing bootstrap kubelet config file at", kubeconfigFile)
 	if err := kubeconfigutil.WriteToDisk(kubeconfigFile, cfg); err != nil {
 		return fmt.Errorf("couldn't save bootstrap-kubelet.conf to disk: %v", err)
 	}
@@ -256,6 +265,7 @@ func (j *Join) Run(out io.Writer) error {
 	}
 
 	// NOTE: flag "--dynamic-config-dir" should be specified in /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+	glog.V(1).Infoln("[join] consuming base kubelet configuration")
 	if features.Enabled(j.cfg.FeatureGates, features.DynamicKubeletConfig) {
 		if err := kubeletphase.ConsumeBaseKubeletConfiguration(j.cfg.NodeName); err != nil {
 			return fmt.Errorf("error consuming base kubelet configuration: %v", err)

--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/normalizer:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/addons.go
@@ -19,6 +19,7 @@ package phases
 import (
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -80,6 +81,7 @@ func EnsureAllAddons(cfg *kubeadmapi.MasterConfiguration, client clientset.Inter
 		proxyaddon.EnsureProxyAddon,
 	}
 
+	glog.V(1).Infoln("[addon] installing all addons")
 	for _, action := range addonActions {
 		err := action(cfg, client)
 		if err != nil {

--- a/cmd/kubeadm/app/cmd/phases/bootstraptoken.go
+++ b/cmd/kubeadm/app/cmd/phases/bootstraptoken.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -316,19 +317,20 @@ func createBootstrapToken(kubeConfigFile string, client clientset.Interface, cfg
 		return err
 	}
 
+	glog.V(1).Infoln("[bootstraptoken] creating/updating token")
 	// Creates or updates the token
 	if err := node.UpdateOrCreateToken(client, internalcfg.Token, false, internalcfg.TokenTTL.Duration, internalcfg.TokenUsages, internalcfg.TokenGroups, description); err != nil {
 		return err
 	}
 
-	fmt.Println("[bootstraptoken] Bootstrap token Created")
-	fmt.Println("[bootstraptoken] You can now join any number of machines by running:")
+	glog.Infoln("[bootstraptoken] bootstrap token created")
+	glog.Infoln("[bootstraptoken] you can now join any number of machines by running:")
 
 	joinCommand, err := cmdutil.GetJoinCommand(kubeConfigFile, internalcfg.Token, skipTokenPrint)
 	if err != nil {
 		return fmt.Errorf("failed to get join command: %v", err)
 	}
-	fmt.Println(joinCommand)
+	glog.Infoln(joinCommand)
 
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/discovery/fake:go_default_library",

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
@@ -55,6 +56,8 @@ func NewCmdPlan(parentFlags *cmdUpgradeFlags) *cobra.Command {
 // RunPlan takes care of outputting available versions to upgrade to for the user
 func RunPlan(parentFlags *cmdUpgradeFlags) error {
 	// Start with the basics, verify that the cluster is healthy, build a client and a versionGetter. Never dry-run when planning.
+	glog.V(1).Infof("[upgrade/plan] verifying health of cluster")
+	glog.V(1).Infof("[upgrade/plan] retrieving configuration from cluster")
 	upgradeVars, err := enforceRequirements(parentFlags, false, "")
 	if err != nil {
 		return err
@@ -64,6 +67,7 @@ func RunPlan(parentFlags *cmdUpgradeFlags) error {
 	etcdCluster := kubeadmutil.LocalEtcdCluster{}
 
 	// Compute which upgrade possibilities there are
+	glog.V(1).Infof("[upgrade/plan] computing upgrade possibilities")
 	availUpgrades, err := upgrade.GetAvailableUpgrades(upgradeVars.versionGetter, parentFlags.allowExperimentalUpgrades, parentFlags.allowRCUpgrades, etcdCluster, upgradeVars.cfg.FeatureGates)
 	if err != nil {
 		return fmt.Errorf("[upgrade/versions] FATAL: %v", err)

--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
@@ -53,6 +54,7 @@ func NewCmdVersion(out io.Writer) *cobra.Command {
 // RunVersion provides the version information of kubeadm in format depending on arguments
 // specified in cobra.Command.
 func RunVersion(out io.Writer, cmd *cobra.Command) error {
+	glog.V(1).Infoln("[version] retrieving version info")
 	clientVersion := version.Get()
 	v := Version{
 		ClientVersion: &clientVersion,

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -17,8 +17,10 @@ limitations under the License.
 package app
 
 import (
+	"flag"
 	"os"
 
+	_ "github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
@@ -31,6 +33,9 @@ func Run() error {
 	pflag.CommandLine.MarkHidden("version")
 	pflag.CommandLine.MarkHidden("google-json-key")
 	pflag.CommandLine.MarkHidden("log-flush-frequency")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	pflag.Set("logtostderr", "true")
 
 	cmd := cmd.NewKubeadmCommand(os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()

--- a/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/BUILD
+++ b/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo/BUILD
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/apis/rbac/v1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/BUILD
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/token:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
@@ -17,7 +17,7 @@ limitations under the License.
 package node
 
 import (
-	"fmt"
+	"github.com/golang/glog"
 
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +47,7 @@ const (
 
 // AllowBootstrapTokensToPostCSRs creates RBAC rules in a way the makes Node Bootstrap Tokens able to post CSRs
 func AllowBootstrapTokensToPostCSRs(client clientset.Interface) error {
-	fmt.Println("[bootstraptoken] Configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials")
+	glog.Infoln("[bootstraptoken] configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials")
 
 	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,7 @@ func AllowBootstrapTokensToPostCSRs(client clientset.Interface) error {
 
 // AutoApproveNodeBootstrapTokens creates RBAC rules in a way that makes Node Bootstrap Tokens' CSR auto-approved by the csrapprover controller
 func AutoApproveNodeBootstrapTokens(client clientset.Interface) error {
-	fmt.Println("[bootstraptoken] Configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token")
+	glog.Infoln("[bootstraptoken] configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token")
 
 	// Always create this kubeadm-specific binding though
 	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
@@ -92,7 +92,7 @@ func AutoApproveNodeBootstrapTokens(client clientset.Interface) error {
 
 // AutoApproveNodeCertificateRotation creates RBAC rules in a way that makes Node certificate rotation CSR auto-approved by the csrapprover controller
 func AutoApproveNodeCertificateRotation(client clientset.Interface) error {
-	fmt.Println("[bootstraptoken] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster")
+	glog.Infoln("[bootstraptoken] configured RBAC rules to allow certificate rotation for all node client certificates in the cluster")
 
 	return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubeadm/app/phases/certs/BUILD
+++ b/cmd/kubeadm/app/phases/certs/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/certs/pkiutil:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
+
 	certutil "k8s.io/client-go/util/cert"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -32,7 +34,7 @@ import (
 // CreatePKIAssets will create and write to disk all PKI assets necessary to establish the control plane.
 // If the PKI assets already exists in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating PKI assets")
 	certActions := []func(cfg *kubeadmapi.MasterConfiguration) error{
 		CreateCACertAndKeyFiles,
 		CreateAPIServerCertAndKeyFiles,
@@ -53,7 +55,7 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
 		}
 	}
 
-	fmt.Printf("[certificates] Valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
+	glog.Infof("[certificates] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
 
 	return nil
 }
@@ -61,7 +63,7 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
 // CreateCACertAndKeyFiles create a new self signed cluster CA certificate and key files.
 // If the CA certificate and key files already exists in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 func CreateCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("create a new self signed cluster CA certificate and key files")
 	caCert, caKey, err := NewCACertAndKey()
 	if err != nil {
 		return err
@@ -79,7 +81,7 @@ func CreateCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
 // If the apiserver certificate and key files already exists in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the cluster CA certificate and key files exist in the CertificatesDir.
 func CreateAPIServerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new certificate and key files for the apiserver")
 	caCert, caKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -103,7 +105,7 @@ func CreateAPIServerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
 // If the apiserver-kubelet-client certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 // It assumes the cluster CA certificate and key files exist in the CertificatesDir.
 func CreateAPIServerKubeletClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new certificate for kubelets calling apiserver")
 	caCert, caKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -128,7 +130,7 @@ func CreateAPIServerKubeletClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfigura
 // This is a separate CA, so that kubernetes client identities cannot connect to etcd directly or peer with the etcd cluster.
 // If the etcd CA certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 func CreateEtcdCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a self signed etcd CA certificate and key files")
 	etcdCACert, etcdCAKey, err := NewEtcdCACertAndKey()
 	if err != nil {
 		return err
@@ -146,7 +148,7 @@ func CreateEtcdCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
 // If the etcd serving certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateEtcdServerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new server certificate and key files for etcd")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -170,7 +172,7 @@ func CreateEtcdServerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error 
 // If the etcd peer certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateEtcdPeerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new certificate and key files for etcd peering")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -194,7 +196,7 @@ func CreateEtcdPeerCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
 // If the apiserver-etcd-client certificate and key file already exist in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 // It assumes the etcd CA certificate and key file exist in the CertificatesDir
 func CreateAPIServerEtcdClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new client certificate for the apiserver calling etcd")
 	etcdCACert, etcdCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.EtcdCACertAndKeyBaseName)
 	if err != nil {
 		return err
@@ -217,7 +219,7 @@ func CreateAPIServerEtcdClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguratio
 // CreateServiceAccountKeyAndPublicKeyFiles create a new public/private key files for signing service account users.
 // If the sa public/private key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 func CreateServiceAccountKeyAndPublicKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new public/private key files for signing service account users")
 	saSigningKey, err := NewServiceAccountSigningKey()
 	if err != nil {
 		return err
@@ -236,7 +238,7 @@ func CreateServiceAccountKeyAndPublicKeyFiles(cfg *kubeadmapi.MasterConfiguratio
 // as front proxies.
 // If the front proxy CA certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 func CreateFrontProxyCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a self signed front proxy CA certificate and key files")
 	frontProxyCACert, frontProxyCAKey, err := NewFrontProxyCACertAndKey()
 	if err != nil {
 		return err
@@ -254,7 +256,7 @@ func CreateFrontProxyCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) erro
 // If the front-proxy-client certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 // It assumes the front proxy CA certificate and key files exist in the CertificatesDir.
 func CreateFrontProxyClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating a new certificate for proxy server client")
 	frontProxyCACert, frontProxyCAKey, err := loadCertificateAuthority(cfg.CertificatesDir, kubeadmconstants.FrontProxyCACertAndKeyBaseName)
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/controlplane/BUILD
+++ b/cmd/kubeadm/app/phases/controlplane/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//pkg/master/reconcilers:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -50,21 +52,25 @@ const (
 
 // CreateInitStaticPodManifestFiles will write all static pod manifest files needed to bring up the control plane.
 func CreateInitStaticPodManifestFiles(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("[controlplane] creating static pod files")
 	return createStaticPodFiles(manifestDir, cfg, kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeScheduler)
 }
 
 // CreateAPIServerStaticPodManifestFile will write APIserver static pod manifest file.
 func CreateAPIServerStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating APIserver static pod files")
 	return createStaticPodFiles(manifestDir, cfg, kubeadmconstants.KubeAPIServer)
 }
 
 // CreateControllerManagerStaticPodManifestFile will write  controller manager static pod manifest file.
 func CreateControllerManagerStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating controller manager static pod files")
 	return createStaticPodFiles(manifestDir, cfg, kubeadmconstants.KubeControllerManager)
 }
 
 // CreateSchedulerStaticPodManifestFile will write scheduler static pod manifest file.
 func CreateSchedulerStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating scheduler static pod files")
 	return createStaticPodFiles(manifestDir, cfg, kubeadmconstants.KubeScheduler)
 }
 
@@ -132,6 +138,7 @@ func createStaticPodFiles(manifestDir string, cfg *kubeadmapi.MasterConfiguratio
 	}
 
 	// gets the StaticPodSpecs, actualized for the current MasterConfiguration
+	glog.V(1).Infoln("[controlplane] getting StaticPodSpecs")
 	specs := GetStaticPodSpecs(cfg, k8sVersion)
 
 	// creates required static pod specs
@@ -147,7 +154,7 @@ func createStaticPodFiles(manifestDir string, cfg *kubeadmapi.MasterConfiguratio
 			return fmt.Errorf("failed to create static pod manifest file for %q: %v", componentName, err)
 		}
 
-		fmt.Printf("[controlplane] Wrote Static Pod manifest for component %s to %q\n", componentName, kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir))
+		glog.Infof("[controlplane] wrote Static Pod manifest for component %s to %q\n", componentName, kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir))
 	}
 
 	return nil
@@ -213,13 +220,13 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 
 		// Warn for unused user supplied variables
 		if cfg.Etcd.CAFile != "" {
-			fmt.Printf("[controlplane] WARNING: Configuration for %s CAFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.CAFile, kubeadmconstants.Etcd)
+			glog.Warningf("[controlplane] configuration for %s CAFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.CAFile, kubeadmconstants.Etcd)
 		}
 		if cfg.Etcd.CertFile != "" {
-			fmt.Printf("[controlplane] WARNING: Configuration for %s CertFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.CertFile, kubeadmconstants.Etcd)
+			glog.Warningf("[controlplane] configuration for %s CertFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.CertFile, kubeadmconstants.Etcd)
 		}
 		if cfg.Etcd.KeyFile != "" {
-			fmt.Printf("[controlplane] WARNING: Configuration for %s KeyFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.KeyFile, kubeadmconstants.Etcd)
+			glog.Warningf("[controlplane] configuration for %s KeyFile, %s, is unused without providing Endpoints for external %s\n", kubeadmconstants.Etcd, cfg.Etcd.KeyFile, kubeadmconstants.Etcd)
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/etcd/BUILD
+++ b/cmd/kubeadm/app/phases/etcd/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/staticpod:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/golang/glog"
+
 	"k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -35,7 +37,7 @@ const (
 
 // CreateLocalEtcdStaticPodManifestFile will write local etcd static pod manifest file.
 func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
-
+	glog.V(1).Infoln("creating local etcd static pod manifest file")
 	// gets etcd StaticPodSpec, actualized for the current MasterConfiguration
 	spec := GetEtcdPodSpec(cfg)
 	// writes etcd StaticPod to disk

--- a/cmd/kubeadm/app/phases/kubeconfig/BUILD
+++ b/cmd/kubeadm/app/phases/kubeconfig/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//cmd/kubeadm/app/phases/certs/pkiutil:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -26,6 +26,8 @@ import (
 
 	"crypto/rsa"
 
+	"github.com/golang/glog"
+
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
@@ -60,6 +62,7 @@ type kubeConfigSpec struct {
 // to establish the control plane, including also the admin kubeconfig file.
 // If kubeconfig files already exists, they are used only if evaluated equal; otherwise an error is returned.
 func CreateInitKubeConfigFiles(outDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating all kubeconfig files")
 	return createKubeConfigFiles(
 		outDir,
 		cfg,
@@ -73,24 +76,28 @@ func CreateInitKubeConfigFiles(outDir string, cfg *kubeadmapi.MasterConfiguratio
 // CreateAdminKubeConfigFile create a kubeconfig file for the admin to use and for kubeadm itself.
 // If the kubeconfig file already exists, it is used only if evaluated equal; otherwise an error is returned.
 func CreateAdminKubeConfigFile(outDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("create a kubeconfig file for the admin and for kubeadm itself")
 	return createKubeConfigFiles(outDir, cfg, kubeadmconstants.AdminKubeConfigFileName)
 }
 
 // CreateKubeletKubeConfigFile create a kubeconfig file for the Kubelet to use.
 // If the kubeconfig file already exists, it is used only if evaluated equal; otherwise an error is returned.
 func CreateKubeletKubeConfigFile(outDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating a kubeconfig file for the Kubelet")
 	return createKubeConfigFiles(outDir, cfg, kubeadmconstants.KubeletKubeConfigFileName)
 }
 
 // CreateControllerManagerKubeConfigFile create a kubeconfig file for the ControllerManager to use.
 // If the kubeconfig file already exists, it is used only if evaluated equal; otherwise an error is returned.
 func CreateControllerManagerKubeConfigFile(outDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating kubeconfig file for the ControllerManager")
 	return createKubeConfigFiles(outDir, cfg, kubeadmconstants.ControllerManagerKubeConfigFileName)
 }
 
 // CreateSchedulerKubeConfigFile create a create a kubeconfig file for the Scheduler to use.
 // If the kubeconfig file already exists, it is used only if evaluated equal; otherwise an error is returned.
 func CreateSchedulerKubeConfigFile(outDir string, cfg *kubeadmapi.MasterConfiguration) error {
+	glog.V(1).Infoln("creating kubeconfig file for Scheduler")
 	return createKubeConfigFiles(outDir, cfg, kubeadmconstants.SchedulerKubeConfigFileName)
 }
 

--- a/cmd/kubeadm/app/phases/markmaster/BUILD
+++ b/cmd/kubeadm/app/phases/markmaster/BUILD
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/markmaster/markmaster.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,9 +37,9 @@ import (
 func MarkMaster(client clientset.Interface, masterName string, taint bool) error {
 
 	if taint {
-		fmt.Printf("[markmaster] Will mark node %s as master by adding a label and a taint\n", masterName)
+		glog.Infof("[markmaster] will mark node %s as master by adding a label and a taint\n", masterName)
 	} else {
-		fmt.Printf("[markmaster] Will mark node %s as master by adding a label\n", masterName)
+		glog.Infof("[markmaster] will mark node %s as master by adding a label\n", masterName)
 	}
 
 	// Loop on every falsy return. Return with an error if raised. Exit successfully if true is returned.

--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/volume/util:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/golang/glog"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,11 +55,12 @@ const (
 //      Otherwise, there is a race condition when we proceed without kubelet having restarted the API server correctly and the next .Create call flakes
 // 9. Do that for the kube-apiserver, kube-controller-manager and kube-scheduler in a loop
 func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubeadmapi.MasterConfiguration, client clientset.Interface, waiter apiclient.Waiter, dryRun bool) error {
-
+	glog.V(1).Infoln("creating self hosted control plane")
 	// Adjust the timeout slightly to something self-hosting specific
 	waiter.SetTimeout(selfHostingWaitTimeout)
 
 	// Here the map of different mutators to use for the control plane's PodSpec is stored
+	glog.V(1).Infoln("getting mutators")
 	mutators := GetMutatorsFromFeatureGates(cfg.FeatureGates)
 
 	// Some extra work to be done if we should store the control plane certificates in Secrets
@@ -124,7 +127,7 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 			return err
 		}
 
-		fmt.Printf("[self-hosted] self-hosted %s ready after %f seconds\n", componentName, time.Since(start).Seconds())
+		glog.Infof("[self-hosted] self-hosted %s ready after %f seconds\n", componentName, time.Since(start).Seconds())
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/phases/uploadconfig/BUILD
+++ b/cmd/kubeadm/app/phases/uploadconfig/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -17,9 +17,8 @@ limitations under the License.
 package uploadconfig
 
 import (
-	"fmt"
-
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,7 @@ import (
 // UploadConfiguration saves the MasterConfiguration used for later reference (when upgrading for instance)
 func UploadConfiguration(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 
-	fmt.Printf("[uploadconfig] Storing the configuration used in ConfigMap %q in the %q Namespace\n", kubeadmconstants.MasterConfigurationConfigMap, metav1.NamespaceSystem)
+	glog.Infof("[uploadconfig] storing the configuration used in ConfigMap %q in the %q Namespace\n", kubeadmconstants.MasterConfigurationConfigMap, metav1.NamespaceSystem)
 
 	// Convert cfg to the external version as that's the only version of the API that can be deserialized later
 	externalcfg := &kubeadmapiext.MasterConfiguration{}

--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -63,6 +63,7 @@ go_library(
         "//test/e2e_node/system:go_default_library",
         "//vendor/github.com/PuerkitoBio/purell:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/PuerkitoBio/purell"
 	"github.com/blang/semver"
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	"net/url"
@@ -99,6 +100,7 @@ func (CRICheck) Name() string {
 
 // Check validates the container runtime through the CRI.
 func (criCheck CRICheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating the container runtime through the CRI")
 	crictlPath, err := criCheck.exec.LookPath("crictl")
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to find command crictl: %s", err))
@@ -130,6 +132,7 @@ func (sc ServiceCheck) Name() string {
 
 // Check validates if the service is enabled and active.
 func (sc ServiceCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating if the service is enabled and active")
 	initSystem, err := initsystem.GetInitSystem()
 	if err != nil {
 		return []error{err}, nil
@@ -170,6 +173,7 @@ func (FirewalldCheck) Name() string {
 
 // Check validates if the firewall is enabled and active.
 func (fc FirewalldCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating if the firewall is enabled and active")
 	initSystem, err := initsystem.GetInitSystem()
 	if err != nil {
 		return []error{err}, nil
@@ -206,6 +210,7 @@ func (poc PortOpenCheck) Name() string {
 
 // Check validates if the particular port is available.
 func (poc PortOpenCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating availability of port %d", poc.port)
 	errors = []error{}
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", poc.port))
 	if err != nil {
@@ -242,6 +247,7 @@ func (dac DirAvailableCheck) Name() string {
 
 // Check validates if a directory does not exist or empty.
 func (dac DirAvailableCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating the existence and emptiness of directory %s", dac.Path)
 	errors = []error{}
 	// If it doesn't exist we are good:
 	if _, err := os.Stat(dac.Path); os.IsNotExist(err) {
@@ -279,6 +285,7 @@ func (fac FileAvailableCheck) Name() string {
 
 // Check validates if the given file does not already exist.
 func (fac FileAvailableCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating the existence of file %s", fac.Path)
 	errors = []error{}
 	if _, err := os.Stat(fac.Path); err == nil {
 		errors = append(errors, fmt.Errorf("%s already exists", fac.Path))
@@ -302,6 +309,7 @@ func (fac FileExistingCheck) Name() string {
 
 // Check validates if the given file already exists.
 func (fac FileExistingCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating the existence of file %s", fac.Path)
 	errors = []error{}
 	if _, err := os.Stat(fac.Path); err != nil {
 		errors = append(errors, fmt.Errorf("%s doesn't exist", fac.Path))
@@ -326,6 +334,7 @@ func (fcc FileContentCheck) Name() string {
 
 // Check validates if the given file contains the given content.
 func (fcc FileContentCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating the contents of file %s", fcc.Path)
 	f, err := os.Open(fcc.Path)
 	if err != nil {
 		return nil, []error{fmt.Errorf("%s does not exist", fcc.Path)}
@@ -366,6 +375,7 @@ func (ipc InPathCheck) Name() string {
 
 // Check validates if the given executable is present in the path.
 func (ipc InPathCheck) Check() (warnings, errs []error) {
+	glog.V(1).Infof("validating the presence of executable %s", ipc.executable)
 	_, err := ipc.exec.LookPath(ipc.executable)
 	if err != nil {
 		if ipc.mandatory {
@@ -395,6 +405,7 @@ func (HostnameCheck) Name() string {
 
 // Check validates if hostname match dns sub domain regex.
 func (hc HostnameCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infof("validating if hostname match dns sub domain")
 	errors = []error{}
 	warnings = []error{}
 	for _, msg := range validation.ValidateNodeName(hc.nodeName, false) {
@@ -424,7 +435,7 @@ func (hst HTTPProxyCheck) Name() string {
 
 // Check validates http connectivity type, direct or via proxy.
 func (hst HTTPProxyCheck) Check() (warnings, errors []error) {
-
+	glog.V(1).Infof("validating if the connectivity type is via proxy or direct")
 	u := (&url.URL{Scheme: hst.Proto, Host: hst.Host}).String()
 
 	req, err := http.NewRequest("GET", u, nil)
@@ -460,7 +471,7 @@ func (HTTPProxyCIDRCheck) Name() string {
 // Check validates http connectivity to first IP address in the CIDR.
 // If it is not directly connected and goes via proxy it will produce warning.
 func (subnet HTTPProxyCIDRCheck) Check() (warnings, errors []error) {
-
+	glog.V(1).Infoln("validating http connectivity to first IP address in the CIDR")
 	if len(subnet.CIDR) == 0 {
 		return nil, nil
 	}
@@ -511,6 +522,7 @@ func (ExtraArgsCheck) Name() string {
 
 // Check validates additional arguments of the control plane components.
 func (eac ExtraArgsCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating additional arguments of the control plane components")
 	argsCheck := func(name string, args map[string]string, f *pflag.FlagSet) []error {
 		errs := []error{}
 		for k, v := range args {
@@ -558,6 +570,7 @@ func (SystemVerificationCheck) Name() string {
 
 // Check runs all individual checks
 func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("running all checks")
 	// Create a buffered writer and choose a quite large value (1M) and suppose the output from the system verification test won't exceed the limit
 	// Run the system verification check, but write to out buffered writer instead of stdout
 	bufw := bufio.NewWriterSize(os.Stdout, 1*1024*1024)
@@ -615,7 +628,7 @@ func (KubernetesVersionCheck) Name() string {
 
 // Check validates kubernetes and kubeadm versions
 func (kubever KubernetesVersionCheck) Check() (warnings, errors []error) {
-
+	glog.V(1).Infoln("validating kubernetes and kubeadm version")
 	// Skip this check for "super-custom builds", where apimachinery/the overall codebase version is not set.
 	if strings.HasPrefix(kubever.KubeadmVersion, "v0.0.0") {
 		return nil, nil
@@ -656,6 +669,7 @@ func (KubeletVersionCheck) Name() string {
 
 // Check validates kubelet version. It should be not less than minimal supported version
 func (kubever KubeletVersionCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating kubelet version")
 	kubeletVersion, err := GetKubeletVersion(kubever.exec)
 	if err != nil {
 		return nil, []error{fmt.Errorf("couldn't get kubelet version: %v", err)}
@@ -686,6 +700,7 @@ func (SwapCheck) Name() string {
 
 // Check validates whether swap is enabled or not
 func (swc SwapCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating whether swap is enabled or not")
 	f, err := os.Open("/proc/swaps")
 	if err != nil {
 		// /proc/swaps not available, thus no reasons to warn
@@ -725,6 +740,7 @@ func (ExternalEtcdVersionCheck) Name() string {
 
 // Check validates external etcd version
 func (evc ExternalEtcdVersionCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating the external etcd version")
 	var config *tls.Config
 	var err error
 	if config, err = evc.configRootCAs(config); err != nil {
@@ -858,6 +874,7 @@ func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.MasterConfi
 	}
 
 	// check if we can use crictl to perform checks via the CRI
+	glog.V(1).Infoln("checking if we can use crictl to perform checks via the CRI")
 	criCtlChecker := InPathCheck{
 		executable: "crictl",
 		mandatory:  false,
@@ -1079,13 +1096,13 @@ func TryStartKubelet(ignorePreflightErrors sets.String) {
 	// If we notice that the kubelet service is inactive, try to start it
 	initSystem, err := initsystem.GetInitSystem()
 	if err != nil {
-		fmt.Println("[preflight] No supported init system detected, won't ensure kubelet is running.")
+		glog.Infoln("[preflight] no supported init system detected, won't ensure kubelet is running.")
 	} else if initSystem.ServiceExists("kubelet") && !initSystem.ServiceIsActive("kubelet") {
 
-		fmt.Println("[preflight] Starting the kubelet service")
+		glog.Infoln("[preflight] starting the kubelet service")
 		if err := initSystem.ServiceStart("kubelet"); err != nil {
-			fmt.Printf("[preflight] WARNING: Unable to start the kubelet service: [%v]\n", err)
-			fmt.Println("[preflight] WARNING: Please ensure kubelet is running manually.")
+			glog.Warningf("[preflight] unable to start the kubelet service: [%v]\n", err)
+			glog.Warningf("[preflight] please ensure kubelet is running manually.")
 		}
 	}
 }

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/node:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
     ],

--- a/cmd/kubeadm/app/util/config/masterconfig.go
+++ b/cmd/kubeadm/app/util/config/masterconfig.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"net"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -91,10 +93,12 @@ func TryLoadMasterConfiguration(cfgPath string, cfg *kubeadmapiext.MasterConfigu
 // Right thereafter, the configuration is defaulted again with dynamic values (like IP addresses of a machine, etc)
 // Lastly, the internal config is validated and returned.
 func ConfigFileAndDefaultsToInternalConfig(cfgPath string, defaultversionedcfg *kubeadmapiext.MasterConfiguration) (*kubeadmapi.MasterConfiguration, error) {
+	glog.V(1).Infoln("configuring files and defaults to internal config")
 	internalcfg := &kubeadmapi.MasterConfiguration{}
 
 	// Loads configuration from config file, if provided
 	// Nb. --config overrides command line flags
+	glog.V(1).Infoln("attempting to load configuration from config file")
 	if err := TryLoadMasterConfiguration(cfgPath, defaultversionedcfg); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[WIP] Adds verbosity feature to init command hierarchy of kubeadm utility.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Implements verbosity feature to kubeadm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#340

**Special notes for your reviewer**:
I will be splitting this work into a smaller PR to keep it separate and clean.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implements verbosity logging feature for kubeadm commands
```
