### PR TITLE
Fix adding FileContentCheck

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -986,12 +986,16 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.NodeConfigura
 			criCtlChecker)
 	}
 
-	if len(cfg.DiscoveryTokenAPIServers) > 0 {
-		if ip := net.ParseIP(cfg.DiscoveryTokenAPIServers[0]); ip != nil {
-			if ip.To4() == nil && ip.To16() != nil {
-				checks = append(checks,
-					FileContentCheck{Path: bridgenf6, Content: []byte{'1'}},
-				)
+	for _, server := range cfg.DiscoveryTokenAPIServers {
+		ipstr, _, err := net.SplitHostPort(server)
+		if err == nil {
+			if ip := net.ParseIP(ipstr); ip != nil {
+				if ip.To4() == nil && ip.To16() != nil {
+					checks = append(checks,
+						FileContentCheck{Path: bridgenf6, Content: []byte{'1'}},
+					)
+					break // Ensure that check is added only once
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Current code adds FileContentCheck only for the first API
Server mentioned in the command line. The test is never added
as net.ParseIP always fails because address:port is passed
to it instead of just an address.

Fixed both issues by introducing a loop over all API Servers
and splitting address:port before passing address to the
net.ParseIP API.

**Release note**:
```release-note
NONE
```
