### PR TITLE
azure disk: if the disk is not found, immediately detach it. This prevents azure keeps the bad request and stops issuing new request

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -43,6 +43,7 @@ const (
 	errLeaseFailed       = "AcquireDiskLeaseFailed"
 	errLeaseIDMissing    = "LeaseIdMissing"
 	errContainerNotFound = "ContainerNotFound"
+	errDiskBlobNotFound  = "DiskBlobNotFound"
 )
 
 var defaultBackOff = kwait.Backoff{
@@ -124,9 +125,9 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	if err != nil {
 		glog.Errorf("azureDisk - azure attach failed, err: %v", err)
 		detail := err.Error()
-		if strings.Contains(detail, errLeaseFailed) {
-			// if lease cannot be acquired, immediately detach the disk and return the original error
-			glog.Infof("azureDisk - failed to acquire disk lease, try detach")
+		if strings.Contains(detail, errLeaseFailed) || strings.Contains(detail, errDiskBlobNotFound) {
+			// if lease cannot be acquired or disk not found, immediately detach the disk and return the original error
+			glog.Infof("azureDisk - err %s, try detach", detail)
 			c.cloud.DetachDiskByName(diskName, diskURI, nodeName)
 		}
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Detach and clear bad disk URI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58344

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Detach and clear bad disk URI
```
