### PR TITLE
fix rbd ConstructVolumeSpec bug

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -357,7 +357,26 @@ func (plugin *rbdPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*vol
 	}
 	s := dstrings.Split(sourceName, "-image-")
 	if len(s) != 2 {
-		return nil, fmt.Errorf("sourceName %s wrong, should be pool+\"-image-\"+imageName", sourceName)
+		// The mountPath parameter is the volume mount path for a specific pod, its format
+		// is /var/lib/kubelet/pods/{podUID}/volumes/{volumePluginName}/{volumeName}.
+		// mounter.GetDeviceNameFromMount will find the device path(such as /dev/rbd0) by
+		// mountPath first, and then try to find the global device mount path from the mounted
+		// path list of this device. sourceName is extracted from this global device mount path.
+		// mounter.GetDeviceNameFromMount expects the global device mount path conforms to canonical
+		// format: /var/lib/kubelet/plugins/kubernetes.io/rbd/mounts/{pool}-image-{image}.
+		// If this assertion failed, it means that the global device mount path is created by
+		// the deprecated format: /var/lib/kubelet/plugins/kubernetes.io/rbd/rbd/{pool}-image-{image}.
+		// So we will try to check whether this old style global device mount path exist or not.
+		// If existed, extract the sourceName from this old style path, otherwise return an error.
+		glog.V(3).Infof("SourceName %s wrong, fallback to old format", sourceName)
+		sourceName, err = plugin.getDeviceNameFromOldMountPath(mounter, mountPath)
+		if err != nil {
+			return nil, err
+		}
+		s = dstrings.Split(sourceName, "-image-")
+		if len(s) != 2 {
+			return nil, fmt.Errorf("sourceName %s wrong, should be pool+\"-image-\"+imageName", sourceName)
+		}
 	}
 	rbdVolume := &v1.Volume{
 		Name: volumeName,
@@ -490,6 +509,22 @@ func (plugin *rbdPlugin) newUnmapperInternal(volName string, podUID types.UID, m
 			mon: make([]string, 0),
 		},
 	}, nil
+}
+
+func (plugin *rbdPlugin) getDeviceNameFromOldMountPath(mounter mount.Interface, mountPath string) (string, error) {
+	refs, err := mount.GetMountRefsByDev(mounter, mountPath)
+	if err != nil {
+		return "", err
+	}
+	// baseMountPath is the prefix of deprecated device global mounted path,
+	// such as: /var/lib/kubelet/plugins/kubernetes.io/rbd/rbd
+	baseMountPath := filepath.Join(plugin.host.GetPluginDir(rbdPluginName), "rbd")
+	for _, ref := range refs {
+		if dstrings.HasPrefix(ref, baseMountPath) {
+			return filepath.Rel(baseMountPath, ref)
+		}
+	}
+	return "", fmt.Errorf("can't find source name from mounted path: %s", mountPath)
 }
 
 func (plugin *rbdPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix rbd `ConstructVolumeSpec` bug as its global device mount path is not canonical. Full details are in #57744 .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57744 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig storage
/kind bug