### PR TITLE
distinguish which labels belong to resource

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -310,7 +310,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		{
 			Message: "Settings Commands:",
 			Commands: []*cobra.Command{
-				NewCmdLabel(f, out),
+				NewCmdLabel(f, out, err),
 				NewCmdAnnotate(f, out),
 				NewCmdCompletion(out, ""),
 			},

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -62,7 +62,8 @@ type LabelOptions struct {
 	removeLabels []string
 
 	// Common shared fields
-	out io.Writer
+	out    io.Writer
+	errout io.Writer
 }
 
 var (
@@ -95,8 +96,11 @@ var (
 		kubectl label pods foo bar-`))
 )
 
-func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
-	options := &LabelOptions{}
+func NewCmdLabel(f cmdutil.Factory, out, errout io.Writer) *cobra.Command {
+	options := &LabelOptions{
+		errout: errout,
+	}
+
 	validArgs := cmdutil.ValidArgList(f)
 
 	cmd := &cobra.Command{
@@ -280,8 +284,13 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 				return err
 			}
 
+			indent := ""
+			if !one {
+				indent = " "
+				fmt.Fprintf(o.errout, "Listing labels for %s.%s/%s:\n", info.Mapping.GroupVersionKind.Kind, info.Mapping.GroupVersionKind.Group, info.Name)
+			}
 			for k, v := range accessor.GetLabels() {
-				fmt.Fprintf(o.out, "%s=%s\n", k, v)
+				fmt.Fprintf(o.out, "%s%s=%s\n", indent, k, v)
 			}
 
 			return nil

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -329,7 +329,7 @@ func TestLabelErrors(t *testing.T) {
 			tf.ClientConfigVal = defaultClientConfig()
 
 			buf := bytes.NewBuffer([]byte{})
-			cmd := NewCmdLabel(tf, buf)
+			cmd := NewCmdLabel(tf, buf, buf)
 			cmd.SetOutput(buf)
 
 			for k, v := range testCase.flags {
@@ -391,7 +391,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	tf.ClientConfigVal = defaultClientConfig()
 
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdLabel(tf, buf)
+	cmd := NewCmdLabel(tf, buf, buf)
 	opts := LabelOptions{FilenameOptions: resource.FilenameOptions{
 		Filenames: []string{"../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}}}
 	err := opts.Complete(buf, cmd, []string{"a=b"})
@@ -424,7 +424,7 @@ func TestLabelLocal(t *testing.T) {
 	tf.ClientConfigVal = defaultClientConfig()
 
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdLabel(tf, buf)
+	cmd := NewCmdLabel(tf, buf, buf)
 	opts := LabelOptions{FilenameOptions: resource.FilenameOptions{
 		Filenames: []string{"../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}},
 		local: true}
@@ -482,8 +482,8 @@ func TestLabelMultipleObjects(t *testing.T) {
 	tf.ClientConfigVal = defaultClientConfig()
 
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdLabel(tf, buf)
 	opts := LabelOptions{all: true}
+	cmd := NewCmdLabel(tf, buf, buf)
 	err := opts.Complete(buf, cmd, []string{"pods", "a=b"})
 	if err == nil {
 		err = opts.Validate()


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Usability improvement for `kubectl label ... --list` when listing labels for more than one resource.
Append resource kind/name before its set of labels.

**Before**
```
$ kubectl label dc myapp test-deployment-config label1=test --list
app=myapp
label1=test
label1=test
```

**After**
```
$ kubectl label dc myapp test-deployment-config label1=test --list
Listing labels for DeploymentConfig/myapp:
  label1=test
  app=myapp
Listing labels for DeploymentConfig/test-deployment-config:
  label1=test
```