### PR TITLE
Monitor the /kubepods cgroup for allocatable metrics

### DIFF
--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -87,6 +87,8 @@ const (
 	SystemContainerRuntime = "runtime"
 	// SystemContainerMisc is the container name for the system container tracking non-kubernetes processes.
 	SystemContainerMisc = "misc"
+	// SystemContainerPods is the container name for the system container tracking user pods.
+	SystemContainerPods = "pods"
 )
 
 // PodStats holds pod-level unprocessed sample stats.

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -91,6 +91,9 @@ type ContainerManager interface {
 	UpdatePluginResources(*schedulercache.NodeInfo, *lifecycle.PodAdmitAttributes) error
 
 	InternalContainerLifecycle() InternalContainerLifecycle
+
+	// GetPodCgroupRoot returns the cgroup which contains all pods.
+	GetPodCgroupRoot() string
 }
 
 type NodeConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -500,6 +500,11 @@ func (cm *containerManagerImpl) GetNodeConfig() NodeConfig {
 	return cm.NodeConfig
 }
 
+// GetPodCgroupRoot returns the literal cgroupfs value for the cgroup containing all pods.
+func (cm *containerManagerImpl) GetPodCgroupRoot() string {
+	return cm.cgroupManager.Name(CgroupName(cm.cgroupRoot))
+}
+
 func (cm *containerManagerImpl) GetMountedSubsystems() *CgroupSubsystems {
 	return cm.subsystems
 }

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -90,6 +90,10 @@ func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLi
 	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager()}
 }
 
