### PR TITLE
update-swagger-spec.sh: when API server fails to start, show the last lines of logs

### DIFF
--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -55,6 +55,7 @@ ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 API_PORT=${API_PORT:-8050}
 API_HOST=${API_HOST:-127.0.0.1}
+API_LOGFILE=/tmp/swagger-api-server.log
 
 kube::etcd::start
 
@@ -70,10 +71,16 @@ kube::log::status "Starting kube-apiserver"
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \
   --runtime-config=$(echo "${KUBE_AVAILABLE_GROUP_VERSIONS}" | sed -E 's|[[:blank:]]+|,|g') \
-  --service-cluster-ip-range="10.0.0.0/24" >/tmp/swagger-api-server.log 2>&1 &
+  --service-cluster-ip-range="10.0.0.0/24" >"${API_LOGFILE}" 2>&1 &
 APISERVER_PID=$!
 
-kube::util::wait_for_url "${API_HOST}:${API_PORT}/healthz" "apiserver: "
+if ! kube::util::wait_for_url "${API_HOST}:${API_PORT}/healthz" "apiserver: "; then
+  kube::log::error "Here are the last 10 lines from kube-apiserver (${API_LOGFILE})"
+  kube::log::error "=== BEGIN OF LOG ==="
+  tail -10 "${API_LOGFILE}" || :
+  kube::log::error "=== END OF LOG ==="
+  exit 1
+fi
 
 SWAGGER_API_PATH="${API_HOST}:${API_PORT}/swaggerapi/"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When API server fails to start there is no easy way to know why. You have to read the script where you will find that there is a log file that could have some useful info. This PR simplifies debugging:
1) it includes the path to the log file in the error message
2) it also shows the last 10 lines from this log

Before this change:
```
+++ [0116 19:33:49] Starting kube-apiserver
!!! [0116 19:34:19] Timed out waiting for apiserver:  to answer at 127.0.0.1:8050/healthz; tried 30 waiting 1 between each
!!! Error in ./hack/update-swagger-spec.sh:42
  Error in ./hack/update-swagger-spec.sh:42. 'return 1' exited with status 1
Call stack:
  1: ./hack/update-swagger-spec.sh:42 main(...)
Exiting with status 1
+++ [0116 19:34:19] Clean up complete
```

After this change:
```
+++ [0116 19:42:41] Starting kube-apiserver
!!! [0116 19:42:51] Timed out waiting for apiserver:  to answer at 127.0.0.1:8050/healthz; tried 30 waiting 1 between each
!!! [0116 19:42:51] Here are the last 10 lines from kube-apiserver (/tmp/swagger-api-server.log)
!!! [0116 19:42:51] === BEGIN OF LOG ===
I0116 19:42:41.689355   30809 server.go:122] Version: v1.10.0-alpha.1.877+a02cb7c1f7d0d6-dirty
I0116 19:42:41.942601   30809 serving.go:295] Generated self-signed cert (/tmp/update-swagger-spec.2Udp/certs/apiserver.crt, /tmp/update-swagger-spec.2Udp/certs/apiserver.key)
I0116 19:42:41.942611   30809 server.go:647] external host was not specified, using 10.10.10.10
W0116 19:42:41.942618   30809 authentication.go:378] AnonymousAuth is not allowed with the AllowAll authorizer.  Resetting AnonymousAuth to false. You should use a different authorizer
error in initializing storage factory: group version podsecuritypolicy.admission.k8s.io/v1beta1 that has not been registered
!!! [0116 19:42:51] === END OF LOG ===
+++ [0116 19:42:51] Clean up complete
```

**Release note**:
```release-note
NONE
```

PTAL @cblecker @sttts 
CC @simo5 