### PR TITLE
remove hard-coded namespace

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
@@ -11,7 +11,10 @@ go_test(
     srcs = ["requestinfo_test.go"],
     embed = [":go_default_library"],
     importpath = "k8s.io/apiserver/pkg/endpoints/request",
-    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
 )
 
 go_library(
@@ -26,6 +29,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -66,8 +67,6 @@ const (
 
 	// auditKey is the context key for the audit event.
 	auditKey
-
-	namespaceDefault = "default" // TODO(sttts): solve import cycle when using metav1.NamespaceDefault
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -77,7 +76,7 @@ func NewContext() Context {
 
 // NewDefaultContext instantiates a base context object for request flows in the default namespace
 func NewDefaultContext() Context {
-	return WithNamespace(NewContext(), namespaceDefault)
+	return WithNamespace(NewContext(), metav1.NamespaceDefault)
 }
 
 // WithValue returns a copy of parent in which the value associated with key is val.
@@ -110,7 +109,7 @@ func NamespaceValue(ctx Context) string {
 func WithNamespaceDefaultIfNone(parent Context) Context {
 	namespace, ok := NamespaceFrom(parent)
 	if !ok || len(namespace) == 0 {
-		return WithNamespace(parent, namespaceDefault)
+		return WithNamespace(parent, metav1.NamespaceDefault)
 	}
 	return parent
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -178,7 +179,7 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 			}
 		}
 	} else {
-		requestInfo.Namespace = "" // TODO(sttts): solve import cycle when using metav1.NamespaceNone
+		requestInfo.Namespace = metav1.NamespaceNone
 	}
 
 	// parsing successful, so we now know the proper value for .Parts

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -31,7 +32,7 @@ func (f fakeRL) TryAccept() bool { return bool(f) }
 func (f fakeRL) Accept()         {}
 
 func TestGetAPIRequestInfo(t *testing.T) {
-	namespaceAll := "" // TODO(sttts): solve import cycle when using metav1.NamespaceAll
+	namespaceAll := metav1.NamespaceAll
 	successCases := []struct {
 		method              string
 		url                 string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Since import cycle is solved, should use metav1.Namespace* instead of hard coding.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
