### PR TITLE
[WIP] split attach/detach and device mount/umount operations into independe…

### DIFF
--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -295,12 +295,20 @@ func (plugin *TestPlugin) NewAttacher() (volume.Attacher, error) {
 	return &attacher, nil
 }
 
+func (plugin *TestPlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
+	return plugin.NewAttacher()
+}
+
 func (plugin *TestPlugin) NewDetacher() (volume.Detacher, error) {
 	detacher := testPluginDetacher{
 		detachedVolumeMap: plugin.detachedVolumeMap,
 		pluginLock:        plugin.pluginLock,
 	}
 	return &detacher, nil
+}
+
+func (plugin *TestPlugin) NewDeviceUmounter() (volume.DeviceUmounter, error) {
+	return plugin.NewDetacher()
 }
 
 func (plugin *TestPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {
@@ -400,15 +408,15 @@ func (attacher *testPluginAttacher) GetDeviceMountPath(spec *volume.Spec) (strin
 	return "", nil
 }
 
-func (attacher *testPluginAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+func (attacher *testPluginAttacher) MountDevice(spec *volume.Spec, devicePath string, pod *v1.Pod) (string, string, error) {
 	attacher.pluginLock.Lock()
 	defer attacher.pluginLock.Unlock()
 	if spec == nil {
 		*attacher.ErrorEncountered = true
 		glog.Errorf("MountDevice called with nil volume spec")
-		return fmt.Errorf("MountDevice called with nil volume spec")
+		return "", "", fmt.Errorf("MountDevice called with nil volume spec")
 	}
-	return nil
+	return "", "", nil
 }
 
 // Detacher

--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -208,7 +208,12 @@ func (a *azureDiskAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error
 	return makeGlobalPDPath(a.plugin.host, volumeSource.DataDiskURI, isManagedDisk)
 }
 
-func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath string, _ *v1.Pod) (string, string, error) {
+	deviceMountPath, err := attacher.GetDeviceMountPath(spec)
+	if err != nil {
+		return devicePath, deviceMountPath, err
+	}
+
 	mounter := attacher.plugin.host.GetMounter(azureDataDiskPluginName)
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 
@@ -220,11 +225,11 @@ func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath str
 				dir = filepath.Dir(deviceMountPath)
 			}
 			if err := os.MkdirAll(dir, 0750); err != nil {
-				return fmt.Errorf("azureDisk - mountDevice:CreateDirectory failed with %s", err)
+				return devicePath, deviceMountPath, fmt.Errorf("azureDisk - mountDevice:CreateDirectory failed with %s", err)
 			}
 			notMnt = true
 		} else {
-			return fmt.Errorf("azureDisk - mountDevice:IsLikelyNotMountPoint failed with %s", err)
+			return devicePath, deviceMountPath, fmt.Errorf("azureDisk - mountDevice:IsLikelyNotMountPoint failed with %s", err)
 		}
 	}
 
@@ -235,7 +240,7 @@ func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath str
 			glog.Warningf("azureDisk - ReadDir %s failed with %v, unmount this directory", deviceMountPath, err)
 			if err := mounter.Unmount(deviceMountPath); err != nil {
 				glog.Errorf("azureDisk - Unmount deviceMountPath %s failed with %v", deviceMountPath, err)
-				return err
+				return devicePath, deviceMountPath, err
 			}
 			notMnt = true
 		}
@@ -243,7 +248,7 @@ func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath str
 
 	volumeSource, err := getVolumeSource(spec)
 	if err != nil {
-		return err
+		return devicePath, deviceMountPath, err
 	}
 
 	options := []string{}
@@ -253,12 +258,12 @@ func (attacher *azureDiskAttacher) MountDevice(spec *volume.Spec, devicePath str
 		err = diskMounter.FormatAndMount(devicePath, deviceMountPath, *volumeSource.FSType, mountOptions)
 		if err != nil {
 			if cleanErr := os.Remove(deviceMountPath); cleanErr != nil {
-				return fmt.Errorf("azureDisk - mountDevice:FormatAndMount failed with %s and clean up failed with :%v", err, cleanErr)
+				return devicePath, deviceMountPath, fmt.Errorf("azureDisk - mountDevice:FormatAndMount failed with %s and clean up failed with :%v", err, cleanErr)
 			}
-			return fmt.Errorf("azureDisk - mountDevice:FormatAndMount failed with %s", err)
+			return devicePath, deviceMountPath, fmt.Errorf("azureDisk - mountDevice:FormatAndMount failed with %s", err)
 		}
 	}
