### PR TITLE
WIP - Stop serving deprecated extensions/v1beta1 resources by default

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -489,11 +489,7 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 
 	// all extensions resources except these are disabled by default
 	ret.EnableResources(
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("daemonsets"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("networkpolicies"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"),
 	)
 


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/43214

From the 1.7 release notes:
> NetworkPolicy has been moved from extensions/v1beta1 to the new (#39164, @danwinship) networking.k8s.io/v1 API group.

From the 1.8 release notes:
> The Deployment, DaemonSet, and ReplicaSet kinds in the extensions/v1beta1 group version are now deprecated, as are the Deployment, StatefulSet, and ControllerRevision kinds in apps/v1beta1. As they will not be removed until after a GA version becomes available, you may continue to use these kinds in existing code. However, all new code should be developed against the apps/v1beta2 group version

This PR disables these extensions/v1beta1 resources from being served by default in 1.10, though they can be re-enabled via --runtime-config.

Objects already stored in etcd in extensions/v1beta1 format can still be read

```release-note
The following deprecated resources in the `extensions/v1beta1` API group are no longer served by default, and will be removed in a future release:
* networkpolicies (use `network.k8s.io/v1` instead)
* daemonsets, deployments, replicasets (use `apps/v1` instead)
```