### PR TITLE
Fix pod security policy capability test.

### DIFF
--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -235,10 +235,10 @@ func testPrivilegedPods(f *framework.Framework, tester func(pod *v1.Pod)) {
 		tester(unconfined)
 	})
 
-	By("Running a CAP_SYS_ADMIN pod", func() {
+	By("Running a SYS_ADMIN pod", func() {
 		sysadmin := restrictedPod(f, "sysadmin")
 		sysadmin.Spec.Containers[0].SecurityContext.Capabilities = &v1.Capabilities{
-			Add: []v1.Capability{"CAP_SYS_ADMIN"},
+			Add: []v1.Capability{"SYS_ADMIN"},
 		}
 		sysadmin.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation = nil
 		tester(sysadmin)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/58901.

In our document, we explicitly say:
```
The following fields take a list of capabilities, specified as the capability name in ALL_CAPS without the CAP_ prefix.
```
https://kubernetes.io/docs/concepts/policy/pod-security-policy/

@kubernetes/sig-node-pr-reviews 

**Release note**:
```release-note
none
```