### PR TITLE
Install gazelle from bazelbuild/bazel-gazelle instead of rules_go

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -476,15 +476,10 @@ kube::util::go_install_from_commit() {
 
   kube::util::ensure-temp-dir
   mkdir -p "${KUBE_TEMP}/go/src"
-  # TODO(spiffxp): remove this brittle workaround for go getting a package that doesn't exist at HEAD
-  repo=$(echo ${pkg} | cut -d/ -f1-3)
-  git clone "https://${repo}" "${KUBE_TEMP}/go/src/${repo}"
-  # GOPATH="${KUBE_TEMP}/go" go get -d -u "${pkg}"
+  GOPATH="${KUBE_TEMP}/go" go get -d -u "${pkg}"
   (
-    cd "${KUBE_TEMP}/go/src/${repo}"
-    git fetch # TODO(spiffxp): workaround
+    cd "${KUBE_TEMP}/go/src/${pkg}"
     git checkout -q "${commit}"
-    GOPATH="${KUBE_TEMP}/go" go get -d "${pkg}" #TODO(spiffxp): workaround
     GOPATH="${KUBE_TEMP}/go" go install "${pkg}"
   )
   PATH="${KUBE_TEMP}/go/bin:${PATH}"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -31,8 +31,8 @@ kube::util::go_install_from_commit \
     github.com/kubernetes/repo-infra/kazel \
     ae4e9a3906ace4ba657b7a09242610c6266e832c
 kube::util::go_install_from_commit \
-    github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-    737df20c53499fd84b67f04c6ca9ccdee2e77089
+    github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
+    31ce76e3acc34a22434d1a783bb9b3cae790d108  # 0.8.0
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: downloads gazelle from its new home; it's being removed from `bazelbuild/rules_go`. It also removes @spiffxp's workaround from a few weeks ago.

**Special notes for your reviewer**: these should really be vendored (https://github.com/kubernetes/kubernetes/pull/57600), but this prevents us from running into issues in the meantime.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/approve no-issue
/assign @BenTheElder 