### PR TITLE
Use probe based plugin watcher mechanism in Device Manager

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//pkg/kubelet/apis/cri:go_default_library",
         "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
+        "//pkg/kubelet/apis/pluginregistration/v1alpha1:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/certificate:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//pkg/kubelet/eviction/api:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
         "//pkg/kubelet/status:go_default_library",
+        "//pkg/kubelet/util/pluginwatcher:go_default_library",
         "//pkg/scheduler/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -28,6 +28,7 @@ import (
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"fmt"
@@ -94,6 +95,7 @@ type ContainerManager interface {
 
 	// GetPodCgroupRoot returns the cgroup which contains all pods.
 	GetPodCgroupRoot() string
+	GetPluginRegistrationHandlerCallback() pluginwatcher.RegisterCallbackFn
 }
 
 type NodeConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 	utilfile "k8s.io/kubernetes/pkg/util/file"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -598,6 +599,10 @@ func (cm *containerManagerImpl) Start(node *v1.Node,
 	}
 
 	return nil
+}
+
+func (cm *containerManagerImpl) GetPluginRegistrationHandlerCallback() pluginwatcher.RegisterCallbackFn {
+	return cm.deviceManager.GetWatcherCallback()
 }
 
 // TODO: move the GetResources logic to PodContainerManager.

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -27,6 +27,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
@@ -74,6 +75,12 @@ func (cm *containerManagerStub) GetCapacity() v1.ResourceList {
 			resource.BinarySI),
 	}
 	return c
