### PR TITLE
Make code generators log to stderr by default

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine, "k8s.io/kubernetes/pkg/apis") // TODO: move this input path out of client-gen
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
@@ -55,6 +55,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/main.go
@@ -63,6 +63,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/main.go
@@ -62,6 +62,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/main.go
@@ -29,6 +29,7 @@ var g = protobuf.New()
 
 func init() {
 	g.BindFlags(flag.CommandLine)
+	goflag.Set("logtostderr", "true")
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
@@ -38,6 +38,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/staging/src/k8s.io/code-generator/cmd/openapi-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/openapi-gen/main.go
@@ -40,6 +40,7 @@ func main() {
 
 	genericArgs.AddFlags(pflag.CommandLine)
 	customArgs.AddFlags(pflag.CommandLine)
+	flag.Set("logtostderr", "true")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Most code generators inside `staging/` are CLI tools. It makes sense for CLI tools (in general) to log to stdout/err, especially knowing that [`glog` has a 30sec flush interval](https://github.com/kubernetes/kubernetes/blob/a227c1ea2cb5e1bfee3a34362c225784f0bb4af7/pkg/kubectl/util/logs/logs.go#L49), which leads to logs being lost and makes troubleshooting tedious for people not aware of that quirk.

Fixes #53791

```release-note
NONE
```
  
  