### PR TITLE
Automated cherry pick of #57432 #57777 #57994 upstream release 1.9

### DIFF
--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -23,6 +23,7 @@ go_library(
         "azure_storage.go",
         "azure_storageaccount.go",
         "azure_util.go",
+        "azure_util_cache.go",
         "azure_util_vmss.go",
         "azure_wrap.go",
         "azure_zones.go",
@@ -52,6 +53,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
@@ -61,6 +63,7 @@ go_test(
     srcs = [
         "azure_loadbalancer_test.go",
         "azure_test.go",
+        "azure_util_cache_test.go",
         "azure_util_test.go",
         "azure_wrap_test.go",
     ],

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -74,23 +74,6 @@ func (az *Cloud) GetScaleSetsVMWithRetry(name types.NodeName) (compute.VirtualMa
 	return machine, exists, err
 }
 
-// VirtualMachineClientGetWithRetry invokes az.VirtualMachinesClient.Get with exponential backoff retry
-func (az *Cloud) VirtualMachineClientGetWithRetry(resourceGroup, vmName string, types compute.InstanceViewTypes) (compute.VirtualMachine, error) {
-	var machine compute.VirtualMachine
-	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
-		var retryErr error
-		az.operationPollRateLimiter.Accept()
-		machine, retryErr = az.VirtualMachinesClient.Get(resourceGroup, vmName, types)
-		if retryErr != nil {
-			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
-			return false, nil
-		}
-		glog.V(2).Infof("backoff: success")
-		return true, nil
-	})
-	return machine, err
-}
-
 // VirtualMachineClientListWithRetry invokes az.VirtualMachinesClient.List with exponential backoff retry
 func (az *Cloud) VirtualMachineClientListWithRetry() ([]compute.VirtualMachine, error) {
 	allNodes := []compute.VirtualMachine{}

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -42,12 +42,11 @@ func (az *Cloud) requestBackoff() (resourceRequestBackoff wait.Backoff) {
 }
 
 // GetVirtualMachineWithRetry invokes az.getVirtualMachine with exponential backoff retry
-func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.VirtualMachine, bool, error) {
+func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.VirtualMachine, error) {
 	var machine compute.VirtualMachine
-	var exists bool
 	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		var retryErr error
-		machine, exists, retryErr = az.getVirtualMachine(name)
+		machine, retryErr = az.getVirtualMachine(name)
 		if retryErr != nil {
 			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
 			return false, nil
@@ -55,7 +54,7 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 		glog.V(2).Infof("backoff: success")
 		return true, nil
 	})
-	return machine, exists, err
+	return machine, err
 }
 
 // GetScaleSetsVMWithRetry invokes az.getScaleSetsVM with exponential backoff retry

--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -134,6 +134,8 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 		}
 	} else {
 		glog.V(4).Infof("azureDisk - azure attach succeeded")
+		// Invalidate the cache right after updating
+		vmCache.Delete(vmName)
 	}
 	return err
 }
@@ -192,6 +194,8 @@ func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName t
 		glog.Errorf("azureDisk - azure disk detach failed, err: %v", err)
 	} else {
 		glog.V(4).Infof("azureDisk - azure disk detach succeeded")
+		// Invalidate the cache right after updating
+		vmCache.Delete(vmName)
 	}
 	return err
 }

--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -71,12 +71,11 @@ type controllerCommon struct {
 // AttachDisk attaches a vhd to vm
 // the vhd must exist, can be identified by diskName, diskURI, and lun.
 func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI string, nodeName types.NodeName, lun int32, cachingMode compute.CachingTypes) error {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return err
-	} else if !exists {
-		return cloudprovider.InstanceNotFound
 	}
