### PR TITLE
kubelet: make --cni-bin-dir accept a comma-separated list of CNI plugin directories

### DIFF
--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -114,12 +114,12 @@ func GetDynamicPluginProber(pluginDir string) volume.DynamicPluginProber {
 }
 
 // ProbeNetworkPlugins collects all compiled-in plugins
-func ProbeNetworkPlugins(cniConfDir, cniBinDir string) []network.NetworkPlugin {
+func ProbeNetworkPlugins(cniConfDir string, cniBinDirs []string) []network.NetworkPlugin {
 	allPlugins := []network.NetworkPlugin{}
 
 	// for each existing plugin, add to the list
-	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, []string{cniBinDir})...)
-	allPlugins = append(allPlugins, kubenet.NewPlugin([]string{cniBinDir}))
+	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, cniBinDirs)...)
+	allPlugins = append(allPlugins, kubenet.NewPlugin(cniBinDirs))
 
 	return allPlugins
 }

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -119,7 +119,7 @@ func ProbeNetworkPlugins(cniConfDir, cniBinDir string) []network.NetworkPlugin {
 
 	// for each existing plugin, add to the list
 	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, []string{cniBinDir})...)
-	allPlugins = append(allPlugins, kubenet.NewPlugin(cniBinDir))
+	allPlugins = append(allPlugins, kubenet.NewPlugin([]string{cniBinDir}))
 
 	return allPlugins
 }

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -118,7 +118,7 @@ func ProbeNetworkPlugins(cniConfDir, cniBinDir string) []network.NetworkPlugin {
 	allPlugins := []network.NetworkPlugin{}
 
 	// for each existing plugin, add to the list
-	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, cniBinDir)...)
+	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, []string{cniBinDir})...)
 	allPlugins = append(allPlugins, kubenet.NewPlugin(cniBinDir))
 
 	return allPlugins

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -78,6 +78,7 @@ import (
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	dynamickubeletconfig "k8s.io/kubernetes/pkg/kubelet/kubeletconfig"
 	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles"
+	"k8s.io/kubernetes/pkg/kubelet/network/cni"
 	"k8s.io/kubernetes/pkg/kubelet/server"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -355,7 +356,7 @@ func UnsecuredDependencies(s *options.KubeletServer) (*kubelet.Dependencies, err
 		ExternalKubeClient:  nil,
 		EventClient:         nil,
 		Mounter:             mounter,
-		NetworkPlugins:      ProbeNetworkPlugins(s.CNIConfDir, s.CNIBinDir),
+		NetworkPlugins:      ProbeNetworkPlugins(s.CNIConfDir, cni.SplitDirs(s.CNIBinDir)),
 		OOMAdjuster:         oom.NewOOMAdjuster(),
 		OSInterface:         kubecontainer.RealOS{},
 		Writer:              writer,
@@ -1096,7 +1097,7 @@ func RunDockershim(f *options.KubeletFlags, c *kubeletconfiginternal.KubeletConf
 		NonMasqueradeCIDR: f.NonMasqueradeCIDR,
 		PluginName:        r.NetworkPluginName,
 		PluginConfDir:     r.CNIConfDir,
-		PluginBinDir:      r.CNIBinDir,
+		PluginBinDirs:     cni.SplitDirs(r.CNIBinDir),
 		MTU:               int(r.NetworkPluginMTU),
 		LegacyRuntimeHost: nh,
 	}

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//pkg/kubelet/metrics/collectors:go_default_library",
         "//pkg/kubelet/mountpod:go_default_library",
         "//pkg/kubelet/network:go_default_library",
+        "//pkg/kubelet/network/cni:go_default_library",
         "//pkg/kubelet/network/dns:go_default_library",
         "//pkg/kubelet/pleg:go_default_library",
         "//pkg/kubelet/pod:go_default_library",

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -98,7 +98,7 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	// Network plugin settings. Shared by both docker and rkt.
 	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, "<Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle")
 	fs.StringVar(&s.CNIConfDir, "cni-conf-dir", s.CNIConfDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d")
-	fs.StringVar(&s.CNIBinDir, "cni-bin-dir", s.CNIBinDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin")
+	fs.StringVar(&s.CNIBinDir, "cni-bin-dir", s.CNIBinDir, "<Warning: Alpha feature> A comma-separated list of full paths of directories in which to search for CNI plugin binaries. Default: /opt/cni/bin")
 	fs.Int32Var(&s.NetworkPluginMTU, "network-plugin-mtu", s.NetworkPluginMTU, "<Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.")
 
 	// Rkt-specific settings.

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -229,7 +229,7 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 		}
 	}
 	// dockershim currently only supports CNI plugins.
-	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDir)
+	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, []string{pluginSettings.PluginBinDir})
 	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDir))
 	netHost := &dockerNetworkHost{
 		pluginSettings.LegacyRuntimeHost,

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -110,10 +110,10 @@ type NetworkPluginSettings struct {
 	NonMasqueradeCIDR string
 	// PluginName is the name of the plugin, runtime shim probes for
 	PluginName string
-	// PluginBinDir is the directory in which the binaries for the plugin with
-	// PluginName is kept. The admin is responsible for provisioning these
-	// binaries before-hand.
-	PluginBinDir string
+	// PluginBinDirs is an array of directories in which the binaries for
+	// the plugin with PluginName may be found. The admin is responsible for
+	// provisioning these binaries before-hand.
+	PluginBinDirs []string
 	// PluginConfDir is the directory in which the admin places a CNI conf.
 	// Depending on the plugin, this may be an optional field, eg: kubenet
 	// generates its own plugin conf.
@@ -229,8 +229,8 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 		}
 	}
 	// dockershim currently only supports CNI plugins.
