### PR TITLE
Add safe way to prevent status from touching objectmeta

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/generic"
 )
 
 type statusStrategy struct {
@@ -48,12 +49,8 @@ func (a statusStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old
 		delete(newCustomResource, "spec")
 	}
 
-	newCustomResourceObject.SetAnnotations(oldCustomResourceObject.GetAnnotations())
-	newCustomResourceObject.SetFinalizers(oldCustomResourceObject.GetFinalizers())
-	newCustomResourceObject.SetGeneration(oldCustomResourceObject.GetGeneration())
-	newCustomResourceObject.SetLabels(oldCustomResourceObject.GetLabels())
-	newCustomResourceObject.SetOwnerReferences(oldCustomResourceObject.GetOwnerReferences())
-	newCustomResourceObject.SetSelfLink(oldCustomResourceObject.GetSelfLink())
+	// Status updates should update only status, not ObjectMeta.
+	generic.ResetObjectMetaForStatus(newCustomResourceObject, oldCustomResourceObject)
 }
 
 // ValidateUpdate is the default update validation for an end user updating status.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -134,14 +134,14 @@ func (statusStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old r
 	newObj := obj.(*apiextensions.CustomResourceDefinition)
 	oldObj := old.(*apiextensions.CustomResourceDefinition)
 	newObj.Spec = oldObj.Spec
+	newFinalizer := newObj.Finalizers
 
