### PR TITLE
Do not set BaseURI twice

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -328,14 +328,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	az.VirtualMachineScaleSetsClient = virtualMachineScaleSetsClient
 
 	storageAccountClient := storage.NewAccountsClientWithBaseURI(az.Environment.ResourceManagerEndpoint, az.SubscriptionID)
-	storageAccountClient.BaseURI = az.Environment.ResourceManagerEndpoint
 	storageAccountClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	storageAccountClient.PollingDelay = 5 * time.Second
 	configureUserAgent(&storageAccountClient.Client)
 	az.StorageAccountClient = storageAccountClient
 
 	disksClient := disk.NewDisksClientWithBaseURI(az.Environment.ResourceManagerEndpoint, az.SubscriptionID)
-	disksClient.BaseURI = az.Environment.ResourceManagerEndpoint
 	disksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	disksClient.PollingDelay = 5 * time.Second
 	configureUserAgent(&disksClient.Client)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Do not set BaseURI again. BaseURI has been set by NewAccountsClientWithBaseURI and NewDisksClientWithBaseURI method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57951

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @karataliu 
  