### PR TITLE
Update cluster addon Calico to v2.6.6

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v2.6.1
+          image: gcr.io/projectcalico-org/node:v2.6.6
           env:
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -86,7 +86,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.11.0
+          image: gcr.io/projectcalico-org/cni:v1.11.2
           command: ["/install-cni.sh"]
           env:
             - name: CNI_CONF_NAME

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico
       containers:
-      - image: calico/typha:v0.5.1
+      - image: gcr.io/projectcalico-org/typha:v0.5.5
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Updates the cluster addon Calico to the 2.6.6 release (in preparation for upgrade to v3.0).
This also switches to pull the images from gcr.io.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@caseydavenport

**Release note**:
Should there be a release note for this? WDYT?
```release-note
Update Calico version to v2.6.6
```
