### PR TITLE
gce: bump version of addon manager

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: gcr.io/google-containers/kube-addon-manager:v6.5
+    image: gcr.io/google-containers/kube-addon-manager:v8.5
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v6.5
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.5
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
to pick up https://github.com/kubernetes/kubernetes/pull/58386

```release-note
NONE
```
