### PR TITLE
periodically flush ResponseWriter when using response compression

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/compression.go
@@ -136,6 +136,7 @@ func (c *compressionResponseWriter) Write(p []byte) (int, error) {
 		return -1, errors.New("compressing error: tried to write data using closed compressor")
 	}
 	c.Header().Set(headerContentEncoding, c.encoding)
+	defer c.compressor.Flush()
 	return c.compressor.Write(p)
 }
 


### PR DESCRIPTION
This PR fixes API Compression when following logs by ensuring the compression writer periodically flushes (at the end of each write).

This is a commit extracted from #51508 to allow testing of flushing while feature remains disabled / in alpha.

Fixes https://github.com/kubernetes/kubernetes/issues/54205

```release-note
NONE
```