### PR TITLE
[E2E Node] [Alpha: DynamicKubeletConfig] Wait for Kubelet to restart in tempSetCurrentKubeletConfig()

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -138,6 +138,12 @@ func setKubeletConfiguration(f *framework.Framework, kubeCfg *kubeletconfig.Kube
 	const (
 		restartGap   = 40 * time.Second
 		pollInterval = 5 * time.Second
+
+		// as we use period=10*time.Second and jitterFactor=0.2
+		// in cc.syncConfigSource(client, nodeName),
+		// so we set waitGap = 12*time.Second to wait for kubelet restart
+		// ref: pkg/kubelet/kubeletconfig/controller.go#L220-L222
+		waitGap = 12 * time.Second
 	)
 
 	// make sure Dynamic Kubelet Configuration feature is enabled on the Kubelet we are about to reconfigure
@@ -171,6 +177,9 @@ func setKubeletConfiguration(f *framework.Framework, kubeCfg *kubeletconfig.Kube
 		}
 		return nil
 	}, time.Minute, time.Second).Should(BeNil())
+
+	// wait for kubelet restart
+	time.Sleep(waitGap)
 
 	// poll for new config, for a maximum wait of restartGap
 	Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Wait for kubelet to restart in `tempSetCurrentKubeletConfig()`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/57701

**Special notes for your reviewer**:

/area kubelet
/sig node
/assign @mtaufen 
/cc @vishh @jiayingz @derekwaynecarr @dchen1107 @liggitt 
PTAL, Thanks!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
