### PR TITLE
Add documentation for out-of-cluster sample-apiserver development

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/local-development/etcd-service.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/local-development/etcd-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wardle-etcd
+  namespace: wardle
+spec:
+  ports:
+  - port: 2379
+    protocol: TCP
+    nodePort: 32379
+  selector:
+    etcd: "true"
+  type: NodePort

--- a/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
+++ b/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
@@ -1,56 +1,67 @@
 # Minikube walkthrough
 
 This document will take you through setting up and trying the sample apiserver on a local minikube from a fresh clone of this repo.
+You can optionally run and develop the sample apiserver on your local machine and use minikube to host the etcd.
 
-## Pre requisites
+## Prerequisites
 
-- Go 1.7.x or later installed and setup. More infomration can be found at [go installation](https://golang.org/doc/install)
+- Go 1.7.x or later installed and setup. More information can be found at [go installation](https://golang.org/doc/install)
 - Dockerhub account to push the image to [Dockerhub](https://hub.docker.com/)
-
-## Install Minikube
-
-Minikube is a single node Kubernetes cluster that runs on your local machine. The Minikube docs have installation instructions for your OS.
-- [minikube installation](https://github.com/kubernetes/minikube#installation)
-
+- Minikube to run a single node Kubernetes cluster on your local machine. The Minikube docs have [installation instructions](https://github.com/kubernetes/minikube#installation) for your OS.
+- kubectl for running commands against the minikube Kubernetes cluster. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 ## Clone the repository
 
-In order to build the sample apiserver image we will need to build the apiserver binary.
+In order to build or develop the sample apiserver image we'll need to clone the repository.
 
-```
+```bash
 cd $GOPATH/src
 mkdir -p k8s.io
 cd k8s.io
 git clone https://github.com/kubernetes/sample-apiserver.git
 ```
 
-## Build the binary
+## Running on minikube or local development against minikube
+
+Two options are available:
+
+- [Running the sample apiserver on minikube](#running-on-minikube)
+- [Developing and debugging the sample apiserver on your machine](#developing-on-your-machine)
+
+## Running on minikube
+
+This section will focus on running the sample apiserver in minikube.
+
+### Build the binary
 
 Next we will want to create a new binary to both test we can build the server and to use for the container image.
 
-From the root of this repo, where ```main.go``` is located, run the following command:
-```
+From the root of this repo, where `main.go` is located, run the following command:
+
+```bash
 export GOOS=linux; go build .
 ```
-if everything went well, you should have a binary called ```sample-apiserver``` present in your current directory.
 
-## Build the container image
+if everything went well, you should have a binary called `sample-apiserver` present in your current directory.
+
+### Build the container image
 
 Using the binary we just built, we will now create a Docker image and push it to our Dockerhub registry so that we deploy it to our cluster.
-There is a sample ```Dockerfile``` located in ```artifacts/simple-image``` we will use this to build our own image.
+There is a sample `Dockerfile` located in `artifacts/simple-image` we will use this to build our own image.
 
 Again from the root of this repo run the following commands:
-```
+
+```bash
 cp ./sample-apiserver ./artifacts/simple-image/kube-sample-apiserver
 docker build -t <YOUR_DOCKERHUB_USER>/kube-sample-apiserver:latest ./artifacts/simple-image
 docker push <YOUR_DOCKERHUB_USER>/kube-sample-apiserver
 ```
 
-## Modify the the replication controller
+### Modify the the replication controller
 
-You need to modify the [artifacts/example/rc.yaml](/artifacts/example/rc.yaml) file to change the ```imagePullPolicy``` to ```Always``` or ```IfNotPresent```.
+You need to modify the [artifacts/example/rc.yaml](/artifacts/example/rc.yaml) file to change the `imagePullPolicy` to `Always` or `IfNotPresent`.
 
-You also need to change the image from ```kube-sample-apiserver:latest``` to ```<YOUR_DOCKERHUB_USER>/kube-sample-apiserver:latest```. For example:
+You also need to change the image from `kube-sample-apiserver:latest` to `<YOUR_DOCKERHUB_USER>/kube-sample-apiserver:latest`. For example:
 
 ```yaml
 ...
@@ -63,11 +74,11 @@ You also need to change the image from ```kube-sample-apiserver:latest``` to ```
 
 Save this file and we are then ready to deploy and try out the sample apiserver.
 
-## Deploy to Minikube
+### Deploy to Minikube
 
-We will need to create several objects in order to setup the sample apiserver so you will need to ensure you have the ```kubectl``` tool installed. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+We will need to create several objects in order to setup the sample apiserver using `kubectl`.
 
-```
+```bash
 # create the namespace to run the apiserver in
 kubectl create ns wardle
 
@@ -86,18 +97,114 @@ kubectl create -f artifacts/example/service.yaml -n wardle
 kubectl create -f artifacts/example/apiservice.yaml
 ```
 
+You can skip to [test your setup](#test-that-your-setup-has-worked)
+
+## Developing on your machine
+
+This section will focus on how to develop and run the sample apisever on your machine and use minikube to host `etcd`.
+
+### Deploying etcd and setting services
+
+```bash
+
+# you'll need the IP address of your machine, otherwise minikube's apiserver cannot talk to your sample-apiserver.
+# On Linux:
+hostname -I
+# On OSX:
+ipconfig getifaddr en0
+
+MACHINE_IP=<YOUR_MACHINE_IP>
+MINIKUBE_IP=$(minikube ip)
+
+# create the namespace to run the apiserver in
+kubectl create ns wardle
+
+# create the etcd
+cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: wardle-etcd
+  namespace: wardle
+  labels:
+    etcd: "true"
+spec:
+  replicas: 1
+  selector:
+    etcd: "true"
+  template:
+    metadata:
+      labels:
+        etcd: "true"
+    spec:
+      containers:
+      - image: quay.io/coreos/etcd:v3.1.10
+        name: etcd
+        command:
+        - etcd
+        - -advertise-client-urls=http://${MINIKUBE_IP}:2379
+        - -listen-client-urls=http://0.0.0.0:2379
+EOF
+
+# create the etcd service and expose it on port 32379
+kubectl create -f artifacts/example/local-development/etcd-service.yaml
+
+# create the sample-apiserver service with external IP address pointing to our local machine
+cat <<EOF | kubectl create -f -
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+  namespace: wardle
+spec:
+  ports:
+  - protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: api
+  namespace: wardle
+subsets:
+- addresses:
+  - ip: ${MACHINE_IP}
+  ports:
+  - port: 8443
+EOF
+
+# create the apiservice object that tells kubernetes about your api extension and where outside of the cluster the server is located
+kubectl create -f artifacts/example/apiservice.yaml
+```
+
+### Run the sample-apiserver locally
+
+We'll reuse minikube's certificates and your local `kubeconfig`:
+
+```bash
+go run main.go \
+ --etcd-servers=$(minikube ip):32379 \
+ --tls-cert-file ~/.minikube/apiserver.crt \
+ --tls-private-key-file ~/.minikube/apiserver.key \
+ --secure-port=8443 \
+ --kubeconfig ~/.kube/config \
+ --authentication-kubeconfig ~/.kube/config \
+ --authorization-kubeconfig ~/.kube/config
+```
+
 ## Test that your setup has worked
 
-You should now be able to create the resource type ```Flunder``` which is the resource type registered by the sample apiserver.
+You should now be able to create the resource type `Flunder` which is the resource type registered by the sample apiserver.
 
-```
+```bash
 kubectl create -f artifacts/flunders/01-flunder.yaml
 # outputs flunder "my-first-flunder" created
 ```
 
 You can then get this resource by running:
 
-```
+```bash
 kubectl get flunder my-first-flunder
 
 #outputs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It shows how a developer can run and develop the `sample-apiserver` out-of-cluster. This improves development cycle without the need to build a binary, build a docker image, push it to registry and then run it on your local `minikube`.

**Which issue(s) this PR fixes** none

**Special notes for your reviewer**: I'm not sure, if it's better to split the guide in 2 parts with multiple `.md` files.

**Release note**: 
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
