### PR TITLE
fix ipvs proxy mode kubeadm usage

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -39,9 +39,11 @@ Then the configuration file is similar to:
 kind: MasterConfiguration
 apiVersion: kubeadm.k8s.io/v1alpha1
 ...
-featureGates:
-  SupportIPVSProxyMode: true
-mode: ipvs
+kubeProxy:
+  config:
+    featureGates: SupportIPVSProxyMode=true
+    mode: ipvs
+...
 ```
 
 ## Debug


### PR DESCRIPTION

**What this PR does / why we need it**:
Fix ipvs proxy mode usage of kubeadm in ipvs README file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Release note**:
```release-note
NONE
```
