### PR TITLE
Force use of Makefile for update

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -149,11 +149,11 @@ define UPDATE_HELP_INFO
 endef
 .PHONY: update
 ifeq ($(PRINT_HELP),y)
-update:
+update: generated_files
 	@echo "$$UPDATE_HELP_INFO"
 else
 update:
-	hack/update-all.sh
+	CALLED_FROM_MAIN_MAKEFILE=1 hack/make-rules/update.sh
 endif
 
 define CHECK_TEST_HELP_INFO

--- a/hack/make-rules/update.sh
+++ b/hack/make-rules/update.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A single script that runs a predefined set of update-* scripts, as they often go together.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+# If called directly, exit.
+if [[ "${CALLED_FROM_MAIN_MAKEFILE:-""}" == "" ]]; then
+    echo "ERROR: $0 should not be run directly." >&2
+    echo >&2
+    echo "Please run this command using \"make update\""
+    exit 1
+fi
+
+SILENT=${SILENT:-true}
+ALL=${FORCE_ALL:-false}
+V=""
+if [[ "${SILENT}" != "true" ]]; then
+	V="-v"
+fi
+
+trap 'exit 1' SIGINT
+
+if ${SILENT} ; then
+	echo "Running in silent mode, run with SILENT=false if you want to see script logs."
+fi
+
+if ! ${ALL} ; then
+	echo "Running in short-circuit mode; run with FORCE_ALL=true to force all scripts to run."
+fi
+
+"${KUBE_ROOT}/hack/godep-restore.sh" ${V}
+
+BASH_TARGETS="
+	update-generated-protobuf
+	update-codegen
+	update-generated-runtime
+	update-generated-device-plugin
+	update-generated-docs
+	update-generated-swagger-docs
+	update-swagger-spec
+	update-openapi-spec
+	update-api-reference-docs
+	update-staging-godeps
+	update-bazel"
+
+for t in ${BASH_TARGETS}; do
+	echo -e "${color_yellow}Running $t${color_norm}"
+	if ${SILENT} ; then
+		if ! bash "${KUBE_ROOT}/hack/$t.sh" 1> /dev/null; then
+			echo -e "${color_red}Running $t FAILED${color_norm}"
+			if ! ${ALL}; then
+				exit 1
+			fi
+		fi
+	else
+		if ! bash "${KUBE_ROOT}/hack/$t.sh"; then
+			echo -e "${color_red}Running $t FAILED${color_norm}"
+			if ! ${ALL}; then
+				exit 1
+			fi
+		fi
+	fi
+done
+
+echo -e "${color_green}Update scripts completed successfully${color_norm}"

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors.
+# Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,77 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A single script that runs a predefined set of update-* scripts, as they often go together.
+# This script is a vestigial redirection.  Please do not add "real" logic.
+# The "true" target of this makerule is `hack/make-rules/update.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${KUBE_ROOT}/hack/lib/init.sh"
-source "${KUBE_ROOT}/hack/lib/util.sh"
 
-SILENT=true
-ALL=false
-V=""
-
-while getopts ":va" opt; do
-	case $opt in
-		a)
-			ALL=true
-			;;
-		v)
-			SILENT=false
-			V="-v"
-			;;
-		\?)
-			echo "Invalid flag: -$OPTARG" >&2
-			exit 1
-			;;
-	esac
-done
-
-trap 'exit 1' SIGINT
-
-if $SILENT ; then
-	echo "Running in silent mode, run with -v if you want to see script logs."
-fi
-
-if ! $ALL ; then
-	echo "Running in short-circuit mode; run with -a to force all scripts to run."
-fi
-
-"${KUBE_ROOT}/hack/godep-restore.sh" ${V}
-
-BASH_TARGETS="
-	update-generated-protobuf
-	update-codegen
-	update-generated-runtime
-	update-generated-device-plugin
-	update-generated-docs
-	update-generated-swagger-docs
-	update-swagger-spec
-	update-openapi-spec
-	update-api-reference-docs
-	update-staging-godeps
-	update-bazel"
-
-for t in $BASH_TARGETS; do
-	echo -e "${color_yellow}Running $t${color_norm}"
-	if $SILENT ; then
-		if ! bash "$KUBE_ROOT/hack/$t.sh" 1> /dev/null; then
-			echo -e "${color_red}Running $t FAILED${color_norm}"
-			if ! $ALL; then
-				exit 1
-			fi
-		fi
-	else
-		if ! bash "$KUBE_ROOT/hack/$t.sh"; then
-			echo -e "${color_red}Running $t FAILED${color_norm}"
-			if ! $ALL; then
-				exit 1
-			fi
-		fi
-	fi
-done
-
-echo -e "${color_green}Update scripts completed successfully${color_norm}"
+echo "NOTE: $0 has been replaced by 'make update'"
+echo
+echo "The equivalent of this invocation is: "
+echo "    make update"
+echo
+echo
+make --no-print-directory -C "${KUBE_ROOT}" update


### PR DESCRIPTION
**What this PR does / why we need it**:
This forces the use of `make update` instead of `hack/update-all.sh`. The main reason for this is ensuring that `make generated_files` runs first, as the files it generates are used in some of the other update scripts. I've seen this a couple times bite contributors where they just haven't regenerated the code yet, so the update-all scripts don't fully do their job.

**Release note**:
```release-note
NONE
```
