### PR TITLE
Clarify error messages in HPA metrics

### DIFF
--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client.go
@@ -58,11 +58,11 @@ type resourceMetricsClient struct {
 func (c *resourceMetricsClient) GetResourceMetric(resource v1.ResourceName, namespace string, selector labels.Selector) (PodMetricsInfo, time.Time, error) {
 	metrics, err := c.client.PodMetricses(namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from API: %v", err)
+		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from resource metrics API: %v", err)
 	}
 
 	if len(metrics.Items) == 0 {
-		return nil, time.Time{}, fmt.Errorf("no metrics returned from heapster")
+		return nil, time.Time{}, fmt.Errorf("no metrics returned from resource metrics API")
 	}
 
 	res := make(PodMetricsInfo, len(metrics.Items))
@@ -101,7 +101,7 @@ type customMetricsClient struct {
 func (c *customMetricsClient) GetRawMetric(metricName string, namespace string, selector labels.Selector) (PodMetricsInfo, time.Time, error) {
 	metrics, err := c.client.NamespacedMetrics(namespace).GetForObjects(schema.GroupKind{Kind: "Pod"}, selector, metricName)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from API: %v", err)
+		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %v", err)
 	}
 
 	if len(metrics.Items) == 0 {
@@ -134,7 +134,7 @@ func (c *customMetricsClient) GetObjectMetric(metricName string, namespace strin
 	}
 
 	if err != nil {
-		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from API: %v", err)
+		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %v", err)
 	}
 
 	return metricValue.Value.MilliValue(), metricValue.Timestamp.Time, nil

--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
@@ -252,7 +252,7 @@ func TestRESTClientQpsSumEqualZero(t *testing.T) {
 func TestRESTClientCPUEmptyMetrics(t *testing.T) {
 	tc := restClientTestCase{
 		resourceName:         v1.ResourceCPU,
-		desiredError:         fmt.Errorf("no metrics returned from heapster"),
+		desiredError:         fmt.Errorf("no metrics returned from resource metrics API"),
 		reportedMetricPoints: []metricPoint{},
 		reportedPodMetrics:   [][]int64{},
 	}

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -579,7 +579,7 @@ func TestReplicaCalcMissingMetrics(t *testing.T) {
 func TestReplicaCalcEmptyMetrics(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas: 4,
-		expectedError:   fmt.Errorf("unable to get metrics for resource cpu: no metrics returned from heapster"),
+		expectedError:   fmt.Errorf("unable to get metrics for resource cpu: no metrics returned from resource metrics API"),
 		resource: &resourceInfo{
 			name:     v1.ResourceCPU,
 			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},


### PR DESCRIPTION
**What this PR does / why we need it**:

With the introduction of the RESTMetrics client, there are two ways to
fetch metrics for auto-scaling. However, they previously shared error
messages. This could be misleading. Make the error message more clearly
show which method is in use.

**Special notes for your reviewer**:

@DirectXMan12 re conversation in #56827 

**Release note**:

```release-note
NONE
```
