### PR TITLE
Don't run godep restore in jenkins verify

### DIFF
--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -40,9 +40,5 @@ export LOG_LEVEL=4
 
 cd /go/src/k8s.io/kubernetes
 
-# hack/verify-client-go.sh requires all dependencies exist in the GOPATH.
-# the retry helps avoid flakes while keeping total time bounded.
-./hack/godep-restore.sh || ./hack/godep-restore.sh
-
 ./hack/install-etcd.sh
 make verify


### PR DESCRIPTION
As far as I can tell, this is not needed any more, and just causes a huge slowdown on every verify run.  

/sig testing

```release-note
NONE
```
