### PR TITLE
cleanup enable/disable api resources code

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -487,15 +487,5 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		admissionregistrationv1beta1.SchemeGroupVersion,
 	)
 
-	// all extensions resources except these are disabled by default
-	ret.EnableResources(
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("daemonsets"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("networkpolicies"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
-		extensionsapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"),
-	)
-
 	return ret
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -316,7 +316,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	// install legacy rest storage
-	if c.ExtraConfig.APIResourceConfigSource.AnyResourcesForVersionEnabled(apiv1.SchemeGroupVersion) {
+	if c.ExtraConfig.APIResourceConfigSource.VersionEnabled(apiv1.SchemeGroupVersion) {
 		legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
 			StorageFactory:       c.ExtraConfig.StorageFactory,
 			ProxyTransport:       c.ExtraConfig.ProxyTransport,
@@ -406,7 +406,7 @@ func (m *Master) InstallAPIs(apiResourceConfigSource serverstorage.APIResourceCo
 
 	for _, restStorageBuilder := range restStorageProviders {
 		groupName := restStorageBuilder.GroupName()
-		if !apiResourceConfigSource.AnyResourcesForGroupEnabled(groupName) {
+		if !apiResourceConfigSource.AnyVersionForGroupEnabled(groupName) {
 			glog.V(1).Infof("Skipping disabled API group %q.", groupName)
 			continue
 		}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -346,8 +346,8 @@ func TestAPIVersionOfDiscoveryEndpoints(t *testing.T) {
 
 func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
 	config := DefaultAPIResourceConfigSource()
-	for gv, gvConfig := range config.GroupVersionResourceConfigs {
-		if gvConfig.Enable && strings.Contains(gv.Version, "alpha") {
+	for gv, enable := range config.GroupVersionConfigs {
+		if enable && strings.Contains(gv.Version, "alpha") {
 			t.Errorf("Alpha API version %s enabled by default", gv.String())
 		}
 	}

--- a/pkg/registry/admissionregistration/rest/storage_apiserver.go
+++ b/pkg/registry/admissionregistration/rest/storage_apiserver.go
@@ -37,11 +37,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(admissionregistrationv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(admissionregistrationv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[admissionregistrationv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = admissionregistrationv1alpha1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(admissionregistrationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(admissionregistrationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[admissionregistrationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = admissionregistrationv1beta1.SchemeGroupVersion
 	}
@@ -49,26 +49,24 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := admissionregistrationv1alpha1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("initializerconfigurations")) {
-		s := initializerconfigurationstorage.NewREST(restOptionsGetter)
-		storage["initializerconfigurations"] = s
-	}
+	// initializerconfigurations
+	s := initializerconfigurationstorage.NewREST(restOptionsGetter)
+	storage["initializerconfigurations"] = s
+
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := admissionregistrationv1beta1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("validatingwebhookconfigurations")) {
-		s := validatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
-		storage["validatingwebhookconfigurations"] = s
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("mutatingwebhookconfigurations")) {
-		s := mutatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
-		storage["mutatingwebhookconfigurations"] = s
-	}
+	// validatingwebhookconfigurations
+	validatingStorage := validatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
+	storage["validatingwebhookconfigurations"] = validatingStorage
+
+	// mutatingwebhookconfigurations
+	mutatingStorage := mutatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
+	storage["mutatingwebhookconfigurations"] = mutatingStorage
+
 	return storage
 }
 

--- a/pkg/registry/apps/rest/storage_apps.go
+++ b/pkg/registry/apps/rest/storage_apps.go
@@ -40,15 +40,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(appsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1beta2.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(appsapiv1beta2.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1beta2.SchemeGroupVersion.Version] = p.v1beta2Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1beta2.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(appsapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1.SchemeGroupVersion
 	}
@@ -57,94 +57,91 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := appsapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
-		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-		storage["deployments"] = deploymentStorage.Deployment
-		storage["deployments/status"] = deploymentStorage.Status
-		storage["deployments/rollback"] = deploymentStorage.Rollback
-		storage["deployments/scale"] = deploymentStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
-		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-		storage["statefulsets"] = statefulSetStorage.StatefulSet
-		storage["statefulsets/status"] = statefulSetStorage.Status
-		storage["statefulsets/scale"] = statefulSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
-		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-		storage["controllerrevisions"] = historyStorage
-	}
+
+	// deployments
+	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+	storage["deployments"] = deploymentStorage.Deployment
+	storage["deployments/status"] = deploymentStorage.Status
+	storage["deployments/rollback"] = deploymentStorage.Rollback
+	storage["deployments/scale"] = deploymentStorage.Scale
+
+	// statefulsets
+	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+	storage["statefulsets"] = statefulSetStorage.StatefulSet
+	storage["statefulsets/status"] = statefulSetStorage.Status
+	storage["statefulsets/scale"] = statefulSetStorage.Scale
+
+	// controllerrevisions
+	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+	storage["controllerrevisions"] = historyStorage
+
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta2Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := appsapiv1beta2.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
-		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-		storage["deployments"] = deploymentStorage.Deployment
-		storage["deployments/status"] = deploymentStorage.Status
-		storage["deployments/scale"] = deploymentStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
-		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-		storage["statefulsets"] = statefulSetStorage.StatefulSet
-		storage["statefulsets/status"] = statefulSetStorage.Status
-		storage["statefulsets/scale"] = statefulSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
-		daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
-		storage["daemonsets"] = daemonSetStorage
-		storage["daemonsets/status"] = daemonSetStatusStorage
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
-		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-		storage["replicasets"] = replicaSetStorage.ReplicaSet
-		storage["replicasets/status"] = replicaSetStorage.Status
-		storage["replicasets/scale"] = replicaSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
-		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-		storage["controllerrevisions"] = historyStorage
-	}
+
+	// deployments
+	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+	storage["deployments"] = deploymentStorage.Deployment
+	storage["deployments/status"] = deploymentStorage.Status
+	storage["deployments/scale"] = deploymentStorage.Scale
+
+	// statefulsets
+	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+	storage["statefulsets"] = statefulSetStorage.StatefulSet
+	storage["statefulsets/status"] = statefulSetStorage.Status
+	storage["statefulsets/scale"] = statefulSetStorage.Scale
+
+	// daemonsets
+	daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
+	storage["daemonsets"] = daemonSetStorage
+	storage["daemonsets/status"] = daemonSetStatusStorage
+
+	// replicasets
+	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+	storage["replicasets"] = replicaSetStorage.ReplicaSet
+	storage["replicasets/status"] = replicaSetStorage.Status
+	storage["replicasets/scale"] = replicaSetStorage.Scale
+
+	// controllerrevisions
+	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+	storage["controllerrevisions"] = historyStorage
+
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := appsapiv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
-		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-		storage["deployments"] = deploymentStorage.Deployment
-		storage["deployments/status"] = deploymentStorage.Status
-		storage["deployments/scale"] = deploymentStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
-		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-		storage["statefulsets"] = statefulSetStorage.StatefulSet
-		storage["statefulsets/status"] = statefulSetStorage.Status
-		storage["statefulsets/scale"] = statefulSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
-		daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
-		storage["daemonsets"] = daemonSetStorage
-		storage["daemonsets/status"] = daemonSetStatusStorage
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
-		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-		storage["replicasets"] = replicaSetStorage.ReplicaSet
-		storage["replicasets/status"] = replicaSetStorage.Status
-		storage["replicasets/scale"] = replicaSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
-		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-		storage["controllerrevisions"] = historyStorage
-	}
+
+	// deployments
+	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+	storage["deployments"] = deploymentStorage.Deployment
+	storage["deployments/status"] = deploymentStorage.Status
+	storage["deployments/scale"] = deploymentStorage.Scale
+
+	// statefulsets
+	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+	storage["statefulsets"] = statefulSetStorage.StatefulSet
+	storage["statefulsets/status"] = statefulSetStorage.Status
+	storage["statefulsets/scale"] = statefulSetStorage.Scale
+
+	// daemonsets
+	daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
+	storage["daemonsets"] = daemonSetStorage
+	storage["daemonsets/status"] = daemonSetStatusStorage
+
+	// replicasets
+	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+	storage["replicasets"] = replicaSetStorage.ReplicaSet
+	storage["replicasets/status"] = replicaSetStorage.Status
+	storage["replicasets/scale"] = replicaSetStorage.Scale
+
+	// controllerrevisions
+	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+	storage["controllerrevisions"] = historyStorage
+
 	return storage
 }
 

--- a/pkg/registry/authentication/rest/storage_authentication.go
+++ b/pkg/registry/authentication/rest/storage_authentication.go
@@ -43,11 +43,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authenticationv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(authenticationv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authenticationv1.SchemeGroupVersion
 	}
@@ -56,29 +56,19 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := authenticationv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
-		if apiResourceConfigSource.ResourceEnabled(version.WithResource("tokenreviews")) {
-			tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
-			storage["tokenreviews"] = tokenReviewStorage
-		}
-	}
+	// tokenreviews
+	tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
+	storage["tokenreviews"] = tokenReviewStorage
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := authenticationv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1.SchemeGroupVersion) {
-		if apiResourceConfigSource.ResourceEnabled(version.WithResource("tokenreviews")) {
-			tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
-			storage["tokenreviews"] = tokenReviewStorage
-		}
-	}
+	// tokenreviews
+	tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
+	storage["tokenreviews"] = tokenReviewStorage
 
 	return storage
 }

--- a/pkg/registry/authorization/rest/storage_authorization.go
+++ b/pkg/registry/authorization/rest/storage_authorization.go
@@ -46,12 +46,12 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authorizationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(authorizationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authorizationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authorizationv1beta1.SchemeGroupVersion
 	}
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authorizationv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(authorizationv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authorizationv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authorizationv1.SchemeGroupVersion
 	}
@@ -60,41 +60,29 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := authorizationv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("subjectaccessreviews")) {
-		storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
-		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("localsubjectaccessreviews")) {
-		storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectrulesreviews")) {
-		storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
-	}
+	// subjectaccessreviews
+	storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
+	// selfsubjectaccessreviews
+	storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
+	// localsubjectaccessreviews
+	storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
+	// selfsubjectrulesreviews
+	storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := authorizationv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("subjectaccessreviews")) {
-		storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
-		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("localsubjectaccessreviews")) {
-		storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectrulesreviews")) {
-		storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
-	}
+	// subjectaccessreviews
+	storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
+	// selfsubjectaccessreviews
+	storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
+	// localsubjectaccessreviews
+	storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
+	// selfsubjectrulesreviews
+	storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
 
 	return storage
 }

--- a/pkg/registry/autoscaling/rest/storage_autoscaling.go
+++ b/pkg/registry/autoscaling/rest/storage_autoscaling.go
@@ -35,11 +35,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv2beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(autoscalingapiv2beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv2beta1.SchemeGroupVersion.Version] = p.v2beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv2beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv1.SchemeGroupVersion
 	}
@@ -48,26 +48,22 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := autoscalingapiv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("horizontalpodautoscalers")) {
-		hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
-		storage["horizontalpodautoscalers"] = hpaStorage
-		storage["horizontalpodautoscalers/status"] = hpaStatusStorage
-	}
+	// horizontalpodautoscalers
+	hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
+	storage["horizontalpodautoscalers"] = hpaStorage
+	storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+
 	return storage
 }
 
 func (p RESTStorageProvider) v2beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := autoscalingapiv2beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("horizontalpodautoscalers")) {
-		hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
-		storage["horizontalpodautoscalers"] = hpaStorage
-		storage["horizontalpodautoscalers/status"] = hpaStatusStorage
-	}
+	// horizontalpodautoscalers
+	hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
+	storage["horizontalpodautoscalers"] = hpaStorage
+	storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+
 	return storage
 }
 

