### PR TITLE
kubectl scale: support Unstructured objects

### DIFF
--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -105,7 +105,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 	mapper, _ := f.Object()
 	r := f.NewBuilder().
-		Internal().
+		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
@@ -169,7 +169,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 				return err
 			}
 			mapping := info.ResourceMapping()
-			client, err := f.ClientForMapping(mapping)
+			client, err := f.UnstructuredClientForMapping(mapping)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Support `Unstructured` objects with kubectl scale.

So that we can use the scale subresource for custom resources (possible after https://github.com/kubernetes/kubernetes/pull/55168 is merged):

```
➜ cluster/kubectl.sh scale --replicas=5 crontabs/my-new-cron-object
crontab "my-new-cron-object" scaled
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts deads2k p0lyn0mial 
