### PR TITLE
dockershim: Return Labels as Info in ImageStatus.

### DIFF
--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -76,7 +76,11 @@ func (ds *dockerService) ImageStatus(_ context.Context, r *runtimeapi.ImageStatu
 		return nil, err
 	}
 
-	return &runtimeapi.ImageStatusResponse{Image: imageStatus}, nil
+	res := runtimeapi.ImageStatusResponse{Image: imageStatus}
+	if r.GetVerbose() {
+		res.Info = imageInspect.Config.Labels
+	}
+	return &res, nil
 }
 
 // PullImage pulls an image with authentication config.


### PR DESCRIPTION
c6ddc749e85f4281628f366d65cf924c22d6cd99 added an Info field to
ImageStatusResponse when Verbose is true. This makes the image's
Labels available in that field, rather than unconditionally returning
an empty map.

**What this PR does / why we need it**:

This PR exposes an image's `Labels` through the CRI. In particular, I want this so I can write an `ImageService` wrapper that delegates all operations to a real `ImageService` but also, when the right `Labels`, ensures any needed [nix store](https://nixos.org/nix/) paths are present on the system when an image is pulled, enabling users to use nix for package distribution while still using containers for isolation and kubernetes for orchestration. In general, though, this should be useful for anything that wants to know about an image's `Labels`

**Special notes for your reviewer**:

I'd prefer to put this change into the `Image` protobuf type instead of putting it into `Info` (gated by `Verbose` or not, available in other requests like `ListImages` or not), but that would be a change to the protocol and it seems `Info` was introduced exactly for this purpose. If it's acceptable to put this into `Image`, I'll rework this.

If this change is acceptable, I will also do the work for `cri-o`, `rktlet`, `frakti`, and `cri-containerd` where applicable.

I have started the process for my employer to sign on to the CLA. I don't have reason to expect it to take long, but because there is more work to do if this change is desired I'd prefer if we can start review before that is completed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
dockershim now makes an Image's Labels available in the Info field of ImageStatusResponse
```

  