### PR TITLE
fix '--user' flag conflict in create rolebinding command

### DIFF
--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -54,7 +54,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ClusterRoleBindingV1GeneratorName)
 	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
 	cmd.MarkFlagCustom("clusterrole", "__kubectl_get_resource_clusterrole")
-	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
+	cmd.Flags().StringArray("roleuser", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")
 	return cmd
@@ -72,7 +72,7 @@ func CreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Co
 		generator = &kubectl.ClusterRoleBindingGeneratorV1{
 			Name:            name,
 			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
-			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "roleuser"),
 			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
 			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
 		}

--- a/pkg/kubectl/cmd/create_clusterrolebinding_test.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding_test.go
@@ -111,7 +111,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateClusterRoleBinding(f, buf)
 	cmd.Flags().Set("clusterrole", "fake-clusterrole")
-	cmd.Flags().Set("user", "fake-user")
+	cmd.Flags().Set("roleuser", "fake-user")
 	cmd.Flags().Set("group", "fake-group")
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("serviceaccount", "fake-namespace:fake-account")

--- a/pkg/kubectl/cmd/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create_rolebinding.go
@@ -54,7 +54,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.RoleBindingV1GeneratorName)
 	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this RoleBinding should reference"))
 	cmd.Flags().String("role", "", i18n.T("Role this RoleBinding should reference"))
-	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
+	cmd.Flags().StringArray("roleuser", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")
 	return cmd
@@ -72,7 +72,7 @@ func CreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, 
 			Name:            name,
 			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
 			Role:            cmdutil.GetFlagString(cmd, "role"),
-			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "roleuser"),
 			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
 			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
 		}

--- a/pkg/kubectl/cmd/create_rolebinding_test.go
+++ b/pkg/kubectl/cmd/create_rolebinding_test.go
@@ -112,7 +112,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateRoleBinding(f, buf)
 	cmd.Flags().Set("role", "fake-role")
-	cmd.Flags().Set("user", "fake-user")
+	cmd.Flags().Set("roleuser", "fake-user")
 	cmd.Flags().Set("group", "fake-group")
 	cmd.Flags().Set("serviceaccount", "fake-namespace:fake-account")
 	cmd.Run(cmd, []string{"fake-binding"})

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -102,7 +102,7 @@ func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&options.Local, "local", false, "If true, set subject will NOT contact api-server but run locally.")
 	cmdutil.AddDryRunFlag(cmd)
-	cmd.Flags().StringArrayVar(&options.Users, "user", []string{}, "Usernames to bind to the role")
+	cmd.Flags().StringArrayVar(&options.Users, "roleuser", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArrayVar(&options.Groups, "group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArrayVar(&options.ServiceAccounts, "serviceaccount", []string{}, "Service accounts to bind to the role")
 	cmdutil.AddIncludeUninitializedFlag(cmd)


### PR DESCRIPTION

**What this PR does / why we need it**:

`--user` is kubectl global flag, but `kubectl create rolebinding` and other command also have this flag with other meaning, that will result in Kubectl doesn't respect `--user` parameter. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubectl#188

**Special notes for your reviewer**:

Change `--user` flag in `kubectl create clusterrolebinding` and other command to `--roleuser`.

**Release note**:
```release-note
NONE
```
