### PR TITLE
Fix update-swagger-spec.sh to always cleanup etcd

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -74,12 +74,16 @@ kube::etcd::start() {
 }
 
 kube::etcd::stop() {
-  kill "${ETCD_PID-}" >/dev/null 2>&1 || :
-  wait "${ETCD_PID-}" >/dev/null 2>&1 || :
+  if [[ -n "${ETCD_PID-}" ]]; then
+    kill "${ETCD_PID}" &>/dev/null || :
+    wait "${ETCD_PID}" &>/dev/null || :
+  fi
 }
 
 kube::etcd::clean_etcd_dir() {
-  rm -rf "${ETCD_DIR-}"
+  if [[ -n "${ETCD_DIR-}" ]]; then
+    rm -rf "${ETCD_DIR}"
+  fi
 }
 
 kube::etcd::cleanup() {

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -37,14 +37,17 @@ make -C "${KUBE_ROOT}" WHAT=cmd/kube-apiserver
 
 function cleanup()
 {
-    [[ -n ${APISERVER_PID-} ]] && kill ${APISERVER_PID} 1>&2 2>/dev/null
+    if [[ -n "${APISERVER_PID-}" ]]; then
+      kill "${APISERVER_PID}" &>/dev/null || :
+      wait "${APISERVER_PID}" &>/dev/null || :
+    fi
 
     kube::etcd::cleanup
 
     kube::log::status "Clean up complete"
 }
 
-trap cleanup EXIT SIGINT
+kube::util::trap_add cleanup EXIT
 
 kube::golang::setup_env
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes `hack/update-swagger-spec.sh` so it always cleanup etcd and to noe leave orphaned process after its execution. This process also doesn't allow to run the script again as it detects existing etcd and won't start.

I also made a minor improvement by adding guard against an empty arguments.

**Release note**:
```release-note
NONE
```

CC @simo5 