### PR TITLE
Add InterestedResources as a pod filter based on pods' requested resources to extender config

### DIFF
--- a/pkg/scheduler/algorithm/predicates/BUILD
+++ b/pkg/scheduler/algorithm/predicates/BUILD
@@ -62,6 +62,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )

--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
@@ -53,6 +54,7 @@ type predicateMetadata struct {
 	serviceAffinityInUse               bool
 	serviceAffinityMatchingPodList     []*v1.Pod
 	serviceAffinityMatchingPodServices []*v1.Service
+	scalaResourcesHandleByExtenders    sets.String
 }
 
 // Ensure that predicateMetadata implements algorithm.PredicateMetadata.
@@ -90,11 +92,12 @@ func (pfactory *PredicateMetadataFactory) GetMetadata(pod *v1.Pod, nodeNameToInf
 		return nil
 	}
 	predicateMetadata := &predicateMetadata{
-		pod:                       pod,
-		podBestEffort:             isPodBestEffort(pod),
-		podRequest:                GetResourceRequest(pod),
-		podPorts:                  schedutil.GetContainerPorts(pod),
-		matchingAntiAffinityTerms: matchingTerms,
+		pod:                             pod,
+		podBestEffort:                   isPodBestEffort(pod),
+		podRequest:                      GetResourceRequest(pod),
+		podPorts:                        schedutil.GetContainerPorts(pod),
+		matchingAntiAffinityTerms:       matchingTerms,
+		scalaResourcesHandleByExtenders: sets.NewString(),
 	}
 	for predicateName, precomputeFunc := range predicateMetadataProducers {
 		glog.V(10).Infof("Precompute: %v", predicateName)

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
@@ -41,10 +42,10 @@ import (
 	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
 	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
 )
 
 const (
@@ -713,8 +714,12 @@ func PodFitsResources(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *s
 	}
 
 	var podRequest *schedulercache.Resource
+	scalaResourcesHandleByExtenders := sets.NewString()
 	if predicateMeta, ok := meta.(*predicateMetadata); ok {
 		podRequest = predicateMeta.podRequest
+		if predicateMeta.scalaResourcesHandleByExtenders != nil {
+			scalaResourcesHandleByExtenders = predicateMeta.scalaResourcesHandleByExtenders
+		}
 	} else {
 		// We couldn't parse metadata - fallback to computing it.
 		podRequest = GetResourceRequest(pod)
@@ -743,6 +748,9 @@ func PodFitsResources(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *s
 	}
 
 	for rName, rQuant := range podRequest.ScalarResources {
+		if scalaResourcesHandleByExtenders.Has(string(rName)) {
+			continue
+		}
 		if allocatable.ScalarResources[rName] < rQuant+nodeInfo.RequestedResource().ScalarResources[rName] {
 			predicateFails = append(predicateFails, NewInsufficientResourceError(rName, podRequest.ScalarResources[rName], nodeInfo.RequestedResource().ScalarResources[rName], allocatable.ScalarResources[rName]))
 		}
@@ -1591,4 +1599,11 @@ func (c *VolumeBindingChecker) predicate(pod *v1.Pod, meta algorithm.PredicateMe
 	// All volumes bound or matching PVs found for all unbound PVCs
 	glog.V(5).Infof("All PVCs found matches for pod %v/%v, node %q", pod.Namespace, pod.Name, node.Name)
 	return true, nil, nil
+}
+
+// RegisterPodFitsResourcesPredicateMetadataProducer registers a PredicateMetadataProducer used by PodFitsResources
+func RegisterPodFitsResourcesPredicateMetadataProducer(scalaResourcesHandleByExtenders sets.String) {
+	RegisterPredicateMetadataProducer("PodFitsResources", func(pm *predicateMetadata) {
+		pm.scalaResourcesHandleByExtenders = scalaResourcesHandleByExtenders
+	})
 }

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -27,6 +27,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
@@ -93,11 +94,12 @@ func PredicateMetadata(p *v1.Pod, nodeInfo map[string]*schedulercache.NodeInfo) 
 
 func TestPodFitsResources(t *testing.T) {
 	enoughPodsTests := []struct {
-		pod      *v1.Pod
-		nodeInfo *schedulercache.NodeInfo
-		fits     bool
-		test     string
-		reasons  []algorithm.PredicateFailureReason
+		pod               *v1.Pod
+		nodeInfo          *schedulercache.NodeInfo
+		fits              bool
+		test              string
+		reasons           []algorithm.PredicateFailureReason
+		extenderResources []string
 	}{
 		{
 			pod: &v1.Pod{},
@@ -240,6 +242,15 @@ func TestPodFitsResources(t *testing.T) {
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 1, 5, 5)},
 		},
 		{
+			pod: newResourcePod(
+				schedulercache.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
+			nodeInfo: schedulercache.NewNodeInfo(
+				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
+			fits:              true,
+			extenderResources: []string{string(extendedResourceA)},
+			test:              "skip extended resource checks since they are handled by an extender",
+		},
+		{
 			pod: newResourceInitPod(newResourcePod(schedulercache.Resource{}),
 				schedulercache.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
 			nodeInfo: schedulercache.NewNodeInfo(
@@ -328,7 +339,9 @@ func TestPodFitsResources(t *testing.T) {
 	for _, test := range enoughPodsTests {
 		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 0, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 0, 32, 5, 20, 5)}}
 		test.nodeInfo.SetNode(&node)
-		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+		meta := PredicateMetadata(test.pod, nil)
+		meta.(*predicateMetadata).scalaResourcesHandleByExtenders = sets.NewString(test.extenderResources...)
+		fits, reasons, err := PodFitsResources(test.pod, meta, test.nodeInfo)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.test, err)
 		}

--- a/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/pkg/scheduler/algorithm/scheduler_interface.go
@@ -41,6 +41,9 @@ type SchedulerExtender interface {
 
 	// IsBinder returns whether this extender is configured for the Bind method.
 	IsBinder() bool
+
+	// IsInterested returns whether this extender is interested in this pod.
+	IsInterested(pod *v1.Pod) bool
 }
 
 // ScheduleAlgorithm is an interface implemented by things that know how to schedule pods

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -170,6 +170,11 @@ type ExtenderConfig struct {
 	// so the scheduler should only send minimal information about the eligible nodes
 	// assuming that the extender already cached full details of all nodes in the cluster
 	NodeCacheCapable bool
+	// InterestedResources is a pod filter based on pods' requested resources.
+	// If it's empty, every pod will be sent to extender for filter/prioritize/bind operations if FilterVerb/PrioritizeVerb/BindVerb isn't empty.
+	// Otherwise, only pods that requests for one of the resources will be.
+	// +optional
+	InterestedResources []string
 }
 
 // ExtenderArgs represents the arguments needed by the extender to filter/prioritize

--- a/pkg/scheduler/api/v1/types.go
+++ b/pkg/scheduler/api/v1/types.go
@@ -152,6 +152,11 @@ type ExtenderConfig struct {
 	// so the scheduler should only send minimal information about the eligible nodes
 	// assuming that the extender already cached full details of all nodes in the cluster
 	NodeCacheCapable bool `json:"nodeCacheCapable,omitempty"`
+	// InterestedResources is a pod filter based on pods' requested resources.
+	// If it's empty, every pod will be sent to extender for filter/prioritize/bind operations if FilterVerb/PrioritizeVerb/BindVerb isn't empty.
+	// Otherwise, only pods that requests for one of the resources will be.
+	// +optional
+	InterestedResources []string `json:"interestedResources,omitempty"`
 }
 
 // ExtenderArgs represents the arguments needed by the extender to filter/prioritize

--- a/pkg/scheduler/api/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/v1/zz_generated.deepcopy.go
@@ -109,6 +109,11 @@ func (in *ExtenderConfig) DeepCopyInto(out *ExtenderConfig) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.InterestedResources != nil {
+		in, out := &in.InterestedResources, &out.InterestedResources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/scheduler/api/validation/BUILD
+++ b/pkg/scheduler/api/validation/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/scheduler/api:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/api/validation/validation_test.go
+++ b/pkg/scheduler/api/validation/validation_test.go
@@ -69,6 +69,14 @@ func TestValidatePolicy(t *testing.T) {
 				}},
 			expected: errors.New("Only one extender can implement bind, found 2"),
 		},
+		{
+			policy: api.Policy{
+				ExtenderConfigs: []api.ExtenderConfig{
+					{URLPrefix: "http://127.0.0.1:8081/extender", InterestedResources: []string{"foo.io/overlay"}},
+					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind", InterestedResources: []string{"foo.io/overlay"}},
+				}},
+			expected: errors.New("Duplicate interested resource name foo.io/overlay"),
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/scheduler/api/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/zz_generated.deepcopy.go
@@ -109,6 +109,11 @@ func (in *ExtenderConfig) DeepCopyInto(out *ExtenderConfig) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.InterestedResources != nil {
+		in, out := &in.InterestedResources, &out.InterestedResources
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -110,6 +110,7 @@ type FakeExtender struct {
 	weight           int
 	nodeCacheCapable bool
 	filteredNodes    []*v1.Node
+	unInterested     bool
 }
 
 func (f *FakeExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[string]*schedulercache.NodeInfo) ([]*v1.Node, schedulerapi.FailedNodesMap, error) {
@@ -181,6 +182,10 @@ func (f *FakeExtender) Bind(binding *v1.Binding) error {
 
 func (f *FakeExtender) IsBinder() bool {
 	return true
+}
+
+func (f *FakeExtender) IsInterested(pod *v1.Pod) bool {
+	return !f.unInterested
 }
 
 var _ algorithm.SchedulerExtender = &FakeExtender{}
@@ -303,6 +308,22 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			nodes:        []string{"machine1", "machine2"},
 			expectedHost: "machine2", // machine2 has higher score
 			name:         "test 7",
+		},
+		{
+			// Scheduler is expected to not send filter requests to extender if it's not interested.
+			// If it does, the errorPredicateExtender will return an error, since expectsErr is false, the test will fail
+			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
+			prioritizers: []algorithm.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			extenders: []FakeExtender{
+				{
+					predicates:   []fitPredicate{errorPredicateExtender},
+					unInterested: true,
+				},
+			},
+			nodes:        []string{"machine1", "machine2"},
+			expectsErr:   false,
+			expectedHost: "machine2", // machine2 has higher score
+			name:         "test 8",
 		},
 	}
 

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -354,6 +354,9 @@ func findNodesThatFit(
 
 	if len(filtered) > 0 && len(extenders) != 0 {
 		for _, extender := range extenders {
+			if !extender.IsInterested(pod) {
+				continue
+			}
 			filteredList, failedMap, err := extender.Filter(pod, filtered, nodeNameToInfo)
 			if err != nil {
 				return []*v1.Node{}, FailedPredicateMap{}, err
@@ -626,6 +629,9 @@ func PrioritizeNodes(
 	if len(extenders) != 0 && nodes != nil {
 		combinedScores := make(map[string]int, len(nodeNameToInfo))
 		for _, extender := range extenders {
+			if !extender.IsInterested(pod) {
+				continue
+			}
 			wg.Add(1)
 			go func(ext algorithm.SchedulerExtender) {
 				defer wg.Done()

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -919,6 +919,7 @@ func (c *configFactory) CreateFromConfig(policy schedulerapi.Policy) (*scheduler
 
 	extenders := make([]algorithm.SchedulerExtender, 0)
 	if len(policy.ExtenderConfigs) != 0 {
+		interestedResources := sets.NewString()
 		for ii := range policy.ExtenderConfigs {
 			glog.V(2).Infof("Creating extender with config %+v", policy.ExtenderConfigs[ii])
 			extender, err := core.NewHTTPExtender(&policy.ExtenderConfigs[ii])
@@ -926,7 +927,9 @@ func (c *configFactory) CreateFromConfig(policy schedulerapi.Policy) (*scheduler
 				return nil, err
 			}
 			extenders = append(extenders, extender)
+			interestedResources.Insert(policy.ExtenderConfigs[ii].InterestedResources...)
 		}
+		predicates.RegisterPodFitsResourcesPredicateMetadataProducer(interestedResources)
 	}
 	// Providing HardPodAffinitySymmetricWeight in the policy config is the new and preferred way of providing the value.
 	// Give it higher precedence than scheduler CLI configuration when it is provided.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -107,7 +107,7 @@ type Config struct {
 	Ecache     *core.EquivalenceCache
 	NodeLister algorithm.NodeLister
 	Algorithm  algorithm.ScheduleAlgorithm
-	Binder     Binder
+	GetBinder  func(pod *v1.Pod) Binder
 	// PodConditionUpdater is used only in case of scheduling errors. If we succeed
 	// with scheduling, PodScheduled condition will be updated in apiserver in /bind
 	// handler so that binding and setting PodCondition it is atomic.
@@ -403,7 +403,7 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 	bindingStart := time.Now()
 	// If binding succeeded then PodScheduled condition will be updated in apiserver so that
 	// it's atomic with setting host.
-	err := sched.config.Binder.Bind(b)
+	err := sched.config.GetBinder(assumed).Bind(b)
 	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
 		glog.Errorf("scheduler cache FinishBinding failed: %v", err)
 	}


### PR DESCRIPTION
The scheduler sends filter/priority requests to the extender only if the pod to be schedulered is interested by the extender. This is helpful to scheduler performance if the extender targets on a small group of pods.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For #53616
Fixes # https://github.com/kubernetes/kubernetes/issues/58850

**Special notes for your reviewer**:

**Release note**:
```release-note
Add InterestedResources as a pod filter based on pods' requested resources to extender config. If it's empty, every pod will be sent to extender for filter/prioritize/bind operations if FilterVerb/PrioritizeVerb/BindVerb isn't empty. Otherwise, only pods that requests for one of the resources will be.
```
