### PR TITLE
[WIP] Fix --hostname-override being ignored when using cloud provider

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -303,7 +303,7 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		// TODO(roberthbailey): Can we do this without having credentials to talk
 		// to the cloud provider?
 		// TODO: ExternalID is deprecated, we'll have to drop this code
-		externalID, err := instances.ExternalID(kl.nodeName)
+		externalID, err := instances.ExternalID(kl.actualHostname)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external ID from cloud provider: %v", err)
 		}
@@ -313,13 +313,13 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		// cloudprovider from arbitrary nodes. At most, we should talk to a
 		// local metadata server here.
 		if node.Spec.ProviderID == "" {
-			node.Spec.ProviderID, err = cloudprovider.GetInstanceProviderID(kl.cloud, kl.nodeName)
+			node.Spec.ProviderID, err = cloudprovider.GetInstanceProviderID(kl.cloud, kl.actualHostname)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		instanceType, err := instances.InstanceType(kl.nodeName)
+		instanceType, err := instances.InstanceType(kl.actualHostname)
 		if err != nil {
 			return nil, err
 		}
@@ -392,6 +392,7 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	if tryNumber == 0 {
 		util.FromApiserverCache(&opts)
 	}
+
 	node, err := kl.heartbeatClient.Nodes().Get(string(kl.nodeName), opts)
 	if err != nil {
 		return fmt.Errorf("error getting node %q: %v", kl.nodeName, err)
@@ -453,7 +454,7 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		// to the cloud provider?
 		// TODO(justinsb): We can if CurrentNodeName() was actually CurrentNode() and returned an interface
 		// TODO: If IP addresses couldn't be fetched from the cloud provider, should kubelet fallback on the other methods for getting the IP below?
-		nodeAddresses, err := instances.NodeAddresses(kl.nodeName)
+		nodeAddresses, err := instances.NodeAddresses(kl.actualHostname)
 		if err != nil {
 			return fmt.Errorf("failed to get node address from cloud provider: %v", err)
 		}


### PR DESCRIPTION
This is an attempt to fix the behavior without changing the kubelet interface.
I believe that it would be better to allow overriding the hostname and the nodeName
separately via CLI args, and to use the hostname for looking up instances by their
DNS names, while using nodeName for its other normal purposes. However,
that sort of design discussion might take a while and we need this to be fixed now.

The solution we came up with is thus:

Keep track of what we want to set as the host/nodename and what the
cloud integration wants to set as separate things. The cloud integration
only cares about being able to identify the node as a cloud instance; it
doesn't actually care what you want to use as your node name.

Signed-off-by: Brett Kochendorfer <brett.kochendorfer@gmail.com>

Fixes #54482 #22984

**Special notes for your reviewer**: I believe that my implementation indicates
a code smell as I described above, so we didn't invest any time in updating the unit
tests to catch a regression, since I suspect the implementation may be subject to
change. After review we'll update the unit tests to catch a regression on this fix.
Hence the WIP.

```release-note
Fixed kubelet --hostname-override arg being ignored when using a cloud provider. See #22984, #54482
```