### PR TITLE
Added metrics for preemption

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -59,6 +59,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
+	SchedulingAlgorithmPremptionEvaluationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: schedulerSubsystem,
+			Name:      "scheduling_algorithm_preemption_evaluation",
+			Help:      "Scheduling algorithm preemption evaluation duration",
+			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
+		},
+	)
 	BindingLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: schedulerSubsystem,
@@ -67,6 +75,18 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
+	PreemptionVictims = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: schedulerSubsystem,
+			Name:      "pod_preemption_victims",
+			Help:      "Number of selected preemption victims",
+		})
+	PreemptionAttempts = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: schedulerSubsystem,
+			Name:      "total_preemption_attempts",
+			Help:      "Total preemption attempts in the cluster till now",
+		})
 )
 
 var registerMetrics sync.Once
@@ -78,8 +98,12 @@ func Register() {
 		prometheus.MustRegister(E2eSchedulingLatency)
 		prometheus.MustRegister(SchedulingAlgorithmLatency)
 		prometheus.MustRegister(BindingLatency)
+
 		prometheus.MustRegister(SchedulingAlgorithmPredicateEvaluationDuration)
 		prometheus.MustRegister(SchedulingAlgorithmPriorityEvaluationDuration)
+		prometheus.MustRegister(SchedulingAlgorithmPremptionEvaluationDuration)
+		prometheus.MustRegister(PreemptionVictims)
+		prometheus.MustRegister(PreemptionAttempts)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Metrics for preemption duration in scheduler.

**Special notes for your reviewer**:
xref:  https://github.com/kubernetes/kubernetes/issues/57471 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
cc @bsalamat 