### PR TITLE
Removal of KubeletConfigFile feature gate: Step 3 (final)

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -37,11 +37,6 @@ const (
 	// alpha: v1.4
 	DynamicKubeletConfig utilfeature.Feature = "DynamicKubeletConfig"
 
-	// owner: @mtaufen
-	// alpha: v1.8
-	// This gate is now a no-op. It will be removed shortly.
-	KubeletConfigFile utilfeature.Feature = "KubeletConfigFile"
-
 	// owner: @pweil-
 	// alpha: v1.5
 	//
@@ -242,7 +237,6 @@ func init() {
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
 	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
-	KubeletConfigFile:                           {Default: false, PreRelease: utilfeature.Alpha}, // KubeletConfigFile is now a no-op gate on the path to removal.
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
 	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
 	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
This PR completes the work started in
https://github.com/kubernetes/kubernetes/pull/58760
by completely removing the KubeletConfigFile feature gate.

We stopped setting the gate in test-infra in
https://github.com/kubernetes/test-infra/pull/6490.

```release-note
The alpha KubeletConfigFile feature gate has been removed, because it was redundant with the Kubelet's --config flag. It is no longer necessary to set this gate to use the flag. The --config flag is still considered alpha.
```
