### PR TITLE
remove duplicated check of device path in aws attacher

### DIFF
--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -168,19 +168,15 @@ func (attacher *awsElasticBlockStoreAttacher) WaitForAttach(spec *volume.Spec, d
 		select {
 		case <-ticker.C:
 			glog.V(5).Infof("Checking AWS Volume %q is attached.", volumeID)
-			if devicePath != "" {
-				devicePaths := getDiskByIdPaths(aws.KubernetesVolumeID(volumeSource.VolumeID), partition, devicePath)
-				path, err := verifyDevicePath(devicePaths)
-				if err != nil {
-					// Log error, if any, and continue checking periodically. See issue #11321
-					glog.Errorf("Error verifying AWS Volume (%q) is attached: %v", volumeID, err)
-				} else if path != "" {
-					// A device path has successfully been created for the PD
-					glog.Infof("Successfully found attached AWS Volume %q.", volumeID)
-					return path, nil
-				}
-			} else {
-				glog.V(5).Infof("AWS Volume (%q) is not attached yet", volumeID)
+			devicePaths := getDiskByIdPaths(aws.KubernetesVolumeID(volumeSource.VolumeID), partition, devicePath)
+			path, err := verifyDevicePath(devicePaths)
+			if err != nil {
+				// Log error, if any, and continue checking periodically. See issue #11321
+				glog.Errorf("Error verifying AWS Volume (%q) is attached: %v", volumeID, err)
+			} else if path != "" {
+				// A device path has successfully been created for the PD
+				glog.Infof("Successfully found attached AWS Volume %q.", volumeID)
+				return path, nil
 			}
 		case <-timer.C:
 			return "", fmt.Errorf("Could not find attached AWS Volume %q. Timeout waiting for mount paths to be created.", volumeID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `devicePath` parameter is already validated in this [code](https://github.com/kubernetes/kubernetes/blob/b7100f1ee7231617891a100dd34b3490a1f578e4/pkg/volume/aws_ebs/attacher.go#L158), so no need to check it again in the `for loop` as it won't be modified.

This can make the code clearer.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig storage
/kind cleanup
