### PR TITLE
remove unused func in FakeConfigurator of scheduler

### DIFF
--- a/pkg/scheduler/testutil.go
+++ b/pkg/scheduler/testutil.go
@@ -69,11 +69,6 @@ func (fc *FakeConfigurator) MakeDefaultErrorFunc(backoff *util.PodBackoff, podQu
 	return nil
 }
 
-// ResponsibleForPod is not implemented yet.
-func (fc *FakeConfigurator) ResponsibleForPod(pod *v1.Pod) bool {
-	panic("not implemented")
-}
-
 // GetNodeLister is not implemented yet.
 func (fc *FakeConfigurator) GetNodeLister() corelisters.NodeLister {
 	return nil
@@ -87,11 +82,6 @@ func (fc *FakeConfigurator) GetClient() clientset.Interface {
 // GetScheduledPodLister is not implemented yet.
 func (fc *FakeConfigurator) GetScheduledPodLister() corelisters.PodLister {
 	return nil
-}
-
-// Run is not implemented yet.
-func (fc *FakeConfigurator) Run() {
-	panic("not implemented")
 }
 
 // Create returns FakeConfigurator.Config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Current scheduler `Configurator` interface looks like this:
```
type Configurator interface {
	GetPriorityFunctionConfigs(priorityKeys sets.String) ([]algorithm.PriorityConfig, error)
	GetPriorityMetadataProducer() (algorithm.PriorityMetadataProducer, error)
	GetPredicateMetadataProducer() (algorithm.PredicateMetadataProducer, error)
	GetPredicates(predicateKeys sets.String) (map[string]algorithm.FitPredicate, error)
	GetHardPodAffinitySymmetricWeight() int32
	GetSchedulerName() string
	MakeDefaultErrorFunc(backoff *util.PodBackoff, podQueue core.SchedulingQueue) func(pod *v1.Pod, err error)

	// Needs to be exposed for things like integration tests where we want to make fake nodes.
	GetNodeLister() corelisters.NodeLister
	GetClient() clientset.Interface
	GetScheduledPodLister() corelisters.PodLister

	Create() (*Config, error)
	CreateFromProvider(providerName string) (*Config, error)
	CreateFromConfig(policy schedulerapi.Policy) (*Config, error)
	CreateFromKeys(predicateKeys, priorityKeys sets.String, extenders []algorithm.SchedulerExtender) (*Config, error)
}
```
Funcs `ResponsibleForPod` and  `Run` once existed have been removed, so the funcs in `FakeConfigurator` should be removed accordingly.

**Special notes for your reviewer**:
/kind cleanup
/sig scheduling

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
