### PR TITLE
verify taint for node.spec.unschedulable in predicates.go

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -99,6 +99,7 @@ go_library(
         "//pkg/util/node:go_default_library",
         "//pkg/util/oom:go_default_library",
         "//pkg/util/removeall:go_default_library",
+        "//pkg/util/taints:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -41,6 +41,7 @@ import (
 	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
 	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/util/taints"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 
 	"github.com/golang/glog"
@@ -1489,7 +1490,7 @@ func CheckNodeConditionPredicate(pod *v1.Pod, meta algorithm.PredicateMetadata, 
 		}
 	}
 
-	if node.Spec.Unschedulable {
+	if node.Spec.Unschedulable || taints.TaintExistsWithEffect(node.Spec.Taints) {
 		reasons = append(reasons, ErrNodeUnschedulable)
 	}
 

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -3621,6 +3621,14 @@ func TestNodeConditionPredicate(t *testing.T) {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node11"}},
 			schedulable: true,
 		},
+		{
+			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node12"}, Spec: v1.NodeSpec{Taints: []v1.Taint{{Key: algorithm.TaintNodeNotReady, Effect: v1.TaintEffectNoExecute}}}},
+			schedulable: false,
+		},
+		{
+			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node13"}, Spec: v1.NodeSpec{Taints: []v1.Taint{{Effect: v1.TaintEffectNoSchedule}}}},
+			schedulable: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/util/taints/BUILD
+++ b/pkg/util/taints/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/helper:go_default_library",
+        "//pkg/scheduler/algorithm:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -311,6 +311,23 @@ func TaintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
+func TaintExistsWithEffect(taints []v1.Taint) bool {
+	noExecuteTaintTemplate := &v1.Taint{
+		Effect: v1.TaintEffectNoExecute,
+	}
+
+	notScheduleTaintTemplate := &v1.Taint{
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	for _, taint := range taints {
+		if taint.Effect == noExecuteTaintTemplate.Effect || taint.Effect == notScheduleTaintTemplate.Effect {
+			return true
+		}
+	}
+	return false
+}
+
 func TaintSetDiff(t1, t2 []v1.Taint) (taintsToAdd []*v1.Taint, taintsToRemove []*v1.Taint) {
 	for _, taint := range t1 {
 		if !TaintExists(t2, &taint) {


### PR DESCRIPTION

**What this PR does / why we need it**:
Following the issuehttps://github.com/kubernetes/kubernetes/issues/58406#issuecomment-358808154 , I propose a first step checking taints in pkg/scheduler/algorithm/predicates/predicate.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58406

**Special notes for your reviewer**:
/assign @yastij @gmarek 

**Release note**:
```release-note
None
```
