### PR TITLE
Introduce a new Prometheus metric which keeps track of Kubelet health check results

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -101,6 +101,14 @@ var (
 			Help:      "Interval in microseconds between relisting in PLEG.",
 		},
 	)
+	ProberResults = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      "probe_result",
+			Help:      "The result of a liveness or readiness probe for a container.",
+		},
+		[]string{"probe_type", "container_name", "pod_name", "namespace", "pod_uid"},
+	)
 	// Metrics of remote runtime operations.
 	RuntimeOperations = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -214,6 +222,7 @@ func Register(containerCache kubecontainer.RuntimeCache) {
 		prometheus.MustRegister(newPodAndContainerCollector(containerCache))
 		prometheus.MustRegister(PLEGRelistLatency)
 		prometheus.MustRegister(PLEGRelistInterval)
+		prometheus.MustRegister(ProberResults)
 		prometheus.MustRegister(RuntimeOperations)
 		prometheus.MustRegister(RuntimeOperationsLatency)
 		prometheus.MustRegister(RuntimeOperationsErrors)

--- a/pkg/kubelet/prober/results/results_manager.go
+++ b/pkg/kubelet/prober/results/results_manager.go
@@ -58,6 +58,17 @@ func (r Result) String() string {
 	}
 }
 
+func (r Result) ToPrometheusType() float64 {
+	switch r {
+	case Success:
+		return 0
+	case Failure:
+		return 1
+	default:
+		return -1
+	}
+}
+
 // Update is an enum of the types of updates sent over the Updates channel.
 type Update struct {
 	ContainerID kubecontainer.ContainerID


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new Prometheus metric to kubelet which exposes the results of liveness and readiness probes. 

Not sure if I need a release note for this?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58235

**Release note**:
```release-note
None
```
cc @miekg
