### PR TITLE
Remove some obselete comments about daemonset from addons README

### DIFF
--- a/cluster/addons/README.md
+++ b/cluster/addons/README.md
@@ -27,10 +27,10 @@ Auto-scaler.
 ## Add-on naming
 
 The suggested naming for most of the resources is `<basename>` (with no version number).
-Though resources like `Pod`, `ReplicationController` and `DaemonSet` are exceptional.
+Though resources like `Pod` and `ReplicationController` are exceptional.
 It would be hard to update `Pod` because many fields in `Pod` are immutable. For
-`ReplicationController` and `DaemonSet`, in-place update may not trigger the underlying
-pods to be re-created. You probably need to change their names during update to trigger
-a complete deletion and creation.
+`ReplicationController`, in-place update may not trigger the underlying pods to be
+re-created. You probably need to change their names during update to trigger a complete
+deletion and creation.
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/README.md?pixel)]()


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor changes to addons README based on the latest documentation regarding DaemonSet rolling update (https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#performing-a-rolling-update). Don't think there is any concern now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
