### PR TITLE
promote PodNodeSelector and PodTolerationRestriction annotations to stable

### DIFF
--- a/pkg/scheduler/algorithm/well_known_labels.go
+++ b/pkg/scheduler/algorithm/well_known_labels.go
@@ -61,4 +61,29 @@ const (
 	// from the cloud-controller-manager intitializes this node, and then removes
 	// the taint
 	TaintExternalCloudProvider = "node.cloudprovider.kubernetes.io/uninitialized"
+
+	// AnnotationDefaultTolerations is an annotation key, used on Namespace objects.
+	// Its value defines a list of default tolerations for pods in that namespace
+	// that do not define their tolerations.
+	AnnotationDefaultTolerations = "scheduler.kubernetes.io/default-tolerations"
+
+	// DeprecatedAnnotationDefaultTolerations is the deprecated version
+	// of AnnotationDefaultTolerations. (It is deprecated since 1.10.)
+	DeprecatedAnnotationDefaultTolerations = "scheduler.alpha.kubernetes.io/defaultTolerations"
+
+	// AnnotationTolerationsWhitelist is an annotation key, used on Namespace objects.
+	// Its value defines a whitelist for pods in that namespace.
+	AnnotationTolerationsWhitelist = "scheduler.kubernetes.io/tolerations-whitelist"
+
+	// DeprecatedAnnotationTolerationsWhitelist is the deprecated version
+	// of AnnotationTolerationsWhitelist. (It is deprecated since 1.10.)
+	DeprecatedAnnotationTolerationsWhitelist = "scheduler.alpha.kubernetes.io/tolerationsWhitelist"
+
+	// AnnotationNamespaceNodeSelector is an annotation key used for assigning
+	// node selectors labels to namespaces
+	AnnotationNamespaceNodeSelector = "scheduler.kubernetes.io/node-selector"
+
+	// DeprecatedAnnotationNamespaceNodeSelector is the deprecated version of AnnotationNamespaceNodeSelector.
+	// It is deprecated since 1.10
+	DeprecatedAnnotationNamespaceNodeSelector = "scheduler.alpha.kubernetes.io/node-selector"
 )

--- a/plugin/pkg/admission/podnodeselector/BUILD
+++ b/plugin/pkg/admission/podnodeselector/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",
+        "//pkg/scheduler/algorithm:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",

--- a/plugin/pkg/admission/podnodeselector/BUILD
+++ b/plugin/pkg/admission/podnodeselector/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/client/listers/core/internalversion:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",
         "//pkg/kubeapiserver/admission/util:go_default_library",
+        "//pkg/scheduler/algorithm:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -158,7 +158,7 @@ func TestPodAdmission(t *testing.T) {
 	}
 	for _, test := range tests {
 		if !test.ignoreTestNamespaceNodeSelector {
-			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.alpha.kubernetes.io/node-selector": test.namespaceNodeSelector}
+			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.kubernetes.io/node-selector": test.namespaceNodeSelector}
 			informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
 		}
 		handler.clusterNodeSelectors = make(map[string]string)
@@ -234,7 +234,7 @@ func TestIgnoreUpdatingInitializedPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "testNamespace",
 			Namespace:   "",
-			Annotations: map[string]string{"scheduler.alpha.kubernetes.io/node-selector": namespaceNodeSelector},
+			Annotations: map[string]string{"scheduler.kubernetes.io/node-selector": namespaceNodeSelector},
 		},
 	}
 	err = informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -244,7 +244,7 @@ func (p *podTolerationsPlugin) getNamespaceDefaultTolerations(nsName string) ([]
 		return nil, err
 	}
 	if defaultTolerations == nil {
-		defaultTolerations, err = extractNSTolerations(ns, algorithm.DeprecatedAnnotationDefaultTolerations)	
+		defaultTolerations, err = extractNSTolerations(ns, algorithm.DeprecatedAnnotationDefaultTolerations)
 	}
 	if err != nil {
 		return nil, err

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -232,7 +232,7 @@ func TestPodAdmission(t *testing.T) {
 	// TODO: remove for loop when support for deprecated alpha annotations removed
 	defaultTolerationsAnnotations := []string{algorithm.AnnotationDefaultTolerations, algorithm.DeprecatedAnnotationDefaultTolerations}
 	tolerationWhitelistAnnotations := []string{algorithm.AnnotationTolerationsWhitelist, algorithm.DeprecatedAnnotationTolerationsWhitelist}
-	
+
 	for i := 0; i < len(defaultTolerationsAnnotations); i++ {
 		defaultTolerationAnnotation := defaultTolerationsAnnotations[i]
 		tolerationWhitelistAnnotation := tolerationWhitelistAnnotations[i]

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -235,7 +235,7 @@ func TestPodAdmission(t *testing.T) {
 			if err != nil {
 				t.Errorf("error in marshalling namespace tolerations %v", test.namespaceTolerations)
 			}
-			namespace.Annotations = map[string]string{NSDefaultTolerations: string(tolerationStr)}
+			namespace.Annotations = map[string]string{algorithm.AnnotationDefaultTolerations: string(tolerationStr)}
 		}
 
 		if test.whitelist != nil {
@@ -243,7 +243,7 @@ func TestPodAdmission(t *testing.T) {
 			if err != nil {
 				t.Errorf("error in marshalling namespace whitelist %v", test.whitelist)
 			}
-			namespace.Annotations[NSWLTolerations] = string(tolerationStr)
+			namespace.Annotations[algorithm.AnnotationTolerationsWhitelist] = string(tolerationStr)
 		}
 
 		informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
@@ -339,7 +339,7 @@ func TestIgnoreUpdatingInitializedPod(t *testing.T) {
 			Namespace: "",
 		},
 	}
-	namespace.Annotations = map[string]string{NSDefaultTolerations: string(tolerationsStr)}
+	namespace.Annotations = map[string]string{algorithm.AnnotationDefaultTolerations: string(tolerationsStr)}
 	err = informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
* fixes #57424 
* moves the annotations for PodNodeSelector (`scheduler.alpha.kubernetes.io/node-selector`) and PodToleration (`scheduler.alpha.kubernetes.io/defaultTolerations`, `scheduler.alpha.kubernetes.io/tolerationsWhitelist`) to stable, by dropping the `.alpha` segment
* removes support for PodNodeSelector to support multiple annotations - this is going GA and only supports the single annotation for now

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57424

**Special notes for your reviewer**: This is sent without the conversion. It seems like overkill for an alpha feature/annotation, plus it doesn't feel right to add a new Namespace informer to the node controller for this.

cc: @resouer, @ericchiang 

Documentation PRs:
* https://github.com/kubernetes/website/pull/7134
* https://github.com/kubernetes/website/pull/7135

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 * Promote (and rename) `scheduler.alpha.kubernetes.io/tolerationsWhitelist` to `scheduler.kubernetes.io/tolerations-whitelist`
 * Promote (and rename) `scheduler.alpha.kubernetes.io/defaultTolerations` to `scheduler.kubernetes.io/default-tolerations`
 * Promote `scheduler.alpha.kubernetes.io/node-selector` to `scheduler.kubernetes.io/node-selector`
```
