### PR TITLE
Remove mikedanese from kubeadm owners since he's no longer actively working on the project

### DIFF
--- a/cmd/kubeadm/OWNERS
+++ b/cmd/kubeadm/OWNERS
@@ -1,11 +1,9 @@
 approvers:
 - jbeda
 - luxas
-- mikedanese
 - krousey
 - timothysc
 reviewers:
-- mikedanese
 - luxas
 - dmmcquay
 - krousey


### PR DESCRIPTION
**What this PR does / why we need it**: OWNERS file cleanup.

**Release note**:
```release-note
NONE
```
