### PR TITLE
Set DefaultHeapsterPort to a more sensible default

### DIFF
--- a/pkg/controller/podautoscaler/metrics/legacy_metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/legacy_metrics_client.go
@@ -39,7 +39,7 @@ const (
 	DefaultHeapsterNamespace = "kube-system"
 	DefaultHeapsterScheme    = "http"
 	DefaultHeapsterService   = "heapster"
-	DefaultHeapsterPort      = "" // use the first exposed port on the service
+	DefaultHeapsterPort      = "80"
 )
 
 var heapsterQueryStart = -5 * time.Minute

--- a/pkg/kubectl/cmd/top_node_test.go
+++ b/pkg/kubectl/cmd/top_node_test.go
@@ -79,7 +79,7 @@ func TestTopNodeAllMetrics(t *testing.T) {
 }
 
 func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
-	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
+	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:8082/proxy"
 	customBaseMetricsAddress := customBaseHeapsterServiceAddress + "/apis/metrics"
 
 	initTestErrorHandler(t)
@@ -116,6 +116,7 @@ func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
 			Namespace: "custom-namespace",
 			Scheme:    "https",
 			Service:   "custom-heapster-service",
+			Port:      "8082",
 		},
 	}
 	cmd := NewCmdTopNode(f, opts, buf)

--- a/pkg/kubectl/cmd/top_pod_test.go
+++ b/pkg/kubectl/cmd/top_pod_test.go
@@ -169,7 +169,7 @@ func TestTopPod(t *testing.T) {
 }
 
 func TestTopPodCustomDefaults(t *testing.T) {
-	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:/proxy"
+	customBaseHeapsterServiceAddress := "/api/v1/namespaces/custom-namespace/services/https:custom-heapster-service:8082/proxy"
 	customBaseMetricsAddress := customBaseHeapsterServiceAddress + "/apis/metrics"
 	customTopPathPrefix := customBaseMetricsAddress + "/" + metricsApiVersion
 
@@ -277,6 +277,7 @@ func TestTopPodCustomDefaults(t *testing.T) {
 				Namespace: "custom-namespace",
 				Scheme:    "https",
 				Service:   "custom-heapster-service",
+				Port:      "8082",
 			},
 		}
 		cmd := NewCmdTopPod(f, opts, buf)

--- a/pkg/kubectl/cmd/top_test.go
+++ b/pkg/kubectl/cmd/top_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	baseHeapsterServiceAddress = "/api/v1/namespaces/kube-system/services/http:heapster:/proxy"
+	baseHeapsterServiceAddress = "/api/v1/namespaces/kube-system/services/http:heapster:80/proxy"
 	baseMetricsAddress         = baseHeapsterServiceAddress + "/apis/metrics"
 	metricsApiVersion          = "v1alpha1"
 )

