### PR TITLE
kube-apiserver: validate options

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -120,6 +120,10 @@ func Run(runOptions *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Get())
 
+	if errs := runOptions.Validate(); len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+
 	server, err := CreateServerChain(runOptions, stopCh)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #57998

```release-note
Fix bug that kube-apiserver flags were not validated.
```
  