### PR TITLE
Don't remove APIService from apiHandlerManager when its Available Conditions is not True

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -80,12 +80,6 @@ func (c *APIServiceRegistrationController) sync(key string) error {
 		return err
 	}
 
-	// remove registration handling for APIServices which are not available
-	if !apiregistration.IsAPIServiceConditionTrue(apiService, apiregistration.Available) {
-		c.apiHandlerManager.RemoveAPIService(key)
-		return nil
-	}
-
 	return c.apiHandlerManager.AddAPIService(apiService)
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -125,6 +125,11 @@ func TestProxyHandler(t *testing.T) {
 					Group:   "foo",
 					Version: "v1",
 				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
+				},
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedBody:       "missing user",
@@ -142,6 +147,11 @@ func TestProxyHandler(t *testing.T) {
 					Group:                 "foo",
 					Version:               "v1",
 					InsecureSkipTLSVerify: true,
+				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
 				},
 			},
 			expectedStatusCode: http.StatusOK,
@@ -170,6 +180,11 @@ func TestProxyHandler(t *testing.T) {
 					Version:  "v1",
 					CABundle: testCACrt,
 				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
+				},
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedCalled:     true,
@@ -183,6 +198,28 @@ func TestProxyHandler(t *testing.T) {
 				"X-Remote-Group":    {"one", "two"},
 			},
 		},
+		"service unavailable": {
+			user: &user.DefaultInfo{
+				Name:   "username",
+				Groups: []string{"one", "two"},
+			},
+			path: "/request/path",
+			apiService: &apiregistration.APIService{
+				ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
+				Spec: apiregistration.APIServiceSpec{
+					Service:  &apiregistration.ServiceReference{Name: "test-service", Namespace: "test-ns"},
+					Group:    "foo",
+					Version:  "v1",
+					CABundle: testCACrt,
+				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionFalse},
+					},
+				},
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+		},
 		"fail on bad serving cert": {
 			user: &user.DefaultInfo{
 				Name:   "username",
@@ -195,6 +232,11 @@ func TestProxyHandler(t *testing.T) {
 					Service: &apiregistration.ServiceReference{},
 					Group:   "foo",
 					Version: "v1",
+				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
 				},
 			},
 			expectedStatusCode: http.StatusServiceUnavailable,
@@ -269,6 +311,11 @@ func TestProxyUpgrade(t *testing.T) {
 					Version:  "v1",
 					Service:  &apiregistration.ServiceReference{Name: "test-service", Namespace: "test-ns"},
 				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
+				},
 			},
 			ExpectError:  false,
 			ExpectCalled: true,
@@ -281,6 +328,11 @@ func TestProxyUpgrade(t *testing.T) {
 					Version: "v1",
 					Service: &apiregistration.ServiceReference{Name: "invalid-service", Namespace: "invalid-ns"},
 				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
+				},
 			},
 			ExpectError:  false,
 			ExpectCalled: true,
@@ -292,6 +344,11 @@ func TestProxyUpgrade(t *testing.T) {
 					Group:    "mygroup",
 					Version:  "v1",
 					Service:  &apiregistration.ServiceReference{Name: "invalid-service", Namespace: "invalid-ns"},
+				},
+				Status: apiregistration.APIServiceStatus{
+					Conditions: []apiregistration.APIServiceCondition{
+						{Type: apiregistration.Available, Status: apiregistration.ConditionTrue},
+					},
 				},
 			},
 			ExpectError:  true,

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -314,7 +314,6 @@ func TestSampleAPIServer(f *framework.Framework, image string) {
 	// is setting up a new namespace, we are just using that.
 	err = framework.WaitForDeploymentComplete(client, deployment)
 
-	// We seem to need to do additional waiting until the extension api service is actually up.
 	err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
 		request := restClient.Get().AbsPath("/apis/wardle.k8s.io/v1alpha1/namespaces/default/flunders")
 		request.SetHeader("Accept", "application/json")
@@ -323,6 +322,9 @@ func TestSampleAPIServer(f *framework.Framework, image string) {
 			status, ok := err.(*apierrs.StatusError)
 			if !ok {
 				return false, err
+			}
+			if status.Status().Code == 503 {
+				return false, nil
 			}
 			if status.Status().Code == 404 && strings.HasPrefix(err.Error(), "the server could not find the requested resource") {
 				return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I use my own apiserver works together with `kube-apiserver`, i have a custom resource: `databases` and created a `database` named: `db-name-1`.

When this apiserver is down(for example: OOMKilled), `kubectl get databases db-name-1 -v 10` returns `404 NotFound`:

```
[{
  "metadata": {},
  "status": "Failure",
  "message": "the server could not find the requested resource (get databases.core.example.com db-name-1)”,
  "reason": "NotFound",
  "details": {
    "name": “db-name-1”,
    "group": "core.example.com",
    "kind": “databases”,
    "causes": [
      {
        "reason": "UnexpectedServerResponse",
        "message": "404 page not found"
      }
    ]
  },
  "code": 404
}]
```

But it is not really `NotFound`.

So if the APIService is not available, just return 503.

There was a PR related with this: #57943 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
kube-apiserver: requests to endpoints handled by unavailable extension API servers (as indicated by an `Available` condition of `false` in the registered APIService) now return `503` errors instead of `404` errors.
```