--- a/pkg/registry/batch/rest/storage_batch.go
+++ b/pkg/registry/batch/rest/storage_batch.go
@@ -37,15 +37,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(batchapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(batchapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv2alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(batchapiv2alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv2alpha1.SchemeGroupVersion.Version] = p.v2alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv2alpha1.SchemeGroupVersion
 	}
@@ -54,38 +54,32 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := batchapiv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("jobs")) {
-		jobsStorage, jobsStatusStorage := jobstore.NewREST(restOptionsGetter)
-		storage["jobs"] = jobsStorage
-		storage["jobs/status"] = jobsStatusStorage
-	}
+	// jobs
+	jobsStorage, jobsStatusStorage := jobstore.NewREST(restOptionsGetter)
+	storage["jobs"] = jobsStorage
+	storage["jobs/status"] = jobsStatusStorage
+
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := batchapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("cronjobs")) {
-		cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
-		storage["cronjobs"] = cronJobsStorage
-		storage["cronjobs/status"] = cronJobsStatusStorage
-	}
+	// cronjobs
+	cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
+	storage["cronjobs"] = cronJobsStorage
+	storage["cronjobs/status"] = cronJobsStatusStorage
+
 	return storage
 }
 
 func (p RESTStorageProvider) v2alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := batchapiv2alpha1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("cronjobs")) {
-		cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
-		storage["cronjobs"] = cronJobsStorage
-		storage["cronjobs/status"] = cronJobsStatusStorage
-	}
+	// cronjobs
+	cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
+	storage["cronjobs"] = cronJobsStorage
+	storage["cronjobs/status"] = cronJobsStatusStorage
+
 	return storage
 }
 

