### PR TITLE
Use []*v1.Node instead of *v1.NodeList in scheduler extender

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -166,7 +166,7 @@ type ExtenderArgs struct {
 	Pod v1.Pod
 	// List of candidate nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == false
-	Nodes *v1.NodeList
+	Nodes []*v1.Node
 	// List of candidate node names where the pod can be scheduled; to be
 	// populated only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string
@@ -179,7 +179,7 @@ type FailedNodesMap map[string]string
 type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == false
-	Nodes *v1.NodeList
+	Nodes []*v1.Node
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string

--- a/pkg/scheduler/api/v1/types.go
+++ b/pkg/scheduler/api/v1/types.go
@@ -158,7 +158,7 @@ type ExtenderArgs struct {
 	Pod apiv1.Pod `json:"pod"`
 	// List of candidate nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == false
-	Nodes *apiv1.NodeList `json:"nodes,omitempty"`
+	Nodes []*apiv1.Node `json:"nodes,omitempty"`
 	// List of candidate node names where the pod can be scheduled; to be
 	// populated only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string `json:"nodenames,omitempty"`
@@ -171,7 +171,7 @@ type FailedNodesMap map[string]string
 type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == false
-	Nodes *apiv1.NodeList `json:"nodes,omitempty"`
+	Nodes []*apiv1.Node `json:"nodes,omitempty"`
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string `json:"nodenames,omitempty"`

--- a/pkg/scheduler/api/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/v1/zz_generated.deepcopy.go
@@ -32,11 +32,14 @@ func (in *ExtenderArgs) DeepCopyInto(out *ExtenderArgs) {
 	in.Pod.DeepCopyInto(&out.Pod)
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.NodeList)
-			(*in).DeepCopyInto(*out)
+		*out = make([]*core_v1.Node, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(core_v1.Node)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
 		}
 	}
 	if in.NodeNames != nil {
@@ -127,11 +130,14 @@ func (in *ExtenderFilterResult) DeepCopyInto(out *ExtenderFilterResult) {
 	*out = *in
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.NodeList)
-			(*in).DeepCopyInto(*out)
+		*out = make([]*core_v1.Node, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(core_v1.Node)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
 		}
 	}
 	if in.NodeNames != nil {

--- a/pkg/scheduler/api/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/zz_generated.deepcopy.go
@@ -32,11 +32,14 @@ func (in *ExtenderArgs) DeepCopyInto(out *ExtenderArgs) {
 	in.Pod.DeepCopyInto(&out.Pod)
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.NodeList)
-			(*in).DeepCopyInto(*out)
+		*out = make([]*v1.Node, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(v1.Node)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
 		}
 	}
 	if in.NodeNames != nil {
@@ -127,11 +130,14 @@ func (in *ExtenderFilterResult) DeepCopyInto(out *ExtenderFilterResult) {
 	*out = *in
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.NodeList)
-			(*in).DeepCopyInto(*out)
+		*out = make([]*v1.Node, len(*in))
+		for i := range *in {
+			if (*in)[i] == nil {
+				(*out)[i] = nil
+			} else {
+				(*out)[i] = new(v1.Node)
+				(*in)[i].DeepCopyInto((*out)[i])
+			}
 		}
 	}
 	if in.NodeNames != nil {

--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -100,7 +100,7 @@ func NewHTTPExtender(config *schedulerapi.ExtenderConfig) (algorithm.SchedulerEx
 func (h *HTTPExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[string]*schedulercache.NodeInfo) ([]*v1.Node, schedulerapi.FailedNodesMap, error) {
 	var (
 		result     schedulerapi.ExtenderFilterResult
-		nodeList   *v1.NodeList
+		nodeList   []*v1.Node
 		nodeNames  *[]string
 		nodeResult []*v1.Node
 		args       *schedulerapi.ExtenderArgs
@@ -117,10 +117,7 @@ func (h *HTTPExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[
 		}
 		nodeNames = &nodeNameSlice
 	} else {
-		nodeList = &v1.NodeList{}
-		for _, node := range nodes {
-			nodeList.Items = append(nodeList.Items, *node)
-		}
+		nodeList = nodes
 	}
 
 	args = &schedulerapi.ExtenderArgs{
@@ -142,10 +139,7 @@ func (h *HTTPExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[
 			nodeResult = append(nodeResult, nodeNameToInfo[(*result.NodeNames)[i]].Node())
 		}
 	} else if result.Nodes != nil {
-		nodeResult = make([]*v1.Node, 0, len(result.Nodes.Items))
-		for i := range result.Nodes.Items {
-			nodeResult = append(nodeResult, &result.Nodes.Items[i])
-		}
+		nodeResult = result.Nodes
 	}
 
 	return nodeResult, result.FailedNodes, nil
@@ -157,7 +151,7 @@ func (h *HTTPExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[
 func (h *HTTPExtender) Prioritize(pod *v1.Pod, nodes []*v1.Node) (*schedulerapi.HostPriorityList, int, error) {
 	var (
 		result    schedulerapi.HostPriorityList
-		nodeList  *v1.NodeList
+		nodeList  []*v1.Node
 		nodeNames *[]string
 		args      *schedulerapi.ExtenderArgs
 	)
@@ -177,10 +171,7 @@ func (h *HTTPExtender) Prioritize(pod *v1.Pod, nodes []*v1.Node) (*schedulerapi.
 		}
 		nodeNames = &nodeNameSlice
 	} else {
-		nodeList = &v1.NodeList{}
-		for _, node := range nodes {
-			nodeList.Items = append(nodeList.Items, *node)
-		}
+		nodeList = nodes
 	}
 
 	args = &schedulerapi.ExtenderArgs{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`v1.NodeList` is a Kubernetes api type for apiserver watch context. We can just use `[]*v1.Node` in extender to simplify the code. ref: #56296 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #33458 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use []*v1.Node instead of *v1.NodeList in scheduler extender
```
