### PR TITLE
Bump fluentd-gcp version

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,13 +1,13 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-gcp-v2.0.13
+  name: fluentd-gcp-v2.0.14
   namespace: kube-system
   labels:
     k8s-app: fluentd-gcp
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v2.0.13
+    version: v2.0.14
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -16,7 +16,7 @@ spec:
       labels:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"
-        version: v2.0.13
+        version: v2.0.14
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.13
+        image: gcr.io/google-containers/fluentd-gcp:2.0.14
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q


### PR DESCRIPTION
**What this PR does / why we need it**: Addresses issues parsing exceptions from logs

**Release note**:
```release-note
fluentd-gcp updated to version 2.0.14.
```
