### PR TITLE
Implement CRD Establishment Utility Function

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/BUILD
@@ -49,6 +49,7 @@ filegroup(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition:all-srcs",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/utils:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/test/integration:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/BUILD
@@ -50,3 +50,11 @@ filegroup(
     ],
     tags = ["automanaged"],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions",
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library"],
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ensure.go"],
+    importpath = "k8s.io/apiextensions-apiserver/pkg/utils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ensure_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/apiextensions-apiserver/pkg/utils",
+    deps = [
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/ensure.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/ensure.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+)
+
+var (
+	// crdEstablishedNumRetries is the maximum number of attempts that a CRD will be given to establish
+	crdEstablishedNumRetries = 5
+	// crdEstablishedRetryInterval is the amount of time that will pass between retries
+	crdEstablishedRetryInterval = 500 * time.Millisecond
+	// crdEstablishedRetryFactor is the scalar by which the prevous interval will be increased
+	crdEstablishedRetryFactor = 1.0
+)
+
+// WaitForEstablished  is a utility function that will ensure that an already created
+// CustomResourceDefinition is ready for use by a Kubernetes cluster. If the CustomResourceDefinition
+// cannot be established within a reasonable amount of retries, an error will be returned.
+func WaitForEstablished(
+	i apiextensionsv1beta1client.ApiextensionsV1beta1Interface,
+	crd *apiextensionsv1beta1.CustomResourceDefinition,
+	stopCh <-chan struct{},
+) error {
+	err := utilwait.ExponentialBackoffUntil(utilwait.Backoff{
+		Factor:   crdEstablishedRetryFactor, // Even though we are using a factor of 1, ExponentialBackoff is preferred over PollImmediate as it provides jitter.
+		Steps:    crdEstablishedNumRetries,
+		Jitter:   rand.Float64(),
+		Duration: crdEstablishedRetryInterval,
+	}, func() (bool, error) {
+		// Attempt to retrieve the CRD that was either already present or just created.
+		crd, err := i.CustomResourceDefinitions().Get(crd.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		// Test if CRD is established. If it is not, attempt
+		// to find a state in which it will never be established
+		// and fail fast.
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1beta1.Established:
+				// This is the state we are looking for.
+				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+					return true, nil
+				}
+			case apiextensionsv1beta1.NamesAccepted:
+				// If we have reached this state, the CRD will never become
+				// established
+				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+					return false, fmt.Errorf("due to the naming conflict %s, the CustomResourceDefinition %s will never become established", cond.Reason, crd.GetName())
+				}
+			}
+		}
+		return false, nil
+	}, stopCh)
+
+	if err == utilwait.ErrWaitTimeout {
+		return fmt.Errorf("the CustomResourceDefinition %s was not established within a reasonable amount of time", crd.GetName())
+	}
+	return err
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/ensure_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/utils/ensure_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+)
+
+func init() {
+	// In order to speed up tests, we're going to overwrite some packages variables
+	crdEstablishedNumRetries, crdEstablishedRetryInterval, crdEstablishedRetryFactor = 1, 1*time.Millisecond, 1.0
+}
+
+var establishedCondition = apiextensionsv1beta1.CustomResourceDefinitionCondition{
+	Type:    apiextensionsv1beta1.Established,
+	Status:  apiextensionsv1beta1.ConditionTrue,
+	Reason:  "InitialNamesAccepted",
+	Message: "the initial names have been accepted",
+}
+
+var notEstablishedCondition = apiextensionsv1beta1.CustomResourceDefinitionCondition{
+	Type:    apiextensionsv1beta1.Established,
+	Status:  apiextensionsv1beta1.ConditionFalse,
+	Reason:  "NotAccepted",
+	Message: "not all names are accepted",
+}
+
+var acceptedCondition = apiextensionsv1beta1.CustomResourceDefinitionCondition{
+	Type:    apiextensionsv1beta1.NamesAccepted,
+	Status:  apiextensionsv1beta1.ConditionTrue,
+	Reason:  "NoConflicts",
+	Message: "no conflicts found",
+}
+
+var notAcceptedCondition = apiextensionsv1beta1.CustomResourceDefinitionCondition{
+	Type:    apiextensionsv1beta1.NamesAccepted,
+	Status:  apiextensionsv1beta1.ConditionFalse,
+	Reason:  "TestConflict",
+	Message: "conflicts found",
+}
+
+type crdBuilder struct {
+	curr apiextensionsv1beta1.CustomResourceDefinition
+}
+
+func newCRD(name string) *crdBuilder {
+	tokens := strings.SplitN(name, ".", 2)
+	return &crdBuilder{
+		curr: apiextensionsv1beta1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				Group: tokens[1],
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Plural: tokens[0],
+				},
+			},
+		},
+	}
+}
+
+func (b *crdBuilder) Condition(c apiextensionsv1beta1.CustomResourceDefinitionCondition) *crdBuilder {
+	b.curr.Status.Conditions = append(b.curr.Status.Conditions, c)
+
+	return b
+}
+
+func (b *crdBuilder) NewOrDie() *apiextensionsv1beta1.CustomResourceDefinition {
+	return &b.curr
+}
+
+func assertErrors(expected, actual error) bool {
+	if expected != nil {
+		return actual != nil && expected.Error() == actual.Error()
+	}
+	return actual == nil
+}
+
+func TestWaitForEstablished(t *testing.T) {
+	tests := []struct {
+		name          string
+		crd           *apiextensionsv1beta1.CustomResourceDefinition
+		expectedError error
+	}{
+		{
+			name:          "timeout",
+			crd:           newCRD("foos.bar.io").NewOrDie(),
+			expectedError: errors.New("the CustomResourceDefinition foos.bar.io was not established within a reasonable amount of time"),
+		},
+		{
+			name:          "established",
+			crd:           newCRD("foos.bar.io").Condition(establishedCondition).NewOrDie(),
+			expectedError: nil,
+		},
+		{
+			name:          "will never be established",
+			crd:           newCRD("foos.bar.io").Condition(notAcceptedCondition).Condition(notEstablishedCondition).NewOrDie(),
+			expectedError: fmt.Errorf("due to the naming conflict %s, the CustomResourceDefinition foos.bar.io will never become established", notAcceptedCondition.Reason),
+		},
+	}
+
+	for _, test := range tests {
+		cli := apiextensionsv1beta1client.NewSimpleClientset()
+		cli.ApiextensionsV1beta1().CustomResourceDefinitions().Create(test.crd)
+		if err := WaitForEstablished(cli.ApiextensionsV1beta1(), test.crd, nil); !assertErrors(test.expectedError, err) {
+			t.Errorf("%v expected %v, got %v", test.name, test.expectedError, err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Once a `CustomResourceDefinition` is created, it cannot be used until it has been *established*. This PR implements a utility function that will create a CRD(s) and wait for its/their establishment. 

**Which issue(s) this PR fixes**
Fixes [https://github.com/kubernetes/apiextensions-apiserver/issues/9](https://github.com/kubernetes/apiextensions-apiserver/issues/9)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
