### PR TITLE
Automated cherry pick of #57918: Update kube-dns to 1.14.8

### DIFF
--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
Cherry pick of #57918 on release-1.9.

#57918: Update kube-dns to 1.14.8

Release Note:
```release-note
Version 1.14.8 of kube-dns includes only small changes to how Prometheus metrics are collected.
```