### PR TITLE
Automated cherry pick of #55813: Add resource limits to prometheus-to-sd to guarantee qos #58104: Introduce METADATA_CONCEALMENT_NO_FIREWALL to prevent #58221: Bump metadata proxy to v1.9

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -38,19 +38,28 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google_containers/metadata-proxy:v0.1.5
+        image: gcr.io/google_containers/metadata-proxy:v0.1.6
         securityContext:
           privileged: true
+        # Request and limit resources to get guaranteed QoS.
         resources:
           requests:
-            memory: "32Mi"
+            memory: "25Mi"
             cpu: "30m"
           limits:
-            memory: "32Mi"
+            memory: "25Mi"
             cpu: "30m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
         image: gcr.io/google_containers/prometheus-to-sd:v0.2.2
+        # Request and limit resources to get guaranteed QoS.
+        resources:
+          requests:
+            memory: "20Mi"
+            cpu: "2m"
+          limits:
+            memory: "20Mi"
+            cpu: "2m"
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -38,7 +38,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google_containers/metadata-proxy:v0.1.6
+        image: gcr.io/google_containers/metadata-proxy:v0.1.9
         securityContext:
           privileged: true
         # Request and limit resources to get guaranteed QoS.

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -190,7 +190,7 @@ if [[ ${ENABLE_METADATA_CONCEALMENT:-} == "true" ]]; then
   # Put the necessary label on the node so the daemonset gets scheduled.
   NODE_LABELS="${NODE_LABELS},beta.kubernetes.io/metadata-proxy-ready=true"
   # Add to the provider custom variables.
-  PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_METADATA_CONCEALMENT"
+  PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_METADATA_CONCEALMENT METADATA_CONCEALMENT_NO_FIREWALL"
 fi
 
 # Optional: Enable node logging.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -218,7 +218,7 @@ if [[ ${ENABLE_METADATA_CONCEALMENT:-} == "true" ]]; then
   # Put the necessary label on the node so the daemonset gets scheduled.
   NODE_LABELS="${NODE_LABELS},beta.kubernetes.io/metadata-proxy-ready=true"
   # Add to the provider custom variables.
-  PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_METADATA_CONCEALMENT"
+  PROVIDER_VARS="${PROVIDER_VARS:-} ENABLE_METADATA_CONCEALMENT METADATA_CONCEALMENT_NO_FIREWALL"
 fi
 
 # Optional: Enable node logging.

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -77,7 +77,9 @@ function config-ip-firewall {
     iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)" -j MASQUERADE
   fi
 
-  if [[ "${ENABLE_METADATA_CONCEALMENT:-}" == "true" ]]; then
+  # If METADATA_CONCEALMENT_NO_FIREWALL is set, don't create a firewall on this
+  # node because we don't expect the daemonset to run on this node.
+  if [[ "${ENABLE_METADATA_CONCEALMENT:-}" == "true" ]] && [[ ! "${METADATA_CONCEALMENT_NO_FIREWALL:-}" == "true" ]]; then
     echo "Add rule for metadata concealment"
     iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 127.0.0.1:988
   fi


### PR DESCRIPTION
Cherry pick of #55813 #58104 #58221 on release-1.9.

#55813: Add resource limits to prometheus-to-sd to guarantee qos
#58104: Introduce METADATA_CONCEALMENT_NO_FIREWALL to prevent
#58221: Bump metadata proxy to v1.9


```release-note
GCP: allow a master to not include a metadata concealment firewall rule (if it's not running the metadata proxy), and reintroduce memory limits & bump metadata proxy to v0.1.9 to pick up security fixes.
```