### PR TITLE
Correct unbound assertions variable error in shell2junit

### DIFF
--- a/third_party/forked/shell2junit/OWNERS
+++ b/third_party/forked/shell2junit/OWNERS
@@ -1,8 +1,10 @@
 reviewers:
+  - cblecker
   - ixdy
   - mengqiy
   - pwittrock
 approvers:
+  - cblecker
   - ixdy
   - mengqiy
   - pwittrock

--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -46,7 +46,7 @@ errfile=/tmp/evErr.$$.log
 function eVal() {
   (eval "$1")
   # stdout and stderr may currently be inverted (see below) so echo may write to stderr
-  echo $? 2>&1 | tr -d "\n" > ${errfile}
+  echo "$?" 2>&1 | tr -d "\n" > "${errfile}"
 }
 
 # Method to clean old tests
@@ -64,7 +64,7 @@ function juLog() {
 
   # parse arguments
   ya=""; icase=""
-  while [ -z "$ya" ]; do
+  while [[ -z "$ya" ]]; do
     case "$1" in
   	  -name=*)   name=`echo "$1" | ${SED} -e 's/-name=//'`;   shift;;
   	  -class=*)  class=`echo "$1" | ${SED} -e 's/-class=//'`;   shift;;
@@ -78,7 +78,7 @@ function juLog() {
   # create output directory
   mkdir -p "${juDIR}" || exit
   # use first arg as name if it was not given
-  if [ -z "${name}" ]; then
+  if [[ -z "${name}" ]]; then
     name="${asserts}-$1"
     shift
   fi
@@ -90,9 +90,9 @@ function juLog() {
   suite=${class}
 
   # calculate command to eval
-  [ -z "$1" ] && return
+  [[ -z "$1" ]] && return
   cmd="$1"; shift
-  while [ -n "${1:-}" ]
+  while [[ -n "${1:-}" ]]
   do
      cmd="${cmd} \"$1\""
      shift
@@ -116,13 +116,13 @@ function juLog() {
   echo "+++ exit code: ${evErr}"        | tee -a ${outf}
 
   # set the appropriate error, based in the exit code and the regex
-  [ ${evErr} != 0 ] && err=1 || err=0
+  [[ ${evErr} != 0 ]] && err=1 || err=0
   out=`cat $outf | ${SED} -e 's/^\([^+]\)/| \1/g'`
   if [ ${err} = 0 -a -n "${ereg:-}" ]; then
       H=`echo "${out}" | egrep ${icase} "${ereg}"`
-      [ -n "${H}" ] && err=1
+      [[ -n "${H}" ]] && err=1
   fi
-  [ ${err} != 0 ] && echo "+++ error: ${err}"         | tee -a ${outf}
+  [[ ${err} != 0 ]] && echo "+++ error: ${err}"         | tee -a ${outf}
   rm -f ${outf}
 
   errMsg=`cat ${errf}`
@@ -135,7 +135,7 @@ function juLog() {
 
   # write the junit xml report
   ## failure tag
-  [ ${err} = 0 ] && failure="" || failure="
+  [[ ${err} = 0 ]] && failure="" || failure="
       <failure type=\"ScriptError\" message=\"Script Error\">
       <![CDATA[
       ${errMsg}
@@ -183,5 +183,5 @@ EOF
 EOF
   fi
 
-  return $err
+  return ${err}
 }

--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -46,13 +46,13 @@ errfile=/tmp/evErr.$$.log
 function eVal() {
   (eval "$1")
   # stdout and stderr may currently be inverted (see below) so echo may write to stderr
-  echo $? 2>&1 | tr -d "\n" > $errfile
+  echo $? 2>&1 | tr -d "\n" > ${errfile}
 }
 
 # Method to clean old tests
 function juLogClean() {
-  echo "+++ Removing old junit reports from: $juDIR "
-  rm -f "$juDIR"/junit-*
+  echo "+++ Removing old junit reports from: ${juDIR} "
+  rm -f "${juDIR}"/junit-*
 }
 
 # Execute a command and record its results
@@ -76,108 +76,108 @@ function juLog() {
   done
 
   # create output directory
-  mkdir -p "$juDIR" || exit
+  mkdir -p "${juDIR}" || exit
   # use first arg as name if it was not given
-  if [ -z "$name" ]; then
-    name="$asserts-$1"
+  if [ -z "${name}" ]; then
+    name="${asserts}-$1"
     shift
   fi
 
-  if [[ "$class" = "" ]]; then
+  if [[ "${class}" = "" ]]; then
     class="default"
   fi
 
-  suite=$class
+  suite=${class}
 
   # calculate command to eval
   [ -z "$1" ] && return
   cmd="$1"; shift
   while [ -n "${1:-}" ]
   do
-     cmd="$cmd \"$1\""
+     cmd="${cmd} \"$1\""
      shift
   done
 
   # eval the command sending output to a file
   outf=/var/tmp/ju$$.txt
   errf=/var/tmp/ju$$-err.txt
-  >$outf
-  echo ""                         | tee -a $outf
-  echo "+++ Running case: $class.$name " | tee -a $outf
-  echo "+++ working dir: "`pwd`           | tee -a $outf
-  echo "+++ command: $cmd"            | tee -a $outf
-  ini=`$date +%s.%N`
+  >${outf}
+  echo ""                         | tee -a ${outf}
+  echo "+++ Running case: ${class}.${name} " | tee -a ${outf}
+  echo "+++ working dir: "`pwd`           | tee -a ${outf}
+  echo "+++ command: ${cmd}"            | tee -a ${outf}
+  ini=`${date} +%s.%N`
   # execute the command, temporarily swapping stderr and stdout so they can be tee'd to separate files,
   # then swapping them back again so that the streams are written correctly for the invoking process
-  ( (eVal "$cmd" | tee -a $outf) 3>&1 1>&2 2>&3 | tee $errf) 3>&1 1>&2 2>&3
-  evErr=`cat $errfile`
-  rm -f $errfile
-  end=`$date +%s.%N`
-  echo "+++ exit code: $evErr"        | tee -a $outf
+  ( (eVal "${cmd}" | tee -a ${outf}) 3>&1 1>&2 2>&3 | tee ${errf}) 3>&1 1>&2 2>&3
+  evErr=`cat ${errfile}`
+  rm -f ${errfile}
+  end=`${date} +%s.%N`
+  echo "+++ exit code: ${evErr}"        | tee -a ${outf}
 
   # set the appropriate error, based in the exit code and the regex
-  [ $evErr != 0 ] && err=1 || err=0
+  [ ${evErr} != 0 ] && err=1 || err=0
   out=`cat $outf | ${SED} -e 's/^\([^+]\)/| \1/g'`
-  if [ $err = 0 -a -n "${ereg:-}" ]; then
-      H=`echo "$out" | egrep $icase "$ereg"`
-      [ -n "$H" ] && err=1
+  if [ ${err} = 0 -a -n "${ereg:-}" ]; then
+      H=`echo "${out}" | egrep ${icase} "${ereg}"`
+      [ -n "${H}" ] && err=1
   fi
-  [ $err != 0 ] && echo "+++ error: $err"         | tee -a $outf
-  rm -f $outf
+  [ ${err} != 0 ] && echo "+++ error: ${err}"         | tee -a ${outf}
+  rm -f ${outf}
 
-  errMsg=`cat $errf`
-  rm -f $errf
+  errMsg=`cat ${errf}`
+  rm -f ${errf}
   # calculate vars
   asserts=$(($asserts+1))
   errors=$(($errors+$err))
-  time=`echo "$end - $ini" | bc -l`
-  total=`echo "$total + $time" | bc -l`
+  time=`echo "${end} - ${ini}" | bc -l`
+  total=`echo "${total} + ${time}" | bc -l`
 
   # write the junit xml report
   ## failure tag
-  [ $err = 0 ] && failure="" || failure="
+  [ ${err} = 0 ] && failure="" || failure="
       <failure type=\"ScriptError\" message=\"Script Error\">
       <![CDATA[
-      $errMsg
+      ${errMsg}
       ]]>
       </failure>
   "
   ## testcase tag
-  content="$content
-    <testcase assertions=\"1\" name=\"$name\" time=\"$time\" classname=\"$class\">
-    $failure
+  content="${content}
+    <testcase assertions=\"1\" name=\"${name}\" time=\"${time}\" classname=\"${class}\">
+    ${failure}
     <system-err>
 <![CDATA[
-$errMsg
+${errMsg}
 ]]>
     </system-err>
     </testcase>
   "
   ## testsuite block
 
-  if [[ -e "$juDIR/junit_$suite.xml" ]]; then
+  if [[ -e "${juDIR}/junit_${suite}.xml" ]]; then
     # file exists. first update the failures count
-    failCount=`${SED} -n "s/.*testsuite.*failures=\"\([0-9]*\)\".*/\1/p" "$juDIR/junit_$suite.xml"`
+    failCount=`${SED} -n "s/.*testsuite.*failures=\"\([0-9]*\)\".*/\1/p" "${juDIR}/junit_${suite}.xml"`
     errors=$(($failCount+$errors))
-    ${SED} -i "0,/failures=\"$failCount\"/ s/failures=\"$failCount\"/failures=\"$errors\"/" "$juDIR/junit_$suite.xml"
-    ${SED} -i "0,/errors=\"$failCount\"/ s/errors=\"$failCount\"/errors=\"$errors\"/" "$juDIR/junit_$suite.xml"
+    ${SED} -i "0,/failures=\"${failCount}\"/ s/failures=\"${failCount}\"/failures=\"${errors}\"/" "${juDIR}/junit_${suite}.xml"
+    ${SED} -i "0,/errors=\"${failCount}\"/ s/errors=\"${failCount}\"/errors=\"${errors}\"/" "${juDIR}/junit_${suite}.xml"
 
     # file exists. Need to append to it. If we remove the testsuite end tag, we can just add it in after.
-    ${SED} -i "s^</testsuite>^^g" $juDIR/junit_$suite.xml ## remove testSuite so we can add it later
-    ${SED} -i "s^</testsuites>^^g" $juDIR/junit_$suite.xml
+    ${SED} -i "s^</testsuite>^^g" ${juDIR}/junit_${suite}.xml ## remove testSuite so we can add it later
+    ${SED} -i "s^</testsuites>^^g" ${juDIR}/junit_${suite}.xml
     cat <<EOF >> "$juDIR/junit_$suite.xml"
-     $content
+     ${content:-}
     </testsuite>
 </testsuites>
 EOF
 
   else
     # no file exists. Adding a new file
-    cat <<EOF > "$juDIR/junit_$suite.xml"
+    cat <<EOF > "${juDIR}/junit_${suite}.xml"
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-    <testsuite failures="$errors" assertions="$assertions" name="$suite" tests="1" errors="$errors" time="$total">
-    $content
+    <testsuite failures="${errors}" assertions="${assertions:-}" name="${suite}" tests="1" errors="${errors}" time="${total}">
+    ${content:-}
     </testsuite>
 </testsuites>
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the following error in the verify job log:
```
W0126 21:47:20.783] hack/make-rules/../../third_party/forked/shell2junit/sh2ju.sh: line 176: assertions: unbound variable
```

Also adds myself as an OWNER to this little forked mess. If I break it, I bought it lol.

**Release note**:
```release-note
NONE
```

/assign ixdy stevekuznetsov