### PR TITLE
Add test/fix for ErrShortBuffer edgecase

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -126,8 +126,8 @@ func (d *YAMLDecoder) Read(data []byte) (n int, err error) {
 	}
 
 	// caller will need to reread
-	copy(data, d.remaining[:left])
-	d.remaining = d.remaining[left:]
+	copy(data, d.remaining[:len(data)])
+	d.remaining = d.remaining[len(data):]
 	return len(data), io.ErrShortBuffer
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Found a bug with YAMLToJSONDecoder where subsequent reads after `io.ErrShortBuffer` would return values from the next yaml section, rather than the rest of the section I was reading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59055 

https://github.com/kubernetes/kubernetes/issues/59055

**Special notes for your reviewer**:

**Release note**:

```release-note
YAMLDecoder Read now tracks rest of buffer on io.ErrShortBuffer
```
