### PR TITLE
Tag multi-az cluster volume e2e test with sig-storage

### DIFF
--- a/test/e2e/scheduling/ubernetes_lite_volumes.go
+++ b/test/e2e/scheduling/ubernetes_lite_volumes.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = SIGDescribe("Multi-AZ Cluster Volumes", func() {
+var _ = SIGDescribe("Multi-AZ Cluster Volumes [sig-storage]", func() {
 	f := framework.NewDefaultFramework("multi-az")
 	var zoneCount int
 	var err error


### PR DESCRIPTION
Follow-on from #58726 to make it clear that responsibility for the test is shared between @kubernetes/sig-scheduling-pr-reviews  and @kubernetes/sig-storage-pr-reviews.

```release-note
NONE
```

cc: @bsalamat @timothysc 