### PR TITLE
fix error when run release.sh not in {KUBE_ROOT}

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -451,8 +451,8 @@ function kube::build::build_image() {
 
   cp /etc/localtime "${LOCAL_OUTPUT_BUILD_CONTEXT}/"
 
-  cp build/build-image/Dockerfile "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
-  cp build/build-image/rsyncd.sh "${LOCAL_OUTPUT_BUILD_CONTEXT}/"
+  cp ${KUBE_ROOT}/build/build-image/Dockerfile "${LOCAL_OUTPUT_BUILD_CONTEXT}/Dockerfile"
+  cp ${KUBE_ROOT}/build/build-image/rsyncd.sh "${LOCAL_OUTPUT_BUILD_CONTEXT}/"
   dd if=/dev/urandom bs=512 count=1 2>/dev/null | LC_ALL=C tr -dc 'A-Za-z0-9' | dd bs=32 count=1 2>/dev/null > "${LOCAL_OUTPUT_BUILD_CONTEXT}/rsyncd.password"
   chmod go= "${LOCAL_OUTPUT_BUILD_CONTEXT}/rsyncd.password"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add `${KUBE_ROOT}/` in directory, otherwise run 
```shell
cd kubernetes/build  
./release.sh
```
will exit:
```shell
+++ [0112 18:18:48] Verifying Prerequisites....
cp: cannot stat ‘build/build-image/Dockerfile’: No such file or directory
!!! [0112 18:18:48] Call tree:
!!! [0112 18:18:48]  1: ./release.sh:35 kube::build::build_image(...)
!!! Error in ./../build/common.sh:454
  Error in ./../build/common.sh:454. '((i<3-1))' exited with status 1
Call stack:
  1: ./../build/common.sh:454 kube::build::build_image(...)
  2: ./release.sh:35 main(...)
Exiting with status 1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
