### PR TITLE
WIP: Enable overriding Metrics Server configuration with environment variable

### DIFF
--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -1359,6 +1359,12 @@ EOF
     fi
   fi
   if [[ "${ENABLE_METRICS_SERVER:-}" == "true" ]]; then
+    if [ -n "${CUSTOM_METRICS_SERVER_YAML}" ]; then
+      local -r metrics_server_file="${dst_dir}/metrics-server/metrics-server-deployment.yaml"
+      cat > "${metrics_server_file}" <<EOF
+$(echo "${CUSTOM_METRICS_SERVER_FILE}")
+EOF
+    fi
     setup-addon-manifests "addons" "metrics-server"
   fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2149,7 +2149,14 @@ EOF
       sed -i -e "s@{{ metadata_agent_memory_request }}@${metadata_agent_memory_request}@g" "${daemon_set_yaml}"
     fi
   fi
+
   if [[ "${ENABLE_METRICS_SERVER:-}" == "true" ]]; then
+    if [ -n "${CUSTOM_METRICS_SERVER_YAML}" ]; then
+      local -r metrics_server_file="${dst_dir}/metrics-server/metrics-server-deployment.yaml"
+      cat > "${metrics_server_file}" <<EOF
+$(echo "${CUSTOM_METRICS_SERVER_FILE}")
+EOF
+    fi
     setup-addon-manifests "addons" "metrics-server"
   fi
   if [[ "${ENABLE_NVIDIA_GPU_DEVICE_PLUGIN:-}" == "true" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables overriding Metrics Server configuration with environment variable to allow for custom configurations

**Release note**:
```release-note
Enables overriding Metrics Server configuration with environment variable to allow for custom configurations
```
