### PR TITLE
cache swagger-2.0 proto schema

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//pkg/version:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

The cached discovery client was not caching the open-api schema.
This caused a variety of kubectl commands to perform a live call to the
/swagger-2.0.0.pb-v1 endpoint every time they were invoked.

cc @smarterclayton @deads2k 