### PR TITLE
Openstack: register metadata.hostname as node name

### DIFF
--- a/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/pkg/cloudprovider/providers/openstack/metadata.go
@@ -69,7 +69,7 @@ type DeviceMetadata struct {
 // See http://docs.openstack.org/user-guide/cli_config_drive.html
 type Metadata struct {
 	Uuid             string           `json:"uuid"`
-	Name             string           `json:"name"`
+	Hostname         string           `json:"hostname"`
 	AvailabilityZone string           `json:"availability_zone"`
 	Devices          []DeviceMetadata `json:"devices,omitempty"`
 	// .. and other fields we don't care about.  Expand as necessary.

--- a/pkg/cloudprovider/providers/openstack/metadata_test.go
+++ b/pkg/cloudprovider/providers/openstack/metadata_test.go
@@ -23,7 +23,7 @@ import (
 
 var FakeMetadata = Metadata{
 	Uuid:             "83679162-1378-4288-a2d4-70e13ec132aa",
-	Name:             "test",
+	Hostname:         "test",
 	AvailabilityZone: "nova",
 }
 
@@ -81,8 +81,8 @@ func TestParseMetadata(t *testing.T) {
 		t.Fatalf("Should succeed when provided with valid data: %s", err)
 	}
 
-	if md.Name != "test" {
-		t.Errorf("incorrect name: %s", md.Name)
+	if md.Hostname != "test.novalocal" {
+		t.Errorf("incorrect hostname: %s", md.Hostname)
 	}
 
 	if md.Uuid != "83679162-1378-4288-a2d4-70e13ec132aa" {

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -58,7 +58,7 @@ func (i *Instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 	if err != nil {
 		return "", err
 	}
-	return types.NodeName(md.Name), nil
+	return types.NodeName(md.Hostname), nil
 }
 
 func (i *Instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently Openstack can boot up instances with the name like `xyz/abc`, which is not a valid kubelet node name. While `hostname` retrieved from `meta_data.json` has already been sanitized 
 by Openstack to valid DNS-1123 format string. It's safe to register this `metadata.hostname` as valid kubelet node name.

/kind bug
/sig openstack

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57765

**Special notes for your reviewer**:
/assign @dims @FengyunPan 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Openstack: register metadata.hostname as node name
```
