### PR TITLE
fix a little typo in BalancedResourceAllocation

### DIFF
--- a/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
+++ b/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	balanceResourcePriority = &ResourceAllocationPriority{"BalanceResourceAllocation", balancedResourceScorer}
+	balancedResourcePriority = &ResourceAllocationPriority{"BalancedResourceAllocation", balancedResourceScorer}
 
 	// BalancedResourceAllocationMap favors nodes with balanced resource usage rate.
 	// BalancedResourceAllocationMap should **NOT** be used alone, and **MUST** be used together
@@ -33,7 +33,7 @@ var (
 	// Detail: score = 10 - abs(cpuFraction-memoryFraction)*10. The algorithm is partly inspired by:
 	// "Wei Huang et al. An Energy Efficient Virtual Machine Placement Algorithm with Balanced
 	// Resource Utilization"
-	BalancedResourceAllocationMap = balanceResourcePriority.PriorityMap
+	BalancedResourceAllocationMap = balancedResourcePriority.PriorityMap
 )
 
 func balancedResourceScorer(requested, allocable *schedulercache.Resource) int64 {


### PR DESCRIPTION
Signed-off-by: Reficul <xuzhenglun@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
fix a little typo in `BalancedResourceAllocation` of scheduler algorithm

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```