### PR TITLE
Remove config parameters for prometheus-to-sd.

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -55,8 +55,7 @@ spec:
         image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
-          - --api-override={{ prometheus_to_sd_endpoint }}
+          - --stackdriver-prefix=container.googleapis.com/internal/addons
           - --source=event_exporter:http://localhost:80?whitelisted=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
           - --pod-id=$(POD_NAME)
           - --namespace-id=$(POD_NAMESPACE)

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -84,8 +84,7 @@ spec:
         image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
-          - --api-override={{ prometheus_to_sd_endpoint }}
+          - --stackdriver-prefix=container.googleapis.com/internal/addons
           - --source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
           - --pod-id=$(POD_NAME)
           - --namespace-id=$(POD_NAMESPACE)


### PR DESCRIPTION
Those configuration parameters can't work in 1.7+, because they have been introduced only in 1.8.

```release-note
Fix a broken configuration of prometheus-to-sd for fluentd and event-exporter.
```
