### PR TITLE
Support out-of-tree / external cloud providers

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -53,6 +53,7 @@ var cloudproviders = []string{
 	"azure",
 	"cloudstack",
 	"gce",
+	"external", // Support for out-of-tree cloud providers
 	"openstack",
 	"ovirt",
 	"photon",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently kubeadm fails in preflight check. We should allow external cloud providers
```
[preflight] Starting the kubelet service
cloudprovider: Invalid value: "external": cloudprovider not supported
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for external cloud providers in kubeadm
```
