### PR TITLE
Add vSphere Cloud Provider vclib tests

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/vclib/BUILD
@@ -59,11 +59,17 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["datacenter_test.go"],
+    srcs = [
+        "datacenter_test.go",
+        "datastore_test.go",
+        "folder_test.go",
+        "virtualmachine_test.go",
+    ],
     embed = [":go_default_library"],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib",
     deps = [
         "//vendor/github.com/vmware/govmomi:go_default_library",
+        "//vendor/github.com/vmware/govmomi/object:go_default_library",
         "//vendor/github.com/vmware/govmomi/simulator:go_default_library",
     ],
 )

--- a/pkg/cloudprovider/providers/vsphere/vclib/constants.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/constants.go
@@ -50,3 +50,10 @@ const (
 	DummyVMPrefixName        = "vsphere-k8s"
 	ActivePowerState         = "poweredOn"
 )
+
+// Test Constants
+const (
+	testDefaultDatacenter = "DC0"
+	testDefaultDatastore  = "LocalDS_0"
+	testNameNotFound      = "enoent"
+)

--- a/pkg/cloudprovider/providers/vsphere/vclib/datastore_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datastore_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestDatastore(t *testing.T) {
+	ctx := context.Background()
+
+	// vCenter model + initial set of objects (cluster, hosts, VMs, network, datastore, etc)
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{GoVmomiClient: c}
+
+	dc, err := GetDatacenter(ctx, vc, testDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	all, err := dc.GetAllDatastores(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range all {
+		ds := info.Datastore
+		kind, cerr := ds.GetType(ctx)
+		if cerr != nil {
+			t.Error(err)
+		}
+		if kind == "" {
+			t.Error("empty Datastore type")
+		}
+
+		dir := object.DatastorePath{
+			Datastore: info.Info.Name,
+			Path:      "kubevols",
+		}
+
+		// TODO: test Datastore.IsCompatibleWithStoragePolicy (vcsim needs PBM support)
+
+		for _, fail := range []bool{false, true} {
+			cerr = ds.CreateDirectory(ctx, dir.String(), false)
+			if fail {
+				if cerr != ErrFileAlreadyExist {
+					t.Errorf("expected %s, got: %s", ErrFileAlreadyExist, cerr)
+				}
+				continue
+			}
+
+			if cerr != nil {
+				t.Error(err)
+			}
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/folder_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/folder_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestFolder(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	// Child folder "F0" will be created under the root folder and datacenter folders,
+	// and all resources are created within the "F0" child folders.
+	model.Folder = 1
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{GoVmomiClient: c}
+
+	dc, err := GetDatacenter(ctx, vc, testDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	const folderName = "F0"
+	vmFolder := path.Join("/", folderName, dc.Name(), "vm")
+
+	tests := []struct {
+		folderPath string
+		expect     int
+	}{
+		{vmFolder, 0},
+		{path.Join(vmFolder, folderName), (model.Host + model.Cluster) * model.Machine},
+	}
+
+	for i, test := range tests {
+		folder, cerr := dc.GetFolderByPath(ctx, test.folderPath)
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+
+		vms, cerr := folder.GetVirtualMachines(ctx)
+		if cerr != nil {
+			t.Fatalf("%d: %s", i, cerr)
+		}
+
+		if len(vms) != test.expect {
+			t.Errorf("%d: expected %d VMs, got: %d", i, test.expect, len(vms))
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/virtualmachine_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestVirtualMachine(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{GoVmomiClient: c}
+
+	dc, err := GetDatacenter(ctx, vc, testDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	folders, err := dc.Folders(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	folder, err := dc.GetFolderByPath(ctx, folders.VmFolder.InventoryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vms, err := folder.GetVirtualMachines(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vms) == 0 {
+		t.Fatal("no VMs")
+	}
+
+	for _, vm := range vms {
+		all, err := vm.GetAllAccessibleDatastores(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(all) == 0 {
+			t.Error("no accessible datastores")
+		}
+
+		_, err = vm.GetResourcePool(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		diskPath, err := vm.GetVirtualDiskPath(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		options := &VolumeOptions{SCSIControllerType: PVSCSIControllerType}
+
+		for _, expect := range []bool{true} { // TODO: vcsim needs to honor FileOperation to attach an existing disk
+			attached, err := vm.IsDiskAttached(ctx, diskPath)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if attached != expect {
+				t.Errorf("attached=%t, expected=%t", attached, expect)
+			}
+
+			uuid, err := vm.AttachDisk(ctx, diskPath, options)
+			if err != nil {
+				t.Error(err)
+			}
+			if uuid == "" {
+				t.Error("missing uuid")
+			}
+
+			err = vm.DetachDisk(ctx, diskPath)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+		for _, expect := range []bool{true, false} {
+			active, err := vm.IsActive(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if active != expect {
+				t.Errorf("active=%t, expected=%t", active, expect)
+			}
+
+			if expect {
+				// Expecting to hit the error path since the VM is still powered on
+				err = vm.DeleteVM(ctx)
+				if err == nil {
+					t.Error("expected error")
+				}
+				_, _ = vm.PowerOff(ctx)
+				continue
+			}
+
+			// Should be able to delete now that VM power is off
+			err = vm.DeleteVM(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Additional vSphere Cloud Provider functional tests against vcsim, providing more test coverage without having to run against a real vCenter instance.

Follow up to #55918

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

This set of tests focuses on Datastore, Folder and VirtualMachine types.  A couple of TODOs depend on changes to vcsim, I will follow up on those.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
