### PR TITLE
fix the problem that kube-proxy can't create clusterIP ipvs rules when externalTrafficPolicy=Local

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1158,7 +1158,9 @@ func (proxier *Proxier) syncProxyRules() {
 		// We need to bind ClusterIP to dummy interface, so set `bindAddr` parameter to `true` in syncService()
 		if err := proxier.syncService(svcNameString, serv, true); err == nil {
 			activeIPVSServices[serv.String()] = true
-			if err := proxier.syncEndpoint(svcName, svcInfo.onlyNodeLocalEndpoints, serv); err != nil {
+			// ExternalTrafficPolicy only works for NodePort and external LB traffic, does not affect ClusterIP
+			// So we still need clusterIP rules in onlyNodeLocalEndpoints mode.
+			if err := proxier.syncEndpoint(svcName, false, serv); err != nil {
 				glog.Errorf("Failed to sync endpoint for service: %v, err: %v", serv, err)
 			}
 		} else {


### PR DESCRIPTION


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57678

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
