### PR TITLE
Automated cherry pick of #57340: Fix garbage collector when leader-elect=false

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -163,9 +163,7 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-		run(stopCh)
+		run(wait.NeverStop)
 		panic("unreachable")
 	}
 

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -163,7 +163,9 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		run(nil)
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		run(stopCh)
 		panic("unreachable")
 	}
 

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -82,12 +82,13 @@ type GraphBuilder struct {
 	// After that it is safe to start them here, before that it is not.
 	informersStarted <-chan struct{}
 
-	// stopCh drives shutdown. If it is nil, it indicates that Run() has not been
-	// called yet. If it is non-nil, then when closed it indicates everything
-	// should shut down.
-	//
+	// stopCh drives shutdown. When a receive from it unblocks, monitors will shut down.
 	// This channel is also protected by monitorLock.
 	stopCh <-chan struct{}
+
+	// running tracks whether Run() has been called.
+	// it is protected by monitorLock.
+	running bool
 
 	// metaOnlyClientPool uses a special codec, which removes fields except for
 	// apiVersion, kind, and metadata during decoding.
@@ -274,7 +275,7 @@ func (gb *GraphBuilder) startMonitors() {
 	gb.monitorLock.Lock()
 	defer gb.monitorLock.Unlock()
 
-	if gb.stopCh == nil {
+	if !gb.running {
 		return
 	}
 
@@ -324,6 +325,7 @@ func (gb *GraphBuilder) Run(stopCh <-chan struct{}) {
 	// Set up the stop channel.
 	gb.monitorLock.Lock()
 	gb.stopCh = stopCh
+	gb.running = true
 	gb.monitorLock.Unlock()
 
 	// Start monitors and begin change processing until the stop channel is


### PR DESCRIPTION
Cherry pick of #57340 #58306 on release-1.8.

#57340: Fix garbage collector when leader-elect=false
#58306: Track run status explicitly rather than non-nil check on

```release-note
Fix garbage collection when the controller-manager uses --leader-elect=false
```