-	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, []string{pluginSettings.PluginBinDir})
-	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDir))
+	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDirs)
+	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDirs))
 	netHost := &dockerNetworkHost{
 		pluginSettings.LegacyRuntimeHost,
 		&namespaceGetter{ds},

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -79,6 +79,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/network/cni"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
@@ -587,7 +588,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		NonMasqueradeCIDR: nonMasqueradeCIDR,
 		PluginName:        crOptions.NetworkPluginName,
 		PluginConfDir:     crOptions.CNIConfDir,
-		PluginBinDir:      crOptions.CNIBinDir,
+		PluginBinDirs:     cni.SplitDirs(crOptions.CNIBinDir),
 		MTU:               int(crOptions.NetworkPluginMTU),
 	}
 

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -68,6 +68,11 @@ type cniPortMapping struct {
 	HostIP        string `json:"hostIP"`
 }
 
+func SplitDirs(dirs string) []string {
+	// Use comma rather than colon to work better with Windows too
+	return strings.Split(dirs, ",")
+}
+
 func ProbeNetworkPlugins(confDir string, binDirs []string) []network.NetworkPlugin {
 	old := binDirs
 	binDirs = make([]string, len(binDirs))

--- a/pkg/kubelet/network/cni/cni_others.go
+++ b/pkg/kubelet/network/cni/cni_others.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 )
 