--- a/pkg/registry/certificates/rest/storage_certificates.go
+++ b/pkg/registry/certificates/rest/storage_certificates.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(certificatesapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(certificatesapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[certificatesapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = certificatesapiv1beta1.SchemeGroupVersion
 	}
@@ -43,15 +43,13 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := certificatesapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("certificatesigningrequests")) {
-		csrStorage, csrStatusStorage, csrApprovalStorage := certificatestore.NewREST(restOptionsGetter)
-		storage["certificatesigningrequests"] = csrStorage
-		storage["certificatesigningrequests/status"] = csrStatusStorage
-		storage["certificatesigningrequests/approval"] = csrApprovalStorage
-	}
+	// certificatesigningrequests
+	csrStorage, csrStatusStorage, csrApprovalStorage := certificatestore.NewREST(restOptionsGetter)
+	storage["certificatesigningrequests"] = csrStorage
+	storage["certificatesigningrequests/status"] = csrStatusStorage
+	storage["certificatesigningrequests/approval"] = csrApprovalStorage
+
 	return storage
 }
 

--- a/pkg/registry/events/rest/storage_events.go
+++ b/pkg/registry/events/rest/storage_events.go
@@ -38,7 +38,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(eventsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(eventsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[eventsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = eventsapiv1beta1.SchemeGroupVersion
 	}
@@ -47,13 +47,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := eventsapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("events")) {
-		eventsStorage := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
-		storage["events"] = eventsStorage
-	}
+	// events
+	eventsStorage := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
+	storage["events"] = eventsStorage
+
 	return storage
 }
 

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -33,15 +33,14 @@ import (
 	networkpolicystore "k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage"
 )
 
