### PR TITLE
handle uniquified holder identities

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,7 +15,7 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v8.4
+VERSION=v8.5
 KUBECTL_VERSION?=v1.8.4
 
 ifeq ($(ARCH),amd64)

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -155,7 +155,7 @@ function is_leader() {
   fi
   KUBE_CONTROLLER_MANAGER_LEADER=`${KUBECTL} -n kube-system get ep kube-controller-manager \
     -o go-template=$'{{index .metadata.annotations "control-plane.alpha.kubernetes.io/leader"}}' \
-    | sed 's/^.*"holderIdentity":"\([^"]*\)".*/\1/'`
+    | sed 's/^.*"holderIdentity":"\([^"]*\)".*/\1/' | awk -F'_' '{print $1}'`
   # If there was any problem with getting the leader election results, var will
   # be empty. Since it's better to have multiple addon managers than no addon
   # managers at all, we're going to assume that we're the leader in such case.


### PR DESCRIPTION
script update for https://github.com/kubernetes/kubernetes/pull/58302

This has to be done first to allow CI to pass.  We need unique leasing identities and hostnames, particularly locally determined ones, aren't unique.  

/assign liggitt
/assign mikedanese