### PR TITLE
Fix format error for sioUtil-UT

### DIFF
--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -159,11 +159,11 @@ func TestUtilSaveConfig(t *testing.T) {
 		confKey.sslEnabled: "false",
 	}
 	if err := saveConfig(config, data); err != nil {
-		t.Fatal("failed while saving data", err)
+		t.Fatalf("failed while saving data: %v", err)
 	}
 	file, err := os.Open(config)
 	if err != nil {
-		t.Fatal("failed to open conf file: ", file)
+		t.Fatalf("failed to open conf file %s: %v", config, err)
 	}
 	defer file.Close()
 	dataRcvd := map[string]string{}


### PR DESCRIPTION
**What this PR does / why we need it**:
1、Use t.Fatalf instead of t.Fatal when format is needed;
2、Before my change, when open file failed you will get such return "failed to open conf file: %!(EXTRA os.file=&{***})". After my change, when open file failed you will get such return "Failed to open conf file: /dir/filename",which is more human readable .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 "NONE"
```
