### PR TITLE
Reduce Metrics Server memory requirement

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -81,7 +81,7 @@ spec:
           - --config-dir=/etc/config
           - --cpu=40m
           - --extra-cpu=0.5m
-          - --memory=140Mi
+          - --memory=40Mi
           - --extra-memory=4Mi
           - --threshold=5
           - --deployment=metrics-server-v0.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduces memory requirements of Metrics Server.

This was tested on GCE. On 16 - node cluster with 30 user pods per node, Metrics Server consumes ~60MB of memory. For larger clusters, the base value matters even less, and the memory utilization will be lower, therefore this change is safe.

**Release note**:
```release-note
Reduce Metrics Server memory requirement
```
