### PR TITLE
Add   HTTPProxyCheck to preflight checks for 'kubeadm join' subcommand

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -999,19 +999,27 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.NodeConfigura
 			criCtlChecker)
 	}
 
+	var bridgenf6Check Checker
 	for _, server := range cfg.DiscoveryTokenAPIServers {
 		ipstr, _, err := net.SplitHostPort(server)
 		if err == nil {
-			if ip := net.ParseIP(ipstr); ip != nil {
-				if ip.To4() == nil && ip.To16() != nil {
-					checks = append(checks,
-						FileContentCheck{Path: bridgenf6, Content: []byte{'1'}},
-					)
-					break // Ensure that check is added only once
+			checks = append(checks,
+				HTTPProxyCheck{Proto: "https", Host: ipstr},
+			)
+			if bridgenf6Check == nil {
+				if ip := net.ParseIP(ipstr); ip != nil {
+					if ip.To4() == nil && ip.To16() != nil {
+						// This check should be added only once
+						bridgenf6Check = FileContentCheck{Path: bridgenf6, Content: []byte{'1'}}
+					}
 				}
 			}
 		}
 	}
+	if bridgenf6Check != nil {
+		checks = append(checks, bridgenf6Check)
+	}
+
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it:**

Add HTTPProxyCheck for API servers
    
It makes sense to check API servers and print warnings if they're
going to be accessed through proxy. This is similar to what's
already done for 'kubeadm init'.