+
 	disks := *vm.StorageProfile.DataDisks
 	if isManagedDisk {
 		disks = append(disks,
@@ -143,8 +142,8 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 // DetachDiskByName detaches a vhd from host
 // the vhd can be identified by diskName or diskURI
 func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName types.NodeName) error {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
-	if err != nil || !exists {
+	vm, err := c.cloud.getVirtualMachine(nodeName)
+	if err != nil {
 		// if host doesn't exist, no need to detach
 		glog.Warningf("azureDisk - cannot find node %s, skip detaching disk %s", nodeName, diskName)
 		return nil
@@ -202,11 +201,9 @@ func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName t
 
 // GetDiskLun finds the lun on the host that the vhd is attached to, given a vhd's diskName and diskURI
 func (c *controllerCommon) GetDiskLun(diskName, diskURI string, nodeName types.NodeName) (int32, error) {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return -1, err
-	} else if !exists {
-		return -1, cloudprovider.InstanceNotFound
 	}
 	disks := *vm.StorageProfile.DataDisks
 	for _, disk := range disks {
@@ -224,11 +221,9 @@ func (c *controllerCommon) GetDiskLun(diskName, diskURI string, nodeName types.N
 // GetNextDiskLun searches all vhd attachment on the host and find unused lun
 // return -1 if all luns are used
 func (c *controllerCommon) GetNextDiskLun(nodeName types.NodeName) (int32, error) {
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
+	vm, err := c.cloud.getVirtualMachine(nodeName)
 	if err != nil {
 		return -1, err
-	} else if !exists {
-		return -1, cloudprovider.InstanceNotFound
 	}
 	used := make([]bool, maxLUN)
 	disks := *vm.StorageProfile.DataDisks
@@ -251,8 +246,8 @@ func (c *controllerCommon) DisksAreAttached(diskNames []string, nodeName types.N
 	for _, diskName := range diskNames {
 		attached[diskName] = false
 	}
-	vm, exists, err := c.cloud.getVirtualMachine(nodeName)
-	if !exists {
+	vm, err := c.cloud.getVirtualMachine(nodeName)
+	if err == cloudprovider.InstanceNotFound {
 		// if host doesn't exist, no need to detach
 		glog.Warningf("azureDisk - Cannot find node %q, DisksAreAttached will assume disks %v are not attached to it.",
 			nodeName, diskNames)

--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -156,14 +156,13 @@ func (az *Cloud) getVmssInstanceID(name types.NodeName) (string, error) {
 
 func (az *Cloud) getStandardInstanceID(name types.NodeName) (string, error) {
 	var machine compute.VirtualMachine
-	var exists bool
 	var err error
 	az.operationPollRateLimiter.Accept()
-	machine, exists, err = az.getVirtualMachine(name)
+	machine, err = az.getVirtualMachine(name)
 	if err != nil {
 		if az.CloudProviderBackoff {
 			glog.V(2).Infof("InstanceID(%s) backing off", name)
-			machine, exists, err = az.GetVirtualMachineWithRetry(name)
+			machine, err = az.GetVirtualMachineWithRetry(name)
 			if err != nil {
 				glog.V(2).Infof("InstanceID(%s) abort backoff", name)
 				return "", err
@@ -171,8 +170,6 @@ func (az *Cloud) getStandardInstanceID(name types.NodeName) (string, error) {
 		} else {
 			return "", err
 		}
-	} else if !exists {
-		return "", cloudprovider.InstanceNotFound
 	}
 	return *machine.ID, nil
 }
@@ -239,12 +236,10 @@ func (az *Cloud) getVmssInstanceType(name types.NodeName) (string, error) {
 
 // getStandardInstanceType gets instance with standard type.
 func (az *Cloud) getStandardInstanceType(name types.NodeName) (string, error) {
-	machine, exists, err := az.getVirtualMachine(name)
+	machine, err := az.getVirtualMachine(name)
 	if err != nil {
 		glog.Errorf("error: az.InstanceType(%s), az.getVirtualMachine(%s) err=%v", name, name, err)
 		return "", err
-	} else if !exists {
-		return "", cloudprovider.InstanceNotFound
 	}
 	return string(machine.HardwareProfile.VMSize), nil
 }

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -1250,15 +1250,12 @@ func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) b
 // participating in the specified LoadBalancer Backend Pool.
 func (az *Cloud) ensureHostInPool(serviceName string, nodeName types.NodeName, backendPoolID string, availabilitySetName string) error {
 	var machine compute.VirtualMachine
-	vmName := mapNodeNameToVMName(nodeName)
 	az.operationPollRateLimiter.Accept()
-	glog.V(10).Infof("VirtualMachinesClient.Get(%q): start", vmName)
-	machine, err := az.VirtualMachineClientGetWithRetry(az.ResourceGroup, vmName, "")
+	machine, err := az.GetVirtualMachineWithRetry(nodeName)
 	if err != nil {
 		glog.V(2).Infof("ensureHostInPool(%s, %s, %s) abort backoff", serviceName, nodeName, backendPoolID)
 		return err
 	}
-	glog.V(10).Infof("VirtualMachinesClient.Get(%q): end", vmName)
 
 	primaryNicID, err := getPrimaryInterfaceID(machine)
 	if err != nil {

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -416,10 +416,7 @@ func (az *Cloud) getIPForMachine(nodeName types.NodeName) (string, error) {
 
 func (az *Cloud) getIPForStandardMachine(nodeName types.NodeName) (string, error) {
 	az.operationPollRateLimiter.Accept()
-	machine, exists, err := az.getVirtualMachine(nodeName)
-	if !exists {
-		return "", cloudprovider.InstanceNotFound
-	}
+	machine, err := az.getVirtualMachine(nodeName)
 	if err != nil {
 		glog.Errorf("error: az.getIPForMachine(%s), az.getVirtualMachine(%s), err=%v", nodeName, nodeName, err)
 		return "", err

--- a/pkg/cloudprovider/providers/azure/azure_util_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_util_cache.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+type timedcacheEntry struct {
+	key  string
+	data interface{}
+}
+
+type timedcache struct {
+	store cache.Store
+	lock  sync.Mutex
+}
+
+// ttl time.Duration
+func newTimedcache(ttl time.Duration) timedcache {
+	return timedcache{
+		store: cache.NewTTLStore(cacheKeyFunc, ttl),
+	}
+}
+
+func cacheKeyFunc(obj interface{}) (string, error) {
+	return obj.(*timedcacheEntry).key, nil
+}
+
+func (t *timedcache) GetOrCreate(key string, createFunc func() interface{}) (interface{}, error) {
+	entry, exists, err := t.store.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return (entry.(*timedcacheEntry)).data, nil
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	entry, exists, err = t.store.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return (entry.(*timedcacheEntry)).data, nil
+	}
+
+	if createFunc == nil {
+		return nil, nil
+	}
+	created := createFunc()
+	t.store.Add(&timedcacheEntry{
+		key:  key,
+		data: created,
+	})
+	return created, nil
+}
+
+func (t *timedcache) Delete(key string) {
+	_ = t.store.Delete(&timedcacheEntry{
+		key: key,
+	})
+}

--- a/pkg/cloudprovider/providers/azure/azure_util_cache_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_util_cache_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCacheReturnsSameObject(t *testing.T) {
+	type cacheTestingStruct struct{}
+	c := newTimedcache(1 * time.Minute)
+	o1 := cacheTestingStruct{}
+	get1, _ := c.GetOrCreate("b1", func() interface{} {
+		return o1
+	})
+	o2 := cacheTestingStruct{}
+	get2, _ := c.GetOrCreate("b1", func() interface{} {
+		return o2
+	})
+	if get1 != get2 {
+		t.Error("Get not equal")
+	}
+}
+
+func TestCacheCallsCreateFuncOnce(t *testing.T) {
+	var callsCount uint32
+	f1 := func() interface{} {
+		atomic.AddUint32(&callsCount, 1)
+		return 1
+	}
+	c := newTimedcache(500 * time.Millisecond)
+	for index := 0; index < 20; index++ {
+		_, _ = c.GetOrCreate("b1", f1)
+	}
+
+	if callsCount != 1 {
+		t.Error("Count not match")
+	}
+	time.Sleep(500 * time.Millisecond)
+	c.GetOrCreate("b1", f1)
+	if callsCount != 2 {
+		t.Error("Count not match")
+	}
+}
+
+func TestCacheExpires(t *testing.T) {
+	f1 := func() interface{} {
+		return 1
+	}
+	c := newTimedcache(500 * time.Millisecond)
+	get1, _ := c.GetOrCreate("b1", f1)
+	if get1 != 1 {
+		t.Error("Value not equal")
+	}
+	time.Sleep(500 * time.Millisecond)
+	get1, _ = c.GetOrCreate("b1", nil)
+	if get1 != nil {
+		t.Error("value not expired")
+	}
+}
+
+func TestCacheDelete(t *testing.T) {
+	f1 := func() interface{} {
+		return 1
+	}
+	c := newTimedcache(500 * time.Millisecond)
+	get1, _ := c.GetOrCreate("b1", f1)
+	if get1 != 1 {
+		t.Error("Value not equal")
+	}
+	get1, _ = c.GetOrCreate("b1", nil)
+	if get1 != 1 {
+		t.Error("Value not equal")
+	}
+	c.Delete("b1")
+	get1, _ = c.GetOrCreate("b1", nil)
+	if get1 != nil {
+		t.Error("value not deleted")
+	}
+}

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -19,6 +19,8 @@ package azure
 import (
 	"errors"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
@@ -62,25 +64,65 @@ func ignoreStatusNotFoundFromError(err error) error {
 	return err
 }
 
+// cache used by getVirtualMachine
+// 15s for expiration duration
+var vmCache = newTimedcache(15 * time.Second)
+
+type vmRequest struct {
+	lock *sync.Mutex
+	vm   *compute.VirtualMachine
+}
+
+/// getVirtualMachine calls 'VirtualMachinesClient.Get' with a timed cache
+/// The service side has throttling control that delays responses if there're multiple requests onto certain vm
+/// resource request in short period.
 func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachine, exists bool, err error) {
 	var realErr error
 
 	vmName := string(nodeName)
-	az.operationPollRateLimiter.Accept()
-	glog.V(10).Infof("VirtualMachinesClient.Get(%s): start", vmName)
-	vm, err = az.VirtualMachinesClient.Get(az.ResourceGroup, vmName, "")
-	glog.V(10).Infof("VirtualMachinesClient.Get(%s): end", vmName)
 
-	exists, realErr = checkResourceExistsFromError(err)
-	if realErr != nil {
-		return vm, false, realErr
+	cachedRequest, err := vmCache.GetOrCreate(vmName, func() interface{} {
+		return &vmRequest{
+			lock: &sync.Mutex{},
+			vm:   nil,
+		}
+	})
+	if err != nil {
+		return compute.VirtualMachine{}, false, err
+	}
+	request := cachedRequest.(*vmRequest)
+
+	if request.vm == nil {
+		request.lock.Lock()
+		defer request.lock.Unlock()
+		if request.vm == nil {
+			// Currently InstanceView request are used by azure_zones, while the calls come after non-InstanceView
+			// request. If we first send an InstanceView request and then a non InstanceView request, the second
+			// request will still hit throttling. This is what happens now for cloud controller manager: In this
+			// case we do get instance view every time to fulfill the azure_zones requirement without hitting
+			// throttling.
+			// Consider adding separate parameter for controlling 'InstanceView' once node update issue #56276 is fixed
+			az.operationPollRateLimiter.Accept()
+			glog.V(10).Infof("VirtualMachinesClient.Get(%s): start", vmName)
+			vm, err = az.VirtualMachinesClient.Get(az.ResourceGroup, vmName, compute.InstanceView)
+			glog.V(10).Infof("VirtualMachinesClient.Get(%s): end", vmName)
+
+			exists, realErr = checkResourceExistsFromError(err)
+			if realErr != nil {
+				return vm, false, realErr
+			}
+
+			if !exists {
+				return vm, false, nil
+			}
+
+			request.vm = &vm
+		}
+		return vm, exists, err
 	}
 
-	if !exists {
-		return vm, false, nil
-	}
-
-	return vm, exists, err
+	glog.V(6).Infof("getVirtualMachine hits cache for(%s)", vmName)
+	return *request.vm, true, nil
 }
 
 func (az *Cloud) getVmssVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachineScaleSetVM, exists bool, err error) {

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -117,7 +117,7 @@ func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualM
 
 			request.vm = &vm
 		}
-		return vm, nil
+		return *request.vm, nil
 	}
 
 	glog.V(6).Infof("getVirtualMachine hits cache for(%s)", vmName)

--- a/pkg/cloudprovider/providers/azure/azure_zones.go
+++ b/pkg/cloudprovider/providers/azure/azure_zones.go
@@ -26,8 +26,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-
-	"github.com/Azure/azure-sdk-for-go/arm/compute"
 )
 
 const instanceInfoURL = "http://169.254.169.254/metadata/v1/InstanceInfo"
@@ -74,8 +72,7 @@ func (az *Cloud) GetZoneByProviderID(providerID string) (cloudprovider.Zone, err
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
 func (az *Cloud) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone, error) {
-
-	vm, err := az.VirtualMachinesClient.Get(az.ResourceGroup, string(nodeName), compute.InstanceView)
+	vm, err := az.getVirtualMachine(nodeName)
 
 	if err != nil {
 		return cloudprovider.Zone{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick of #57432 #57777 #57994 onto release 1.9

Add VM get cache to avoid api throttling, this helps: allow cloud-controller-manager initialization and also saves other VM get api calls.

**Which issue(s) this PR fixes**
Related #57031

**Release note**:
```release-note
Add cache for VM get operation in azure cloud provider
```


cc @andyzhangx 