### PR TITLE
[e2e util] Remove static IP functions based on gcloud

### DIFF
--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -22,83 +22,11 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
-	"time"
-
-	"github.com/golang/glog"
-
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
 // TODO: These should really just use the GCE API client library or at least use
 // better formatted output from the --format flag.
-
-func CreateGCEStaticIP(name string) (string, error) {
-	// gcloud compute --project "abshah-kubernetes-001" addresses create "test-static-ip" --region "us-central1"
-	// abshah@abhidesk:~/go/src/code.google.com/p/google-api-go-client/compute/v1$ gcloud compute --project "abshah-kubernetes-001" addresses create "test-static-ip" --region "us-central1"
-	// Created [https://www.googleapis.com/compute/v1/projects/abshah-kubernetes-001/regions/us-central1/addresses/test-static-ip].
-	// NAME           REGION      ADDRESS       STATUS
-	// test-static-ip us-central1 104.197.143.7 RESERVED
-
-	var outputBytes []byte
-	var err error
-	region, err := gce.GetGCERegion(TestContext.CloudConfig.Zone)
-	if err != nil {
-		return "", fmt.Errorf("failed to convert zone to region: %v", err)
-	}
-	glog.Infof("Creating static IP with name %q in project %q in region %q", name, TestContext.CloudConfig.ProjectID, region)
-	for attempts := 0; attempts < 4; attempts++ {
-		outputBytes, err = exec.Command("gcloud", "compute", "addresses", "create",
-			name, "--project", TestContext.CloudConfig.ProjectID,
-			"--region", region, "-q", "--format=yaml").CombinedOutput()
-		if err == nil {
-			break
-		}
-		glog.Errorf("output from failed attempt to create static IP: %s", outputBytes)
-		time.Sleep(time.Duration(5*attempts) * time.Second)
-	}
-	if err != nil {
-		// Ditch the error, since the stderr in the output is what actually contains
-		// any useful info.
-		return "", fmt.Errorf("failed to create static IP: %s", outputBytes)
-	}
-	output := string(outputBytes)
-	if strings.Contains(output, "RESERVED") {
-		r, _ := regexp.Compile("[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")
-		staticIP := r.FindString(output)
-		if staticIP == "" {
-			return "", fmt.Errorf("static IP not found in gcloud command output: %v", output)
-		} else {
-			return staticIP, nil
-		}
-	} else {
-		return "", fmt.Errorf("static IP %q could not be reserved: %v", name, output)
-	}
-}
-
-func DeleteGCEStaticIP(name string) error {
-	// gcloud compute --project "abshah-kubernetes-001" addresses create "test-static-ip" --region "us-central1"
-	// abshah@abhidesk:~/go/src/code.google.com/p/google-api-go-client/compute/v1$ gcloud compute --project "abshah-kubernetes-001" addresses create "test-static-ip" --region "us-central1"
-	// Created [https://www.googleapis.com/compute/v1/projects/abshah-kubernetes-001/regions/us-central1/addresses/test-static-ip].
-	// NAME           REGION      ADDRESS       STATUS
-	// test-static-ip us-central1 104.197.143.7 RESERVED
-
-	region, err := gce.GetGCERegion(TestContext.CloudConfig.Zone)
-	if err != nil {
-		return fmt.Errorf("failed to convert zone to region: %v", err)
-	}
-	glog.Infof("Deleting static IP with name %q in project %q in region %q", name, TestContext.CloudConfig.ProjectID, region)
-	outputBytes, err := exec.Command("gcloud", "compute", "addresses", "delete",
-		name, "--project", TestContext.CloudConfig.ProjectID,
-		"--region", region, "-q").CombinedOutput()
-	if err != nil {
-		// Ditch the error, since the stderr in the output is what actually contains
-		// any useful info.
-		return fmt.Errorf("failed to delete static IP %q: %v", name, string(outputBytes))
-	}
-	return nil
-}
 
 // Returns master & node image string, or error
 func lookupClusterImageSources() (string, string, error) {

--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Use GCE library for static IP instead of calling gcloud in e2e test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
