### PR TITLE
Limit all category to apps group for ds/deployment/replicaset

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1397,11 +1397,15 @@ run_kubectl_get_tests() {
   kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/pods 200 OK"
   kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/replicationcontrollers 200 OK"
   kube::test::if_has_string "${output_message}" "/api/v1/namespaces/default/services 200 OK"
+  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/daemonsets 200 OK"
+  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/deployments 200 OK"
+  kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/replicasets 200 OK"
   kube::test::if_has_string "${output_message}" "/apis/apps/v1/namespaces/default/statefulsets 200 OK"
   kube::test::if_has_string "${output_message}" "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers 200"
   kube::test::if_has_string "${output_message}" "/apis/batch/v1/namespaces/default/jobs 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/deployments 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/replicasets 200 OK"
+  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/daemonsets 200 OK"
+  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/deployments 200 OK"
+  kube::test::if_has_not_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/replicasets 200 OK"
 
   ### Test kubectl get chunk size
   output_message=$(kubectl --v=6 get clusterrole --chunk-size=10 2>&1 "${kube_flags[@]}")

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -33,6 +33,7 @@ import (
 // rest implements a RESTStorage for DaemonSets
 type REST struct {
 	*genericregistry.Store
+	categories []string
 }
 
 // NewREST returns a RESTStorage object that will work against DaemonSets.
@@ -56,7 +57,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	statusStore := *store
 	statusStore.UpdateStrategy = daemonset.StatusStrategy
 
-	return &REST{store}, &StatusREST{store: &statusStore}
+	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}
 }
 
 // Implement ShortNamesProvider
@@ -71,7 +72,12 @@ var _ rest.CategoriesProvider = &REST{}
 
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (r *REST) Categories() []string {
-	return []string{"all"}
+	return r.categories
+}
+
+func (r *REST) WithCategories(categories []string) *REST {
+	r.categories = categories
+	return r
 }
 
 // StatusREST implements the REST endpoint for changing the status of a daemonset

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -63,6 +63,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) DeploymentStorage {
 
 type REST struct {
 	*genericregistry.Store
+	categories []string
 }
 
 // NewREST returns a RESTStorage object that will work against deployments.
@@ -83,7 +84,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Rollbac
 
 	statusStore := *store
 	statusStore.UpdateStrategy = deployment.StatusStrategy
-	return &REST{store}, &StatusREST{store: &statusStore}, &RollbackREST{store: store}
+	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}, &RollbackREST{store: store}
 }
 
 // Implement ShortNamesProvider
@@ -99,7 +100,12 @@ var _ rest.CategoriesProvider = &REST{}
 
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (r *REST) Categories() []string {
-	return []string{"all"}
+	return r.categories
+}
+
+func (r *REST) WithCategories(categories []string) *REST {
+	r.categories = categories
+	return r
 }
 
 // StatusREST implements the REST endpoint for changing the status of a deployment

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -62,6 +62,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) ReplicaSetStorage {
 
 type REST struct {
 	*genericregistry.Store
+	categories []string
 }
 
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
@@ -86,7 +87,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	statusStore := *store
 	statusStore.UpdateStrategy = replicaset.StatusStrategy
 
-	return &REST{store}, &StatusREST{store: &statusStore}
+	return &REST{store, []string{"all"}}, &StatusREST{store: &statusStore}
 }
 
 // Implement ShortNamesProvider
@@ -102,7 +103,12 @@ var _ rest.CategoriesProvider = &REST{}
 
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (r *REST) Categories() []string {
-	return []string{"all"}
+	return r.categories
+}
+
+func (r *REST) WithCategories(categories []string) *REST {
+	r.categories = categories
+	return r
 }
 
 // StatusREST implements the REST endpoint for changing the status of a ReplicaSet

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -62,12 +62,12 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
 		daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
-		storage["daemonsets"] = daemonSetStorage
+		storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
 		storage["daemonsets/status"] = daemonSetStatusStorage
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
 		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-		storage["deployments"] = deploymentStorage.Deployment
+		storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
 		storage["deployments/status"] = deploymentStorage.Status
 		storage["deployments/rollback"] = deploymentStorage.Rollback
 		storage["deployments/scale"] = deploymentStorage.Scale
@@ -83,7 +83,7 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
 		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-		storage["replicasets"] = replicaSetStorage.ReplicaSet
+		storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
 		storage["replicasets/status"] = replicaSetStorage.Status
 		storage["replicasets/scale"] = replicaSetStorage.Scale
 	}


### PR DESCRIPTION
There's lots of confusion around the resources we are moving out of the extensions api group appearing twice when using the `kubectl get all` category. Fortunately, we control that category serverside. For resources that appear in multiple API groups (deployments, daemonsets, replicasets), this updates the server to only include the `apps` resources in the `all` category, so they only appear once when doing `kubectl get all`.

Fixes https://github.com/kubernetes/kubectl/issues/189
Fixes https://github.com/kubernetes/kubectl/issues/167
Fixes https://github.com/kubernetes/kubernetes/issues/55720
Fixes https://github.com/kubernetes/kubernetes/issues/57270
Fixes https://github.com/kubernetes/kubernetes/issues/57931

```release-note
NONE
```