-type RESTStorageProvider struct {
-}
+type RESTStorageProvider struct{}
 
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(extensions.GroupName, legacyscheme.Registry, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(extensionsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(extensionsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[extensionsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = extensionsapiv1beta1.SchemeGroupVersion
 	}
@@ -50,8 +49,6 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := extensionsapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
 
 	// This is a dummy replication controller for scale subresource purposes.
@@ -60,37 +57,35 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	storage["replicationcontrollers"] = controllerStorage.ReplicationController
 	storage["replicationcontrollers/scale"] = controllerStorage.Scale
 
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
-		daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
-		storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
-		storage["daemonsets/status"] = daemonSetStatusStorage
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
-		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-		storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
-		storage["deployments/status"] = deploymentStorage.Status
-		storage["deployments/rollback"] = deploymentStorage.Rollback
-		storage["deployments/scale"] = deploymentStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("ingresses")) {
-		ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
-		storage["ingresses"] = ingressStorage
-		storage["ingresses/status"] = ingressStatusStorage
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("podsecuritypolicy")) || apiResourceConfigSource.ResourceEnabled(version.WithResource("podsecuritypolicies")) {
-		podSecurityExtensionsStorage := pspstore.NewREST(restOptionsGetter)
-		storage["podSecurityPolicies"] = podSecurityExtensionsStorage
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
-		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-		storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
-		storage["replicasets/status"] = replicaSetStorage.Status
-		storage["replicasets/scale"] = replicaSetStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("networkpolicies")) {
-		networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
-		storage["networkpolicies"] = networkExtensionsStorage
-	}
+	// daemonsets
+	daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
+	storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
+	storage["daemonsets/status"] = daemonSetStatusStorage
+
+	//deployments
+	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+	storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
+	storage["deployments/status"] = deploymentStorage.Status
+	storage["deployments/rollback"] = deploymentStorage.Rollback
+	storage["deployments/scale"] = deploymentStorage.Scale
+	// ingresses
+	ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
+	storage["ingresses"] = ingressStorage
+	storage["ingresses/status"] = ingressStatusStorage
+
+	// podsecuritypolicy
+	podSecurityExtensionsStorage := pspstore.NewREST(restOptionsGetter)
+	storage["podSecurityPolicies"] = podSecurityExtensionsStorage
+
+	// replicasets
+	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+	storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
+	storage["replicasets/status"] = replicaSetStorage.Status
+	storage["replicasets/scale"] = replicaSetStorage.Scale
+
+	// networkpolicies
+	networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
+	storage["networkpolicies"] = networkExtensionsStorage
 
 	return storage
 }

--- a/pkg/registry/networking/rest/storage_settings.go
+++ b/pkg/registry/networking/rest/storage_settings.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(networkingapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(networkingapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[networkingapiv1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = networkingapiv1.SchemeGroupVersion
 	}
@@ -43,13 +43,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := networkingapiv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("networkpolicies")) {
-		networkPolicyStorage := networkpolicystore.NewREST(restOptionsGetter)
-		storage["networkpolicies"] = networkPolicyStorage
-	}
+	// networkpolicies
+	networkPolicyStorage := networkpolicystore.NewREST(restOptionsGetter)
+	storage["networkpolicies"] = networkPolicyStorage
+
 	return storage
 }
 

--- a/pkg/registry/policy/rest/storage_policy.go
+++ b/pkg/registry/policy/rest/storage_policy.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(policyapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(policyapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[policyapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = policyapiv1beta1.SchemeGroupVersion
 	}
@@ -42,13 +42,12 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := policyapiv1beta1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("poddisruptionbudgets")) {
-		poddisruptionbudgetStorage, poddisruptionbudgetStatusStorage := poddisruptionbudgetstore.NewREST(restOptionsGetter)
-		storage["poddisruptionbudgets"] = poddisruptionbudgetStorage
-		storage["poddisruptionbudgets/status"] = poddisruptionbudgetStatusStorage
-	}
+	// poddisruptionbudgets
+	poddisruptionbudgetStorage, poddisruptionbudgetStatusStorage := poddisruptionbudgetstore.NewREST(restOptionsGetter)
+	storage["poddisruptionbudgets"] = poddisruptionbudgetStorage
+	storage["poddisruptionbudgets/status"] = poddisruptionbudgetStatusStorage
+
 	return storage
 }
 

--- a/pkg/registry/scheduling/rest/storage_scheduling.go
+++ b/pkg/registry/scheduling/rest/storage_scheduling.go
@@ -32,7 +32,7 @@ type RESTStorageProvider struct{}
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(scheduling.GroupName, legacyscheme.Registry, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(schedulingapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(schedulingapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[schedulingapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = schedulingapiv1alpha1.SchemeGroupVersion
 	}
@@ -41,13 +41,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := schedulingapiv1alpha1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("priorityclasses")) {
-		priorityClassStorage := priorityclassstore.NewREST(restOptionsGetter)
-		storage["priorityclasses"] = priorityClassStorage
-	}
+	// priorityclasses
+	priorityClassStorage := priorityclassstore.NewREST(restOptionsGetter)
+	storage["priorityclasses"] = priorityClassStorage
+
 	return storage
 }
 

--- a/pkg/registry/settings/rest/storage_settings.go
+++ b/pkg/registry/settings/rest/storage_settings.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(settingsapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(settingsapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[settingsapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = settingsapiv1alpha1.SchemeGroupVersion
 	}
@@ -43,13 +43,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := settingsapiv1alpha1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("podpresets")) {
-		podPresetStorage := podpresetstore.NewREST(restOptionsGetter)
-		storage["podpresets"] = podPresetStorage
-	}
+	// podpresets
+	podPresetStorage := podpresetstore.NewREST(restOptionsGetter)
+	storage["podpresets"] = podPresetStorage
+
 	return storage
 }
 

--- a/pkg/registry/storage/rest/storage_storage.go
+++ b/pkg/registry/storage/rest/storage_storage.go
@@ -38,15 +38,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(storageapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1alpha1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.VersionEnabled(storageapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1.SchemeGroupVersion
 	}
@@ -55,40 +55,28 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := storageapiv1alpha1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("volumeattachments")) {
-		volumeAttachmentStorage := volumeattachmentstore.NewREST(restOptionsGetter)
-		storage["volumeattachments"] = volumeAttachmentStorage
-	}
+	// volumeattachments
+	volumeAttachmentStorage := volumeattachmentstore.NewREST(restOptionsGetter)
+	storage["volumeattachments"] = volumeAttachmentStorage
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := storageapiv1beta1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("storageclasses")) {
-		storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
-		storage["storageclasses"] = storageClassStorage
-	}
+	// storageclasses
+	storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
+	storage["storageclasses"] = storageClassStorage
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	version := storageapiv1.SchemeGroupVersion
-
 	storage := map[string]rest.Storage{}
-
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("storageclasses")) {
-		storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
-		storage["storageclasses"] = storageClassStorage
-	}
+	// storageclasses
+	storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
+	storage["storageclasses"] = storageClassStorage
 
 	return storage
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -134,15 +134,14 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 
 	apiResourceConfig := c.GenericConfig.MergedResourceConfig
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(apiextensions.GroupName, Registry, Scheme, metav1.ParameterCodec, Codecs)
-	if apiResourceConfig.AnyResourcesForVersionEnabled(v1beta1.SchemeGroupVersion) {
+	if apiResourceConfig.VersionEnabled(v1beta1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1beta1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
-		version := v1beta1.SchemeGroupVersion
-		if apiResourceConfig.ResourceEnabled(version.WithResource("customresourcedefinitions")) {
-			customResourceDefintionStorage := customresourcedefinition.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
-			storage["customresourcedefinitions"] = customResourceDefintionStorage
-			storage["customresourcedefinitions/status"] = customresourcedefinition.NewStatusREST(Scheme, customResourceDefintionStorage)
-		}
+		// customresourcedefinitions
+		customResourceDefintionStorage := customresourcedefinition.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
+		storage["customresourcedefinitions"] = customResourceDefintionStorage
+		storage["customresourcedefinitions/status"] = customresourcedefinition.NewStatusREST(Scheme, customResourceDefintionStorage)
+
 		apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = storage
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -25,7 +25,6 @@ import (
 type APIResourceConfigSource interface {
 	AnyVersionOfResourceEnabled(resource schema.GroupResource) bool
 	ResourceEnabled(resource schema.GroupVersionResource) bool
-	AllResourcesForVersionEnabled(version schema.GroupVersion) bool
 	AnyResourcesForVersionEnabled(version schema.GroupVersion) bool
 	AnyResourcesForGroupEnabled(group string) bool
 }
@@ -85,31 +84,6 @@ func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 	}
 }
 
-func (o *ResourceConfig) DisableResources(resources ...schema.GroupVersionResource) {
-	for _, resource := range resources {
-		version := resource.GroupVersion()
-		_, versionExists := o.GroupVersionResourceConfigs[version]
-		if !versionExists {
-			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
-		}
-
-		o.GroupVersionResourceConfigs[version].DisabledResources.Insert(resource.Resource)
-	}
-}
-
-func (o *ResourceConfig) EnableResources(resources ...schema.GroupVersionResource) {
-	for _, resource := range resources {
-		version := resource.GroupVersion()
-		_, versionExists := o.GroupVersionResourceConfigs[version]
-		if !versionExists {
-			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
-		}
-
-		o.GroupVersionResourceConfigs[version].EnabledResources.Insert(resource.Resource)
-		o.GroupVersionResourceConfigs[version].DisabledResources.Delete(resource.Resource)
-	}
-}
-
 // AnyResourcesForVersionEnabled only considers matches based on exactly group/resource lexical matching.  This means that
 // resource renames across versions are NOT considered to be the same resource by this method. You'll need to manually check
 // using the ResourceEnabled function.
@@ -145,22 +119,6 @@ func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) b
 	}
 
 	return true
