### PR TITLE
Benchmarking script pretty-prints results into a separate file

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -35,6 +35,7 @@ export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
 retry go get github.com/tools/godep && godep version
 retry go get github.com/jstemmer/go-junit-report
+retry go get github.com/cespare/prettybench
 
 # Disable the Go race detector.
 export KUBE_RACE=" "
@@ -48,4 +49,6 @@ cd /go/src/k8s.io/kubernetes
 
 ./hack/install-etcd.sh
 
-make test-integration WHAT="$*" KUBE_TEST_ARGS="-run='XXX' -bench=. -benchmem"
+# Run the benchmark tests and pretty-print the results into a separate file.
+make test-integration WHAT="$*" KUBE_TEST_ARGS="-run='XXX' -bench=. -benchmem" \
+  | tee >(prettybench -no-passthrough > ${ARTIFACTS_DIR}/BenchmarkResults.txt)


### PR DESCRIPTION
Towards https://github.com/kubernetes/kubernetes/issues/58154

Here's how the results would be printed into a file with this change:

```
benchmark                                              iter      time/iter     bytes alloc             allocs
---------                                              ----      ---------     -----------             ------
BenchmarkScheduling/100Nodes/0Pods-12                   300     3.51 ms/op     451788 B/op     5050 allocs/op
BenchmarkScheduling/100Nodes/1000Pods-12                200     5.40 ms/op     604585 B/op     7465 allocs/op
BenchmarkScheduling/1000Nodes/0Pods-12                  100    31.41 ms/op    2391316 B/op    27358 allocs/op
BenchmarkScheduling/1000Nodes/1000Pods-12               100    39.77 ms/op    3037734 B/op    39370 allocs/op
BenchmarkSchedulingAntiAffinity/500Nodes/250Pods-12     250    62.14 ms/op    3611034 B/op    28690 allocs/op
BenchmarkSchedulingAntiAffinity/500Nodes/5000Pods-12    250   208.25 ms/op   37093899 B/op   241132 allocs/op
```

/cc @wojtek-t @porridge - Could one of you please review?

```release-note
NONE
```