### PR TITLE
Avoid panic in Cloud CIDR Allocator

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -191,9 +191,13 @@ func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 
 // updateCIDRAllocation assigns CIDR to Node and sends an update to the API server.
 func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
-	var err error
-	var node *v1.Node
 	defer ca.removeNodeFromProcessing(nodeName)
+
+	node, err := ca.nodeLister.Get(nodeName)
+	if err != nil {
+		glog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %v", nodeName, err)
+		return err
+	}
 
 	cidrs, err := ca.cloud.AliasRanges(types.NodeName(nodeName))
 	if err != nil {
@@ -209,12 +213,6 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 		return fmt.Errorf("failed to parse string '%s' as a CIDR: %v", cidrs[0], err)
 	}
 	podCIDR := cidr.String()
-
-	node, err = ca.nodeLister.Get(nodeName)
-	if err != nil {
-		glog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %v", nodeName, err)
-		return err
-	}
 
 	if node.Spec.PodCIDR == podCIDR {
 		glog.V(4).Infof("Node %v already has allocated CIDR %v. It matches the proposed one.", node.Name, podCIDR)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I suspect a race exists where we attempt to look up the CIDR for a terminating node. By the time `updateCIDRAllocation` is called the node has disappeared. We determine it does not have a cloud CIDR (i.e. Alias IP Range) and attempt to record a `CIDRNotAvailable` node status. Unfortunately we reference `node.Name` while `node` is still nil.

By getting the node before looking up the cloud CIDR we avoid the nil pointer dereference, and potentially fail fast in the case the node has disappeared.

**Which issue(s) this PR fixes**:
Fixes #58181

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid panic when failing to allocate a Cloud CIDR (aka GCE Alias IP Range). 
```