-	// Status updates are for only for updating status, not objectmeta.
-	// TODO: Update after ResetObjectMetaForStatus is added to meta/v1.
-	newObj.Labels = oldObj.Labels
-	newObj.Annotations = oldObj.Annotations
-	newObj.OwnerReferences = oldObj.OwnerReferences
-	newObj.Generation = oldObj.Generation
-	newObj.SelfLink = oldObj.SelfLink
+	// Status updates should update only status, not ObjectMeta.
+	generic.ResetObjectMetaForStatus(newObj, oldObj)
+
+	// allow updating finalizers since we need to update
+	// CustomResourceCleanupFinalizer while deleting CRDs.
+	newObj.Finalizers = newFinalizer
 }
 
 func (statusStrategy) AllowCreateOnUpdate() bool {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
@@ -142,7 +142,7 @@ func (gv *GroupVersion) UnmarshalJSON(value []byte) error {
 	return gv.unmarshal(value)
 }
 
-// UnmarshalTEXT implements the Ugorji's encoding.TextUnmarshaler interface.
+// UnmarshalText implements the Ugorji's encoding.TextUnmarshaler interface.
 func (gv *GroupVersion) UnmarshalText(value []byte) error {
 	return gv.unmarshal(value)
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -42,4 +43,16 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/testing:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["matcher_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher.go
@@ -34,7 +34,7 @@ func ObjectMetaFieldsSet(objectMeta *metav1.ObjectMeta, hasNamespaceField bool) 
 	}
 }
 
-// AdObjectMetaField add fields that represent the ObjectMeta to source.
+// AddObjectMetaFieldsSet adds fields that represent the ObjectMeta to source.
 func AddObjectMetaFieldsSet(source fields.Set, objectMeta *metav1.ObjectMeta, hasNamespaceField bool) fields.Set {
 	source["metadata.name"] = objectMeta.Name
 	if hasNamespaceField {
@@ -49,4 +49,15 @@ func MergeFieldsSets(source fields.Set, fragment fields.Set) fields.Set {
 		source[k] = value
 	}
 	return source
+}
+
+// ResetObjectMetaForStatus forces the meta fields for a status update to match the meta fields
+// for a pre-existing object. Status updates should only update status, not ObjectMeta.
+func ResetObjectMetaForStatus(meta, existingMeta metav1.Object) {
+	meta.SetGeneration(existingMeta.GetGeneration())
+	meta.SetSelfLink(existingMeta.GetSelfLink())
+	meta.SetLabels(existingMeta.GetLabels())
+	meta.SetAnnotations(existingMeta.GetAnnotations())
+	meta.SetFinalizers(existingMeta.GetFinalizers())
+	meta.SetOwnerReferences(existingMeta.GetOwnerReferences())
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/matcher_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"reflect"
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestResetObjectMetaForStatus(t *testing.T) {
+	meta := &metav1.ObjectMeta{}
+	existingMeta := &metav1.ObjectMeta{}
+
+	// fuzz the existingMeta to set every field, no nils
+	f := fuzz.New().NilChance(0).NumElements(1, 1)
+	f.Fuzz(existingMeta)
+
+	ResetObjectMetaForStatus(meta, existingMeta)
+
+	// Not all fields are stomped during the reset. These fields should not have been set.
+	// Set them all to their zero values. Before you add anything to this list, consider whether or not
+	// you're enforcing immutability (those are fine) and whether /status should be able to update
+	// these values (these are usually not fine).
+
+	// generateName doesn't do anything after create
+	existingMeta.SetGenerateName("")
+	// resourceVersion is enforced in validation and used during the storage update
+	existingMeta.SetResourceVersion("")
+	// fields made immutable in validation
+	existingMeta.SetUID(types.UID(""))
+	existingMeta.SetName("")
+	existingMeta.SetNamespace("")
+	existingMeta.SetClusterName("")
+	existingMeta.SetCreationTimestamp(metav1.Time{})
+	existingMeta.SetDeletionTimestamp(nil)
+	existingMeta.SetDeletionGracePeriodSeconds(nil)
+	existingMeta.SetInitializers(nil)
+
+	if !reflect.DeepEqual(meta, existingMeta) {
+		t.Error(diff.ObjectDiff(meta, existingMeta))
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/options.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/options.go
@@ -35,7 +35,7 @@ type RESTOptions struct {
 	CountMetricPollPeriod   time.Duration
 }
 
-// Implement RESTOptionsGetter so that RESTOptions can directly be used when available (i.e. tests)
+// GetRESTOptions implements RESTOptionsGetter so that RESTOptions can directly be used when available (i.e. tests)
 func (opts RESTOptions) GetRESTOptions(schema.GroupResource) (RESTOptions, error) {
 	return opts, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package etcd has a generic implementation of a registry that
+// Package registry has a generic implementation of a registry that
 // stores things in etcd.
 package registry // import "k8s.io/apiserver/pkg/registry/generic/registry"

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -843,7 +843,7 @@ func markAsDeleting(obj runtime.Object) (err error) {
 		objectMeta.SetGeneration(objectMeta.GetGeneration() + 1)
 	}
 	objectMeta.SetDeletionTimestamp(&now)
-	var zero int64 = 0
+	var zero int64
 	objectMeta.SetDeletionGracePeriodSeconds(&zero)
 	return nil
 }
@@ -974,7 +974,7 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 	}
 	pendingFinalizers := len(accessor.GetFinalizers()) != 0
 	var ignoreNotFound bool
-	var deleteImmediately bool = true
+	var deleteImmediately = true
 	var lastExisting, out runtime.Object
 
 	// Handle combinations of graceful deletion and finalization by issuing

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -97,10 +97,9 @@ func (apiServerStatusStrategy) PrepareForUpdate(ctx genericapirequest.Context, o
 	newAPIService := obj.(*apiregistration.APIService)
 	oldAPIService := old.(*apiregistration.APIService)
 	newAPIService.Spec = oldAPIService.Spec
-	newAPIService.Labels = oldAPIService.Labels
-	newAPIService.Annotations = oldAPIService.Annotations
-	newAPIService.Finalizers = oldAPIService.Finalizers
-	newAPIService.OwnerReferences = oldAPIService.OwnerReferences
+
+	// Status updates should update only status, not ObjectMeta.
+	generic.ResetObjectMetaForStatus(newAPIService, oldAPIService)
 }
 
 func (apiServerStatusStrategy) AllowCreateOnUpdate() bool {


### PR DESCRIPTION
Follow up for #45552.

We should not allow `/status` to mutate objectmeta. The idea is to enable this for new resources only for now (see discussion in https://github.com/kubernetes/kubernetes/pull/45552#issuecomment-308801858, https://github.com/kubernetes/kubernetes/issues/45539, https://github.com/kubernetes/kubernetes/issues/20978):

- CRDs, custom resources and APIService (in this PR)
- Flunder in sample-apiserver (in https://github.com/kubernetes/kubernetes/pull/58305 after this is merged)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc deads2k sttts liggitt lavalamp 