### PR TITLE
Revert "no need delete endpoint explicitly in endpoint controller"

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -394,7 +394,15 @@ func (e *EndpointController) syncService(key string) error {
 	}
 	service, err := e.serviceLister.Services(namespace).Get(name)
 	if err != nil {
-		// Service has been deleted. So no need to do any more operations.
+		// Delete the corresponding endpoint, as the service has been deleted.
+		// TODO: Please note that this will delete an endpoint when a
+		// service is deleted. However, if we're down at the time when
+		// the service is deleted, we will miss that deletion, so this
+		// doesn't completely solve the problem. See #6877.
+		err = e.client.CoreV1().Endpoints(namespace).Delete(name, nil)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#57747

For: 
1.  `checkLeftoverEndpoints` does not work any more.
2. service delete auto trigger endpoint delete in apiserver, if service is successfully deleted but fail on endpoint delete. Then this endpoint will be garbage resource.
  