### PR TITLE
check taint when node.spec.unschedule is checkcked

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -99,6 +99,7 @@ go_library(
         "//pkg/util/node:go_default_library",
         "//pkg/util/oom:go_default_library",
         "//pkg/util/removeall:go_default_library",
+        "//pkg/util/taints:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
+	"k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 )
@@ -948,7 +949,7 @@ var oldNodeUnschedulable bool
 // record if node schedulable change.
 func (kl *Kubelet) recordNodeSchedulableEvent(node *v1.Node) {
 	if oldNodeUnschedulable != node.Spec.Unschedulable {
-		if node.Spec.Unschedulable {
+		if node.Spec.Unschedulable || taints.TaintExistsWithEffect(node.Spec.Taints) {
 			kl.recordNodeStatusEvent(v1.EventTypeNormal, events.NodeNotSchedulable)
 		} else {
 			kl.recordNodeStatusEvent(v1.EventTypeNormal, events.NodeSchedulable)

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -311,6 +311,15 @@ func TaintExists(taints []v1.Taint, taintToFind *v1.Taint) bool {
 	return false
 }
 
+func TaintExistsWithEffect(taints []v1.Taint) bool {
+	for _, taint := range taints {
+		if taint.Effect == v1.TaintEffectNoExecute || taint.Effect == v1.TaintEffectNoSchedule {
+			return true
+		}
+	}
+	return false
+}
+
 func TaintSetDiff(t1, t2 []v1.Taint) (taintsToAdd []*v1.Taint, taintsToRemove []*v1.Taint) {
 	for _, taint := range t1 {
 		if !TaintExists(t2, &taint) {

--- a/pkg/util/taints/taints_test.go
+++ b/pkg/util/taints/taints_test.go
@@ -685,3 +685,41 @@ func TestParseTaints(t *testing.T) {
 		}
 	}
 }
+
+func TestTaintExistsWithEffect(t *testing.T) {
+	firstSetOfTaints := []v1.Taint{
+		{
+			Key:    "foo_1",
+			Value:  "bar_1",
+			Effect: v1.TaintEffectNoExecute,
+		},
+		{
+			Key:    "foo_2",
+			Value:  "bar_2",
+			Effect: v1.TaintEffectNoSchedule,
+		},
+		{
+			Key:    "foo_3",
+			Value:  "bar_3",
+			Effect: v1.TaintEffectPreferNoSchedule,
+		},
+	}
+
+	result := TaintExistsWithEffect(firstSetOfTaints)
+	if result != true {
+		t.Errorf("[%s] unexpected results: %v", "Taint should exist", result)
+	}
+
+	secondSetOfTaints := []v1.Taint{
+		{
+			Key:    "foo_3",
+			Value:  "bar_3",
+			Effect: v1.TaintEffectPreferNoSchedule,
+		},
+	}
+
+	result = TaintExistsWithEffect(secondSetOfTaints)
+	if result != false {
+		t.Errorf("[%s] unexpected results: %v", "Taint should not exist", result)
+	}
+}


### PR DESCRIPTION
check taint when node.spec.unschedule is checkcked

**What this PR does / why we need it**:
Following the issue #58406  here is a check of taint when checking Node.Spec.Unschedulable in the kubelet_node_status.go 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58406

**Special notes for your reviewer**:
/assign @yastij @gmarek

**Release note**:
```release-note
None
```
