### PR TITLE
Do not time-out profiler requests.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/longrunning.go
@@ -18,18 +18,22 @@ package filters
 
 import (
 	"net/http"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
-// BasicLongRunningRequestCheck returns true if the given request has one of the specified verbs or one of the specified subresources
+// BasicLongRunningRequestCheck returns true if the given request has one of the specified verbs or one of the specified subresources, or is a profiler request.
 func BasicLongRunningRequestCheck(longRunningVerbs, longRunningSubresources sets.String) apirequest.LongRunningRequestCheck {
 	return func(r *http.Request, requestInfo *apirequest.RequestInfo) bool {
 		if longRunningVerbs.Has(requestInfo.Verb) {
 			return true
 		}
 		if requestInfo.IsResourceRequest && longRunningSubresources.Has(requestInfo.Subresource) {
+			return true
+		}
+		if !requestInfo.IsResourceRequest && strings.HasPrefix(requestInfo.Path, "/debug/pprof/") {
 			return true
 		}
 		return false


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables collection of longer profile samples.

**Which issue(s) this PR fixes**
Fixes #57708

**Release note**:
```release-note
NONE
```