### PR TITLE
[FC Plugin] Create proper volumeSpec during ConstructVolumeSpec

### DIFF
--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -19,6 +19,8 @@ package fc
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -410,5 +412,77 @@ func Test_getWwnsLunWwidsError(t *testing.T) {
 	// expected no wwn and lun and wwid
 	if (len(wwn) != 0 && lun != "" && len(wwid) != 0) || err == nil {
 		t.Errorf("unexpected fc disk found")
+	}
+}
+
+func Test_ConstructVolumeSpec(t *testing.T) {
+	fm := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{
+			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
+			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/fc/50060e801049cfd1-lun-0"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod2"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/fc/volumeDevices/3600508b400105e210000900000490000"},
+		},
+	}
+	mountPaths := []string{
+		"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1",
+		"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod2",
+	}
+	for _, path := range mountPaths {
+		refs, _ := mount.GetMountRefs(fm, path)
+		var globalPDPath string
+		for _, ref := range refs {
+			if strings.Contains(ref, "kubernetes.io/fc") {
+				globalPDPath = ref
+				break
+			}
+		}
+		if len(globalPDPath) == 0 {
+			t.Errorf("couldn't fetch mountrefs")
+		}
+		arr := strings.Split(globalPDPath, "/")
+		if len(arr) < 1 {
+			t.Errorf("failed to retrieve volume plugin information from globalPDPath: %v", globalPDPath)
+		}
+		volumeInfo := arr[len(arr)-1]
+		if strings.Contains(volumeInfo, "-lun-") {
+			wwnLun := strings.Split(volumeInfo, "-lun-")
+			if len(wwnLun) < 2 {
+				t.Errorf("failed to retrieve TargetWWN and Lun. volumeInfo is invalid: %v", volumeInfo)
+			}
+			lun, _ := strconv.Atoi(wwnLun[1])
+			lun32 := int32(lun)
+			if wwnLun[0] != "50060e801049cfd1" || lun32 != 0 {
+				t.Errorf("failed to retrieve TargetWWN and Lun")
+			}
+		} else {
+			if volumeInfo != "3600508b400105e210000900000490000" {
+				t.Errorf("failed to retrieve WWIDs")
+			}
+		}
+	}
+}
+
+func Test_ConstructVolumeSpecNoRefs(t *testing.T) {
+	fm := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{
+			{Device: "/dev/sdd", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
+		},
+	}
+	mountPaths := []string{
+		"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1",
+	}
+	for _, path := range mountPaths {
+		refs, _ := mount.GetMountRefs(fm, path)
+		var globalPDPath string
+		for _, ref := range refs {
+			if strings.Contains(ref, "kubernetes.io/fc") {
+				globalPDPath = ref
+				break
+			}
+		}
+		if len(globalPDPath) != 0 {
+			t.Errorf("invalid globalPDPath")
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently, FC plugin returns volume name and empty FCVolumeSource during ConstrutVolumeSpec of filesystem volume's reconstruction.

In this fix, ConstructVolumeSpec retrieves global mount path, and analyzes volume parameters such as
WWN, LUN, WWID from the path.

**Which issue(s) this PR fixes** :
Fixes #58085

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @rootfs @jsafrane 
/sig storage
