### PR TITLE
Hide generated files only on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 hack/verify-flags/known-flags.txt merge=union
 test/test_owners.csv merge=union
 
-**/zz_generated.*.go -diff linguist-generated=true
-**/types.generated.go -diff linguist-generated=true
-**/generated.pb.go -diff linguist-generated=true
-**/generated.proto -diff
-**/types_swagger_doc_generated.go -diff linguist-generated=true
-docs/api-reference/** -diff linguist-generated=true
-api/swagger-spec/*.json -diff linguist-generated=true
-api/openapi-spec/*.json -diff linguist-generated=true
+**/zz_generated.*.go linguist-generated=true
+**/types.generated.go linguist-generated=true
+**/generated.pb.go linguist-generated=true
+**/generated.proto
+**/types_swagger_doc_generated.go linguist-generated=true
+docs/api-reference/** linguist-generated=true
+api/swagger-spec/*.json linguist-generated=true
+api/openapi-spec/*.json linguist-generated=true


### PR DESCRIPTION
**What this PR does / why we need it**:
#54766 and #55114 introduced ability to hide generated files in diffs. It's nice and reasonable in github UI, but locally it's very frequent that author wants to verify the generated changes. This PR modifes `.gitattributes` so that the generated files are hidden only on github, leaving diff-able locally. 

/assign @liggitt 
@mikekap fyi, since you authored the original PRs

**Release note**:
```release-note
NONE
```
