### PR TITLE
Use the regionless mirror alias

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -243,11 +243,11 @@ function set-preferred-region() {
   else
     KUBE_ADDON_REGISTRY="gcr.io/google_containers"
   fi
-
-  if [[ "${ENABLE_DOCKER_REGISTRY_CACHE:-}" == "true" ]]; then
-    DOCKER_REGISTRY_MIRROR_URL="https://${preferred}-mirror.gcr.io"
-  fi
 }
+
+if [[ "${ENABLE_DOCKER_REGISTRY_CACHE:-}" == "true" ]]; then
+  DOCKER_REGISTRY_MIRROR_URL="https://mirror.gcr.io"
+fi
 
 # Take the local tar files and upload them to Google Storage.  They will then be
 # downloaded by the master as part of the start up script for the master.


### PR DESCRIPTION
```release-note
NONE
```
mirror.gcr.io is a read-only alias for the regional mirror, explicit routing is unnecessary and potentially deleterious. 