### PR TITLE
[GCE] Set --kubelet-preferred-address-types on apiserver by default

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1527,6 +1527,7 @@ function start-kube-apiserver {
   params+=" --secure-port=443"
   params+=" --tls-cert-file=${APISERVER_SERVER_CERT_PATH}"
   params+=" --tls-private-key-file=${APISERVER_SERVER_KEY_PATH}"
+  params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
   if [[ -s "${REQUESTHEADER_CA_CERT_PATH:-}" ]]; then
     params+=" --requestheader-client-ca-file=${REQUESTHEADER_CA_CERT_PATH}"
     params+=" --requestheader-allowed-names=aggregator"
@@ -1686,8 +1687,6 @@ function start-kube-apiserver {
       params+=" --advertise-address=${vm_external_ip}"
       params+=" --ssh-user=${PROXY_SSH_USER}"
       params+=" --ssh-keyfile=/etc/srv/sshproxy/.sshkeyfile"
-    else
-      params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
     fi
   elif [ -n "${MASTER_ADVERTISE_ADDRESS:-}" ]; then
     params="${params} --advertise-address=${MASTER_ADVERTISE_ADDRESS}"


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently set the default value of `PreferredAddressTypes` in `KubeletConfig` for apiserver as below:
https://github.com/kubernetes/kubernetes/blob/2f403b7ad18a179514f1de77e29f1a2549ef030a/cmd/kube-apiserver/app/options/options.go#L99-L110

It denotes the ways (order matters) we prefer to use for kubelet connections, in which `NodeHostName` is listed as the most preferred one. However, it is not safe to assume `NodeHostName` will always be resolvable. This PR makes `InternalIP` as the most preferred one instead.

Note that this doesn't affect how the ssh tunnel is setup, which is configured explicitly elsewhere:
https://github.com/kubernetes/kubernetes/blob/d0d1e1dcc473d75c5dae6d4710ac67f4f8ba44c6/pkg/master/master.go#L442-L445
https://github.com/kubernetes/kubernetes/blob/d0d1e1dcc473d75c5dae6d4710ac67f4f8ba44c6/pkg/master/master.go#L388-L389

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @bowei @cjcullen 
cc @dnardo in case I made terrible mistakes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[GCE] Apiserver uses `InternalIP` as the most preferred kubelet address type by default.
```
