### PR TITLE
Refactor AttrFunc in k8s.io/apiserver/pkg/storage

### DIFF
--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -180,12 +180,14 @@ func JobToSelectableFields(job *batch.Job) fields.Set {
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	job, ok := obj.(*batch.Job)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a job.")
+		return result, fmt.Errorf("given object is not a job.")
 	}
-	return labels.Set(job.ObjectMeta.Labels), JobToSelectableFields(job), job.Initializers != nil, nil
+	result.FieldSet = JobToSelectableFields(job)
+	return result, nil
 }
 
 // MatchJob is the filter used by the generic etcd backend to route

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -78,13 +78,15 @@ func (eventStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-// GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+// GetAttrs returns fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	event, ok := obj.(*api.Event)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not an event")
+		return result, fmt.Errorf("not an event")
 	}
-	return labels.Set(event.Labels), EventToSelectableFields(event), event.Initializers != nil, nil
+	result.FieldSet = EventToSelectableFields(event)
+	return result, nil
 }
 
 func MatchEvent(label labels.Selector, field fields.Selector) storage.SelectionPredicate {

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -139,12 +139,15 @@ func (namespaceFinalizeStrategy) PrepareForUpdate(ctx genericapirequest.Context,
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (apistorage.ObjectAttrs, error) {
+	result := apistorage.ObjectAttrs{}
 	namespaceObj, ok := obj.(*api.Namespace)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not a namespace")
+		return result, fmt.Errorf("not a namespace")
 	}
-	return labels.Set(namespaceObj.Labels), NamespaceToSelectableFields(namespaceObj), namespaceObj.Initializers != nil, nil
+
+	result.FieldSet = NamespaceToSelectableFields(namespaceObj)
+	return result, nil
 }
 
 // MatchNamespace returns a generic matcher for a given label and field selector.

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -109,12 +109,14 @@ func (persistentvolumeStatusStrategy) ValidateUpdate(ctx genericapirequest.Conte
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	persistentvolumeObj, ok := obj.(*api.PersistentVolume)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not a persistentvolume")
+		return result, fmt.Errorf("not a persistentvolume")
 	}
-	return labels.Set(persistentvolumeObj.Labels), PersistentVolumeToSelectableFields(persistentvolumeObj), persistentvolumeObj.Initializers != nil, nil
+	result.FieldSet = PersistentVolumeToSelectableFields(persistentvolumeObj)
+	return result, nil
 }
 
 // MatchPersistentVolume returns a generic matcher for a given label and field selector.

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -105,12 +105,14 @@ func (persistentvolumeclaimStatusStrategy) ValidateUpdate(ctx genericapirequest.
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	persistentvolumeclaimObj, ok := obj.(*api.PersistentVolumeClaim)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not a persistentvolumeclaim")
+		return result, fmt.Errorf("not a persistentvolumeclaim")
 	}
-	return labels.Set(persistentvolumeclaimObj.Labels), PersistentVolumeClaimToSelectableFields(persistentvolumeclaimObj), persistentvolumeclaimObj.Initializers != nil, nil
+	result.FieldSet = PersistentVolumeClaimToSelectableFields(persistentvolumeclaimObj)
+	return result, nil
 }
 
 // MatchPersistentVolumeClaim returns a generic matcher for a given label and field selector.

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -205,13 +205,15 @@ func (podStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old 
 	return validation.ValidatePodStatusUpdate(obj.(*api.Pod), old.(*api.Pod))
 }
 
-// GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+// GetAttrs returns fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	pod, ok := obj.(*api.Pod)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not a pod")
+		return result, fmt.Errorf("not a pod")
 	}
-	return labels.Set(pod.ObjectMeta.Labels), PodToSelectableFields(pod), pod.Initializers != nil, nil
+	result.FieldSet = PodToSelectableFields(pod)
+	return result, nil
 }
 
 // MatchPod returns a generic matcher for a given label and field selector.

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -158,12 +158,14 @@ func ControllerToSelectableFields(controller *api.ReplicationController) fields.
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (apistorage.ObjectAttrs, error) {
+	result := apistorage.ObjectAttrs{}
 	rc, ok := obj.(*api.ReplicationController)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a replication controller.")
+		return result, fmt.Errorf("given object is not a replication controller.")
 	}
-	return labels.Set(rc.ObjectMeta.Labels), ControllerToSelectableFields(rc), rc.Initializers != nil, nil
+	result.FieldSet = ControllerToSelectableFields(rc)
+	return result, nil
 }
 
 // MatchController is the filter used by the generic etcd backend to route

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -98,12 +98,14 @@ func (s strategy) Export(ctx genericapirequest.Context, obj runtime.Object, exac
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (apistorage.ObjectAttrs, error) {
+	result := apistorage.ObjectAttrs{}
 	secret, ok := obj.(*api.Secret)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("not a secret")
+		return result, fmt.Errorf("not a secret")
 	}
-	return labels.Set(secret.Labels), SelectableFields(secret), secret.Initializers != nil, nil
+	result.FieldSet = SelectableFields(secret)
+	return result, nil
 }
 
 // Matcher returns a generic matcher for a given label and field selector.

