### PR TITLE
Uniform Azure VM api calls

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -42,12 +42,11 @@ func (az *Cloud) requestBackoff() (resourceRequestBackoff wait.Backoff) {
 }
 
 // GetVirtualMachineWithRetry invokes az.getVirtualMachine with exponential backoff retry
-func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.VirtualMachine, bool, error) {
+func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.VirtualMachine, error) {
 	var machine compute.VirtualMachine
-	var exists bool
 	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		var retryErr error
-		machine, exists, retryErr = az.getVirtualMachine(name)
+		machine, retryErr = az.getVirtualMachine(name)
 		if retryErr != nil {
 			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
 			return false, nil
@@ -55,7 +54,7 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 		glog.V(2).Infof("backoff: success")
 		return true, nil
 	})
-	return machine, exists, err
+	return machine, err
 }
 
 // VirtualMachineClientGetWithRetry invokes az.VirtualMachinesClient.Get with exponential backoff retry

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -57,23 +57,6 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 	return machine, err
 }
 
-// VirtualMachineClientGetWithRetry invokes az.VirtualMachinesClient.Get with exponential backoff retry
-func (az *Cloud) VirtualMachineClientGetWithRetry(resourceGroup, vmName string, types compute.InstanceViewTypes) (compute.VirtualMachine, error) {
-	var machine compute.VirtualMachine
-	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
-		var retryErr error
-		az.operationPollRateLimiter.Accept()
-		machine, retryErr = az.VirtualMachinesClient.Get(resourceGroup, vmName, types)
-		if retryErr != nil {
-			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
-			return false, nil
-		}
-		glog.V(2).Infof("backoff: success")
-		return true, nil
-	})
-	return machine, err
-}
-
 // VirtualMachineClientListWithRetry invokes az.VirtualMachinesClient.List with exponential backoff retry
 func (az *Cloud) VirtualMachineClientListWithRetry() ([]compute.VirtualMachine, error) {
 	allNodes := []compute.VirtualMachine{}

--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -71,12 +71,11 @@ type controllerCommon struct {
 // AttachDisk attaches a vhd to vm
 // the vhd must exist, can be identified by diskName, diskURI, and lun.
 func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI string, nodeName types.NodeName, lun int32, cachingMode compute.CachingTypes) error {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return err
-	} else if !exists {
-		return cloudprovider.InstanceNotFound
 	}
+
 	disks := *vm.StorageProfile.DataDisks
 	if isManagedDisk {
 		disks = append(disks,
@@ -143,8 +142,8 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 // DetachDiskByName detaches a vhd from host
 // the vhd can be identified by diskName or diskURI
 func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName types.NodeName) error {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
-	if err != nil || !exists {
+	vm, err := c.cloud.getVirtualMachine(nodeName)
+	if err != nil {
 		// if host doesn't exist, no need to detach
 		glog.Warningf("azureDisk - cannot find node %s, skip detaching disk %s", nodeName, diskName)
 		return nil
@@ -202,11 +201,9 @@ func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName t
 
 // GetDiskLun finds the lun on the host that the vhd is attached to, given a vhd's diskName and diskURI
 func (c *controllerCommon) GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, error) {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return -1, err
-	} else if !exists {
-		return -1, cloudprovider.InstanceNotFound
 	}
 	disks := *vm.StorageProfile.DataDisks
 	for _, disk := range disks {
@@ -224,11 +221,9 @@ func (c *controllerCommon) GetDiskLun(diskName, diskURI string, nodeName types.N
 // GetNextDiskLun searches all vhd attachment on the host and find unused lun
 // return -1 if all luns are used
 func (c *controllerCommon) GetNextDiskLun(nodeName types.NodeName) (int32, error) {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return -1, err
-	} else if !exists {
-		return -1, cloudprovider.InstanceNotFound
 	}
 	used := make([]bool, maxLUN)
 	disks := *vm.StorageProfile.DataDisks
@@ -251,8 +246,8 @@ func (c *controllerCommon) DisksAreAttached(diskNames []string, nodeName types.N
 	for _, diskName := range diskNames {
 		attached[diskName] = false
 	}
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
-	if !exists {
+	vm, err := c.cloud.getVirtualMachine(nodeName)
+	if err == cloudprovider.InstanceNotFound {
 		// if host doesn't exist, no need to detach
 		glog.Warningf("azureDisk - Cannot find node %q, DisksAreAttached will assume disks %v are not attached to it.",
 			nodeName, diskNames)

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -387,15 +387,14 @@ func newAvailabilitySet(az *Cloud) VMSet {
 // not exist or is no longer running.
 func (as *availabilitySet) GetInstanceIDByNodeName(name string) (string, error) {
 	var machine compute.VirtualMachine
-	var exists bool
 	var err error
 
 	as.operationPollRateLimiter.Accept()
-	machine, exists, err = as.getVirtualMachine(types.NodeName(name))
+	machine, err = as.getVirtualMachine(types.NodeName(name))
 	if err != nil {
 		if as.CloudProviderBackoff {
 			glog.V(2).Infof("InstanceID(%s) backing off", name)
-			machine, exists, err = as.GetVirtualMachineWithRetry(types.NodeName(name))
+			machine, err = as.GetVirtualMachineWithRetry(types.NodeName(name))
 			if err != nil {
 				glog.V(2).Infof("InstanceID(%s) abort backoff", name)
 				return "", err
@@ -403,8 +402,6 @@ func (as *availabilitySet) GetInstanceIDByNodeName(name string) (string, error) 
 		} else {
 			return "", err
 		}
-	} else if !exists {
-		return "", cloudprovider.InstanceNotFound
 	}
 	return *machine.ID, nil
 }
@@ -422,12 +419,10 @@ func (as *availabilitySet) GetNodeNameByProviderID(providerID string) (types.Nod
 
 // GetInstanceTypeByNodeName gets the instance type by node name.
 func (as *availabilitySet) GetInstanceTypeByNodeName(name string) (string, error) {
-	machine, exists, err := as.getVirtualMachine(types.NodeName(name))
+	machine, err := as.getVirtualMachine(types.NodeName(name))
 	if err != nil {
 		glog.Errorf("error: as.GetInstanceTypeByNodeName(%s), as.getVirtualMachine(%s) err=%v", name, name, err)
 		return "", err
-	} else if !exists {
-		return "", cloudprovider.InstanceNotFound
 	}
 
 	return string(machine.HardwareProfile.VMSize), nil
@@ -435,13 +430,9 @@ func (as *availabilitySet) GetInstanceTypeByNodeName(name string) (string, error
 
 // GetZoneByNodeName gets zone from instance view.
 func (as *availabilitySet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
-	vm, exists, err := as.getVirtualMachine(types.NodeName(name))
+	vm, err := as.getVirtualMachine(types.NodeName(name))
 	if err != nil {
 		return cloudprovider.Zone{}, err
-	}
-
-	if !exists {
-		return cloudprovider.Zone{}, cloudprovider.InstanceNotFound
 	}
 
 	failureDomain := strconv.Itoa(int(*vm.VirtualMachineProperties.InstanceView.PlatformFaultDomain))

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -564,13 +564,11 @@ func (as *availabilitySet) GetPrimaryInterface(nodeName, vmSetName string) (netw
 	var machine compute.VirtualMachine
 
 	as.operationPollRateLimiter.Accept()
-	glog.V(10).Infof("VirtualMachinesClient.Get(%q): start", nodeName)
-	machine, err := as.VirtualMachineClientGetWithRetry(as.ResourceGroup, nodeName, "")
+	machine, err := as.GetVirtualMachineWithRetry(types.NodeName(nodeName))
 	if err != nil {
 		glog.V(2).Infof("GetPrimaryInterface(%s, %s) abort backoff", nodeName, vmSetName)
 		return network.Interface{}, err
 	}
-	glog.V(10).Infof("VirtualMachinesClient.Get(%q): end", nodeName)
 
 	primaryNicID, err := getPrimaryInterfaceID(machine)
 	if err != nil {

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 // checkExistsFromError inspects an error and returns a true if err is nil,
@@ -71,9 +72,7 @@ type vmRequest struct {
 /// getVirtualMachine calls 'VirtualMachinesClient.Get' with a timed cache
 /// The service side has throttling control that delays responses if there're multiple requests onto certain vm
 /// resource request in short period.
-func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachine, exists bool, err error) {
-	var realErr error
-
+func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachine, err error) {
 	vmName := string(nodeName)
 
 	cachedRequest, err := vmCache.GetOrCreate(vmName, func() interface{} {
@@ -83,7 +82,7 @@ func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualM
 		}
 	})
 	if err != nil {
-		return compute.VirtualMachine{}, false, err
+		return compute.VirtualMachine{}, err
 	}
 	request := cachedRequest.(*vmRequest)
 
@@ -102,22 +101,22 @@ func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualM
 			vm, err = az.VirtualMachinesClient.Get(az.ResourceGroup, vmName, compute.InstanceView)
 			glog.V(10).Infof("VirtualMachinesClient.Get(%s): end", vmName)
 
-			exists, realErr = checkResourceExistsFromError(err)
+			exists, realErr := checkResourceExistsFromError(err)
 			if realErr != nil {
-				return vm, false, realErr
+				return vm, realErr
 			}
 
 			if !exists {
-				return vm, false, nil
+				return vm, cloudprovider.InstanceNotFound
 			}
 
 			request.vm = &vm
 		}
-		return vm, exists, err
+		return vm, nil
 	}
 
 	glog.V(6).Infof("getVirtualMachine hits cache for(%s)", vmName)
-	return *request.vm, true, nil
+	return *request.vm, nil
 }
 
 func (az *Cloud) getRouteTable() (routeTable network.RouteTable, exists bool, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
There is still a call to 'VirtualMachinesClient.Get' directly in azure_backoff, which does not go through the cache approach.

This PR uniforms all calls for getting azure vm to use 'getVirtualMachine'. Also refine unused 'exists' return value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related #57031
Follow-up #57432

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
