### PR TITLE
Fix vet errors in e2e scheduling tests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -232,7 +232,7 @@ values:
 			Param("watch", "true").
 			DoRaw()
 		if !errors.IsNotAcceptable(err) {
-			t.Fatal("expected not acceptable error, got %v (%s)", err, string(result))
+			t.Fatalf("expected not acceptable error, got %v (%s)", err, string(result))
 		}
 		obj, err := decodeYAML(result)
 		if err != nil {
@@ -294,7 +294,7 @@ values:
 			t.Fatal(v, ok, err, string(result))
 		}
 		if obj.GetUID() != uid {
-			t.Fatal("uid changed: %v vs %v", uid, obj.GetUID())
+			t.Fatalf("uid changed: %v vs %v", uid, obj.GetUID())
 		}
 	}
 
@@ -302,7 +302,7 @@ values:
 	{
 		yamlBody := []byte(fmt.Sprintf(`
 values:
-  numVal: 3`, apiVersion, kind, uid, resourceVersion))
+  numVal: 3`))
 		result, err := rest.Patch(types.MergePatchType).
 			SetHeader("Accept", "application/yaml").
 			SetHeader("Content-Type", "application/yaml").

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -623,7 +623,7 @@ func TestFailGettingIPv4Routes(t *testing.T) {
 	errStrFrag := "no such file"
 	_, err := v4File.extract()
 	if err == nil {
-		fmt.Errorf("Expected error trying to read non-existent v4 route file")
+		t.Errorf("Expected error trying to read non-existent v4 route file")
 	}
 	if !strings.Contains(err.Error(), errStrFrag) {
 		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())
@@ -638,7 +638,7 @@ func TestFailGettingIPv6Routes(t *testing.T) {
 	errStrFrag := "no such file"
 	_, err := v6File.extract()
 	if err == nil {
-		fmt.Errorf("Expected error trying to read non-existent v6 route file")
+		t.Errorf("Expected error trying to read non-existent v6 route file")
 	}
 	if !strings.Contains(err.Error(), errStrFrag) {
 		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())
@@ -653,7 +653,7 @@ func TestGetAllDefaultRoutesFailNoV4RouteFile(t *testing.T) {
 	errStrFrag := "no such file"
 	_, err := getAllDefaultRoutes()
 	if err == nil {
-		fmt.Errorf("Expected error trying to read non-existent v4 route file")
+		t.Errorf("Expected error trying to read non-existent v4 route file")
 	}
 	if !strings.Contains(err.Error(), errStrFrag) {
 		t.Errorf("Unable to find %q in error string %q", errStrFrag, err.Error())

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
@@ -103,7 +103,7 @@ func (m *Matcher) MatchNamespaceSelector(h *v1beta1.Webhook, attr admission.Attr
 		if !ok {
 			return false, apierrors.NewInternalError(err)
 		}
-		return false, &apierrors.StatusError{status.Status()}
+		return false, &apierrors.StatusError{ErrStatus: status.Status()}
 	}
 	if err != nil {
 		return false, apierrors.NewInternalError(err)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
@@ -77,13 +77,13 @@ func testCache(cache cache, t *testing.T) {
 	// when empty, record is stored
 	cache.set("foo", record1, time.Hour)
 	if result, ok := cache.get("foo"); !ok || result != record1 {
-		t.Errorf("Expected %#v, true, got %#v, %v", record1, ok)
+		t.Errorf("Expected %#v, true, got %#v, %v", record1, result, ok)
 	}
 
 	// newer record overrides
 	cache.set("foo", record2, time.Hour)
 	if result, ok := cache.get("foo"); !ok || result != record2 {
-		t.Errorf("Expected %#v, true, got %#v, %v", record2, ok)
+		t.Errorf("Expected %#v, true, got %#v, %v", record2, result, ok)
 	}
 
 	// removing the current value removes

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -848,7 +848,7 @@ func TestAuditIDHttpHeader(t *testing.T) {
 			}
 		} else {
 			if resp.Header.Get("Audit-ID") != "" {
-				t.Errorf("[%s] expected no Audit-ID http header returned, but got %p", test.desc, resp.Header.Get("Audit-ID"))
+				t.Errorf("[%s] expected no Audit-ID http header returned, but got %s", test.desc, resp.Header.Get("Audit-ID"))
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -99,7 +99,7 @@ func fakeScaleClient(t *testing.T) (ScalesGetter, []schema.GroupResource) {
 
 	restMapperRes, err := discovery.GetAPIGroupResources(fakeDiscoveryClient)
 	if err != nil {
-		t.Fatalf("unexpected error while constructing resource list from fake discovery client: %v")
+		t.Fatalf("unexpected error while constructing resource list from fake discovery client: %v", fakeDiscoveryClient)
 	}
 	restMapper := discovery.NewRESTMapper(restMapperRes, apimeta.InterfacesForUnstructured)
 

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -246,7 +246,7 @@ func TestSetRotationDeadline(t *testing.T) {
 				t.Errorf("%d metrics were recorded, wanted %d", g.calls, 1)
 			}
 			if g.lastValue != float64(tc.notAfter.Unix()) {
-				t.Errorf("%d value for metric was recorded, wanted %d", g.lastValue, tc.notAfter.Unix())
+				t.Errorf("%f value for metric was recorded, wanted %d", g.lastValue, tc.notAfter.Unix())
 			}
 		})
 	}

--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -200,7 +200,13 @@ func SetupNVIDIAGPUNode(f *framework.Framework, setupResourceGatherer bool) *fra
 	var rsgather *framework.ContainerResourceGatherer
 	if setupResourceGatherer {
 		framework.Logf("Starting ResourceUsageGather for the created DaemonSet pods.")
-		rsgather, err = framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{false, false, 2 * time.Second, 2 * time.Second, true}, pods)
+		rsgather, err := framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{
+			InKubemark:                  false,
+			MasterOnly:                  false,
+			ResourceDataGatheringPeriod: 2 * time.Second,
+			ProbeDuration:               2 * time.Second,
+			PrintVerboseLogs:            true,
+		}, pods)
 		framework.ExpectNoError(err, "creating ResourceUsageGather for the daemonset pods")
 		go rsgather.StartGatheringData()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I have encountered a vet error `test/e2e/scheduling/nvidia-gpus.go:192: k8s.io/kubernetes/test/e2e/framework.ResourceGathererOptions composite literal uses unkeyed fields` when running verify scripts. This PR fixes the error message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
`NONE`
