### PR TITLE
Automated cherry pick of #58208 upstream release 1.9

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -537,7 +537,7 @@ func getSubnetIDForLB(compute *gophercloud.ServiceClient, node v1.Node) (string,
 	for _, intf := range interfaces {
 		for _, fixedIP := range intf.FixedIPs {
 			if fixedIP.IPAddress == ipAddress {
-				return intf.NetID, nil
+				return fixedIP.SubnetID, nil
 			}
 		}
 	}


### PR DESCRIPTION
Cherry pick of #58208 on release-1.9.
#58208: The lbaas.opts.SubnetId should be set by subnet id.

**Release note**:
```release-note
The getSubnetIDForLB() should return subnet id rather than net id.
```
