### PR TITLE
kubectl: indicate deleted resource while watching

### DIFF
--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -542,6 +542,11 @@ func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []s
 				return false, nil
 			}
 
+			if e.Type == watch.Deleted {
+				e.Object.(*unstructured.Unstructured).
+					Object["status"].(map[string]interface{})["phase"] = "Deleted"
+			}
+
 			if isFiltered, err := filterFuncs.Filter(e.Object, filterOpts); !isFiltered {
 				if err != nil {
 					glog.V(2).Infof("Unable to filter resource: %v", err)

--- a/pkg/kubectl/cmd/resource/get_test.go
+++ b/pkg/kubectl/cmd/resource/get_test.go
@@ -1084,6 +1084,9 @@ func watchTestData() ([]api.Pod, []watch.Event) {
 					ResourceVersion: "12",
 				},
 				Spec: apitesting.DeepEqualSafePodSpec(),
+				Status: api.PodStatus{
+					Phase: "Deleted",
+				},
 			},
 		},
 	}

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -591,7 +591,9 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1alpha1.Table
 		}
 	}
 
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == node.NodeUnreachablePodReason {
+	if pod.Status.Phase == "Deleted" {
+		reason = "Deleted"
+	} else if pod.DeletionTimestamp != nil && pod.Status.Reason == node.NodeUnreachablePodReason {
 		reason = "Unknown"
 	} else if pod.DeletionTimestamp != nil {
 		reason = "Terminating"
@@ -1226,7 +1228,7 @@ func printPersistentVolumeClaim(obj *api.PersistentVolumeClaim, options printers
 	}
 
 	phase := obj.Status.Phase
-	if obj.ObjectMeta.DeletionTimestamp != nil {
+	if obj.Status.Phase != "Deleted" && obj.ObjectMeta.DeletionTimestamp != nil {
 		phase = "Terminating"
 	}
 

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1668,6 +1668,22 @@ func TestPrintPod(t *testing.T) {
 			},
 			[]metav1alpha1.TableRow{{Cells: []interface{}{"test5", "1/2", "podReason", 6, "<unknown>"}}},
 		},
+		{
+			// Test Deleted status phase
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test6"},
+				Spec:       api.PodSpec{Containers: make([]api.Container, 2)},
+				Status: api.PodStatus{
+					Reason: "podReason",
+					Phase:  "Deleted",
+					ContainerStatuses: []api.ContainerStatus{
+						{RestartCount: 3, State: api.ContainerState{Terminated: &api.ContainerStateTerminated{}}},
+						{RestartCount: 3, State: api.ContainerState{Terminated: &api.ContainerStateTerminated{}}},
+					},
+				},
+			},
+			[]metav1alpha1.TableRow{{Cells: []interface{}{"test6", "0/2", "Deleted", 6, "<unknown>"}}},
+		},
 	}
 
 	for i, test := range tests {
@@ -3072,6 +3088,26 @@ func TestPrintPersistentVolumeClaim(t *testing.T) {
 				},
 			},
 			"test4\tPending\tmy-volume\t10Gi\tRWO\tmy-scn\t<unknown>\n",
+		},
+		{
+			// Test Deleted status phase
+			api.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test5",
+				},
+				Spec: api.PersistentVolumeClaimSpec{
+					VolumeName:       "my-volume",
+					StorageClassName: &myScn,
+				},
+				Status: api.PersistentVolumeClaimStatus{
+					Phase:       "Deleted",
+					AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
+					Capacity: map[api.ResourceName]resource.Quantity{
+						api.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+			},
+			"test5\tDeleted\tmy-volume\t10Gi\tRWO\tmy-scn\t<unknown>\n",
 		},
 	}
 	buf := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This change adds "Deleted" status to the resources that are deleted
while watching the resources.

```
$ kubectl get pods --watch
NAME                    READY     STATUS    RESTARTS   AGE
sise-85bd7d686b-zwkdj   1/1       Running   1          17h
....
sise-85bd7d686b-zwkdj   0/1       Terminating   1         18h
sise-85bd7d686b-zwkdj   0/1       Deleted   1         18h
```

**Which issue(s) this PR fixes**
<!--
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
-->
Fixes https://github.com/kubernetes/kubectl/issues/185

**Special notes for your reviewer**:
I've hardcoded "Deleted" similar to the "Terminating" and "Unknown" status. Should I create constants and refer them everywhere?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

  