### PR TITLE
Use the bazel version check function from bazel-skylib

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -12,6 +12,13 @@ http_archive(
     urls = ["https://github.com/kubernetes/repo-infra/archive/1fb0a3ff0cc5308a6d8e2f3f9c57d1f2f940354e.tar.gz"],
 )
 
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+    strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+)
+
 ETCD_VERSION = "3.1.10"
 
 new_http_archive(
@@ -39,9 +46,9 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/8bbe2a8abd382641e65ff7127a3700a8530f02ce.tar.gz"],
 )
 
-load("@io_kubernetes_build//defs:bazel_version.bzl", "check_version")
+load("@bazel_skylib//:lib.bzl", "versions")
 
-check_version("0.8.0")
+versions.check(minimum_bazel_version = "0.8.0")
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_download_sdk")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")


### PR DESCRIPTION
**What this PR does / why we need it**: fixes a bug in parsing the bazel version when a component has more than one digit, e.g. "0.10.0".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
x-ref https://github.com/bazelbuild/bazel/issues/4425

**Special notes for your reviewer**: we also need to update rules_go, but that's a more invasive change, so I've saved that for another PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder @mikedanese 