### PR TITLE
Avoid error on closed pipe

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -265,7 +265,7 @@ kube::test::if_has_string() {
   local message=$1
   local match=$2
 
-  if echo "$message" | grep -q "$match"; then
+  if grep -q "${match}" <<< "${message}"; then
     echo "Successful"
     echo "message:$message"
     echo "has:$match"
@@ -283,7 +283,7 @@ kube::test::if_has_not_string() {
   local message=$1
   local match=$2
 
-  if echo "$message" | grep -q "$match"; then
+  if grep -q "${match}" <<< "${message}"; then
     echo "FAIL!"
     echo "message:$message"
     echo "has:$match"


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/57706

from @stevekuznetsov:
> If you do `echo | grep -q`, `grep` will exit when it finds the first match
> If the `echo` is still writing to stdout it fails because there's no reader on that pipe anymore
> So we always use `grep -q <<<"${content}"` now
> since that uses a FIFO
  
```release-note
NONE
```