### PR TITLE
Unmarshal Time to UTC instead of local time

### DIFF
--- a/pkg/api/unversioned/time.go
+++ b/pkg/api/unversioned/time.go
@@ -55,7 +55,7 @@ func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.L
 
 // Now returns the current local time.
 func Now() Time {
-	return Time{time.Now()}
+	return Time{time.Now().UTC()}
 }
 
 // IsZero returns true if the value is nil or time is zero.
@@ -103,7 +103,7 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.UTC()
 	return nil
 }
 
@@ -124,7 +124,7 @@ func (t *Time) UnmarshalQueryParameter(str string) error {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.UTC()
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go
@@ -59,7 +59,7 @@ func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.L
 
 // Now returns the current local time.
 func Now() Time {
-	return Time{time.Now()}
+	return Time{time.Now().UTC()}
 }
 
 // IsZero returns true if the value is nil or time is zero.
@@ -113,7 +113,7 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.UTC()
 	return nil
 }
 
@@ -134,7 +134,7 @@ func (t *Time) UnmarshalQueryParameter(str string) error {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.UTC()
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -57,7 +57,7 @@ func TestTimeUnmarshalYAML(t *testing.T) {
 		result Time
 	}{
 		{"t: null\n", Time{}},
-		{"t: 1998-05-05T05:05:05Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"t: 1998-05-05T05:05:05Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).UTC()}},
 	}
 
 	for _, c := range cases {
@@ -99,7 +99,7 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		result Time
 	}{
 		{"{\"t\":null}", Time{}},
-		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).UTC()}},
 	}
 
 	for _, c := range cases {
@@ -118,8 +118,8 @@ func TestTimeMarshalJSONUnmarshalYAML(t *testing.T) {
 		input Time
 	}{
 		{Time{}},
-		{Date(1998, time.May, 5, 5, 5, 5, 50, time.Local).Rfc3339Copy()},
-		{Date(1998, time.May, 5, 5, 5, 5, 0, time.Local).Rfc3339Copy()},
+		{Date(1998, time.May, 5, 5, 5, 5, 50, time.UTC).Rfc3339Copy()},
+		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Rfc3339Copy()},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
It currently converts to local time, but should remain as close to the wire-format as possible.

Anywhere we display time and want to show local time should be ensuring conversion to local time at point of output.

Fixes #21402 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts deads2k liggitt ironcladlou 

I am guessing this could lead to backward incompatible changes (?).  If so,
/hold