### PR TITLE
[e2e ingress-gce] Add test for pre-shared certificate

### DIFF
--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pre-shared-cert
+  # Below annotation will be added upon test:
+  # annotations:
+  #  ingress.gcp.kubernetes.io/pre-shared-cert: "test-pre-shared-cert"
+spec:
+  rules:
+  - host: test.ingress.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: echoheaders-https
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: echoheaders-https
+    spec:
+      containers:
+      - name: echoheaders-https
+        image: gcr.io/google_containers/echoserver:1.6
+        ports:
+        - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheaders-https
+  labels:
+    app: echoheaders-https
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders-https

--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -94,8 +94,8 @@ func (t *IngressUpgradeTest) Setup(f *framework.Framework) {
 	// Create a working basic Ingress
 	By(fmt.Sprintf("allocated static ip %v: %v through the GCE cloud provider", t.ipName, t.ip))
 	jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "static-ip-2"), ns.Name, map[string]string{
-		"kubernetes.io/ingress.global-static-ip-name": t.ipName,
-		"kubernetes.io/ingress.allow-http":            "false",
+		framework.IngressStaticIPKey:  t.ipName,
+		framework.IngressAllowHTTPKey: "false",
 	}, map[string]string{})
 	t.jig.AddHTTPS("tls-secret", "ingress.test.com")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an e2e test for the pre-shared certificate feature (`ingress.gcp.kubernetes.io/pre-shared-cert`). Also made some changes to ingress_util.go mostly for certificate generation and polling on ingress.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @rramkumar1 @nicksardo 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
