### PR TITLE
Update kubectl set command description

### DIFF
--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -41,7 +41,7 @@ import (
 var (
 	validEnvNameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
 	envResources       = `
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs)`
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs), cronjob`
 
 	envLong = templates.LongDesc(`
 		Update environment variables on a pod template.

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -63,7 +63,7 @@ type ImageOptions struct {
 
 var (
 	image_resources = `
-  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), replicaset (rs)`
+  	pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), replicaset (rs), cronjob`
 
 	image_long = templates.LongDesc(`
 		Update existing container image(s) of resources.


### PR DESCRIPTION
Since kubectl set env/image support cronjob, update the commands
description to include cronjob resource.

Related Patch: https://github.com/kubernetes/kubernetes/commit/2f9532f047034d607ec44217e5baaeaa3b604a6d

**Release note**:
-->
```release-note
None
```