### PR TITLE
sample-apiserver: add status subresource for Flunder

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -25,6 +25,7 @@ import (
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
+
 	"k8s.io/sample-apiserver/pkg/cmd/server"
 )
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
@@ -112,8 +112,10 @@ func (c completedConfig) New() (*WardleServer, error) {
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(wardle.GroupName, registry, Scheme, metav1.ParameterCodec, Codecs)
 	apiGroupInfo.GroupMeta.GroupVersion = v1alpha1.SchemeGroupVersion
+	flunderStorage := wardleregistry.RESTInPeace(flunderstorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter))
 	v1alpha1storage := map[string]rest.Storage{}
-	v1alpha1storage["flunders"] = wardleregistry.RESTInPeace(flunderstorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter))
+	v1alpha1storage["flunders"] = flunderStorage
+	v1alpha1storage["flunders/status"] = flunderstorage.NewStatusREST(Scheme, flunderStorage.(*wardleregistry.REST))
 	v1alpha1storage["fischers"] = wardleregistry.RESTInPeace(fischerstorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter))
 	apiGroupInfo.VersionedResourcesStorageMap["v1alpha1"] = v1alpha1storage
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+
 	"k8s.io/sample-apiserver/pkg/admission/plugin/banflunder"
 	"k8s.io/sample-apiserver/pkg/admission/wardleinitializer"
 	"k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
@@ -31,7 +31,7 @@ type REST struct {
 // RESTInPeace is just a simple function that panics on error.
 // Otherwise returns the given storage object. It is meant to be
 // a wrapper for wardle registries.
-func RESTInPeace(storage rest.StandardStorage, err error) rest.StandardStorage {
+func RESTInPeace(storage rest.Storage, err error) rest.Storage {
 	if err != nil {
 		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
 		panic(err)

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/etcd.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/etcd.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 	"k8s.io/sample-apiserver/pkg/registry"
 )

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 )
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     importpath = "k8s.io/sample-apiserver/pkg/registry/wardle/flunder",
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -20,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -19,15 +19,16 @@ package flunder
 import (
 	"fmt"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 )
 
@@ -63,31 +64,99 @@ type flunderStrategy struct {
 	names.NameGenerator
 }
 
+// NamespaceScoped returns true because all Flunders need to be within a namespace.
 func (flunderStrategy) NamespaceScoped() bool {
 	return true
 }
 
+// PrepareForCreate clears the status of a Flunder before creation.
 func (flunderStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
+	flunder := obj.(*wardle.Flunder)
+
+	// create cannot set status
+	flunder.Status = wardle.FlunderStatus{}
+	flunder.Generation = 1
 }
 
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (flunderStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
+	newFlunder := obj.(*wardle.Flunder)
+	oldFlunder := old.(*wardle.Flunder)
+
+	// Update is not allowed to set status
+	newFlunder.Status = oldFlunder.Status
+
+	// Any changes to the spec increment the generation number, any changes to the
+	// status should reflect the generation number of the corresponding object.
+	// See metav1.ObjectMeta description for more information on Generation.
+	if !apiequality.Semantic.DeepEqual(oldFlunder.Spec, newFlunder.Spec) {
+		newFlunder.Generation = oldFlunder.Generation + 1
+	}
 }
 
+// Validate validates a new Flunder.
 func (flunderStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	return field.ErrorList{}
 }
 
+// AllowCreateOnUpdate is false for Flunder; this means POST is needed to create one.
 func (flunderStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
+// AllowUnconditionalUpdate is the default update policy for Flunder objects.
 func (flunderStrategy) AllowUnconditionalUpdate() bool {
 	return false
 }
 
+// Canonicalize normalizes the object after validation.
 func (flunderStrategy) Canonicalize(obj runtime.Object) {
 }
 
+// ValidateUpdate is the default update validation for an end user.
 func (flunderStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
+	return field.ErrorList{}
+}
+
+type flunderStatusStrategy struct {
+	runtime.ObjectTyper
+	names.NameGenerator
+}
+
+func NewFlunderStatusStrategy(typer runtime.ObjectTyper) flunderStatusStrategy {
+	return flunderStatusStrategy{typer, names.SimpleNameGenerator}
+}
+
+func (flunderStatusStrategy) NamespaceScoped() bool {
+	return false
+}
+
+func (flunderStatusStrategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+func (flunderStatusStrategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+func (flunderStatusStrategy) Canonicalize(obj runtime.Object) {
+}
+
+// PrepareForUpdate clears fields that are not allowed to be set by end users on update of status.
+func (flunderStatusStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
+	newObj := obj.(*wardle.Flunder)
+	oldObj := old.(*wardle.Flunder)
+	newObj.Spec = oldObj.Spec
+
+	// Status updates are for only for updating status, not objectmeta.
+	newObj.Labels = oldObj.Labels
+	newObj.Annotations = oldObj.Annotations
+	newObj.OwnerReferences = oldObj.OwnerReferences
+	newObj.Generation = oldObj.Generation
+	newObj.SelfLink = oldObj.SelfLink
+}
+
+// ValidateUpdate is the default update validation for an end user updating status.
+func (flunderStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	return field.ErrorList{}
 }

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -454,7 +454,7 @@ func testAPIResourceList(t *testing.T, client rest.Interface) {
 		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.k8s.io/v1alpha1", err)
 	}
 	assert.Equal(t, groupVersion.String(), apiResourceList.GroupVersion)
-	assert.Equal(t, 2, len(apiResourceList.APIResources))
+	assert.Equal(t, 3, len(apiResourceList.APIResources))
 	assert.Equal(t, "fischers", apiResourceList.APIResources[0].Name)
 	assert.False(t, apiResourceList.APIResources[0].Namespaced)
 	assert.Equal(t, "flunders", apiResourceList.APIResources[1].Name)


### PR DESCRIPTION
Shows how to use the status subresource in the sample-apiserver.

Would be nice to include an example of a subresource.

Moreover, we also generate the `UpdateStatus` method (because of the prescence of `FlunderStatus`). We should either not generate it or support the status subresource.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts deads2k liggitt 
