### PR TITLE
Categorize deprecated feature gate more accurately

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -169,7 +169,7 @@ const (
 	ServiceNodeExclusion utilfeature.Feature = "ServiceNodeExclusion"
 
 	// owner @brendandburns
-	// stable: v1.10
+	// deprecated: v1.10
 	//
 	// Enable the service proxy to contact external IP addresses. Note this feature is present
 	// only for backward compatability, it will be removed in the 1.11 release.
@@ -283,6 +283,6 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	// unintentionally on either side:
 	apiextensionsfeatures.CustomResourceValidation: {Default: true, PreRelease: utilfeature.Beta},
 
-	// backward compatability features that enable backwards compatability but should be removed soon.
-	ServiceProxyAllowExternalIPs: {Default: false, PreRelease: utilfeature.Beta},
+	// features that enable backwards compatability but are scheduled to be removed
+	ServiceProxyAllowExternalIPs: {Default: false, PreRelease: utilfeature.Deprecated},
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -67,6 +67,9 @@ const (
 	Alpha = prerelease("ALPHA")
 	Beta  = prerelease("BETA")
 	GA    = prerelease("")
+
+	// Deprecated
+	Deprecated = prerelease("DEPRECATED")
 )
 
 // FeatureGate parses and stores flag gates for known features from
@@ -157,7 +160,7 @@ func (f *featureGate) Set(value string) error {
 		}
 		arr := strings.SplitN(s, "=", 2)
 		k := Feature(strings.TrimSpace(arr[0]))
-		_, ok := known[k]
+		featureSpec, ok := known[k]
 		if !ok {
 			return fmt.Errorf("unrecognized key: %s", k)
 		}
@@ -170,6 +173,9 @@ func (f *featureGate) Set(value string) error {
 			return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
 		}
 		enabled[k] = boolValue
+		if boolValue && featureSpec.PreRelease == Deprecated {
+			glog.Warningf("enabling deprecated feature gate %s", k)
+		}
 
 		// Handle "special" features like "all alpha gates"
 		if fn, found := f.special[k]; found {


### PR DESCRIPTION
related to #58761

follow up from https://github.com/kubernetes/kubernetes/pull/57265 to clarify the status of the feature gate

```release-note
NONE
```