### PR TITLE
auth/gcp: configurable scopes for gcp default credentials

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
@@ -18,6 +18,7 @@ package gcp
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -114,6 +115,114 @@ func TestHelperProcess(t *testing.T) {
 	}
 	fmt.Fprintf(os.Stdout, output.output)
 	os.Exit(0)
+}
+
+func Test_isCmdTokenSource(t *testing.T) {
+	c1 := map[string]string{"cmd-path": "foo"}
+	if v := isCmdTokenSource(c1); !v {
+		t.Fatalf("cmd-path present in config (%+v), but got %v", c1, v)
+	}
+
+	c2 := map[string]string{"cmd-args": "foo bar"}
+	if v := isCmdTokenSource(c2); v {
+		t.Fatalf("cmd-path not present in config (%+v), but got %v", c2, v)
+	}
+}
+
+func Test_tokenSource_cmd(t *testing.T) {
+	if _, err := tokenSource(true, map[string]string{}); err == nil {
+		t.Fatalf("expected error, cmd-args not present in config")
+	}
+
+	c := map[string]string{
+		"cmd-path": "foo",
+		"cmd-args": "bar"}
+	ts, err := tokenSource(true, c)
+	if err != nil {
+		t.Fatalf("failed to return cmd token source: %+v", err)
+	}
+	if ts == nil {
+		t.Fatal("returned nil token source")
+	}
+	if _, ok := ts.(*commandTokenSource); !ok {
+		t.Fatalf("returned token source type:(%T) expected:(*commandTokenSource)", ts)
+	}
+}
+
+func Test_tokenSource_cmdCannotBeUsedWithScopes(t *testing.T) {
+	c := map[string]string{
+		"cmd-path": "foo",
+		"scopes":   "A,B"}
+	if _, err := tokenSource(true, c); err == nil {
+		t.Fatal("expected error when scopes is used with cmd-path")
+	}
+}
+
+func Test_tokenSource_applicationDefaultCredentials_fails(t *testing.T) {
+	// try to use empty ADC file
+	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+	if err != nil {
+		t.Fatalf("failed to create fake token file: +%v", err)
+	}
+	fakeTokenFile.Close()
+	defer os.Remove(fakeTokenFile.Name())
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if _, err := tokenSource(false, map[string]string{}); err == nil {
+		t.Fatalf("expected error because specified ADC token file is not a JSON")
+	}
+}
+
+func Test_tokenSource_applicationDefaultCredentials(t *testing.T) {
+	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+	if err != nil {
+		t.Fatalf("failed to create fake token file: +%v", err)
+	}
+	fakeTokenFile.Close()
+	defer os.Remove(fakeTokenFile.Name())
+	if err := ioutil.WriteFile(fakeTokenFile.Name(), []byte(`{"type":"service_account"}`), 0600); err != nil {
+		t.Fatalf("failed to write to fake token file: %+v", err)
+	}
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	ts, err := tokenSource(false, map[string]string{})
+	if err != nil {
+		t.Fatalf("failed to get a token source: %+v", err)
+	}
+	if ts == nil {
+		t.Fatal("returned nil token soruce")
+	}
+}
+
+func Test_parseScopes(t *testing.T) {
+	cases := []struct {
+		in  map[string]string
+		out []string
+	}{
+		{
+			map[string]string{},
+			[]string{
+				"https://www.googleapis.com/auth/cloud-platform",
+				"https://www.googleapis.com/auth/userinfo.email"},
+		},
+		{
+			map[string]string{"scopes": ""},
+			[]string{},
+		},
+		{
+			map[string]string{"scopes": "A,B,C"},
+			[]string{"A", "B", "C"},
+		},
+	}
+
+	for _, c := range cases {
+		got := parseScopes(c.in)
+		if !reflect.DeepEqual(got, c.out) {
+			t.Errorf("expected=%v, got=%v", c.out, got)
+		}
+	}
 }
 
 func errEquiv(got, want error) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

- add `config.scopes` field comma-separated scope URLs, to be used with Google
  Application Default Credentials (i.e. GOOGLE_APPLICATION_CREDENTIALS env)
- users now should be able to set a gserviceaccount key in GOOGLE_APPLICATION_CREDENTIALS
  env, craft a kubeconfig file with GKE master IP+CA cert and should be able to authenticate
  to GKE in headless mode _without requiring gcloud_ CLI, and they can now use the
  email address of the gserviceaccount in RBAC role bindings and _not use Google Cloud IAM at all._
- gcp default scopes now include userinfo.email scope, so authenticating to GKE
  using gserviceaccount keys can now be done without gcloud as well.
- since userinfo.email scope is now a default, users who have existing RBAC bindings
  that use numeric uniqueID of the gserviceaccount will be broken (this behavior was
  never documented/guaranteed). from now on email address of the service account
  should be used as the subject in RBAC Role Bindings.


**Release note**:
```release-note
Google Cloud Service Account email addresses can now be used in RBAC
Role bindings since the default scopes now include the "userinfo.email"
scope. This is a breaking change if the numeric uniqueIDs of the Google
service accounts were being used in RBAC role bindings. The behavior
can be overridden by explicitly specifying the scope values as
comma-separated string in the "users[*].config.scopes" field in the
KUBECONFIG file.
```

/assign @cjcullen 
/sig gcp