### PR TITLE
using unused variable

### DIFF
--- a/cmd/clicheck/check_cli_conventions.go
+++ b/cmd/clicheck/check_cli_conventions.go
@@ -27,14 +27,14 @@ import (
 )
 
 var (
-	skip = []string{}
+	skipCmd = []string{}
 )
 
 func main() {
 	var errorCount int
 
 	kubectl := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, ioutil.Discard, ioutil.Discard)
-	errors := cmdsanity.RunCmdChecks(kubectl, cmdsanity.AllCmdChecks, []string{})
+	errors := cmdsanity.RunCmdChecks(kubectl, cmdsanity.AllCmdChecks, skipCmd)
 	for _, err := range errors {
 		errorCount++
 		fmt.Fprintf(os.Stderr, "     %d. %s\n", errorCount, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The array variable `skip` unused, we should use it in function `RunCmdChecks()`.
In order to make it more clear, we rename `ship` to `skipCmd`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
