### PR TITLE
Return the correct set of supported mime types for non-streaming requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -61,7 +61,7 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 		ctx = request.WithNamespace(ctx, namespace)
 
 		gv := scope.Kind.GroupVersion()
-		s, err := negotiation.NegotiateInputSerializer(req, scope.Serializer)
+		s, err := negotiation.NegotiateInputSerializer(req, false, scope.Serializer)
 		if err != nil {
 			scope.err(err, w, req)
 			return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -60,7 +60,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope RequestSco
 				return
 			}
 			if len(body) > 0 {
-				s, err := negotiation.NegotiateInputSerializer(req, metainternalversion.Codecs)
+				s, err := negotiation.NegotiateInputSerializer(req, false, metainternalversion.Codecs)
 				if err != nil {
 					scope.err(err, w, req)
 					return
@@ -228,7 +228,7 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope RequestSco
 				return
 			}
 			if len(body) > 0 {
-				s, err := negotiation.NegotiateInputSerializer(req, scope.Serializer)
+				s, err := negotiation.NegotiateInputSerializer(req, false, scope.Serializer)
 				if err != nil {
 					scope.err(err, w, req)
 					return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -73,31 +73,30 @@ func NegotiateOutputStreamSerializer(req *http.Request, ns runtime.NegotiatedSer
 }
 
 // NegotiateInputSerializer returns the input serializer for the provided request.
-func NegotiateInputSerializer(req *http.Request, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
+func NegotiateInputSerializer(req *http.Request, streaming bool, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
 	mediaType := req.Header.Get("Content-Type")
-	return NegotiateInputSerializerForMediaType(mediaType, ns)
+	return NegotiateInputSerializerForMediaType(mediaType, streaming, ns)
 }
 
 // NegotiateInputSerializerForMediaType returns the appropriate serializer for the given media type or an error.
-func NegotiateInputSerializerForMediaType(mediaType string, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
+func NegotiateInputSerializerForMediaType(mediaType string, streaming bool, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
 	mediaTypes := ns.SupportedMediaTypes()
 	if len(mediaType) == 0 {
 		mediaType = mediaTypes[0].MediaType
 	}
-	mediaType, _, err := mime.ParseMediaType(mediaType)
-	if err != nil {
-		_, supported := MediaTypesForSerializer(ns)
-		return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(supported)
-	}
-
-	for _, info := range mediaTypes {
-		if info.MediaType != mediaType {
-			continue
+	if mediaType, _, err := mime.ParseMediaType(mediaType); err == nil {
+		for _, info := range mediaTypes {
+			if info.MediaType != mediaType {
+				continue
+			}
+			return info, nil
 		}
-		return info, nil
 	}
 
-	_, supported := MediaTypesForSerializer(ns)
+	supported, streamingSupported := MediaTypesForSerializer(ns)
+	if streaming {
+		return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(streamingSupported)
+	}
 	return runtime.SerializerInfo{}, NewUnsupportedMediaTypeError(supported)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -56,7 +56,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 			return
 		}
 
-		s, err := negotiation.NegotiateInputSerializer(req, scope.Serializer)
+		s, err := negotiation.NegotiateInputSerializer(req, false, scope.Serializer)
 		if err != nil {
 			scope.err(err, w, req)
 			return


### PR DESCRIPTION
Fixes the error response when submitting unsupported mime types to non-streaming endpoints

See https://github.com/kubernetes/kubernetes/issues/37455#issuecomment-353526250

```release-note
NONE
```