### PR TITLE
make controller port exposure optional

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -128,7 +128,9 @@ func Run(s *options.CMServer) error {
 		return err
 	}
 
-	go startHTTP(s)
+	if s.Port >= 0 {
+		go startHTTP(s)
+	}
 
 	recorder := createRecorder(kubeClient)
 


### PR DESCRIPTION
Makes it possible to disable the http server part of controllers if a user wishes.