### PR TITLE
Cherry pick of #56967 to release-1.8

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1381,208 +1381,208 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.27.3",
-			"Rev": "b69b9b62f57a6480a9cee48f80a857f2e5e25029"
+			"Comment": "v0.27.4",
+			"Rev": "492322b3b5936e49f3dbc797b3adb7dd67ee3fd7"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/vendor/github.com/google/cadvisor/container/docker/docker.go
+++ b/vendor/github.com/google/cadvisor/container/docker/docker.go
@@ -24,26 +24,33 @@ import (
 	dockertypes "github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 
+	"time"
+
 	"github.com/google/cadvisor/info/v1"
 	"github.com/google/cadvisor/machine"
 )
+
+const defaultTimeout = time.Second * 5
+
+func defaultContext() context.Context {
+	ctx, _ := context.WithTimeout(context.Background(), defaultTimeout)
+	return ctx
+}
 
 func Status() (v1.DockerStatus, error) {
 	client, err := Client()
 	if err != nil {
 		return v1.DockerStatus{}, fmt.Errorf("unable to communicate with docker daemon: %v", err)
 	}
-	dockerInfo, err := client.Info(context.Background())
+	dockerInfo, err := client.Info(defaultContext())
 	if err != nil {
 		return v1.DockerStatus{}, err
 	}
-	return StatusFromDockerInfo(dockerInfo), nil
+	return StatusFromDockerInfo(dockerInfo)
 }
 
