### PR TITLE
Add proxy_read_timeout flag to kubeapi_load_balancer charm.

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/config.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/config.yaml
@@ -9,3 +9,7 @@ options:
     description: |
       Space-separated list of extra SAN entries to add to the x509 certificate
       created for the load balancers.
+  proxy_read_timeout:
+    type: int
+    default: 90
+    description: Timeout in seconds for reading a response from proxy server.

--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -151,6 +151,7 @@ def install_load_balancer(apiserver, tls):
                 port=port,
                 server_certificate=server_cert_path,
                 server_key=server_key_path,
+                proxy_read_timeout=hookenv.config('proxy_read_timeout')
         )
 
         maybe_write_apilb_logrotate_config()

--- a/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
+++ b/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
@@ -36,6 +36,6 @@ server {
       add_header              X-Stream-Protocol-Version $upstream_http_x_stream_protocol_version;
 
       proxy_pass              https://target_service;
-      proxy_read_timeout      90;
+      proxy_read_timeout      {{ proxy_read_timeout }};
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Add proxy_read_timeout flag to kubeapi_load_balancer charm.

**Release note**:
```release-note
Add proxy_read_timeout flag to kubeapi_load_balancer charm.
```
