### PR TITLE
Don't compute SMP on conflicts if it is not supported

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -337,6 +337,12 @@ func (tc *patchTestCase) Run(t *testing.T) {
 
 		}
 
+		supportedTypes := []string{
+			string(types.JSONPatchType),
+			string(types.MergePatchType),
+			string(types.StrategicMergePatchType),
+		}
+
 		resultObj, err := patchResource(
 			ctx,
 			admissionMutation,
@@ -348,7 +354,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 			name,
 			patchType,
 			patch,
-			namer, creater, defaulter, convertor, kind, resource, codec, utiltrace.New("Patch"+name))
+			namer, creater, defaulter, convertor, kind, resource, codec, utiltrace.New("Patch"+name), supportedTypes)
 		if len(tc.expectedError) != 0 {
 			if err == nil || err.Error() != tc.expectedError {
 				t.Errorf("%s: expected error %v, but got %v", tc.name, tc.expectedError, err)


### PR DESCRIPTION
When a patch (json, merge) conflict occurs, the server fallsback to a strategic merge patch to detect overlapping patch content.

This assumption does not hold true for `Unstructured` objects since we cannot compute SMP on them.

So, for `Unstructured` objects, we should return early indicating a conflict error.

Fixes #58017 

/assign sttts deads2k liggitt 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
