### PR TITLE
Automated cherry pick of #58520: Make IsConnectionReset work with more error implementations.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/util.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/util.go
@@ -18,6 +18,8 @@ package net
 
 import (
 	"net"
+	"net/url"
+	"os"
 	"reflect"
 	"syscall"
 )
@@ -38,8 +40,16 @@ func IPNetEqual(ipnet1, ipnet2 *net.IPNet) bool {
 
 // Returns if the given err is "connection reset by peer" error.
 func IsConnectionReset(err error) bool {
-	opErr, ok := err.(*net.OpError)
-	if ok && opErr.Err.Error() == syscall.ECONNRESET.Error() {
+	if urlErr, ok := err.(*url.Error); ok {
+		err = urlErr.Err
+	}
+	if opErr, ok := err.(*net.OpError); ok {
+		err = opErr.Err
+	}
+	if osErr, ok := err.(*os.SyscallError); ok {
+		err = osErr.Err
+	}
+	if errno, ok := err.(syscall.Errno); ok && errno == syscall.ECONNRESET {
 		return true
 	}
 	return false


### PR DESCRIPTION
Cherry pick of #58520 on release-1.9.

#58520: Make IsConnectionReset work with more error implementations.