### PR TITLE
Bump bazelbuild/rules_go and kubernetes/repo-infra to tip, and use fast pkg_tar builder everywhere

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 # We do not include kube-scheduler, kube-controller-manager,
 # kube-apiserver, and kube-proxy in this list even though we

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",
@@ -38,12 +38,11 @@ grep ^STABLE_BUILD_GIT_COMMIT bazel-out/stable-status.txt | cut -d' ' -f2 >>$@
 
 pkg_tar(
     name = "kubernetes-src",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    extension = "tar.gz",
-    files = select({
+    srcs = select({
         ":package_src": ["//:all-srcs"],
         "//conditions:default": ["README-src.txt"],
     }),
+    extension = "tar.gz",
     package_dir = "kubernetes",
     strip_prefix = select({
         ":package_src": "//",
@@ -66,8 +65,7 @@ filegroup(
 
 pkg_tar(
     name = "_client-bin",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = ["//build:client-targets"],
+    srcs = ["//build:client-targets"],
     mode = "0755",
     package_dir = "client/bin",
     visibility = ["//visibility:private"],
@@ -75,7 +73,6 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes-client-%s" % PLATFORM_ARCH_STRING,
-    build_tar = "@io_kubernetes_build//tools/build_tar",
     extension = "tar.gz",
     package_dir = "kubernetes",
     deps = [
@@ -85,8 +82,7 @@ pkg_tar(
 
 pkg_tar(
     name = "_node-bin",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = [
+    srcs = [
         "//build:client-targets",
         "//build:node-targets",
     ],
@@ -97,9 +93,8 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes-node-%s" % PLATFORM_ARCH_STRING,
-    build_tar = "@io_kubernetes_build//tools/build_tar",
+    srcs = [":license-targets"],
     extension = "tar.gz",
-    files = [":license-targets"],
     mode = "0644",
     package_dir = "kubernetes",
     deps = [
@@ -109,8 +104,7 @@ pkg_tar(
 
 pkg_tar(
     name = "_server-bin",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = [
+    srcs = [
         "//build:client-targets",
         "//build:docker-artifacts",
         "//build:node-targets",
@@ -131,8 +125,7 @@ genrule(
 # Some of the startup scripts fail if there isn't an addons/ directory in the server tarball.
 pkg_tar(
     name = "_server-addons",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = [
+    srcs = [
         ":.dummy",
     ],
     package_dir = "addons",
@@ -141,9 +134,8 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes-server-%s" % PLATFORM_ARCH_STRING,
-    build_tar = "@io_kubernetes_build//tools/build_tar",
+    srcs = [":license-targets"],
     extension = "tar.gz",
-    files = [":license-targets"],
     mode = "0644",
     package_dir = "kubernetes",
     deps = [
@@ -154,8 +146,7 @@ pkg_tar(
 
 pkg_tar(
     name = "_test-bin",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = ["//build:test-targets"],
+    srcs = ["//build:test-targets"],
     mode = "0755",
     package_dir = "platforms/" + PLATFORM_ARCH_STRING.replace("-", "/"),
     # TODO: how to make this multiplatform?
@@ -164,9 +155,8 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes-test",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
+    srcs = ["//build:test-portable-targets"],
     extension = "tar.gz",
-    files = ["//build:test-portable-targets"],
     package_dir = "kubernetes",
     strip_prefix = "//",
     deps = [
@@ -177,8 +167,7 @@ pkg_tar(
 
 pkg_tar(
     name = "_full_server",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    files = [
+    srcs = [
         ":kubernetes-manifests.tar.gz",
     ],
     package_dir = "server",
@@ -187,9 +176,7 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         "//:Godeps/LICENSES",
         "//:README.md",
         "//:version",
@@ -199,6 +186,7 @@ pkg_tar(
         "//hack/lib:all-srcs",
         "//third_party/htpasswd:all-srcs",
     ],
+    extension = "tar.gz",
     package_dir = "kubernetes",
     strip_prefix = "//",
     deps = [
@@ -208,7 +196,6 @@ pkg_tar(
 
 pkg_tar(
     name = "kubernetes-manifests",
-    build_tar = "@io_kubernetes_build//tools/build_tar",
     extension = "tar.gz",
     deps = [
         "//cluster:manifests",

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,15 +1,15 @@
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "e8c7f1fda9ee482745a5b35e8314ac3ae744d4ba30f3e6de28148fd166044306",
-    strip_prefix = "rules_go-737df20c53499fd84b67f04c6ca9ccdee2e77089",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/737df20c53499fd84b67f04c6ca9ccdee2e77089.tar.gz"],
+    sha256 = "0efdc3cca8ac1c29e1c837bee260dab537dfd373eb4c43c7d50246a142a7c098",
+    strip_prefix = "rules_go-74d8ad8f9f59a1d9a7cf066d0980f9e394acccd7",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/74d8ad8f9f59a1d9a7cf066d0980f9e394acccd7.tar.gz"],
 )
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "cf138e48871629345548b4aaf23101314b5621c1bdbe45c4e75edb45b08891f0",
-    strip_prefix = "repo-infra-1fb0a3ff0cc5308a6d8e2f3f9c57d1f2f940354e",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/1fb0a3ff0cc5308a6d8e2f3f9c57d1f2f940354e.tar.gz"],
+    sha256 = "f4946917d95c54aaa98d1092757256e491f8f48fd550179134f00f902bc0b4ce",
+    strip_prefix = "repo-infra-c75960142a50de16ac6225b0843b1ff3476ab0b4",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/c75960142a50de16ac6225b0843b1ff3476ab0b4.tar.gz"],
 )
 
 http_archive(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -29,16 +29,6 @@ new_http_archive(
     urls = ["https://github.com/coreos/etcd/releases/download/v%s/etcd-v%s-linux-amd64.tar.gz" % (ETCD_VERSION, ETCD_VERSION)],
 )
 
-# This contains a patch to not prepend ./ to tarfiles produced by pkg_tar.
-# When merged upstream, we'll no longer need to use ixdy's fork:
-# https://bazel-review.googlesource.com/#/c/10390/
-http_archive(
-    name = "io_bazel",
-    sha256 = "892a84aa1e7c1f99fb57bb056cb648745c513077252815324579a012d263defb",
-    strip_prefix = "bazel-df2c687c22bdd7c76f3cdcc85f38fefd02f0b844",
-    urls = ["https://github.com/ixdy/bazel/archive/df2c687c22bdd7c76f3cdcc85f38fefd02f0b844.tar.gz"],
-)
-
 http_archive(
     name = "io_bazel_rules_docker",
     sha256 = "c440717ee9b1b2f4a1e9bf5622539feb5aef9db83fc1fa1517818f13c041b0be",

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",

--- a/cluster/addons/BUILD
+++ b/cluster/addons/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "addon-srcs",
@@ -16,10 +16,10 @@ filegroup(
 
 pkg_tar(
     name = "addons",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         ":addon-srcs",
     ],
+    extension = "tar.gz",
     mode = "0644",
     strip_prefix = ".",
 )

--- a/cluster/gce/BUILD
+++ b/cluster/gce/BUILD
@@ -1,24 +1,17 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "gci-trusty-manifests",
-    files = [
-        "gci/configure-helper.sh",
-        "gci/health-monitor.sh",
-        "//cluster/gce/gci/mounter",
-    ],
+    files = {
+        "//cluster/gce/gci/mounter": "gci-mounter",
+        "gci/configure-helper.sh": "gci-configure-helper.sh",
+        "gci/health-monitor.sh": "health-monitor.sh",
+    },
     mode = "0755",
     strip_prefix = ".",
-    # pkg_tar doesn't support renaming the files we add, so instead create symlinks.
-    symlinks = {
-        "gci-configure-helper.sh": "gci/configure-helper.sh",
-        "health-monitor.sh": "gci/health-monitor.sh",
-        "gci-mounter": "gci/mounter/mounter",
-        "trusty-configure-helper.sh": "trusty/configure-helper.sh",
-    },
 )
 
 filegroup(
@@ -52,7 +45,7 @@ release_filegroup(
 
 pkg_tar(
     name = "gce-master-manifests",
-    files = [
+    srcs = [
         "manifests/abac-authz-policy.jsonl",
         "manifests/cluster-autoscaler.manifest",
         "manifests/e2e-image-puller.manifest",

--- a/cluster/gce/addons/BUILD
+++ b/cluster/gce/addons/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "addon-srcs",
@@ -16,10 +16,10 @@ filegroup(
 
 pkg_tar(
     name = "addons",
-    extension = "tar.gz",
-    files = [
+    srcs = [
         ":addon-srcs",
     ],
+    extension = "tar.gz",
     mode = "0644",
     strip_prefix = ".",
 )


### PR DESCRIPTION
**What this PR does / why we need it**: a variety of improvements:
* new `rules_go` includes bug fixes to support Bazel 0.10+ and also fixes some race detector/thread sanitizer bugs experienced by some Googelrs, among other enhancements
* new `repo-infra` includes a `pkg_tar` macro which enables the faster go-based tar builder by default, which we now use everywhere; additionally
  * we no longer need to use my fork of the `bazelbuild/bazel` tree 
  * we can fix some symlinking hacks, using the new `files` dict-based attributes on `pkg_tar`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

The net effect of all of these things is that `make bazel-release` should be faster. Yay!

/assign @mikedanese @BenTheElder 
/approve no-issue