### PR TITLE
Remove invalid comments in unit tests

### DIFF
--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -242,7 +242,6 @@ func TestAttach(t *testing.T) {
 						body := objBody(codec, test.pod)
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 					default:
-						// Ensures no GET is performed when deleting by name
 						t.Errorf("%s: unexpected request: %s %#v\n%#v", p, req.Method, req.URL, req)
 						return nil, fmt.Errorf("unexpected request")
 					}

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -206,7 +206,6 @@ func TestExec(t *testing.T) {
 						body := objBody(codec, test.pod)
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 					default:
-						// Ensures no GET is performed when deleting by name
 						t.Errorf("%s: unexpected request: %s %#v\n%#v", test.name, req.Method, req.URL, req)
 						return nil, fmt.Errorf("unexpected request")
 					}

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -67,7 +67,6 @@ func TestLog(t *testing.T) {
 						body := ioutil.NopCloser(bytes.NewBufferString(logContent))
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 					default:
-						// Ensures no GET is performed when deleting by name
 						t.Errorf("%s: unexpected request: %#v\n%#v", test.name, req.URL, req)
 						return nil, nil
 					}

--- a/pkg/kubectl/cmd/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward_test.go
@@ -89,7 +89,6 @@ func testPortForward(t *testing.T, flags map[string]string, args []string) {
 						body := objBody(codec, test.pod)
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 					default:
-						// Ensures no GET is performed when deleting by name
 						t.Errorf("%s: unexpected request: %#v\n%#v", test.name, req.URL, req)
 						return nil, nil
 					}

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -330,7 +330,6 @@ func TestGenerateService(t *testing.T) {
 						}
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 					default:
-						// Ensures no GET is performed when deleting by name
 						t.Errorf("%s: unexpected request: %s %#v\n%#v", test.name, req.Method, req.URL, req)
 						return nil, fmt.Errorf("unexpected request")
 					}


### PR DESCRIPTION
**Release note**:

```release-note
NONE
```
