### PR TITLE
Add ResourceVersionObfuscation alpha feature to apiserver

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -268,11 +268,12 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
-	genericfeatures.Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
-	genericfeatures.APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.StreamingProxyRedirects:    {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.AdvancedAuditing:           {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.APIResponseCompression:     {Default: false, PreRelease: utilfeature.Alpha},
+	genericfeatures.Initializers:               {Default: false, PreRelease: utilfeature.Alpha},
+	genericfeatures.APIListChunking:            {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.ResourceVersionObfuscation: {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/plugin/pkg/admission/resourcequota/resource_access.go
+++ b/plugin/pkg/admission/resourcequota/resource_access.go
@@ -88,7 +88,7 @@ func (e *quotaAccessor) UpdateQuotaStatus(newQuota *api.ResourceQuota) error {
 	return nil
 }
 
-var etcdVersioner = etcd.APIObjectVersioner{}
+var etcdVersioner = etcd.NewAPIObjectVersioner()
 
 // checkCache compares the passed quota against the value in the look-aside cache and returns the newer
 // if the cache is out of date, it deletes the stale entry.  This only works because of etcd resourceVersions

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -63,6 +63,13 @@ const (
 	// Allow API clients to retrieve resource lists in chunks rather than
 	// all at once.
 	APIListChunking utilfeature.Feature = "APIListChunking"
+
+	// owner: @jennybuckley
+	// alpha: v1.10
+	//
+	// Stop apiserver from exposing storage backend resource versions of objects
+	// by obfuscating the value used by clients.
+	ResourceVersionObfuscation utilfeature.Feature = "ResourceVersionObfuscation"
 )
 
 func init() {
@@ -73,9 +80,10 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
-	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
-	Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
-	APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	StreamingProxyRedirects:    {Default: true, PreRelease: utilfeature.Beta},
+	AdvancedAuditing:           {Default: true, PreRelease: utilfeature.Beta},
+	APIResponseCompression:     {Default: false, PreRelease: utilfeature.Alpha},
+	Initializers:               {Default: false, PreRelease: utilfeature.Alpha},
+	APIListChunking:            {Default: true, PreRelease: utilfeature.Beta},
+	ResourceVersionObfuscation: {Default: false, PreRelease: utilfeature.Alpha},
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -52,7 +52,7 @@ func StorageWithCacher(capacity int) generic.StorageDecorator {
 		cacherConfig := storage.CacherConfig{
 			CacheCapacity:        capacity,
 			Storage:              s,
-			Versioner:            etcdstorage.APIObjectVersioner{},
+			Versioner:            etcdstorage.NewAPIObjectVersioner(),
 			Type:                 objectType,
 			ResourcePrefix:       resourcePrefix,
 			KeyFunc:              keyFunc,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -191,7 +191,7 @@ type Cacher struct {
 // its internal cache and updating its cache in the background based on the
 // given configuration.
 func NewCacherFromConfig(config CacherConfig) *Cacher {
-	watchCache := newWatchCache(config.CacheCapacity, config.KeyFunc, config.GetAttrsFunc)
+	watchCache := newWatchCache(config.CacheCapacity, config.KeyFunc, config.GetAttrsFunc, config.Versioner)
 	listerWatcher := newCacherListerWatcher(config.Storage, config.ResourcePrefix, config.NewListFunc)
 	reflectorName := "storage/cacher.go:" + config.ResourcePrefix
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "api_object_version_obfuscator_test.go",
         "api_object_versioner_test.go",
         "etcd_helper_test.go",
         "etcd_watcher_test.go",
@@ -42,10 +43,12 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "api_object_version_obfuscator.go",
         "api_object_versioner.go",
         "doc.go",
         "etcd_helper.go",
         "etcd_watcher.go",
+        "interfaces.go",
     ],
     importpath = "k8s.io/apiserver/pkg/storage/etcd",
     deps = [
@@ -60,9 +63,11 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd/util:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_version_obfuscator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_version_obfuscator.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+)
+
+// IdentityObfuscator implements Obfuscator.
+type IdentityObfuscator struct{}
+
+// NewIdentityObfuscator instantiates a IdentityObfuscator object.
+func NewIdentityObfuscator() IdentityObfuscator {
+	return IdentityObfuscator{}
+}
+
+// Decode implements Obfuscator.
+func (i IdentityObfuscator) Decode(key string, clientResourceVersion uint64) uint64 {
+	return clientResourceVersion
+}
+
+// Encode implements Obfuscator.
+func (i IdentityObfuscator) Encode(key string, etcdResourceVersion uint64) uint64 {
+	return etcdResourceVersion
+}
+
+// FeistelObfuscator implements Obfuscator.
+type FeistelObfuscator struct {
+	KeyScheduleFunc func(key string) []uint32
+	RoundFunc       func(block uint32, roundKey uint32) uint32
+}
+
+// NewFeistelObfuscator instantiates a FeistelObfuscator object.
+func NewFeistelObfuscator() FeistelObfuscator {
+	return FeistelObfuscator{
+		KeyScheduleFunc: HashKeySchedule,
+		RoundFunc:       ProductRoundFunc,
+	}
+}
+
+// HashKeySchedule takes the 128 hash of a string and breaks it
+// into 4 32-bit keys to be used as a key schedule.
+func HashKeySchedule(key string) []uint32 {
+	hash := fnv.New128a()
+	hash.Write([]byte(key))
+	hashBytes := hash.Sum(make([]byte, 0))
+	roundKeys := make([]uint32, 0)
+	for i := 0; i < len(hashBytes); i += 4 {
+		roundKey := binary.BigEndian.Uint32(hashBytes[i : i+4])
+		roundKeys = append(roundKeys, roundKey)
+	}
+	return roundKeys
+}
+
+// ProductRoundFunc is a round function that just multiplies the values
+// of the block and the roundKey.
+func ProductRoundFunc(block uint32, roundKey uint32) uint32 {
+	return block * roundKey
+}
+
+// Decode implements Obfuscator.
+func (f FeistelObfuscator) Decode(key string, clientResourceVersion uint64) uint64 {
+	left, right := splitUint(clientResourceVersion)
+	keySchedule := f.KeyScheduleFunc(key)
+	for i := len(keySchedule) - 1; i >= 0; i-- {
+		roundKey := keySchedule[i]
+		left, right = right^f.RoundFunc(left, roundKey), left
+	}
+	etcdResourceVersion := joinUint(left, right)
+	return etcdResourceVersion
+}
+
+// Encode implements Obfuscator. For a FeistelObfuscator, it should always map from 0 to 0,
+// and for two randomly selected uint64 values x and y, (x > y) should have no predictable
+// relationship with (Encode(x) > Encode(y)).
+func (f FeistelObfuscator) Encode(key string, etcdResourceVersion uint64) uint64 {
+	left, right := splitUint(etcdResourceVersion)
+	keySchedule := f.KeyScheduleFunc(key)
+	for i := 0; i < len(keySchedule); i++ {
+		roundKey := keySchedule[i]
+		left, right = right, left^f.RoundFunc(right, roundKey)
+	}
+	clientResourceVersion := joinUint(left, right)
+	return clientResourceVersion
+}
+
+func splitUint(in uint64) (uint32, uint32) {
+	left := uint32(in >> 32)
+	right := uint32(in & 0xffffffff)
+	return left, right
+}
+
+func joinUint(left, right uint32) uint64 {
+	return uint64(left)<<32 | uint64(right)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_version_obfuscator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_version_obfuscator_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"math"
+	"testing"
+	"testing/quick"
+)
+
+func TestFeistelObfuscatorSymmetric(t *testing.T) {
+	o := NewFeistelObfuscator()
+	checkRoundTrip := func(key string, etcdResourceVersion uint64) bool {
+		clientResourceVersion := o.Encode(key, etcdResourceVersion)
+		roundTripResourceVersion := o.Decode(key, clientResourceVersion)
+		return roundTripResourceVersion == etcdResourceVersion
+	}
+	testCases := []struct {
+		Key                 string
+		EtcdResourceVersion uint64
+	}{
+		{Key: "aaaa", EtcdResourceVersion: 0},
+		{Key: "bbb", EtcdResourceVersion: 1},
+		{Key: "cc", EtcdResourceVersion: math.MaxUint64},
+		{Key: "d", EtcdResourceVersion: math.MaxUint64 - 1},
+		{Key: "", EtcdResourceVersion: 1000000},
+	}
+	for _, testCase := range testCases {
+		if !checkRoundTrip(testCase.Key, testCase.EtcdResourceVersion) {
+			t.Errorf("%q %v: version returned after a round trip conversion was different",
+				testCase.Key,
+				testCase.EtcdResourceVersion,
+			)
+		}
+	}
+	if err := quick.Check(checkRoundTrip, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestFeistelObfuscatorFixedAtZero(t *testing.T) {
+	o := NewFeistelObfuscator()
+	checkZeroFixed := func(key string) bool {
+		clientResourceVersion := o.Encode(key, 0)
+		return clientResourceVersion == 0
+	}
+	if err := quick.Check(checkZeroFixed, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -67,7 +67,7 @@ func NewEtcdStorage(client etcd.Client, codec runtime.Codec, prefix string, quor
 		etcdMembersAPI: etcd.NewMembersAPI(client),
 		etcdKeysAPI:    etcd.NewKeysAPI(client),
 		codec:          codec,
-		versioner:      APIObjectVersioner{},
+		versioner:      NewAPIObjectVersioner(),
 		transformer:    transformer,
 		pathPrefix:     path.Join("/", prefix),
 		quorum:         quorum,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/interfaces.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+// Obfuscator represents a symmetric encryption algorithm. he value of the output of this
+// function should be pseudorandom, but the purpose isn't to securely protect data, only to make it
+// very clear that the only valid operation for a client to perform on two resource versions is to
+// check if they are equal.
+type Obfuscator interface {
+	// Encode takes a key and a resource version and performs a symmetric encryption
+	// algorithm on it.
+	Encode(key string, etcdResourceVersion uint64) uint64
+	// Encode takes a key and an encoded resource version and reverses the encryption
+	// algorithm. The value of v == Decode(key, Encode(key, v)) should always be true.
+	Decode(key string, clientResourceVersion uint64) uint64
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -97,7 +97,7 @@ func NewWithNoQuorumRead(c *clientv3.Client, codec runtime.Codec, prefix string,
 }
 
 func newStore(c *clientv3.Client, quorumRead, pagingEnabled bool, codec runtime.Codec, prefix string, transformer value.Transformer) *store {
-	versioner := etcd.APIObjectVersioner{}
+	versioner := etcd.NewAPIObjectVersioner()
 	result := &store{
 		client:        c,
 		codec:         codec,

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -35,12 +35,12 @@ type Versioner interface {
 	// UpdateObject sets storage metadata into an API object. Returns an error if the object
 	// cannot be updated correctly. May return nil if the requested object does not need metadata
 	// from database.
-	UpdateObject(obj runtime.Object, resourceVersion uint64) error
+	UpdateObject(obj runtime.Object, storageBackendResourceVersion uint64) error
 	// UpdateList sets the resource version into an API list object. Returns an error if the object
 	// cannot be updated correctly. May return nil if the requested object does not need metadata
 	// from database. continueValue is optional and indicates that more results are available if
 	// the client passes that value to the server in a subsequent call.
-	UpdateList(obj runtime.Object, resourceVersion uint64, continueValue string) error
+	UpdateList(obj runtime.Object, storageBackendResourceVersion uint64, continueValue string) error
 	// PrepareObjectForStorage should set SelfLink and ResourceVersion to the empty value. Should
 	// return an error if the specified object cannot be updated.
 	PrepareObjectForStorage(obj runtime.Object) error

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -99,7 +99,7 @@ func newEtcdTestStorage(t *testing.T, prefix string) (*etcdtesting.EtcdTestServe
 
 func newTestCacher(s storage.Interface, cap int) (*storage.Cacher, storage.Versioner) {
 	prefix := "pods"
-	v := etcdstorage.APIObjectVersioner{}
+	v := etcdstorage.NewAPIObjectVersioner()
 	config := storage.CacherConfig{
 		CacheCapacity:  cap,
 		Storage:        s,

--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
@@ -19,7 +19,6 @@ package storage
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -133,12 +132,16 @@ type watchCache struct {
 
 	// for testing timeouts.
 	clock clock.Clock
+
+	// An underlying storage.Versioner.
+	versioner Versioner
 }
 
 func newWatchCache(
 	capacity int,
 	keyFunc func(runtime.Object) (string, error),
-	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, bool, error)) *watchCache {
+	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, bool, error),
+	versioner Versioner) *watchCache {
 	wc := &watchCache{
 		capacity:        capacity,
 		keyFunc:         keyFunc,
@@ -149,6 +152,7 @@ func newWatchCache(
 		store:           cache.NewStore(storeElementKey),
 		resourceVersion: 0,
 		clock:           clock.RealClock{},
+		versioner:       versioner,
 	}
 	wc.cond = sync.NewCond(wc.RLocker())
 	return wc
@@ -156,7 +160,7 @@ func newWatchCache(
 
 // Add takes runtime.Object as an argument.
 func (w *watchCache) Add(obj interface{}) error {
-	object, resourceVersion, err := objectToVersionedRuntimeObject(obj)
+	object, resourceVersion, err := w.objectToVersionedRuntimeObject(obj)
 	if err != nil {
 		return err
 	}
@@ -168,7 +172,7 @@ func (w *watchCache) Add(obj interface{}) error {
 
 // Update takes runtime.Object as an argument.
 func (w *watchCache) Update(obj interface{}) error {
-	object, resourceVersion, err := objectToVersionedRuntimeObject(obj)
+	object, resourceVersion, err := w.objectToVersionedRuntimeObject(obj)
 	if err != nil {
 		return err
 	}
@@ -180,7 +184,7 @@ func (w *watchCache) Update(obj interface{}) error {
 
 // Delete takes runtime.Object as an argument.
 func (w *watchCache) Delete(obj interface{}) error {
-	object, resourceVersion, err := objectToVersionedRuntimeObject(obj)
+	object, resourceVersion, err := w.objectToVersionedRuntimeObject(obj)
 	if err != nil {
 		return err
 	}
@@ -190,7 +194,7 @@ func (w *watchCache) Delete(obj interface{}) error {
 	return w.processEvent(event, resourceVersion, f)
 }
 
-func objectToVersionedRuntimeObject(obj interface{}) (runtime.Object, uint64, error) {
+func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Object, uint64, error) {
 	object, ok := obj.(runtime.Object)
 	if !ok {
 		return nil, 0, fmt.Errorf("obj does not implement runtime.Object interface: %v", obj)
@@ -199,19 +203,11 @@ func objectToVersionedRuntimeObject(obj interface{}) (runtime.Object, uint64, er
 	if err != nil {
 		return nil, 0, err
 	}
-	resourceVersion, err := parseResourceVersion(meta.GetResourceVersion())
+	resourceVersion, err := w.versioner.ParseWatchResourceVersion(meta.GetResourceVersion())
 	if err != nil {
 		return nil, 0, err
 	}
 	return object, resourceVersion, nil
-}
-
-func parseResourceVersion(resourceVersion string) (uint64, error) {
-	if resourceVersion == "" {
-		return 0, nil
-	}
-	// Use bitsize being the size of int on the machine.
-	return strconv.ParseUint(resourceVersion, 10, 0)
 }
 
 func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, updateFunc func(*storeElement) error) error {
@@ -364,7 +360,7 @@ func (w *watchCache) GetByKey(key string) (interface{}, bool, error) {
 
 // Replace takes slice of runtime.Object as a paramater.
 func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
-	version, err := parseResourceVersion(resourceVersion)
+	version, err := w.versioner.ParseWatchResourceVersion(resourceVersion)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache_test.go
@@ -53,7 +53,7 @@ func newTestWatchCache(capacity int) *watchCache {
 	getAttrsFunc := func(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
 		return nil, nil, false, nil
 	}
-	wc := newWatchCache(capacity, keyFunc, getAttrsFunc)
+	wc := newWatchCache(capacity, keyFunc, getAttrsFunc, testVersioner{})
 	wc.clock = clock.NewFakeClock(time.Now())
 	return wc
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a default-off alpha feature, ResourceVersionObfuscation, which obfuscates the resourceVersions of objects used by clients of the apiserver when they list, watche, etc. This will make resourceVersions no longer monotonically increase. There was never a guarantee that they would be increasing, it just happens to be that way right now. Turning this flag on is a way to make sure your cluster set up does not rely on the faulty assumption that resourceVersions are monotonically increasing.

When the flag ```--feature-gates=ResourceVersionObfuscation=true``` is set, it stops apiserver from exposing the resourceVersion stored in etcd to clients, by implementing a [Feistel Cipher](https://en.wikipedia.org/wiki/Feistel_cipher). This is an ideal candidate for the algorithm because it runs in constant time, and is symmetric (which should guarantee that no two internal resourceVersions will be obfuscated to the same value). The purpose of the obfuscation is not to securely encrypt the value, just to make clear to clients that they cannot compare resource versions of objects to see which is more recent, only check if they are the same version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58112

**Special notes for your reviewers**:
This PR is based on top of #59069

**Release note**:
```release-note
Adds a default-off alpha feature, ResourceVersionObfuscation, which obfuscates the resourceVersions of objects used by clients of the apiserver when they list, watche, etc. This will make resourceVersions no longer monotonically increase. There was never a guarantee that they would be increasing, it just happens to be that way right now. Turning this flag on is a way to make sure your cluster set up does not rely on the faulty assumption that resourceVersions are monotonically increasing.
```
