### PR TITLE
Improve the error message.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -30,7 +30,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
-var errConnKilled = fmt.Errorf("kill connection/stream")
+var errConnKilled = fmt.Errorf("killing connection/stream because serving request timed out and response had been started")
 
 // WithTimeoutForNonLongRunningRequests times out non-long-running requests after the time given by timeout.
 func WithTimeoutForNonLongRunningRequests(handler http.Handler, requestContextMapper apirequest.RequestContextMapper, longRunning apirequest.LongRunningRequestCheck, timeout time.Duration) http.Handler {


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the error message more descriptive and less scary. Previously it
is far from obvious whether connection kill is a symptom or cause of the
problem, see for example https://github.com/kubernetes/kubernetes/issues/55779#issuecomment-353582852

In paricular the crucial missing piece of information is that this is a
way of handling a timeout.

**Release note**:
```release-note
NONE
```