### PR TITLE
use containing API group when resolving shortname from discovery

### DIFF
--- a/pkg/kubectl/cmd/util/shortcut_restmapper.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper.go
@@ -115,6 +115,7 @@ func (e shortcutExpander) expandResourceShortcut(resource schema.GroupVersionRes
 			}
 			if resource.Resource == item.ShortForm.Resource {
 				resource.Resource = item.LongForm.Resource
+				resource.Group = item.LongForm.Group
 				return resource
 			}
 		}

--- a/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
@@ -46,7 +46,7 @@ func TestReplaceAliases(t *testing.T) {
 		{
 			name:     "hpa-priority",
 			arg:      "hpa",
-			expected: schema.GroupVersionResource{Resource: "superhorizontalpodautoscalers"},
+			expected: schema.GroupVersionResource{Resource: "superhorizontalpodautoscalers", Group: "autoscaling"},
 			srvRes: []*metav1.APIResourceList{
 				{
 					GroupVersion: "autoscaling/v1",
@@ -63,6 +63,31 @@ func TestReplaceAliases(t *testing.T) {
 						{
 							Name:       "horizontalpodautoscalers",
 							ShortNames: []string{"hpa"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "resource-override",
+			arg:      "dpl",
+			expected: schema.GroupVersionResource{Resource: "deployments", Group: "foo"},
+			srvRes: []*metav1.APIResourceList{
+				{
+					GroupVersion: "foo/v1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "deployments",
+							ShortNames: []string{"dpl"},
+						},
+					},
+				},
+				{
+					GroupVersion: "extension/v1beta1",
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "deployments",
+							ShortNames: []string{"deploy"},
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kubectl does not use containing API group when resolving shortname from discovery 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58695

**Special notes for your reviewer**:
/assign @liggitt 
/cc @nikhita @zjj2wry 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use containing API group when resolving shortname from discovery
```
