### PR TITLE
Automated cherry pick of #57340: Fix garbage collector when leader-elect=false

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -162,9 +162,7 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-		run(stopCh)
+		run(wait.NeverStop)
 		panic("unreachable")
 	}
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -162,7 +162,9 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		run(nil)
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		run(stopCh)
 		panic("unreachable")
 	}
 


### PR DESCRIPTION
Cherry pick of #57340 #58306 on release-1.9.

#57340: Fix garbage collector when leader-elect=false
#58306: Track run status explicitly rather than non-nil check on

```release-note
Fix garbage collection and resource quota when the controller-manager uses --leader-elect=false
```
