### PR TITLE
Fail fast if HugePages is not enabled

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -161,6 +162,9 @@ const (
 
 	// Minimum number of dead containers to keep in a pod
 	minDeadContainerInPod = 1
+
+	// The root directory for configuring hugetlb cgroup
+	hugepagesDirectory = "/sys/fs/cgroup/hugetlb/"
 )
 
 // SyncHandler is an interface implemented by Kubelet, for testability
@@ -880,6 +884,15 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			glog.Errorf("Accelerators feature is supported with docker runtime only. Disabling this feature internally.")
 		}
 	}
+
+	// fail fast if huge pages support is not present
+	if utilfeature.DefaultFeatureGate.Enabled(features.HugePages) {
+		if _, err := ioutil.ReadDir(hugepagesDirectory); err != nil {
+			glog.Warningln("HugePages feature is not available, please disable the feature.")
+			return nil, err
+		}
+	}
+
 	// Set GPU manager to a stub implementation if it is not enabled or cannot be supported.
 	if klet.gpuManager == nil {
 		klet.gpuManager = gpu.NewGPUManagerStub()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently the kubelet seems to start properly the first time and
then fails to restart. So let's check and fail early.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58296

**Special notes for your reviewer**:
/assign @derekwaynecarr 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HugePages feature is now in Beta. Kubelet now fails fast when huge pages support is not present in your environment.
```
