### PR TITLE
Remove useless recorder field from volume attach/detach controller.

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -247,9 +247,6 @@ type attachDetachController struct {
 	// desiredStateOfWorldPopulator runs an asynchronous periodic loop to
 	// populate the current pods using podInformer.
 	desiredStateOfWorldPopulator populator.DesiredStateOfWorldPopulator
-
-	// recorder is used to record events in the API server
-	recorder record.EventRecorder
 }
 
 func (adc *attachDetachController) Run(stopCh <-chan struct{}) {


### PR DESCRIPTION
Remove useless recorder field from volume attach/detach controller.

As the recorder related code are are in operation executor and reconciler

**Release note**:
```
None
```