### PR TITLE
Automated cherry pick of #55448: Adjust GKE spec to validate images with kernel version 4.10+

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -135,6 +135,7 @@ go_test(
         "//test/e2e_node/services:go_default_library",
         "//test/e2e_node/system:go_default_library",
         "//test/utils/image:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/coreos/go-systemd/util:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/e2e_node/system/specs/gke.yaml
+++ b/test/e2e_node/system/specs/gke.yaml
@@ -5,7 +5,9 @@ os: Linux
 kernelSpec:
   versions:
   # GKE requires kernel version 4.4+.
-  - 4\.[4-9].*
+  - '4\.[4-9].*'
+  - '4\.[1-9][0-9].*'
+  - '[5-9].*'
 
   # Required kernel configurations -- the configuration must be set to "y" or
   # "m".


### PR DESCRIPTION
Cherry pick of #55448 on release-1.8.

#55448: Adjust GKE spec to validate images with kernel version 4.10+