### PR TITLE
Improve default error logging of HandleError

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -142,6 +142,11 @@
 			"Rev": "c0ef4539dfab4d21c8ef20ba2924f9fc6f186d35"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Comment": "v1.2.1",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/appc/spec/schema",
 			"Comment": "v0.8.9-17-gfc380db",
 			"Rev": "fc380db5fc13c6dd71a5b0bf2af0d182865d1b1d"

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -504,7 +504,6 @@ staging/src/k8s.io/apimachinery/pkg/util/net
 staging/src/k8s.io/apimachinery/pkg/util/proxy
 staging/src/k8s.io/apimachinery/pkg/util/rand
 staging/src/k8s.io/apimachinery/pkg/util/remotecommand
-staging/src/k8s.io/apimachinery/pkg/util/runtime
 staging/src/k8s.io/apimachinery/pkg/util/sets
 staging/src/k8s.io/apimachinery/pkg/util/sets/types
 staging/src/k8s.io/apimachinery/pkg/util/strategicpatch

--- a/staging/src/k8s.io/api/Godeps/Godeps.json
+++ b/staging/src/k8s.io/api/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
@@ -17,6 +21,10 @@
 		{
 			"ImportPath": "github.com/golang/glog",
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",
@@ -96,6 +104,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/clock",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -23,6 +23,10 @@
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/asaskevich/govalidator",
 			"Rev": "593d64559f7600f29581a3ee42177f5dbded27a9"
 		},

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/BUILD
@@ -10,13 +10,23 @@ go_test(
     name = "go_default_test",
     srcs = ["runtime_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/agext/levenshtein:go_default_library",
+        "//vendor/github.com/golang/groupcache/lru:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+    ],
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["runtime.go"],
     importpath = "k8s.io/apimachinery/pkg/util/runtime",
-    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+    deps = [
+        "//vendor/github.com/agext/levenshtein:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/golang/groupcache/lru:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -18,11 +18,19 @@ package runtime
 
 import (
 	"fmt"
+	"reflect"
+	"regexp"
 	"runtime"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/agext/levenshtein"
 	"github.com/golang/glog"
+	"github.com/golang/groupcache/lru"
+
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 var (
@@ -62,11 +70,10 @@ func HandleCrash(additionalHandlers ...func(interface{})) {
 
 // logPanic logs the caller tree when a panic occurs.
 func logPanic(r interface{}) {
-	callers := getCallers(r)
-	glog.Errorf("Observed a panic: %#v (%v)\n%v", r, r, callers)
+	glog.Errorf("Observed a panic: %#v (%v)\n%v", r, r, getCallers())
 }
 
-func getCallers(r interface{}) string {
+func getCallers() string {
 	callers := ""
 	for i := 0; true; i++ {
 		_, file, line, ok := runtime.Caller(i)
@@ -79,12 +86,34 @@ func getCallers(r interface{}) string {
 	return callers
 }
 
+// these constants determine the default behavior of dedupingErrorHandler
+const (
+	// cacheSize determines how many "unique" errors to track (see errKey and dedupingErrorHandler.getVal below)
+	cacheSize = 1000
+	// errorDepth determines how many callers need to be skipped to find the stack of HandleError's caller
+	// HandleError -> ErrorHandlers iteration -> dedupingErrorHandler.handleErr -> dedupingErrorHandler.getStackHandler -> dedupingErrorHandler.getStack
+	errorDepth = 5
+	// delta determines how long we can go in between logging the same error that we have seen multiple times
+	// it mainly exists to handle the extreme ends of the error spectrum:
+	// 1. a component that sends the same error very infrequently (we want to log these so we do not miss them)
+	// 2. a component that sends the same error as fast as it can (we want to suppress most of these, but still see it every so often)
+	delta = 5 * time.Minute
+	// similar determines if two strings are close enough to be considered equal via levenshtein ratio
+	// TODO: set this to something like 0.75 to actually have fuzzy matching
+	// once we are comfortable with using this throughout the system
+	similar = 1
+)
+
+// DedupingErrorHandler is exported to allow external callers to override dedupingErrorHandler.Similar
+// TODO remove this global var once we have a useful default value for similar
+var DedupingErrorHandler = newDedupingErrorHandler(cacheSize, errorDepth, delta, similar)
+
 // ErrorHandlers is a list of functions which will be invoked when an unreturnable
 // error occurs.
 // TODO(lavalamp): for testability, this and the below HandleError function
 // should be packaged up into a testable and reusable object.
 var ErrorHandlers = []func(error){
-	logError,
+	DedupingErrorHandler.handleErr,
 	(&rudimentaryErrorBackoff{
 		lastErrorTime: time.Now(),
 		// 1ms was the number folks were able to stomach as a global rate limit.
@@ -94,7 +123,7 @@ var ErrorHandlers = []func(error){
 	}).OnError,
 }
 
-// HandlerError is a method to invoke when a non-user facing piece of code cannot
+// HandleError is a method to invoke when a non-user facing piece of code cannot
 // return an error and needs to indicate it has been ignored. Invoking this method
 // is preferable to logging the error - the default behavior is to log but the
 // errors may be sent to a remote server for analysis.
@@ -152,7 +181,7 @@ func GetCaller() string {
 // handlers to handle errors and panics the same way.
 func RecoverFromPanic(err *error) {
 	if r := recover(); r != nil {
-		callers := getCallers(r)
+		callers := getCallers()
 
 		*err = fmt.Errorf(
 			"recovered from panic %q. (err=%v) Call stack:\n%v",
@@ -160,4 +189,214 @@ func RecoverFromPanic(err *error) {
 			*err,
 			callers)
 	}
+}
+
+func newDedupingErrorHandler(cacheSize, errorDepth int, delta time.Duration, similar float64) *dedupingErrorHandler {
+	d := &dedupingErrorHandler{
+		cache: lru.New(cacheSize),
+		count: make(map[errKey]errVal),
+
+		errorDepth: errorDepth,
+		delta:      delta,
+		Similar:    similar,
+		clock:      clock.RealClock{},
+	}
+
+	d.cache.OnEvicted = func(key lru.Key, _ interface{}) {
+		// remove the associated entry in the count map when this key is evicted from the LRU cache
+		// d.cache.Add is only invoked when the mutex is held, so this delete is not a data race
+		delete(d.count, key.(errKey))
+	}
+	d.logErrorHandler = d.logError
+	d.getStackHandler = d.getStack
+
+	return d
+}
+
+// dedupingErrorHandler provides a go routine safe error handler via handleErr.
+// It tracks errors via the caller stack, the error type and the error message (err.Error() value).
+// An error is considered unique based on these properties (see errKey), with one exception:
+// errors with the same stack and type are considered equal if their message is similar enough (see getVal).
+// To prevent from using an infinite amount of memory, it uses a LRU cache to purge old error values.
+// The cache and count map are separated to allow easy access to all keys, which is required for fuzzy matching.
+type dedupingErrorHandler struct {
+	mutex sync.Mutex
+
+	// cache tracks (stack + type + message) and cleans up old entries in count as they roll off the cache
+	cache *lru.Cache
+	// count tracks (stack + type + message) -> (count + logged)
+	// since rudimentaryErrorBackoff rate limits HandleError to 1000 errors/second,
+	// this counter will effectively never overflow (nothing bad happens even if it does)
+	count map[errKey]errVal
+
+	// errorDepth is how many frames to skip from handleErr
+	errorDepth int
+
+	// delta is the minimum difference between the current time and
+	// errVal.logged required for us to log the associated error again
+	delta time.Duration
+
+	// Similar is the levenshtein ratio used to determine equivalence
+	// TODO unexport this field once we change the default value from 1
+	Similar float64
+
+	// clock allows us to control time in unit tests
+	clock clock.Clock
+
+	// logErrorHandler allows us to check err and count in unit tests
+	logErrorHandler func(err error, count uint64)
+
+	// getStackHandler allows us to control the perceived stack in unit tests
+	getStackHandler func() (stack string)
+}
+
+// errKey tracks uniqueness based on the caller's stack and the type/message of the error
+// it is stored in both the count map and the LRU cache
+// it is removed from the count map when it gets evicted from the LRU cache
+// it is comparable via ==
+type errKey struct {
+	stack   string
+	errType reflect.Type
+	// message is the err.Error() value
+	message string
+}
+
+// errVal tracks how many times we have seen an error, and the last time we logged it
+type errVal struct {
+	count  uint64
+	logged time.Time
+}
+
+// handleErr logs the given error if it is considered new or "not recently logged"
+// currently it logs errors whenever:
+// 1. the associated errKey does not exist in d.count (see d.getVal for specifics on how this is calculated)
+// 2. the associated counter is a power of two
+// 3. the associated logged time's delta from the current time is greater than d.delta
+func (d *dedupingErrorHandler) handleErr(err error) {
+	// the operations below that do not acquire the lock do not mutate d
+
+	// we must determine our stack in this function since getStack counts frames
+	stack := d.getStackHandler()
+	key := errKey{stack: stack, errType: reflect.TypeOf(err), message: err.Error()}
+
+	// operations after this point can mutate d
+	// we must acquire the lock before calling getVal since we cannot
+	// have concurrent reads and writes against d.count
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	// increment our counter
+	val, isNewErr := d.getVal(&key)
+	val.count++
+
+	if isNewErr {
+		// we did not find the error, so add
+		// the associated entry in the LRU cache
+		d.cache.Add(key, nil)
+	} else {
+		// we found this error, so tell the cache that we saw it
+		// cache.Get should always return nil, true
+		d.cache.Get(key)
+	}
+
+	// determine if we need to log this time
+	if isNewErr || isPowerOfTwo(val.count) || d.clock.Since(val.logged) >= d.delta {
+		val.logged = d.clock.Now()
+		d.logErrorHandler(err, val.count)
+	}
+
+	// update the counter in the map after we determine if we need to log it
+	d.count[key] = val
+}
+
+// getVal returns the errVal associated with key, and if the key represents a new error.
+// If the exact key does not exist in d.count, a similar enough fuzzy match on key.message
+// will be used as a fallback (the stack and error type must always match via ==).
+// If fuzzy matching is used, the given key's message will be updated to the similar message.
+// Thus this method requires that key be passed in as a pointer.
+func (d *dedupingErrorHandler) getVal(key *errKey) (errVal, bool) {
+	val, isOldErr := d.count[*key]
+	// found direct match, use that before doing levenshtein fuzzy lookup
+	if isOldErr {
+		return val, false // return false because this is not a new error
+	}
+
+	// Do not bother doing fuzzy checks if the direct match failed and we are set to require identical strings
+	// TODO remove this once we have a useful default value for similar
+	if d.Similar >= 1 {
+		return errVal{}, true // return true because this is a new error
+	}
+
+	var (
+		// fuzzySimilarity is initialized to d.similar since that is the
+		// lowest similarity value we consider as the strings being "equal"
+		fuzzySimilarity = d.Similar
+		fuzzyFound      bool
+		fuzzyMessage    string
+		fuzzyVal        errVal
+	)
+
+	// we have to iterate over the whole map to do fuzzy matching on errKey.message
+	// this is ok because d.count should always be relatively small
+	// note that we cannot exit this loop early since we want to pick the most similar message
+	for k, v := range d.count {
+		// the stack and error type must match
+		if key.stack == k.stack && key.errType == k.errType {
+			// now we perform fuzzy matching on the message
+			if s := levenshtein.Similarity(key.message, k.message, nil); s > fuzzySimilarity {
+				fuzzySimilarity = s
+				fuzzyFound = true
+				fuzzyMessage = k.message
+				fuzzyVal = v
+			}
+		}
+	}
+
+	if fuzzyFound {
+		// update the input key's message to match our fuzzy search
+		key.message = fuzzyMessage
+		return fuzzyVal, false // return false because we do not consider this a new error
+	}
+
+	return errVal{}, true // return true because this is a new error
+}
+
+// logError uses glog to log at the call site of HandleError
+// it must be called from dedupingErrorHandler.handleErr
+func (d *dedupingErrorHandler) logError(err error, count uint64) {
+	// get the full name of the file since glog likes to strip it
+	// TODO if we are ok with multi line messages, we could simply print the whole stack
+	_, file, line, ok := runtime.Caller(d.errorDepth)
+	if !ok {
+		file = "unknown_file"
+		line = -1
+	}
+	glog.ErrorDepth(d.errorDepth, fmt.Sprintf("%s:%d err=%v count=%d value=%#v", file, line, err, count, err))
+}
+
+var (
+	hexNumberRE  = regexp.MustCompile(`0x[0-9a-f]+`)
+	emptyAddress = []byte("0x?")
+)
+
+// getStack returns the important part of the stack trace
+// it must be called from dedupingErrorHandler.handleErr
+// it must not mutate d (or even read d.cache/d.count) since it is called when the lock is not held
+func (d *dedupingErrorHandler) getStack() string {
+	// remove all hex addresses from the stack dump because closures can have volatile values
+	stack := string(hexNumberRE.ReplaceAll(debug.Stack(), emptyAddress))
+	// strip the redundant stuff at the top of the stack
+	// add 1 to error depth for debug.Stack (since it calls runtime.Stack), times the sum by 2 since each frame has 2 lines
+	// add 1 for go routine number header
+	strip := (d.errorDepth+1)*2 + 1
+	stackLines := strings.Split(stack, "\n")
+	// do not panic trying to strip a stack trace that does not meet our expectations
+	if strip >= len(stackLines) {
+		return stack
+	}
+	return strings.Join(stackLines[strip:], "\n")
+}
+
+func isPowerOfTwo(n uint64) bool {
+	return (n & (n - 1)) == 0
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime_test.go
@@ -18,7 +18,16 @@ package runtime
 
 import (
 	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/agext/levenshtein"
+	"github.com/golang/groupcache/lru"
+
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 func TestHandleCrash(t *testing.T) {
@@ -69,3 +78,676 @@ func TestCustomHandleError(t *testing.T) {
 		t.Errorf("did not receive custom handler")
 	}
 }
+
+func TestGlobalDedupingErrorHandlerChangeSimilar(t *testing.T) {
+	oldCount := DedupingErrorHandler.count
+	oldCache := DedupingErrorHandler.cache
+	oldSimilar := DedupingErrorHandler.Similar
+	defer func() {
+		DedupingErrorHandler.count = oldCount
+		DedupingErrorHandler.cache = oldCache
+		DedupingErrorHandler.Similar = oldSimilar
+	}()
+
+	// temporarily reset any global state
+	resetGlobalDedupingErrorHandler()
+
+	errs := []error{
+		fmt.Errorf("test1"),
+		fmt.Errorf("test2"),
+		fmt.Errorf("test3"),
+	}
+
+	// with the default similar of 1, these are all considered different errors
+	// we must do this in a for loop otherwise the errors will have a different stack
+	for _, err := range errs {
+		HandleError(err)
+	}
+
+	checkGlobalDedupingErrorHandlerCount(t, 3, 1)
+
+	// reset again so we can see the effects of changing similar
+	resetGlobalDedupingErrorHandler()
+
+	// enable fuzzy matching
+	DedupingErrorHandler.Similar = 0.75
+
+	// now these should all be considered the same error
+	for _, err := range errs {
+		HandleError(err)
+	}
+
+	checkGlobalDedupingErrorHandlerCount(t, 1, 3)
+}
+
+func TestGlobalDedupingErrorHandlerGoroutineSafe(t *testing.T) {
+	oldCount := DedupingErrorHandler.count
+	oldCache := DedupingErrorHandler.cache
+	oldSimilar := DedupingErrorHandler.Similar
+	defer func() {
+		DedupingErrorHandler.count = oldCount
+		DedupingErrorHandler.cache = oldCache
+		DedupingErrorHandler.Similar = oldSimilar
+	}()
+
+	// temporarily reset any global state
+	resetGlobalDedupingErrorHandler()
+
+	// use untyped ints to make comparisons easier
+	const (
+		uniqueErrs   = 50
+		errFrequency = 70
+	)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < errFrequency; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < uniqueErrs; j++ {
+				HandleError(fmt.Errorf("testwithenoughsamedata%d", j))
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	checkGlobalDedupingErrorHandlerCount(t, uniqueErrs, errFrequency)
+
+	// reset again so we can see the effects of changing similar
+	resetGlobalDedupingErrorHandler()
+
+	// enable fuzzy matching
+	DedupingErrorHandler.Similar = 0.75
+
+	// now these should all be considered the same error
+	wg2 := sync.WaitGroup{}
+	for i := 0; i < errFrequency; i++ {
+		wg2.Add(1)
+		go func() {
+			for j := 0; j < uniqueErrs; j++ {
+				HandleError(fmt.Errorf("testwithenoughsamedata%d", j))
+			}
+			wg2.Done()
+		}()
+	}
+	wg2.Wait()
+
+	checkGlobalDedupingErrorHandlerCount(t, 1, uniqueErrs*errFrequency)
+}
+
+func checkGlobalDedupingErrorHandlerCount(t *testing.T, unique int, frequency uint64) {
+	t.Helper()
+
+	if length := len(DedupingErrorHandler.count); length != unique {
+		t.Errorf("expected length %d got %d", unique, length)
+	}
+
+	for key, val := range DedupingErrorHandler.count {
+		if val.count != frequency {
+			t.Errorf("expected count of %d for key=%#v val=%#v", frequency, key, val)
+		}
+	}
+}
+
+func resetGlobalDedupingErrorHandler() {
+	DedupingErrorHandler.count = make(map[errKey]errVal)
+	DedupingErrorHandler.cache = lru.New(cacheSize)
+	DedupingErrorHandler.cache.OnEvicted = func(key lru.Key, _ interface{}) {
+		delete(DedupingErrorHandler.count, key.(errKey))
+	}
+}
+
+func BenchmarkGlobalDedupingErrorHandlerDirectMatch(b *testing.B) {
+	oldCount := DedupingErrorHandler.count
+	oldCache := DedupingErrorHandler.cache
+	oldSimilar := DedupingErrorHandler.Similar
+	defer func() {
+		DedupingErrorHandler.count = oldCount
+		DedupingErrorHandler.cache = oldCache
+		DedupingErrorHandler.Similar = oldSimilar
+	}()
+
+	// temporarily reset any global state
+	resetGlobalDedupingErrorHandler()
+
+	// only the iterations with the same i should be considered the same error
+	for i := 0; i < b.N; i++ {
+		HandleError(fmt.Errorf("testwithenoughsamedata%d", i))
+	}
+}
+
+func BenchmarkGlobalDedupingErrorHandlerFuzzyMatch(b *testing.B) {
+	oldCount := DedupingErrorHandler.count
+	oldCache := DedupingErrorHandler.cache
+	oldSimilar := DedupingErrorHandler.Similar
+	defer func() {
+		DedupingErrorHandler.count = oldCount
+		DedupingErrorHandler.cache = oldCache
+		DedupingErrorHandler.Similar = oldSimilar
+	}()
+
+	// temporarily reset any global state
+	resetGlobalDedupingErrorHandler()
+
+	// enable fuzzy matching
+	DedupingErrorHandler.Similar = 0.75
+
+	// now these should all be considered the same error
+	for i := 0; i < b.N; i++ {
+		HandleError(fmt.Errorf("testwithenoughsamedata%d", i))
+	}
+}
+
+var testRudimentaryErrorBackoff = &rudimentaryErrorBackoff{
+	lastErrorTime: time.Now(),
+	minPeriod:     time.Millisecond,
+}
+
+func BenchmarkGlobalDedupingErrorHandlerBaseline(b *testing.B) {
+	// this lets us determine the overhead of dedupingErrorHandler
+	for i := 0; i < b.N; i++ {
+		testRudimentaryErrorBackoff.OnError(fmt.Errorf("testwithenoughsamedata%d", i))
+	}
+}
+
+type stringErr string
+
+func (s stringErr) Error() string {
+	return string(s)
+}
+
+type logErrTracker struct {
+	called int
+}
+
+func (l *logErrTracker) logErr(err error, count uint64) {
+	l.called++
+}
+
+type dedupingErrorHandlerTestRunner struct {
+	t       *testing.T
+	handler *dedupingErrorHandler
+	tracker *logErrTracker
+}
+
+func (tr *dedupingErrorHandlerTestRunner) checkState(expectedCount map[error]int, expectedCache int, expectedLog int) {
+	tr.t.Helper()
+
+	tr.checkCount(expectedCount)
+	tr.checkCache(expectedCache)
+	tr.checkLog(expectedLog)
+}
+
+func (tr *dedupingErrorHandlerTestRunner) checkCount(expected map[error]int) {
+	tr.t.Helper()
+
+	if len(tr.handler.count) != len(expected) {
+		tr.t.Errorf("count: length mismatch %#v %#v", tr.handler.count, expected)
+	}
+
+	for err, count := range expected {
+		key := errKey{
+			stack:   "",
+			errType: reflect.TypeOf(err),
+			message: err.Error(),
+		}
+		val, ok := tr.handler.count[key]
+		if !ok {
+			tr.t.Errorf("count: missing key %#v in %#v", err, tr.handler.count)
+			continue
+		}
+		if val.count != uint64(count) {
+			tr.t.Errorf("count: key %#v expected count %d got %d", err, count, val.count)
+		}
+	}
+}
+
+func (tr *dedupingErrorHandlerTestRunner) compareCount(expected map[errKey]errVal) {
+	tr.t.Helper()
+
+	if !reflect.DeepEqual(expected, tr.handler.count) {
+		tr.t.Errorf("compareCount: expected count %#v != actual count %#v", expected, tr.handler.count)
+	}
+}
+
+func (tr *dedupingErrorHandlerTestRunner) checkCache(expected int) {
+	tr.t.Helper()
+
+	// TODO is it possible to do any check other than Len against the cache that does not mutate it?
+	if actual := tr.handler.cache.Len(); actual != expected {
+		tr.t.Errorf("cache: expected length %d got %d", expected, actual)
+	}
+}
+
+func (tr *dedupingErrorHandlerTestRunner) checkLog(called int) {
+	tr.t.Helper()
+
+	if tr.tracker.called != called {
+		tr.t.Errorf("log: expected %d got %d", called, tr.tracker.called)
+	}
+}
+
+func TestDedupingErrorHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		check func(r *dedupingErrorHandlerTestRunner)
+	}{
+		{
+			name: "simple unique errors",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				err1 := fmt.Errorf("1")
+				err2 := fmt.Errorf("2")
+				err3 := fmt.Errorf("3")
+
+				r.handler.handleErr(err1)
+				r.handler.handleErr(err2)
+				r.handler.handleErr(err3)
+
+				r.checkState(
+					map[error]int{
+						err1: 1,
+						err2: 1,
+						err3: 1,
+					},
+					3,
+					3,
+				)
+			},
+		},
+		{
+			name: "same error string but different types",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				err1 := fmt.Errorf("1")
+				err2 := stringErr("1")
+
+				r.handler.handleErr(err1)
+				r.handler.handleErr(err2)
+
+				r.checkState(
+					map[error]int{
+						err1: 1,
+						err2: 1,
+					},
+					2,
+					2,
+				)
+			},
+		},
+		{
+			name: "lru cache rollover to prevent infinite memory use",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				r.handler.cache.MaxEntries = 3
+
+				err1 := fmt.Errorf("1")
+				err2 := fmt.Errorf("2")
+				err3 := fmt.Errorf("3")
+				err4 := fmt.Errorf("4")
+
+				r.handler.handleErr(err1)
+				r.handler.handleErr(err2)
+				r.handler.handleErr(err3)
+				r.handler.handleErr(err4)
+
+				r.checkState(
+					map[error]int{
+						err2: 1,
+						err3: 1,
+						err4: 1,
+					},
+					3,
+					4,
+				)
+			},
+		},
+		{
+			name: "same error with different stack is not considered equal",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				// return a predictable stack string each time
+				stacks := []string{"1", "2", "1", "1", "2", "1", "1"}
+				idx := -1
+				r.handler.getStackHandler = func() (stack string) {
+					idx++
+					return stacks[idx]
+				}
+
+				err := fmt.Errorf("1")
+				errType := reflect.TypeOf(err)
+				errMsg := err.Error()
+
+				// same error but possibly different stack each time
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 1},
+					},
+				)
+				r.checkCache(1)
+				r.checkLog(1)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 1},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 1},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(2)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 2},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 1},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(3)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 3},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 1},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(3)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 3},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 2},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(4)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 4},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 2},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(5)
+
+				r.handler.handleErr(err)
+				r.compareCount(
+					map[errKey]errVal{
+						{
+							stack:   stacks[0],
+							errType: errType,
+							message: errMsg,
+						}: {count: 5},
+						{
+							stack:   stacks[1],
+							errType: errType,
+							message: errMsg,
+						}: {count: 2},
+					},
+				)
+				r.checkCache(2)
+				r.checkLog(5)
+
+				if expectedIndex := len(stacks) - 1; expectedIndex != idx {
+					r.t.Errorf("did not use all stack test data %d %d", expectedIndex, idx)
+				}
+			},
+		},
+		{
+			name: "time based logging",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				err1 := fmt.Errorf("1")
+
+				// new error logs and increments counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 1,
+					},
+					1,
+					1,
+				)
+
+				// no time has passed but this is a power of 2 so we should log and increment counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 2,
+					},
+					1,
+					2,
+				)
+
+				// no time has passed and this is not a power of 2 so should not log, only increment counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 3,
+					},
+					1,
+					2,
+				)
+
+				// no time has passed but this is a power of 2 so we should log and increment counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 4,
+					},
+					1,
+					3,
+				)
+
+				// no time has passed and this is not a power of 2 so should not log, only increment counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 5,
+					},
+					1,
+					3,
+				)
+
+				// make some time pass
+				r.handler.clock.Sleep(r.handler.delta)
+
+				// time has passed so we should log and increment counters
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 6,
+					},
+					1,
+					4,
+				)
+			},
+		},
+		{
+			name: "similarity based deduplication",
+			check: func(r *dedupingErrorHandlerTestRunner) {
+				r.handler.Similar = 0.75
+
+				err1 := fmt.Errorf("testwithenoughsamedata1")
+				err2 := stringErr("testwithenoughsamedata1")
+				err3 := fmt.Errorf("testwithenoughsamedata2")
+				err4 := fmt.Errorf("testwithenoughsamedata3")
+
+				// new err
+				r.handler.handleErr(err1)
+				r.checkState(
+					map[error]int{
+						err1: 1,
+					},
+					1,
+					1,
+				)
+
+				// should not be the same as err1
+				r.handler.handleErr(err2)
+				r.checkState(
+					map[error]int{
+						err1: 1,
+						err2: 1,
+					},
+					2,
+					2,
+				)
+
+				// should be the same as err1, log due to power of 2
+				r.handler.handleErr(err3)
+				r.checkState(
+					map[error]int{
+						err1: 2,
+						err2: 1,
+					},
+					2,
+					3,
+				)
+
+				// should be the same as err1, do not log
+				r.handler.handleErr(err4)
+				r.checkState(
+					map[error]int{
+						err1: 3,
+						err2: 1,
+					},
+					2,
+					3,
+				)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// setup a test version of dedupingErrorHandler
+			d := newDedupingErrorHandler(10, 0, delta, 1)
+			d.clock = clock.NewFakeClock(time.Time{})
+			l := &logErrTracker{}
+			d.logErrorHandler = l.logErr
+			d.getStackHandler = func() (stack string) { return "" } // make all errors have the same stack
+			r := &dedupingErrorHandlerTestRunner{t: t, handler: d, tracker: l}
+
+			// run the test and check results
+			tc.check(r)
+		})
+	}
+}
+
+func TestDedupingErrorHandlerGetStack(t *testing.T) {
+	oldGetStackHandler := DedupingErrorHandler.getStackHandler
+	defer func() {
+		DedupingErrorHandler.getStackHandler = oldGetStackHandler
+	}()
+	var lastStack string
+	DedupingErrorHandler.getStackHandler = func() (stack string) {
+		// do not use oldGetStackHandler here because our getStackHandler adds another frame
+		lastStack = DedupingErrorHandler.getStack()
+		return lastStack
+	}
+
+	// pretend we have a really deep call stack
+	func() {
+		func() {
+			func() {
+				func() {
+					func() {
+						func() {
+							HandleError(fmt.Errorf("some error"))
+						}()
+					}()
+				}()
+			}()
+		}()
+	}()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot get filename")
+	}
+	expectedStack := fmt.Sprintf(
+		expectedStackBase,
+		filename,
+		filename,
+		filename,
+		filename,
+		filename,
+		filename,
+		filename,
+		runtime.GOROOT(),
+		runtime.GOROOT(),
+	)
+
+	// We use levenshtein fuzzy matching to prevent this stack trace from
+	// causing test failure when the stacks are only slightly different
+	if levenshtein.Similarity(expectedStack, lastStack, nil) < 0.95 {
+		t.Errorf("stack does not match: %s != %s", expectedStack, lastStack)
+	}
+}
+
+const expectedStackBase = `k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3.1.1.1.1.1()
+	%s:703 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3.1.1.1.1()
+	%s:704 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3.1.1.1()
+	%s:705 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3.1.1()
+	%s:706 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3.1()
+	%s:707 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack.func3()
+	%s:708 +0x?
+k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.TestDedupingErrorHandlerGetStack(0x?)
+	%s:709 +0x?
+testing.tRunner(0x?, 0x?)
+	%s/src/testing/testing.go:746 +0x?
+created by testing.(*T).Run
+	%s/src/testing/testing.go:789 +0x?
+`

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -23,6 +23,10 @@
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
 			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
 		},

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -31,6 +31,10 @@
 			"Rev": "d4e6b95c12a08b4de2d48b45d5b4d594e5d32fab"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
 		},

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -23,6 +23,10 @@
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
 			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
 		},
