### PR TITLE
generate-bindata.sh: make output cleanly by suppressing pushd/popd output

### DIFF
--- a/hack/generate-bindata.sh
+++ b/hack/generate-bindata.sh
@@ -39,7 +39,7 @@ if ! which go-bindata &>/dev/null ; then
 fi
 
 # run the generation from the root directory for stable output
-pushd "${KUBE_ROOT}"
+pushd "${KUBE_ROOT}" >/dev/null
 
 # These are files for e2e tests.
 BINDATA_OUTPUT="test/e2e/generated/bindata.go"
@@ -84,4 +84,4 @@ fi
 
 rm -f "${BINDATA_OUTPUT}.tmp"
 
-popd
+popd >/dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:
`generate-bindata.sh` script produce extra output that is caused by `pushd`/`popd` usage. To make script output clean and to simplify debugging process, I suggest to suppress pushd/popd output.

Before this PR:
```console
$ make generated_files 
+++ [0112 15:46:26] Building the toolchain targets:
	k8s.io/kubernetes/hack/cmd/teststale
	k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 15:46:27] Generating bindata:
	test/e2e/generated/gobindata_util.go
~/git/src/home/kubernetes ~/git/src/home/kubernetes/test/e2e/generated
~/git/src/home/kubernetes/test/e2e/generated
+++ [0112 15:46:27] Building go targets for linux/amd64:
	./vendor/k8s.io/code-generator/cmd/deepcopy-gen
+++ [0112 15:46:34] Building the toolchain targets:
	k8s.io/kubernetes/hack/cmd/teststale
	k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 15:46:34] Generating bindata:
	test/e2e/generated/gobindata_util.go
~/git/src/home/kubernetes ~/git/src/home/kubernetes/test/e2e/generated
~/git/src/home/kubernetes/test/e2e/generated
+++ [0112 15:46:34] Building go targets for linux/amd64:
	./vendor/k8s.io/code-generator/cmd/defaulter-gen
+++ [0112 15:46:38] Building the toolchain targets:
	k8s.io/kubernetes/hack/cmd/teststale
	k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 15:46:38] Generating bindata:
	test/e2e/generated/gobindata_util.go
~/git/src/home/kubernetes ~/git/src/home/kubernetes/test/e2e/generated
~/git/src/home/kubernetes/test/e2e/generated
+++ [0112 15:46:39] Building go targets for linux/amd64:
	./vendor/k8s.io/code-generator/cmd/conversion-gen
```

After this PR:
```console
$ make generated_files 
+++ [0112 16:28:31] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
    k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 16:28:32] Generating bindata:
    test/e2e/generated/gobindata_util.go
+++ [0112 16:28:32] Building go targets for linux/amd64:
    ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
+++ [0112 16:28:39] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
    k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 16:28:39] Generating bindata:
    test/e2e/generated/gobindata_util.go
+++ [0112 16:28:39] Building go targets for linux/amd64:
    ./vendor/k8s.io/code-generator/cmd/defaulter-gen
+++ [0112 16:28:43] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
    k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0112 16:28:43] Generating bindata:
    test/e2e/generated/gobindata_util.go
+++ [0112 16:28:44] Building go targets for linux/amd64:
    ./vendor/k8s.io/code-generator/cmd/conversion-gen

```

**Release note**:
```release-note
NONE
```

CC @simo5 