### PR TITLE
add webhook admission configuration decoding test cases

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
@@ -30,6 +30,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "authentication_test.go",
+        "kubeconfig_test.go",
         "serviceresolver_test.go",
     ],
     embed = [":go_default_library"],

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// create a place holder file to hold per test config
+	configFile, err := ioutil.TempFile("", "admission-config")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	configFileName := configFile.Name()
+	defer os.Remove(configFileName)
+
+	if err = configFile.Close(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// individual test scenarios
+	testCases := []struct {
+		CaseName   string
+		ConfigBody string
+		ExpecteErr bool
+	}{
+		// valid configuration
+		{
+			CaseName: "valid configuration",
+			ConfigBody: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+metadata:
+  name: webhook-config
+kubeConfigFile: /var/run/kubernetes/webhook.kubeconfig
+`,
+			ExpecteErr: false,
+		},
+
+		// invalid configuration: kubeConfigFile should be with absolute path
+		{
+			CaseName: "invalid configuration kubeConfigFile",
+			ConfigBody: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+metadata:
+  name: webhook-config
+kubeConfigFile: webhook.kubeconfig
+`,
+			ExpecteErr: true,
+		},
+
+		// invalid configuration kind
+		{
+			CaseName: "invalid configuration",
+			ConfigBody: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: InvalidWebhookAdmission
+metadata:
+  name: webhook-config
+kubeConfigFile: /var/run/kubernetes/webhook.kubeconfig
+`,
+			ExpecteErr: true,
+		},
+	}
+
+	for _, testcase := range testCases {
+		func() {
+			if err = ioutil.WriteFile(configFileName, []byte(testcase.ConfigBody), 0644); err != nil {
+				t.Fatalf("unexpected err writing temp file: %v", err)
+			}
+
+			configFile, err := os.Open(configFileName)
+			if err != nil {
+				t.Fatalf("failed to read test config: %v", err)
+			}
+			defer configFile.Close()
+
+			_, err = LoadConfig(configFile)
+			if testcase.ExpecteErr && err == nil {
+				t.Errorf("expect error but got none")
+			}
+			if !testcase.ExpecteErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add test cases for webhook admission configuration decoding.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/assign @liggitt @sttts 