### PR TITLE
cmd/kubectl: fix broken error formatting for run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -501,7 +501,7 @@ func getRestartPolicy(cmd *cobra.Command, interactive bool) (api.RestartPolicy, 
 	case api.RestartPolicyNever:
 		return api.RestartPolicyNever, nil
 	}
-	return "", cmdutil.UsageErrorf(cmd, "invalid restart policy: %s")
+	return "", cmdutil.UsageErrorf(cmd, "invalid restart policy: %s", restart)
 }
 
 func verifyImagePullPolicy(cmd *cobra.Command) error {


### PR DESCRIPTION
This patch adds missing value to a format string (%s) in --restart flag
validation for "kubectl run".

"kubectl run --restart=foo" was giving error:

    error: invalid restart policy: %!s(MISSING)

Now it says:

    error: invalid restart policy: foo

/release-note-none