### PR TITLE
Better check for GCE VM

### DIFF
--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -39,7 +39,6 @@ const (
 	metadataEmail            = metadataUrl + "instance/service-accounts/default/email"
 	storageScopePrefix       = "https://www.googleapis.com/auth/devstorage"
 	cloudPlatformScopePrefix = "https://www.googleapis.com/auth/cloud-platform"
-	googleProductName        = "Google"
 	defaultServiceAccount    = "default/"
 )
 
@@ -121,7 +120,8 @@ func onGCEVM() bool {
 		glog.V(2).Infof("Error while reading product_name: %v", err)
 		return false
 	}
-	return strings.Contains(string(data), googleProductName)
+	name := strings.TrimSpace(string(data))
+	return name == "Google" || name == "Google Compute Engine"
 }
 
 // Enabled implements DockerConfigProvider for all of the Google implementations.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
we should do what is being done in GoogleCloudPlatform/google-cloud-go:
https://github.com/GoogleCloudPlatform/google-cloud-go/blob/master/compute/metadata/metadata.go#L259-L267

Looks like folks are reusing appliances which end up with
```
$ cat /sys/class/dmi/id/product_name
Google Search Appliance
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57760

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
