### PR TITLE
Honor configmap/secret/projected permissions combined with fsGroup

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -377,7 +377,7 @@ func (b *awsElasticBlockStoreMounter) SetUpAt(dir string, fsGroup *int64) error 
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 
 	glog.V(4).Infof("Successfully mounted %s", dir)

--- a/pkg/volume/azure_dd/azure_mounter.go
+++ b/pkg/volume/azure_dd/azure_mounter.go
@@ -160,7 +160,7 @@ func (m *azureDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if volumeSource.ReadOnly == nil || !*volumeSource.ReadOnly {
-		volume.SetVolumeOwnership(m, fsGroup)
+		volume.SetVolumeOwnership(m, fsGroup, true)
 	}
 
 	glog.V(2).Infof("azureDisk - successfully mounted disk %s on %s", diskName, dir)

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -375,7 +375,7 @@ func (b *cinderVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 	glog.V(3).Infof("Cinder volume %s mounted to %s", b.pdName, dir)
 

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -235,7 +235,8 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(b, fsGroup)
+	// Don't add permissions, since volume specifies a default mode and per-file permissions already
+	err = volume.SetVolumeOwnership(b, fsGroup, false)
 	if err != nil {
 		glog.Errorf("Error applying volume ownership settings for group: %v", fsGroup)
 		return err

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -203,7 +203,8 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(b, fsGroup)
+	// Don't add permissions, since volume specifies a default mode and per-file permissions already
+	err = volume.SetVolumeOwnership(b, fsGroup, false)
 	if err != nil {
 		glog.Errorf("Error applying volume ownership settings for group: %v", fsGroup)
 		return err

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -233,7 +233,7 @@ func (ed *emptyDir) SetUpAt(dir string, fsGroup *int64) error {
 		err = fmt.Errorf("unknown storage medium %q", ed.medium)
 	}
 
-	volume.SetVolumeOwnership(ed, fsGroup)
+	volume.SetVolumeOwnership(ed, fsGroup, true)
 
 	if err == nil {
 		volumeutil.SetReady(ed.getMetaDir())

--- a/pkg/volume/fc/disk_manager.go
+++ b/pkg/volume/fc/disk_manager.go
@@ -87,7 +87,7 @@ func diskSetUp(manager diskManager, b fcDiskMounter, volPath string, mounter mou
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(&b, fsGroup)
+		volume.SetVolumeOwnership(&b, fsGroup, true)
 	}
 
 	return nil

--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -93,7 +93,7 @@ func (f *flexVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !f.readOnly {
-		volume.SetVolumeOwnership(f, fsGroup)
+		volume.SetVolumeOwnership(f, fsGroup, true)
 	}
 
 	return nil

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -362,7 +362,7 @@ func (b *flockerVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 
 	glog.V(4).Infof("successfully mounted %s", dir)

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -340,7 +340,7 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 
 	glog.V(4).Infof("Successfully mounted %s", dir)

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -234,7 +234,7 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return fmt.Errorf("failed to exec 'git reset --hard': %s: %v", output, err)
 	}
 
-	volume.SetVolumeOwnership(b, fsGroup)
+	volume.SetVolumeOwnership(b, fsGroup, true)
 
 	volumeutil.SetReady(b.getMetaDir())
 	return nil

--- a/pkg/volume/iscsi/disk_manager.go
+++ b/pkg/volume/iscsi/disk_manager.go
@@ -93,7 +93,7 @@ func diskSetUp(manager diskManager, b iscsiDiskMounter, volPath string, mounter 
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(&b, fsGroup)
+		volume.SetVolumeOwnership(&b, fsGroup, true)
 	}
 
 	return nil

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -285,7 +285,7 @@ func (m *localVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if !m.readOnly {
 		// Volume owner will be written only once on the first volume mount
 		if len(refs) == 0 {
-			return volume.SetVolumeOwnership(m, fsGroup)
+			return volume.SetVolumeOwnership(m, fsGroup, true)
 		}
 	}
 	return nil

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -296,7 +296,7 @@ func (b *portworxVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 	glog.Infof("Portworx Volume %s setup at %s", b.volumeID, dir)
 	return nil

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -211,7 +211,8 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(s, fsGroup)
+	// Don't add permissions, since volume specifies a default mode and per-file permissions already
+	err = volume.SetVolumeOwnership(s, fsGroup, false)
 	if err != nil {
 		glog.Errorf("Error applying volume ownership settings for group: %v", fsGroup)
 		return err

--- a/pkg/volume/rbd/disk_manager.go
+++ b/pkg/volume/rbd/disk_manager.go
@@ -94,7 +94,7 @@ func diskSetUp(manager diskManager, b rbdMounter, volPath string, mounter mount.
 	glog.V(3).Infof("rbd: successfully bind mount %s to %s with options %v", globalPDPath, volPath, mountOptions)
 
 	if !b.ReadOnly {
-		volume.SetVolumeOwnership(&b, fsGroup)
+		volume.SetVolumeOwnership(&b, fsGroup, true)
 	}
 
 	return nil

--- a/pkg/volume/scaleio/sio_volume.go
+++ b/pkg/volume/scaleio/sio_volume.go
@@ -156,7 +156,7 @@ func (v *sioVolume) SetUpAt(dir string, fsGroup *int64) error {
 
 	if !v.readOnly && fsGroup != nil {
 		glog.V(4).Info(log("applying  value FSGroup ownership"))
-		volume.SetVolumeOwnership(v, fsGroup)
+		volume.SetVolumeOwnership(v, fsGroup, true)
 	}
 
 	glog.V(4).Info(log("successfully setup PV %s: volume %s mapped as %s mounted at %s", v.volSpecName, v.volName, devicePath, dir))

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -234,7 +234,8 @@ func (b *secretVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(b, fsGroup)
+	// Don't add permissions, since volume specifies a default mode and per-file permissions already
+	err = volume.SetVolumeOwnership(b, fsGroup, false)
 	if err != nil {
 		glog.Errorf("Error applying volume ownership settings for group: %v", fsGroup)
 		return err

--- a/pkg/volume/storageos/storageos.go
+++ b/pkg/volume/storageos/storageos.go
@@ -415,7 +415,7 @@ func (b *storageosMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, fsGroup)
+		volume.SetVolumeOwnership(b, fsGroup, true)
 	}
 	glog.V(4).Infof("StorageOS volume setup complete on %s", dir)
 	return nil

--- a/pkg/volume/volume_unsupported.go
+++ b/pkg/volume/volume_unsupported.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package volume
 
-func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
+func SetVolumeOwnership(mounter Mounter, fsGroup *int64, addPermissions bool) error {
 	return nil
 }
 

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -253,7 +253,7 @@ func (b *vsphereVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		os.Remove(dir)
 		return err
 	}
-	volume.SetVolumeOwnership(b, fsGroup)
+	volume.SetVolumeOwnership(b, fsGroup, true)
 	glog.V(3).Infof("vSphere volume %s mounted to %s", b.volPath, dir)
 
 	return nil

--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -106,6 +106,7 @@ test/e2e/common/secrets_volume.go: "should be consumable from pods in volume as 
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume with mappings "
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume with mappings and Item Mode set "
 test/e2e/common/secrets_volume.go: "should be consumable in multiple volumes in a pod "
+test/e2e/common/secrets_volume.go: "should be mounted with the correct mode"
 test/e2e/common/secrets_volume.go: "optional updates should be reflected in volume "
 test/e2e/kubectl/kubectl.go: "should create and stop a replication controller "
 test/e2e/kubectl/kubectl.go: "should scale a replication controller "


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/57923

* Stops overwriting permissions for volumes set up by atomic writer with explicitly set modes on all files
* Adds e2e test to ensure default mode and individual modes are honored
* Adds to conformance test suite

```release-note
secret, configMap, projected, and downwardAPI volumes now honor specified mode permissions even when the pod also specifies an fsGroup
```
  