### PR TITLE
kube-proxy: fix field name comments & json tags

### DIFF
--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -430,7 +430,7 @@ mode: "%s"
 oomScoreAdj: 17
 portRange: "2-7"
 resourceContainer: /foo
-udpTimeoutMilliseconds: 123ms
+udpIdleTimeout: 123ms
 `
 
 	testCases := []struct {

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -26,7 +26,7 @@ import (
 
 // ClientConnectionConfiguration contains details for constructing a client.
 type ClientConnectionConfiguration struct {
-	// kubeConfigFile is the path to a kubeconfig file.
+	// kubeconfig is the path to a kubeconfig file.
 	KubeConfigFile string
 	// acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
 	// default value of 'application/json'. This field will control all connections to the server used by a particular
@@ -97,13 +97,13 @@ type KubeProxyConntrackConfiguration struct {
 type KubeProxyConfiguration struct {
 	metav1.TypeMeta
 
-	// featureGates is a comma-separated list of key=value pairs that control
-	// which alpha/beta features are enabled.
-	//
-	// TODO this really should be a map but that requires refactoring all
+	// TODO FeatureGates really should be a map but that requires refactoring all
 	// components to use config files because local-up-cluster.sh only supports
 	// the --feature-gates flag right now, which is comma-separated key=value
 	// pairs.
+	//
+	// featureGates is a comma-separated list of key=value pairs that control
+	// which alpha/beta features are enabled.
 	FeatureGates string
 
 	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
@@ -22,7 +22,7 @@ import (
 
 // ClientConnectionConfiguration contains details for constructing a client.
 type ClientConnectionConfiguration struct {
-	// kubeConfigFile is the path to a kubeconfig file.
+	// kubeconfig is the path to a kubeconfig file.
 	KubeConfigFile string `json:"kubeconfig"`
 	// acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
 	// default value of 'application/json'. This field will control all connections to the server used by a particular
@@ -30,7 +30,7 @@ type ClientConnectionConfiguration struct {
 	AcceptContentTypes string `json:"acceptContentTypes"`
 	// contentType is the content type used when sending data to the server from this client.
 	ContentType string `json:"contentType"`
-	// cps controls the number of queries per second allowed for this connection.
+	// qps controls the number of queries per second allowed for this connection.
 	QPS float32 `json:"qps"`
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
 	Burst int `json:"burst"`
@@ -93,13 +93,13 @@ type KubeProxyConntrackConfiguration struct {
 type KubeProxyConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// featureGates is a comma-separated list of key=value pairs that control
-	// which alpha/beta features are enabled.
-	//
-	// TODO this really should be a map but that requires refactoring all
+	// TODO FeatureGates really should be a map but that requires refactoring all
 	// components to use config files because local-up-cluster.sh only supports
 	// the --feature-gates flag right now, which is comma-separated key=value
 	// pairs.
+	//
+	// featureGates is a comma-separated list of key=value pairs that control
+	// which alpha/beta features are enabled.
 	FeatureGates string `json:"featureGates"`
 
 	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
@@ -140,7 +140,7 @@ type KubeProxyConfiguration struct {
 	ResourceContainer string `json:"resourceContainer"`
 	// udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
 	// Must be greater than 0. Only applicable for proxyMode=userspace.
-	UDPIdleTimeout metav1.Duration `json:"udpTimeoutMilliseconds"`
+	UDPIdleTimeout metav1.Duration `json:"udpIdleTimeout"`
 	// conntrack contains conntrack-related configuration options.
 	Conntrack KubeProxyConntrackConfiguration `json:"conntrack"`
 	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: correct some minor issues in the comments and json tags for some of the fields in the kube-proxy config structs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The udpTimeoutMilliseconds field in the kube-proxy configuration file has been renamed to udpIdleTimeout. Action required: administrators need to update their files accordingly.
```

This was extracted from my currently unmerged https://github.com/kubernetes/kubernetes/pull/52198/commits/f074b28fe9cae52871c76e2834e70975ab473f7e, as requested [here](https://github.com/kubernetes/kubernetes/pull/52198#pullrequestreview-85538637).

@kubernetes/sig-network-pr-reviews @luxas 
  
  