### PR TITLE
Fix flake8 lint error in kubernetes-master charm

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -137,6 +137,7 @@ def snap_resources_changed():
         any_file_changed(paths)
         return 'unknown'
 
+
 def upgrade_for_etcd():
     # we are upgrading the charm.
     # If this is an old deployment etcd_version is not set


### PR DESCRIPTION
**What this PR does / why we need it**:

This trivial whitespace change fixes a lint error from flake8 on the kubernetes-master charm:

```
reactive/kubernetes_master.py:140:1: E302 expected 2 blank lines, found 1
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
