### PR TITLE
The lbaas.opts.SubnetId should be set by subnet id.

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -537,7 +537,7 @@ func getSubnetIDForLB(compute *gophercloud.ServiceClient, node v1.Node) (string,
 	for _, intf := range interfaces {
 		for _, fixedIP := range intf.FixedIPs {
 			if fixedIP.IPAddress == ipAddress {
-				return intf.NetID, nil
+				return fixedIP.SubnetID, nil
 			}
 		}
 	}


### PR DESCRIPTION
Fix #58145
The getSubnetIDForLB() should return subnet id rather than net id.

**Release note**:
```release-note
The getSubnetIDForLB() should return subnet id rather than net id.
```
