### PR TITLE
Wait for healthy extension server before registering APIService, handle ServiceUnavailable errors

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -120,7 +120,8 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	location.Scheme = "https"
 	rloc, err := r.serviceResolver.ResolveEndpoint(handlingInfo.serviceNamespace, handlingInfo.serviceName)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("missing route (%s)", err.Error()), http.StatusInternalServerError)
+		glog.Errorf("error resolving %s/%s: %v", handlingInfo.serviceNamespace, handlingInfo.serviceName, err)
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	location.Host = rloc.Host

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1200,6 +1200,10 @@ func hasRemainingContent(c clientset.Interface, clientPool dynamic.ClientPool, n
 			if apierrs.IsMethodNotSupported(err) || apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {
 				continue
 			}
+			// skip unavailable servers
+			if apierrs.IsServiceUnavailable(err) {
+				continue
+			}
 			return false, err
 		}
 		unstructuredList, ok := obj.(*unstructured.UnstructuredList)


### PR DESCRIPTION
fixes #58642 
followup to #58070

* Because a registered APIService appears in discovery immediately, we should wait until the backing deployment is healthy before exposing it
* In e2e hasRemainingContent(), add ServiceUnavailable to the types of errors we tolerate when looking for remaining content.
* In proxy handler, return a ServiceUnavailable error if the referenced service cannot be resolved
```release-note
NONE
```