### PR TITLE
Kubeadm: clean up MarshalToYamlForCodecs

### DIFF
--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,19 +40,4 @@ func MarshalToYamlForCodecs(obj runtime.Object, gv schema.GroupVersion, codecs s
 
 	encoder := codecs.EncoderForVersion(info.Serializer, gv)
 	return runtime.Encode(encoder, obj)
-}
-
-// MarshalToYamlForCodecsWithShift adds spaces in front of each line so the indents line up
-// correctly in the manifest
-func MarshalToYamlForCodecsWithShift(obj runtime.Object, gv schema.GroupVersion, codecs serializer.CodecFactory) (string, error) {
-	serial, err := MarshalToYamlForCodecs(obj, gv, codecs)
-	if err != nil {
-		return "", err
-	}
-	lines := strings.Split(string(serial), "\n")
-	var newSerial string
-	for _, line := range lines {
-		newSerial = newSerial + "    " + line + "\n"
-	}
-	return newSerial, err
 }


### PR DESCRIPTION
Proxy will use PrintBytesWithLinePrefix to indent.


**What this PR does / why we need it**:
This removed the function MarshalToYamlForCodecsWithShift() and the proxy
code will use PrintBytesWithLinePrefix() to shift over the yaml lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57907

**Special notes for your reviewer**:

**Release note**:

```release-note-none
```
