### PR TITLE
Fix format string in describers

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -1081,7 +1081,7 @@ func printFlexPersistentVolumeSource(flex *api.FlexPersistentVolumeSource, w Pre
 		"    Driver:\t%v\n"+
 		"    FSType:\t%v\n"+
 		"    SecretRef:\t%v\n"+
-		"    ReadOnly:\t%v\n",
+		"    ReadOnly:\t%v\n"+
 		"    Options:\t%v\n",
 		flex.Driver, flex.FSType, flex.SecretRef, flex.ReadOnly, flex.Options)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes bug in the Vsphere PersistentVolume Source.
Before this fix `kubectl describe` could show something like this:
```shell
Source:
    Type:    FlexVolume (a generic volume resource that is provisioned/attached using an exec based plugin)
    Driver:      Options:  %v

    FSType:                                           foo/lvm
    SecretRef:                                        
    ReadOnly:                                         <nil>
%!(EXTRA bool=false, map[string]string=map[])Events:  <none>
```
After fix, it's normal:
```shell
Source:
    Type:       FlexVolume (a generic volume resource that is provisioned/attached using an exec based plugin)
    Driver:     foo/lvm
    FSType:     
    SecretRef:  <nil>
    ReadOnly:   false
    Options:    map[]
Events:         <none>
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://github.com/kubernetes/kubernetes/issues/57694](https://github.com/kubernetes/kubernetes/issues/57694)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
