### PR TITLE
deprecate insecure http flags and remove already deprecated flags

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -125,7 +125,6 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 	s.GenericServerRunOptions.AddUniversalFlags(fs)
 	s.Etcd.AddFlags(fs)
 	s.SecureServing.AddFlags(fs)
-	s.SecureServing.AddDeprecatedFlags(fs)
 	s.InsecureServing.AddFlags(fs)
 	s.InsecureServing.AddDeprecatedFlags(fs)
 	s.Audit.AddFlags(fs)

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package options contains flags and options for initializing an apiserver
+// Package options contains flags and options for initializing kube-apiserver
 package options
 
 import (
@@ -31,7 +31,7 @@ import (
 	kubeserver "k8s.io/kubernetes/pkg/kubeapiserver/server"
 )
 
-// NewSecureServingOptions gives default values for the kube-apiserver and federation-apiserver which are not the options wanted by
+// NewSecureServingOptions gives default values for the kube-apiserver which are not the options wanted by
 // "normal" API servers running on the platform
 func NewSecureServingOptions() *genericoptions.SecureServingOptions {
 	return &genericoptions.SecureServingOptions{
@@ -56,8 +56,8 @@ func DefaultAdvertiseAddress(s *genericoptions.ServerRunOptions, insecure *Insec
 	if s.AdvertiseAddress == nil || s.AdvertiseAddress.IsUnspecified() {
 		hostIP, err := insecure.DefaultExternalAddress()
 		if err != nil {
-			return fmt.Errorf("Unable to find suitable network address.error='%v'. "+
-				"Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this.", err)
+			return fmt.Errorf("unable to find suitable network address.error='%v'. "+
+				"Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this", err)
 		}
 		s.AdvertiseAddress = hostIP
 	}
@@ -85,7 +85,7 @@ func (s InsecureServingOptions) Validate(portArg string) []error {
 	errors := []error{}
 
 	if s.BindPort < 0 || s.BindPort > 65535 {
-		errors = append(errors, fmt.Errorf("--insecure-port %v must be between 0 and 65535, inclusive. 0 for turning off insecure (HTTP) port.", s.BindPort))
+		errors = append(errors, fmt.Errorf("--insecure-port %v must be between 0 and 65535, inclusive. 0 for turning off insecure (HTTP) port", s.BindPort))
 	}
 
 	return errors
@@ -98,14 +98,17 @@ func (s *InsecureServingOptions) DefaultExternalAddress() (net.IP, error) {
 func (s *InsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IPVar(&s.BindAddress, "insecure-bind-address", s.BindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all interfaces).")
+	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in a future version.")
 
 	fs.IntVar(&s.BindPort, "insecure-port", s.BindPort, ""+
 		"The port on which to serve unsecured, unauthenticated access. It is assumed "+
 		"that firewall rules are set up such that this port is not reachable from outside of "+
 		"the cluster and that port 443 on the cluster's public address is proxied to this "+
-		"port. This is performed by nginx in the default setup. Set to zero to disable")
+		"port. This is performed by nginx in the default setup. Set to zero to disable.")
+	fs.MarkDeprecated("insecure-port", "This flag will be removed in a future version.")
 }
 
+// TODO: remove it until kops stop using `--address`
 func (s *InsecureServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {
 	fs.IPVar(&s.BindAddress, "address", s.BindAddress,
 		"DEPRECATED: see --insecure-bind-address instead.")

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -98,7 +98,7 @@ func (s *SecureServingOptions) Validate() []error {
 	errors := []error{}
 
 	if s.BindPort < 0 || s.BindPort > 65535 {
-		errors = append(errors, fmt.Errorf("--secure-port %v must be between 0 and 65535, inclusive. 0 for turning off secure port.", s.BindPort))
+		errors = append(errors, fmt.Errorf("--secure-port %v must be between 0 and 65535, inclusive. 0 for turning off secure port", s.BindPort))
 	}
 
 	return errors
@@ -153,12 +153,6 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.String("tls-ca-file", "", "This flag has no effect.")
 	fs.MarkDeprecated("tls-ca-file", "This flag has no effect.")
 
-}
-
-func (s *SecureServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {
-	fs.IPVar(&s.BindAddress, "public-address-override", s.BindAddress,
-		"DEPRECATED: see --bind-address instead.")
-	fs.MarkDeprecated("public-address-override", "see --bind-address instead.")
 }
 
 // ApplyTo fills up serving information in the server configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
1. deprecate `insecure-bind-address` `insecure-port` flags
2. remove flags `public-address-override` `address` `port` They are mark deprecated in #36604, which is more than a year ago.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58951 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate insecure flags `--insecure-bind-address`, `--insecure-port` and remove  `--public-address-override`.
```
