### PR TITLE
Fixing typo in e2e test variable

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -120,7 +120,7 @@ const (
 	// provisioner daemonSetName name
 	daemonSetName = "local-volume-provisioner"
 	// provisioner default mount point folder
-	provisionerDefaultMountRoot = "/mnt-local-storage"
+	provisionerDefaultMountRoot = "/mnt/local-storage"
 	// provisioner node/pv cluster role binding
 	nodeBindingName         = "local-storage:provisioner-node-binding"
 	pvBindingName           = "local-storage:provisioner-pv-binding"
@@ -1071,7 +1071,7 @@ func createProvisionerDaemonset(config *localTestConfig) {
 								},
 								{
 									Name:      "local-disks",
-									MountPath: "/mnt/local-storage",
+									MountPath: provisionerDefaultMountRoot,
 								},
 							},
 						},


### PR DESCRIPTION
Fixing a typo in a value of one constant.
```release-note

```
