### PR TITLE
Update Kubeadm proxy handling for IPv6

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -425,9 +425,9 @@ func (hst HTTPProxyCheck) Name() string {
 // Check validates http connectivity type, direct or via proxy.
 func (hst HTTPProxyCheck) Check() (warnings, errors []error) {
 
-	url := fmt.Sprintf("%s://%s", hst.Proto, hst.Host)
+	u := (&url.URL{Scheme: hst.Proto, Host: hst.Host}).String()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -437,7 +437,7 @@ func (hst HTTPProxyCheck) Check() (warnings, errors []error) {
 		return nil, []error{err}
 	}
 	if proxy != nil {
-		return []error{fmt.Errorf("Connection to %q uses proxy %q. If that is not intended, adjust your proxy settings", url, proxy)}, nil
+		return []error{fmt.Errorf("Connection to %q uses proxy %q. If that is not intended, adjust your proxy settings", u, proxy)}, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This updates HTTPProxyCheck with brackets around
the ipv6 address to handle adding :port


**What this PR does / why we need it**:
For IPv6 addressing, brackets need to be around the IPv6 address when a :port is added.
This change adds the brackets, and also, during testing, an IPV6 NO_PROXY
was not being handled correctly, so this is fixed also by using
netutil.SetOldTransportDefaults as is how HTTPProxyCIDRCheck
handles it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58397

**Special notes for your reviewer**:

**Release note**:

```release-note-none
```
