### PR TITLE
Allow to set additionalProperties to a schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal.go
@@ -30,7 +30,7 @@ func (s JSONSchemaPropsOrBool) MarshalJSON() ([]byte, error) {
 		return json.Marshal(s.Schema)
 	}
 
-	if s.Schema == nil && !s.Allows {
+	if !s.Allows {
 		return jsFalse, nil
 	}
 	return jsTrue, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -206,13 +206,13 @@ func ValidateCustomResourceDefinitionOpenAPISchema(schema *apiextensions.JSONSch
 
 	allErrs = append(allErrs, ssv.validate(schema, fldPath)...)
 
-	if schema.UniqueItems == true {
+	if schema.UniqueItems {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("uniqueItems"), "uniqueItems cannot be set to true since the runtime complexity becomes quadratic"))
 	}
 
 	// additionalProperties contradicts Kubernetes API convention to ignore unknown fields
 	if schema.AdditionalProperties != nil {
-		if schema.AdditionalProperties.Allows == false {
+		if !schema.AdditionalProperties.Allows && schema.AdditionalProperties.Schema == nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("additionalProperties"), "additionalProperties cannot be set to false"))
 		}
 		allErrs = append(allErrs, ValidateCustomResourceDefinitionOpenAPISchema(schema.AdditionalProperties.Schema, fldPath.Child("additionalProperties"), ssv)...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently it is not possible to set `additionalProperties` in a CRD validation section of the spec to a schema. If set, validation rejects such CRD.

In json/openapi schema `additionalProperties` can be either set to a boolean true/false OR a schema object. Currently validation looks at the `Allows` field and errors out if it is `false`. But the schema may have been provided and this is an invalid behavior. It should only error out if `Allows` field is `false` and schema is not provided i.e. is `nil`.

**Release note**:
```release-note
NONE
```
/sig api-machinery
/kind bug
/area custom-resources
/cc @sttts @nikhita 