### PR TITLE
Skip NoNewPrivileges test when SELinux is enabled

### DIFF
--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -373,6 +373,18 @@ var _ = framework.KubeDescribe("Security Context", func() {
 				if !isSupported {
 					framework.Skipf("Skipping because no_new_privs is not supported in this docker")
 				}
+				// It turns out SELinux policy in RHEL 7 does not play well with
+				// the "NoNewPrivileges" flag. So let's skip this test when running
+				// with SELinux support enabled.
+				//
+				// TODO(filbranden): Remove this after the fix for
+				// https://github.com/projectatomic/container-selinux/issues/45
+				// has been backported to RHEL 7 (expected on RHEL 7.5)
+				selinuxEnabled, err := isDockerSELinuxSupportEnabled()
+				framework.ExpectNoError(err)
+				if selinuxEnabled {
+					framework.Skipf("Skipping because Docker daemon is running with SELinux support enabled")
+				}
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A bug in the SELinux policy prevented NoNewPrivileges from working on Docker with SELinux support enabled.

The problem has been fixed upstream (see projectatomic/container-selinux#45)

But hasn't been backported yet (a fix might come in RHEL 7.5)

For now, let's skip the NoNewPrivileges test when SELinux support is enabled in Docker.

Tested:

- Before this commit, the test fails:
```
    $ make test-e2e-node REMOTE=true FOCUS="allow privilege escalation"
    (on a host with SELinux enabled)

    • [SLOW TEST:22.798 seconds] (passed)
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should allow privilege escalation when true

    • Failure [16.539 seconds]
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should not allow privilege escalation when false [It]

        wait for pod "alpine-nnp-false-aef03e47-0090-11e8-886f-42010af00009" to success
        Expected success, but got an error:
            <*errors.errorString | 0xc4204e26d0>: {
                s: "pod \"alpine-nnp-false-aef03e47-0090-11e8-886f-42010af00009\" failed with reason: \"\", message: \"\"",
            }
            pod "alpine-nnp-false-aef03e47-0090-11e8-886f-42010af00009" failed with reason: "", message: ""

    • [SLOW TEST:26.572 seconds] (passed)
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should allow privilege escalation when not explicitly set and uid != 0

    Ran 3 of 257 Specs in 45.364 seconds
    FAIL! -- 2 Passed | 1 Failed | 0 Pending | 254 Skipped

    Ginkgo ran 1 suite in 49.389123442s
    Test Suite Failed
```
- After this commit, the test is skipped:
```
    $ make test-e2e-node REMOTE=true FOCUS="allow privilege escalation"
    (on a host with SELinux enabled)

    S [SKIPPING] in Spec Setup (BeforeEach) [12.452 seconds]
    S [SKIPPING] in Spec Setup (BeforeEach) [16.298 seconds]
    S [SKIPPING] in Spec Setup (BeforeEach) [18.183 seconds]

    Ran 0 of 257 Specs in 39.174 seconds
    SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 257 Skipped

    Ginkgo ran 1 suite in 43.570630357s
    Test Suite Passed
```
- No changes when SELinux is disabled:
```
    $ make test-e2e-node REMOTE=true FOCUS="allow privilege escalation"
    (on a host with SELinux disabled)

    • [SLOW TEST:15.013 seconds]
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should not allow privilege escalation when false

    • [SLOW TEST:19.155 seconds]
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should allow privilege escalation when true

    • [SLOW TEST:21.087 seconds]
    [k8s.io] Security Context
      when creating containers with AllowPrivilegeEscalation
        should allow privilege escalation when not explicitly set and uid != 0

    Ran 3 of 259 Specs in 38.560 seconds
    SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 256 Skipped

    Ginkgo ran 1 suite in 41.937918928s
    Test Suite Passed
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
