### PR TITLE
Skip rescheduler test.

### DIFF
--- a/test/e2e/scheduling/rescheduler.go
+++ b/test/e2e/scheduling/rescheduler.go
@@ -42,7 +42,7 @@ var _ = SIGDescribe("Rescheduler [Serial]", func() {
 	var totalMillicores int
 
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce", "gke")
+		framework.Skipf("Rescheduler is being deprecated soon in Kubernetes 1.10")
 		ns = f.Namespace.Name
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		nodeCount := len(nodes.Items)


### PR DESCRIPTION
Skip the rescheduler test per discussion https://github.com/kubernetes/kubernetes/issues/59002.

The test `[sig-scheduling] Rescheduler [Serial] should ensure that critical pod is scheduled in case there is no resources available` has failing for a long time. And the serial suite is never green because of it. https://k8s-testgrid.appspot.com/google-gce#gci-gce-serial

@kubernetes/sig-scheduling-misc 
Signed-off-by: Lantao Liu <lantaol@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
