### PR TITLE
clean up useless func in pkg/kubelet/network/plugins.go

### DIFF
--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -165,10 +165,6 @@ func InitNetworkPlugin(plugins []NetworkPlugin, networkPluginName string, host H
 	return chosenPlugin, utilerrors.NewAggregate(allErrs)
 }
 
-func UnescapePluginName(in string) string {
-	return strings.Replace(in, "~", "/", -1)
-}
-
 type NoopNetworkPlugin struct {
 	Sysctl utilsysctl.Interface
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
clean up useless func in pkg/kubelet/network/plugins.go

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```NONE
