### PR TITLE
Automated cherry pick of #58025: Let mutating webhook defaults the object after applying the

### DIFF
--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -99,7 +99,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		// Note that in 1.9 we will have backwards incompatible change to
 		// admission webhooks, so the image will be updated to 1.9 sometime in
 		// the development 1.9 cycle.
-		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6", context)
+		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1", context)
 	})
 	AfterEach(func() {
 		cleanWebhookTest(client, namespaceName)
@@ -129,6 +129,12 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		registerMutatingWebhookForConfigMap(f, context)
 		defer client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(mutatingWebhookConfigName, nil)
 		testMutatingConfigMapWebhook(f)
+	})
+
+	It("Should mutate pod and apply defaults after mutation", func() {
+		registerMutatingWebhookForPod(f, context)
+		defer client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(mutatingWebhookConfigName, nil)
+		testMutatingPodWebhook(f)
 	})
 
 	It("Should mutate crd", func() {
@@ -421,6 +427,7 @@ func registerMutatingWebhookForConfigMap(f *framework.Framework, context *certCo
 	// The webhook configuration is honored in 1s.
 	time.Sleep(10 * time.Second)
 }
+
 func testMutatingConfigMapWebhook(f *framework.Framework) {
 	By("create a configmap that should be updated by the webhook")
 	client := f.ClientSet
@@ -434,6 +441,77 @@ func testMutatingConfigMapWebhook(f *framework.Framework) {
 	}
 	if !reflect.DeepEqual(expectedConfigMapData, mutatedConfigMap.Data) {
 		framework.Failf("\nexpected %#v\n, got %#v\n", expectedConfigMapData, mutatedConfigMap.Data)
+	}
+}
+
+func registerMutatingWebhookForPod(f *framework.Framework, context *certContext) {
+	client := f.ClientSet
+	By("Registering the mutating pod webhook via the AdmissionRegistration API")
+
+	namespace := f.Namespace.Name
+
+	_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(&v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mutatingWebhookConfigName,
+		},
+		Webhooks: []v1beta1.Webhook{
+			{
+				Name: "adding-init-container.k8s.io",
+				Rules: []v1beta1.RuleWithOperations{{
+					Operations: []v1beta1.OperationType{v1beta1.Create},
+					Rule: v1beta1.Rule{
+						APIGroups:   []string{""},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"pods"},
+					},
+				}},
+				ClientConfig: v1beta1.WebhookClientConfig{
+					Service: &v1beta1.ServiceReference{
+						Namespace: namespace,
+						Name:      serviceName,
+						Path:      strPtr("/mutating-pods"),
+					},
+					CABundle: context.signingCert,
+				},
+			},
+		},
+	})
+	framework.ExpectNoError(err, "registering mutating webhook config %s with namespace %s", mutatingWebhookConfigName, namespace)
+
+	// The webhook configuration is honored in 1s.
+	time.Sleep(10 * time.Second)
+}
+
+func testMutatingPodWebhook(f *framework.Framework) {
+	By("create a pod that should be updated by the webhook")
+	client := f.ClientSet
+	configMap := toBeMutatedPod(f)
+	mutatedPod, err := client.CoreV1().Pods(f.Namespace.Name).Create(configMap)
+	Expect(err).To(BeNil())
+	if len(mutatedPod.Spec.InitContainers) != 1 {
+		framework.Failf("expect pod to have 1 init container, got %#v", mutatedPod.Spec.InitContainers)
+	}
+	if got, expected := mutatedPod.Spec.InitContainers[0].Name, "webhook-added-init-container"; got != expected {
+		framework.Failf("expect the init container name to be %q, got %q", expected, got)
+	}
+	if got, expected := mutatedPod.Spec.InitContainers[0].TerminationMessagePolicy, v1.TerminationMessageReadFile; got != expected {
+		framework.Failf("expect the init terminationMessagePolicy to be default to %q, got %q", expected, got)
+	}
+}
+
+func toBeMutatedPod(f *framework.Framework) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook-to-be-mutated",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "example",
+					Image: framework.GetPauseImageName(f.ClientSet),
+				},
+			},
+		},
 	}
 }
 

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -40,6 +40,9 @@ const (
 	patch2 string = `[
          { "op": "add", "path": "/data/mutation-stage-2", "value": "yes" }
      ]`
+	addInitContainerPatch string = `[
+		 {"op":"add","path":"/spec/initContainers","value":[{"image":"webhook-added-image","name":"webhook-added-init-container","resources":{}}]}
+	]`
 )
 
 // Config contains the server (the webhook) cert and key.
@@ -99,6 +102,31 @@ func admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	}
 	if !reviewResponse.Allowed {
 		reviewResponse.Result = &metav1.Status{Message: strings.TrimSpace(msg)}
+	}
+	return &reviewResponse
+}
+
+func mutatePods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("mutating pods")
+	podResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	if ar.Request.Resource != podResource {
+		glog.Errorf("expect resource to be %s", podResource)
+		return nil
+	}
+
+	raw := ar.Request.Object.Raw
+	pod := corev1.Pod{}
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, &pod); err != nil {
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+	reviewResponse := v1beta1.AdmissionResponse{}
+	reviewResponse.Allowed = true
+	if pod.Name == "webhook-to-be-mutated" {
+		reviewResponse.Patch = []byte(addInitContainerPatch)
+		pt := v1beta1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
 	}
 	return &reviewResponse
 }
@@ -266,6 +294,10 @@ func servePods(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, admitPods)
 }
 
+func serveMutatePods(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, mutatePods)
+}
+
 func serveConfigmaps(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, admitConfigMaps)
 }
@@ -288,6 +320,7 @@ func main() {
 	flag.Parse()
 
 	http.HandleFunc("/pods", servePods)
+	http.HandleFunc("/mutating-pods", serveMutatePods)
 	http.HandleFunc("/configmaps", serveConfigmaps)
 	http.HandleFunc("/mutating-configmaps", serveMutateConfigmaps)
 	http.HandleFunc("/crd", serveCRD)


### PR DESCRIPTION
Cherry pick of #58025 on release-1.9.

#58025: Let mutating webhook defaults the object after applying the

```release note
Mutating webhook controller now defaults the object after applying each patch sent back by the webhook.
```