### PR TITLE
Move some old security controls to KubeletFlags and mark them deprecated

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -66,7 +66,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.KubeletConfiguration = kubeadm.KubeletConfiguration{
 				BaseConfig: &kubeletconfigv1alpha1.KubeletConfiguration{
 					PodManifestPath: "foo",
-					AllowPrivileged: utilpointer.BoolPtr(true),
 					ClusterDNS:      []string{"foo"},
 					ClusterDomain:   "foo",
 					Authorization:   kubeletconfigv1alpha1.KubeletAuthorization{Mode: "foo"},

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -185,9 +185,6 @@ func SetDefaults_KubeletConfiguration(obj *MasterConfiguration) {
 	if obj.KubeletConfiguration.BaseConfig.PodManifestPath == "" {
 		obj.KubeletConfiguration.BaseConfig.PodManifestPath = DefaultManifestsDir
 	}
-	if obj.KubeletConfiguration.BaseConfig.AllowPrivileged == nil {
-		obj.KubeletConfiguration.BaseConfig.AllowPrivileged = utilpointer.BoolPtr(true)
-	}
 	if obj.KubeletConfiguration.BaseConfig.ClusterDNS == nil {
 		dnsIP, err := constants.GetDNSIP(obj.Networking.ServiceSubnet)
 		if err != nil {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -662,17 +662,17 @@ func RunKubelet(kubeFlags *options.KubeletFlags, kubeCfg *kubeletconfiginternal.
 	//                prefer this to be done as part of an independent validation step on the
 	//                KubeletConfiguration. But as far as I can tell, we don't have an explicit
 	//                place for validation of the KubeletConfiguration yet.
-	hostNetworkSources, err := kubetypes.GetValidatedSources(kubeCfg.HostNetworkSources)
+	hostNetworkSources, err := kubetypes.GetValidatedSources(kubeFlags.HostNetworkSources)
 	if err != nil {
 		return err
 	}
 
-	hostPIDSources, err := kubetypes.GetValidatedSources(kubeCfg.HostPIDSources)
+	hostPIDSources, err := kubetypes.GetValidatedSources(kubeFlags.HostPIDSources)
 	if err != nil {
 		return err
 	}
 
-	hostIPCSources, err := kubetypes.GetValidatedSources(kubeCfg.HostIPCSources)
+	hostIPCSources, err := kubetypes.GetValidatedSources(kubeFlags.HostIPCSources)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func RunKubelet(kubeFlags *options.KubeletFlags, kubeCfg *kubeletconfiginternal.
 		HostPIDSources:     hostPIDSources,
 		HostIPCSources:     hostIPCSources,
 	}
-	capabilities.Setup(kubeCfg.AllowPrivileged, privilegedSources, 0)
+	capabilities.Setup(kubeFlags.AllowPrivileged, privilegedSources, 0)
 
 	credentialprovider.SetPreferredDockercfgPath(kubeFlags.RootDirectory)
 	glog.V(2).Infof("Using root directory: %v", kubeFlags.RootDirectory)

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -56,9 +56,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.FileCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 			obj.HealthzBindAddress = "127.0.0.1"
 			obj.HealthzPort = 10248
-			obj.HostNetworkSources = []string{kubetypes.AllSource}
-			obj.HostPIDSources = []string{kubetypes.AllSource}
-			obj.HostIPCSources = []string{kubetypes.AllSource}
 			obj.HTTPCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 			obj.ImageMinimumGCAge = metav1.Duration{Duration: 2 * time.Minute}
 			obj.ImageGCHighThresholdPercent = 85

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -138,7 +138,6 @@ var (
 	// KubeletConfiguration fields that do not contain file paths.
 	kubeletConfigurationNonPathFieldPaths = sets.NewString(
 		"Address",
-		"AllowPrivileged",
 		"Authentication.Anonymous.Enabled",
 		"Authentication.Webhook.CacheTTL.Duration",
 		"Authentication.Webhook.Enabled",
@@ -176,9 +175,6 @@ var (
 		"HairpinMode",
 		"HealthzBindAddress",
 		"HealthzPort",
-		"HostIPCSources[*]",
-		"HostNetworkSources[*]",
-		"HostPIDSources[*]",
 		"IPTablesDropBit",
 		"IPTablesMasqueradeBit",
 		"ImageGCHighThresholdPercent",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -89,19 +89,6 @@ type KubeletConfiguration struct {
 	Authentication KubeletAuthentication
 	// authorization specifies how requests to the Kubelet's server are authorized
 	Authorization KubeletAuthorization
-	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
-	AllowPrivileged bool
-	// hostNetworkSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use of host network. Defaults to "*". Valid
-	// options are "file", "http", "api", and "*" (all sources).
-	HostNetworkSources []string
-	// hostPIDSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use the host pid namespace. Defaults to "*".
-	HostPIDSources []string
-	// hostIPCSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use the host ipc namespace. Defaults to "*".
-	HostIPCSources []string
 	// registryPullQPS is the limit of registry pulls per second. If 0,
 	// unlimited. Set to 0 for no limit. Defaults to 5.0.
 	RegistryPullQPS int32

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
@@ -108,15 +108,6 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 	if obj.HealthzPort == nil {
 		obj.HealthzPort = utilpointer.Int32Ptr(10248)
 	}
-	if obj.HostNetworkSources == nil {
-		obj.HostNetworkSources = []string{kubetypes.AllSource}
-	}
-	if obj.HostPIDSources == nil {
-		obj.HostPIDSources = []string{kubetypes.AllSource}
-	}
-	if obj.HostIPCSources == nil {
-		obj.HostIPCSources = []string{kubetypes.AllSource}
-	}
 	if obj.HTTPCheckFrequency == zeroDuration {
 		obj.HTTPCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 	}

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
@@ -89,19 +89,6 @@ type KubeletConfiguration struct {
 	Authentication KubeletAuthentication `json:"authentication"`
 	// authorization specifies how requests to the Kubelet's server are authorized
 	Authorization KubeletAuthorization `json:"authorization"`
-	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
-	AllowPrivileged *bool `json:"allowPrivileged"`
-	// hostNetworkSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use of host network. Defaults to "*". Valid
-	// options are "file", "http", "api", and "*" (all sources).
-	HostNetworkSources []string `json:"hostNetworkSources"`
-	// hostPIDSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use the host pid namespace. Defaults to "*".
-	HostPIDSources []string `json:"hostPIDSources"`
-	// hostIPCSources is a comma-separated list of sources from which the
-	// Kubelet allows pods to use the host ipc namespace. Defaults to "*".
-	HostIPCSources []string `json:"hostIPCSources"`
 	// registryPullQPS is the limit of registry pulls per second. If 0,
 	// unlimited. Set to 0 for no limit. Defaults to 5.0.
 	RegistryPullQPS *int32 `json:"registryPullQPS"`

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -164,12 +164,6 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfigura
 	if err := Convert_v1alpha1_KubeletAuthorization_To_kubeletconfig_KubeletAuthorization(&in.Authorization, &out.Authorization, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_Pointer_bool_To_bool(&in.AllowPrivileged, &out.AllowPrivileged, s); err != nil {
-		return err
-	}
-	out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
-	out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
-	out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
 	if err := v1.Convert_Pointer_int32_To_int32(&in.RegistryPullQPS, &out.RegistryPullQPS, s); err != nil {
 		return err
 	}
@@ -291,12 +285,6 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	if err := Convert_kubeletconfig_KubeletAuthorization_To_v1alpha1_KubeletAuthorization(&in.Authorization, &out.Authorization, s); err != nil {
 		return err
 	}
-	if err := v1.Convert_bool_To_Pointer_bool(&in.AllowPrivileged, &out.AllowPrivileged, s); err != nil {
-		return err
-	}
-	out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
-	out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
-	out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
 	if err := v1.Convert_int32_To_Pointer_int32(&in.RegistryPullQPS, &out.RegistryPullQPS, s); err != nil {
 		return err
 	}

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.deepcopy.go
@@ -134,30 +134,6 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	}
 	in.Authentication.DeepCopyInto(&out.Authentication)
 	out.Authorization = in.Authorization
-	if in.AllowPrivileged != nil {
-		in, out := &in.AllowPrivileged, &out.AllowPrivileged
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
-	}
-	if in.HostNetworkSources != nil {
-		in, out := &in.HostNetworkSources, &out.HostNetworkSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.HostPIDSources != nil {
-		in, out := &in.HostPIDSources, &out.HostPIDSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.HostIPCSources != nil {
-		in, out := &in.HostIPCSources, &out.HostIPCSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.RegistryPullQPS != nil {
 		in, out := &in.RegistryPullQPS, &out.RegistryPullQPS
 		if *in == nil {

--- a/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
@@ -107,21 +107,6 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	}
 	out.Authentication = in.Authentication
 	out.Authorization = in.Authorization
-	if in.HostNetworkSources != nil {
-		in, out := &in.HostNetworkSources, &out.HostNetworkSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.HostPIDSources != nil {
-		in, out := &in.HostPIDSources, &out.HostPIDSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.HostIPCSources != nil {
-		in, out := &in.HostIPCSources, &out.HostIPCSources
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ClusterDNS != nil {
 		in, out := &in.ClusterDNS, &out.ClusterDNS
 		*out = make([]string, len(*in))

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -157,9 +157,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 	kc.VolumeStatsAggPeriod = metav1.Duration{Duration: 10 * time.Second} // Aggregate volumes frequently so tests don't need to wait as long
 	kubeletConfigFlags = append(kubeletConfigFlags, "volume-stats-agg-period")
 
-	kc.AllowPrivileged = true
-	kubeletConfigFlags = append(kubeletConfigFlags, "allow-privileged")
-
 	kc.SerializeImagePulls = false
 	kubeletConfigFlags = append(kubeletConfigFlags, "serialize-image-pulls")
 
@@ -264,6 +261,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--root-dir", KubeletRootDirectory,
 		"--docker-disable-shared-pid=false",
 		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
+		"--allow-privileged", "true",
 	)
 
 	// Apply test framework feature gates by default. This could also be overridden


### PR DESCRIPTION
Related to @timstclair's comment: https://github.com/kubernetes/kubernetes/pull/53833#issuecomment-355399163


```release-note
NONE
```
