### PR TITLE
Update comments for getting and removing loopback device for iSCSI,FC,RBD

### DIFF
--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -348,6 +348,11 @@ func (util *FCUtil) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, devicePath stri
 	glog.V(4).Infof("fc: find destination device path from symlink: %v", dstPath)
 
 	// Get loopback device which takes fd lock for device beofore detaching a volume from node.
+	// TODO: This is a workaround for issue #54108
+	// Currently local attach plugins such as FC, iSCSI, RBD can't obtain devicePath during
+	// GenerateUnmapDeviceFunc() in operation_generator. As a result, these plugins fail to get
+	// and remove loopback device then it will be remained on kubelet node. To avoid the problem,
+	// local attach plugins needs to remove loopback device during TearDownDevice().
 	var devices []string
 	blkUtil := volumeutil.NewBlockVolumePathHandler()
 	dm := c.deviceUtil.FindMultipathDeviceForDevice(dstPath)

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -512,8 +512,12 @@ func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string)
 	if mappedDevicePath := c.deviceUtil.FindMultipathDeviceForDevice(devicePath); mappedDevicePath != "" {
 		devicePath = mappedDevicePath
 	}
-	// Get loopback device which takes fd lock for devicePath before
-	// detaching a volume from node.
+	// Get loopback device which takes fd lock for devicePath before detaching a volume from node.
+	// TODO: This is a workaround for issue #54108
+	// Currently local attach plugins such as FC, iSCSI, RBD can't obtain devicePath during
+	// GenerateUnmapDeviceFunc() in operation_generator. As a result, these plugins fail to get
+	// and remove loopback device then it will be remained on kubelet node. To avoid the problem,
+	// local attach plugins needs to remove loopback device during TearDownDevice().
 	blkUtil := volumeutil.NewBlockVolumePathHandler()
 	loop, err := volumeutil.BlockVolumePathHandler.GetLoopDevice(blkUtil, devicePath)
 	if err != nil {

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -921,6 +921,12 @@ func (rbd *rbdDiskUnmapper) TearDownDevice(mapPath, _ string) error {
 	if err != nil {
 		return fmt.Errorf("rbd: failed to get loopback for device: %v, err: %v", device, err)
 	}
+	// Get loopback device which takes fd lock for device beofore detaching a volume from node.
+	// TODO: This is a workaround for issue #54108
+	// Currently local attach plugins such as FC, iSCSI, RBD can't obtain devicePath during
+	// GenerateUnmapDeviceFunc() in operation_generator. As a result, these plugins fail to get
+	// and remove loopback device then it will be remained on kubelet node. To avoid the problem,
+	// local attach plugins needs to remove loopback device during TearDownDevice().
 	blkUtil := volutil.NewBlockVolumePathHandler()
 	loop, err := volutil.BlockVolumePathHandler.GetLoopDevice(blkUtil, device)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds comments of the background why plugin gets loopback device and removes loopback device even if operation_generator has same functionality.

**Which issue(s) this PR fixes** : No

**Special notes for your reviewer**:
/cc @rootfs @sbezverk 
related PR: https://github.com/kubernetes/kubernetes/pull/56651

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
