### PR TITLE
add number measurement for bound/unbound pv/pvc

### DIFF
--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/cloudprovider:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/volume/events:go_default_library",
+        "//pkg/controller/volume/persistentvolume/metrics:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/goroutinemap:go_default_library",
         "//pkg/util/goroutinemap/exponentialbackoff:go_default_library",
@@ -114,6 +115,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/controller/volume/persistentvolume/metrics:all-srcs",
         "//pkg/controller/volume/persistentvolume/options:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/controller/volume/persistentvolume/metrics/BUILD
+++ b/pkg/controller/volume/persistentvolume/metrics/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics",
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// Subsystem names.
+	pvControllerSubsystem = "pv_collector"
+
+	// Metric names.
+	boundPVKey    = "bound_pv_count"
+	unboundPVKey  = "unbound_pv_count"
+	boundPVCKey   = "bound_pvc_count"
+	unboundPVCKey = "unbound_pvc_count"
+
+	// Label names.
+	namespaceLabel    = "namespace"
+	storageClassLabel = "storage_class"
+)
+
+var registerMetrics sync.Once
+
+// PVLister used to list persistent volumes.
+type PVLister interface {
+	List() []interface{}
+}
+
+// PVCLister used to list persistent volume claims.
+type PVCLister interface {
+	List() []interface{}
+}
+
+// Register all metrics for pv controller.
+func Register(pvLister PVLister, pvcLister PVCLister) {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(newPVAndPVCCountCollector(pvLister, pvcLister))
+	})
+}
+
+func newPVAndPVCCountCollector(pvLister PVLister, pvcLister PVCLister) *pvAndPVCCountCollector {
+	return &pvAndPVCCountCollector{pvLister, pvcLister}
+}
+
+// Custom collector for current pod and container counts.
+type pvAndPVCCountCollector struct {
+	// Cache for accessing information about PersistentVolumes.
+	pvLister PVLister
+	// Cache for accessing information about PersistentVolumeClaims.
+	pvcLister PVCLister
+}
+
+var (
+	boundPVCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("", pvControllerSubsystem, boundPVKey),
+		"Gauge measuring number of persistent volume currently bound",
+		[]string{storageClassLabel}, nil)
+	unboundPVCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("", pvControllerSubsystem, unboundPVKey),
+		"Gauge measuring number of persistent volume currently unbound",
+		[]string{storageClassLabel}, nil)
+
+	boundPVCCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("", pvControllerSubsystem, boundPVCKey),
+		"Gauge measuring number of persistent volume claim currently bound",
+		[]string{namespaceLabel}, nil)
+	unboundPVCCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("", pvControllerSubsystem, unboundPVCKey),
+		"Gauge measuring number of persistent volume claim currently unbound",
+		[]string{namespaceLabel}, nil)
+)
+
+func (collector *pvAndPVCCountCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- boundPVCountDesc
+	ch <- unboundPVCountDesc
+	ch <- boundPVCCountDesc
+	ch <- unboundPVCCountDesc
+}
+
+func (collector *pvAndPVCCountCollector) Collect(ch chan<- prometheus.Metric) {
+	collector.pvCollect(ch)
+	collector.pvcCollect(ch)
+}
+
+func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- prometheus.Metric) {
+	boundNumberByStorageClass := make(map[string]int)
+	unboundNumberByStorageClass := make(map[string]int)
+	for _, pvObj := range collector.pvLister.List() {
+		pv, ok := pvObj.(*v1.PersistentVolume)
+		if !ok {
+			continue
+		}
+		if pv.Status.Phase == v1.VolumeBound {
+			boundNumberByStorageClass[pv.Spec.StorageClassName]++
+		} else {
+			unboundNumberByStorageClass[pv.Spec.StorageClassName]++
+		}
+	}
+	for storageClassName, number := range boundNumberByStorageClass {
+		metric, err := prometheus.NewConstMetric(
+			boundPVCountDesc,
+			prometheus.GaugeValue,
+			float64(number),
+			storageClassName)
+		if err != nil {
+			glog.Warningf("Create bound pv number metric failed: %v", err)
+			continue
+		}
+		ch <- metric
+	}
+	for storageClassName, number := range unboundNumberByStorageClass {
+		metric, err := prometheus.NewConstMetric(
+			unboundPVCountDesc,
+			prometheus.GaugeValue,
+			float64(number),
+			storageClassName)
+		if err != nil {
+			glog.Warningf("Create unbound pv number metric failed: %v", err)
+			continue
+		}
+		ch <- metric
+	}
+}
+
+func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- prometheus.Metric) {
+	boundNumberByNamespace := make(map[string]int)
+	unboundNumberByNamespace := make(map[string]int)
+	for _, pvcObj := range collector.pvcLister.List() {
+		pvc, ok := pvcObj.(*v1.PersistentVolumeClaim)
+		if !ok {
+			continue
+		}
+		if pvc.Status.Phase == v1.ClaimBound {
+			boundNumberByNamespace[pvc.Namespace]++
+		} else {
+			unboundNumberByNamespace[pvc.Namespace]++
+		}
+	}
+	for namespace, number := range boundNumberByNamespace {
+		metric, err := prometheus.NewConstMetric(
+			boundPVCCountDesc,
+			prometheus.GaugeValue,
+			float64(number),
+			namespace)
+		if err != nil {
+			glog.Warningf("Create bound pvc number metric failed: %v", err)
+			continue
+		}
+		ch <- metric
+	}
+	for namespace, number := range unboundNumberByNamespace {
+		metric, err := prometheus.NewConstMetric(
+			unboundPVCCountDesc,
+			prometheus.GaugeValue,
+			float64(number),
+			namespace)
+		if err != nil {
+			glog.Warningf("Create unbound pvc number metric failed: %v", err)
+			continue
+		}
+		ch <- metric
+	}
+}

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics"
 	"k8s.io/kubernetes/pkg/util/goroutinemap"
 	vol "k8s.io/kubernetes/pkg/volume"
 
@@ -273,6 +274,8 @@ func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
 	go wait.Until(ctrl.resync, ctrl.resyncPeriod, stopCh)
 	go wait.Until(ctrl.volumeWorker, time.Second, stopCh)
 	go wait.Until(ctrl.claimWorker, time.Second, stopCh)
+
+	metrics.Register(ctrl.volumes.store, ctrl.claims)
 
 	<-stopCh
 }

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -263,6 +263,11 @@ func createPV(c clientset.Interface, pv *v1.PersistentVolume) (*v1.PersistentVol
 	return pv, nil
 }
 
+// create the PV resource. Fails test on error.
+func CreatePV(c clientset.Interface, pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	return createPV(c, pv)
+}
+
 // create the PVC resource. Fails test on error.
 func CreatePVC(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
 	pvc, err := c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/prometheus/common/model:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Implement number measurement for bound/unbound pv/pvc defined in the [Metrics Spec](https://docs.google.com/document/d/1Fh0T60T_y888LsRwC51CQHO75b2IZ3A34ZQS71s_F0g/edit#heading=h.bwzmc2tktae)

ref feature: [ kubernetes/features#496](https://github.com/kubernetes/features/issues/496)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Intended for post-1.9
```
