### PR TITLE
Use GinkgoRecover to avoid panic.

### DIFF
--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e_node/perftype"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
@@ -373,6 +374,7 @@ func deletePodsSync(f *framework.Framework, pods []*v1.Pod) {
 	for _, pod := range pods {
 		wg.Add(1)
 		go func(pod *v1.Pod) {
+			defer GinkgoRecover()
 			defer wg.Done()
 
 			err := f.PodClient().Delete(pod.ObjectMeta.Name, metav1.NewDeleteOptions(30))


### PR DESCRIPTION
See this in the test:
```
I0111 14:28:31.010] panic: 
I0111 14:28:31.010] Your test failed.
I0111 14:28:31.010] Ginkgo panics to prevent subsequent assertions from running.
I0111 14:28:31.011] Normally Ginkgo rescues this panic so you shouldn't see it.
I0111 14:28:31.011] 
I0111 14:28:31.011] But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
I0111 14:28:31.011] To circumvent this, you should call
I0111 14:28:31.011] 
I0111 14:28:31.012] 	defer GinkgoRecover()
I0111 14:28:31.012] 
I0111 14:28:31.012] at the top of the goroutine that caused this panic.
I0111 14:28:31.012] 
I0111 14:28:31.012] 
I0111 14:28:31.012] goroutine 1028 [running]:
I0111 14:28:31.013] k8s.io/kubernetes/vendor/github.com/onsi/ginkgo.Fail(0xc421098000, 0xb0, 0xc420da24c8, 0x1, 0x1)
I0111 14:28:31.013] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:255 +0xda
I0111 14:28:31.014] k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).match(0xc4220bd700, 0x9e897e0, 0xa123640, 0x0, 0x0, 0x0, 0x0, 0xa123640)
I0111 14:28:31.014] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:69 +0x1ef
I0111 14:28:31.014] k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).NotTo(0xc4220bd700, 0x9e897e0, 0xa123640, 0x0, 0x0, 0x0, 0xc4220bd700)
I0111 14:28:31.015] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion/assertion.go:43 +0xae
I0111 14:28:31.015] k8s.io/kubernetes/test/e2e_node.deletePodsSync.func1(0xc421485220, 0xc421321680, 0xc421517180)
I0111 14:28:31.015] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e_node/resource_collector.go:382 +0x320
I0111 14:28:31.015] created by k8s.io/kubernetes/test/e2e_node.deletePodsSync
I0111 14:28:31.016] 	/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e_node/resource_collector.go:375 +0x9e
```

e.g.: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cri-containerd-node-e2e-serial/17/build-log.txt

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
