### PR TITLE
Make eviction manager work with CRI container runtime.

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -242,16 +242,3 @@ func (cc *cadvisorClient) getFsInfo(label string) (cadvisorapiv2.FsInfo, error) 
 func (cc *cadvisorClient) WatchEvents(request *events.Request) (*events.EventChannel, error) {
 	return cc.WatchForEvents(request)
 }
-
-// HasDedicatedImageFs returns true if the imagefs has a dedicated device.
-func (cc *cadvisorClient) HasDedicatedImageFs() (bool, error) {
-	imageFsInfo, err := cc.ImagesFsInfo()
-	if err != nil {
-		return false, err
-	}
-	rootFsInfo, err := cc.RootFsInfo()
-	if err != nil {
-		return false, err
-	}
-	return imageFsInfo.Device != rootFsInfo.Device, nil
-}

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -77,10 +77,6 @@ func (cu *cadvisorUnsupported) WatchEvents(request *events.Request) (*events.Eve
 	return nil, unsupportedErr
 }
 
-func (cu *cadvisorUnsupported) HasDedicatedImageFs() (bool, error) {
-	return false, unsupportedErr
-}
-
 func (c *cadvisorUnsupported) GetFsInfoByFsUUID(uuid string) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -77,10 +77,6 @@ func (cu *cadvisorClient) WatchEvents(request *events.Request) (*events.EventCha
 	return &events.EventChannel{}, nil
 }
 
-func (cu *cadvisorClient) HasDedicatedImageFs() (bool, error) {
-	return false, nil
-}
-
 func (c *cadvisorClient) GetFsInfoByFsUUID(uuid string) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }

--- a/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
@@ -76,10 +76,6 @@ func (c *Fake) WatchEvents(request *events.Request) (*events.EventChannel, error
 	return new(events.EventChannel), nil
 }
 
-func (c *Fake) HasDedicatedImageFs() (bool, error) {
-	return false, nil
-}
-
 func (c *Fake) GetFsInfoByFsUUID(uuid string) (cadvisorapiv2.FsInfo, error) {
 	return cadvisorapiv2.FsInfo{}, nil
 }

--- a/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_mock.go
@@ -84,11 +84,6 @@ func (c *Mock) WatchEvents(request *events.Request) (*events.EventChannel, error
 	return args.Get(0).(*events.EventChannel), args.Error(1)
 }
 
-func (c *Mock) HasDedicatedImageFs() (bool, error) {
-	args := c.Called()
-	return args.Get(0).(bool), args.Error(1)
-}
-
 func (c *Mock) GetFsInfoByFsUUID(uuid string) (cadvisorapiv2.FsInfo, error) {
 	args := c.Called(uuid)
 	return args.Get(0).(cadvisorapiv2.FsInfo), args.Error(1)

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -42,9 +42,6 @@ type Interface interface {
 	// Get events streamed through passedChannel that fit the request.
 	WatchEvents(request *events.Request) (*events.EventChannel, error)
 
-	// HasDedicatedImageFs returns true iff a dedicated image filesystem exists for storing images.
-	HasDedicatedImageFs() (bool, error)
-
 	// GetFsInfoByFsUUID returns the stats of the filesystem with the specified
 	// uuid.
 	GetFsInfoByFsUUID(uuid string) (cadvisorapiv2.FsInfo, error)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1321,7 +1321,7 @@ func (kl *Kubelet) initializeRuntimeDependentModules() {
 		glog.Fatalf("Failed to start cAdvisor %v", err)
 	}
 	// eviction manager must start after cadvisor because it needs to know if the container runtime has a dedicated imagefs
-	kl.evictionManager.Start(kl.cadvisor, kl.GetActivePods, kl.podResourcesAreReclaimed, kl.containerManager, evictionMonitoringPeriod)
+	kl.evictionManager.Start(kl.StatsProvider, kl.GetActivePods, kl.podResourcesAreReclaimed, kl.containerManager, evictionMonitoringPeriod)
 }
 
 // Run starts the kubelet reacting to config updates

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -220,6 +220,16 @@ func (p *cadvisorStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 	}, nil
 }
 
+// ImageFsDevice returns name of the device where the image filesystem locates,
+// e.g. /dev/sda1.
+func (p *cadvisorStatsProvider) ImageFsDevice() (string, error) {
+	imageFsInfo, err := p.cadvisor.ImagesFsInfo()
+	if err != nil {
+		return "", err
+	}
+	return imageFsInfo.Device, nil
+}
+
 // buildPodRef returns a PodReference that identifies the Pod managing cinfo
 func buildPodRef(containerLabels map[string]string) statsapi.PodReference {
 	podName := kubetypes.GetPodName(containerLabels)

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package stats
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -200,6 +201,22 @@ func (p *criStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 	}
 
 	return nil, fmt.Errorf("imageFs information is unavailable")
+}
+
+// ImageFsDevice returns name of the device where the image filesystem locates,
+// e.g. /dev/sda1.
+func (p *criStatsProvider) ImageFsDevice() (string, error) {
+	resp, err := p.imageService.ImageFsInfo()
+	if err != nil {
+		return "", err
+	}
+	for _, fs := range resp {
+		fsInfo := p.getFsInfo(fs.GetStorageId())
+		if fsInfo != nil {
+			return fsInfo.Device, nil
+		}
+	}
+	return "", errors.New("imagefs device is not found")
 }
 
 // getFsInfo returns the information of the filesystem with the specified

--- a/pkg/kubelet/stats/stats_provider.go
+++ b/pkg/kubelet/stats/stats_provider.go
@@ -84,6 +84,7 @@ type StatsProvider struct {
 type containerStatsProvider interface {
 	ListPodStats() ([]statsapi.PodStats, error)
 	ImageFsStats() (*statsapi.FsStats, error)
+	ImageFsDevice() (string, error)
 }
 
 // GetCgroupStats returns the stats of the cgroup with the cgroupName. Note that
@@ -166,4 +167,17 @@ func (p *StatsProvider) GetRawContainerInfo(containerName string, req *cadvisora
 	return map[string]*cadvisorapiv1.ContainerInfo{
 		containerInfo.Name: containerInfo,
 	}, nil
+}
+
+// HasDedicatedImageFs returns true if a dedicated image filesystem exists for storing images.
+func (p *StatsProvider) HasDedicatedImageFs() (bool, error) {
+	device, err := p.containerStatsProvider.ImageFsDevice()
+	if err != nil {
+		return false, err
+	}
+	rootFsInfo, err := p.cadvisor.RootFsInfo()
+	if err != nil {
+		return false, err
+	}
+	return device != rootFsInfo.Device, nil
 }


### PR DESCRIPTION
Previously, eviction manager uses a function `HasDedicatedImageFs` in `pkg/kubelet/cadvisor` to detect whether image fs and root fs are on the same device.

However, it doesn't work with CRI container runtime which provides container/image stats through CRI. Thus all eviction tests for containerd are failing now. https://k8s-testgrid.appspot.com/sig-node-containerd#node-e2e-flaky

This PR makes it work with CRI container runtime.

@kubernetes/sig-node-pr-reviews 
@yujuhong @yguo0905 @feiskyer @mrunalp @abhi @dashpole 
Signed-off-by: Lantao Liu <lantaol@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
