### PR TITLE
Treat deployment with empty image as paused

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -23,6 +23,7 @@ package deployment
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -556,6 +557,44 @@ func (dc *DeploymentController) getPodMapForDeployment(d *extensions.Deployment,
 	return podMap, nil
 }
 
+// syncContainerImages will determine whether the deployment should be paused when any of the containers
+// has empty (" ") image field. In case empty image fields are found, this function return 'true'.
+func (dc *DeploymentController) syncContainerImages(d *extensions.Deployment) bool {
+	pendingContainerNames := util.GetEmptyContainerImages(d)
+	hasEmptyImage := len(pendingContainerNames) != 0
+
+	cond := util.GetDeploymentCondition(d.Status, extensions.DeploymentProgressing)
+	isWaiting := cond != nil && cond.Status == v1.ConditionUnknown && cond.Reason == util.WaitingForImagesReason
+
+	if hasEmptyImage {
+		// Only update deployment status once.
+		if !isWaiting {
+			util.RemoveDeploymentCondition(&d.Status, extensions.DeploymentProgressing)
+			condition := util.NewDeploymentCondition(extensions.DeploymentProgressing, v1.ConditionUnknown, util.WaitingForImagesReason,
+				fmt.Sprintf("waiting for container non-empty image fields (%s)", strings.Join(pendingContainerNames, ",")))
+			util.SetDeploymentCondition(&d.Status, *condition)
+			// Only fire event once and only when the update succeed.
+			if _, err := dc.client.ExtensionsV1beta1().Deployments(d.Namespace).UpdateStatus(d); err == nil {
+				dc.eventRecorder.Eventf(d, v1.EventTypeNormal, util.WaitingForImagesReason,
+					"A non-empty image field is required for containers: %s.", strings.Join(pendingContainerNames, ","))
+			}
+		}
+		return true
+	}
+	if isWaiting {
+		util.RemoveDeploymentCondition(&d.Status, extensions.DeploymentProgressing)
+		// If error occurs during updating status, don't emit the event but reconcile one more time.
+		if _, err := dc.client.ExtensionsV1beta1().Deployments(d.Namespace).UpdateStatus(d); err == nil {
+			// Only fire event once and only when the update succeed.
+			dc.eventRecorder.Eventf(d, v1.EventTypeNormal, util.WaitingForImagesReason, "This deployment has now all image fields set.")
+		}
+		// At this point we already have the images available, but let make controller reconcile this again
+		// to swallow the status update.
+		return true
+	}
+	return false
+}
+
 // syncDeployment will sync the deployment with the given key.
 // This function is not meant to be invoked concurrently with the same key.
 func (dc *DeploymentController) syncDeployment(key string) error {
@@ -620,6 +659,12 @@ func (dc *DeploymentController) syncDeployment(key string) error {
 	}
 
 	if d.Spec.Paused {
+		return dc.sync(d, rsList, podMap)
+	}
+
+	// Controller is waiting for all containers (both initContainers and containers) to have non-empty
+	// image fields. Until that the deployment is paused (the progressing=false/reason=WaitForImages).
+	if waitingForImages := dc.syncContainerImages(d); waitingForImages {
 		return dc.sync(d, rsList, podMap)
 	}
 

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployment
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -271,6 +272,113 @@ func filterInformerActions(actions []core.Action) []core.Action {
 	}
 
 	return ret
+}
+
+func TestSyncDeploymentImages(t *testing.T) {
+	f := newFixture(t)
+
+	tc := []struct {
+		name                 string
+		prepareDeploymentFn  func() *extensions.Deployment
+		validateDeploymentFn func(d *extensions.Deployment) error
+		expect               bool
+	}{
+		{
+			name: "empty image, single container",
+			prepareDeploymentFn: func() *extensions.Deployment {
+				d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+				d.Spec.Template.Spec.Containers[0].Image = " "
+				return d
+			},
+			expect: true,
+			validateDeploymentFn: func(d *extensions.Deployment) error {
+				c := util.GetDeploymentCondition(d.Status, extensions.DeploymentProgressing)
+				if c == nil {
+					return fmt.Errorf("expected Progressing condition")
+				}
+				if c.Status != v1.ConditionUnknown {
+					return fmt.Errorf("expected Progressing condition to be unknown")
+				}
+				if c.Reason != util.WaitingForImagesReason {
+					return fmt.Errorf("expected reason to be %s, is %s", util.WaitingForImagesReason, c.Reason)
+				}
+				return nil
+			},
+		},
+		{
+			name: "image present, single container",
+			prepareDeploymentFn: func() *extensions.Deployment {
+				d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+				d.Spec.Template.Spec.Containers[0].Image = "foo"
+				return d
+			},
+			expect: false,
+			validateDeploymentFn: func(d *extensions.Deployment) error {
+				c := util.GetDeploymentCondition(d.Status, extensions.DeploymentProgressing)
+				if c != nil && c.Reason == util.WaitingForImagesReason {
+					return fmt.Errorf("unexpected Progressing condition")
+				}
+				return nil
+			},
+		},
+		{
+			name: "image present after pending, single container",
+			prepareDeploymentFn: func() *extensions.Deployment {
+				d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+				d.Spec.Template.Spec.Containers[0].Image = "foo"
+				d.Status.Conditions = append(d.Status.Conditions, extensions.DeploymentCondition{
+					Type:   extensions.DeploymentProgressing,
+					Status: v1.ConditionUnknown,
+					Reason: util.WaitingForImagesReason,
+				})
+				return d
+			},
+			expect: true, // controller have to reconcile after status update
+			validateDeploymentFn: func(d *extensions.Deployment) error {
+				c := util.GetDeploymentCondition(d.Status, extensions.DeploymentProgressing)
+				if c != nil {
+					return fmt.Errorf("unexpected Progressing condition")
+				}
+				return nil
+			},
+		},
+		{
+			name: "image missing in one container, multiple containers",
+			prepareDeploymentFn: func() *extensions.Deployment {
+				d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+				d.Spec.Template.Spec.Containers[0].Image = "foo"
+				d.Spec.Template.Spec.InitContainers = append(d.Spec.Template.Spec.InitContainers, d.Spec.Template.Spec.Containers[0])
+				d.Spec.Template.Spec.InitContainers[0].Name = "foo-init"
+				d.Spec.Template.Spec.InitContainers[0].Image = " "
+				return d
+			},
+			expect: true, // controller have to reconcile after status update
+			validateDeploymentFn: func(d *extensions.Deployment) error {
+				c := util.GetDeploymentCondition(d.Status, extensions.DeploymentProgressing)
+				if c == nil && c.Status != v1.ConditionUnknown {
+					return fmt.Errorf("expected Progressing condition to be false")
+				}
+				return nil
+			},
+		},
+	}
+
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range tc {
+		d := c.prepareDeploymentFn()
+		got := dc.syncContainerImages(d)
+		if got != c.expect {
+			t.Errorf("%s: expected %v, got %v", c.name, c.expect, got)
+		}
+		err := c.validateDeploymentFn(d)
+		if err != nil {
+			t.Errorf("%s: %v", c.name, err)
+		}
+	}
 }
 
 func TestSyncDeploymentCreatesReplicaSet(t *testing.T) {

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -91,6 +91,10 @@ const (
 	// ResumedDeployReason is added in a deployment when it is resumed. Useful for not failing accidentally
 	// deployments that paused amidst a rollout and are bounded by a deadline.
 	ResumedDeployReason = "DeploymentResumed"
+	// WaitingForImagesReason is added in a deployment when the deployment has one or more image fields empty either in
+	// initContainers or containers. In that case the progress of this deployment is false and we have to wait until
+	// user or external entity provide valid, non-empty image fields.
+	WaitingForImagesReason = "WaitingForImages"
 	//
 	// Available:
 	//
@@ -933,6 +937,18 @@ func WaitForObservedDeploymentInternal(getDeploymentFunc func() (*internalextens
 		}
 		return deployment.Status.ObservedGeneration >= desiredGeneration, nil
 	})
+}
+
+// GetEmptyContainerImages returns a list of container names that has empty (" ") image fields.
+func GetEmptyContainerImages(d *extensions.Deployment) []string {
+	containers := append(d.Spec.Template.Spec.Containers, d.Spec.Template.Spec.InitContainers...)
+	pendingContainers := []string{}
+	for _, container := range containers {
+		if len(strings.TrimSpace(container.Image)) == 0 {
+			pendingContainers = append(pendingContainers, container.Name)
+		}
+	}
+	return pendingContainers
 }
 
 // ResolveFenceposts resolves both maxSurge and maxUnavailable. This needs to happen in one


### PR DESCRIPTION
**What this PR does / why we need it**:

When a deployment have empty image specified either in Containers or InitContainers, the rollout of such deployment is likely going to fail or be incomplete. This change will treat such deployment as it was paused, which allows external processes to supply an image and only after then trigger the initial rollout.

@smarterclayton we need this to make the `new-app` flow working for deployments.

TODO: 

- [x] Need test for empty images and for pause
- [x] Need an event to tell users reason why the deployment is paused

**Release note**:
```release-note
Deployments with empty image specified in any container are now acting as "paused" deployments.
```
