### PR TITLE
Fix vm cache in concurrent case in azure_util.go

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -112,7 +112,7 @@ func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualM
 
 			request.vm = &vm
 		}
-		return vm, nil
+		return *request.vm, nil
 	}
 
 	glog.V(6).Infof("getVirtualMachine hits cache for(%s)", vmName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in azure vm cache. In case two callers call 'getVirtualMachine', if the second caller sees non-empty request.VM, it should return that value, instead of the default 'vm' variable.

**Which issue(s) this PR fixes**
Follow up of #57031

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
