### PR TITLE
Add timeout option for docker's exec operation

### DIFF
--- a/pkg/kubelet/dockershim/exec.go
+++ b/pkg/kubelet/dockershim/exec.go
@@ -102,7 +102,7 @@ func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container 
 		RawTerminal:  tty,
 		ExecStarted:  execStarted,
 	}
-	err = client.StartExec(execObj.ID, startOpts, streamOpts)
+	err = client.StartExec(execObj.ID, startOpts, streamOpts, timeout)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/dockershim/libdocker/client.go
+++ b/pkg/kubelet/dockershim/libdocker/client.go
@@ -65,7 +65,7 @@ type Interface interface {
 	Version() (*dockertypes.Version, error)
 	Info() (*dockertypes.Info, error)
 	CreateExec(string, dockertypes.ExecConfig) (*dockertypes.IDResponse, error)
-	StartExec(string, dockertypes.ExecStartCheck, StreamOptions) error
+	StartExec(string, dockertypes.ExecStartCheck, StreamOptions, time.Duration) error
 	InspectExec(id string) (*dockertypes.ContainerExecInspect, error)
 	AttachToContainer(string, dockertypes.ContainerAttachOptions, StreamOptions) error
 	ResizeContainerTTY(id string, height, width uint) error

--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -736,7 +736,7 @@ func (f *FakeDockerClient) CreateExec(id string, opts dockertypes.ExecConfig) (*
 	return &dockertypes.IDResponse{ID: "12345678"}, nil
 }
 
-func (f *FakeDockerClient) StartExec(startExec string, opts dockertypes.ExecStartCheck, sopts StreamOptions) error {
+func (f *FakeDockerClient) StartExec(startExec string, opts dockertypes.ExecStartCheck, sopts StreamOptions, timeout time.Duration) error {
 	f.Lock()
 	defer f.Unlock()
 	f.appendCalled(calledDetail{name: "start_exec"})

--- a/pkg/kubelet/dockershim/libdocker/instrumented_client.go
+++ b/pkg/kubelet/dockershim/libdocker/instrumented_client.go
@@ -208,11 +208,11 @@ func (in instrumentedInterface) CreateExec(id string, opts dockertypes.ExecConfi
 	return out, err
 }
 
-func (in instrumentedInterface) StartExec(startExec string, opts dockertypes.ExecStartCheck, sopts StreamOptions) error {
+func (in instrumentedInterface) StartExec(startExec string, opts dockertypes.ExecStartCheck, sopts StreamOptions, timeout time.Duration) error {
 	const operation = "start_exec"
 	defer recordOperation(operation, time.Now())
 
-	err := in.client.StartExec(startExec, opts, sopts)
+	err := in.client.StartExec(startExec, opts, sopts, timeout)
 	recordError(operation, err)
 	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, docker's exec operation never timeout. This patch introduces a new `ExecOptions` that contains a timeout value into the parameters of `libdocker.StartExec`. When a positive timeout is passed and the exec operation timeouts, the `StartExec` function returns the `libdocker.OperationTimeout` error.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add timeout option into libdocker.StartExec
```