### PR TITLE
Eviction Node e2e test checks for eviction reason

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -143,7 +143,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	glog.Warningf("Failed to admit pod %s - node has conditions: %v", format.Pod(attrs.Pod), m.nodeConditions)
 	return lifecycle.PodAdmitResult{
 		Admit:   false,
-		Reason:  reason,
+		Reason:  Reason,
 		Message: fmt.Sprintf(message, m.nodeConditions),
 	}
 }
@@ -569,10 +569,10 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 	status := v1.PodStatus{
 		Phase:   v1.PodFailed,
 		Message: evictMsg,
-		Reason:  reason,
+		Reason:  Reason,
 	}
 	// record that we are evicting the pod
-	m.recorder.Eventf(pod, v1.EventTypeWarning, reason, evictMsg)
+	m.recorder.Eventf(pod, v1.EventTypeWarning, Reason, evictMsg)
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	err := m.killPodFunc(pod, status, &gracePeriodOverride)
 	if err != nil {

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -38,8 +38,8 @@ import (
 
 const (
 	unsupportedEvictionSignal = "unsupported eviction signal %v"
-	// the reason reported back in status.
-	reason = "Evicted"
+	// Reason is the reason reported back in status.
+	Reason = "Evicted"
 	// the message associated with the reason.
 	message = "The node was low on resource: %v. "
 	// additional information for containers exceeding requests
@@ -1028,7 +1028,7 @@ func buildSignalToRankFunc(withImageFs bool) map[evictionapi.Signal]rankFunc {
 
 // PodIsEvicted returns true if the reported pod status is due to an eviction.
 func PodIsEvicted(podStatus v1.PodStatus) bool {
-	return podStatus.Phase == v1.PodFailed && podStatus.Reason == reason
+	return podStatus.Phase == v1.PodFailed && podStatus.Reason == Reason
 }
 
 // buildSignalToNodeReclaimFuncs returns reclaim functions associated with resources.

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -128,6 +128,7 @@ go_test(
         "//pkg/kubelet/cm/cpumanager:go_default_library",
         "//pkg/kubelet/cm/cpuset:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/eviction:go_default_library",
         "//pkg/kubelet/images:go_default_library",
         "//pkg/kubelet/kubeletconfig:go_default_library",
         "//pkg/kubelet/kubeletconfig/status:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the eviction test simply ensures that pods are marked `Failed`.  However, this could occur because of an OOM, rather than an eviction.
To ensure that pods are actually being evicted, check for the Reason in the pod status to ensure it is evicted.

**Release note**:
```release-note
NONE
```

cc @kubernetes/sig-node-pr-reviews 