### PR TITLE
Adjust the Stackdriver Logging length test

### DIFF
--- a/test/e2e/instrumentation/logging/stackdrvier/basic.go
+++ b/test/e2e/instrumentation/logging/stackdrvier/basic.go
@@ -108,7 +108,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 			})
 
 			ginkgo.By("Checking that too long lines are trimmed", func() {
-				maxLength := 100000
+				maxLength := 100 * 1024
 				cmd := []string{
 					"/bin/sh",
 					"-c",


### PR DESCRIPTION
Fixes failures in https://k8s-testgrid.appspot.com/google-gke#gke-ubuntustable1-k8sdev-default

```release-note
NONE
```