### PR TITLE
Discard `transport endpoint is not connected` error when unmounting GlusterFS volumes.

### DIFF
--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -46,6 +46,7 @@ const (
 	ErrDeviceNotFound     = "device not found"
 	ErrDeviceNotSupported = "device not supported"
 	ErrNotAvailable       = "not available"
+	ErrGlusterTransport   = "Transport endpoint is not connected"
 )
 
 // IsReady checks for the existence of a regular file
@@ -141,6 +142,8 @@ func UnmountMountPoint(mountPath string, mounter mount.Interface, extensiveMount
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
+		return true, nil
+	} else if strings.Contains(err.Error(), ErrGlusterTransport) {
 		return true, nil
 	} else if os.IsNotExist(err) {
 		return false, nil


### PR DESCRIPTION


Why we need this: In a scenario like pod termination which uses
the glusterfs mount,  the unmounter will try to unmount the pod volume
from the kubelet. The unmount codepath looks like this:

UnmountPath()
       -> PathExists() which calls "stat()" on "glusterfs fuse mount path.

At times due to different reasons, the subjected fuse mount can be `stale mount`.
For ex: something wrong with the glusterfs servers or fuse client process
is down when `stat()` is attempted. In these scenarios, stat() receive error
called `Transport endpoint is not connected`. In current code path this cause
PathExists() to return error and thus `pathErr` to be filled and skip the
`unmount/umount` action. For gluster, its safe to proceed further and try unmount
in the scenario where it receive above mentioned error. This patch add one more
error check in PathExist() to not block the unmount operation.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
