### PR TITLE
Fix windows UT for proxy mode

### DIFF
--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -30,6 +30,12 @@ import (
 )
 
 func TestValidateKubeProxyConfiguration(t *testing.T) {
+	var proxyMode kubeproxyconfig.ProxyMode
+	if runtime.GOOS == "windows" {
+		proxyMode = kubeproxyconfig.ProxyModeKernelspace
+	} else {
+		proxyMode = kubeproxyconfig.ProxyModeIPVS
+	}
 	successCases := []kubeproxyconfig.KubeProxyConfiguration{
 		{
 			BindAddress:        "192.168.59.103",
@@ -43,7 +49,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 			},
-			Mode: kubeproxyconfig.ProxyModeIPVS,
+			Mode: proxyMode,
 			IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
 				SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

/kind bug

Fix windows UT for proxy mode.

Run UTs for `kubeproxyconfig/validation` in windows,

```
=== RUN   TestValidateKubeProxyConfiguration
--- FAIL: TestValidateKubeProxyConfiguration (0.00s)
        validation_test.go:83: expected success: [KubeProxyConfiguration.Mode.ProxyMode: Invalid value: "ipvs": must be kernelspace,userspace or blank (blank means the most-available proxy [currently userspace])]
```

That's because proxy mode "IPVS" is not valid in windows.


**Which issue(s) this PR fixes**:
Fixes #58037

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

  