@@ -145,6 +149,10 @@
 		{
 			"ImportPath": "github.com/golang/glog",
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 		},
 		{
 			"ImportPath": "github.com/golang/protobuf/proto",

--- a/staging/src/k8s.io/metrics/Godeps/Godeps.json
+++ b/staging/src/k8s.io/metrics/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/ghodss/yaml",
 			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 		},
@@ -21,6 +25,10 @@
 		{
 			"ImportPath": "github.com/golang/glog",
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 		},
 		{
 			"ImportPath": "github.com/golang/protobuf/proto",

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -23,6 +23,10 @@
 			"Rev": "5bd2802263f21d8788851d5305584c82a5c75d7e"
 		},
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/beorn7/perks/quantile",
 			"Rev": "3ac7bf7a47d159a033b107610db8a1b6575507a4"
 		},
@@ -137,6 +141,10 @@
 		{
 			"ImportPath": "github.com/golang/glog",
 			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
+		},
+		{
+			"ImportPath": "github.com/golang/groupcache/lru",
+			"Rev": "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 		},
 		{
 			"ImportPath": "github.com/golang/protobuf/proto",

--- a/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -7,6 +7,10 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/agext/levenshtein",
+			"Rev": "5f10fee965225ac1eecdc234c09daf5cd9e7f7b6"
+		},
+		{
 			"ImportPath": "github.com/davecgh/go-spew/spew",
 			"Rev": "782f4967f2dc4564575ca782fe2d04090b5faca8"
 		},

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -31,6 +31,7 @@ filegroup(
         "//vendor/github.com/PuerkitoBio/purell:all-srcs",
         "//vendor/github.com/PuerkitoBio/urlesc:all-srcs",
         "//vendor/github.com/abbot/go-http-auth:all-srcs",
+        "//vendor/github.com/agext/levenshtein:all-srcs",
         "//vendor/github.com/appc/spec/schema:all-srcs",
         "//vendor/github.com/armon/circbuf:all-srcs",
         "//vendor/github.com/asaskevich/govalidator:all-srcs",

--- a/vendor/github.com/agext/levenshtein/.gitignore
+++ b/vendor/github.com/agext/levenshtein/.gitignore
@@ -1,0 +1,2 @@
+README.html
+coverage.out

--- a/vendor/github.com/agext/levenshtein/.travis.yml
+++ b/vendor/github.com/agext/levenshtein/.travis.yml
@@ -1,0 +1,70 @@
+language: go
+sudo: false
+go:
+  - 1.8
+  - 1.7.5
+  - 1.7.4
+  - 1.7.3
+  - 1.7.2
+  - 1.7.1
+  - 1.7
+  - tip
+  - 1.6.4
+  - 1.6.3
+  - 1.6.2
+  - 1.6.1
+  - 1.6
+  - 1.5.4
+  - 1.5.3
+  - 1.5.2
+  - 1.5.1
+  - 1.5
+  - 1.4.3
+  - 1.4.2
+  - 1.4.1
+  - 1.4
+  - 1.3.3
+  - 1.3.2
+  - 1.3.1
+  - 1.3
+  - 1.2.2
+  - 1.2.1
+  - 1.2
+  - 1.1.2
+  - 1.1.1
+  - 1.1
+before_install:
+  - go get github.com/mattn/goveralls
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci
+notifications:
+  email:
+    on_success: never
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+    - go: 1.6.4
+    - go: 1.6.3
+    - go: 1.6.2
+    - go: 1.6.1
+    - go: 1.6
+    - go: 1.5.4
+    - go: 1.5.3
+    - go: 1.5.2
+    - go: 1.5.1
+    - go: 1.5
+    - go: 1.4.3
+    - go: 1.4.2
+    - go: 1.4.1
+    - go: 1.4
+    - go: 1.3.3
+    - go: 1.3.2
+    - go: 1.3.1
+    - go: 1.3
+    - go: 1.2.2
+    - go: 1.2.1
+    - go: 1.2
+    - go: 1.1.2
+    - go: 1.1.1
+    - go: 1.1

--- a/vendor/github.com/agext/levenshtein/BUILD
+++ b/vendor/github.com/agext/levenshtein/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "levenshtein.go",
+        "params.go",
+    ],
+    importpath = "github.com/agext/levenshtein",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/agext/levenshtein/DCO
+++ b/vendor/github.com/agext/levenshtein/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/vendor/github.com/agext/levenshtein/LICENSE
+++ b/vendor/github.com/agext/levenshtein/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/agext/levenshtein/MAINTAINERS
+++ b/vendor/github.com/agext/levenshtein/MAINTAINERS
@@ -1,0 +1,1 @@
+Alex Bucataru <alex@alrux.com> (@AlexBucataru)

--- a/vendor/github.com/agext/levenshtein/NOTICE
+++ b/vendor/github.com/agext/levenshtein/NOTICE
@@ -1,0 +1,5 @@
+Alrux Go EXTensions (AGExt) - package levenshtein
+Copyright 2016 ALRUX Inc.
+
+This product includes software developed at ALRUX Inc.
+(http://www.alrux.com/).

--- a/vendor/github.com/agext/levenshtein/README.md
+++ b/vendor/github.com/agext/levenshtein/README.md
@@ -1,0 +1,38 @@
+# A Go package for calculating the Levenshtein distance between two strings
+
+[![Release](https://img.shields.io/github/release/agext/levenshtein.svg?style=flat)](https://github.com/agext/levenshtein/releases/latest)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/agext/levenshtein) 
+[![Build Status](https://travis-ci.org/agext/levenshtein.svg?branch=master&style=flat)](https://travis-ci.org/agext/levenshtein)
+[![Coverage Status](https://coveralls.io/repos/github/agext/levenshtein/badge.svg?style=flat)](https://coveralls.io/github/agext/levenshtein)
+[![Go Report Card](https://goreportcard.com/badge/github.com/agext/levenshtein?style=flat)](https://goreportcard.com/report/github.com/agext/levenshtein)
+
+
+This package implements distance and similarity metrics for strings, based on the Levenshtein measure, in [Go](http://golang.org).
+
+## Project Status
+
+v1.2.1 Stable: Guaranteed no breaking changes to the API in future v1.x releases. Probably safe to use in production, though provided on "AS IS" basis.
+
+This package is being actively maintained. If you encounter any problems or have any suggestions for improvement, please [open an issue](https://github.com/agext/levenshtein/issues). Pull requests are welcome.
+
+## Overview
+
+The Levenshtein `Distance` between two strings is the minimum total cost of edits that would convert the first string into the second. The allowed edit operations are insertions, deletions, and substitutions, all at character (one UTF-8 code point) level. Each operation has a default cost of 1, but each can be assigned its own cost equal to or greater than 0.
+
+A `Distance` of 0 means the two strings are identical, and the higher the value the more different the strings. Since in practice we are interested in finding if the two strings are "close enough", it often does not make sense to continue the calculation once the result is mathematically guaranteed to exceed a desired threshold. Providing this value to the `Distance` function allows it to take a shortcut and return a lower bound instead of an exact cost when the threshold is exceeded.
+
+The `Similarity` function calculates the distance, then converts it into a normalized metric within the range 0..1, with 1 meaning the strings are identical, and 0 that they have nothing in common. A minimum similarity threshold can be provided to speed up the calculation of the metric for strings that are far too dissimilar for the purpose at hand. All values under this threshold are rounded down to 0.
+
+The `Match` function provides a similarity metric, with the same range and meaning as `Similarity`, but with a bonus for string pairs that share a common prefix and have a similarity above a "bonus threshold". It uses the same method as proposed by Winkler for the Jaro distance, and the reasoning behind it is that these string pairs are very likely spelling variations or errors, and they are more closely linked than the edit distance alone would suggest.
+
+The underlying `Calculate` function is also exported, to allow the building of other derivative metrics, if needed.
+
+## Installation
+
+```
+go get github.com/agext/levenshtein
+```
+
+## License
+
+Package levenshtein is released under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/vendor/github.com/agext/levenshtein/levenshtein.go
+++ b/vendor/github.com/agext/levenshtein/levenshtein.go
@@ -1,0 +1,290 @@
+// Copyright 2016 ALRUX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package levenshtein implements distance and similarity metrics for strings, based on the Levenshtein measure.
+
+The Levenshtein `Distance` between two strings is the minimum total cost of edits that would convert the first string into the second. The allowed edit operations are insertions, deletions, and substitutions, all at character (one UTF-8 code point) level. Each operation has a default cost of 1, but each can be assigned its own cost equal to or greater than 0.
+
+A `Distance` of 0 means the two strings are identical, and the higher the value the more different the strings. Since in practice we are interested in finding if the two strings are "close enough", it often does not make sense to continue the calculation once the result is mathematically guaranteed to exceed a desired threshold. Providing this value to the `Distance` function allows it to take a shortcut and return a lower bound instead of an exact cost when the threshold is exceeded.
+
+The `Similarity` function calculates the distance, then converts it into a normalized metric within the range 0..1, with 1 meaning the strings are identical, and 0 that they have nothing in common. A minimum similarity threshold can be provided to speed up the calculation of the metric for strings that are far too dissimilar for the purpose at hand. All values under this threshold are rounded down to 0.
+
+The `Match` function provides a similarity metric, with the same range and meaning as `Similarity`, but with a bonus for string pairs that share a common prefix and have a similarity above a "bonus threshold". It uses the same method as proposed by Winkler for the Jaro distance, and the reasoning behind it is that these string pairs are very likely spelling variations or errors, and they are more closely linked than the edit distance alone would suggest.
+
+The underlying `Calculate` function is also exported, to allow the building of other derivative metrics, if needed.
+*/
+package levenshtein
+
+// Calculate determines the Levenshtein distance between two strings, using
+// the given costs for each edit operation. It returns the distance along with
+// the lengths of the longest common prefix and suffix.
+//
+// If maxCost is non-zero, the calculation stops as soon as the distance is determined
+// to be greater than maxCost. Therefore, any return value higher than maxCost is a
+// lower bound for the actual distance.
+func Calculate(str1, str2 []rune, maxCost, insCost, subCost, delCost int) (dist, prefixLen, suffixLen int) {
+	l1, l2 := len(str1), len(str2)
+	// trim common prefix, if any, as it doesn't affect the distance
+	for ; prefixLen < l1 && prefixLen < l2; prefixLen++ {
+		if str1[prefixLen] != str2[prefixLen] {
+			break
+		}
+	}
+	str1, str2 = str1[prefixLen:], str2[prefixLen:]
+	l1 -= prefixLen
+	l2 -= prefixLen
+	// trim common suffix, if any, as it doesn't affect the distance
+	for 0 < l1 && 0 < l2 {
+		if str1[l1-1] != str2[l2-1] {
+			str1, str2 = str1[:l1], str2[:l2]
+			break
+		}
+		l1--
+		l2--
+		suffixLen++
+	}
+	// if the first string is empty, the distance is the length of the second string times the cost of insertion
+	if l1 == 0 {
+		dist = l2 * insCost
+		return
+	}
+	// if the second string is empty, the distance is the length of the first string times the cost of deletion
+	if l2 == 0 {
+		dist = l1 * delCost
+		return
+	}
+
+	// variables used in inner "for" loops
+	var y, dy, c, l int
+
+	// if maxCost is greater than or equal to the maximum possible distance, it's equivalent to 'unlimited'
+	if maxCost > 0 {
+		if subCost < delCost+insCost {
+			if maxCost >= l1*subCost+(l2-l1)*insCost {
+				maxCost = 0
+			}
+		} else {
+			if maxCost >= l1*delCost+l2*insCost {
+				maxCost = 0
+			}
+		}
+	}
+
+	if maxCost > 0 {
+		// prefer the longer string first, to minimize time;
+		// a swap also transposes the meanings of insertion and deletion.
+		if l1 < l2 {
+			str1, str2, l1, l2, insCost, delCost = str2, str1, l2, l1, delCost, insCost
+		}
+
+		// the length differential times cost of deletion is a lower bound for the cost;
+		// if it is higher than the maxCost, there is no point going into the main calculation.
+		if dist = (l1 - l2) * delCost; dist > maxCost {
+			return
+		}
+
+		d := make([]int, l1+1)
+
+		// offset and length of d in the current row
+		doff, dlen := 0, 1
+		for y, dy = 1, delCost; y <= l1 && dy <= maxCost; dlen++ {
+			d[y] = dy
+			y++
+			dy = y * delCost
+		}
+		// fmt.Printf("%q -> %q: init doff=%d dlen=%d d[%d:%d]=%v\n", str1, str2, doff, dlen, doff, doff+dlen, d[doff:doff+dlen])
+
+		for x := 0; x < l2; x++ {
+			dy, d[doff] = d[doff], d[doff]+insCost
+			for d[doff] > maxCost && dlen > 0 {
+				if str1[doff] != str2[x] {
+					dy += subCost
+				}
+				doff++
+				dlen--
+				if c = d[doff] + insCost; c < dy {
+					dy = c
+				}
+				dy, d[doff] = d[doff], dy
+			}
+			for y, l = doff, doff+dlen-1; y < l; dy, d[y] = d[y], dy {
+				if str1[y] != str2[x] {
+					dy += subCost
+				}
+				if c = d[y] + delCost; c < dy {
+					dy = c
+				}
+				y++
+				if c = d[y] + insCost; c < dy {
+					dy = c
+				}
+			}
+			if y < l1 {
+				if str1[y] != str2[x] {
+					dy += subCost
+				}
+				if c = d[y] + delCost; c < dy {
+					dy = c
+				}
+				for ; dy <= maxCost && y < l1; dy, d[y] = dy+delCost, dy {
+					y++
+					dlen++
+				}
+			}
+			// fmt.Printf("%q -> %q: x=%d doff=%d dlen=%d d[%d:%d]=%v\n", str1, str2, x, doff, dlen, doff, doff+dlen, d[doff:doff+dlen])
+			if dlen == 0 {
+				dist = maxCost + 1
+				return
+			}
+		}
+		if doff+dlen-1 < l1 {
+			dist = maxCost + 1
+			return
+		}
+		dist = d[l1]
+	} else {
+		// ToDo: This is O(l1*l2) time and O(min(l1,l2)) space; investigate if it is
+		// worth to implement diagonal approach - O(l1*(1+dist)) time, up to O(l1*l2) space
+		// http://www.csse.monash.edu.au/~lloyd/tildeStrings/Alignment/92.IPL.html
+
+		// prefer the shorter string first, to minimize space; time is O(l1*l2) anyway;
+		// a swap also transposes the meanings of insertion and deletion.
+		if l1 > l2 {
+			str1, str2, l1, l2, insCost, delCost = str2, str1, l2, l1, delCost, insCost
+		}
+		d := make([]int, l1+1)
+
+		for y = 1; y <= l1; y++ {
+			d[y] = y * delCost
+		}
+		for x := 0; x < l2; x++ {
+			dy, d[0] = d[0], d[0]+insCost
+			for y = 0; y < l1; dy, d[y] = d[y], dy {
+				if str1[y] != str2[x] {
+					dy += subCost
+				}
+				if c = d[y] + delCost; c < dy {
+					dy = c
+				}
+				y++
+				if c = d[y] + insCost; c < dy {
+					dy = c
+				}
+			}
+		}
+		dist = d[l1]
+	}
+
+	return
+}
+
+// Distance returns the Levenshtein distance between str1 and str2, using the
+// default or provided cost values. Pass nil for the third argument to use the
+// default cost of 1 for all three operations, with no maximum.
+func Distance(str1, str2 string, p *Params) int {
+	if p == nil {
+		p = defaultParams
+	}
+	dist, _, _ := Calculate([]rune(str1), []rune(str2), p.maxCost, p.insCost, p.subCost, p.delCost)
+	return dist
+}
+
+// Similarity returns a score in the range of 0..1 for how similar the two strings are.
+// A score of 1 means the strings are identical, and 0 means they have nothing in common.
+//
+// A nil third argument uses the default cost of 1 for all three operations.
+//
+// If a non-zero MinScore value is provided in the parameters, scores lower than it
+// will be returned as 0.
+func Similarity(str1, str2 string, p *Params) float64 {
+	return Match(str1, str2, p.Clone().BonusThreshold(1.1)) // guaranteed no bonus
+}
+
+// Match returns a similarity score adjusted by the same method as proposed by Winkler for
+// the Jaro distance - giving a bonus to string pairs that share a common prefix, only if their
+// similarity score is already over a threshold.
+//
+// The score is in the range of 0..1, with 1 meaning the strings are identical,
+// and 0 meaning they have nothing in common.
+//
+// A nil third argument uses the default cost of 1 for all three operations, maximum length of
+// common prefix to consider for bonus of 4, scaling factor of 0.1, and bonus threshold of 0.7.
+//
+// If a non-zero MinScore value is provided in the parameters, scores lower than it
+// will be returned as 0.
+func Match(str1, str2 string, p *Params) float64 {
+	s1, s2 := []rune(str1), []rune(str2)
+	l1, l2 := len(s1), len(s2)
+	// two empty strings are identical; shortcut also avoids divByZero issues later on.
+	if l1 == 0 && l2 == 0 {
+		return 1
+	}
+
+	if p == nil {
+		p = defaultParams
+	}
+
+	// a min over 1 can never be satisfied, so the score is 0.
+	if p.minScore > 1 {
+		return 0
+	}
+
+	insCost, delCost, maxDist, max := p.insCost, p.delCost, 0, 0
+	if l1 > l2 {
+		l1, l2, insCost, delCost = l2, l1, delCost, insCost
+	}
+
+	if p.subCost < delCost+insCost {
+		maxDist = l1*p.subCost + (l2-l1)*insCost
+	} else {
+		maxDist = l1*delCost + l2*insCost
+	}
+
+	// a zero min is always satisfied, so no need to set a max cost.
+	if p.minScore > 0 {
+		// if p.minScore is lower than p.bonusThreshold, we can use a simplified formula
+		// for the max cost, because a sim score below min cannot receive a bonus.
+		if p.minScore < p.bonusThreshold {
+			// round down the max - a cost equal to a rounded up max would already be under min.
+			max = int((1 - p.minScore) * float64(maxDist))
+		} else {
+			// p.minScore <= sim + p.bonusPrefix*p.bonusScale*(1-sim)
+			// p.minScore <= (1-dist/maxDist) + p.bonusPrefix*p.bonusScale*(1-(1-dist/maxDist))
+			// p.minScore <= 1 - dist/maxDist + p.bonusPrefix*p.bonusScale*dist/maxDist
+			// 1 - p.minScore >= dist/maxDist - p.bonusPrefix*p.bonusScale*dist/maxDist
+			// (1-p.minScore)*maxDist/(1-p.bonusPrefix*p.bonusScale) >= dist
+			max = int((1 - p.minScore) * float64(maxDist) / (1 - float64(p.bonusPrefix)*p.bonusScale))
+		}
+	}
+
+	dist, pl, _ := Calculate(s1, s2, max, p.insCost, p.subCost, p.delCost)
+	if max > 0 && dist > max {
+		return 0
+	}
+	sim := 1 - float64(dist)/float64(maxDist)
+
+	if sim >= p.bonusThreshold && sim < 1 && p.bonusPrefix > 0 && p.bonusScale > 0 {
+		if pl > p.bonusPrefix {
+			pl = p.bonusPrefix
+		}
+		sim += float64(pl) * p.bonusScale * (1 - sim)
+	}
+
+	if sim < p.minScore {
+		return 0
+	}
+
+	return sim
+}

--- a/vendor/github.com/agext/levenshtein/params.go
+++ b/vendor/github.com/agext/levenshtein/params.go
@@ -1,0 +1,152 @@
+// Copyright 2016 ALRUX Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package levenshtein
+
+// Params represents a set of parameter values for the various formulas involved
+// in the calculation of the Levenshtein string metrics.
+type Params struct {
+	insCost        int
+	subCost        int
+	delCost        int
+	maxCost        int
+	minScore       float64
+	bonusPrefix    int
+	bonusScale     float64
+	bonusThreshold float64
+}
+
+var (
+	defaultParams = NewParams()
+)
+
+// NewParams creates a new set of parameters and initializes it with the default values.
+func NewParams() *Params {
+	return &Params{
+		insCost:        1,
+		subCost:        1,
+		delCost:        1,
+		maxCost:        0,
+		minScore:       0,
+		bonusPrefix:    4,
+		bonusScale:     .1,
+		bonusThreshold: .7,
+	}
+}
+
+// Clone returns a pointer to a copy of the receiver parameter set, or of a new
+// default parameter set if the receiver is nil.
+func (p *Params) Clone() *Params {
+	if p == nil {
+		return NewParams()
+	}
+	return &Params{
+		insCost:        p.insCost,
+		subCost:        p.subCost,
+		delCost:        p.delCost,
+		maxCost:        p.maxCost,
+		minScore:       p.minScore,
+		bonusPrefix:    p.bonusPrefix,
+		bonusScale:     p.bonusScale,
+		bonusThreshold: p.bonusThreshold,
+	}
+}
+
+// InsCost overrides the default value of 1 for the cost of insertion.
+// The new value must be zero or positive.
+func (p *Params) InsCost(v int) *Params {
+	if v >= 0 {
+		p.insCost = v
+	}
+	return p
+}
+
+// SubCost overrides the default value of 1 for the cost of substitution.
+// The new value must be zero or positive.
+func (p *Params) SubCost(v int) *Params {
+	if v >= 0 {
+		p.subCost = v
+	}
+	return p
+}
+
+// DelCost overrides the default value of 1 for the cost of deletion.
+// The new value must be zero or positive.
+func (p *Params) DelCost(v int) *Params {
+	if v >= 0 {
+		p.delCost = v
+	}
+	return p
+}
+
+// MaxCost overrides the default value of 0 (meaning unlimited) for the maximum cost.
+// The calculation of Distance() stops when the result is guaranteed to exceed
+// this maximum, returning a lower-bound rather than exact value.
+// The new value must be zero or positive.
+func (p *Params) MaxCost(v int) *Params {
+	if v >= 0 {
+		p.maxCost = v
+	}
+	return p
+}
+
+// MinScore overrides the default value of 0 for the minimum similarity score.
+// Scores below this threshold are returned as 0 by Similarity() and Match().
+// The new value must be zero or positive. Note that a minimum greater than 1
+// can never be satisfied, resulting in a score of 0 for any pair of strings.
+func (p *Params) MinScore(v float64) *Params {
+	if v >= 0 {
+		p.minScore = v
+	}
+	return p
+}
+
+// BonusPrefix overrides the default value for the maximum length of
+// common prefix to be considered for bonus by Match().
+// The new value must be zero or positive.
+func (p *Params) BonusPrefix(v int) *Params {
+	if v >= 0 {
+		p.bonusPrefix = v
+	}
+	return p
+}
+
+// BonusScale overrides the default value for the scaling factor used by Match()
+// in calculating the bonus.
+// The new value must be zero or positive. To guarantee that the similarity score
+// remains in the interval 0..1, this scaling factor is not allowed to exceed
+// 1 / BonusPrefix.
+func (p *Params) BonusScale(v float64) *Params {
+	if v >= 0 {
+		p.bonusScale = v
+	}
+
+	// the bonus cannot exceed (1-sim), or the score may become greater than 1.
+	if float64(p.bonusPrefix)*p.bonusScale > 1 {
+		p.bonusScale = 1 / float64(p.bonusPrefix)
+	}
+
+	return p
+}
+
+// BonusThreshold overrides the default value for the minimum similarity score
+// for which Match() can assign a bonus.
+// The new value must be zero or positive. Note that a threshold greater than 1
+// effectively makes Match() become the equivalent of Similarity().
+func (p *Params) BonusThreshold(v float64) *Params {
+	if v >= 0 {
+		p.bonusThreshold = v
+	}
+	return p
+}


### PR DESCRIPTION
This change replaces the default logError error handler with a custom implementation: newDedupingErrorHandler.handleErr.  This handler adds features to make logging less noisy and more useful:

1. Deduplication based on HandleError's caller's stack, the error type and the error message (err.Error())
2. A simple heuristic to determine when to log or suppress a duplicate error (based on error count and last time it was logged)
3. When an error is logged, it includes more metadata such as the error's type, its error count and the caller's stack
4. A LRU cache to prevent it from using an infinite amount of memory

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Sample output:

```
E0223 17:25:08.041194   30876 cronjob_controller.go:118] ${GO}/src/k8s.io/kubernetes/pkg/controller/cronjob/cronjob_controller.go:118 err=can't list Jobs: Unauthorized count=32 value=&errors.errorString{s:"can't list Jobs: Unauthorized"}
```

---

```release-note
NONE
```

/assign @smarterclayton @lavalamp @deads2k @eparis @juanvallejo