### PR TITLE
fix webhook admission README

### DIFF
--- a/test/images/webhook/README.md
+++ b/test/images/webhook/README.md
@@ -20,12 +20,6 @@ Please enable the admission webhook feature
 make build
 ```
 
-## Deploy the code
-
-```bash
-make deploy-only 
-```
-
 The Makefile assumes your cluster is created by the
 [hack/local-up-cluster.sh](https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh).
 Please modify the Makefile accordingly if your cluster is created differently.


### PR DESCRIPTION
There is no target `deploy-only` in the Makefile
**Release note**:

```release-note
NONE
```
