### PR TITLE
Automated cherry pick of #55448: Adjust GKE spec to validate images with kernel version 4.10+

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -118,6 +118,7 @@ go_test(
         "//test/e2e_node/services:go_default_library",
         "//test/e2e_node/system:go_default_library",
         "//test/utils:go_default_library",
+        "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/coreos/go-systemd/util:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/e2e_node/gke_environment_test.go
+++ b/test/e2e_node/gke_environment_test.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/framework"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/ginkgo"
 )
 
@@ -122,6 +123,18 @@ func checkDockerConfig() error {
 		}
 		missing = map[string]bool{}
 	)
+
+	// Whitelists CONFIG_DEVPTS_MULTIPLE_INSTANCES (meaning allowing it to be
+	// absent) if the kernel version is >= 4.8, because this option has been
+	// removed from the 4.8 kernel.
+	kernelVersion, err := getKernelVersion()
+	if err != nil {
+		return err
+	}
+	if kernelVersion.GTE(semver.MustParse("4.8.0")) {
+		whitelist["CONFIG_DEVPTS_MULTIPLE_INSTANCES"] = true
+	}
+
 	for _, bin := range bins {
 		if _, err := os.Stat(bin); os.IsNotExist(err) {
 			continue
@@ -409,4 +422,19 @@ func getCmdToProcessMap() (map[string][]process, error) {
 		result[cmd] = append(result[cmd], process{pid, ppid})
 	}
 	return result, nil
+}
+
+// getKernelVersion returns the kernel version in the semantic version format.
+func getKernelVersion() (*semver.Version, error) {
+	output, err := runCommand("uname", "-r")
+	if err != nil {
+		return nil, err
+	}
+	// An example 'output' could be "4.13.0-1001-gke".
+	v := strings.TrimSpace(strings.Split(output, "-")[0])
+	kernelVersion, err := semver.Make(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert %q to semantic version: %s", v, err)
+	}
+	return &kernelVersion, nil
 }

--- a/test/e2e_node/system/specs/gke.yaml
+++ b/test/e2e_node/system/specs/gke.yaml
@@ -5,7 +5,9 @@ os: Linux
 kernelSpec:
   versions:
   # GKE requires kernel version 4.4+.
-  - 4\.[4-9].*
+  - '4\.[4-9].*'
+  - '4\.[1-9][0-9].*'
+  - '[5-9].*'
 
   # Required kernel configurations -- the configuration must be set to "y" or
   # "m".


### PR DESCRIPTION
Cherry pick of #55448 on release-1.7.

#55448: Adjust GKE spec to validate images with kernel version 4.10+