### PR TITLE
Add UT for kuberuntime-container to cover more situations

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -197,6 +197,31 @@ func TestToKubeContainerStatus(t *testing.T) {
 				StartedAt: time.Unix(0, startedAt),
 			},
 		},
+		"container with annotations and labels": {
+			input: &runtimeapi.ContainerStatus{
+				Id:        cid.ID,
+				Metadata:  meta,
+				Image:     imageSpec,
+				State:     runtimeapi.ContainerState_CONTAINER_RUNNING,
+				CreatedAt: createdAt,
+				StartedAt: startedAt,
+				Annotations: map[string]string{
+					"io.kubernetes.container.restartCount": "3",
+					"io.kubernetes.container.hash":         "666",
+				},
+				Labels: map[string]string{"io.kubernetes.container.name": "cname"},
+			},
+			expected: &kubecontainer.ContainerStatus{
+				Name:         "cname",
+				ID:           *cid,
+				Image:        imageSpec.Image,
+				RestartCount: 3,
+				Hash:         0x666,
+				State:        kubecontainer.ContainerStateRunning,
+				CreatedAt:    time.Unix(0, createdAt),
+				StartedAt:    time.Unix(0, startedAt),
+			},
+		},
 	} {
 		actual := toKubeContainerStatus(test.input, cid.Type)
 		assert.Equal(t, test.expected, actual, desc)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add UT for kuberuntime-container to cover more situations, such as if "**Annotations**" and "**Labels**" are present in "ContainerStatus", container "**Name**" and "**RestartCount**" should be picked out accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
