### PR TITLE
[kube-proxy]fix bad error message in kube-proxy.log when run cluster in local

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -92,7 +92,11 @@ func (h *netlinkHandle) EnsureDummyDevice(devName string) (bool, error) {
 func (h *netlinkHandle) DeleteDummyDevice(devName string) error {
 	link, err := h.LinkByName(devName)
 	if err != nil {
-		return fmt.Errorf("error deleting a non-exist dummy device: %s", devName)
+		_, ok := err.(netlink.LinkNotFoundError)
+		if ok {
+			return nil
+		}
+		return fmt.Errorf("error deleting a non-exist dummy device: %s, %v", devName, err)
 	}
 	dummy, ok := link.(*netlink.Dummy)
 	if !ok {

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -356,8 +356,8 @@ func (runner *runner) FlushSet(set string) error {
 
 // DestroySet is used to destroy a named set.
 func (runner *runner) DestroySet(set string) error {
-	if _, err := runner.exec.Command(IPSetCmd, "destroy", set).CombinedOutput(); err != nil {
-		return fmt.Errorf("error destroying set %s:, error: %v", set, err)
+	if out, err := runner.exec.Command(IPSetCmd, "destroy", set).CombinedOutput(); err != nil {
+		return fmt.Errorf("error destroying set %s, error: %v(%s)", set, err, out)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When run `hack/local-up-cluster.sh` in local with `iptable` proxymode, we can see `/tmp/kube-proxy.log ` include some error messages, like that:
```shell
E0117 09:10:45.720142  108141 proxier.go:863] Error deleting dummy device kube-ipvs0 created by IPVS proxier: error deleting a non-exist dummy device: kube-ipvs0
E0117 09:10:45.729617  108141 proxier.go:838] Failed to execute iptables-restore for nat: exit status 1 (iptables-restore: line 7 failed
)
E0117 09:10:45.730508  108141 proxier.go:876] Error removing ipset KUBE-LOOP-BACK, error: error destroying set KUBE-LOOP-BACK:, error: exit status 1
E0117 09:10:45.731329  108141 proxier.go:876] Error removing ipset KUBE-CLUSTER-IP, error: error destroying set KUBE-CLUSTER-IP:, error: exit status 1
E0117 09:10:45.732100  108141 proxier.go:876] Error removing ipset KUBE-LOAD-BALANCER, error: error destroying set KUBE-LOAD-BALANCER:, error: exit status 1
E0117 09:10:45.732855  108141 proxier.go:876] Error removing ipset KUBE-NODE-PORT-TCP, error: error destroying set KUBE-NODE-PORT-TCP:, error: exit status 1
E0117 09:10:45.735082  108141 proxier.go:876] Error removing ipset KUBE-NODE-PORT-UDP, error: error destroying set KUBE-NODE-PORT-UDP:, error: exit status 1
E0117 09:10:45.735829  108141 proxier.go:876] Error removing ipset KUBE-EXTERNAL-IP, error: error destroying set KUBE-EXTERNAL-IP:, error: exit status 1
E0117 09:10:45.736619  108141 proxier.go:876] Error removing ipset KUBE-LOAD-BALANCER-SOURCE-IP, error: error destroying set KUBE-LOAD-BALANCER-SOURCE-IP:, error: exit status 1
E0117 09:10:45.737360  108141 proxier.go:876] Error removing ipset KUBE-LOAD-BALANCER-SOURCE-CIDR, error: error destroying set KUBE-LOAD-BALANCER-SOURCE-CIDR:, error: exit status 1
E0117 09:10:45.738114  108141 proxier.go:876] Error removing ipset KUBE-LOAD-BALANCER-MASQ, error: error destroying set KUBE-LOAD-BALANCER-MASQ:, error: exit status 1
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://github.com/kubernetes/kubernetes/issues/58366](https://github.com/kubernetes/kubernetes/issues/58366)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
