### PR TITLE
fix bug of swallowing missing merge key error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1322,23 +1322,23 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 		// If they're both maps or lists, recurse into the value.
 		switch originalType.Kind() {
 		case reflect.Map:
-			subschema, patchMeta, err := schema.LookupPatchMetadataForStruct(k)
-			if err != nil {
-				return nil, err
+			subschema, patchMeta, err2 := schema.LookupPatchMetadataForStruct(k)
+			if err2 != nil {
+				return nil, err2
 			}
-			_, patchStrategy, err := extractRetainKeysPatchStrategy(patchMeta.GetPatchStrategies())
-			if err != nil {
-				return nil, err
+			_, patchStrategy, err2 := extractRetainKeysPatchStrategy(patchMeta.GetPatchStrategies())
+			if err2 != nil {
+				return nil, err2
 			}
 			original[k], err = mergeMapHandler(original[k], patchV, subschema, patchStrategy, mergeOptions)
 		case reflect.Slice:
-			subschema, patchMeta, err := schema.LookupPatchMetadataForSlice(k)
-			if err != nil {
-				return nil, err
+			subschema, patchMeta, err2 := schema.LookupPatchMetadataForSlice(k)
+			if err2 != nil {
+				return nil, err2
 			}
-			_, patchStrategy, err := extractRetainKeysPatchStrategy(patchMeta.GetPatchStrategies())
-			if err != nil {
-				return nil, err
+			_, patchStrategy, err2 := extractRetainKeysPatchStrategy(patchMeta.GetPatchStrategies())
+			if err2 != nil {
+				return nil, err2
 			}
 			original[k], err = mergeSliceHandler(original[k], patchV, subschema, patchStrategy, patchMeta.GetPatchMergeKey(), isDeleteList, mergeOptions)
 		default:

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -654,6 +654,21 @@ mergingIntList:
 			ExpectedError: "doesn't match",
 		},
 	},
+	{
+		Description: "missing merge key should error out",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+  - name: 1
+    value: a
+`),
+			TwoWay: []byte(`
+mergingList:
+  - value: b
+`),
+			ExpectedError: "does not contain declared merge key",
+		},
+	},
 }
 
 func TestCustomStrategicMergePatch(t *testing.T) {


### PR DESCRIPTION
The bug is caused by variable shadowing.

Fixes #57834

```release-note
NONE
```

/assign @liggitt 
