### PR TITLE
Initialize node ahead in case we need to refer to it in error cases

### DIFF
--- a/pkg/controller/node/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/node/ipam/cloud_cidr_allocator.go
@@ -195,7 +195,7 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 
 	node, err := ca.nodeLister.Get(nodeName)
 	if err != nil {
-		glog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %v", nodeName, err)
+		glog.Errorf("Failed to get node %v: %v", nodeName, err)
 		return err
 	}
 

--- a/pkg/controller/node/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/node/ipam/cloud_cidr_allocator.go
@@ -191,9 +191,13 @@ func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 
 // updateCIDRAllocation assigns CIDR to Node and sends an update to the API server.
 func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
-	var err error
-	var node *v1.Node
 	defer ca.removeNodeFromProcessing(nodeName)
+
+	node, err := ca.nodeLister.Get(nodeName)
+	if err != nil {
+		glog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDR: %v", nodeName, err)
+		return err
+	}
 
 	cidrs, err := ca.cloud.AliasRanges(types.NodeName(nodeName))
 	if err != nil {


### PR DESCRIPTION
Initialize node ahead in case we need to refer to it in error cases. This is a backport of https://github.com/kubernetes/kubernetes/pull/58186. We cannot intact backport to it due to a refactor PR https://github.com/kubernetes/kubernetes/pull/56352.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We want to cherry pick to 1.9. Master already has the fix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58181

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid controller-manager to crash when enabling IP alias for K8s cluster.
```
