### PR TITLE
Track run status explicitly rather than non-nil check on stopCh

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -171,9 +171,7 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-		run(stopCh)
+		run(wait.NeverStop)
 		panic("unreachable")
 	}
 


### PR DESCRIPTION
Fixes #57044

GC and quota controllers use a non-nil stop channel as a signal Run() has been called, so ensure that condition holds even when a nil stop channel is passed in

```release-note
NONE
```