### PR TITLE
Fixed crash in kubectl cp when path has multiple leading slashes

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -378,11 +378,8 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 }
 
 func getPrefix(file string) string {
-	if file[0] == '/' {
-		// tar strips the leading '/' if it's there, so we will too
-		return file[1:]
-	}
-	return file
+	// tar strips the leading '/' if it's there, so we will too
+	return strings.TrimLeft(file, "/")
 }
 
 func execute(f cmdutil.Factory, cmd *cobra.Command, options *ExecOptions) error {


### PR DESCRIPTION
**What this PR does / why we need it**: Fixed crash in kubectl cp when path has multiple leading slashes
For example:
```
$ kubectl cp pod://path/to/somewhere localfile
tar: Removing leading `//' from member names
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubectl/cmd.untarAll(0x363e840, 0xc420198120, 0x7fff5fbffc13, 0x1, 0x7fff5fbffbfa, 0x18, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go:329 +0x7b4
k8s.io/kubernetes/pkg/kubectl/cmd.copyFromPod(0x3671940, 0xc420261dd0, 0xc4202f9200, 0x3644480, 0xc42000c020, 0x0, 0x0, 0x7fff5fbffbed, 0xb, 0x7fff5fbffbf9, ...)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go:237 +0x375
k8s.io/kubernetes/pkg/kubectl/cmd.runCopy(0x3671940, 0xc420261dd0, 0xc4202f9200, 0x3644480, 0xc42000c018, 0x3644480, 0xc42000c020, 0xc4203490a0, 0x2, 0x2, ...)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go:134 +0x35b
k8s.io/kubernetes/pkg/kubectl/cmd.NewCmdCp.func1(0xc4202f9200, 0xc4203490a0, 0x2, 0x2)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go:72 +0x89
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc4202f9200, 0xc420348ee0, 0x2, 0x2, 0xc4202f9200, 0xc420348ee0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:603 +0x234
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42038d440, 0x8000104, 0x0, 0xffffffffffffffff)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:689 +0x2fe
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42038d440, 0xc420261dd0, 0x3644440)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:648 +0x2b
k8s.io/kubernetes/cmd/kubectl/app.Run(0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubectl/app/kubectl.go:41 +0xd5
main.main()
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:27 +0x26
```

**Which issue(s) this PR fixes** None

**Special notes for your reviewer**: None

**Release note**:
```release-note
Fixed crash in kubectl cp when path has multiple leading slashes
```