+}
+
+func (cm *containerManagerStub) GetPluginRegistrationHandlerCallback() pluginwatcher.RegisterCallbackFn {
+	return func(name string, endpoint string, versions []string, sockPath string) (chan bool, error) {
+		return nil, nil
+	}
 }
 
 func (cm *containerManagerStub) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {

--- a/pkg/kubelet/cm/devicemanager/BUILD
+++ b/pkg/kubelet/cm/devicemanager/BUILD
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/kubelet/apis/deviceplugin/v1beta1:go_default_library",
+        "//pkg/kubelet/apis/pluginregistration/v1alpha1:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/checkpointmanager/errors:go_default_library",
         "//pkg/kubelet/cm/devicemanager/checkpoint:go_default_library",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
         "//pkg/kubelet/metrics:go_default_library",
+        "//pkg/kubelet/util/pluginwatcher:go_default_library",
         "//pkg/scheduler/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -40,8 +42,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis/deviceplugin/v1beta1:go_default_library",
+        "//pkg/kubelet/apis/pluginregistration/v1alpha1:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
+        "//pkg/kubelet/util/pluginwatcher:go_default_library",
         "//pkg/scheduler/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
+++ b/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
@@ -28,12 +28,15 @@ import (
 	"google.golang.org/grpc"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+	watcherapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1alpha1"
 )
 
 // Stub implementation for DevicePlugin.
 type Stub struct {
-	devs   []*pluginapi.Device
-	socket string
+	devs                  []*pluginapi.Device
+	socket                string
+	resourceName          string
+	preStartContainerFlag bool
 
 	stop   chan interface{}
 	wg     sync.WaitGroup
@@ -43,6 +46,10 @@ type Stub struct {
 
 	// allocFunc is used for handling allocation request
 	allocFunc stubAllocFunc
+
+	registrationStatus chan watcherapi.RegistrationStatus // for testing
+	endpoint           string                             // for testing
+
 }
 
 // stubAllocFunc is the function called when receive an allocation request from Kubelet
@@ -55,10 +62,12 @@ func defaultAllocFunc(r *pluginapi.AllocateRequest, devs map[string]pluginapi.De
 }
 
 // NewDevicePluginStub returns an initialized DevicePlugin Stub.
-func NewDevicePluginStub(devs []*pluginapi.Device, socket string) *Stub {
+func NewDevicePluginStub(devs []*pluginapi.Device, socket string, name string, preStartContainerFlag bool) *Stub {
 	return &Stub{
-		devs:   devs,
-		socket: socket,
+		devs:                  devs,
+		socket:                socket,
+		resourceName:          name,
+		preStartContainerFlag: preStartContainerFlag,
 
 		stop:   make(chan interface{}),
 		update: make(chan []*pluginapi.Device),
@@ -88,6 +97,7 @@ func (m *Stub) Start() error {
 	m.wg.Add(1)
 	m.server = grpc.NewServer([]grpc.ServerOption{}...)
 	pluginapi.RegisterDevicePluginServer(m.server, m)
+	watcherapi.RegisterRegistrationServer(m.server, m)
 
 	go func() {
 		defer m.wg.Done()
@@ -118,8 +128,36 @@ func (m *Stub) Stop() error {
 	return m.cleanup()
 }
 
+// GetInfo is the RPC which return pluginInfo
+func (m *Stub) GetInfo(ctx context.Context, req *watcherapi.InfoRequest) (*watcherapi.PluginInfo, error) {
+	log.Println("GetInfo")
+	return &watcherapi.PluginInfo{
+		Type:              watcherapi.DevicePlugin,
+		Name:              m.resourceName,
+		Endpoint:          m.endpoint,
+		SupportedVersions: []string{pluginapi.Version}}, nil
+}
+
+// NotifyRegistrationStatus receives the registration notification from watcher
+func (m *Stub) NotifyRegistrationStatus(ctx context.Context, status *watcherapi.RegistrationStatus) (*watcherapi.RegistrationStatusResponse, error) {
+	if m.registrationStatus != nil {
+		m.registrationStatus <- *status
+	}
+	if !status.PluginRegistered {
+		log.Println("Registration failed: ", status.Error)
+	}
+	return &watcherapi.RegistrationStatusResponse{}, nil
+}
+
 // Register registers the device plugin for the given resourceName with Kubelet.
-func (m *Stub) Register(kubeletEndpoint, resourceName string, preStartContainerFlag bool) error {
+func (m *Stub) Register(kubeletEndpoint, resourceName string, pluginSockDir string) error {
+	if pluginSockDir != "" {
+		if _, err := os.Stat(pluginSockDir + "DEPRECATION"); err == nil {
+			log.Println("Deprecation file found. Skip registration.")
+			return nil
+		}
+	}
+	log.Println("Deprecation file not found. Invoke registration")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -136,7 +174,7 @@ func (m *Stub) Register(kubeletEndpoint, resourceName string, preStartContainerF
 		Version:      pluginapi.Version,
 		Endpoint:     path.Base(m.socket),
 		ResourceName: resourceName,
-		Options:      &pluginapi.DevicePluginOptions{PreStartRequired: preStartContainerFlag},
+		Options:      &pluginapi.DevicePluginOptions{PreStartRequired: m.preStartContainerFlag},
 	}
 
 	_, err = client.Register(context.Background(), reqt)
@@ -148,7 +186,7 @@ func (m *Stub) Register(kubeletEndpoint, resourceName string, preStartContainerF
 
 // GetDevicePluginOptions returns DevicePluginOptions settings for the device plugin.
 func (m *Stub) GetDevicePluginOptions(ctx context.Context, e *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
-	return &pluginapi.DevicePluginOptions{}, nil
+	return &pluginapi.DevicePluginOptions{PreStartRequired: m.preStartContainerFlag}, nil
 }
 
 // PreStartContainer resets the devices received

--- a/pkg/kubelet/cm/devicemanager/endpoint_test.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint_test.go
@@ -180,7 +180,7 @@ func TestGetDevices(t *testing.T) {
 }
 
 func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string, callback monitorCallback) (*Stub, *endpointImpl) {
-	p := NewDevicePluginStub(devs, socket)
+	p := NewDevicePluginStub(devs, socket, resourceName, false)
 
 	err := p.Start()
 	require.NoError(t, err)

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -21,6 +21,7 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
@@ -60,4 +61,11 @@ func (h *ManagerStub) GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Co
 // GetCapacity simply returns nil capacity and empty removed resource list.
 func (h *ManagerStub) GetCapacity() (v1.ResourceList, v1.ResourceList, []string) {
 	return nil, nil, []string{}
+}
+
+// GetWatcherCallback returns plugin watcher callback
+func (h *ManagerStub) GetWatcherCallback() pluginwatcher.RegisterCallbackFn {
+	return func(name string, endpoint string, versions []string, sockPath string) (chan bool, error) {
+		return nil, nil
+	}
 }

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -33,8 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+	watcherapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
@@ -65,31 +68,16 @@ func TestNewManagerImplStart(t *testing.T) {
 	socketDir, socketName, pluginSocketName, err := tmpSocketDir()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-	m, p := setup(t, []*pluginapi.Device{}, func(n string, a, u, r []pluginapi.Device) {}, socketName, pluginSocketName)
-	cleanup(t, m, p)
-	// Stop should tolerate being called more than once.
-	cleanup(t, m, p)
+	m, p := setup(t, []*pluginapi.Device{}, func(n string, a, u, r []pluginapi.Device) {}, socketName, pluginSocketName, false)
+	cleanup(t, m, p, nil)
 }
 
-func TestNewManagerImplStop(t *testing.T) {
+func TestNewManagerImplStartProbeMode(t *testing.T) {
 	socketDir, socketName, pluginSocketName, err := tmpSocketDir()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
-
-	m, err := newManagerImpl(socketName)
-	require.NoError(t, err)
-	// No prior Start, but that should be okay.
-	err = m.Stop()
-	require.NoError(t, err)
-
-	devs := []*pluginapi.Device{
-		{ID: "Dev1", Health: pluginapi.Healthy},
-		{ID: "Dev2", Health: pluginapi.Healthy},
-	}
-	p := NewDevicePluginStub(devs, pluginSocketName)
-	// Same here.
-	err = p.Stop()
-	require.NoError(t, err)
+	m, p, w := setupInProbeMode(t, []*pluginapi.Device{}, func(n string, a, u, r []pluginapi.Device) {}, socketName, pluginSocketName)
+	cleanup(t, m, p, w)
 }
 
 // Tests that the device plugin manager correctly handles registration and re-registration by
@@ -118,9 +106,9 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			}
 			callbackChan <- callbackCount
 		}
-		m, p1 := setup(t, devs, callback, socketName, pluginSocketName)
+		m, p1 := setup(t, devs, callback, socketName, pluginSocketName, preStartContainerFlag)
 		atomic.StoreInt32(&expCallbackCount, 1)
-		p1.Register(socketName, testResourceName, preStartContainerFlag)
+		p1.Register(socketName, testResourceName, "")
 		// Wait for the first callback to be issued.
 
 		select {
@@ -132,11 +120,11 @@ func TestDevicePluginReRegistration(t *testing.T) {
 		devices := m.Devices()
 		require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
 
-		p2 := NewDevicePluginStub(devs, pluginSocketName+".new")
+		p2 := NewDevicePluginStub(devs, pluginSocketName+".new", testResourceName, preStartContainerFlag)
 		err = p2.Start()
 		require.NoError(t, err)
 		atomic.StoreInt32(&expCallbackCount, 2)
-		p2.Register(socketName, testResourceName, preStartContainerFlag)
+		p2.Register(socketName, testResourceName, "")
 		// Wait for the second callback to be issued.
 		select {
 		case <-callbackChan:
@@ -149,11 +137,11 @@ func TestDevicePluginReRegistration(t *testing.T) {
 		require.Equal(t, 2, len(devices2[testResourceName]), "Devices shouldn't change.")
 
 		// Test the scenario that a plugin re-registers with different devices.
-		p3 := NewDevicePluginStub(devsForRegistration, pluginSocketName+".third")
+		p3 := NewDevicePluginStub(devsForRegistration, pluginSocketName+".third", testResourceName, preStartContainerFlag)
 		err = p3.Start()
 		require.NoError(t, err)
 		atomic.StoreInt32(&expCallbackCount, 3)
-		p3.Register(socketName, testResourceName, preStartContainerFlag)
+		p3.Register(socketName, testResourceName, "")
 		// Wait for the second callback to be issued.
 		select {
 		case <-callbackChan:
@@ -161,16 +149,93 @@ func TestDevicePluginReRegistration(t *testing.T) {
 		case <-time.After(time.Second):
 			t.FailNow()
 		}
+
 		devices3 := m.Devices()
 		require.Equal(t, 1, len(devices3[testResourceName]), "Devices of plugin previously registered should be removed.")
 		p2.Stop()
 		p3.Stop()
-		cleanup(t, m, p1)
+		cleanup(t, m, p1, nil)
 		close(callbackChan)
+
 	}
 }
 
-func setup(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string, pluginSocketName string) (Manager, *Stub) {
+// Tests that the device plugin manager correctly handles registration and re-registration by
+// making sure that after registration, devices are correctly updated and if a re-registration
+// happens, we will NOT delete devices; and no orphaned devices left.
+// While testing above scenario, plugin discovery and registration will be done using
+// Kubelet probe based mechanism
+func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
+	socketDir, socketName, pluginSocketName, err := tmpSocketDir()
+	require.NoError(t, err)
+	defer os.RemoveAll(socketDir)
+	devs := []*pluginapi.Device{
+		{ID: "Dev1", Health: pluginapi.Healthy},
+		{ID: "Dev2", Health: pluginapi.Healthy},
+	}
+	devsForRegistration := []*pluginapi.Device{
+		{ID: "Dev3", Health: pluginapi.Healthy},
+	}
+
+	expCallbackCount := int32(0)
+	callbackCount := int32(0)
+	callbackChan := make(chan int32)
+	callback := func(n string, a, u, r []pluginapi.Device) {
+		callbackCount++
+		if callbackCount > atomic.LoadInt32(&expCallbackCount) {
+			t.FailNow()
+		}
+		callbackChan <- callbackCount
+	}
+	m, p1, w := setupInProbeMode(t, devs, callback, socketName, pluginSocketName)
+	atomic.StoreInt32(&expCallbackCount, 1)
+	// Wait for the first callback to be issued.
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+	devices := m.Devices()
+	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
+
+	p2 := NewDevicePluginStub(devs, pluginSocketName+".new", testResourceName, false)
+	err = p2.Start()
+	require.NoError(t, err)
+	atomic.StoreInt32(&expCallbackCount, 2)
+	// Wait for the second callback to be issued.
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	devices2 := m.Devices()
+	require.Equal(t, 2, len(devices2[testResourceName]), "Devices shouldn't change.")
+
+	// Test the scenario that a plugin re-registers with different devices.
+	p3 := NewDevicePluginStub(devsForRegistration, pluginSocketName+".third", testResourceName, false)
+	err = p3.Start()
+	require.NoError(t, err)
+	atomic.StoreInt32(&expCallbackCount, 3)
+	// Wait for the second callback to be issued.
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	devices3 := m.Devices()
+	require.Equal(t, 1, len(devices3[testResourceName]), "Devices of plugin previously registered should be removed.")
+	p2.Stop()
+	p3.Stop()
+	cleanup(t, m, p1, w)
+	close(callbackChan)
+}
+
+func setup(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string, pluginSocketName string, preStartContainerFlag bool) (Manager, *Stub) {
 	m, err := newManagerImpl(socketName)
 	require.NoError(t, err)
 
@@ -182,16 +247,43 @@ func setup(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, soc
 	err = m.Start(activePods, &sourcesReadyStub{})
 	require.NoError(t, err)
 
-	p := NewDevicePluginStub(devs, pluginSocketName)
+	p := NewDevicePluginStub(devs, pluginSocketName, testResourceName, preStartContainerFlag)
 	err = p.Start()
 	require.NoError(t, err)
 
 	return m, p
 }
 
-func cleanup(t *testing.T, m Manager, p *Stub) {
+func setupInProbeMode(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string, pluginSocketName string) (Manager, *Stub, *pluginwatcher.Watcher) {
+	w := pluginwatcher.NewWatcher(filepath.Dir(pluginSocketName))
+
+	m, err := newManagerImpl(socketName)
+	require.NoError(t, err)
+
+	w.AddHandler(watcherapi.DevicePlugin, m.GetWatcherCallback())
+	w.Start()
+
+	m.callback = callback
+
+	activePods := func() []*v1.Pod {
+		return []*v1.Pod{}
+	}
+	err = m.Start(activePods, &sourcesReadyStub{})
+	require.NoError(t, err)
+
+	p := NewDevicePluginStub(devs, pluginSocketName, testResourceName, false /*preStart*/)
+	err = p.Start()
+	require.NoError(t, err)
+
+	return m, p, &w
+}
+
+func cleanup(t *testing.T, m Manager, p *Stub, w *pluginwatcher.Watcher) {
 	p.Stop()
 	m.Stop()
+	if w != nil {
+		require.NoError(t, w.Stop())
+	}
 }
 
 func TestUpdateCapacityAllocatable(t *testing.T) {

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	watcher "k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
 
@@ -58,6 +59,7 @@ type Manager interface {
 	// GetCapacity returns the amount of available device plugin resource capacity, resource allocatable
 	// and inactive device plugin resources previously registered on the node.
 	GetCapacity() (v1.ResourceList, v1.ResourceList, []string)
+	GetWatcherCallback() watcher.RegisterCallbackFn
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
+	pluginwatcherapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	kubeletcertificate "k8s.io/kubernetes/pkg/kubelet/certificate"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
@@ -1352,6 +1353,8 @@ func (kl *Kubelet) initializeRuntimeDependentModules() {
 	if kl.enablePluginsWatcher {
 		// Adding Registration Callback function for CSI Driver
 		kl.pluginWatcher.AddHandler("CSIPlugin", csi.RegistrationCallback)
+		// Adding Registration Callback function for Device Manager
+		kl.pluginWatcher.AddHandler(pluginwatcherapi.DevicePlugin, kl.containerManager.GetPluginRegistrationHandlerCallback())
 		// Start the plugin watcher
 		glog.V(4).Infof("starting watcher")
 		if err := kl.pluginWatcher.Start(); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses this probe based utility in the device plugin manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56944 

**Notes For Reviewers**:
Changes are backward compatible and existing device plugins will continue to work. At the same time, any new plugins that has required support for probing model (Identity service implementation), will also work. 


**Release note**
```release-note
Add support kubelet plugin watcher in device manager.
```
/sig node
/area hw-accelerators
/cc /cc @jiayingz @RenaudWasTaken @vishh @ScorpioCPH @sjenning @derekwaynecarr @jeremyeder @lichuqiang @tengqm @saad-ali @chakri-nelluri @ConnorDoyle 