### PR TITLE
Add gnufied as AWS approver.

### DIFF
--- a/pkg/cloudprovider/providers/aws/OWNERS
+++ b/pkg/cloudprovider/providers/aws/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - justinsb
 - zmerlynn
+- gnufied
 reviewers:
 - gnufied
 - jsafrane


### PR DESCRIPTION
@gnufied has been maintaining the storage part of AWS cloud provider for a long while and he deserves to be approver.

```release-note
NONE
```

/sig aws