-func StatusFromDockerInfo(dockerInfo dockertypes.Info) v1.DockerStatus {
+func StatusFromDockerInfo(dockerInfo dockertypes.Info) (v1.DockerStatus, error) {
 	out := v1.DockerStatus{}
-	out.Version = VersionString()
-	out.APIVersion = APIVersionString()
 	out.KernelVersion = machine.KernelVersion()
 	out.OS = dockerInfo.OperatingSystem
 	out.Hostname = dockerInfo.Name
@@ -56,7 +63,18 @@ func StatusFromDockerInfo(dockerInfo dockertypes.Info) v1.DockerStatus {
 	for _, v := range dockerInfo.DriverStatus {
 		out.DriverStatus[v[0]] = v[1]
 	}
-	return out
+	var err error
+	ver, err := VersionString()
+	if err != nil {
+		return out, err
+	}
+	out.Version = ver
+	ver, err = APIVersionString()
+	if err != nil {
+		return out, err
+	}
+	out.APIVersion = ver
+	return out, nil
 }
 
 func Images() ([]v1.DockerImage, error) {
@@ -64,7 +82,7 @@ func Images() ([]v1.DockerImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to communicate with docker daemon: %v", err)
 	}
-	images, err := client.ImageList(context.Background(), dockertypes.ImageListOptions{All: false})
+	images, err := client.ImageList(defaultContext(), dockertypes.ImageListOptions{All: false})
 	if err != nil {
 		return nil, err
 	}
@@ -97,14 +115,14 @@ func ValidateInfo() (*dockertypes.Info, error) {
 		return nil, fmt.Errorf("unable to communicate with docker daemon: %v", err)
 	}
 
-	dockerInfo, err := client.Info(context.Background())
+	dockerInfo, err := client.Info(defaultContext())
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect Docker info: %v", err)
 	}
 
 	// Fall back to version API if ServerVersion is not set in info.
 	if dockerInfo.ServerVersion == "" {
-		version, err := client.ServerVersion(context.Background())
+		version, err := client.ServerVersion(defaultContext())
 		if err != nil {
 			return nil, fmt.Errorf("unable to get docker version: %v", err)
 		}
@@ -134,35 +152,43 @@ func ValidateInfo() (*dockertypes.Info, error) {
 }
 
 func Version() ([]int, error) {
-	return parseVersion(VersionString(), version_re, 3)
+	ver, err := VersionString()
+	if err != nil {
+		return nil, err
+	}
+	return parseVersion(ver, version_re, 3)
 }
 
 func APIVersion() ([]int, error) {
-	return parseVersion(APIVersionString(), apiversion_re, 2)
+	ver, err := APIVersionString()
+	if err != nil {
+		return nil, err
+	}
+	return parseVersion(ver, apiversion_re, 2)
 }
 
-func VersionString() string {
+func VersionString() (string, error) {
 	docker_version := "Unknown"
 	client, err := Client()
 	if err == nil {
-		version, err := client.ServerVersion(context.Background())
+		version, err := client.ServerVersion(defaultContext())
 		if err == nil {
 			docker_version = version.Version
 		}
 	}
-	return docker_version
+	return docker_version, err
 }
 
-func APIVersionString() string {
+func APIVersionString() (string, error) {
 	docker_api_version := "Unknown"
 	client, err := Client()
 	if err == nil {
-		version, err := client.ServerVersion(context.Background())
+		version, err := client.ServerVersion(defaultContext())
 		if err == nil {
 			docker_api_version = version.APIVersion
 		}
 	}
-	return docker_api_version
+	return docker_api_version, err
 }
 
 func parseVersion(version_string string, regex *regexp.Regexp, length int) ([]int, error) {

--- a/vendor/github.com/google/cadvisor/container/docker/factory.go
+++ b/vendor/github.com/google/cadvisor/container/docker/factory.go
@@ -340,7 +340,8 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, ignoreMetrics c
 			glog.Errorf("devicemapper filesystem stats will not be reported: %v", err)
 		}
 
-		status := StatusFromDockerInfo(*dockerInfo)
+		// Safe to ignore error - driver status should always be populated.
+		status, _ := StatusFromDockerInfo(*dockerInfo)
 		thinPoolName = status.DriverStatus[dockerutil.DriverStatusPoolName]
 	}
 

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -1305,8 +1305,14 @@ func getVersionInfo() (*info.VersionInfo, error) {
 
 	kernel_version := machine.KernelVersion()
 	container_os := machine.ContainerOsVersion()
-	docker_version := docker.VersionString()
-	docker_api_version := docker.APIVersionString()
+	docker_version, err := docker.VersionString()
+	if err != nil {
+		return nil, err
+	}
+	docker_api_version, err := docker.APIVersionString()
+	if err != nil {
+		return nil, err
+	}
 
 	return &info.VersionInfo{
 		KernelVersion:      kernel_version,

--- a/vendor/github.com/google/cadvisor/metrics/prometheus.go
+++ b/vendor/github.com/google/cadvisor/metrics/prometheus.go
@@ -767,11 +767,19 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 		glog.Warningf("Couldn't get containers: %s", err)
 		return
 	}
+	rawLabels := map[string]struct{}{}
 	for _, container := range containers {
-		labels, values := []string{}, []string{}
-		for l, v := range c.containerLabelsFunc(container) {
+		for l := range c.containerLabelsFunc(container) {
+			rawLabels[l] = struct{}{}
+		}
+	}
+	for _, container := range containers {
+		values := make([]string, 0, len(rawLabels))
+		labels := make([]string, 0, len(rawLabels))
+		containerLabels := c.containerLabelsFunc(container)
+		for l := range rawLabels {
 			labels = append(labels, sanitizeLabelName(l))
-			values = append(values, v)
+			values = append(values, containerLabels[l])
 		}
 
 		// Container spec

--- a/vendor/github.com/google/cadvisor/pages/static/assets.go
+++ b/vendor/github.com/google/cadvisor/pages/static/assets.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/google/cadvisor/pages/templates.go
+++ b/vendor/github.com/google/cadvisor/pages/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/vendor/github.com/vishvananda/netns/BUILD
+++ b/vendor/github.com/vishvananda/netns/BUILD
@@ -1,11 +1,4 @@
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -18,7 +11,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -32,4 +25,5 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds timeout around docker queries, to prevent wedging kubelet on node status updates if docker is non-responsive.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #53207
Cherry picks #56967

**Special notes for your reviewer**:
Kubelet's node status update queries cadvisor, which had no timeout on underlying docker queries. As a result, if docker was non responsive, kubelet would never be able to recover itself without a restart.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Timeout docker queries to prevent node going NotReady indefinitely.
```
  