### PR TITLE
Only run verify-staging-godeps if staging/godeps are touched

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -49,6 +49,7 @@ readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
 if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/' && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'vendor/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/lib/' && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/.*godep'; then
   exit 0
 fi

--- a/hack/verify-staging-godeps.sh
+++ b/hack/verify-staging-godeps.sh
@@ -24,8 +24,10 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
 if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'staging/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'build/' && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/' && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'vendor/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/lib/' && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/.*godep'; then
   exit 0
 fi

--- a/hack/verify-staging-godeps.sh
+++ b/hack/verify-staging-godeps.sh
@@ -19,4 +19,15 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
+if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'staging/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'vendor/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/.*godep'; then
+  exit 0
+fi
+
 KUBE_VERBOSE="${KUBE_VERBOSE:-3}" KUBE_RUN_COPY_OUTPUT=N ${KUBE_ROOT}/hack/update-staging-godeps.sh -d -f "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
I had a lightbulb moment. On presubmit, we only verify godeps if one of the following is changed:
- The godep scripts
- The Godeps/ dir
- The vendor/ dir

The same should apply to verifying the staging godeps, adding in the staging dir itself. The logic being, if we don't touch Godeps/vendor, we don't touch the script that generates stuff, and we don't make changes to the staging dir itself (like adding/removing imports), then we don't need to verify godeps.

Note that post-submit CI jobs will still check these, as I'm copying the same logic that's in verify-godeps

This seems too easy, so *please* point out if I'm missing something.

**Release note**:
```release-note
NONE
```
