### PR TITLE
kubeadm: add better test coverage to reset.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -86,6 +86,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -18,12 +18,15 @@ package cmd
 
 import (
 	"errors"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	"k8s.io/utils/exec"
@@ -52,8 +55,38 @@ func assertDirEmpty(t *testing.T, path string) {
 	}
 }
 
+func TestNewReset(t *testing.T) {
+	certsDir := kubeadmapiext.DefaultCertificatesDir
+	criSocketPath := "/var/run/dockershim.sock"
+	skipPreFlight := false
+
+	ignorePreflightErrors := []string{"all"}
+	ignorePreflightErrorsSet, _ := validation.ValidateIgnorePreflightErrors(ignorePreflightErrors, skipPreFlight)
+	NewReset(ignorePreflightErrorsSet, certsDir, criSocketPath)
+
+	ignorePreflightErrors = []string{}
+	ignorePreflightErrorsSet, _ = validation.ValidateIgnorePreflightErrors(ignorePreflightErrors, skipPreFlight)
+	NewReset(ignorePreflightErrorsSet, certsDir, criSocketPath)
+}
+
+func TestNewCmdReset(t *testing.T) {
+	var out io.Writer
+	cmd := NewCmdReset(out)
+
+	tmpDir, err := ioutil.TempDir("", "kubeadm-reset-test")
+	if err != nil {
+		t.Errorf("Unable to create temporary directory: %v", err)
+	}
+	args := []string{"--ignore-preflight-errors=all", "--cert-dir=" + tmpDir}
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Cannot execute reset command: %v", err)
+	}
+}
+
 func TestConfigDirCleaner(t *testing.T) {
 	tests := map[string]struct {
+		resetDir        string
 		setupDirs       []string
 		setupFiles      []string
 		verifyExists    []string
@@ -139,6 +172,12 @@ func TestConfigDirCleaner(t *testing.T) {
 				"manifests",
 			},
 		},
+		"not a directory": {
+			resetDir: "test-path",
+			setupFiles: []string{
+				"test-path",
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -167,7 +206,10 @@ func TestConfigDirCleaner(t *testing.T) {
 			defer f.Close()
 		}
 
-		resetConfigDir(tmpDir, filepath.Join(tmpDir, "pki"))
+		if test.resetDir == "" {
+			test.resetDir = "pki"
+		}
+		resetConfigDir(tmpDir, filepath.Join(tmpDir, test.resetDir))
 
 		// Verify the files we cleanup implicitly in every test:
 		assertExists(t, tmpDir)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
a PR for adding some more tests in `kubeadm/cmd` for `reset.go`.
increasing coverage from ~11% to ~92%

the remaining 8% are kind of hard to test or not worth the complexity.

original idea to add more tests in kubeadm was suggested to me by @luxas at slack.
in time, i might add better coverage to all cmd `.go` files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

please, link issue # if you know of such.

**Special notes for your reviewer**:
none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
