### PR TITLE
csi: Update version comparison model

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -118,9 +118,15 @@ func (c *csiDriverClient) AssertSupportedVersion(ctx grpctx.Context, ver *csipb.
 	vers := rsp.GetSupportedVersions()
 	glog.V(4).Info(log("driver reports %d versions supported: %s", len(vers), versToStr(vers)))
 
+	// If our supported version is still at 0.X.X, then check
+	// also the minor number. If our supported version is >= 1.X.X
+	// then check only the major number.
 	for _, v := range vers {
-		//TODO (vladimirvivien) use more lenient/heuristic for exact or match of ranges etc
-		if verToStr(v) == verToStr(ver) {
+		if ver.GetMajor() == uint32(0) &&
+			(ver.GetMajor() == v.GetMajor() && ver.GetMinor() == v.GetMinor()) {
+			supported = true
+			break
+		} else if ver.GetMajor() != uint32(0) && ver.GetMajor() == v.GetMajor() {
 			supported = true
 			break
 		}

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -46,8 +46,13 @@ func TestClientAssertSupportedVersion(t *testing.T) {
 		mustFail bool
 		err      error
 	}{
+		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 0, Patch: 0}},
 		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 1, Patch: 0}},
-		{testName: "unsupported version", ver: &csipb.Version{Major: 0, Minor: 0, Patch: 0}, mustFail: true},
+		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 1, Patch: 10}},
+		{testName: "supported version", ver: &csipb.Version{Major: 1, Minor: 1, Patch: 0}},
+		{testName: "supported version", ver: &csipb.Version{Major: 1, Minor: 0, Patch: 10}},
+		{testName: "unsupported version", ver: &csipb.Version{Major: 10, Minor: 0, Patch: 0}, mustFail: true},
+		{testName: "unsupported version", ver: &csipb.Version{Major: 0, Minor: 10, Patch: 0}, mustFail: true},
 		{testName: "grpc error", ver: &csipb.Version{Major: 0, Minor: 1, Patch: 0}, mustFail: true, err: errors.New("grpc error")},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CSI version matching needed to be updated to be able to support different patch levels during 0.x.x versions, and different minor.patch levels during >=1.x.x versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58813

```release-note
NONE
```
