### PR TITLE
fix kubectl fails when having duplicate entry in KUBECONFIG

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -159,6 +159,9 @@ func ModifyConfig(configAccess ConfigAccess, newConfig clientcmdapi.Config, rela
 	// to avoid deadlock (note: this can fail w/ symlinks, but... come on).
 	sort.Strings(possibleSources)
 	for _, filename := range possibleSources {
+		if _, err := os.Stat(lockName(filename)); err == nil {
+			continue
+		}
 		if err := lockFile(filename); err != nil {
 			return err
 		}


### PR DESCRIPTION

**What this PR does / why we need it**:

kubectl fails with ambiguous error when having duplicate entry in KUBECONFIG.

Add lock file check to avoid this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58957

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
