### PR TITLE
kubeadm init: skip checking cri socket in preflight checks

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -184,7 +184,7 @@ func resetWithCrictl(execer utilsexec.Interface, dockerCheck preflight.Checker, 
 	if criSocketPath != "" {
 		fmt.Printf("[reset] Cleaning up running containers using crictl with socket %s\n", criSocketPath)
 		listcmd := fmt.Sprintf(crictlSandboxesParamsFormat, crictlPath, criSocketPath)
-		output, err := execer.Command("sh", "-c", listcmd).CombinedOutput()
+		output, err := execer.Command(listcmd).CombinedOutput()
 		if err != nil {
 			fmt.Println("[reset] Failed to list running pods using crictl. Trying using docker instead.")
 			resetWithDocker(execer, dockerCheck)
@@ -193,13 +193,13 @@ func resetWithCrictl(execer utilsexec.Interface, dockerCheck preflight.Checker, 
 		sandboxes := strings.Split(string(output), " ")
 		for _, s := range sandboxes {
 			stopcmd := fmt.Sprintf(crictlStopParamsFormat, crictlPath, criSocketPath, s)
-			if err := execer.Command("sh", "-c", stopcmd).Run(); err != nil {
+			if err := execer.Command(stopcmd).Run(); err != nil {
 				fmt.Println("[reset] Failed to stop the running containers using crictl. Trying using docker instead.")
 				resetWithDocker(execer, dockerCheck)
 				return
 			}
 			removecmd := fmt.Sprintf(crictlRemoveParamsFormat, crictlPath, criSocketPath, s)
-			if err := execer.Command("sh", "-c", removecmd).Run(); err != nil {
+			if err := execer.Command(removecmd).Run(); err != nil {
 				fmt.Println("[reset] Failed to remove the running containers using crictl. Trying using docker instead.")
 				resetWithDocker(execer, dockerCheck)
 				return

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -278,10 +278,10 @@ func TestResetWithCrictl(t *testing.T) {
 	if fcmd.RunCalls != 3 {
 		t.Errorf("expected 3 calls to Run, got %d", fcmd.RunCalls)
 	}
-	if !strings.Contains(fcmd.RunLog[1][2], "crictl") {
+	if !strings.Contains(fcmd.RunLog[1][0], "crictl") {
 		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
 	}
-	if !strings.Contains(fcmd.RunLog[2][2], "crictl") {
+	if !strings.Contains(fcmd.RunLog[2][0], "crictl") {
 		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
 	}
 
@@ -330,7 +330,7 @@ func TestReset(t *testing.T) {
 	if fcmd.RunCalls != 2 {
 		t.Errorf("expected 2 call to Run, got %d", fcmd.RunCalls)
 	}
-	if !strings.Contains(fcmd.RunLog[0][2], "crictl") {
+	if !strings.Contains(fcmd.RunLog[0][0], "crictl") {
 		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kubeadm init` does not need to require `dockershim.sock` to be present.
Remove the check for `dockershim.sock`.
xref #55055

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#657

**Special notes for your reviewer**:
/area kubeadm
/kind bug
/assign @luxas 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm init: skip checking cri socket in preflight checks
```
