### PR TITLE
Automated cherry pick of #57286 upstream release-1.9 

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -217,7 +217,7 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 
 	// Only on controller node it is required to register listeners.
 	// Register callbacks for node updates
-	client := clientBuilder.ClientOrDie("vSphere-cloud-provider")
+	client := clientBuilder.ClientOrDie("vsphere-cloud-provider")
 	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
 	nodeInformer := factory.Core().V1().Nodes()
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
Cherry pick of #57286 on release-1.9
#57286: Fixing vSphere Cloud Provider to use "vsphere-cloud-provider" to create ClientBuilder

**Release note:**
```
This fixes controller manager crash in certain vSphere cloud provider environment.
```

cc: @rohitjogvmw @abrarshivani 