--- a/pkg/registry/events/event/strategy.go
+++ b/pkg/registry/events/event/strategy.go
@@ -85,12 +85,15 @@ func SelectableFields(pip *api.Event) fields.Set {
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (apistorage.ObjectAttrs, error) {
+	result := apistorage.ObjectAttrs{}
+
 	pip, ok := obj.(*api.Event)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a Event")
+		return result, fmt.Errorf("given object is not a Event")
 	}
-	return labels.Set(pip.ObjectMeta.Labels), SelectableFields(pip), pip.Initializers != nil, nil
+	result.FieldSet = SelectableFields(pip)
+	return result, nil
 }
 
 // Matcher is the filter used by the generic etcd backend to watch events

--- a/pkg/registry/extensions/replicaset/strategy.go
+++ b/pkg/registry/extensions/replicaset/strategy.go
@@ -159,12 +159,14 @@ func ReplicaSetToSelectableFields(rs *extensions.ReplicaSet) fields.Set {
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (apistorage.ObjectAttrs, error) {
+	result := apistorage.ObjectAttrs{}
 	rs, ok := obj.(*extensions.ReplicaSet)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a ReplicaSet.")
+		return result, fmt.Errorf("given object is not a ReplicaSet.")
 	}
-	return labels.Set(rs.ObjectMeta.Labels), ReplicaSetToSelectableFields(rs), rs.Initializers != nil, nil
+	result.FieldSet = ReplicaSetToSelectableFields(rs)
+	return result, nil
 }
 
 // MatchReplicaSet is the filter used by the generic etcd backend to route

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -87,12 +87,14 @@ func (a customResourceDefinitionStorageStrategy) ValidateUpdate(ctx genericapire
 	return a.validator.ValidateUpdate(ctx, obj, old)
 }
 
-func (a customResourceDefinitionStorageStrategy) GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func (a customResourceDefinitionStorageStrategy) GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		return nil, nil, false, err
+		return result, err
 	}
