### PR TITLE
Openstack: Fill size attribute for the V3 API volumes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -222,6 +222,7 @@ func (volumes *VolumesV3) getVolume(volumeID string) (Volume, error) {
 		ID:     volumeV3.ID,
 		Name:   volumeV3.Name,
 		Status: volumeV3.Status,
+		Size:   volumeV3.Size,
 	}
 
 	if len(volumeV3.Attachments) > 0 {


### PR DESCRIPTION
The getVolume method in OpenStack provider is not filling the Size for the V3 API type volumes. This
breaks the PV resizing of Cinder volumes which compares the existing volume size with the new request. This leads to redundant volume resize calls to the cloud provider that end with errors.

cc: @gnufied

```release-note
Fix volume resize with OpenStack cinder
```
