### PR TITLE
Fix pod sandbox privilege.

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -302,7 +302,7 @@ func GetContainerSpec(pod *v1.Pod, containerName string) *v1.Container {
 
 // HasPrivilegedContainer returns true if any of the containers in the pod are privileged.
 func HasPrivilegedContainer(pod *v1.Pod) bool {
-	for _, c := range pod.Spec.Containers {
+	for _, c := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 		if c.SecurityContext != nil &&
 			c.SecurityContext.Privileged != nil &&
 			*c.SecurityContext.Privileged {

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -254,6 +254,20 @@ func TestHasPrivilegedContainer(t *testing.T) {
 			t.Errorf("%s expected %t but got %t", k, v.expected, actual)
 		}
 	}
+	// Test init containers as well.
+	for k, v := range tests {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				InitContainers: []v1.Container{
+					{SecurityContext: v.securityContext},
+				},
+			},
+		}
+		actual := HasPrivilegedContainer(pod)
+		if actual != v.expected {
+			t.Errorf("%s expected %t but got %t", k, v.expected, actual)
+		}
+	}
 }
 
 func TestMakePortMappings(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/58979.

In cri-containerd, we start enforcing that a privileged container can't be created in privileged sandbox in https://github.com/containerd/cri-containerd/pull/577.

However, after that the e2e-gci-device-plugin-gpu test starts failing. https://k8s-testgrid.appspot.com/sig-node-containerd#e2e-gci-device-plugin-gpu
```
I0128 06:49:09.117] Jan 28 06:49:09.086: INFO: At 2018-01-28 06:41:10 +0000 UTC - event for nvidia-driver-installer-5kkrz: {kubelet bootstrap-e2e-minion-group-7s2v} Failed: (combined from similar events): Error: failed to generate container "cfb9f4f01fc2685db6469d3f6348077b94d4aa577e2e6345bf890f8871ec80dd" spec: no privileged container allowed in sandbox
```

The reason is that kubelet doesn't check init container when setting sandbox privilege.

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none.
```
@kubernetes/sig-node-bugs @yujuhong @feiskyer @mrunalp 