### PR TITLE
Ensure UnstructuredContent returns a deep copy without mutating contents

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -1782,14 +1782,14 @@ URL:	http://localhost
 				"name":              "MyName",
 				"namespace":         "MyNamespace",
 				"creationTimestamp": "2017-04-01T00:00:00Z",
-				"resourceVersion":   123,
+				"resourceVersion":   int64(123),
 				"uid":               "00000000-0000-0000-0000-000000000001",
 				"dummy3":            "present",
 			},
 			"items": []interface{}{
 				map[string]interface{}{
 					"itemBool": true,
-					"itemInt":  42,
+					"itemInt":  int64(42),
 				},
 			},
 			"url":    "http://localhost",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -82,9 +82,9 @@ func (obj *Unstructured) EachListItem(fn func(runtime.Object) error) error {
 
 func (obj *Unstructured) UnstructuredContent() map[string]interface{} {
 	if obj.Object == nil {
-		obj.Object = make(map[string]interface{})
+		return make(map[string]interface{})
 	}
-	return obj.Object
+	return runtime.DeepCopyJSON(obj.Object)
 }
 
 func (obj *Unstructured) SetUnstructuredContent(content map[string]interface{}) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
@@ -53,19 +53,21 @@ func (u *UnstructuredList) EachListItem(fn func(runtime.Object) error) error {
 }
 
 // UnstructuredContent returns a map contain an overlay of the Items field onto
-// the Object field. Items always overwrites overlay. Changing "items" in the
-// returned object will affect items in the underlying Items field, but changing
-// the "items" slice itself will have no effect.
-// TODO: expose SetUnstructuredContent on runtime.Unstructured that allows
-// items to be changed.
+// the Object field. Items always overwrites overlay.
 func (u *UnstructuredList) UnstructuredContent() map[string]interface{} {
-	out := u.Object
-	if out == nil {
-		out = make(map[string]interface{})
+	out := make(map[string]interface{}, len(u.Object)+1)
+
+	// deep copy every property but items
+	for k, v := range u.Object {
+		if k == "items" {
+			continue
+		}
+		out[k] = runtime.DeepCopyJSONValue(v)
 	}
+
 	items := make([]interface{}, len(u.Items))
 	for i, item := range u.Items {
-		items[i] = item.Object
+		items[i] = item.UnstructuredContent()
 	}
 	out["items"] = items
 	return out

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
@@ -41,6 +41,25 @@ func TestUnstructuredList(t *testing.T) {
 	assert.Equal(t, "test", val)
 }
 
+// Ensure UnstructuredContent() returns a deep copy of the contents
+func TestUnstructuredListContent(t *testing.T) {
+	obj := map[string]interface{}{
+		"a": "b",
+	}
+	item := Unstructured{
+		Object: obj,
+	}
+	list := &UnstructuredList{
+		Items: []Unstructured{item},
+	}
+
+	content := list.UnstructuredContent()
+	retObjs := content["items"].([]interface{})
+	retObj := retObjs[0].(map[string]interface{})
+	retObj["a"] = "c"
+	assert.Equal(t, "b", obj["a"])
+}
+
 func TestNilDeletionTimestamp(t *testing.T) {
 	var u Unstructured
 	del := u.GetDeletionTimestamp()

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstructured
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNilUnstructuredContent(t *testing.T) {
+	var u Unstructured
+	content := u.UnstructuredContent()
+	expContent := make(map[string]interface{})
+	assert.EqualValues(t, expContent, content)
+}
+
+// TestUnstructuredContentCopy validates that UnstructuredContent returns a deep copy of the contents
+func TestUnstructuredContentCopy(t *testing.T) {
+	expMap := map[string]interface{}{
+		"a": "b",
+	}
+	u := &Unstructured{
+		Object: map[string]interface{}{
+			"map": expMap,
+		},
+	}
+	content := u.UnstructuredContent()
+	cMap := content["map"].(map[string]interface{})
+	cMap["a"] = "c"
+	assert.EqualValues(t, expMap, u.Object["map"])
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -411,8 +411,7 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 	var u map[string]interface{}
 	var err error
 	if unstr, ok := obj.(Unstructured); ok {
-		// UnstructuredContent() mutates the object so we need to make a copy first
-		u = unstr.DeepCopyObject().(Unstructured).UnstructuredContent()
+		u = unstr.UnstructuredContent()
 	} else {
 		t := reflect.TypeOf(obj)
 		value := reflect.ValueOf(obj)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -234,9 +234,9 @@ type Object interface {
 // to JSON allowed.
 type Unstructured interface {
 	Object
-	// UnstructuredContent returns a non-nil, mutable map of the contents of this object. Values may be
+	// UnstructuredContent returns a non-nil map with a deep-copy of this object's contents. Values may be
 	// []interface{}, map[string]interface{}, or any primitive type. Contents are typically serialized to
-	// and from JSON.
+	// and from JSON. SetUnstructuredContent should be used to mutate the contents.
 	UnstructuredContent() map[string]interface{}
 	// SetUnstructuredContent updates the object content to match the provided map.
 	SetUnstructuredContent(map[string]interface{})

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
@@ -265,7 +265,7 @@ func (obj *Unstructured) UnstructuredContent() map[string]interface{} {
 	if obj.Object == nil {
 		obj.Object = make(map[string]interface{})
 	}
-	return obj.Object
+	return runtime.DeepCopyJSON(obj.Object)
 }
 
 func (obj *Unstructured) SetUnstructuredContent(content map[string]interface{}) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package testing
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package testing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnstructuredContentCopy validates that UnstructuredContent returns a deep copy of the contents
+func TestUnstructuredContentCopy(t *testing.T) {
+	expMap := map[string]interface{}{
+		"a": "b",
+	}
+	u := &Unstructured{
+		Object: map[string]interface{}{
+			"map": expMap,
+		},
+	}
+	content := u.UnstructuredContent()
+	cMap := content["map"].(map[string]interface{})
+	cMap["a"] = "c"
+	assert.EqualValues(t, expMap, u.Object["map"])
+}


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR solves the issues described in https://github.com/kubernetes/kubernetes/issues/56316

Before this change:
- A call to `UnstructuredContent` potentially modified `Object`
- The values returned by `UnstructuredContent` could be manipulated to modify the value in `Object`. Going through the history it looks like this behavior was added before the addition of `SetUnstructuredContent`. IMO it makes more sense **now** to use `SetUnstructuredContent` or make changes to the exposed `Object` property
- `UnstructuredList` did not implement the behavior described in the godoc. The godoc stated that the value returned should be mutable, but if `u.Object == nil` the map returned had no effect on `Object`

With this PR I'm proposing `UnstructuredContent` returns a copy of the data instead of a mutable map. It also ensures all implementations of the `Unstructured` interface abide by the doc

**Which issue(s) this PR fixes** :
Fixes #56316


**Release note**:
NONE
```release-note

```
