### PR TITLE
Add support of hyperv isolation for windows containers

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -225,6 +225,12 @@ const (
 	//
 	// Implement support for limiting pids in pods
 	SupportPodPidsLimit utilfeature.Feature = "SupportPodPidsLimit"
+
+	// owner: @feiskyer
+	// alpha: v1.10
+	//
+	// Enable Hyper-V containers on Windows
+	HyperVContainer utilfeature.Feature = "HyperVContainer"
 )
 
 func init() {
@@ -265,6 +271,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ResourceLimitsPriorityFunction:              {Default: false, PreRelease: utilfeature.Alpha},
 	SupportIPVSProxyMode:                        {Default: false, PreRelease: utilfeature.Beta},
 	SupportPodPidsLimit:                         {Default: false, PreRelease: utilfeature.Alpha},
+	HyperVContainer:                             {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -124,7 +124,13 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//pkg/features:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -587,6 +587,8 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 		return nil, fmt.Errorf("failed to generate sandbox security options for sandbox %q: %v", c.Metadata.Name, err)
 	}
 	hc.SecurityOpt = append(hc.SecurityOpt, securityOpts...)
+
+	applyExperimentalCreateConfig(createConfig, c.Annotations)
 	return createConfig, nil
 }
 

--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -145,3 +145,7 @@ func getNetworkNamespace(c *dockertypes.ContainerJSON) (string, error) {
 	}
 	return fmt.Sprintf(dockerNetNSFmt, c.State.Pid), nil
 }
+
+// applyExperimentalCreateConfig applys experimental configures from sandbox annotations.
+func applyExperimentalCreateConfig(createConfig *dockertypes.ContainerCreateConfig, annotations map[string]string) {
+}

--- a/pkg/kubelet/dockershim/helpers_unsupported.go
+++ b/pkg/kubelet/dockershim/helpers_unsupported.go
@@ -53,3 +53,7 @@ func (ds *dockerService) determinePodIPBySandboxID(uid string) string {
 func getNetworkNamespace(c *dockertypes.ContainerJSON) (string, error) {
 	return "", fmt.Errorf("unsupported platform")
 }
+
+// applyExperimentalCreateConfig applys experimental configures from sandbox annotations.
+func applyExperimentalCreateConfig(createConfig *dockertypes.ContainerCreateConfig, annotations map[string]string) {
+}

--- a/pkg/kubelet/dockershim/helpers_windows.go
+++ b/pkg/kubelet/dockershim/helpers_windows.go
@@ -29,6 +29,13 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+const (
+	hypervIsolationAnnotationKey = "experimental.windows.kubernetes.io/isolation-type"
+
+	// Refer https://aka.ms/hyperv-container.
+	hypervIsolation = "hyperv"
+)
+
 func DefaultMemorySwap() int64 {
 	return 0
 }
@@ -40,6 +47,22 @@ func (ds *dockerService) getSecurityOpts(seccompProfile string, separator rune) 
 	return nil, nil
 }
 
+func shouldIsolatedByHyperV(annotations map[string]string) bool {
+	v, ok := annotations[hypervIsolationAnnotationKey]
+	return ok && v == hypervIsolation
+}
+
+// applyExperimentalCreateConfig applys experimental configures from sandbox annotations.
+func applyExperimentalCreateConfig(createConfig *dockertypes.ContainerCreateConfig, annotations map[string]string) {
+	if shouldIsolatedByHyperV(annotations) {
+		createConfig.HostConfig.Isolation = hypervIsolation
+
+		if networkMode := os.Getenv("CONTAINER_NETWORK"); networkMode == "" {
+			createConfig.HostConfig.NetworkMode = dockercontainer.NetworkMode("none")
+		}
+	}
+}
+
 func (ds *dockerService) updateCreateConfig(
 	createConfig *dockertypes.ContainerCreateConfig,
 	config *runtimeapi.ContainerConfig,
@@ -47,10 +70,12 @@ func (ds *dockerService) updateCreateConfig(
 	podSandboxID string, securityOptSep rune, apiVersion *semver.Version) error {
 	if networkMode := os.Getenv("CONTAINER_NETWORK"); networkMode != "" {
 		createConfig.HostConfig.NetworkMode = dockercontainer.NetworkMode(networkMode)
-	} else {
+	} else if !shouldIsolatedByHyperV(sandboxConfig.Annotations) {
 		// Todo: Refactor this call in future for calling methods directly in security_context.go
 		modifyHostNetworkOptionForContainer(false, podSandboxID, createConfig.HostConfig)
 	}
+
+	applyExperimentalCreateConfig(createConfig, sandboxConfig.Annotations)
 
 	return nil
 }
@@ -87,8 +112,17 @@ func (ds *dockerService) determinePodIPBySandboxID(sandboxID string) string {
 		// Todo: Add a kernel version check for more validation
 
 		if networkMode := os.Getenv("CONTAINER_NETWORK"); networkMode == "" {
-			// Do not return any IP, so that we would continue and get the IP of the Sandbox
-			ds.getIP(sandboxID, r)
+			if r.HostConfig.Isolation == hypervIsolation {
+				// Hyper-V only supports one container per Pod yet and the container will have a different
+				// IP address from sandbox. Return the first non-sandbox container IP as POD IP.
+				// TODO(feiskyer): remove this workaround after Hyper-V supports multiple containers per Pod.
+				if containerIP := ds.getIP(c.ID, r); containerIP != "" {
+					return containerIP
+				}
+			} else {
+				// Do not return any IP, so that we would continue and get the IP of the Sandbox
+				ds.getIP(sandboxID, r)
+			}
 		} else {
 			// On Windows, every container that is created in a Sandbox, needs to invoke CNI plugin again for adding the Network,
 			// with the shared container name as NetNS info,

--- a/pkg/kubelet/dockershim/helpers_windows.go
+++ b/pkg/kubelet/dockershim/helpers_windows.go
@@ -26,6 +26,9 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/golang/glog"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
@@ -48,6 +51,10 @@ func (ds *dockerService) getSecurityOpts(seccompProfile string, separator rune) 
 }
 
 func shouldIsolatedByHyperV(annotations map[string]string) bool {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.HyperVContainer) {
+		return false
+	}
+
 	v, ok := annotations[hypervIsolationAnnotationKey]
 	return ok && v == hypervIsolation
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add support of hyperv isolation for windows containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58750

**Special notes for your reviewer**:

Only one container per pod is supported yet.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows containers now support experimental Hyper-V isolation by setting annotation `experimental.windows.kubernetes.io/isolation-type=hyperv` and feature gates HyperVContainer. Only one container per pod is supported yet.
```
