### PR TITLE
remove dead testing code

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -35,11 +35,9 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/storage/etcd/testing:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/utils.go
@@ -285,32 +285,6 @@ func NewEtcdTestClientServer(t *testing.T) *EtcdTestServer {
 	return server
 }
 
-// NewUnsecuredEtcdTestClientServer DEPRECATED creates a new client and server for testing
-func NewUnsecuredEtcdTestClientServer(t *testing.T) *EtcdTestServer {
-	server := configureTestCluster(t, "foo", false)
-	err := server.launch(t)
-	if err != nil {
-		t.Fatalf("Failed to start etcd server error=%v", err)
-		return nil
-	}
-	cfg := etcd.Config{
-		Endpoints: server.ClientURLs.StringSlice(),
-		Transport: newHttpTransport(t, server.CertFile, server.KeyFile, server.CAFile),
-	}
-	server.Client, err = etcd.New(cfg)
-	if err != nil {
-		t.Errorf("Unexpected error in NewUnsecuredEtcdTestClientServer (%v)", err)
-		server.Terminate(t)
-		return nil
-	}
-	if err := server.waitUntilUp(); err != nil {
-		t.Errorf("Unexpected error in waitUntilUp (%v)", err)
-		server.Terminate(t)
-		return nil
-	}
-	return server
-}
-
 // NewEtcd3TestClientServer creates a new client and server for testing
 func NewUnsecuredEtcd3TestClientServer(t *testing.T) (*EtcdTestServer, *storagebackend.Config) {
 	server := &EtcdTestServer{


### PR DESCRIPTION
Removes a deprecated etcd server init function and stops starting an etc server during unit tests that we never use.