### PR TITLE
fix(kubectl): dereference symlink on tar archiving

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -184,7 +184,7 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 	}()
 
 	// TODO: Improve error messages by first testing if 'tar' is present in the container?
-	cmdArr := []string{"tar", "xf", "-"}
+	cmdArr := []string{"tar", "hxf", "-"}
 	destDir := path.Dir(dest.File)
 	if len(destDir) > 0 {
 		cmdArr = append(cmdArr, "-C", destDir)
@@ -224,7 +224,7 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 		},
 
 		// TODO: Improve error messages by first testing if 'tar' is present in the container?
-		Command:  []string{"tar", "cf", "-", src.File},
+		Command:  []string{"tar", "hcf", "-", src.File},
 		Executor: &DefaultRemoteExecutor{},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When we try to `kubectl cp` a symbolic link from a pod, either the symlink will be an empty file or 
 kubectl may crush unexpectedly.

Adding `-h` flag will make tar try to travel the symlink and copies the true file correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58011 

**Special notes for your reviewer**:

I thought dereferencing symlink may potentially be dangerous because of cyclic symlinks. After trying copying cyclic symlinks from arbitrary pods in my local minikube, I find it causes nothing seriously and the pod itself still works fine. But kubectl will failed with:
```shell
$ kubectl cp tf-hub-0:/root/c/ .
readlink /root/c: no such file or directory
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
error: open d/d/d/d/d/d/....(dups of 'd/')..../b: file name too long
```
Seems it's forbidden by OS for 4096 byte limitation of file path.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deference symlink on kubectl cp
```

  