-}
-
-func (o *ResourceConfig) AllResourcesForVersionEnabled(version schema.GroupVersion) bool {
-	versionOverride, versionExists := o.GroupVersionResourceConfigs[version]
-	if !versionExists {
-		return false
-	}
-	if !versionOverride.Enable {
-		return false
-	}
-
-	if len(versionOverride.EnabledResources) == 0 && len(versionOverride.DisabledResources) == 0 {
-		return true
-	}
-
-	return false
 }
 
 func (o *ResourceConfig) AnyResourcesForVersionEnabled(version schema.GroupVersion) bool {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -18,122 +18,50 @@ package storage
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// APIResourceConfigSource is the interface to determine which versions and resources are enabled
+// APIResourceConfigSource is the interface to determine which groups and versions are enabled
 type APIResourceConfigSource interface {
-	AnyVersionOfResourceEnabled(resource schema.GroupResource) bool
-	ResourceEnabled(resource schema.GroupVersionResource) bool
-	AnyResourcesForVersionEnabled(version schema.GroupVersion) bool
-	AnyResourcesForGroupEnabled(group string) bool
-}
-
-// Specifies the overrides for various API group versions.
-// This can be used to enable/disable entire group versions or specific resources.
-type GroupVersionResourceConfig struct {
-	// Whether to enable or disable this entire group version.  This dominates any enablement check.
-	// Enable=true means the group version is enabled, and EnabledResources/DisabledResources are considered.
-	// Enable=false means the group version is disabled, and EnabledResources/DisabledResources are not considered.
-	Enable bool
-
-	// DisabledResources lists the resources that are specifically disabled for a group/version
-	// DisabledResources trumps EnabledResources
-	DisabledResources sets.String
-
-	// EnabledResources lists the resources that should be enabled by default.  This is a little
-	// unusual, but we need it for compatibility with old code for now.  An empty set means
-	// enable all, a non-empty set means that all other resources are disabled.
-	EnabledResources sets.String
+	VersionEnabled(version schema.GroupVersion) bool
+	AnyVersionForGroupEnabled(group string) bool
 }
 
 var _ APIResourceConfigSource = &ResourceConfig{}
 
 type ResourceConfig struct {
-	GroupVersionResourceConfigs map[schema.GroupVersion]*GroupVersionResourceConfig
+	GroupVersionConfigs map[schema.GroupVersion]bool
 }
 
 func NewResourceConfig() *ResourceConfig {
-	return &ResourceConfig{GroupVersionResourceConfigs: map[schema.GroupVersion]*GroupVersionResourceConfig{}}
+	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}}
 }
 
