### PR TITLE
Check if we can find an expandable plugin when expanding volumes.

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -1254,6 +1254,10 @@ func (og *operationGenerator) GenerateExpandVolumeFunc(
 		return volumetypes.GeneratedOperations{}, fmt.Errorf("Error finding plugin for expanding volume: %q with error %v", pvcWithResizeRequest.QualifiedName(), err)
 	}
 
+	if volumePlugin == nil {
+		return volumetypes.GeneratedOperations{}, fmt.Errorf("Error finding an expandable plugin for expanding volume: %q", pvcWithResizeRequest.QualifiedName())
+	}
+
 	expandVolumeFunc := func() (error, error) {
 		newSize := pvcWithResizeRequest.ExpectedSize
 		pvSize := pvcWithResizeRequest.PersistentVolume.Spec.Capacity[v1.ResourceStorage]


### PR DESCRIPTION
Found the issue while working on enabling FlexVolume to support volume resizing. If we do not check the returned volumePlugin, may introduce nil pointer panic.

Need to check if we can find an expandable plugin when taking expand
volume actions.

@gnufied, please help to review the change, thanks

**Release note**:
```release-note
None
```