### PR TITLE
remove duplicate function getBuggyHostportChain

### DIFF
--- a/pkg/kubelet/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/network/hostport/hostport_manager.go
@@ -178,8 +178,6 @@ func (hm *hostportManager) Remove(id string, podPortMapping *PodPortMapping) (er
 	chainsToRemove := []utiliptables.Chain{}
 	for _, pm := range hostportMappings {
 		chainsToRemove = append(chainsToRemove, getHostportChain(id, pm))
-		// TODO remove this after release 1.9, please refer https://github.com/kubernetes/kubernetes/pull/55153
-		chainsToRemove = append(chainsToRemove, getBuggyHostportChain(id, pm))
 	}
 
 	// remove rules that consists of target chains
@@ -251,16 +249,6 @@ func (hm *hostportManager) closeHostports(hostportMappings []*PortMapping) error
 // identify existing iptables chains.
 func getHostportChain(id string, pm *PortMapping) utiliptables.Chain {
 	hash := sha256.Sum256([]byte(id + strconv.Itoa(int(pm.HostPort)) + string(pm.Protocol)))
-	encoded := base32.StdEncoding.EncodeToString(hash[:])
-	return utiliptables.Chain(kubeHostportChainPrefix + encoded[:16])
-}
-
-// This bugy func does bad conversion on HostPort from int32 to string.
-// It may generates same chain names for different ports of the same pod, e.g. port 57119/55429/56833.
-// `getHostportChain` fixed this bug. In order to cleanup the legacy chains/rules, it is temporarily left.
-// TODO remove this after release 1.9, please refer https://github.com/kubernetes/kubernetes/pull/55153
-func getBuggyHostportChain(id string, pm *PortMapping) utiliptables.Chain {
-	hash := sha256.Sum256([]byte(id + string(pm.HostPort) + string(pm.Protocol)))
 	encoded := base32.StdEncoding.EncodeToString(hash[:])
 	return utiliptables.Chain(kubeHostportChainPrefix + encoded[:16])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
remove `TODO remove this after release 1.9, please refer https://github.com/kubernetes/kubernetes/pull/55153`
function `getBuggyHostportChain`  does bad conversion on HostPort from int32 to string, now that `getHostportChain` does right, we remove function `getBuggyHostportChain` .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