-func getLoNetwork(binDir, vendorDirPrefix string) *cniNetwork {
+func getLoNetwork(binDirs []string) *cniNetwork {
 	loConfig, err := libcni.ConfListFromBytes([]byte(`{
   "cniVersion": "0.2.0",
   "name": "cni-loopback",
@@ -39,13 +39,10 @@ func getLoNetwork(binDir, vendorDirPrefix string) *cniNetwork {
 		// catch this
 		panic(err)
 	}
-	cninet := &libcni.CNIConfig{
-		Path: []string{vendorCNIDir(vendorDirPrefix, "loopback"), binDir},
-	}
 	loNetwork := &cniNetwork{
 		name:          "lo",
 		NetworkConfig: loConfig,
-		CNIConfig:     cninet,
+		CNIConfig:     &libcni.CNIConfig{Path: binDirs},
 	}
 
 	return loNetwork

--- a/pkg/kubelet/network/cni/cni_windows.go
+++ b/pkg/kubelet/network/cni/cni_windows.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 )
 
-func getLoNetwork(binDir, vendorDirPrefix string) *cniNetwork {
+func getLoNetwork(binDirs []string) *cniNetwork {
 	return nil
 }
 

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -563,7 +563,7 @@ func (plugin *kubenetNetworkPlugin) Status() error {
 	}
 
 	if !plugin.checkRequiredCNIPlugins() {
-		return fmt.Errorf("could not locate kubenet required CNI plugins %v at %q or %q", requiredCNIPlugins, plugin.binDirs)
+		return fmt.Errorf("could not locate kubenet required CNI plugins %v at %q", requiredCNIPlugins, plugin.binDirs)
 	}
 	return nil
 }

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -66,7 +66,7 @@ const (
 	defaultIPAMDir = "/var/lib/cni/networks"
 )
 
-// CNI plugins required by kubenet in /opt/cni/bin or vendor directory
+// CNI plugins required by kubenet in /opt/cni/bin or user-specified directory
 var requiredCNIPlugins = [...]string{"bridge", "host-local", "loopback"}
 
 type kubenetNetworkPlugin struct {
@@ -91,15 +91,15 @@ type kubenetNetworkPlugin struct {
 	iptables        utiliptables.Interface
 	sysctl          utilsysctl.Interface
 	ebtables        utilebtables.Interface
-	// vendorDir is passed by kubelet cni-bin-dir parameter.
-	// kubenet will search for cni binaries in DefaultCNIDir first, then continue to vendorDir.
-	vendorDir         string
+	// binDirs is passed by kubelet cni-bin-dir parameter.
+	// kubenet will search for CNI binaries in DefaultCNIDir first, then continue to binDirs.
+	binDirs           []string
 	nonMasqueradeCIDR string
 	podCidr           string
 	gateway           net.IP
 }
 
-func NewPlugin(networkPluginDir string) network.NetworkPlugin {
+func NewPlugin(networkPluginDirs []string) network.NetworkPlugin {
 	protocol := utiliptables.ProtocolIpv4
 	execer := utilexec.New()
 	dbus := utildbus.New()
@@ -110,7 +110,7 @@ func NewPlugin(networkPluginDir string) network.NetworkPlugin {
 		execer:            utilexec.New(),
 		iptables:          iptInterface,
 		sysctl:            sysctl,
-		vendorDir:         networkPluginDir,
+		binDirs:           append([]string{DefaultCNIDir}, networkPluginDirs...),
 		hostportSyncer:    hostport.NewHostportSyncer(iptInterface),
 		hostportManager:   hostport.NewHostportManager(iptInterface),
 		nonMasqueradeCIDR: "10.0.0.0/8",
@@ -121,9 +121,7 @@ func (plugin *kubenetNetworkPlugin) Init(host network.Host, hairpinMode kubeletc
 	plugin.host = host
 	plugin.hairpinMode = hairpinMode
 	plugin.nonMasqueradeCIDR = nonMasqueradeCIDR
-	plugin.cniConfig = &libcni.CNIConfig{
-		Path: []string{DefaultCNIDir, plugin.vendorDir},
-	}
+	plugin.cniConfig = &libcni.CNIConfig{Path: plugin.binDirs}
 
 	if mtu == network.UseDefaultMTU {
 		if link, err := findMinMTU(); err == nil {
@@ -564,22 +562,24 @@ func (plugin *kubenetNetworkPlugin) Status() error {
 		return fmt.Errorf("Kubenet does not have netConfig. This is most likely due to lack of PodCIDR")
 	}
 
-	if !plugin.checkCNIPlugin() {
-		return fmt.Errorf("could not locate kubenet required CNI plugins %v at %q or %q", requiredCNIPlugins, DefaultCNIDir, plugin.vendorDir)
+	if !plugin.checkRequiredCNIPlugins() {
+		return fmt.Errorf("could not locate kubenet required CNI plugins %v at %q or %q", requiredCNIPlugins, plugin.binDirs)
 	}
 	return nil
 }
 
-// checkCNIPlugin returns if all kubenet required cni plugins can be found at /opt/cni/bin or user specified NetworkPluginDir.
-func (plugin *kubenetNetworkPlugin) checkCNIPlugin() bool {
-	if plugin.checkCNIPluginInDir(DefaultCNIDir) || plugin.checkCNIPluginInDir(plugin.vendorDir) {
-		return true
+// checkRequiredCNIPlugins returns if all kubenet required cni plugins can be found at /opt/cni/bin or user specified NetworkPluginDir.
+func (plugin *kubenetNetworkPlugin) checkRequiredCNIPlugins() bool {
+	for _, dir := range plugin.binDirs {
+		if plugin.checkRequiredCNIPluginsInOneDir(dir) {
+			return true
+		}
 	}
 	return false
 }
 
-// checkCNIPluginInDir returns if all required cni plugins are placed in dir
-func (plugin *kubenetNetworkPlugin) checkCNIPluginInDir(dir string) bool {
+// checkRequiredCNIPluginsInOneDir returns true if all required cni plugins are placed in dir
+func (plugin *kubenetNetworkPlugin) checkRequiredCNIPluginsInOneDir(dir string) bool {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return false

--- a/pkg/kubelet/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/network/kubenet/kubenet_unsupported.go
@@ -30,7 +30,7 @@ type kubenetNetworkPlugin struct {
 	network.NoopNetworkPlugin
 }
 
-func NewPlugin(networkPluginDir string) network.NetworkPlugin {
+func NewPlugin(networkPluginDirs []string) network.NetworkPlugin {
 	return &kubenetNetworkPlugin{}
 }
 

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1215,6 +1215,7 @@ func TestGenerateRunCommand(t *testing.T) {
 	hostName := "test-hostname"
 	boolTrue := true
 	boolFalse := false
+	pluginDirs := []string{"/tmp"}
 
 	tests := []struct {
 		networkPlugin network.NetworkPlugin
@@ -1231,7 +1232,7 @@ func TestGenerateRunCommand(t *testing.T) {
 	}{
 		// Case #0, returns error.
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1250,7 +1251,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #1, returns no dns, with private-net.
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1269,7 +1270,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #2, returns no dns, with host-net.
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1290,7 +1291,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #3, returns dns, dns searches, with private-net.
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1311,7 +1312,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #4, returns no dns, dns searches, with host-network.
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1351,7 +1352,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #6, if all containers are privileged, the result should have 'insecure-options=all-run'
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",
@@ -1373,7 +1374,7 @@ func TestGenerateRunCommand(t *testing.T) {
 		},
 		// Case #7, if not all containers are privileged, the result should not have 'insecure-options=all-run'
 		{
-			kubenet.NewPlugin("/tmp"),
+			kubenet.NewPlugin(pluginDirs),
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-name-foo",


### PR DESCRIPTION
Allow CNI-related network plugin drivers (kubenet, cni) to search a list of
directories for plugin binaries instead of just one.  This allows using an
administrator-provided path and fallbacks to others (like the previous default
of /opt/cni/bin) for backwards compatibility.

```release-note
kubelet's --cni-bin-dir option now accepts multiple comma-separated CNI binary directory paths, which are search for CNI plugins in the given order.
```

@kubernetes/rh-networking @kubernetes/sig-network-misc @freehan @pecameron @rajatchopra 