### PR TITLE
Return useful error when failing to upgrade to spdy

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -299,7 +299,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 		} else {
 			// TODO: I don't belong here, I should be abstracted from this class
 			if obj, _, err := statusCodecs.UniversalDecoder().Decode(responseErrorBytes, nil, &metav1.Status{}); err == nil {
-				if status, ok := obj.(*metav1.Status); ok {
+				if status, ok := obj.(*metav1.Status); ok && *status != (metav1.Status{}) {
 					return nil, &apierrors.StatusError{ErrStatus: *status}
 				}
 			}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -137,7 +137,7 @@ func (pf *PortForwarder) ForwardPorts() error {
 	var err error
 	pf.streamConn, _, err = pf.dialer.Dial(PortForwardProtocolV1Name)
 	if err != nil {
-		return fmt.Errorf("error upgrading connection: %s", err)
+		return fmt.Errorf("error upgrading connection: %v", err)
 	}
 	defer pf.streamConn.Close()
 


### PR DESCRIPTION
For example, if one tries to connect to a resource for which they don't have
permissions the resp.Body will contain something like:

User "eparis@redhat.com" cannot post path "/api/v1/namespaces/NAMESPACE/pods/POD/portforward"

Which will apparently decode into a completely empty metav1.Status. We then
use that completely empty metav1.Status in the error return and all information
back to the caller is lost. In this case only use the decoded status if it
is not equal to the zero value status. So now we fall through and return the
actual rejected body to the caller and they can figure out what went wrong.

```release-note
NONE
```
