### PR TITLE
Remove dependency on v1 API in base credential provider

### DIFF
--- a/pkg/credentialprovider/BUILD
+++ b/pkg/credentialprovider/BUILD
@@ -19,7 +19,6 @@ go_library(
     deps = [
         "//vendor/github.com/docker/docker/api/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
@@ -51,6 +50,7 @@ filegroup(
         "//pkg/credentialprovider/azure:all-srcs",
         "//pkg/credentialprovider/gcp:all-srcs",
         "//pkg/credentialprovider/rancher:all-srcs",
+        "//pkg/credentialprovider/secrets:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -17,7 +17,6 @@ limitations under the License.
 package credentialprovider
 
 import (
-	"encoding/json"
 	"net"
 	"net/url"
 	"path/filepath"
@@ -27,7 +26,6 @@ import (
 	"github.com/golang/glog"
 
 	dockertypes "github.com/docker/docker/api/types"
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -284,14 +282,12 @@ func (f *FakeKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
 	return f.auth, f.ok
 }
 
-// unionDockerKeyring delegates to a set of keyrings.
-type unionDockerKeyring struct {
-	keyrings []DockerKeyring
-}
+// UnionDockerKeyring delegates to a set of keyrings.
+type UnionDockerKeyring []DockerKeyring
 
-func (k *unionDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
+func (k UnionDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool) {
 	authConfigs := []LazyAuthConfiguration{}
-	for _, subKeyring := range k.keyrings {
+	for _, subKeyring := range k {
 		if subKeyring == nil {
 			continue
 		}
@@ -301,38 +297,4 @@ func (k *unionDockerKeyring) Lookup(image string) ([]LazyAuthConfiguration, bool
 	}
 
 	return authConfigs, (len(authConfigs) > 0)
-}
-
-// MakeDockerKeyring inspects the passedSecrets to see if they contain any DockerConfig secrets.  If they do,
-// then a DockerKeyring is built based on every hit and unioned with the defaultKeyring.
-// If they do not, then the default keyring is returned
-func MakeDockerKeyring(passedSecrets []v1.Secret, defaultKeyring DockerKeyring) (DockerKeyring, error) {
-	passedCredentials := []DockerConfig{}
-	for _, passedSecret := range passedSecrets {
-		if dockerConfigJsonBytes, dockerConfigJsonExists := passedSecret.Data[v1.DockerConfigJsonKey]; (passedSecret.Type == v1.SecretTypeDockerConfigJson) && dockerConfigJsonExists && (len(dockerConfigJsonBytes) > 0) {
-			dockerConfigJson := DockerConfigJson{}
-			if err := json.Unmarshal(dockerConfigJsonBytes, &dockerConfigJson); err != nil {
-				return nil, err
-			}
-
-			passedCredentials = append(passedCredentials, dockerConfigJson.Auths)
-		} else if dockercfgBytes, dockercfgExists := passedSecret.Data[v1.DockerConfigKey]; (passedSecret.Type == v1.SecretTypeDockercfg) && dockercfgExists && (len(dockercfgBytes) > 0) {
-			dockercfg := DockerConfig{}
-			if err := json.Unmarshal(dockercfgBytes, &dockercfg); err != nil {
-				return nil, err
-			}
-
-			passedCredentials = append(passedCredentials, dockercfg)
-		}
-	}
-
-	if len(passedCredentials) > 0 {
-		basicKeyring := &BasicDockerKeyring{}
-		for _, currCredentials := range passedCredentials {
-			basicKeyring.Add(currCredentials)
-		}
-		return &unionDockerKeyring{[]DockerKeyring{basicKeyring, defaultKeyring}}, nil
-	}
-
-	return defaultKeyring, nil
 }

--- a/pkg/credentialprovider/secrets/BUILD
+++ b/pkg/credentialprovider/secrets/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["secrets.go"],
+    importpath = "k8s.io/kubernetes/pkg/credentialprovider/secrets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/credentialprovider:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/credentialprovider/secrets/secrets.go
+++ b/pkg/credentialprovider/secrets/secrets.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets
+
+import (
+	"encoding/json"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+// MakeDockerKeyring inspects the passedSecrets to see if they contain any DockerConfig secrets.  If they do,
+// then a DockerKeyring is built based on every hit and unioned with the defaultKeyring.
+// If they do not, then the default keyring is returned
+func MakeDockerKeyring(passedSecrets []v1.Secret, defaultKeyring credentialprovider.DockerKeyring) (credentialprovider.DockerKeyring, error) {
+	passedCredentials := []credentialprovider.DockerConfig{}
+	for _, passedSecret := range passedSecrets {
+		if dockerConfigJSONBytes, dockerConfigJSONExists := passedSecret.Data[v1.DockerConfigJsonKey]; (passedSecret.Type == v1.SecretTypeDockerConfigJson) && dockerConfigJSONExists && (len(dockerConfigJSONBytes) > 0) {
+			dockerConfigJSON := credentialprovider.DockerConfigJson{}
+			if err := json.Unmarshal(dockerConfigJSONBytes, &dockerConfigJSON); err != nil {
+				return nil, err
+			}
+
+			passedCredentials = append(passedCredentials, dockerConfigJSON.Auths)
+		} else if dockercfgBytes, dockercfgExists := passedSecret.Data[v1.DockerConfigKey]; (passedSecret.Type == v1.SecretTypeDockercfg) && dockercfgExists && (len(dockercfgBytes) > 0) {
+			dockercfg := credentialprovider.DockerConfig{}
+			if err := json.Unmarshal(dockercfgBytes, &dockercfg); err != nil {
+				return nil, err
+			}
+
+			passedCredentials = append(passedCredentials, dockercfg)
+		}
+	}
+
+	if len(passedCredentials) > 0 {
+		basicKeyring := &credentialprovider.BasicDockerKeyring{}
+		for _, currCredentials := range passedCredentials {
+			basicKeyring.Add(currCredentials)
+		}
+		return credentialprovider.UnionDockerKeyring{basicKeyring, defaultKeyring}, nil
+	}
+
+	return defaultKeyring, nil
+}

--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/credentialprovider:go_default_library",
+        "//pkg/credentialprovider/secrets:go_default_library",
         "//pkg/kubelet/apis/cri:go_default_library",
         "//pkg/kubelet/apis/cri/v1alpha1/runtime:go_default_library",
         "//pkg/kubelet/cm:go_default_library",

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/parsers"
@@ -35,7 +36,7 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 		return "", err
 	}
 
-	keyring, err := credentialprovider.MakeDockerKeyring(pullSecrets, m.keyring)
+	keyring, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, m.keyring)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubelet/rkt/BUILD
+++ b/pkg/kubelet/rkt/BUILD
@@ -22,6 +22,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/rkt",
     deps = [
         "//pkg/credentialprovider:go_default_library",
+        "//pkg/credentialprovider/secrets:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/images:go_default_library",

--- a/pkg/kubelet/rkt/image.go
+++ b/pkg/kubelet/rkt/image.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/parsers"
 )
@@ -54,7 +55,7 @@ func (r *Runtime) PullImage(image kubecontainer.ImageSpec, pullSecrets []v1.Secr
 		return "", err
 	}
 
-	keyring, err := credentialprovider.MakeDockerKeyring(pullSecrets, r.dockerKeyring)
+	keyring, err := credentialprovidersecrets.MakeDockerKeyring(pullSecrets, r.dockerKeyring)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Credential provider is useful without the v1 API, move the only
dependency out so that we can more easily move credential provider to a
utility library in the future (other callers besides Kubelet may need to
load pull secrets like Docker).