-	return labels.Set(accessor.GetLabels()), objectMetaFieldsSet(accessor, a.namespaceScoped), accessor.GetInitializers() != nil, nil
+	result.FieldSet = objectMetaFieldsSet(accessor, a.namespaceScoped)
+	return result, nil
 }
 
 // objectMetaFieldsSet returns a fields that represent the ObjectMeta.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -143,12 +143,14 @@ func (statusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old run
 	return validation.ValidateUpdateCustomResourceDefinitionStatus(obj.(*apiextensions.CustomResourceDefinition), old.(*apiextensions.CustomResourceDefinition))
 }
 
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	apiserver, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a CustomResourceDefinition.")
+		return result, fmt.Errorf("given object is not a CustomResourceDefinition.")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), CustomResourceDefinitionToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	result.FieldSet = CustomResourceDefinitionToSelectableFields(apiserver)
+	return result, nil
 }
 
 // MatchCustomResourceDefinition is the filter used by the generic etcd backend to watch events

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -63,7 +63,7 @@ type CacherConfig struct {
 	KeyFunc func(runtime.Object) (string, error)
 
 	// GetAttrsFunc is used to get object labels, fields, and the uninitialized bool
-	GetAttrsFunc func(runtime.Object) (label labels.Set, field fields.Set, uninitialized bool, err error)
+	GetAttrsFunc AttrFunc
 
 	// TriggerPublisherFunc is used for optimizing amount of watchers that
 	// needs to process an incoming event.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
@@ -249,9 +249,11 @@ func TestListFiltered(t *testing.T) {
 	p := storage.SelectionPredicate{
 		Label: labels.Everything(),
 		Field: fields.SelectorFromSet(fields.Set{"metadata.name": "bar"}),
-		GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+		GetAttrs: func(obj runtime.Object) (storage.ObjectAttrs, error) {
 			pod := obj.(*example.Pod)
-			return labels.Set(pod.Labels), fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+			return storage.ObjectAttrs{
+				FieldSet: fields.Set{"metadata.name": pod.Name},
+			}, nil
 		},
 	}
 	var got example.PodList

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -312,9 +312,11 @@ func TestGetToList(t *testing.T) {
 		pred: storage.SelectionPredicate{
 			Label: labels.Everything(),
 			Field: fields.ParseSelectorOrDie("metadata.name!=" + storedObj.Name),
-			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+			GetAttrs: func(obj runtime.Object) (storage.ObjectAttrs, error) {
 				pod := obj.(*example.Pod)
-				return nil, fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+				return storage.ObjectAttrs{
+					FieldSet: fields.Set{"metadata.name": pod.Name},
+				}, nil
 			},
 		},
 		expectedOut: nil,
@@ -785,9 +787,11 @@ func TestList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	getAttrs := func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+	getAttrs := func(obj runtime.Object) (storage.ObjectAttrs, error) {
 		pod := obj.(*example.Pod)
-		return nil, fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+		return storage.ObjectAttrs{
+			FieldSet: fields.Set{"metadata.name": pod.Name},
+		}, nil
 	}
 
 	tests := []struct {
@@ -1090,9 +1094,11 @@ func TestListContinuation(t *testing.T) {
 			Continue: continueValue,
 			Label:    labels.Everything(),
 			Field:    fields.Everything(),
-			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+			GetAttrs: func(obj runtime.Object) (storage.ObjectAttrs, error) {
 				pod := obj.(*example.Pod)
-				return nil, fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+				return storage.ObjectAttrs{
+					FieldSet: fields.Set{"metadata.name": pod.Name},
+				}, nil
 			},
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -73,9 +73,11 @@ func testWatch(t *testing.T, recursive bool) {
 		pred: storage.SelectionPredicate{
 			Label: labels.Everything(),
 			Field: fields.ParseSelectorOrDie("metadata.name=bar"),
-			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+			GetAttrs: func(obj runtime.Object) (storage.ObjectAttrs, error) {
 				pod := obj.(*example.Pod)
-				return nil, fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+				return storage.ObjectAttrs{
+					FieldSet: fields.Set{"metadata.name": pod.Name},
+				}, nil
 			},
 		},
 	}, { // update
@@ -88,9 +90,11 @@ func testWatch(t *testing.T, recursive bool) {
 		pred: storage.SelectionPredicate{
 			Label: labels.Everything(),
 			Field: fields.ParseSelectorOrDie("metadata.name!=bar"),
-			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+			GetAttrs: func(obj runtime.Object) (storage.ObjectAttrs, error) {
 				pod := obj.(*example.Pod)
-				return nil, fields.Set{"metadata.name": pod.Name}, pod.Initializers != nil, nil
+				return storage.ObjectAttrs{
+					FieldSet: fields.Set{"metadata.name": pod.Name},
+				}, nil
 			},
 		},
 	}}

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/BUILD
@@ -15,7 +15,6 @@ go_test(
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/testing:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache_test.go
@@ -25,8 +25,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,8 +48,8 @@ func newTestWatchCache(capacity int) *watchCache {
 	keyFunc := func(obj runtime.Object) (string, error) {
 		return NamespaceKeyFunc("prefix", obj)
 	}
-	getAttrsFunc := func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
-		return nil, nil, false, nil
+	getAttrsFunc := func(obj runtime.Object) (ObjectAttrs, error) {
+		return ObjectAttrs{}, nil
 	}
 	wc := newWatchCache(capacity, keyFunc, getAttrsFunc)
 	wc.clock = clock.NewFakeClock(time.Now())

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -118,12 +118,14 @@ func (apiServerStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj
 	return validation.ValidateAPIServiceStatusUpdate(obj.(*apiregistration.APIService), old.(*apiregistration.APIService))
 }
 
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	apiserver, ok := obj.(*apiregistration.APIService)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a APIService.")
+		return result, fmt.Errorf("given object is not a APIService.")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), APIServiceToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	result.FieldSet = APIServiceToSelectableFields(apiserver)
+	return result, nil
 }
 
 // MatchAPIService is the filter used by the generic etcd backend to watch events

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
@@ -35,12 +35,14 @@ func NewStrategy(typer runtime.ObjectTyper) fischerStrategy {
 	return fischerStrategy{typer, names.SimpleNameGenerator}
 }
 
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	apiserver, ok := obj.(*wardle.Fischer)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a Fischer.")
+		return result, fmt.Errorf("given object is not a Fischer.")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), fischerToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	result.FieldSet = fischerToSelectableFields(apiserver)
+	return result, nil
 }
 
 // MatchFischer is the filter used by the generic etcd backend to watch events

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -35,12 +35,14 @@ func NewStrategy(typer runtime.ObjectTyper) flunderStrategy {
 	return flunderStrategy{typer, names.SimpleNameGenerator}
 }
 
-func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+func GetAttrs(obj runtime.Object) (storage.ObjectAttrs, error) {
+	result := storage.ObjectAttrs{}
 	apiserver, ok := obj.(*wardle.Flunder)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a Flunder.")
+		return result, fmt.Errorf("given object is not a Flunder.")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), FlunderToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	result.FieldSet = FlunderToSelectableFields(apiserver)
+	return result, nil
 }
 
 // MatchFlunder is the filter used by the generic etcd backend to watch events


### PR DESCRIPTION
- Create an ObjectAttrs struct to keep the collected attributes. It
  makes future extension easier, because you don't need to change
  signature of the method.
- Move label and uninitialized out from the configurable AttrFuc. The
  behavior is always default for now.

**What this PR does / why we need it**: Towards support #1348

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Prepare for #1348

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
