### PR TITLE
Fix cadvisor flag registration for cross build

### DIFF
--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -12,7 +12,42 @@ go_library(
         "container_runtime.go",
         "globalflags.go",
         "options.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "globalflags_linux.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "globalflags_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "globalflags_other.go",
+        ],
+        "//conditions:default": [],
+    }),
     importpath = "k8s.io/kubernetes/cmd/kubelet/app/options",
     deps = [
         "//pkg/apis/componentconfig:go_default_library",
@@ -29,19 +64,23 @@ go_library(
         "//pkg/util/taints:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/google/cadvisor/container/common:go_default_library",
-        "//vendor/github.com/google/cadvisor/container/containerd:go_default_library",
-        "//vendor/github.com/google/cadvisor/container/docker:go_default_library",
-        "//vendor/github.com/google/cadvisor/container/raw:go_default_library",
-        "//vendor/github.com/google/cadvisor/machine:go_default_library",
-        "//vendor/github.com/google/cadvisor/manager:go_default_library",
-        "//vendor/github.com/google/cadvisor/storage:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/github.com/google/cadvisor/container/common:go_default_library",
+            "//vendor/github.com/google/cadvisor/container/containerd:go_default_library",
+            "//vendor/github.com/google/cadvisor/container/docker:go_default_library",
+            "//vendor/github.com/google/cadvisor/container/raw:go_default_library",
+            "//vendor/github.com/google/cadvisor/machine:go_default_library",
+            "//vendor/github.com/google/cadvisor/manager:go_default_library",
+            "//vendor/github.com/google/cadvisor/storage:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -30,13 +30,6 @@ import (
 
 	// ensure libs have a chance to globally register their flags
 	_ "github.com/golang/glog"
-	_ "github.com/google/cadvisor/container/common"
-	_ "github.com/google/cadvisor/container/containerd"
-	_ "github.com/google/cadvisor/container/docker"
-	_ "github.com/google/cadvisor/container/raw"
-	_ "github.com/google/cadvisor/machine"
-	_ "github.com/google/cadvisor/manager"
-	_ "github.com/google/cadvisor/storage"
 	_ "k8s.io/kubernetes/pkg/credentialprovider/azure"
 	_ "k8s.io/kubernetes/pkg/credentialprovider/gcp"
 )
@@ -119,49 +112,5 @@ func addGlogFlags(fs *pflag.FlagSet) {
 	register(global, local, "log_backtrace_at")
 	register(global, local, "log_dir")
 
-	fs.AddFlagSet(local)
-}
-
-// addCadvisorFlags adds flags from cadvisor
-func addCadvisorFlags(fs *pflag.FlagSet) {
-	// lookup flags in global flag set and re-register the values with our flagset
-	global := flag.CommandLine
-	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
-
-	// These flags were also implicit from cadvisor, but are actually used by something in the core repo:
-	// TODO(mtaufen): This one is stil used by our salt, but for heaven's sake it's even deprecated in cadvisor
-	register(global, local, "docker_root")
-	// e2e node tests rely on this
-	register(global, local, "housekeeping_interval")
-
-	// These flags were implicit from cadvisor, and are mistakes that should be registered deprecated:
-	const deprecated = "This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed."
-
-	registerDeprecated(global, local, "application_metrics_count_limit", deprecated)
-	registerDeprecated(global, local, "boot_id_file", deprecated)
-	registerDeprecated(global, local, "container_hints", deprecated)
-	registerDeprecated(global, local, "containerd", deprecated)
-	registerDeprecated(global, local, "docker", deprecated)
-	registerDeprecated(global, local, "docker_env_metadata_whitelist", deprecated)
-	registerDeprecated(global, local, "docker_only", deprecated)
-	registerDeprecated(global, local, "docker-tls", deprecated)
-	registerDeprecated(global, local, "docker-tls-ca", deprecated)
-	registerDeprecated(global, local, "docker-tls-cert", deprecated)
-	registerDeprecated(global, local, "docker-tls-key", deprecated)
-	registerDeprecated(global, local, "enable_load_reader", deprecated)
-	registerDeprecated(global, local, "event_storage_age_limit", deprecated)
-	registerDeprecated(global, local, "event_storage_event_limit", deprecated)
-	registerDeprecated(global, local, "global_housekeeping_interval", deprecated)
-	registerDeprecated(global, local, "log_cadvisor_usage", deprecated)
-	registerDeprecated(global, local, "machine_id_file", deprecated)
-	registerDeprecated(global, local, "storage_driver_user", deprecated)
-	registerDeprecated(global, local, "storage_driver_password", deprecated)
-	registerDeprecated(global, local, "storage_driver_host", deprecated)
-	registerDeprecated(global, local, "storage_driver_db", deprecated)
-	registerDeprecated(global, local, "storage_driver_table", deprecated)
-	registerDeprecated(global, local, "storage_driver_secure", deprecated)
-	registerDeprecated(global, local, "storage_driver_buffer_duration", deprecated)
-
-	// finally, add cadvisor flags to the provided flagset
 	fs.AddFlagSet(local)
 }

--- a/cmd/kubelet/app/options/globalflags_linux.go
+++ b/cmd/kubelet/app/options/globalflags_linux.go
@@ -1,0 +1,79 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	// ensure libs have a chance to globally register their flags
+	_ "github.com/google/cadvisor/container/common"
+	_ "github.com/google/cadvisor/container/containerd"
+	_ "github.com/google/cadvisor/container/docker"
+	_ "github.com/google/cadvisor/container/raw"
+	_ "github.com/google/cadvisor/machine"
+	_ "github.com/google/cadvisor/manager"
+	_ "github.com/google/cadvisor/storage"
+)
+
+// addCadvisorFlags adds flags from cadvisor
+func addCadvisorFlags(fs *pflag.FlagSet) {
+	// lookup flags in global flag set and re-register the values with our flagset
+	global := flag.CommandLine
+	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+	// These flags were also implicit from cadvisor, but are actually used by something in the core repo:
+	// TODO(mtaufen): This one is stil used by our salt, but for heaven's sake it's even deprecated in cadvisor
+	register(global, local, "docker_root")
+	// e2e node tests rely on this
+	register(global, local, "housekeeping_interval")
+
+	// These flags were implicit from cadvisor, and are mistakes that should be registered deprecated:
+	const deprecated = "This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed."
+
+	registerDeprecated(global, local, "application_metrics_count_limit", deprecated)
+	registerDeprecated(global, local, "boot_id_file", deprecated)
+	registerDeprecated(global, local, "container_hints", deprecated)
+	registerDeprecated(global, local, "containerd", deprecated)
+	registerDeprecated(global, local, "docker", deprecated)
+	registerDeprecated(global, local, "docker_env_metadata_whitelist", deprecated)
+	registerDeprecated(global, local, "docker_only", deprecated)
+	registerDeprecated(global, local, "docker-tls", deprecated)
+	registerDeprecated(global, local, "docker-tls-ca", deprecated)
+	registerDeprecated(global, local, "docker-tls-cert", deprecated)
+	registerDeprecated(global, local, "docker-tls-key", deprecated)
+	registerDeprecated(global, local, "enable_load_reader", deprecated)
+	registerDeprecated(global, local, "event_storage_age_limit", deprecated)
+	registerDeprecated(global, local, "event_storage_event_limit", deprecated)
+	registerDeprecated(global, local, "global_housekeeping_interval", deprecated)
+	registerDeprecated(global, local, "log_cadvisor_usage", deprecated)
+	registerDeprecated(global, local, "machine_id_file", deprecated)
+	registerDeprecated(global, local, "storage_driver_user", deprecated)
+	registerDeprecated(global, local, "storage_driver_password", deprecated)
+	registerDeprecated(global, local, "storage_driver_host", deprecated)
+	registerDeprecated(global, local, "storage_driver_db", deprecated)
+	registerDeprecated(global, local, "storage_driver_table", deprecated)
+	registerDeprecated(global, local, "storage_driver_secure", deprecated)
+	registerDeprecated(global, local, "storage_driver_buffer_duration", deprecated)
+
+	// finally, add cadvisor flags to the provided flagset
+	fs.AddFlagSet(local)
+}

--- a/cmd/kubelet/app/options/globalflags_other.go
+++ b/cmd/kubelet/app/options/globalflags_other.go
@@ -1,0 +1,26 @@
+// +build !linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+)
+
+func addCadvisorFlags(fs *pflag.FlagSet) {
+}


### PR DESCRIPTION
Fixed cross build by only importing linux-only cadvisor packages on linux (unconditional import added in https://github.com/kubernetes/kubernetes/pull/57613)

Fixes https://github.com/kubernetes/kubernetes/issues/58106

```release-note
NONE
```