-	return nil
+	return devicePath, deviceMountPath, nil
 }
 
 // Detach detaches disk from Azure VM.

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -126,6 +126,11 @@ func (plugin *azureDataDiskPlugin) NewAttacher() (volume.Attacher, error) {
 	}, nil
 }
 
+// NewDeviceMounter initializes a DeviceMounter. For azure disk, this is an Attacher.
+func (plugin *azureDataDiskPlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
+	return plugin.NewAttacher()
+}
+
 func (plugin *azureDataDiskPlugin) NewDetacher() (volume.Detacher, error) {
 	azure, err := getCloud(plugin.host)
 	if err != nil {
@@ -137,6 +142,11 @@ func (plugin *azureDataDiskPlugin) NewDetacher() (volume.Detacher, error) {
 		plugin: plugin,
 		cloud:  azure,
 	}, nil
+}
+
+// NewDeviceUmounter initializes a DeviceUmounter. For azure disk, this is a Detacher.
+func (plugin *azureDataDiskPlugin) NewDeviceUmounter() (volume.DeviceUmounter, error) {
+	return plugin.NewDetacher()
 }
 
 func (plugin *azureDataDiskPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -532,7 +532,7 @@ func TestAttacherMountDevice(t *testing.T) {
 		}()
 
 		// Run
-		err = csiAttacher.MountDevice(spec, tc.devicePath, tc.deviceMountPath)
+		tc.devicePath, tc.deviceMountPath, err = csiAttacher.MountDevice(spec, tc.devicePath, nil)
 
 		// Verify
 		if err != nil {
@@ -544,6 +544,8 @@ func TestAttacherMountDevice(t *testing.T) {
 		if err == nil && tc.shouldFail {
 			t.Errorf("test should fail, but no error occurred")
 		}
+
+		plug.host.GetMounter(plug.GetPluginName()).Unmount(tc.deviceMountPath)
 
 		// Verify call goes through all the way
 		numStaged := 1

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -194,6 +194,11 @@ func (p *csiPlugin) NewAttacher() (volume.Attacher, error) {
 	}, nil
 }
 
+// NewDeviceMounter initializes a DeviceMounter. For CSI, this is an Attacher.
+func (p *csiPlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
+	return p.NewAttacher()
+}
+
 func (p *csiPlugin) NewDetacher() (volume.Detacher, error) {
 	k8s := p.host.GetKubeClient()
 	if k8s == nil {
@@ -206,6 +211,11 @@ func (p *csiPlugin) NewDetacher() (volume.Detacher, error) {
 		k8s:           k8s,
 		waitSleepTime: 1 * time.Second,
 	}, nil
+}
+
+// NewDeviceUmounter initializes a DeviceUmounter. For CSI, this is a Detacher.
+func (p *csiPlugin) NewDeviceUmounter() (volume.DeviceUmounter, error) {
+	return p.NewDetacher()
 }
 
 func (p *csiPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {

--- a/pkg/volume/flexvolume/attacher_test.go
+++ b/pkg/volume/flexvolume/attacher_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/volume"
+	"path"
 )
 
 func TestAttach(t *testing.T) {
@@ -53,14 +54,15 @@ func TestWaitForAttach(t *testing.T) {
 func TestMountDevice(t *testing.T) {
 	spec := fakeVolumeSpec()
 
-	plugin, rootDir := testPlugin()
+	plugin, _ := testPlugin()
+	deviceMountPath := path.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts", spec.Name())
 	plugin.runner = fakeRunner(
-		assertDriverCall(t, notSupportedOutput(), mountDeviceCmd, rootDir+"/mount-dir", "/dev/sdx",
+		assertDriverCall(t, notSupportedOutput(), getVolumeNameCmd, specJson(plugin, spec, nil)),
+		assertDriverCall(t, notSupportedOutput(), mountDeviceCmd, deviceMountPath, "/dev/sdx",
 			specJson(plugin, spec, nil)),
 	)
-
 	a, _ := plugin.NewAttacher()
-	a.MountDevice(spec, "/dev/sdx", rootDir+"/mount-dir")
+	a.MountDevice(spec, "/dev/sdx", nil)
 }
 
 func TestIsVolumeAttached(t *testing.T) {

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -218,9 +218,19 @@ func (plugin *flexVolumeAttachablePlugin) NewAttacher() (volume.Attacher, error)
 	return &flexVolumeAttacher{plugin}, nil
 }
 
+// NewDeviceMounter initializes a DeviceMounter. For flex, this is an Attacher.
+func (plugin *flexVolumeAttachablePlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
+	return plugin.NewAttacher()
+}
+
 // NewDetacher is part of the volume.AttachableVolumePlugin interface.
 func (plugin *flexVolumeAttachablePlugin) NewDetacher() (volume.Detacher, error) {
 	return &flexVolumeDetacher{plugin}, nil
+}
+
+// NewDeviceUmounter initializes a DeviceUmounter. For flex, this is a Detacher.
+func (plugin *flexVolumeAttachablePlugin) NewDeviceUmounter() (volume.DeviceUmounter, error) {
+	return plugin.NewDetacher()
 }
 
 // ConstructVolumeSpec is part of the volume.AttachableVolumePlugin interface.
@@ -273,7 +283,6 @@ func (plugin *flexVolumePlugin) getDeviceMountPath(spec *volume.Spec) (string, e
 	if err != nil {
 		return "", fmt.Errorf("GetVolumeName failed from getDeviceMountPath: %s", err)
 	}
-
 	mountsDir := path.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts")
 	return path.Join(mountsDir, volumeName), nil
 }

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -55,6 +55,11 @@ func (plugin *gcePersistentDiskPlugin) NewAttacher() (volume.Attacher, error) {
 	}, nil
 }
 
+// NewDeviceMounter initializes a DeviceMounter. For gce pd, this is an Attacher.
+func (plugin *gcePersistentDiskPlugin) NewDeviceMounter() (volume.DeviceMounter, error) {
+	return plugin.NewAttacher()
+}
+
 func (plugin *gcePersistentDiskPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string, error) {
 	mounter := plugin.host.GetMounter(plugin.GetPluginName())
 	return mount.GetMountRefs(mounter, deviceMountPath)
@@ -183,24 +188,29 @@ func (attacher *gcePersistentDiskAttacher) GetDeviceMountPath(
 	return makeGlobalPDName(attacher.host, volumeSource.PDName), nil
 }
 
-func (attacher *gcePersistentDiskAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+func (attacher *gcePersistentDiskAttacher) MountDevice(spec *volume.Spec, devicePath string, _ *v1.Pod) (string, string, error) {
+	deviceMountPath, err := attacher.GetDeviceMountPath(spec)
+	if err != nil {
+		return devicePath, deviceMountPath, err
+	}
+
 	// Only mount the PD globally once.
 	mounter := attacher.host.GetMounter(gcePersistentDiskPluginName)
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := os.MkdirAll(deviceMountPath, 0750); err != nil {
-				return err
+				return devicePath, deviceMountPath, err
 			}
 			notMnt = true
 		} else {
-			return err
+			return devicePath, deviceMountPath, err
 		}
 	}
 
 	volumeSource, readOnly, err := getVolumeSource(spec)
 	if err != nil {
-		return err
+		return devicePath, deviceMountPath, err
 	}
 
 	options := []string{}
@@ -213,11 +223,11 @@ func (attacher *gcePersistentDiskAttacher) MountDevice(spec *volume.Spec, device
 		err = diskMounter.FormatAndMount(devicePath, deviceMountPath, volumeSource.FSType, mountOptions)
 		if err != nil {
 			os.Remove(deviceMountPath)
-			return err
+			return devicePath, deviceMountPath, err
 		}
 		glog.V(4).Infof("formatting spec %v devicePath %v deviceMountPath %v fs %v with options %+v", spec.Name(), devicePath, deviceMountPath, volumeSource.FSType, options)
 	}
-	return nil
+	return devicePath, deviceMountPath, nil
 }
 
 type gcePersistentDiskDetacher struct {
@@ -237,6 +247,11 @@ func (plugin *gcePersistentDiskPlugin) NewDetacher() (volume.Detacher, error) {
 		host:     plugin.host,
 		gceDisks: gceCloud,
 	}, nil
+}
+
+// NewDeviceUmounter initializes a DeviceUmounter. For gce pd, this is an Detacher.
+func (plugin *gcePersistentDiskPlugin) NewDeviceUmounter() (volume.DeviceUmounter, error) {
+	return plugin.NewDetacher()
 }
 
 // Detach checks with the GCE cloud provider if the specified volume is already

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -201,9 +201,17 @@ type ProvisionableVolumePlugin interface {
 // AttachableVolumePlugin is an extended interface of VolumePlugin and is used for volumes that require attachment
 // to a node before mounting.
 type AttachableVolumePlugin interface {
-	VolumePlugin
+	DeviceMountableVolumePlugin
 	NewAttacher() (Attacher, error)
 	NewDetacher() (Detacher, error)
+}
+
+// DeviceMountableVolumePlugin is an extended interface of VolumePlugin and is used
+// for volumes that requires mount device to a node before binding to volume to pod.
+type DeviceMountableVolumePlugin interface {
+	VolumePlugin
+	NewDeviceMounter() (DeviceMounter, error)
+	NewDeviceUmounter() (DeviceUmounter, error)
 	GetDeviceMountRefs(deviceMountPath string) ([]string, error)
 }
 
@@ -694,6 +702,32 @@ func (pm *VolumePluginMgr) FindAttachablePluginByName(name string) (AttachableVo
 	}
 	if attachablePlugin, ok := volumePlugin.(AttachableVolumePlugin); ok {
 		return attachablePlugin, nil
+	}
+	return nil, nil
+}
+
+// FindDeviceMountablePluginBySpec fetches a device mountable volume
+// plugin by spec. This does not return error if no plugin is found.
+func (pm *VolumePluginMgr) FindDeviceMountablePluginBySpec(spec *Spec) (DeviceMountableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if deviceMountablePlugin, ok := volumePlugin.(DeviceMountableVolumePlugin); ok {
+		return deviceMountablePlugin, nil
+	}
+	return nil, nil
+}
+
+// FindDeviceMountablePluginByName fetches a device mountable volume
+// plugin by spec. This does not return error if no plugin is found.
+func (pm *VolumePluginMgr) FindDeviceMountablePluginByName(name string) (DeviceMountableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginByName(name)
+	if err != nil {
+		return nil, err
+	}
+	if deviceMountablePlugin, ok := volumePlugin.(DeviceMountableVolumePlugin); ok {
+		return deviceMountablePlugin, nil
 	}
 	return nil, nil
 }

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -56,9 +56,11 @@ var _ volume.VolumePlugin = &rbdPlugin{}
 var _ volume.PersistentVolumePlugin = &rbdPlugin{}
 var _ volume.DeletableVolumePlugin = &rbdPlugin{}
 var _ volume.ProvisionableVolumePlugin = &rbdPlugin{}
-var _ volume.AttachableVolumePlugin = &rbdPlugin{}
 var _ volume.ExpandableVolumePlugin = &rbdPlugin{}
 var _ volume.BlockVolumePlugin = &rbdPlugin{}
+
+// TODO: We should make rbd implementing DeviceMountableVolumePlugin only.
+var _ volume.AttachableVolumePlugin = &rbdPlugin{}
 
 const (
 	rbdPluginName                  = "kubernetes.io/rbd"

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -218,16 +218,12 @@ func doTestPlugin(t *testing.T, c *testcase) {
 	if devicePath != c.expectedDevicePath {
 		t.Errorf("Unexpected path, expected %q, not: %q", c.expectedDevicePath, devicePath)
 	}
-	deviceMountPath, err := attacher.GetDeviceMountPath(c.spec)
+	devicePath, deviceMountPath, err := attacher.MountDevice(c.spec, devicePath, c.pod)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if deviceMountPath != c.expectedDeviceMountPath {
 		t.Errorf("Unexpected mount path, expected %q, not: %q", c.expectedDeviceMountPath, deviceMountPath)
-	}
-	err = attacher.MountDevice(c.spec, devicePath, deviceMountPath)
-	if err != nil {
-		t.Fatal(err)
 	}
 	if _, err := os.Stat(deviceMountPath); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -359,6 +359,10 @@ func (plugin *FakeVolumePlugin) NewAttacher() (Attacher, error) {
 	return plugin.getFakeVolume(&plugin.Attachers), nil
 }
 
+func (plugin *FakeVolumePlugin) NewDeviceMounter() (DeviceMounter, error) {
+	return plugin.NewAttacher()
+}
+
 func (plugin *FakeVolumePlugin) GetAttachers() (Attachers []*FakeVolume) {
 	plugin.RLock()
 	defer plugin.RUnlock()
@@ -376,6 +380,10 @@ func (plugin *FakeVolumePlugin) NewDetacher() (Detacher, error) {
 	defer plugin.Unlock()
 	plugin.NewDetacherCallCount = plugin.NewDetacherCallCount + 1
 	return plugin.getFakeVolume(&plugin.Detachers), nil
+}
+
+func (plugin *FakeVolumePlugin) NewDeviceUmounter() (DeviceUmounter, error) {
+	return plugin.NewDetacher()
 }
 
 func (plugin *FakeVolumePlugin) GetDetachers() (Detachers []*FakeVolume) {
@@ -657,11 +665,11 @@ func (fv *FakeVolume) GetDeviceMountPath(spec *Spec) (string, error) {
 	return "", nil
 }
 
-func (fv *FakeVolume) MountDevice(spec *Spec, devicePath string, deviceMountPath string) error {
+func (fv *FakeVolume) MountDevice(spec *Spec, devicePath string, pod *v1.Pod) (string, string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.MountDeviceCallCount++
-	return nil
+	return "", "", nil
 }
 
 func (fv *FakeVolume) GetMountDeviceCallCount() int {

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -473,6 +473,13 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 	if attachableVolumePlugin != nil {
 		volumeAttacher, _ = attachableVolumePlugin.NewAttacher()
 	}
+	// Get device mounter if possible.
+	deviceMountableVolumePlugin, _ :=
+		og.volumePluginMgr.FindDeviceMountablePluginBySpec(volumeToMount.VolumeSpec)
+	var volumeDeviceMounter volume.DeviceMounter
+	if deviceMountableVolumePlugin != nil {
+		volumeDeviceMounter, _ = deviceMountableVolumePlugin.NewDeviceMounter()
+	}
 
 	var fsGroup *int64
 	if volumeToMount.Pod.Spec.SecurityContext != nil &&
@@ -491,21 +498,19 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 				// On failure, return error. Caller will log and retry.
 				return volumeToMount.GenerateError("MountVolume.WaitForAttach failed", err)
 			}
+			// Write the attached device path back to volumeToMount, which can be used for MountDevice.
+			volumeToMount.DevicePath = devicePath
 
 			glog.Infof(volumeToMount.GenerateMsgDetailed("MountVolume.WaitForAttach succeeded", fmt.Sprintf("DevicePath %q", devicePath)))
+		}
 
-			deviceMountPath, err :=
-				volumeAttacher.GetDeviceMountPath(volumeToMount.VolumeSpec)
-			if err != nil {
-				// On failure, return error. Caller will log and retry.
-				return volumeToMount.GenerateError("MountVolume.GetDeviceMountPath failed", err)
-			}
-
-			// Mount device to global mount path
-			err = volumeAttacher.MountDevice(
-				volumeToMount.VolumeSpec,
-				devicePath,
-				deviceMountPath)
+		if volumeDeviceMounter != nil {
+			// Mount device to global mount path. For local volumes(fc, iscsi, rbd, etc.) that implement
+			// DeviceMountableVolumePlugin only(in other words, no Attach/Detach operation), the DevicePath
+			// in volumeToMount is empty. These volumes should generate the device path internally.
+			// TODO: Add a SetDevicePath method to DeviceMounter interface, and invoke this method explicitly
+			// if volumeToMount.DevicePath is not empty.
+			devicePath, deviceMountPath, err := volumeDeviceMounter.MountDevice(volumeToMount.VolumeSpec, volumeToMount.DevicePath, volumeToMount.Pod)
 			if err != nil {
 				// On failure, return error. Caller will log and retry.
 				return volumeToMount.GenerateError("MountVolume.MountDevice failed", err)
@@ -716,20 +721,33 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 	deviceToDetach AttachedVolume,
 	actualStateOfWorld ActualStateOfWorldMounterUpdater,
 	mounter mount.Interface) (volumetypes.GeneratedOperations, error) {
-	// Get attacher plugin
-	attachableVolumePlugin, err :=
-		og.volumePluginMgr.FindAttachablePluginByName(deviceToDetach.PluginName)
-	if err != nil || attachableVolumePlugin == nil {
-		return volumetypes.GeneratedOperations{}, deviceToDetach.GenerateErrorDetailed("UnmountDevice.FindAttachablePluginBySpec failed", err)
+	// Get device mountable plugin
+	deviceMountablePlugin, err :=
+		og.volumePluginMgr.FindDeviceMountablePluginByName(deviceToDetach.PluginName)
+	if err != nil || deviceMountablePlugin == nil {
+		return volumetypes.GeneratedOperations{}, deviceToDetach.GenerateErrorDetailed("UnmountDevice.FindDeviceMountablePluginBySpec failed", err)
 	}
 
-	volumeDetacher, err := attachableVolumePlugin.NewDetacher()
+	volumeDeviceUmounter, err := deviceMountablePlugin.NewDeviceUmounter()
 	if err != nil {
-		return volumetypes.GeneratedOperations{}, deviceToDetach.GenerateErrorDetailed("UnmountDevice.NewDetacher failed", err)
+		return volumetypes.GeneratedOperations{},
+			deviceToDetach.GenerateErrorDetailed("UnmountDevice.NewDeviceUmounter failed", err)
 	}
+
+	volumeDeviceMounter, err := deviceMountablePlugin.NewDeviceMounter()
+	if err != nil {
+		return volumetypes.GeneratedOperations{},
+			deviceToDetach.GenerateErrorDetailed("UnmountDevice.NewDeviceMounter failed", err)
+	}
+
 	unmountDeviceFunc := func() (error, error) {
-		deviceMountPath := deviceToDetach.DeviceMountPath
-		refs, err := attachableVolumePlugin.GetDeviceMountRefs(deviceMountPath)
+		deviceMountPath, err :=
+			volumeDeviceMounter.GetDeviceMountPath(deviceToDetach.VolumeSpec)
+		if err != nil {
+			// On failure, return error. Caller will log and retry.
+			return deviceToDetach.GenerateError("GetDeviceMountPath failed", err)
+		}
+		refs, err := deviceMountablePlugin.GetDeviceMountRefs(deviceMountPath)
 
 		if err != nil || mount.HasMountRefs(deviceMountPath, refs) {
 			if err == nil {
@@ -737,8 +755,25 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 			}
 			return deviceToDetach.GenerateError("GetDeviceMountRefs check failed", err)
 		}
+
+		// deviceToDetach.DevicePath is retrieved from Node API object, for local volumes
+		// that not implement AttachableVolumePlugin, this maybe empty, so we need to get the
+		// real device path from global mount path.
+		// TODO: Currently the device path is only used to check if device is opened, but this
+		// is a useless operation for DeviceMountableVolumePlugin only volumes as the device
+		// path is not exist after UnmountDevice succeeded. So this operation is not necessary.
+		if len(deviceToDetach.DevicePath) == 0 {
+			devicePath, _, getDeviceErr := mount.GetDeviceNameFromMount(mounter, deviceMountPath)
+			if getDeviceErr != nil {
+				return deviceToDetach.GenerateError("GetDeviceNameFromMount failed", getDeviceErr)
+			}
+			deviceToDetach.DevicePath = devicePath
+			glog.V(5).Info(deviceToDetach.GenerateMsgDetailed(
+				fmt.Sprintf("Get device path %s from global mount path %s", devicePath, deviceMountPath), ""))
+		}
+
 		// Execute unmount
-		unmountDeviceErr := volumeDetacher.UnmountDevice(deviceMountPath)
+		unmountDeviceErr := volumeDeviceUmounter.UnmountDevice(deviceMountPath)
 		if unmountDeviceErr != nil {
 			// On failure, return error. Caller will log and retry.
 			return deviceToDetach.GenerateError("UnmountDevice failed", unmountDeviceErr)
@@ -747,6 +782,8 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 		// use mounter.PathIsDevice to check if the path is a device,
 		// if so use mounter.DeviceOpened to check if the device is in use anywhere
 		// else on the system. Retry if it returns true.
+		// TODO: For DeviceMountableVolumePlugin only volumes, device is not exist after UmountDevice
+		// succeeded, so we can only execute this validation if deviceToDetach.DevicePath not empty.
 		deviceOpened, deviceOpenedErr := isDeviceOpened(deviceToDetach, mounter)
 		if deviceOpenedErr != nil {
 			return nil, deviceOpenedErr
@@ -773,7 +810,7 @@ func (og *operationGenerator) GenerateUnmountDeviceFunc(
 
 	return volumetypes.GeneratedOperations{
 		OperationFunc:     unmountDeviceFunc,
-		CompleteFunc:      util.OperationCompleteHook(attachableVolumePlugin.GetPluginName(), "unmount_device"),
+		CompleteFunc:      util.OperationCompleteHook(deviceMountablePlugin.GetPluginName(), "unmount_device"),
 		EventRecorderFunc: nil, // nil because we do not want to generate event on error
 	}, nil
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -200,6 +200,8 @@ type Deleter interface {
 
 // Attacher can attach a volume to a node.
 type Attacher interface {
+	DeviceMounter
+
 	// Attaches the volume specified by the given spec to the node with the given Name.
 	// On success, returns the device path where the device was attached on the
 	// node.
@@ -215,15 +217,19 @@ type Attacher interface {
 	// is returned. Otherwise, if the device does not attach after
 	// the given timeout period, an error will be returned.
 	WaitForAttach(spec *Spec, devicePath string, pod *v1.Pod, timeout time.Duration) (string, error)
+}
 
+// DeviceMounter can mount a volume to node.
+type DeviceMounter interface {
 	// GetDeviceMountPath returns a path where the device should
 	// be mounted after it is attached. This is a global mount
 	// point which should be bind mounted for individual volumes.
 	GetDeviceMountPath(spec *Spec) (string, error)
 
-	// MountDevice mounts the disk to a global path which
-	// individual pods can then bind mount
-	MountDevice(spec *Spec, devicePath string, deviceMountPath string) error
+	// MountDevice mounts the disk to a global path which individual pods
+	// can then bind mount. Returns the device path and global mount path if succeeded,
+	// otherwise returns an error.
+	MountDevice(spec *Spec, devicePath string, pod *v1.Pod) (string, string, error)
 }
 
 type BulkVolumeVerifier interface {
@@ -236,11 +242,15 @@ type BulkVolumeVerifier interface {
 
 // Detacher can detach a volume from a node.
 type Detacher interface {
+	DeviceUmounter
 	// Detach the given volume from the node with the given Name.
 	// volumeName is name of the volume as returned from plugin's
 	// GetVolumeName().
 	Detach(volumeName string, nodeName types.NodeName) error
+}
 
+// Deviceumounter can umount a volume from a node.
+type DeviceUmounter interface {
 	// UnmountDevice unmounts the global mount of the disk. This
 	// should only be called once all bind mounts have been
 	// unmounted.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This is the first part of kubernetes/community#1683:

1. Refactor the `AttachableVolumePlugin` interface to `AttachableVolumePlugin`(only for attach/detach operations) and `DeviceMountableVolumePlugin`(only for device mount/umount operations)

2. Refactor kubelet volume manager to use the new interfaces.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