--- a/pkg/kubectl/metricsutil/metrics_client.go
+++ b/pkg/kubectl/metricsutil/metrics_client.go
@@ -33,7 +33,7 @@ const (
 	DefaultHeapsterNamespace = "kube-system"
 	DefaultHeapsterScheme    = "http"
 	DefaultHeapsterService   = "heapster"
-	DefaultHeapsterPort      = "" // use the first exposed port on the service
+	DefaultHeapsterPort      = "80"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Because it seems `kubectl top` is broken. The code comments (removed by PR) indicate that this should _"use the first exposed port on the service"_ but this does not seem to be the case.

Below is what I get when trying to use it on a node:

```console
$ kubectl top node ip-xx-xx-xxx-xxx.ec2.internal
Error from server (InternalError): an error on the server ("unknown") has prevented the request from succeeding (get services http:heapster:)

$ kubectl top node ip-xx-xx-xxx-xxx.ec2.internal --heapster-port=80
NAME                            CPU(cores)   CPU%      MEMORY(bytes)   MEMORY%
ip-xx-xx-xxx-xxx.ec2.internal   3105m        77%       21849Mi         71%
```

Below is what I get when trying to use it on a pod:

```console
$ kubectl top pod kubernetes-dashboard-344955092-cd9ln -n kube-system
W0115 15:03:09.478178   58206 top_pod.go:192] Metrics not available for pod kube-system/kubernetes-dashboard-344955092-cd9ln, age: 3h5m27.47814s
error: Metrics not available for pod kube-system/kubernetes-dashboard-344955092-cd9ln, age: 3h5m27.47814s

$ kubectl top pod kubernetes-dashboard-344955092-cd9ln -n kube-system --heapster-port=80
NAME                                   CPU(cores)   MEMORY(bytes)
kubernetes-dashboard-344955092-cd9ln   0m           24Mi
```

Poking around the API server logs i.e. every time the error happens ... I find a trace that looks like this.

```
I0115 11:12:55.338202       7 wrap.go:42] GET /api/v1/namespaces/kube-system/services/http:heapster:/proxy/apis/metrics/v1alpha1/nodes?labelSelector=: (1.624838ms) 503
goroutine 85287885 [running]:
[... TRACE HERE ...]
logging error output: "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"no endpoints available for service \\\"http:heapster:\\\"\",\"reason\":\"ServiceUnavailable\",\"code\":503}\n"
 [[kubectl/v1.9.1 (darwin/amd64) kubernetes/3a1c944] 10.83.6.153:28306]
```

Which led me to believe that the port was missing, notice the `http:heapster:`, and it does seem like the default is to use `DefaultHeapsterPort` which is [set to an empty string](https://github.com/kubernetes/kubernetes/blob/v1.9.1/pkg/kubectl/cmd/top_node.go#L62-L64). As you've seen, adding the port, fixes the issue.

**Which issue(s) this PR fixes**

This improves defaults so that `kubectl top` works out of the box. No more need to set the `--heapster-port` flag whenever you're using it (assuming one has Heapster running on port 80).

Might be related to these issues:

* k8s-org:
  * https://github.com/kubernetes/kubernetes/issues/54221
  * https://github.com/kubernetes/kubernetes/issues/44540
* non-k8s-org:
  * https://github.com/luxas/kubeadm-workshop/issues/22

**Special notes for your reviewer**:

Official heapster documentation/examples all use port 80 for heapster, so it seems to me to be a good default. See:

* [Example 1](https://github.com/kubernetes/heapster/blob/v1.5.0/deploy/kube-config/google/heapster.yaml#L54)
* [Example 2](https://github.com/kubernetes/heapster/blob/v1.5.0/deploy/kube-config/influxdb/heapster.yaml#L43)
* [Example 3](https://github.com/kubernetes/heapster/blob/v1.5.0/deploy/kube-config/standalone-test/heapster-service.yaml#L8) 
* [Example 4](https://github.com/kubernetes/heapster/blob/v1.5.0/deploy/kube-config/standalone-with-apiserver/heapster-service.yaml#L15)
* [Example 5](https://github.com/kubernetes/heapster/blob/v1.5.0/deploy/kube-config/standalone/heapster-controller.yaml#L42)

Even other non-heapsters-official (but still kubernetes-org) examples set it up on port 80:

* Kops
    * [k8s 1.6 Example](https://github.com/kubernetes/kops/blob/1.8.0/addons/monitoring-xstandalone/v1.6.0.yaml#L89)
    * [k8s 1.7 Example](https://github.com/kubernetes/kops/blob/1.8.0/addons/monitoring-standalone/v1.7.0.yaml#L90)

I also noticed that the legacy metrics client uses [picks up this value](https://github.com/kubernetes/kubernetes/blob/v1.9.1/cmd/kube-controller-manager/app/autoscaling.go).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
The `DefaultHeapsterPort` on the metrics client has been explicitly set to 80 which means that your heapster service should expose your heapster deployment on port 80.

```