### PR TITLE
add kubelet configflags:experimental-pleg-relist-threshold

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -441,6 +441,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		mainfs.AddFlagSet(fs)
 	}()
 
+	fs.DurationVar(&c.PlegRelistThreshold.Duration, "experimental-pleg-relist-threshold", c.PlegRelistThreshold.Duration, "Kubelet will reports PLEG error and be notReady if pleg relist take times greater than experimental-pleg-relist-threshold. Needs to be greater than the pleg relisting period(1s) + the relisting time, which can vary significantly. Set a conservative threshold to avoid flipping between healthy and unhealthy. Default: '3m'")
 	fs.BoolVar(&c.FailSwapOn, "fail-swap-on", c.FailSwapOn, "Makes the Kubelet fail to start if swap is enabled on the node. ")
 	fs.BoolVar(&c.FailSwapOn, "experimental-fail-swap-on", c.FailSwapOn, "DEPRECATED: please use --fail-swap-on instead.")
 	fs.MarkDeprecated("experimental-fail-swap-on", "This flag is deprecated and will be removed in future releases. please use --fail-swap-on instead.")

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -168,6 +168,7 @@ var (
 		"EvictionSoft[*]",
 		"EvictionSoftGracePeriod[*]",
 		"FailSwapOn",
+		"PlegRelistThreshold.Duration",
 		"FeatureGates[*]",
 		"FileCheckFrequency.Duration",
 		"HTTPCheckFrequency.Duration",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -240,6 +240,8 @@ type KubeletConfiguration struct {
 	FeatureGates map[string]bool
 	// Tells the Kubelet to fail to start if swap is enabled on the node.
 	FailSwapOn bool
+	// Kubelet will reports PLEG error and be notReady if pleg relist take times greater than experimental-pleg-relist-threshold.
+	PlegRelistThreshold metav1.Duration
 	// A quantity defines the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".
 	ContainerLogMaxSize string
 	// Maximum number of container log files that can be present for a container.

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
@@ -201,4 +201,7 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement
 	}
+	if obj.PlegRelistThreshold == zeroDuration {
+		obj.FileCheckFrequency = metav1.Duration{Duration: 3 * time.Minute}
+	}
 }

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -390,6 +390,10 @@ type KubeletConfiguration struct {
 	// Default: true
 	// +optional
 	FailSwapOn *bool `json:"failSwapOn,omitempty"`
+	// Kubelet will report PLEG error and be notReady if PLEG relist takes time greater than experimental-pleg-relist-threshold.
+	// Default: 3m
+	// +optional
+	PlegRelistThreshold metav1.Duration `json:"plegRelistThreshold"`
 	// A quantity defines the maximum size of the container log file before it is rotated. For example: "5Mi" or "256Ki".
 	// Default: "10Mi"
 	// +optional

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
@@ -244,6 +244,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfigurat
 	if err := v1.Convert_Pointer_bool_To_bool(&in.FailSwapOn, &out.FailSwapOn, s); err != nil {
 		return err
 	}
+	out.PlegRelistThreshold = in.PlegRelistThreshold
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	if err := v1.Convert_Pointer_int32_To_int32(&in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles, s); err != nil {
 		return err
@@ -365,6 +366,7 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1beta1_KubeletConfigurat
 	if err := v1.Convert_bool_To_Pointer_bool(&in.FailSwapOn, &out.FailSwapOn, s); err != nil {
 		return err
 	}
+	out.PlegRelistThreshold = in.PlegRelistThreshold
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	if err := v1.Convert_int32_To_Pointer_int32(&in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles, s); err != nil {
 		return err

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
@@ -311,6 +311,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 			**out = **in
 		}
 	}
+	out.PlegRelistThreshold = in.PlegRelistThreshold
 	if in.ContainerLogMaxFiles != nil {
 		in, out := &in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles
 		if *in == nil {

--- a/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
@@ -149,6 +149,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	out.PlegRelistThreshold = in.PlegRelistThreshold
 	if in.SystemReserved != nil {
 		in, out := &in.SystemReserved, &out.SystemReserved
 		*out = make(map[string]string, len(*in))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -741,7 +741,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			klet.containerRuntime)
 	}
 
-	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, klet.podCache, clock.RealClock{})
+	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, kubeCfg.PlegRelistThreshold.Duration, klet.podCache, clock.RealClock{})
 	klet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	klet.runtimeState.addHealthCheck("PLEG", klet.pleg.Healthy)
 	klet.updatePodCIDR(kubeCfg.PodCIDR)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -280,7 +280,7 @@ func newTestKubeletWithImageList(
 	kubelet.resyncInterval = 10 * time.Second
 	kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
 	// Relist period does not affect the tests.
-	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, nil, clock.RealClock{})
+	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, 3*time.Minute,  nil, clock.RealClock{})
 	kubelet.clock = fakeClock
 	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -280,7 +280,7 @@ func newTestKubeletWithImageList(
 	kubelet.resyncInterval = 10 * time.Second
 	kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
 	// Relist period does not affect the tests.
-	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, 3*time.Minute,  nil, clock.RealClock{})
+	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, 3*time.Minute, nil, clock.RealClock{})
 	kubelet.clock = fakeClock
 	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add kubelet configflags:experimental-pleg-relist-threshold
Kubelet will reports PLEG error and be notReady if pleg relist take times greater than experimental-pleg-relist-threshold. If we add this flag user can set a suitable threshold to avoid flipping between healthy and unhealthy. The default value is '3m'.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #45419

**Special notes for your reviewer**:
NONE

**Release note**:

```kubelet: `--experimental-pleg-relist-threshold` can now be specified pleg-relist-threshold, Kubelet will reports PLEG error and be notReady if pleg relist take times greater than experimental-pleg-relist-threshold.

```
