### PR TITLE
Add CustomResourceValidation example in sample-controller

### DIFF
--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -73,6 +73,22 @@ type User struct {
 }
 ```
 
+## Validation
+
+To validate custom resources, use the [`CustomResourceValidation`](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation) feature.
+
+This feature is beta and enabled by default in v1.9. If you are using v1.8, enable the feature using
+the `CustomResourceValidation` feature gate on the [kube-apiserver](https://kubernetes.io/docs/admin/kube-apiserver):
+
+```sh
+--feature-gates=CustomResourceValidation=true
+```
+
+### Example
+
+The schema in the [example CRD](./artifacts/examples/crd.yaml) applies the following validation on the custom resource:
+`spec.replicas` must be an integer and must have a minimum value of 1 and a maximum value of 10.
+
 ## Cleanup
 
 You can clean up the created CustomResourceDefinition with:

--- a/staging/src/k8s.io/sample-controller/artifacts/examples/crd.yaml
+++ b/staging/src/k8s.io/sample-controller/artifacts/examples/crd.yaml
@@ -9,3 +9,12 @@ spec:
     kind: Foo
     plural: foos
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            replicas:
+              type: integer
+              minimum: 1
+              maximum: 10


### PR DESCRIPTION
Add `CustomResourceValidation` example in sample-controller.

Addresses the following part of https://github.com/kubernetes/sample-controller/issues/2:

> CRDs support json-schema schemas. These CRDs don't have them. It would be nice to show how to add them

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts munnerz 
