### PR TITLE
[Alpha: DynamicKubeletConfig] Double check before setKubeletConfiguration

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -107,6 +107,10 @@ func tempSetCurrentKubeletConfig(f *framework.Framework, updateFunction func(ini
 		framework.ExpectNoError(err)
 		newCfg := oldCfg.DeepCopy()
 		updateFunction(newCfg)
+		if reflect.DeepEqual(*newCfg, *oldCfg) {
+			return
+		}
+
 		framework.ExpectNoError(setKubeletConfiguration(f, newCfg))
 	})
 	AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Double check the `newCfg` is not equal to the `oldCfg` before we call `setKubeletConfiguration(newCfg)` in `tempSetCurrentKubeletConfig()`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/57701

**Special notes for your reviewer**:

/area kubelet
/sig node
/assign @mtaufen 
/cc @vishh @jiayingz @derekwaynecarr @dchen1107 @liggitt 
PTAL, Thanks!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
