### PR TITLE
Fix kubectl explain for cronjobs

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4120,6 +4120,8 @@ run_kubectl_explain_tests() {
   # shortcuts work
   kubectl explain po
   kubectl explain po.status.message
+  # cronjob work
+  kubectl explain cronjob
 
   set +o nounset
   set +o errexit

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -26,19 +26,18 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/explain"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
 var (
 	explainLong = templates.LongDesc(`
 		List the fields for supported resources
-		
+
 		This command describes the fields associated with each supported API resource.
-		Fields are identified via a simple JSONPath identifier: 
-		
+		Fields are identified via a simple JSONPath identifier:
+
 			<type>.<fieldName>[.<fieldName>]
-			
+
 		Add the --recursive flag to display all of the fields at once without descriptions.
 		Information about each field is retrieved from the server in OpenAPI format.`)
 
@@ -81,7 +80,6 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 
 	recursive := cmdutil.GetFlagBool(cmd, "recursive")
 	apiVersionString := cmdutil.GetFlagString(cmd, "api-version")
-	apiVersion := schema.GroupVersion{}
 
 	mapper, _ := f.Object()
 	// TODO: After we figured out the new syntax to separate group and resource, allow
@@ -105,20 +103,13 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 		}
 	}
 
-	if len(apiVersionString) == 0 {
-		groupMeta, err := scheme.Registry.Group(gvk.Group)
+	if len(apiVersionString) != 0 {
+		apiVersion, err := schema.ParseGroupVersion(apiVersionString)
 		if err != nil {
 			return err
 		}
-		apiVersion = groupMeta.GroupVersion
-
-	} else {
-		apiVersion, err = schema.ParseGroupVersion(apiVersionString)
-		if err != nil {
-			return err
-		}
+		gvk = apiVersion.WithKind(gvk.Kind)
 	}
-	gvk = apiVersion.WithKind(gvk.Kind)
 
 	resources, err := f.OpenAPISchema()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubectl explain cronjob` was failing with `error: Couldn't find resource for "batch/v1, Kind=CronJob"` the reason for that is that even though we were getting the group and version from the mapper, we always rewrote it with the default value for a specific group, unless user specified the output version. 


**Special notes for your reviewer**:

**Release note**:
```release-note
Fix kubectl explain for resources not existing in default version of API group
```
for review:
/assign @juanvallejo 
for approval:
/assign @deads2k 