### PR TITLE
Let mutating webhook defaults the object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -112,6 +112,7 @@ type MutatingWebhook struct {
 	namespaceMatcher namespace.Matcher
 	clientManager    config.ClientManager
 	convertor        versioned.Convertor
+	defaulter        runtime.ObjectDefaulter
 	jsonSerializer   runtime.Serializer
 }
 
@@ -137,6 +138,7 @@ func (a *MutatingWebhook) SetScheme(scheme *runtime.Scheme) {
 			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
 		}))
 		a.convertor.Scheme = scheme
+		a.defaulter = scheme
 		a.jsonSerializer = json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, false)
 	}
 }
@@ -170,6 +172,9 @@ func (a *MutatingWebhook) ValidateInitialization() error {
 	}
 	if err := a.convertor.Validate(); err != nil {
 		return fmt.Errorf("MutatingWebhook.convertor is not properly setup: %v", err)
+	}
+	if a.defaulter == nil {
+		return fmt.Errorf("MutatingWebhook.defaulter is not properly setup: %v")
 	}
 	go a.hookSource.Run(wait.NeverStop)
 	return nil
@@ -312,10 +317,9 @@ func (a *MutatingWebhook) callAttrMutatingHook(ctx context.Context, h *v1beta1.W
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
-	// TODO: if we have multiple mutating webhooks, we can remember the json
-	// instead of encoding and decoding for each one.
 	if _, _, err := a.jsonSerializer.Decode(patchedJS, nil, attr.Object); err != nil {
 		return apierrors.NewInternalError(err)
 	}
+	a.defaulter.Default(attr.Object)
 	return nil
 }

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -40,6 +40,9 @@ const (
 	patch2 string = `[
          { "op": "add", "path": "/data/mutation-stage-2", "value": "yes" }
      ]`
+	addInitContainerPatch string = `[
+		 {"op":"add","path":"/spec/initContainers","value":[{"image":"webhook-added-image","name":"webhook-added-init-container","resources":{}}]}
+	]`
 )
 
 // Config contains the server (the webhook) cert and key.
@@ -104,6 +107,31 @@ func admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	}
 	if !reviewResponse.Allowed {
 		reviewResponse.Result = &metav1.Status{Message: strings.TrimSpace(msg)}
+	}
+	return &reviewResponse
+}
+
+func mutatePods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("mutating pods")
+	podResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	if ar.Request.Resource != podResource {
+		glog.Errorf("expect resource to be %s", podResource)
+		return nil
+	}
+
+	raw := ar.Request.Object.Raw
+	pod := corev1.Pod{}
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, &pod); err != nil {
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+	reviewResponse := v1beta1.AdmissionResponse{}
+	reviewResponse.Allowed = true
+	if pod.Name == "webhook-to-be-mutated" {
+		reviewResponse.Patch = []byte(addInitContainerPatch)
+		pt := v1beta1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
 	}
 	return &reviewResponse
 }
@@ -271,6 +299,10 @@ func servePods(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, admitPods)
 }
 
+func serveMutatePods(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, mutatePods)
+}
+
 func serveConfigmaps(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, admitConfigMaps)
 }
@@ -293,6 +325,7 @@ func main() {
 	flag.Parse()
 
 	http.HandleFunc("/pods", servePods)
+	http.HandleFunc("/mutating-pods", serveMutatePods)
 	http.HandleFunc("/configmaps", serveConfigmaps)
 	http.HandleFunc("/mutating-configmaps", serveMutateConfigmaps)
 	http.HandleFunc("/crd", serveCRD)

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -48,7 +48,7 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.8v7", true}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.9v1", true}
 	APIServer                = ImageConfig{e2eRegistry, "k8s-aggregator-sample-apiserver", "1.7v2", true}
 	AppArmorLoader           = ImageConfig{gcRegistry, "apparmor-loader", "0.1", false}
 	BusyBox                  = ImageConfig{gcRegistry, "busybox", "1.24", false}


### PR DESCRIPTION
...after applying the patch sent back by the webhook

This should be treated as a bug and cherrypicked to 1.9.

Fixes #57982

```release note
Mutating webhook controller now defaults the object after applying each patch sent back by the webhook.
```
