### PR TITLE
Add gce-ingress e2e test for sync failure case

### DIFF
--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -21,9 +21,11 @@ import (
 	"path/filepath"
 	"time"
 
+	extensions "k8s.io/api/extensions/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -151,6 +153,96 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			// restarter.restart()
 			// By("should continue serving on provided static-ip for 30 seconds")
 			// framework.ExpectNoError(jig.verifyURL(fmt.Sprintf("https://%v/", ip), "", 30, 1*time.Second, httpClient))
+		})
+
+		It("should update ingress while sync failures occur on other ingresses", func() {
+			By("Creating ingresses that would fail on sync.")
+			ingFailTLSBackend := &extensions.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing-fail-on-tls-backend",
+				},
+				Spec: extensions.IngressSpec{
+					TLS: []extensions.IngressTLS{
+						{SecretName: "tls-secret-notexist"},
+					},
+					Backend: &extensions.IngressBackend{
+						ServiceName: "echoheaders-notexist",
+						ServicePort: intstr.IntOrString{
+							Type:   intstr.Int,
+							IntVal: 80,
+						},
+					},
+				},
+			}
+			_, err := jig.Client.ExtensionsV1beta1().Ingresses(ns).Create(ingFailTLSBackend)
+			defer func() {
+				if err := jig.Client.ExtensionsV1beta1().Ingresses(ns).Delete(ingFailTLSBackend.Name, nil); err != nil {
+					framework.Logf("Failed to delete ingress %s: %v", ingFailTLSBackend.Name, err)
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+
+			ingFailRules := &extensions.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing-fail-on-rules",
+				},
+				Spec: extensions.IngressSpec{
+					Rules: []extensions.IngressRule{
+						{
+							Host: "foo.bar.com",
+							IngressRuleValue: extensions.IngressRuleValue{
+								HTTP: &extensions.HTTPIngressRuleValue{
+									Paths: []extensions.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: extensions.IngressBackend{
+												ServiceName: "echoheaders-notexist",
+												ServicePort: intstr.IntOrString{
+													Type:   intstr.Int,
+													IntVal: 80,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err = jig.Client.ExtensionsV1beta1().Ingresses(ns).Create(ingFailRules)
+			defer func() {
+				if err := jig.Client.ExtensionsV1beta1().Ingresses(ns).Delete(ingFailRules.Name, nil); err != nil {
+					framework.Logf("Failed to delete ingress %s: %v", ingFailRules.Name, err)
+				}
+			}()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a basic HTTP ingress and wait for it to come up")
+			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "http"), ns, nil, nil)
+			jig.WaitForIngress(true)
+
+			By("Updating the path on ingress and wait for it to take effect")
+			jig.Update(func(ing *extensions.Ingress) {
+				updatedRule := extensions.IngressRule{
+					Host: "ingress.test.com",
+					IngressRuleValue: extensions.IngressRuleValue{
+						HTTP: &extensions.HTTPIngressRuleValue{
+							Paths: []extensions.HTTPIngressPath{
+								{
+									Path: "/test",
+									// Copy backend from the first rule.
+									Backend: ing.Spec.Rules[0].HTTP.Paths[0].Backend,
+								},
+							},
+						},
+					},
+				}
+				// Replace the first rule.
+				ing.Spec.Rules[0] = updatedRule
+			})
+			// Wait for change to take effect on the updated ingress.
+			jig.WaitForIngress(false)
 		})
 
 		It("multicluster ingress should get instance group annotation", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a test that verifies sync failures on some inrgesses would not stop gce ingress controller from syncing others.

Basically:
- Create two ingresses each has something wrong (TLS missing, backend missing etc.).
- Create a normal ingress and test it works.
- Update this ingress and test it takes effect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Special notes for your reviewer**:
Ref https://docs.google.com/document/d/1E2ufxZGujFCYKYOsvBjb4VMNjBy8CM-MMycoT_UVwIs/edit#heading=h.wxzdzliw64t8.
/assign @rramkumar1 @nicksardo 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