-func NewGroupVersionResourceConfig() *GroupVersionResourceConfig {
-	return &GroupVersionResourceConfig{Enable: true, DisabledResources: sets.String{}, EnabledResources: sets.String{}}
-}
-
-// DisableVersions disables the versions entirely.  No resources (even those whitelisted in EnabledResources) will be enabled
+// DisableVersions disables the versions entirely.
 func (o *ResourceConfig) DisableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
-		_, versionExists := o.GroupVersionResourceConfigs[version]
-		if !versionExists {
-			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
-		}
-
-		o.GroupVersionResourceConfigs[version].Enable = false
+		o.GroupVersionConfigs[version] = false
 	}
 }
 
 func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
-		_, versionExists := o.GroupVersionResourceConfigs[version]
-		if !versionExists {
-			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
-		}
-
-		o.GroupVersionResourceConfigs[version].Enable = true
+		o.GroupVersionConfigs[version] = true
 	}
 }
 
-// AnyResourcesForVersionEnabled only considers matches based on exactly group/resource lexical matching.  This means that
-// resource renames across versions are NOT considered to be the same resource by this method. You'll need to manually check
-// using the ResourceEnabled function.
-func (o *ResourceConfig) AnyVersionOfResourceEnabled(resource schema.GroupResource) bool {
-	for version := range o.GroupVersionResourceConfigs {
-		if version.Group != resource.Group {
-			continue
-		}
-
-		if o.ResourceEnabled(version.WithResource(resource.Resource)) {
-			return true
-		}
+func (o *ResourceConfig) VersionEnabled(version schema.GroupVersion) bool {
+	enabled, _ := o.GroupVersionConfigs[version]
+	if enabled {
+		return true
 	}
 
 	return false
 }
 
-func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) bool {
-	versionOverride, versionExists := o.GroupVersionResourceConfigs[resource.GroupVersion()]
-	if !versionExists {
-		return false
-	}
-	if !versionOverride.Enable {
-		return false
-	}
-
-	if versionOverride.DisabledResources.Has(resource.Resource) {
-		return false
-	}
-
-	if len(versionOverride.EnabledResources) > 0 {
-		return versionOverride.EnabledResources.Has(resource.Resource)
-	}
-
-	return true
-}
-
-func (o *ResourceConfig) AnyResourcesForVersionEnabled(version schema.GroupVersion) bool {
-	versionOverride, versionExists := o.GroupVersionResourceConfigs[version]
-	if !versionExists {
-		return false
-	}
-
-	return versionOverride.Enable
-}
-
-func (o *ResourceConfig) AnyResourcesForGroupEnabled(group string) bool {
-	for version := range o.GroupVersionResourceConfigs {
+func (o *ResourceConfig) AnyVersionForGroupEnabled(group string) bool {
+	for version := range o.GroupVersionConfigs {
 		if version.Group == group {
-			if o.AnyResourcesForVersionEnabled(version) {
+			if o.VersionEnabled(version) {
 				return true
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -26,76 +26,21 @@ func TestDisabledVersion(t *testing.T) {
 	g1v1 := schema.GroupVersion{Group: "group1", Version: "version1"}
 	g1v2 := schema.GroupVersion{Group: "group1", Version: "version2"}
 	g2v1 := schema.GroupVersion{Group: "group2", Version: "version1"}
-	g3v1 := schema.GroupVersion{Group: "group3", Version: "version1"}
-
-	resourceType := "the-resource"
-	disabledResourceType := "the-disabled-resource"
 
 	config := NewResourceConfig()
 
 	config.DisableVersions(g1v1)
-	config.EnableVersions(g1v2, g3v1)
-	config.EnableResources(g1v1.WithResource(resourceType), g2v1.WithResource(resourceType))
-	config.DisableResources(g1v2.WithResource(disabledResourceType))
+	config.EnableVersions(g1v2, g2v1)
 
-	expectedEnabledResources := []schema.GroupVersionResource{
-		g1v2.WithResource(resourceType),
-		g2v1.WithResource(resourceType),
+	if config.AnyResourcesForVersionEnabled(g1v1) {
+		t.Errorf("expected disabled for %v, from %v", g1v1, config)
 	}
-	expectedDisabledResources := []schema.GroupVersionResource{
-		g1v1.WithResource(resourceType), g1v1.WithResource(disabledResourceType),
-		g1v2.WithResource(disabledResourceType),
-		g2v1.WithResource(disabledResourceType),
+	if !config.AnyResourcesForVersionEnabled(g1v2) {
+		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
-
-	for _, expectedResource := range expectedEnabledResources {
-		if !config.ResourceEnabled(expectedResource) {
-			t.Errorf("expected enabled for %v, from %v", expectedResource, config)
-		}
+	if !config.AnyResourcesForVersionEnabled(g2v1) {
+		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
-	for _, expectedResource := range expectedDisabledResources {
-		if config.ResourceEnabled(expectedResource) {
-			t.Errorf("expected disabled for %v, from %v", expectedResource, config)
-		}
-	}
-
-	if e, a := false, config.AnyResourcesForVersionEnabled(g1v1); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := false, config.AllResourcesForVersionEnabled(g1v1); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := true, config.AnyResourcesForVersionEnabled(g1v2); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := false, config.AllResourcesForVersionEnabled(g1v2); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := true, config.AnyResourcesForVersionEnabled(g3v1); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := true, config.AllResourcesForVersionEnabled(g3v1); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-
-	expectedEnabledAnyVersionResources := []schema.GroupResource{
-		{Group: "group1", Resource: resourceType},
-	}
-	expectedDisabledAnyResources := []schema.GroupResource{
-		{Group: "group1", Resource: disabledResourceType},
-	}
-
-	for _, expectedResource := range expectedEnabledAnyVersionResources {
-		if !config.AnyVersionOfResourceEnabled(expectedResource) {
-			t.Errorf("expected enabled for %v, from %v", expectedResource, config)
-		}
-	}
-	for _, expectedResource := range expectedDisabledAnyResources {
-		if config.AnyVersionOfResourceEnabled(expectedResource) {
-			t.Errorf("expected disabled for %v, from %v", expectedResource, config)
-		}
-	}
-
 }
 
 func TestAnyResourcesForGroupEnabled(t *testing.T) {
@@ -132,18 +77,6 @@ func TestAnyResourcesForGroupEnabled(t *testing.T) {
 				ret := NewResourceConfig()
 				ret.DisableVersions(schema.GroupVersion{Group: "one", Version: "version1"})
 				ret.EnableVersions(schema.GroupVersion{Group: "one", Version: "version2"})
-				return ret
-			},
-			testGroup: "one",
-
-			expectedResult: true,
-		},
-		{
-			name: "present, and one resource",
-			creator: func() APIResourceConfigSource {
-				ret := NewResourceConfig()
-				ret.DisableVersions(schema.GroupVersion{Group: "one", Version: "version1"})
-				ret.EnableResources(schema.GroupVersionResource{Group: "one", Version: "version2", Resource: "foo"})
 				return ret
 			},
 			testGroup: "one",

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -32,18 +32,18 @@ func TestDisabledVersion(t *testing.T) {
 	config.DisableVersions(g1v1)
 	config.EnableVersions(g1v2, g2v1)
 
-	if config.AnyResourcesForVersionEnabled(g1v1) {
+	if config.VersionEnabled(g1v1) {
 		t.Errorf("expected disabled for %v, from %v", g1v1, config)
 	}
-	if !config.AnyResourcesForVersionEnabled(g1v2) {
+	if !config.VersionEnabled(g1v2) {
 		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
-	if !config.AnyResourcesForVersionEnabled(g2v1) {
+	if !config.VersionEnabled(g2v1) {
 		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
 }
 
-func TestAnyResourcesForGroupEnabled(t *testing.T) {
+func TestAnyVersionForGroupEnabled(t *testing.T) {
 	tests := []struct {
 		name      string
 		creator   func() APIResourceConfigSource
@@ -86,7 +86,7 @@ func TestAnyResourcesForGroupEnabled(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if e, a := tc.expectedResult, tc.creator().AnyResourcesForGroupEnabled(tc.testGroup); e != a {
+		if e, a := tc.expectedResult, tc.creator().AnyVersionForGroupEnabled(tc.testGroup); e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -240,7 +240,7 @@ func getAllResourcesAlias(resource schema.GroupResource) schema.GroupResource {
 
 func (s *DefaultStorageFactory) getStorageGroupResource(groupResource schema.GroupResource) schema.GroupResource {
 	for _, potentialStorageResource := range s.Overrides[groupResource].cohabitatingResources {
-		if s.APIResourceConfigSource.AnyVersionOfResourceEnabled(potentialStorageResource) {
+		if s.APIResourceConfigSource.AnyVersionForGroupEnabled(potentialStorageResource.Group) {
 			return potentialStorageResource
 		}
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -185,26 +185,23 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 
 	apiResourceConfig := c.GenericConfig.MergedResourceConfig
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(apiregistration.GroupName, Registry, Scheme, metav1.ParameterCodec, Codecs)
-	if apiResourceConfig.AnyResourcesForVersionEnabled(v1beta1.SchemeGroupVersion) {
+	if apiResourceConfig.VersionEnabled(v1beta1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1beta1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
-		version := v1beta1.SchemeGroupVersion
-		if apiResourceConfig.ResourceEnabled(version.WithResource("apiservices")) {
-			apiServiceREST := apiservicestorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
-			storage["apiservices"] = apiServiceREST
-			storage["apiservices/status"] = apiservicestorage.NewStatusREST(Scheme, apiServiceREST)
-		}
+		// apiservices
+		apiServiceREST := apiservicestorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
+		storage["apiservices"] = apiServiceREST
+		storage["apiservices/status"] = apiservicestorage.NewStatusREST(Scheme, apiServiceREST)
 		apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = storage
 	}
-	if apiResourceConfig.AnyResourcesForVersionEnabled(v1.SchemeGroupVersion) {
+	if apiResourceConfig.VersionEnabled(v1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
-		version := v1.SchemeGroupVersion
-		if apiResourceConfig.ResourceEnabled(version.WithResource("apiservices")) {
-			apiServiceREST := apiservicestorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
-			storage["apiservices"] = apiServiceREST
-			storage["apiservices/status"] = apiservicestorage.NewStatusREST(Scheme, apiServiceREST)
-		}
+		// apiservices
+		apiServiceREST := apiservicestorage.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
+		storage["apiservices"] = apiServiceREST
+		storage["apiservices/status"] = apiservicestorage.NewStatusREST(Scheme, apiServiceREST)
+
 		apiGroupInfo.VersionedResourcesStorageMap["v1"] = storage
 	}
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -1134,8 +1134,5 @@ func getEtcdKVClient(config storagebackend.Config) (clientv3.KV, error) {
 
 type allResourceSource struct{}
 
-func (*allResourceSource) AnyVersionOfResourceEnabled(resource schema.GroupResource) bool { return true }
-func (*allResourceSource) AllResourcesForVersionEnabled(version schema.GroupVersion) bool { return true }
-func (*allResourceSource) AnyResourcesForGroupEnabled(group string) bool                  { return true }
-func (*allResourceSource) ResourceEnabled(resource schema.GroupVersionResource) bool      { return true }
-func (*allResourceSource) AnyResourcesForVersionEnabled(version schema.GroupVersion) bool { return true }
+func (*allResourceSource) AnyVersionForGroupEnabled(group string) bool     { return true }
+func (*allResourceSource) VersionEnabled(version schema.GroupVersion) bool { return true }


### PR DESCRIPTION


**What this PR does / why we need it**:

After #57228, `runtime-config` flag has stop support enable/disable resources of a specific groupVersion,
so this pr does some clean work about this.

Mainly delete unused code in  `k8s.io/apiserver/pkg/server/storage/resource_config.go`

**Special notes for your reviewer**:
/assign @deads2k  @sttts 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind cleanup