### PR TITLE
Automated cherry pick of #56249

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -98,18 +98,23 @@ function kube::release::package_tarballs() {
 
 # Package the source code we built, for compliance/licensing/audit/yadda.
 function kube::release::package_src_tarball() {
+  local -r src_tarball="${RELEASE_TARS}/kubernetes-src.tar.gz"
   kube::log::status "Building tarball: src"
-  local source_files=(
-    $(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
-      -not \( \
-        \( -path ./_\*        -o \
-           -path ./.git\*     -o \
-           -path ./.config\* -o \
-           -path ./.gsutil\*    \
-        \) -prune \
-      \))
-  )
-  "${TAR}" czf "${RELEASE_TARS}/kubernetes-src.tar.gz" -C "${KUBE_ROOT}" "${source_files[@]}"
+  if [[ "${KUBE_GIT_TREE_STATE-}" == "clean" ]]; then
+    git archive -o "${src_tarball}" HEAD
+  else
+    local source_files=(
+      $(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
+        -not \( \
+          \( -path ./_\*        -o \
+             -path ./.git\*     -o \
+             -path ./.config\* -o \
+             -path ./.gsutil\*    \
+          \) -prune \
+        \))
+    )
+    "${TAR}" czf "${src_tarball}" -C "${KUBE_ROOT}" "${source_files[@]}"
+  fi
 }
 
 # Package up all of the cross compiled clients. Over time this should grow into

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -22,6 +22,7 @@
 #          source code.
 #    KUBE_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
 #        "dirty" indicates source code changes after the git commit id
+#        "archive" indicates the tree was produced by 'git archive'
 #    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
 #    KUBE_GIT_MAJOR - The major part of the version
 #    KUBE_GIT_MINOR - The minor component of the version
@@ -40,7 +41,7 @@ kube::version::get_version_vars() {
   # we likely don't have a git tree, but these magic values may be filled in.
   if [[ '$Format:%%$' == "%" ]]; then
     KUBE_GIT_COMMIT='$Format:%H$'
-    KUBE_GIT_TREE_STATE="git archive"
+    KUBE_GIT_TREE_STATE="archive"
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.


### PR DESCRIPTION
Cherry pick of #56249 on release-1.8.

#56249: Rename tree state from 'git archive' to 'archive'

Fixes #56346