### PR TITLE
[WIP] get secret from CSI PV annotation and pass into user credential in NodePublishVolume

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -41,6 +41,7 @@ type csiClient interface {
 		accessMode api.PersistentVolumeAccessMode,
 		volumeInfo map[string]string,
 		volumeAttribs map[string]string,
+		userCredentials map[string]string,
 		fsType string,
 	) error
 	NodeUnpublishVolume(ctx grpctx.Context, volID string, targetPath string) error
@@ -151,6 +152,7 @@ func (c *csiDriverClient) NodePublishVolume(
 	accessMode api.PersistentVolumeAccessMode,
 	volumeInfo map[string]string,
 	volumeAttribs map[string]string,
+	userCredentials map[string]string,
 	fsType string,
 ) error {
 	glog.V(4).Info(log("calling NodePublishVolume rpc [volid=%s,target_path=%s]", volID, targetPath))
@@ -172,7 +174,7 @@ func (c *csiDriverClient) NodePublishVolume(
 		Readonly:          readOnly,
 		PublishVolumeInfo: volumeInfo,
 		VolumeAttributes:  volumeAttribs,
-
+		UserCredentials:   userCredentials,
 		VolumeCapability: &csipb.VolumeCapability{
 			AccessMode: &csipb.VolumeCapability_AccessMode{
 				Mode: asCSIAccessMode(accessMode),

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -32,9 +32,10 @@ import (
 )
 
 const (
-	csiPluginName              = "kubernetes.io/csi"
-	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
-
+	csiPluginName                   = "kubernetes.io/csi"
+	csiVolAttribsAnnotationKey      = "csi.volume.kubernetes.io/volume-attributes"
+	csiSecretNameAnnotationKey      = "csi.volume.kubernetes.io/user-credential-name"
+	csiSecretNamespaceAnnotationKey = "csi.volume.kubernetes.io/user-credential-namespace"
 	// TODO (vladimirvivien) implement a more dynamic way to discover
 	// the unix domain socket path for each installed csi driver.
 	// TODO (vladimirvivien) would be nice to name socket with a .sock extension


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass user credentials into NodePublishVolume. Volumes such like rbd need credentials to map images.

THIS IS a temporary solution for 1.9. Long term fix will be different from @sbezverk 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58524

**Special notes for your reviewer**:
/sig storage
**Release note**:
```release-note
NONE

```
