### PR TITLE
fix generator_for_scheme: remove blank new line

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/fake/register.go
+++ b/pkg/client/clientset_generated/internalclientset/fake/register.go
@@ -79,5 +79,4 @@ func AddToScheme(scheme *runtime.Scheme) {
 	schedulinginternalversion.AddToScheme(scheme)
 	settingsinternalversion.AddToScheme(scheme)
 	storageinternalversion.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	apiextensionsv1beta1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	apiextensionsv1beta1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	apiextensionsinternalversion.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/scheme/register.go
@@ -43,5 +43,4 @@ func init() {
 // Install registers the API group and adds types to a scheme
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	apiextensions.Install(groupFactoryRegistry, registry, scheme)
-
 }

--- a/staging/src/k8s.io/client-go/kubernetes/fake/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/register.go
@@ -103,5 +103,4 @@ func AddToScheme(scheme *runtime.Scheme) {
 	storagev1beta1.AddToScheme(scheme)
 	storagev1.AddToScheme(scheme)
 	storagev1alpha1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
+++ b/staging/src/k8s.io/client-go/kubernetes/scheme/register.go
@@ -103,5 +103,4 @@ func AddToScheme(scheme *runtime.Scheme) {
 	storagev1beta1.AddToScheme(scheme)
 	storagev1.AddToScheme(scheme)
 	storagev1alpha1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	exampleinternalversion.AddToScheme(scheme)
 	secondexampleinternalversion.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme/register.go
@@ -45,5 +45,4 @@ func init() {
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	example.Install(groupFactoryRegistry, registry, scheme)
 	secondexample.Install(groupFactoryRegistry, registry, scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	examplev1.AddToScheme(scheme)
 	secondexamplev1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	examplev1.AddToScheme(scheme)
 	secondexamplev1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	examplev1.AddToScheme(scheme)
 	secondexamplev1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/scheme/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	examplev1.AddToScheme(scheme)
 	secondexamplev1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
@@ -149,9 +149,12 @@ func init() {
 
 // Install registers the API group and adds types to a scheme
 func Install(groupFactoryRegistry $.announcedAPIGroupFactoryRegistry|raw$, registry *$.registeredAPIRegistrationManager|raw$, scheme *$.runtimeScheme|raw$) {
-	$range .allInstallGroups$ $.InstallPackageAlias$.Install(groupFactoryRegistry, registry, scheme)
-	$end$
-	$if .customRegister$ExtraInstall(groupFactoryRegistry, registry, scheme)$end$
+	$- range .allInstallGroups$
+	$.InstallPackageAlias$.Install(groupFactoryRegistry, registry, scheme)
+	$- end$
+	$if .customRegister$
+	ExtraInstall(groupFactoryRegistry, registry, scheme)
+	$end -$
 }
 `
 
@@ -178,8 +181,11 @@ func init() {
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
 func AddToScheme(scheme *$.runtimeScheme|raw$) {
-	$range .allGroupVersions$ $.PackageAlias$.AddToScheme(scheme)
-	$end$
-	$if .customRegister$ExtraAddToScheme(scheme)$end$
+	$- range .allGroupVersions$
+	$.PackageAlias$.AddToScheme(scheme)
+	$- end$
+	$if .customRegister$
+	ExtraAddToScheme(scheme)
+	$end -$
 }
 `

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	apiregistrationv1beta1.AddToScheme(scheme)
 	apiregistrationv1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	apiregistrationv1beta1.AddToScheme(scheme)
 	apiregistrationv1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	apiregistrationinternalversion.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme/register.go
@@ -43,5 +43,4 @@ func init() {
 // Install registers the API group and adds types to a scheme
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	apiregistration.Install(groupFactoryRegistry, registry, scheme)
-
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake/register.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	metricsv1alpha1.AddToScheme(scheme)
 	metricsv1beta1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme/register.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme/register.go
@@ -51,5 +51,4 @@ func init() {
 func AddToScheme(scheme *runtime.Scheme) {
 	metricsv1alpha1.AddToScheme(scheme)
 	metricsv1beta1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/fake/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	wardleinternalversion.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/scheme/register.go
@@ -43,5 +43,4 @@ func init() {
 // Install registers the API group and adds types to a scheme
 func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	wardle.Install(groupFactoryRegistry, registry, scheme)
-
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	wardlev1alpha1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/scheme/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	wardlev1alpha1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/fake/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/fake/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	samplecontrollerv1alpha1.AddToScheme(scheme)
-
 }

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/scheme/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/scheme/register.go
@@ -49,5 +49,4 @@ func init() {
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
 	samplecontrollerv1alpha1.AddToScheme(scheme)
-
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

1. remove new blank line in `AddToScheme`
https://github.com/kubernetes/kubernetes/blob/80e344644e2b6222296f2f03551a8d0273c7cbce/pkg/client/clientset_generated/internalclientset/fake/register.go#L81-L83

2. remove new blank line in `Install`
https://github.com/kubernetes/kubernetes/blob/3d69cea1e589add1d24fc72e9a8c46081664a719/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme/register.go#L44-L47


**Special notes for your reviewer**:

the first commit changes the code generator for schema register.
https://github.com/kubernetes/kubernetes/commit/c8c9ca77af97381e8d6e0d1592751f6e88ae9780 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
