### PR TITLE
Add kawych to Metrics Server owners

### DIFF
--- a/cluster/addons/metrics-server/OWNERS
+++ b/cluster/addons/metrics-server/OWNERS
@@ -1,6 +1,8 @@
 approvers:
 - DirectXMan12
+- kawych
 - piosz
 reviewers:
 - DirectXMan12
+- kawych
 - piosz


### PR DESCRIPTION
**What this PR does / why we need it**:
Add kawych to Metrics Server owners

**Release note**:
```release-note
NONE
```
