### PR TITLE
client-go: fix bootstrap token imports

### DIFF
--- a/staging/src/k8s.io/client-go/tools/bootstrap/token/api/doc.go
+++ b/staging/src/k8s.io/client-go/tools/bootstrap/token/api/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package api (pkg/bootstrap/api) contains constants and types needed for
+// Package api (pkg/bootstrap/token/api) contains constants and types needed for
 // bootstrap tokens as maintained by the BootstrapSigner and TokenCleaner
 // controllers (in pkg/controller/bootstrap)
-package api // import "k8s.io/client-go/tools/bootstrap/api"
+package api // import "k8s.io/client-go/tools/bootstrap/token/api"


### PR DESCRIPTION
Fixes the publishing-bot https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-358429408.

Introduced by https://github.com/kubernetes/kubernetes/pull/55595