### PR TITLE
Automated cherry pick of #57953

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -225,6 +225,19 @@ func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath str
 		}
 	}
 
+	if !notMnt {
+		// testing original mount point, make sure the mount link is valid
+		if _, err := (&osIOHandler{}).ReadDir(deviceMountPath); err != nil {
+			// mount link is invalid, now unmount and remount later
+			glog.Warningf("azureDisk - ReadDir %s failed with %v, unmount this directory", deviceMountPath, err)
+			if err := mounter.Unmount(deviceMountPath); err != nil {
+				glog.Errorf("azureDisk - Unmount deviceMountPath %s failed with %v", deviceMountPath, err)
+				return err
+			}
+			notMnt = true
+		}
+	}
+
 	volumeSource, err := getVolumeSource(spec)
 	if err != nil {
 		return err

--- a/pkg/volume/azure_dd/azure_mounter.go
+++ b/pkg/volume/azure_dd/azure_mounter.go
@@ -83,8 +83,19 @@ func (m *azureDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 	if !mountPoint {
-		glog.V(4).Infof("azureDisk - already mounted to target %s", dir)
-		return nil
+		// testing original mount point, make sure the mount link is valid
+		_, err := (&osIOHandler{}).ReadDir(dir)
+		if err == nil {
+			glog.V(4).Infof("azureDisk - already mounted to target %s", dir)
+			return nil
+		}
+		// mount link is invalid, now unmount and remount later
+		glog.Warningf("azureDisk - ReadDir %s failed with %v, unmount this directory", dir, err)
+		if err := mounter.Unmount(dir); err != nil {
+			glog.Errorf("azureDisk - Unmount directory %s failed with %v", dir, err)
+			return err
+		}
+		mountPoint = true
 	}
 
 	if err := os.MkdirAll(dir, 0750); err != nil {


### PR DESCRIPTION
Cherry pick of #57953 on release-1.7.

#57953: add remount logic if original mount path is invalid