### PR TITLE
Support passing boolean flags to kubectl plugins

### DIFF
--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 
 	"github.com/golang/glog"
@@ -128,7 +129,15 @@ func NewCmdForPlugin(f cmdutil.Factory, plugin *plugins.Plugin, runner plugins.P
 	}
 
 	for _, flag := range plugin.Flags {
-		cmd.Flags().StringP(flag.Name, flag.Shorthand, flag.DefValue, flag.Desc)
+		switch flag.Type {
+		case plugins.BoolFlagType:
+			// The default value has already been validated above
+			defValue, _ := strconv.ParseBool(flag.DefValue)
+			cmd.Flags().BoolP(flag.Name, flag.Shorthand, defValue, flag.Desc)
+		default:
+			// By default flags are of type string which was the original behavior before Type was introduced
+			cmd.Flags().StringP(flag.Name, flag.Shorthand, flag.DefValue, flag.Desc)
+		}
 	}
 
 	for _, childPlugin := range plugin.Tree {

--- a/pkg/kubectl/plugins/examples/flags/plugin.yaml
+++ b/pkg/kubectl/plugins/examples/flags/plugin.yaml
@@ -1,0 +1,9 @@
+name: "flags"
+shortDesc: "I echo all the flags that have been passed to my plugin as environment variables"
+command: "bash -c env"
+flags:
+  - name: foo
+    desc: foo
+  - name: version
+    desc: Display the version of the plugin
+    type: bool

--- a/pkg/kubectl/plugins/plugins_test.go
+++ b/pkg/kubectl/plugins/plugins_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package plugins
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestPlugin(t *testing.T) {
 	tests := []struct {
@@ -128,9 +131,66 @@ func TestPlugin(t *testing.T) {
 					Command:   "echo 1",
 					Flags: []Flag{
 						{
+							Name: "aflag",
+							Desc: "Invalid flag type",
+							Type: "stringArray",
+						},
+					},
+				},
+			},
+			expectedErr: ErrInvalidFlagType,
+		},
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "The test",
+					Command:   "echo 1",
+					Flags: []Flag{
+						{
+							Name:     "aflag",
+							Desc:     "boolean flag with a default value",
+							Type:     BoolFlagType,
+							DefValue: "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "The test",
+					Command:   "echo 1",
+					Flags: []Flag{
+						{
+							Name:     "aflag",
+							Desc:     "Invalid flag default value",
+							Type:     BoolFlagType,
+							DefValue: "yes",
+						},
+					},
+				},
+			},
+			expectedErr: ErrInvalidFlagDefaultValue,
+		},
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "The test",
+					Command:   "echo 1",
+					Flags: []Flag{
+						{
 							Name:      "aflag",
 							Desc:      "A flag",
 							Shorthand: "a",
+						},
+						{
+							Name: "boolflag",
+							Desc: "A bool flag",
+							Type: BoolFlagType,
 						},
 					},
 					Tree: Plugins{
@@ -165,5 +225,44 @@ func TestPlugin(t *testing.T) {
 		if err != test.expectedErr {
 			t.Errorf("%s: expected error %v, got %v", test.plugin.Name, test.expectedErr, err)
 		}
+	}
+}
+
+func TestPluginFlagTypeDefaultsToString(t *testing.T) {
+	f := Flag{
+		Name: "aflag",
+		Desc: "a flag with an unspecified type",
+		Type: "",
+	}
+
+	err := f.Validate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if f.Type != StringFlagType {
+		t.Fatalf("expected flag type to default to %v, got %v", StringFlagType, f.Type)
+	}
+}
+
+func TestPluginBoolFlagDefaultsToFalse(t *testing.T) {
+	f := Flag{
+		Name:     "aflag",
+		Desc:     "a bool flag with an unspecified default value",
+		Type:     BoolFlagType,
+		DefValue: "",
+	}
+
+	err := f.Validate()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defVal, err := strconv.ParseBool(f.DefValue)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defVal != false {
+		t.Fatalf("expected bool flag to default to %v, got %v", false, defVal)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows kubectl plugins to define boolean flags. Boolean flags are set to true when the flag is present and no value is specified. --flag is equivalent to --flag=true and is useful for commands such as `kubectl plugin svcat --version`.

To preserve backwards compatibility with existing plugins, all flags by default are string flags, but now a new field has been introduced to the flag definition, type, which allows specifying the type of pflag to use. Currently only string and bool are supported, but this allows for other types to be added in the future.

Bool flags support a default value, and when defValue is set, kubectl validates that it can be parsed as a boolean when validating the plugin. Acceptable values can be found at https://golang.org/pkg/strconv/#ParseBool.

**Example**
```yaml
name: "svcat"
shortDesc: "Service Catalog CLI"
command: "./svcat"
flags:
  - name: version
    desc: Display the version of the plugin
    type: bool
```

**Which issue(s) this PR fixes**
Fixes #53640

**Special notes for your reviewer**:
None

**Release note**:
```release-note
Support passing boolean flags to kubectl plugins
```

/sig cli