### PR TITLE
fix kubectl cp command tar warning message

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -214,6 +214,8 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 	}
 
 	reader, outStream := io.Pipe()
+	prefix := getPrefix(src.File)
+	prefix = path.Clean(prefix)
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
 			In:  nil,
@@ -225,7 +227,7 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 		},
 
 		// TODO: Improve error messages by first testing if 'tar' is present in the container?
-		Command:  []string{"tar", "cf", "-", src.File},
+		Command:  []string{"tar", "cf", "-", prefix},
 		Executor: &DefaultRemoteExecutor{},
 	}
 
@@ -233,8 +235,6 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 		defer outStream.Close()
 		execute(f, cmd, options)
 	}()
-	prefix := getPrefix(src.File)
-	prefix = path.Clean(prefix)
 	return untarAll(reader, dest.File, prefix)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
when run `kubectl cp <pod namespaces>/<pod name>:<remote absolute path> <local path>`, tar will throw warning message,
```shell
tar: Removing leading `/' from member names
```
 for it unreasonable using `absolute path` to tar a file, tar will remove it automatically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [https://github.com/kubernetes/kubernetes/issues/58692](https://github.com/kubernetes/kubernetes/issues/58692)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix kubectl cp command tar warning message
```
