### PR TITLE
Fix exists status for azure GetLoadBalancer

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -78,10 +78,10 @@ func (az *Cloud) GetLoadBalancer(clusterName string, service *v1.Service) (statu
 	if err != nil {
 		return nil, false, err
 	}
-	if exists == false {
+	if !exists {
 		serviceName := getServiceName(service)
-		glog.V(5).Infof("getloadbalancer (cluster:%s) (service:%s)- IP doesn't exist in any of the lbs", clusterName, serviceName)
-		return nil, false, fmt.Errorf("Service(%s) - Loadbalancer not found", serviceName)
+		glog.V(5).Infof("getloadbalancer (cluster:%s) (service:%s) - doesn't exist", clusterName, serviceName)
+		return nil, false, nil
 	}
 	return status, true, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We see a lot of log indicating load balancer not found in azure:
```
E0109 07:00:31.126306       1 service_controller.go:776] Failed to process service kube-system/heapster. Retrying in 5m0s: error getting LB for service kube-system/heapster: Service(kube-system/heapster) - Loadbalancer not found
I0109 07:00:31.126384       1 event.go:218] Event(v1.ObjectReference{Kind:"Service", Namespace:"kube-system", Name:"heapster", UID:"400266e7-f507-11e7-bbc2-000d3af86f66", APIVersion:"v1", ResourceVersion:"450", FieldPath:""}): type: 'Warning' reason: 'CreatingLoadBalancerFailed' Error creating load balancer (will retry): error getting LB for service kube-system/heapster: Service(kube-system/heapster) - Loadbalancer not found
I0109 07:00:31.158858       1 azure_backoff.go:177] LoadBalancerClient.List(name) - backoff: success
E0109 07:00:31.158930       1 service_controller.go:776] Failed to process service kube-system/kubernetes-dashboard. Retrying in 5m0s: error getting LB for service kube-system/kubernetes-dashboard: Service(kube-system/kubernetes-dashboard) - Loadbalancer not found
I0109 07:00:31.158988       1 event.go:218] Event(v1.ObjectReference{Kind:"Service", Namespace:"kube-system", Name:"kubernetes-dashboard", UID:"4052f12b-f507-11e7-bbc2-000d3af86f66", APIVersion:"v1", ResourceVersion:"498", FieldPath:""}): type: 'Warning' reason: 'CreatingLoadBalancerFailed' Error creating load balancer (will retry): error getting LB for service kube-system/kubernetes-dashboard: Service(kube-system/kubernetes-dashboard) - Loadbalancer not found
```

It's interesting that those service does not need loadbalancer, and caller is just checking whether one loadbalancer exists.
https://github.com/kubernetes/kubernetes/blob/009701f1816b20fe08f7c9fa0b0ff41fae972655/pkg/controller/service/service_controller.go#L287

And in we can see when err is not nil, it will not check exists value. Thus we should not return error when exists=false.

This was changed in:
https://github.com/kubernetes/kubernetes/commit/edfb2ad55293841abd3cbabe45fa162499831a7a#diff-c901394068476b4ccb003a6c6efad57cR63

The PR removes the error when exists=false.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix exists status for azure GetLoadBalancer
```
