### PR TITLE
mark RunOnce deprecated for kubelet and fix some typos for reconciling

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -60,7 +60,7 @@ type KubeletFlags struct {
 	// TODO(mtaufen): It is increasingly looking like nobody actually uses the
 	//                Kubelet's runonce mode anymore, so it may be a candidate
 	//                for deprecation and removal.
-	// If runOnce is true, the Kubelet will check the API server once for pods,
+	// If RunOnce is true, the Kubelet will check the API server once for pods,
 	// run those in addition to the pods specified by the local manifest, and exit.
 	RunOnce bool
 
@@ -78,20 +78,20 @@ type KubeletFlags struct {
 	// Container-runtime-specific options.
 	config.ContainerRuntimeOptions
 
-	// certDirectory is the directory where the TLS certs are located (by
+	// CertDirectory is the directory where the TLS certs are located (by
 	// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
 	// are provided, this flag will be ignored.
 	CertDirectory string
 
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	// +optional
 	CloudProvider string
 
-	// cloudConfigFile is the path to the cloud provider configuration file.
+	// CloudConfigFile is the path to the cloud provider configuration file.
 	// +optional
 	CloudConfigFile string
 
-	// rootDirectory is the directory path to place kubelet files (volume
+	// RootDirectory is the directory path to place kubelet files (volume
 	// mounts,etc).
 	RootDirectory string
 
@@ -108,10 +108,10 @@ type KubeletFlags struct {
 	// To use this flag, the KubeletConfigFile feature gate must be enabled.
 	KubeletConfigFile flag.StringFlag
 
-	// registerNode enables automatic registration with the apiserver.
+	// RegisterNode enables automatic registration with the apiserver.
 	RegisterNode bool
 
-	// registerWithTaints are an array of taints to add to a node object when
+	// RegisterWithTaints are an array of taints to add to a node object when
 	// the kubelet registers itself. This only takes effect when registerNode
 	// is true and upon the initial registration of the node.
 	RegisterWithTaints []core.Taint
@@ -120,13 +120,13 @@ type KubeletFlags struct {
 	// Whitelist of unsafe sysctls or sysctl patterns (ending in *).
 	// +optional
 	AllowedUnsafeSysctls []string
-	// containerized should be set to true if kubelet is running in a container.
+	// Containerized should be set to true if kubelet is running in a container.
 	Containerized bool
-	// remoteRuntimeEndpoint is the endpoint of remote runtime service
+	// RemoteRuntimeEndpoint is the endpoint of remote runtime service
 	RemoteRuntimeEndpoint string
-	// remoteImageEndpoint is the endpoint of remote image service
+	// RemoteImageEndpoint is the endpoint of remote image service
 	RemoteImageEndpoint string
-	// experimentalMounterPath is the path of mounter binary. Leave empty to use the default mount path
+	// ExperimentalMounterPath is the path of mounter binary. Leave empty to use the default mount path
 	ExperimentalMounterPath string
 	// If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.
 	// +optional
@@ -142,12 +142,12 @@ type KubeletFlags struct {
 	// how pod resource requests are reserved at the QoS level.
 	// Currently only memory is supported. [default=none]"
 	ExperimentalQOSReserved map[string]string
-	// Node Labels are the node labels to add when registering the node in the cluster
+	// NodeLabels are the node labels to add when registering the node in the cluster
 	NodeLabels map[string]string
-	// volumePluginDir is the full path of the directory in which to search
+	// VolumePluginDir is the full path of the directory in which to search
 	// for additional third party volume plugins
 	VolumePluginDir string
-	// lockFilePath is the path that kubelet will use to as a lock file.
+	// LockFilePath is the path that kubelet will use to as a lock file.
 	// It uses this file as a lock to synchronize with other kubelet processes
 	// that may be running.
 	LockFilePath string
@@ -156,49 +156,49 @@ type KubeletFlags struct {
 	// This will cause the kubelet to listen to inotify events on the lock file,
 	// releasing it and exiting when another process tries to open that file.
 	ExitOnLockContention bool
-	// seccompProfileRoot is the directory path for seccomp profiles.
+	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot string
-	// bootstrapCheckpointPath is the path to the directory containing pod checkpoints to
+	// BootstrapCheckpointPath is the path to the directory containing pod checkpoints to
 	// run on restore
 	BootstrapCheckpointPath string
 
 	// DEPRECATED FLAGS
-	// minimumGCAge is the minimum age for a finished container before it is
+	// MinimumGCAge is the minimum age for a finished container before it is
 	// garbage collected.
 	MinimumGCAge metav1.Duration
-	// maxPerPodContainerCount is the maximum number of old instances to
+	// MaxPerPodContainerCount is the maximum number of old instances to
 	// retain per container. Each container takes up some disk space.
 	MaxPerPodContainerCount int32
-	// maxContainerCount is the maximum number of old instances of containers
+	// MaxContainerCount is the maximum number of old instances of containers
 	// to retain globally. Each container takes up some disk space.
 	MaxContainerCount int32
-	// masterServiceNamespace is The namespace from which the kubernetes
+	// MasterServiceNamespace is The namespace from which the kubernetes
 	// master services should be injected into pods.
 	MasterServiceNamespace string
-	// registerSchedulable tells the kubelet to register the node as
+	// RegisterSchedulable tells the kubelet to register the node as
 	// schedulable. Won't have any effect if register-node is false.
 	// DEPRECATED: use registerWithTaints instead
 	RegisterSchedulable bool
 	// RequireKubeConfig is deprecated! A valid KubeConfig is now required if --kubeconfig is provided.
 	RequireKubeConfig bool
-	// nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
+	// NonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.
 	NonMasqueradeCIDR string
 	// This flag, if set, instructs the kubelet to keep volumes from terminated pods mounted to the node.
 	// This can be useful for debugging volume related issues.
 	KeepTerminatedPodVolumes bool
 	// enable gathering custom metrics.
 	EnableCustomMetrics bool
-	// allowPrivileged enables containers to request privileged mode.
+	// AllowPrivileged enables containers to request privileged mode.
 	// Defaults to false.
 	AllowPrivileged bool
-	// hostNetworkSources is a comma-separated list of sources from which the
+	// HostNetworkSources is a comma-separated list of sources from which the
 	// Kubelet allows pods to use of host network. Defaults to "*". Valid
 	// options are "file", "http", "api", and "*" (all sources).
 	HostNetworkSources []string
-	// hostPIDSources is a comma-separated list of sources from which the
+	// HostPIDSources is a comma-separated list of sources from which the
 	// Kubelet allows pods to use the host pid namespace. Defaults to "*".
 	HostPIDSources []string
-	// hostIPCSources is a comma-separated list of sources from which the
+	// HostIPCSources is a comma-separated list of sources from which the
 	// Kubelet allows pods to use the host ipc namespace. Defaults to "*".
 	HostIPCSources []string
 }
@@ -326,6 +326,7 @@ func (f *KubeletFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.Float64Var(&f.ChaosChance, "chaos-chance", f.ChaosChance, "If > 0.0, introduce random client errors and latency. Intended for testing.")
 
 	fs.BoolVar(&f.RunOnce, "runonce", f.RunOnce, "If true, exit after spawning pods from local manifests or remote urls. Exclusive with --enable-server")
+	fs.MarkDeprecated("runonce", "it may be a candidate for deprecation and removal")
 
 	fs.StringVar(&f.HostnameOverride, "hostname-override", f.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

As I see [https://github.com/kubernetes/kubernetes/blob/bc0e706a0a4f8a67b6e0d0525baac42c198c4f47/cmd/kubelet/app/options/options.go#L60](https://github.com/kubernetes/kubernetes/blob/bc0e706a0a4f8a67b6e0d0525baac42c198c4f47/cmd/kubelet/app/options/options.go#L60)
so I mark RunOnce deprecated. And some typos below may should be reconciling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