+func (cm *containerManagerStub) GetPodCgroupRoot() string {
+	return ""
+}
+
 func NewStubContainerManager() ContainerManager {
 	return &containerManagerStub{}
 }

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -53,7 +53,7 @@ type Config struct {
 // Manager evaluates when an eviction threshold for node stability has been met on the node.
 type Manager interface {
 	// Start starts the control loop to monitor eviction thresholds at specified interval.
-	Start(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc, podCleanedUpFunc PodCleanedUpFunc, capacityProvider CapacityProvider, monitoringInterval time.Duration)
+	Start(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc, podCleanedUpFunc PodCleanedUpFunc, monitoringInterval time.Duration)
 
 	// IsUnderMemoryPressure returns true if the node is under memory pressure.
 	IsUnderMemoryPressure() bool
@@ -69,14 +69,6 @@ type Manager interface {
 type DiskInfoProvider interface {
 	// HasDedicatedImageFs returns true if the imagefs is on a separate device from the rootfs.
 	HasDedicatedImageFs() (bool, error)
-}
-
-// CapacityProvider is responsible for providing the resource capacity and reservation information
-type CapacityProvider interface {
-	// GetCapacity returns the amount of compute resources tracked by container manager available on the node.
-	GetCapacity() v1.ResourceList
-	// GetNodeAllocatableReservation returns the amount of compute resources that have to be reserved from scheduling.
-	GetNodeAllocatableReservation() v1.ResourceList
 }
 
 // ImageGC is responsible for performing garbage collection of unused images.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1318,7 +1318,7 @@ func (kl *Kubelet) initializeRuntimeDependentModules() {
 		glog.Fatalf("Failed to start cAdvisor %v", err)
 	}
 	// eviction manager must start after cadvisor because it needs to know if the container runtime has a dedicated imagefs
-	kl.evictionManager.Start(kl.StatsProvider, kl.GetActivePods, kl.podResourcesAreReclaimed, kl.containerManager, evictionMonitoringPeriod)
+	kl.evictionManager.Start(kl.StatsProvider, kl.GetActivePods, kl.podResourcesAreReclaimed, evictionMonitoringPeriod)
 
 	// trigger on-demand stats collection once so that we have capacity information for ephemeral storage.
 	// ignore any errors, since if stats collection is not successful, the container manager will fail to start below.

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -211,6 +211,11 @@ func (kl *Kubelet) GetNodeConfig() cm.NodeConfig {
 	return kl.containerManager.GetNodeConfig()
 }
 
+// GetPodCgroupRoot returns the listeral cgroupfs value for the cgroup containing all pods
+func (kl *Kubelet) GetPodCgroupRoot() string {
+	return kl.containerManager.GetPodCgroupRoot()
+}
+
 // GetHostIP returns host IP or nil in case of error.
 func (kl *Kubelet) GetHostIP() (net.IP, error) {
 	node, err := kl.GetNode()

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -168,6 +168,7 @@ func (fk *fakeKubelet) StreamingConnectionIdleTimeout() time.Duration {
 // Unused functions
 func (_ *fakeKubelet) GetNode() (*v1.Node, error)   { return nil, nil }
 func (_ *fakeKubelet) GetNodeConfig() cm.NodeConfig { return cm.NodeConfig{} }
+func (_ *fakeKubelet) GetPodCgroupRoot() string     { return "" }
 
 func (fk *fakeKubelet) ListVolumesForPod(podUID types.UID) (map[string]volume.Volume, bool) {
 	return map[string]volume.Volume{}, true

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -81,6 +81,9 @@ type StatsProvider interface {
 
 	// RlimitStats returns the rlimit stats of system.
 	RlimitStats() (*statsapi.RlimitStats, error)
+
+	// GetPodCgroupRoot returns the literal cgroupfs value for the cgroup containing all pods
+	GetPodCgroupRoot() string
 }
 
 type handler struct {

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -83,19 +83,23 @@ func (sp *summaryProviderImpl) Get(updateStats bool) (*statsapi.Summary, error) 
 		Rlimit:    rlimit,
 	}
 
-	systemContainers := map[string]string{
-		statsapi.SystemContainerKubelet: nodeConfig.KubeletCgroupsName,
-		statsapi.SystemContainerRuntime: nodeConfig.RuntimeCgroupsName,
-		statsapi.SystemContainerMisc:    nodeConfig.SystemCgroupsName,
+	systemContainers := map[string]struct {
+		name             string
+		forceStatsUpdate bool
+	}{
+		statsapi.SystemContainerKubelet: {nodeConfig.KubeletCgroupsName, false},
+		statsapi.SystemContainerRuntime: {nodeConfig.RuntimeCgroupsName, false},
+		statsapi.SystemContainerMisc:    {nodeConfig.SystemCgroupsName, false},
+		statsapi.SystemContainerPods:    {sp.provider.GetPodCgroupRoot(), updateStats},
 	}
-	for sys, name := range systemContainers {
+	for sys, cont := range systemContainers {
 		// skip if cgroup name is undefined (not all system containers are required)
-		if name == "" {
+		if cont.name == "" {
 			continue
 		}
-		s, _, err := sp.provider.GetCgroupStats(name, false)
+		s, _, err := sp.provider.GetCgroupStats(cont.name, cont.forceStatsUpdate)
 		if err != nil {
-			glog.Errorf("Failed to get system container stats for %q: %v", name, err)
+			glog.Errorf("Failed to get system container stats for %q: %v", cont.name, err)
 			continue
 		}
 		// System containers don't have a filesystem associated with them.

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -49,6 +49,7 @@ func TestSummaryProvider(t *testing.T) {
 			SystemCgroupsName:  "/misc",
 			KubeletCgroupsName: "/kubelet",
 		}
+		cgroupRoot     = "/kubepods"
 		cgroupStatsMap = map[string]struct {
 			cs *statsapi.ContainerStats
 			ns *statsapi.NetworkStats
@@ -57,6 +58,7 @@ func TestSummaryProvider(t *testing.T) {
 			"/runtime": {cs: getContainerStats(), ns: getNetworkStats()},
 			"/misc":    {cs: getContainerStats(), ns: getNetworkStats()},
 			"/kubelet": {cs: getContainerStats(), ns: getNetworkStats()},
+			"/pods":    {cs: getContainerStats(), ns: getNetworkStats()},
 		}
 		rlimitStats = getRlimitStats()
 	)
@@ -67,6 +69,7 @@ func TestSummaryProvider(t *testing.T) {
 	mockStatsProvider.
 		On("GetNode").Return(node, nil).
 		On("GetNodeConfig").Return(nodeConfig).
+		On("GetPodCgroupRoot").Return(cgroupRoot).
 		On("ListPodStats").Return(podStats, nil).
 		On("ImageFsStats").Return(imageFsStats, nil).
 		On("RootFsStats").Return(rootFsStats, nil).
@@ -74,7 +77,8 @@ func TestSummaryProvider(t *testing.T) {
 		On("GetCgroupStats", "/", true).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).
 		On("GetCgroupStats", "/runtime", false).Return(cgroupStatsMap["/runtime"].cs, cgroupStatsMap["/runtime"].ns, nil).
 		On("GetCgroupStats", "/misc", false).Return(cgroupStatsMap["/misc"].cs, cgroupStatsMap["/misc"].ns, nil).
-		On("GetCgroupStats", "/kubelet", false).Return(cgroupStatsMap["/kubelet"].cs, cgroupStatsMap["/kubelet"].ns, nil)
+		On("GetCgroupStats", "/kubelet", false).Return(cgroupStatsMap["/kubelet"].cs, cgroupStatsMap["/kubelet"].ns, nil).
+		On("GetCgroupStats", "/kubepods", true).Return(cgroupStatsMap["/pods"].cs, cgroupStatsMap["/pods"].ns, nil)
 
 	provider := NewSummaryProvider(mockStatsProvider)
 	summary, err := provider.Get(true)
@@ -88,7 +92,7 @@ func TestSummaryProvider(t *testing.T) {
 	assert.Equal(summary.Node.Fs, rootFsStats)
 	assert.Equal(summary.Node.Runtime, &statsapi.RuntimeStats{ImageFs: imageFsStats})
 
-	assert.Equal(len(summary.Node.SystemContainers), 3)
+	assert.Equal(len(summary.Node.SystemContainers), 4)
 	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
 		Name:               "kubelet",
 		StartTime:          cgroupStatsMap["/kubelet"].cs.StartTime,
@@ -112,6 +116,14 @@ func TestSummaryProvider(t *testing.T) {
 		Memory:             cgroupStatsMap["/runtime"].cs.Memory,
 		Accelerators:       cgroupStatsMap["/runtime"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/runtime"].cs.UserDefinedMetrics,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:               "pods",
+		StartTime:          cgroupStatsMap["/pods"].cs.StartTime,
+		CPU:                cgroupStatsMap["/pods"].cs.CPU,
+		Memory:             cgroupStatsMap["/pods"].cs.Memory,
+		Accelerators:       cgroupStatsMap["/pods"].cs.Accelerators,
+		UserDefinedMetrics: cgroupStatsMap["/pods"].cs.UserDefinedMetrics,
 	})
 	assert.Equal(summary.Pods, podStats)
 }

--- a/pkg/kubelet/server/stats/testing/mock_stats_provider.go
+++ b/pkg/kubelet/server/stats/testing/mock_stats_provider.go
@@ -125,6 +125,20 @@ func (_m *StatsProvider) GetNodeConfig() cm.NodeConfig {
 	return r0
 }
 
+// GetPodCgroupRoot provides a mock function with given fields:
+func (_m *StatsProvider) GetPodCgroupRoot() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetPodByName provides a mock function with given fields: namespace, name
 func (_m *StatsProvider) GetPodByName(namespace string, name string) (*corev1.Pod, bool) {
 	ret := _m.Called(namespace, name)

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -107,9 +107,21 @@ var _ = framework.KubeDescribe("Summary API", func() {
 					"UserDefinedMetrics": BeEmpty(),
 				})
 			}
+			podsContExpectations := sysContExpectations().(*gstruct.FieldsMatcher)
+			podsContExpectations.Fields["Memory"] = ptrMatchAllFields(gstruct.Fields{
+				"Time": recent(maxStatsAge),
+				// Pods are limited by Node Allocatable
+				"AvailableBytes":  bounded(1*framework.Kb, memoryLimit),
+				"UsageBytes":      bounded(10*framework.Kb, 20*framework.Mb),
+				"WorkingSetBytes": bounded(10*framework.Kb, 20*framework.Mb),
+				"RSSBytes":        bounded(1*framework.Kb, 20*framework.Mb),
+				"PageFaults":      bounded(0, 1000000),
+				"MajorPageFaults": bounded(0, 10),
+			})
 			systemContainers := gstruct.Elements{
 				"kubelet": sysContExpectations(),
 				"runtime": sysContExpectations(),
+				"pods":    podsContExpectations,
 			}
 			// The Kubelet only manages the 'misc' system container if the host is not running systemd.
 			if !systemdutil.IsRunningSystemd() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation of allocatable memory evictions sums the usage of pods in order to compute the total usage by user processes.
This PR changes this to instead monitor the `/kubepods` cgroup, which contains all pods, and use this value directly.  This is more accurate than summing pod usage, as it is measured at a single point in time.
This also collects metrics from this cgroup on-demand.
This PR is a precursor to memcg notifications on the `/kubepods` cgroup.
This removes the dependency the eviction manager has on the container manager, and adds a dependency for the summary collector on the container manager (to get Cgroup Root)
This also changes the way that the allocatable memory eviction signal and threshold are added to make them in-line with the memory eviction signal to address #53902

**Which issue(s) this PR fixes**:
Fixes #55638
Fixes #53902

**Special notes for your reviewer**:
I have tested this, and can confirm that it works when CgroupsPerQos is set to false.  In this case, it returns node metrics, as it is monitoring the `/` cgroup, rather than the `/kubepods` cgroup (which doesn't exist).

**Release note**:
```release-note
Expose total usage of pods through the "pods" SystemContainer in the Kubelet Summary API
```
cc @sjenning @derekwaynecarr @vishh @kubernetes/sig-node-pr-reviews 

  
  
  