### PR TITLE
decrease pod with pvc failover time in case of node is shutdowned.

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -602,6 +602,32 @@ func (os *OpenStack) DiskIsAttached(instanceID, volumeID string) (bool, error) {
 	return instanceID == volume.AttachedServerId, nil
 }
 
+
+// SafeToDetachNode queries if a node is safe to detach volume
+func (os *OpenStack) SafeToDetachNode(nodeName types.NodeName) (bool, error) {
+	cClient, err := os.NewComputeV2()
+	if err != nil {
+		return false, err
+	}
+	srv, err := getServerByName(cClient, nodeName, false)
+	if err != nil {
+		if err == ErrNotFound {
+			// instance not found anymore in cloudprovider, assume that cinder is safe to detach
+			return true, nil
+		} else {
+			return false, err
+		}
+	}
+	glog.V(4).Infof("Node %s status %s", nodeName, srv.Status)
+	// all states listed here where it is safe to detach drive without problems
+	if srv.Status == "SHUTOFF" {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+
 // DiskIsAttachedByName queries if a volume is attached to a compute instance by name
 func (os *OpenStack) DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error) {
 	cClient, err := os.NewComputeV2()

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -197,8 +197,10 @@ func (rc *reconciler) reconcile() {
 			}
 			// Check whether timeout has reached the maximum waiting time
 			timeout := elapsedTime > rc.maxWaitForUnmountDuration
-			// Check whether volume is still mounted. Skip detach if it is still mounted unless timeout
-			if attachedVolume.MountedByNode && !timeout {
+			safeToDetach := rc.desiredStateOfWorld.SafeToDetach(attachedVolume.NodeName)
+
+			// Check whether volume is still mounted. Skip detach if it is still mounted unless timeout or node is safe to detach
+			if attachedVolume.MountedByNode && !timeout && !safeToDetach {
 				glog.V(12).Infof(attachedVolume.GenerateMsgDetailed("Cannot detach volume because it is still mounted", ""))
 				continue
 			}

--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -263,6 +263,11 @@ func (detacher *awsElasticBlockStoreDetacher) Detach(volumeName string, nodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *awsElasticBlockStoreDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *awsElasticBlockStoreDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -295,6 +295,12 @@ func (d *azureDiskDetacher) Detach(diskURI string, nodeName types.NodeName) erro
 	return err
 }
 
+
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (d *azureDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 // UnmountDevice unmounts the volume on the node
 func (detacher *azureDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	err := volumeutil.UnmountPath(deviceMountPath, detacher.plugin.host.GetMounter(detacher.plugin.GetPluginName()))

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -393,6 +393,11 @@ func (detacher *cinderDiskDetacher) Detach(volumeName string, nodeName types.Nod
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *cinderDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return detacher.cinderProvider.SafeToDetachNode(nodeName)
+}
+
 func (detacher *cinderDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -55,6 +55,7 @@ type CinderProvider interface {
 	DiskIsAttachedByName(nodeName types.NodeName, volumeID string) (bool, string, error)
 	DisksAreAttachedByName(nodeName types.NodeName, volumeIDs []string) (map[string]bool, error)
 	ShouldTrustDevicePath() bool
+	SafeToDetachNode(nodeName types.NodeName) (bool, error) 
 	Instances() (cloudprovider.Instances, bool)
 	ExpandVolume(volumeID string, oldSize resource.Quantity, newSize resource.Quantity) (resource.Quantity, error)
 }

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -221,6 +221,11 @@ func (c *csiAttacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return c.waitForVolumeDetachment(volID, attachID)
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (c *csiAttacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (c *csiAttacher) waitForVolumeDetachment(volumeHandle, attachID string) error {
 	glog.V(4).Info(log("probing for updates from CSI driver for [attachment.ID=%v]", attachID))
 

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -141,6 +141,11 @@ func (detacher *fcDetacher) Detach(volumeName string, nodeName types.NodeName) e
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *fcDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
 	// Specify device name for DetachDisk later
 	devName, _, err := mount.GetDeviceNameFromMount(detacher.mounter, deviceMountPath)

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -46,6 +46,11 @@ func (d *flexVolumeDetacher) Detach(volumeName string, hostName types.NodeName) 
 	return err
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (d *flexVolumeDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 // UnmountDevice is part of the volume.Detacher interface.
 func (d *flexVolumeDetacher) UnmountDevice(deviceMountPath string) error {
 

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -272,6 +272,11 @@ func (detacher *gcePersistentDiskDetacher) Detach(volumeName string, nodeName ty
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *gcePersistentDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *gcePersistentDiskDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.host.GetMounter(gcePersistentDiskPluginName))
 }

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -143,6 +143,11 @@ func (detacher *iscsiDetacher) Detach(volumeName string, nodeName types.NodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *iscsiDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *iscsiDetacher) UnmountDevice(deviceMountPath string) error {
 	unMounter := volumeSpecToUnmounter(detacher.mounter, detacher.host)
 	err := detacher.manager.DetachDisk(*unMounter, deviceMountPath)

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -268,6 +268,11 @@ func (detacher *photonPersistentDiskDetacher) Detach(volumeName string, nodeName
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *photonPersistentDiskDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *photonPersistentDiskDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
 	ticker := time.NewTicker(checkSleepDuration)
 	defer ticker.Stop()

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -223,3 +223,9 @@ func (detacher *rbdDetacher) UnmountDevice(deviceMountPath string) error {
 func (detacher *rbdDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }
+
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *rbdDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -245,6 +245,10 @@ type Detacher interface {
 	// should only be called once all bind mounts have been
 	// unmounted.
 	UnmountDevice(deviceMountPath string) error
+
+	// SafeToDetachFromNode shows is the node in safe mode to detach volume
+	// for instance if node is shutdowned in cloud provider it is safe to detach without waiting
+	SafeToDetachFromNode(nodeName types.NodeName) (bool, error)
 }
 
 // NewDeletedVolumeInUseError returns a new instance of DeletedVolumeInUseError

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -277,6 +277,11 @@ func (detacher *vsphereVMDKDetacher) Detach(volumeName string, nodeName types.No
 	return nil
 }
 
+// SafeToDetachFromNode returns true if it is safe to detach drive from node immediately
+func (detacher *vsphereVMDKDetacher) SafeToDetachFromNode(nodeName types.NodeName) (bool, error) {
+	return false, nil
+}
+
 func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: this PR decreases the failover time when node is shutdowned which contains POD which have PVC attached. Before this fix the time was something between 8-10minutes because the reconciler will always wait maxWaitForUnmountDuration in https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/volume/attachdetach/reconciler/reconciler.go#L201 However, that wait is not always needed if the node is in safe state to detach volume. For instance in openstack this safe state is at least SHUTOFF

**Which issue(s) this PR fixes**:
Fixes #58079
Fixes #53059

**Special notes for your reviewer**: 
This PR contains only implementation to openstack cloudprovider. That is implemented as example to others. All other cloudproviders should implement SafeToDetachFromNode in order to get this working like should. This implementation does not change any behaviour how it is working currently in other cloud providers. In openstack this decreases failover time **from 9-10minutes to 1min 10seconds** - which is quite huge improvement.

**Release note**:

```release-note
NONE
```

cc @gnufied @jingxu97 