### PR TITLE
remove --tls-ca-file which had no effect

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -554,7 +554,6 @@ function start_apiserver {
       --secure-port="${API_SECURE_PORT}" \
       --tls-cert-file="${CERT_DIR}/serving-kube-apiserver.crt" \
       --tls-private-key-file="${CERT_DIR}/serving-kube-apiserver.key" \
-      --tls-ca-file="${CERT_DIR}/server-ca.crt" \
       --insecure-bind-address="${API_HOST_IP}" \
       --insecure-port="${API_PORT}" \
       --storage-backend=${STORAGE_BACKEND} \

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -216,10 +216,6 @@ type SecureServingInfo struct {
 	// allowed to be in SNICerts.
 	Cert *tls.Certificate
 
-	// CACert is an optional certificate authority used for the loopback connection of the Admission controllers.
-	// If this is nil, the certificate authority is extracted from Cert or a matching SNI certificate.
-	CACert *tls.Certificate
-
 	// SNICerts are the TLS certificates by name used for SNI.
 	SNICerts map[string]*tls.Certificate
 


### PR DESCRIPTION
The flag has had no effect since we started configuring loopback based on the direct cert.  I've marked it deprecated this release so we don't break launch scripts right away, but its coming.  I think we should remove it in 1.11.


```release-note-action-required
kube-apiserver flag --tls-ca-file has had no effect for some time.  It is now deprecated and slated for removal in 1.11.  If you are specifying this flag, you must remove it from your launch config before ugprading to 1.11.
```