### PR TITLE
Make Attributesrecord use pointers to reduce copying

### DIFF
--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -123,7 +123,7 @@ func TestAuthorizeV0(t *testing.T) {
 		{User: uChuck, Verb: "get", Path: "/", Resource: "", NS: "", ExpectDecision: authorizer.DecisionNoOpinion},
 	}
 	for i, tc := range testCases {
-		attr := authorizer.AttributesRecord{
+		attr := &authorizer.AttributesRecord{
 			User:      &tc.User,
 			Verb:      tc.Verb,
 			Resource:  tc.Resource,
@@ -319,7 +319,7 @@ func TestRulesFor(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		attr := authorizer.AttributesRecord{
+		attr := &authorizer.AttributesRecord{
 			User:      &tc.User,
 			Namespace: tc.Namespace,
 		}
@@ -441,7 +441,7 @@ func TestAuthorizeV1beta1(t *testing.T) {
 		{User: uAPIGroup, Verb: "get", APIGroup: "x", Resource: "foo", NS: "projectXGroup", ExpectDecision: authorizer.DecisionAllow},
 	}
 	for i, tc := range testCases {
-		attr := authorizer.AttributesRecord{
+		attr := &authorizer.AttributesRecord{
 			User:            &tc.User,
 			Verb:            tc.Verb,
 			Resource:        tc.Resource,
@@ -804,7 +804,7 @@ func TestSubjectMatches(t *testing.T) {
 			t.Errorf("%s: error converting: %v", k, err)
 			continue
 		}
-		attr := authorizer.AttributesRecord{
+		attr := &authorizer.AttributesRecord{
 			User: &tc.User,
 		}
 		actualMatch := subjectMatches(*policy, attr.GetUser())
@@ -843,7 +843,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				Readonly: true,
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -857,7 +857,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				User: "foo",
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "bar",
 					Groups: []string{user.AllAuthenticated},
@@ -870,7 +870,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				Resource: "foo",
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -887,7 +887,7 @@ func TestPolicy(t *testing.T) {
 				Resource:  "foo",
 				Namespace: "foo",
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -903,7 +903,7 @@ func TestPolicy(t *testing.T) {
 		// v0 matches
 		{
 			policy: &v0.Policy{},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -917,7 +917,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				Readonly: true,
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -931,7 +931,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				User: "foo",
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -944,7 +944,7 @@ func TestPolicy(t *testing.T) {
 			policy: &v0.Policy{
 				Resource: "foo",
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -959,7 +959,7 @@ func TestPolicy(t *testing.T) {
 		// v1 mismatches
 		{
 			policy: &v1beta1.Policy{},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -975,7 +975,7 @@ func TestPolicy(t *testing.T) {
 					User: "foo",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "bar",
 					Groups: []string{user.AllAuthenticated},
@@ -992,7 +992,7 @@ func TestPolicy(t *testing.T) {
 					Readonly: true,
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1009,7 +1009,7 @@ func TestPolicy(t *testing.T) {
 					Resource: "foo",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1028,7 +1028,7 @@ func TestPolicy(t *testing.T) {
 					Resource:  "baz",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1047,7 +1047,7 @@ func TestPolicy(t *testing.T) {
 					NonResourcePath: "/api",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1065,7 +1065,7 @@ func TestPolicy(t *testing.T) {
 					NonResourcePath: "/api/*",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1084,7 +1084,7 @@ func TestPolicy(t *testing.T) {
 					User: "foo",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1100,7 +1100,7 @@ func TestPolicy(t *testing.T) {
 					User: "*",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1116,7 +1116,7 @@ func TestPolicy(t *testing.T) {
 					Group: "bar",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{"bar", user.AllAuthenticated},
@@ -1132,7 +1132,7 @@ func TestPolicy(t *testing.T) {
 					Group: "*",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{"bar", user.AllAuthenticated},
@@ -1149,7 +1149,7 @@ func TestPolicy(t *testing.T) {
 					Readonly: true,
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1167,7 +1167,7 @@ func TestPolicy(t *testing.T) {
 					Resource: "foo",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1186,7 +1186,7 @@ func TestPolicy(t *testing.T) {
 					Resource:  "baz",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1205,7 +1205,7 @@ func TestPolicy(t *testing.T) {
 					NonResourcePath: "/api",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1223,7 +1223,7 @@ func TestPolicy(t *testing.T) {
 					NonResourcePath: "*",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},
@@ -1241,7 +1241,7 @@ func TestPolicy(t *testing.T) {
 					NonResourcePath: "/api/*",
 				},
 			},
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "foo",
 					Groups: []string{user.AllAuthenticated},

--- a/pkg/kubelet/server/auth.go
+++ b/pkg/kubelet/server/auth.go
@@ -81,7 +81,7 @@ func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 	requestPath := r.URL.Path
 
 	// Default attributes mirror the API attributes that would allow this access to the kubelet API
-	attrs := authorizer.AttributesRecord{
+	attrs := &authorizer.AttributesRecord{
 		User:            u,
 		Verb:            apiVerb,
 		Namespace:       "",

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -660,7 +660,7 @@ Otherwise, add it to the expected list of paths that map to the "proxy" subresou
 	for _, tc := range testcases {
 		var (
 			expectedUser       = &user.DefaultInfo{Name: "test"}
-			expectedAttributes = authorizer.AttributesRecord{
+			expectedAttributes = &authorizer.AttributesRecord{
 				User:            expectedUser,
 				APIGroup:        "",
 				APIVersion:      "v1",
@@ -690,7 +690,7 @@ Otherwise, add it to the expected list of paths that map to the "proxy" subresou
 		}
 		fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (decision authorizer.Decision, reason string, err error) {
 			calledAuthorize = true
-			if a != expectedAttributes {
+			if !reflect.DeepEqual(a, expectedAttributes) {
 				t.Fatalf("%s: expected attributes\n\t%#v\ngot\n\t%#v", tc.Path, expectedAttributes, a)
 			}
 			return authorizer.DecisionNoOpinion, "", nil

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -54,7 +54,7 @@ func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, createV
 		return nil, apierrors.NewBadRequest("no user present on request")
 	}
 
-	var authorizationAttributes authorizer.AttributesRecord
+	var authorizationAttributes *authorizer.AttributesRecord
 	if selfSAR.Spec.ResourceAttributes != nil {
 		authorizationAttributes = authorizationutil.ResourceAttributesFrom(userToCheck, *selfSAR.Spec.ResourceAttributes)
 	} else {

--- a/pkg/registry/authorization/subjectaccessreview/rest_test.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest_test.go
@@ -66,7 +66,7 @@ func TestCreate(t *testing.T) {
 			decision: authorizer.DecisionNoOpinion,
 			reason:   "myreason",
 			err:      errors.New("myerror"),
-			expectedAttrs: authorizer.AttributesRecord{
+			expectedAttrs: &authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				Verb:            "get",
 				Path:            "/mypath",
@@ -87,7 +87,7 @@ func TestCreate(t *testing.T) {
 			decision: authorizer.DecisionAllow,
 			reason:   "allowed",
 			err:      nil,
-			expectedAttrs: authorizer.AttributesRecord{
+			expectedAttrs: &authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				Verb:            "get",
 				Path:            "/mypath",
@@ -116,7 +116,7 @@ func TestCreate(t *testing.T) {
 			decision: authorizer.DecisionNoOpinion,
 			reason:   "myreason",
 			err:      errors.New("myerror"),
-			expectedAttrs: authorizer.AttributesRecord{
+			expectedAttrs: &authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				Namespace:       "myns",
 				Verb:            "create",
@@ -151,7 +151,7 @@ func TestCreate(t *testing.T) {
 			decision: authorizer.DecisionAllow,
 			reason:   "allowed",
 			err:      nil,
-			expectedAttrs: authorizer.AttributesRecord{
+			expectedAttrs: &authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				Namespace:       "myns",
 				Verb:            "create",
@@ -176,7 +176,7 @@ func TestCreate(t *testing.T) {
 				ResourceAttributes: &authorizationapi.ResourceAttributes{},
 			},
 			decision: authorizer.DecisionDeny,
-			expectedAttrs: authorizer.AttributesRecord{
+			expectedAttrs: &authorizer.AttributesRecord{
 				User:            &user.DefaultInfo{Name: "bob"},
 				ResourceRequest: true,
 			},

--- a/pkg/registry/authorization/util/helpers.go
+++ b/pkg/registry/authorization/util/helpers.go
@@ -23,8 +23,8 @@ import (
 )
 
 // ResourceAttributesFrom combines the API object information and the user.Info from the context to build a full authorizer.AttributesRecord for resource access
-func ResourceAttributesFrom(user user.Info, in authorizationapi.ResourceAttributes) authorizer.AttributesRecord {
-	return authorizer.AttributesRecord{
+func ResourceAttributesFrom(user user.Info, in authorizationapi.ResourceAttributes) *authorizer.AttributesRecord {
+	return &authorizer.AttributesRecord{
 		User:            user,
 		Verb:            in.Verb,
 		Namespace:       in.Namespace,
@@ -38,8 +38,8 @@ func ResourceAttributesFrom(user user.Info, in authorizationapi.ResourceAttribut
 }
 
 // NonResourceAttributesFrom combines the API object information and the user.Info from the context to build a full authorizer.AttributesRecord for non resource access
-func NonResourceAttributesFrom(user user.Info, in authorizationapi.NonResourceAttributes) authorizer.AttributesRecord {
-	return authorizer.AttributesRecord{
+func NonResourceAttributesFrom(user user.Info, in authorizationapi.NonResourceAttributes) *authorizer.AttributesRecord {
+	return &authorizer.AttributesRecord{
 		User:            user,
 		ResourceRequest: false,
 		Path:            in.Path,
@@ -60,7 +60,7 @@ func convertToUserInfoExtra(extra map[string]authorizationapi.ExtraValue) map[st
 }
 
 // AuthorizationAttributesFrom takes a spec and returns the proper authz attributes to check it.
-func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) authorizer.AttributesRecord {
+func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) *authorizer.AttributesRecord {
 	userToCheck := &user.DefaultInfo{
 		Name:   spec.User,
 		Groups: spec.Groups,
@@ -68,12 +68,9 @@ func AuthorizationAttributesFrom(spec authorizationapi.SubjectAccessReviewSpec) 
 		Extra:  convertToUserInfoExtra(spec.Extra),
 	}
 
-	var authorizationAttributes authorizer.AttributesRecord
 	if spec.ResourceAttributes != nil {
-		authorizationAttributes = ResourceAttributesFrom(userToCheck, *spec.ResourceAttributes)
-	} else {
-		authorizationAttributes = NonResourceAttributesFrom(userToCheck, *spec.NonResourceAttributes)
+		return ResourceAttributesFrom(userToCheck, *spec.ResourceAttributes)
 	}
 
-	return authorizationAttributes
+	return NonResourceAttributesFrom(userToCheck, *spec.NonResourceAttributes)
 }

--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -54,7 +54,7 @@ func BindingAuthorized(ctx genericapirequest.Context, roleRef rbac.RoleRef, bind
 		return false
 	}
 
-	attrs := authorizer.AttributesRecord{
+	attrs := &authorizer.AttributesRecord{
 		User: user,
 		Verb: "bind",
 		// check against the namespace where the binding is being created (or the empty namespace for clusterrolebindings).

--- a/plugin/pkg/admission/gc/gc_admission.go
+++ b/plugin/pkg/admission/gc/gc_admission.go
@@ -92,7 +92,7 @@ func (a *gcPermissionsEnforcement) Validate(attributes admission.Attributes) (er
 		return nil
 	}
 
-	deleteAttributes := authorizer.AttributesRecord{
+	deleteAttributes := &authorizer.AttributesRecord{
 		User:            attributes.GetUserInfo(),
 		Verb:            "delete",
 		Namespace:       attributes.GetNamespace(),
@@ -167,8 +167,8 @@ func isChangingOwnerReference(newObj, oldObj runtime.Object) bool {
 // Translates ref to a DeleteAttribute deleting the object referred by the ref.
 // OwnerReference only records the object kind, which might map to multiple
 // resources, so multiple DeleteAttribute might be returned.
-func (a *gcPermissionsEnforcement) ownerRefToDeleteAttributeRecords(ref metav1.OwnerReference, attributes admission.Attributes) ([]authorizer.AttributesRecord, error) {
-	var ret []authorizer.AttributesRecord
+func (a *gcPermissionsEnforcement) ownerRefToDeleteAttributeRecords(ref metav1.OwnerReference, attributes admission.Attributes) ([]*authorizer.AttributesRecord, error) {
+	var ret []*authorizer.AttributesRecord
 	groupVersion, err := schema.ParseGroupVersion(ref.APIVersion)
 	if err != nil {
 		return ret, err
@@ -178,7 +178,7 @@ func (a *gcPermissionsEnforcement) ownerRefToDeleteAttributeRecords(ref metav1.O
 		return ret, err
 	}
 	for _, mapping := range mappings {
-		ret = append(ret, authorizer.AttributesRecord{
+		ret = append(ret, &authorizer.AttributesRecord{
 			User: attributes.GetUserInfo(),
 			Verb: "update",
 			// ownerReference can only refer to an object in the same namespace, so attributes.GetNamespace() equals to the owner's namespace

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -369,7 +369,7 @@ func authorizedForPolicy(info user.Info, namespace string, policyName string, au
 // buildAttributes builds an attributes record for a SAR based on the user info and policy.
 func buildAttributes(info user.Info, namespace string, policyName string) authorizer.Attributes {
 	// check against the namespace that the pod is being created in to allow per-namespace PSP grants.
-	attr := authorizer.AttributesRecord{
+	attr := &authorizer.AttributesRecord{
 		User:            info,
 		Verb:            "use",
 		Namespace:       namespace,

--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -56,63 +56,63 @@ func TestAuthorizer(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		attrs  authorizer.AttributesRecord
+		attrs  *authorizer.AttributesRecord
 		expect authorizer.Decision
 	}{
 		{
 			name:   "allowed configmap",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed shared secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-shared", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-shared", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed shared secret via pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node0-ns0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node0-ns0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed pv",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node0-ns0", Namespace: ""},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node0-ns0", Namespace: ""},
 			expect: authorizer.DecisionAllow,
 		},
 
 		{
 			name:   "disallowed configmap",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed shared secret via pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node1-ns0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node1-ns0", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed pv",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node1-ns0", Namespace: ""},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node1-ns0", Namespace: ""},
 			expect: authorizer.DecisionNoOpinion,
 		},
 	}
@@ -186,7 +186,7 @@ func TestAuthorizerSharedResources(t *testing.T) {
 	}
 
 	for i, tc := range testcases {
-		decision, _, err := authz.Authorize(authorizer.AttributesRecord{User: tc.User, ResourceRequest: true, Verb: "get", Resource: "secrets", Namespace: "ns1", Name: tc.Secret})
+		decision, _, err := authz.Authorize(&authorizer.AttributesRecord{User: tc.User, ResourceRequest: true, Verb: "get", Resource: "secrets", Namespace: "ns1", Name: tc.Secret})
 		if err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
@@ -300,47 +300,47 @@ func BenchmarkAuthorization(b *testing.B) {
 
 	tests := []struct {
 		name   string
-		attrs  authorizer.AttributesRecord
+		attrs  *authorizer.AttributesRecord
 		expect authorizer.Decision
 	}{
 		{
 			name:   "allowed configmap",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "allowed shared secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-shared", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-shared", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,
 		},
 		{
 			name:   "disallowed configmap",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "configmaps", Name: "configmap0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed secret via pod",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed shared secret via pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node1-ns0", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "secrets", Name: "secret-pv0-pod0-node1-ns0", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed pvc",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node1", Namespace: "ns0"},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumeclaims", Name: "pvc0-pod0-node1", Namespace: "ns0"},
 			expect: authorizer.DecisionNoOpinion,
 		},
 		{
 			name:   "disallowed pv",
-			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node1-ns0", Namespace: ""},
+			attrs:  &authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "persistentvolumes", Name: "pv0-pod0-node1-ns0", Namespace: ""},
 			expect: authorizer.DecisionNoOpinion,
 		},
 	}

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -178,32 +178,32 @@ func TestAuthorizer(t *testing.T) {
 				newClusterRoleBinding("non-resource-url-prefix", "User:prefixed", "Group:prefixed"),
 			},
 			shouldPass: []authorizer.Attributes{
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "get", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "get", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "get", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "watch", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "watch", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "get", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "get", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "get", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "watch", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "watch", Path: "/apis"},
 
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1/foobar"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1/foorbar"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/apis/v1/foobar"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/apis/v1/foorbar"},
 			},
 			shouldFail: []authorizer.Attributes{
 				// wrong verb
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "watch", Path: "/apis"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "watch", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "watch", Path: "/apis"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "watch", Path: "/apis"},
 
 				// wrong path
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "get", Path: "/api/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "get", Path: "/api/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "get", Path: "/api/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "foo"}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"bar"}}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "admin"}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"admin"}}, Verb: "get", Path: "/api/v1"},
 
 				// not covered by prefix
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/api/v1"},
-				authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "prefixed"}, Verb: "get", Path: "/api/v1"},
+				&authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"prefixed"}}, Verb: "get", Path: "/api/v1"},
 			},
 		},
 		{
@@ -265,12 +265,12 @@ func TestRuleMatches(t *testing.T) {
 		name string
 		rule rbac.PolicyRule
 
-		requestsToExpected map[authorizer.AttributesRecord]bool
+		requestsToExpected map[*authorizer.AttributesRecord]bool
 	}{
 		{
 			name: "star verb, exact match other",
 			rule: rbac.NewRule("*").Groups("group1").Resources("resource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
 				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
@@ -284,7 +284,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star group, exact match other",
 			rule: rbac.NewRule("verb1").Groups("*").Resources("resource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
@@ -298,7 +298,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star resource, exact match other",
 			rule: rbac.NewRule("verb1").Groups("group1").Resources("*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
 				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
@@ -312,7 +312,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "tuple expansion",
 			rule: rbac.NewRule("verb1", "verb2").Groups("group1", "group2").Resources("resource1", "resource2").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
 				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
@@ -326,7 +326,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "subresource expansion",
 			rule: rbac.NewRule("*").Groups("*").Resources("resource1/subresource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				resourceRequest("verb1").Group("group1").Resource("resource1").Subresource("subresource1").New(): true,
 				resourceRequest("verb1").Group("group2").Resource("resource1").Subresource("subresource2").New(): false,
 				resourceRequest("verb1").Group("group1").Resource("resource2").Subresource("subresource1").New(): false,
@@ -340,7 +340,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star nonresource, exact match other",
 			rule: rbac.NewRule("verb1").URLs("*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				nonresourceRequest("verb1").URL("/foo").New():         true,
 				nonresourceRequest("verb1").URL("/foo/bar").New():     true,
 				nonresourceRequest("verb1").URL("/foo/baz").New():     true,
@@ -356,7 +356,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star nonresource subpath",
 			rule: rbac.NewRule("verb1").URLs("/foo/*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				nonresourceRequest("verb1").URL("/foo").New():            false,
 				nonresourceRequest("verb1").URL("/foo/bar").New():        true,
 				nonresourceRequest("verb1").URL("/foo/baz").New():        true,
@@ -372,7 +372,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star verb, exact nonresource",
 			rule: rbac.NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
+			requestsToExpected: map[*authorizer.AttributesRecord]bool{
 				nonresourceRequest("verb1").URL("/foo").New():         true,
 				nonresourceRequest("verb1").URL("/foo/bar").New():     false,
 				nonresourceRequest("verb1").URL("/foo/baz").New():     false,
@@ -396,18 +396,18 @@ func TestRuleMatches(t *testing.T) {
 }
 
 type requestAttributeBuilder struct {
-	request authorizer.AttributesRecord
+	request *authorizer.AttributesRecord
 }
 
 func resourceRequest(verb string) *requestAttributeBuilder {
 	return &requestAttributeBuilder{
-		request: authorizer.AttributesRecord{ResourceRequest: true, Verb: verb},
+		request: &authorizer.AttributesRecord{ResourceRequest: true, Verb: verb},
 	}
 }
 
 func nonresourceRequest(verb string) *requestAttributeBuilder {
 	return &requestAttributeBuilder{
-		request: authorizer.AttributesRecord{ResourceRequest: false, Verb: verb},
+		request: &authorizer.AttributesRecord{ResourceRequest: false, Verb: verb},
 	}
 }
 
@@ -436,7 +436,7 @@ func (r *requestAttributeBuilder) URL(url string) *requestAttributeBuilder {
 	return r
 }
 
-func (r *requestAttributeBuilder) New() authorizer.AttributesRecord {
+func (r *requestAttributeBuilder) New() *authorizer.AttributesRecord {
 	return r.request
 }
 
@@ -469,7 +469,7 @@ func BenchmarkAuthorize(b *testing.B) {
 	}{
 		{
 			"allow list pods",
-			authorizer.AttributesRecord{
+			&authorizer.AttributesRecord{
 				ResourceRequest: true,
 				User:            nodeUser,
 				Verb:            "list",
@@ -483,7 +483,7 @@ func BenchmarkAuthorize(b *testing.B) {
 		},
 		{
 			"allow update pods/status",
-			authorizer.AttributesRecord{
+			&authorizer.AttributesRecord{
 				ResourceRequest: true,
 				User:            nodeUser,
 				Verb:            "update",
@@ -497,7 +497,7 @@ func BenchmarkAuthorize(b *testing.B) {
 		},
 		{
 			"forbid educate dolphins",
-			authorizer.AttributesRecord{
+			&authorizer.AttributesRecord{
 				ResourceRequest: true,
 				User:            nodeUser,
 				Verb:            "educate",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/initialization/initialization.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/initialization/initialization.go
@@ -260,7 +260,7 @@ func (i *initializer) Admit(a admission.Attributes) (err error) {
 
 func (i *initializer) canInitialize(a admission.Attributes, message string) error {
 	// caller must have the ability to mutate un-initialized resources
-	decision, reason, err := i.authorizer.Authorize(authorizer.AttributesRecord{
+	decision, reason, err := i.authorizer.Authorize(&authorizer.AttributesRecord{
 		Name:            a.GetName(),
 		ResourceRequest: true,
 		User:            a.GetUserInfo(),

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
@@ -101,47 +101,47 @@ type AttributesRecord struct {
 	Path            string
 }
 
-func (a AttributesRecord) GetUser() user.Info {
+func (a *AttributesRecord) GetUser() user.Info {
 	return a.User
 }
 
-func (a AttributesRecord) GetVerb() string {
+func (a *AttributesRecord) GetVerb() string {
 	return a.Verb
 }
 
-func (a AttributesRecord) IsReadOnly() bool {
+func (a *AttributesRecord) IsReadOnly() bool {
 	return a.Verb == "get" || a.Verb == "list" || a.Verb == "watch"
 }
 
-func (a AttributesRecord) GetNamespace() string {
+func (a *AttributesRecord) GetNamespace() string {
 	return a.Namespace
 }
 
-func (a AttributesRecord) GetResource() string {
+func (a *AttributesRecord) GetResource() string {
 	return a.Resource
 }
 
-func (a AttributesRecord) GetSubresource() string {
+func (a *AttributesRecord) GetSubresource() string {
 	return a.Subresource
 }
 
-func (a AttributesRecord) GetName() string {
+func (a *AttributesRecord) GetName() string {
 	return a.Name
 }
 
-func (a AttributesRecord) GetAPIGroup() string {
+func (a *AttributesRecord) GetAPIGroup() string {
 	return a.APIGroup
 }
 
-func (a AttributesRecord) GetAPIVersion() string {
+func (a *AttributesRecord) GetAPIVersion() string {
 	return a.APIVersion
 }
 
-func (a AttributesRecord) IsResourceRequest() bool {
+func (a *AttributesRecord) IsResourceRequest() bool {
 	return a.ResourceRequest
 }
 
-func (a AttributesRecord) GetPath() string {
+func (a *AttributesRecord) GetPath() string {
 	return a.Path
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin_test.go
@@ -40,8 +40,8 @@ func TestNewAlwaysDenyAuthorizer(t *testing.T) {
 func TestPrivilegedGroupAuthorizer(t *testing.T) {
 	auth := NewPrivilegedGroups("allow-01", "allow-01")
 
-	yes := authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "allow-01"}}}
-	no := authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "deny-01"}}}
+	yes := &authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "allow-01"}}}
+	no := &authorizer.AttributesRecord{User: &user.DefaultInfo{Groups: []string{"no", "deny-01"}}}
 
 	if authorized, _, _ := auth.Authorize(yes); authorized != authorizer.DecisionAllow {
 		t.Errorf("failed")

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -69,15 +69,15 @@ func TestForbidden(t *testing.T) {
 		contentType string
 	}{
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"forbidden: User \"NAME\" cannot GET path \"/whatever\"","reason":"Forbidden","details":{},"code":403}
-`, authorizer.AttributesRecord{User: u, Verb: "GET", Path: "/whatever"}, "", "application/json"},
+`, &authorizer.AttributesRecord{User: u, Verb: "GET", Path: "/whatever"}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"forbidden: User \"NAME\" cannot GET path \"/\u0026lt;script\u0026gt;\"","reason":"Forbidden","details":{},"code":403}
-`, authorizer.AttributesRecord{User: u, Verb: "GET", Path: "/<script>"}, "", "application/json"},
+`, &authorizer.AttributesRecord{User: u, Verb: "GET", Path: "/<script>"}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pod is forbidden: User \"NAME\" cannot GET pod at the cluster scope","reason":"Forbidden","details":{"kind":"pod"},"code":403}
-`, authorizer.AttributesRecord{User: u, Verb: "GET", Resource: "pod", ResourceRequest: true}, "", "application/json"},
+`, &authorizer.AttributesRecord{User: u, Verb: "GET", Resource: "pod", ResourceRequest: true}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pod \"mypod\" is forbidden: User \"NAME\" cannot GET pod at the cluster scope","reason":"Forbidden","details":{"name":"mypod","kind":"pod"},"code":403}
-`, authorizer.AttributesRecord{User: u, Verb: "GET", Resource: "pod", ResourceRequest: true, Name: "mypod"}, "", "application/json"},
+`, &authorizer.AttributesRecord{User: u, Verb: "GET", Resource: "pod", ResourceRequest: true, Name: "mypod"}, "", "application/json"},
 		{`{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pod.v2 is forbidden: User \"NAME\" cannot GET pod.v2/quota in the namespace \"test\"","reason":"Forbidden","details":{"group":"v2","kind":"pod"},"code":403}
-`, authorizer.AttributesRecord{User: u, Verb: "GET", Namespace: "test", APIGroup: "v2", Resource: "pod", Subresource: "quota", ResourceRequest: true}, "", "application/json"},
+`, &authorizer.AttributesRecord{User: u, Verb: "GET", Namespace: "test", APIGroup: "v2", Resource: "pod", Subresource: "quota", ResourceRequest: true}, "", "application/json"},
 	}
 	for _, test := range cases {
 		observer := httptest.NewRecorder()

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
@@ -392,7 +392,7 @@ func TestTLSConfig(t *testing.T) {
 				return
 			}
 
-			attr := authorizer.AttributesRecord{User: &user.DefaultInfo{}}
+			attr := &authorizer.AttributesRecord{User: &user.DefaultInfo{}}
 
 			// Allow all and see if we get an error.
 			service.Allow()
@@ -466,7 +466,7 @@ func TestWebhook(t *testing.T) {
 		want v1beta1.SubjectAccessReview
 	}{
 		{
-			attr: authorizer.AttributesRecord{User: &user.DefaultInfo{}},
+			attr: &authorizer.AttributesRecord{User: &user.DefaultInfo{}},
 			want: v1beta1.SubjectAccessReview{
 				TypeMeta: expTypeMeta,
 				Spec: v1beta1.SubjectAccessReviewSpec{
@@ -475,7 +475,7 @@ func TestWebhook(t *testing.T) {
 			},
 		},
 		{
-			attr: authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "jane"}},
+			attr: &authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "jane"}},
 			want: v1beta1.SubjectAccessReview{
 				TypeMeta: expTypeMeta,
 				Spec: v1beta1.SubjectAccessReviewSpec{
@@ -485,7 +485,7 @@ func TestWebhook(t *testing.T) {
 			},
 		},
 		{
-			attr: authorizer.AttributesRecord{
+			attr: &authorizer.AttributesRecord{
 				User: &user.DefaultInfo{
 					Name:   "jane",
 					UID:    "1",
@@ -543,7 +543,7 @@ func TestWebhook(t *testing.T) {
 }
 
 type webhookCacheTestCase struct {
-	attr authorizer.AttributesRecord
+	attr *authorizer.AttributesRecord
 
 	allow      bool
 	statusCode int
@@ -593,8 +593,8 @@ func TestWebhookCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	aliceAttr := authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "alice"}}
-	bobAttr := authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "bob"}}
+	aliceAttr := &authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "alice"}}
+	bobAttr := &authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "bob"}}
 
 	tests := []webhookCacheTestCase{
 		// server error and 429's retry

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -887,9 +887,9 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 		URL                string
 		expectedAttributes authorizer.Attributes
 	}{
-		"prefix/version/resource":        {"GET", "/api/v1/pods", authorizer.AttributesRecord{APIGroup: api.GroupName, Resource: "pods"}},
-		"prefix/group/version/resource":  {"GET", "/apis/extensions/v1/pods", authorizer.AttributesRecord{APIGroup: extensions.GroupName, Resource: "pods"}},
-		"prefix/group/version/resource2": {"GET", "/apis/autoscaling/v1/horizontalpodautoscalers", authorizer.AttributesRecord{APIGroup: autoscaling.GroupName, Resource: "horizontalpodautoscalers"}},
+		"prefix/version/resource":        {"GET", "/api/v1/pods", &authorizer.AttributesRecord{APIGroup: api.GroupName, Resource: "pods"}},
+		"prefix/group/version/resource":  {"GET", "/apis/extensions/v1/pods", &authorizer.AttributesRecord{APIGroup: extensions.GroupName, Resource: "pods"}},
+		"prefix/group/version/resource2": {"GET", "/apis/autoscaling/v1/horizontalpodautoscalers", &authorizer.AttributesRecord{APIGroup: autoscaling.GroupName, Resource: "horizontalpodautoscalers"}},
 	}
 
 	currentAuthorizationAttributesIndex := 0


### PR DESCRIPTION
Change AttributesRecord to use a pointer receiver
Allows to use the structure without copying a bunch of stuff around every time

```release-note
NONE
```
