### PR TITLE
Automated cherry pick of #57122: Schedule Calico components even on tainted nodes

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -149,5 +149,10 @@ spec:
           hostPath:
             path: /etc/cni/net.d
       tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
+        # Make sure calico/node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists


### PR DESCRIPTION
Cherry pick of #57122 on release-1.9.

#57122: Schedule Calico components even on tainted nodes