### PR TITLE
Don't bind PVs and PVCs with different access modes.

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -802,6 +802,13 @@ func claimWithAnnotation(name, value string, claims []*v1.PersistentVolumeClaim)
 	return claims
 }
 
+// claimWithAccessMode saves given access into given claims.
+// Meant to be used to compose claims specified inline in a test.
+func claimWithAccessMode(modes []v1.PersistentVolumeAccessMode, claims []*v1.PersistentVolumeClaim) []*v1.PersistentVolumeClaim {
+	claims[0].Spec.AccessModes = modes
+	return claims
+}
+
 func testSyncClaim(ctrl *PersistentVolumeController, reactor *volumeReactor, test controllerTest) error {
 	return ctrl.syncClaim(test.initialClaims[0])
 }


### PR DESCRIPTION
PVC pre-bound to a PV can bind to the PV only if it has correct access mode. Report an event if it does not and keep the PVC Pending.

++ minor refactoring of `syncClaim`, `isMisMatch` was declared too far away from place when it's used.

/sig storage
/assign @gnufied @rootfs 

```release-note
None
```
