### PR TITLE
fix error message about DeleteOptions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -17,8 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -78,13 +76,13 @@ func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorLi
 func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath(""), options, "OrphanDependents and DeletionPropagation cannot be both set"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("propagationPolicy"), options.PropagationPolicy, "orphanDependents and deletionPropagation cannot be both set"))
 	}
 	if options.PropagationPolicy != nil &&
 		*options.PropagationPolicy != metav1.DeletePropagationForeground &&
 		*options.PropagationPolicy != metav1.DeletePropagationBackground &&
 		*options.PropagationPolicy != metav1.DeletePropagationOrphan {
-		allErrs = append(allErrs, field.Invalid(field.NewPath(""), options, fmt.Sprintf("DeletionPropagation need to be one of %q, %q, %q or nil", metav1.DeletePropagationForeground, metav1.DeletePropagationBackground, metav1.DeletePropagationOrphan)))
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("propagationPolicy"), options.PropagationPolicy, []string{string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground), string(metav1.DeletePropagationOrphan), "nil"}))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go
@@ -74,7 +74,7 @@ func BeforeDelete(strategy RESTDeleteStrategy, ctx genericapirequest.Context, ob
 		return false, false, kerr
 	}
 	if errs := validation.ValidateDeleteOptions(options); len(errs) > 0 {
-		return false, false, errors.NewInvalid(schema.GroupKind{}, "", errs)
+		return false, false, errors.NewInvalid(schema.GroupKind{Group: metav1.GroupName, Kind: "DeleteOptions"}, "", errs)
 	}
 	// Checking the Preconditions here to fail early. They'll be enforced later on when we actually do the deletion, too.
 	if options.Preconditions != nil && options.Preconditions.UID != nil && *options.Preconditions.UID != objectMeta.GetUID() {


### PR DESCRIPTION
Before this change:
```shell
$ curl -k  -XDELETE  -H "Accept: application/json" -H "Content-Type: application/json" -H "User-Agent: kubectl/v1.10.0 (linux/amd64) kubernetes/d7e5bd1" http://172.16.29.130:8080/apis/extensions/v1beta1/namespaces/default/deployments/nginx --data '{"propagationPolicy":"Background11111"}'
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":" \"\" is invalid: []: Invalid value: v1.DeleteOptions{TypeMeta:v1.TypeMeta{Kind:\"\", APIVersion:\"\"}, GracePeriodSeconds:(*int64)(nil), Preconditions:(*v1.Preconditions)(nil), OrphanDependents:(*bool)(nil), PropagationPolicy:(*v1.DeletionPropagation)(0xc429aa9ed0)}: DeletionPropagation need to be one of \"Foreground\", \"Background\", \"Orphan\" or nil","reason":"Invalid","details":{"causes":[{"reason":"FieldValueInvalid","message":"Invalid value: v1.DeleteOptions{TypeMeta:v1.TypeMeta{Kind:\"\", APIVersion:\"\"}, GracePeriodSeconds:(*int64)(nil), Preconditions:(*v1.Preconditions)(nil), OrphanDependents:(*bool)(nil), PropagationPolicy:(*v1.DeletionPropagation)(0xc429aa9ed0)}: DeletionPropagation need to be one of \"Foreground\", \"Background\", \"Orphan\" or nil","field":"[]"}]},"code":422}
```
After this change:
```shell
$ curl -k  -XDELETE  -H "Accept: application/json" -H "Content-Type: application/json" -H "User-Agent: kubectl/v1.10.0 (linux/amd64) kubernetes/d7e5bd1" http://172.16.29.130:8080/apis/extensions/v1beta1/namespaces/default/deployments/nginx --data '{"propagationPolicy":"Background11111"}'
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"DeleteOptions.meta.k8s.io \"\" is invalid: propagationPolicy: Unsupported value: \"Foreground1111\": supported values: \"Foreground\", \"Background\", \"Orphan\", \"nil\"","reason":"Invalid","details":{"group":"meta.k8s.io","kind":"DeleteOptions","causes":[{"reason":"FieldValueNotSupported","message":"Unsupported value: \"Foreground1111\": supported values: \"Foreground\", \"Background\", \"Orphan\", \"nil\"","field":"propagationPolicy"}]},"code":422}
```

**Release note**:
```
NONE
```

  