### PR TITLE
fail earlier on discovery failures

### DIFF
--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -78,11 +78,13 @@ func NewObjectMappingFactory(clientAccessFactory ClientAccessFactory) ObjectMapp
 // the built in mapper if necessary. It supports unstructured objects either way, since
 // the underlying Scheme supports Unstructured. The mapper will return converters that can
 // convert versioned types to unstructured and back.
+// It can return an error and the best effort unstructured mapper and typer.
 func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, error) {
 	discoveryClient, err := f.clientAccessFactory.DiscoveryClient()
 	if err != nil {
-		glog.V(3).Infof("Unable to get a discovery client to find server resources, falling back to hardcoded types: %v", err)
-		return legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme, nil
+		unstructuredMapper := discovery.NewRESTMapper(nil, meta.InterfacesForUnstructured)
+		unstructuredTyper := discovery.NewUnstructuredObjectTyper(nil)
+		return unstructuredMapper, unstructuredTyper, err
 	}
 
 	groupResources, err := discovery.GetAPIGroupResources(discoveryClient)
@@ -90,9 +92,11 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 		discoveryClient.Invalidate()
 		groupResources, err = discovery.GetAPIGroupResources(discoveryClient)
 	}
+	// even if we can't get all the results, we're better off continuing with what we can than not presenting
+	// anything.  This mirrors old behavior that used to fallback to a hardcoded list of API types compiled
+	// into kubernetes.
 	if err != nil {
-		glog.V(3).Infof("Unable to retrieve API resources, falling back to hardcoded types: %v", err)
-		return legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme, nil
+		glog.V(1).Infof("Unable to retrieve all API resources, continuing with partial results: %v", err)
 	}
 
 	// allow conversion between typed and unstructured objects

--- a/test/integration/etcd/BUILD
+++ b/test/integration/etcd/BUILD
@@ -22,7 +22,6 @@ go_test(
         "//cmd/kube-apiserver/app/options:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/master:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
@@ -40,8 +39,6 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -44,14 +44,11 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/test/integration/framework"
 
 	// install all APIs
@@ -798,9 +795,7 @@ func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV
 		t.Fatal(err)
 	}
 
-	mapper, _ := util.NewFactory(clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})).Object()
-
-	return client, kvClient, mapper
+	return client, kvClient, legacyscheme.Registry.RESTMapper()
 }
 
 func dumpEtcdKVOnFailure(t *testing.T, kvClient clientv3.KV) {


### PR DESCRIPTION
When discovery fails, the object mapper and typer are incomplete.  This change reflects that and returns errors instead of nils.

@juanvallejo 