### PR TITLE
set fsGroup by securityContext.fsGroup in azure file

### DIFF
--- a/pkg/volume/azure_file/BUILD
+++ b/pkg/volume/azure_file/BUILD
@@ -43,6 +43,7 @@ go_test(
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -227,7 +227,7 @@ func (b *azureFileMounter) SetUpAt(dir string, fsGroup *int64) error {
 			options = append(options, "ro")
 		}
 		mountOptions = volume.JoinMountOptions(b.mountOptions, options)
-		mountOptions = appendDefaultMountOptions(mountOptions)
+		mountOptions = appendDefaultMountOptions(mountOptions, fsGroup)
 	}
 
 	err = b.mounter.Mount(source, dir, "cifs", mountOptions)

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -364,32 +365,55 @@ func TestGetSecretNameAndNamespaceForPV(t *testing.T) {
 func TestAppendDefaultMountOptions(t *testing.T) {
 	tests := []struct {
 		options  []string
+		fsGroup  *int64
 		expected []string
 	}{
 		{
-			options:  []string{"dir_mode=0777"},
-			expected: []string{"dir_mode=0777", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
+			options: []string{"dir_mode=0777"},
+			fsGroup: nil,
+			expected: []string{"dir_mode=0777",
+				fmt.Sprintf("%s=%s", fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
 		{
-			options:  []string{"file_mode=0777"},
-			expected: []string{"file_mode=0777", fmt.Sprintf("%s=%s", dirMode, defaultDirMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
+			options: []string{"file_mode=0777"},
+			fsGroup: to.Int64Ptr(0),
+			expected: []string{"file_mode=0777",
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", vers, defaultVers),
+				fmt.Sprintf("%s=0", gid)},
 		},
 		{
-			options:  []string{"vers=2.1"},
-			expected: []string{"vers=2.1", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", dirMode, defaultDirMode)},
+			options: []string{"vers=2.1"},
+			fsGroup: to.Int64Ptr(1000),
+			expected: []string{"vers=2.1",
+				fmt.Sprintf("%s=%s", fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=1000", gid)},
 		},
 		{
-			options:  []string{""},
-			expected: []string{"", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", dirMode, defaultDirMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
+			options: []string{""},
+			expected: []string{"", fmt.Sprintf("%s=%s",
+				fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
 		{
 			options:  []string{"file_mode=0777", "dir_mode=0777"},
 			expected: []string{"file_mode=0777", "dir_mode=0777", fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
+		{
+			options: []string{"gid=2000"},
+			fsGroup: to.Int64Ptr(1000),
+			expected: []string{"gid=2000",
+				fmt.Sprintf("%s=%s", fileMode, defaultFileMode),
+				fmt.Sprintf("%s=%s", dirMode, defaultDirMode),
+				"vers=3.0"},
+		},
 	}
 
 	for _, test := range tests {
-		result := appendDefaultMountOptions(test.options)
+		result := appendDefaultMountOptions(test.options, test.fsGroup)
 		if !reflect.DeepEqual(result, test.expected) {
 			t.Errorf("input: %q, appendDefaultMountOptions result: %q, expected: %q", test.options, result, test.expected)
 		}

--- a/pkg/volume/azure_file/azure_util.go
+++ b/pkg/volume/azure_file/azure_util.go
@@ -29,6 +29,7 @@ import (
 const (
 	fileMode        = "file_mode"
 	dirMode         = "dir_mode"
+	gid             = "gid"
 	vers            = "vers"
 	defaultFileMode = "0755"
 	defaultDirMode  = "0755"
@@ -95,11 +96,12 @@ func (s *azureSvc) SetAzureCredentials(host volume.VolumeHost, nameSpace, accoun
 	return secretName, err
 }
 
-// check whether mountOptions contain file_mode and dir_mode, if not, append default mode
-func appendDefaultMountOptions(mountOptions []string) []string {
+// check whether mountOptions contain file_mode, dir_mode, vers, gid, if not, append default mode
+func appendDefaultMountOptions(mountOptions []string, fsGroup *int64) []string {
 	fileModeFlag := false
 	dirModeFlag := false
 	versFlag := false
+	gidFlag := false
 
 	for _, mountOption := range mountOptions {
 		if strings.HasPrefix(mountOption, fileMode) {
@@ -110,6 +112,9 @@ func appendDefaultMountOptions(mountOptions []string) []string {
 		}
 		if strings.HasPrefix(mountOption, vers) {
 			versFlag = true
+		}
+		if strings.HasPrefix(mountOption, gid) {
+			gidFlag = true
 		}
 	}
 
@@ -124,6 +129,10 @@ func appendDefaultMountOptions(mountOptions []string) []string {
 
 	if !versFlag {
 		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", vers, defaultVers))
+	}
+
+	if !gidFlag && fsGroup != nil {
+		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%d", gid, *fsGroup))
 	}
 	return allMountOptions
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
set fsGroup by securityContext.fsGroup in azure file
This PR respects `securityContext.fsGroup`, while if user both sets `gid=xxx` in mountOptions in azure storage class and `securityContext.fsGroup`,  `gid=xxx` setting in mountOptions will win.

```
apiVersion: v1
kind: Pod
metadata:
  name: security-context-demo
spec:
  securityContext:
    fsGroup: 2000
  volumes:
  - name: sec-ctx-vol
    emptyDir: {}
  containers:
  - name: sec-ctx-demo
    image: gcr.io/google-samples/node-hello:1.0
    volumeMounts:
    - name: sec-ctx-vol
      mountPath: /data/demo
    securityContext:
      allowPrivilegeEscalation: false
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #44085

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
set fsGroup by securityContext.fsGroup in azure file
```

/assign @karataliu 
cc @rootfs @avaranovich 