### PR TITLE
GCE: Use GA API for managing internal addresses

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_address_manager.go
+++ b/pkg/cloudprovider/providers/gce/gce_address_manager.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	computebeta "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 
 	"github.com/golang/glog"
 )
@@ -63,7 +63,7 @@ func (am *addressManager) HoldAddress() (string, error) {
 	// calls since it indicates whether a Delete is necessary before Reserve.
 	glog.V(4).Infof("%v: attempting hold of IP %q Type %q", am.logPrefix, am.targetIP, am.addressType)
 	// Get the address in case it was orphaned earlier
-	addr, err := am.svc.GetBetaRegionAddress(am.name, am.region)
+	addr, err := am.svc.GetRegionAddress(am.name, am.region)
 	if err != nil && !isNotFound(err) {
 		return "", err
 	}
@@ -118,7 +118,7 @@ func (am *addressManager) ReleaseAddress() error {
 func (am *addressManager) ensureAddressReservation() (string, error) {
 	// Try reserving the IP with controller-owned address name
 	// If am.targetIP is an empty string, a new IP will be created.
-	newAddr := &computebeta.Address{
+	newAddr := &compute.Address{
 		Name:        am.name,
 		Description: fmt.Sprintf(`{"kubernetes.io/service-name":"%s"}`, am.serviceName),
 		Address:     am.targetIP,
@@ -126,7 +126,7 @@ func (am *addressManager) ensureAddressReservation() (string, error) {
 		Subnetwork:  am.subnetURL,
 	}
 
-	reserveErr := am.svc.ReserveBetaRegionAddress(newAddr, am.region)
+	reserveErr := am.svc.ReserveRegionAddress(newAddr, am.region)
 	if reserveErr == nil {
 		if newAddr.Address != "" {
 			glog.V(4).Infof("%v: successfully reserved IP %q with name %q", am.logPrefix, newAddr.Address, newAddr.Name)
@@ -155,7 +155,7 @@ func (am *addressManager) ensureAddressReservation() (string, error) {
 
 	// Reserving the address failed due to a conflict or bad request. The address manager just checked that no address
 	// exists with the name, so it may belong to the user.
-	addr, err := am.svc.GetBetaRegionAddressByIP(am.region, am.targetIP)
+	addr, err := am.svc.GetRegionAddressByIP(am.region, am.targetIP)
 	if err != nil {
 		return "", fmt.Errorf("failed to get address by IP %q after reservation attempt, err: %q, reservation err: %q", am.targetIP, err, reserveErr)
 	}
@@ -178,7 +178,7 @@ func (am *addressManager) ensureAddressReservation() (string, error) {
 	return addr.Address, nil
 }
 
-func (am *addressManager) validateAddress(addr *computebeta.Address) error {
+func (am *addressManager) validateAddress(addr *compute.Address) error {
 	if am.targetIP != "" && am.targetIP != addr.Address {
 		return fmt.Errorf("address %q does not have the expected IP %q, actual: %q", addr.Name, am.targetIP, addr.Address)
 	}
@@ -189,7 +189,7 @@ func (am *addressManager) validateAddress(addr *computebeta.Address) error {
 	return nil
 }
 
-func (am *addressManager) isManagedAddress(addr *computebeta.Address) bool {
+func (am *addressManager) isManagedAddress(addr *compute.Address) bool {
 	return addr.Name == am.name
 }
 

--- a/pkg/cloudprovider/providers/gce/gce_address_manager_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_address_manager_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	computebeta "google.golang.org/api/compute/v0.beta"
+	compute "google.golang.org/api/compute/v1"
 )
 
 const testSvcName = "my-service"
@@ -55,8 +55,8 @@ func TestAddressManagerOrphaned(t *testing.T) {
 	svc := NewFakeCloudAddressService()
 	targetIP := "1.1.1.1"
 
-	addr := &computebeta.Address{Name: testLBName, Address: targetIP, AddressType: string(schemeInternal)}
-	err := svc.ReserveBetaRegionAddress(addr, testRegion)
+	addr := &compute.Address{Name: testLBName, Address: targetIP, AddressType: string(schemeInternal)}
+	err := svc.ReserveRegionAddress(addr, testRegion)
 	require.NoError(t, err)
 
 	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
@@ -71,8 +71,8 @@ func TestAddressManagerOutdatedOrphan(t *testing.T) {
 	previousAddress := "1.1.0.0"
 	targetIP := "1.1.1.1"
 
-	addr := &computebeta.Address{Name: testLBName, Address: previousAddress, AddressType: string(schemeExternal)}
-	err := svc.ReserveBetaRegionAddress(addr, testRegion)
+	addr := &compute.Address{Name: testLBName, Address: previousAddress, AddressType: string(schemeExternal)}
+	err := svc.ReserveRegionAddress(addr, testRegion)
 	require.NoError(t, err)
 
 	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
@@ -86,8 +86,8 @@ func TestAddressManagerExternallyOwned(t *testing.T) {
 	svc := NewFakeCloudAddressService()
 	targetIP := "1.1.1.1"
 
-	addr := &computebeta.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeInternal)}
-	err := svc.ReserveBetaRegionAddress(addr, testRegion)
+	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeInternal)}
+	err := svc.ReserveRegionAddress(addr, testRegion)
 	require.NoError(t, err)
 
 	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
@@ -107,8 +107,8 @@ func TestAddressManagerBadExternallyOwned(t *testing.T) {
 	svc := NewFakeCloudAddressService()
 	targetIP := "1.1.1.1"
 
-	addr := &computebeta.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeExternal)}
-	err := svc.ReserveBetaRegionAddress(addr, testRegion)
+	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeExternal)}
+	err := svc.ReserveRegionAddress(addr, testRegion)
 	require.NoError(t, err)
 
 	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
@@ -121,7 +121,7 @@ func testHoldAddress(t *testing.T, mgr *addressManager, svc CloudAddressService,
 	require.NoError(t, err)
 	assert.NotEmpty(t, ipToUse)
 
-	addr, err := svc.GetBetaRegionAddress(name, region)
+	addr, err := svc.GetRegionAddress(name, region)
 	require.NoError(t, err)
 	if targetIP != "" {
 		assert.EqualValues(t, targetIP, addr.Address)
@@ -132,6 +132,6 @@ func testHoldAddress(t *testing.T, mgr *addressManager, svc CloudAddressService,
 func testReleaseAddress(t *testing.T, mgr *addressManager, svc CloudAddressService, name, region string) {
 	err := mgr.ReleaseAddress()
 	require.NoError(t, err)
-	_, err = svc.GetBetaRegionAddress(name, region)
+	_, err = svc.GetRegionAddress(name, region)
 	assert.True(t, isNotFound(err))
 }


### PR DESCRIPTION
Updates the address manager to use the GA API for retrieving and creating internal addresses. 

**Release note**:
```release-note
NONE
```
