### PR TITLE
Stop all running containers in the sandbox in StopPodSandbox.

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -224,6 +224,24 @@ func (ds *dockerService) StopPodSandbox(ctx context.Context, r *runtimeapi.StopP
 	// since it is stopped. With empty network namespcae, CNI bridge plugin will conduct best
 	// effort clean up and will not return error.
 	errList := []error{}
+
+	// Stop all running containers in the sandbox.
+	opts := dockertypes.ContainerListOptions{All: true}
+	opts.Filters = dockerfilters.NewArgs()
+	f := newDockerFilter(&opts.Filters)
+	f.AddLabel(sandboxIDLabelKey, podSandboxID)
+
+	containers, err := ds.client.ListContainers(opts)
+	if err != nil {
+		errList = append(errList, err)
+	}
+
+	for i := range containers {
+		if _, err := ds.StopContainer(ctx, &runtimeapi.StopContainerRequest{ContainerId: containers[i].ID, Timeout: 10}); err != nil && !libdocker.IsContainerNotFoundError(err) {
+			errList = append(errList, err)
+		}
+	}
+
 	ready, ok := ds.getNetworkReady(podSandboxID)
 	if !hostNetwork && (ready || !ok) {
 		// Only tear down the pod network if we haven't done so already
@@ -250,7 +268,6 @@ func (ds *dockerService) StopPodSandbox(ctx context.Context, r *runtimeapi.StopP
 		return resp, nil
 	}
 
-	// TODO: Stop all running containers in the sandbox.
 	return nil, utilerrors.NewAggregate(errList)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`TODO: Stop all running containers in the sandbox` remains in function `StopPodSandbox` under `pkg/kubelet/dockershim/docker_sandbox.go`. This PR stops all running containers with a grace period when `StopPodSandbox` is called.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
`NONE`
