### PR TITLE
Created bootstrap logic for vSphere test

### DIFF
--- a/test/e2e/storage/vsphere/BUILD
+++ b/test/e2e/storage/vsphere/BUILD
@@ -62,6 +62,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/storage/vsphere/bootstrap:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/test/e2e/storage/vsphere/bootstrap/BUILD
+++ b/test/e2e/storage/vsphere/bootstrap/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bootstrap.go",
+        "context.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/e2e/storage/vsphere/bootstrap",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/storage/vsphere/bootstrap/bootstrap.go
+++ b/test/e2e/storage/vsphere/bootstrap/bootstrap.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"sync"
+)
+
+var once sync.Once
+var waiting = make(chan bool)
+
+// Bootstrap takes care of initializing necessary test context for vSphere tests
+func Bootstrap() {
+	done := make(chan bool)
+	go func() {
+		once.Do(bootstrapOnce)
+		<-waiting
+		done <- true
+	}()
+	<-done
+}
+
+func bootstrapOnce() {
+	// TBD
+	// 1. Read vSphere conf and get VSphere instances
+	// 2. Get Node to VSphere mapping
+	// 3. Set NodeMapper in vSphere context
+	TestContext = Context{}
+	close(waiting)
+}

--- a/test/e2e/storage/vsphere/bootstrap/context.go
+++ b/test/e2e/storage/vsphere/bootstrap/context.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+// Context holds common information for vSphere tests
+type Context struct {
+	// NodeMapper and other instances, common to vSphere tests
+}
+
+// TestContext should be used by all tests to access common context data. It should be initialized only once, during bootstrapping the tests.
+var TestContext Context


### PR DESCRIPTION
**What this PR does / why we need it**:
Add bootstrapping logic and Context for vSphere tests. This context can be utilized to hold information like node-vsphere mapping, which needs to be initialized only once per test suit run.

sync.Once takes care of executing bootstrapping only once for all the specs. 'waiting' channel takes care of making sure that parallel test spec executions wait for bootstrapping to finish before moving on.

**Which issue(s) this PR fixes** 
Fixes https://github.com/vmware/kubernetes/issues/437, partly

**Special notes for your reviewer**:
Successfully ran make.
Tested by added additional log messages to bootstrap process (now removed). Made sure bootstrapping logic is getting invoked just once and bootstrapping is done by the time It-blocks are executed.

**Release note**:
```release-note
NONE
```
