### PR TITLE
optimize volumeResizeMap lock

### DIFF
--- a/pkg/controller/volume/expand/cache/volume_resize_map.go
+++ b/pkg/controller/volume/expand/cache/volume_resize_map.go
@@ -52,7 +52,7 @@ type volumeResizeMap struct {
 	// kube client for making API calls
 	kubeClient clientset.Interface
 	// for guarding access to pvcrs map
-	sync.RWMutex
+	sync.Mutex
 }
 
 // PVCWithResizeRequest struct defines data structure that stores state needed for
@@ -103,9 +103,6 @@ func (resizeMap *volumeResizeMap) AddPVCUpdate(pvc *v1.PersistentVolumeClaim, pv
 		return
 	}
 
-	resizeMap.Lock()
-	defer resizeMap.Unlock()
-
 	pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 	pvcStatusSize := pvc.Status.Capacity[v1.ResourceStorage]
 
@@ -121,6 +118,9 @@ func (resizeMap *volumeResizeMap) AddPVCUpdate(pvc *v1.PersistentVolumeClaim, pv
 		ExpectedSize:     pvcSize,
 		PersistentVolume: pv,
 	}
+
+	resizeMap.Lock()
+	defer resizeMap.Unlock()
 	resizeMap.pvcrs[types.UniquePVCName(pvc.UID)] = pvcRequest
 }
 
@@ -141,18 +141,15 @@ func (resizeMap *volumeResizeMap) GetPVCsWithResizeRequest() []*PVCWithResizeReq
 // DeletePVC removes given pvc object from list of pvcs that needs resizing.
 // deleting a pvc in this map doesn't affect operations that are already inflight.
 func (resizeMap *volumeResizeMap) DeletePVC(pvc *v1.PersistentVolumeClaim) {
-	resizeMap.Lock()
-	defer resizeMap.Unlock()
 	pvcUniqueName := types.UniquePVCName(pvc.UID)
 	glog.V(5).Infof("Removing PVC %v from resize map", pvcUniqueName)
+	resizeMap.Lock()
+	defer resizeMap.Unlock()
 	delete(resizeMap.pvcrs, pvcUniqueName)
 }
 
 // MarkAsResized marks a pvc as fully resized
 func (resizeMap *volumeResizeMap) MarkAsResized(pvcr *PVCWithResizeRequest, newSize resource.Quantity) error {
-	resizeMap.Lock()
-	defer resizeMap.Unlock()
-
 	emptyCondition := []v1.PersistentVolumeClaimCondition{}
 
 	err := resizeMap.updatePVCCapacityAndConditions(pvcr, newSize, emptyCondition)
@@ -165,9 +162,6 @@ func (resizeMap *volumeResizeMap) MarkAsResized(pvcr *PVCWithResizeRequest, newS
 
 // UpdatePVSize updates just pv size after cloudprovider resizing is successful
 func (resizeMap *volumeResizeMap) UpdatePVSize(pvcr *PVCWithResizeRequest, newSize resource.Quantity) error {
-	resizeMap.Lock()
-	defer resizeMap.Unlock()
-
 	oldPv := pvcr.PersistentVolume
 	pvClone := oldPv.DeepCopy()
 
@@ -201,7 +195,6 @@ func (resizeMap *volumeResizeMap) UpdatePVSize(pvcr *PVCWithResizeRequest, newSi
 }
 
 func (resizeMap *volumeResizeMap) updatePVCCapacityAndConditions(pvcr *PVCWithResizeRequest, newSize resource.Quantity, pvcConditions []v1.PersistentVolumeClaimCondition) error {
-
 	claimClone := pvcr.PVC.DeepCopy()
 
 	claimClone.Status.Capacity[v1.ResourceStorage] = newSize


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

volumeResizeMap implements VolumeResizeMap interface, but has several useless lock section and one too large critical section.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
