### PR TITLE
Forcing get_node_name to continue searching for a node name.

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -979,31 +979,30 @@ def get_node_name():
     while time.time() < deadline:
         try:
             raw = check_output(cmd)
-            break
         except CalledProcessError:
             hookenv.log('Failed to get node name for node %s.'
                         ' Will retry.' % (gethostname()))
             time.sleep(1)
-    else:
-        msg = 'Failed to get node name for node %s' % gethostname()
-        raise GetNodeNameFailed(msg)
+            continue
 
-    result = json.loads(raw.decode('utf-8'))
-    if 'items' in result:
-        for node in result['items']:
-            if 'status' not in node:
-                continue
-            if 'addresses' not in node['status']:
-                continue
+        result = json.loads(raw.decode('utf-8'))
+        if 'items' in result:
+            for node in result['items']:
+                if 'status' not in node:
+                    continue
+                if 'addresses' not in node['status']:
+                    continue
 
-            # find the hostname
-            for address in node['status']['addresses']:
-                if address['type'] == 'Hostname':
-                    if address['address'] == gethostname():
-                        return node['metadata']['name']
+                # find the hostname
+                for address in node['status']['addresses']:
+                    if address['type'] == 'Hostname':
+                        if address['address'] == gethostname():
+                            return node['metadata']['name']
 
-                    # if we didn't match, just bail to the next node
-                    break
+                        # if we didn't match, just bail to the next node
+                        break
+        time.sleep(1)
+
     msg = 'Failed to get node name for node %s' % gethostname()
     raise GetNodeNameFailed(msg)
 


### PR DESCRIPTION
There was a race condition where the kubelet was restarting and we were querying the api server for this node. In that case, we may get a valid list of nodes that doesn't include our node. This would cause the code to just raise an exception. Now we wait the full timeout before raising the exception.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes a race condition on the get_node_name function inside the kubernetes-worker charm.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a race condition inside kubernetes-worker that would result in a temporary error situation.
```
