### PR TITLE
fix apply --force w/ invalid resource

### DIFF
--- a/hack/testdata/deployment-label-change3.yaml
+++ b/hack/testdata/deployment-label-change3.yaml
@@ -8,12 +8,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: nginx2
+      name: invalid
   replicas: 3
   template:
     metadata:
       labels:
-        name: nginx2
+        name: nginx3
     spec:
       containers:
       - name: nginx

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -675,13 +675,13 @@ func (p *patcher) patch(current runtime.Object, modified []byte, source, namespa
 		}
 		patchBytes, patchObject, err = p.patchSimple(current, modified, source, namespace, name, errOut)
 	}
-	if err != nil && p.force {
-		patchBytes, patchObject, err = p.deleteAndCreate(modified, namespace, name)
+	if err != nil && errors.IsConflict(err) && p.force {
+		patchBytes, patchObject, err = p.deleteAndCreate(current, modified, namespace, name)
 	}
 	return patchBytes, patchObject, err
 }
 
-func (p *patcher) deleteAndCreate(modified []byte, namespace, name string) ([]byte, runtime.Object, error) {
+func (p *patcher) deleteAndCreate(original runtime.Object, modified []byte, namespace, name string) ([]byte, runtime.Object, error) {
 	err := p.delete(namespace, name)
 	if err != nil {
 		return modified, nil, err
@@ -700,5 +700,15 @@ func (p *patcher) deleteAndCreate(modified []byte, namespace, name string) ([]by
 		return modified, nil, err
 	}
 	createdObject, err := p.helper.Create(namespace, true, versionedObject)
+	if err != nil {
+		// restore the original object if we fail to create the new one
+		// but still propagate and advertise error to user
+		recreated, recreateErr := p.helper.Create(namespace, true, original)
+		if recreateErr != nil {
+			err = fmt.Errorf("An error ocurred force-replacing the existing object with the newly provided one:\n\n%v.\n\nAdditionally, an error ocurred attempting to restore the original object:\n\n%v\n", err, recreateErr)
+		} else {
+			createdObject = recreated
+		}
+	}
 	return modified, createdObject, err
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/58984

- First commit: Fixes cases where `--force` is provided with `kubectl apply`, with an object that is BOTH invalid and will cause a conflict error
- Second commit: Fixes cases where `--force` is provided with `kubectl apply`, with an invalid object 

Justification for the first commit here: https://bugzilla.redhat.com/show_bug.cgi?id=1539529#c3

**Release note**:
```release-note
NONE
```

cc @ironcladlou 