### PR TITLE
Add UT case to cover the func legacyLogSymlink  in legacy.go

### DIFF
--- a/pkg/kubelet/kuberuntime/legacy_test.go
+++ b/pkg/kubelet/kuberuntime/legacy_test.go
@@ -45,3 +45,14 @@ func TestLogSymLink(t *testing.T) {
 	expectedPath := path.Join(containerLogsDir, fmt.Sprintf("%s_%s-%s", podFullName, containerName, dockerId)[:251]+".log")
 	as.Equal(expectedPath, logSymlink(containerLogsDir, podFullName, containerName, dockerId))
 }
+
+func TestLegacyLogSymLink(t *testing.T) {
+	as := assert.New(t)
+	containerID := randStringBytes(80)
+	containerName := randStringBytes(70)
+	podName := randStringBytes(128)
+	podNamespace := randStringBytes(10)
+	// The file name cannot exceed 255 characters. Since .log suffix is required, the prefix cannot exceed 251 characters.
+	expectedPath := path.Join(legacyContainerLogsDir, fmt.Sprintf("%s_%s_%s-%s", podName, podNamespace, containerName, containerID)[:251]+".log")
+	as.Equal(expectedPath, legacyLogSymlink(containerID, containerName, podName, podNamespace))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add UT case to cover the func legacyLogSymlink in legacy.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
