### PR TITLE
Add UT test to openstack and two para in configFromEnv

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -188,6 +188,8 @@ func configFromEnv() (cfg Config, ok bool) {
 	cfg.Global.Username = os.Getenv("OS_USERNAME")
 	cfg.Global.Password = os.Getenv("OS_PASSWORD")
 	cfg.Global.Region = os.Getenv("OS_REGION_NAME")
+	cfg.Global.UserId = os.Getenv("OS_USER_ID")
+	cfg.Global.TrustId = os.Getenv("OS_TRUST_ID")
 
 	cfg.Global.TenantId = os.Getenv("OS_TENANT_ID")
 	if cfg.Global.TenantId == "" {
@@ -211,7 +213,7 @@ func configFromEnv() (cfg Config, ok bool) {
 		cfg.Global.Username != "" &&
 		cfg.Global.Password != "" &&
 		(cfg.Global.TenantId != "" || cfg.Global.TenantName != "" ||
-			cfg.Global.DomainId != "" || cfg.Global.DomainName != "")
+			cfg.Global.DomainId != "" || cfg.Global.DomainName != "" || cfg.Global.Region != "" || cfg.Global.UserId != "" || cfg.Global.TrustId != "")
 
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
 	cfg.BlockStorage.BSVersion = "auto"
@@ -671,7 +673,7 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 	}
 
 	if !netExts["extraroute"] {
-		glog.V(3).Infof("Neutron extraroute extension not found, required for Routes support")
+		glog.V(3).Info("Neutron extraroute extension not found, required for Routes support")
 		return nil, false
 	}
 
@@ -704,21 +706,21 @@ func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
 		if err != nil {
 			return nil, err
 		}
-		glog.V(3).Infof("Using Blockstorage API V1")
+		glog.V(3).Info("Using Blockstorage API V1")
 		return &VolumesV1{sClient, os.bsOpts}, nil
 	case "v2":
 		sClient, err := os.NewBlockStorageV2()
 		if err != nil {
 			return nil, err
 		}
-		glog.V(3).Infof("Using Blockstorage API V2")
+		glog.V(3).Info("Using Blockstorage API V2")
 		return &VolumesV2{sClient, os.bsOpts}, nil
 	case "v3":
 		sClient, err := os.NewBlockStorageV3()
 		if err != nil {
 			return nil, err
 		}
-		glog.V(3).Infof("Using Blockstorage API V3")
+		glog.V(3).Info("Using Blockstorage API V3")
 		return &VolumesV3{sClient, os.bsOpts}, nil
 	case "auto":
 		// Currently kubernetes support Cinder v1 / Cinder v2 / Cinder v3.
@@ -726,17 +728,17 @@ func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
 		// If kubernetes can't initialize cinder v2 client, try to initialize cinder v1 client.
 		// Return appropriate message when kubernetes can't initialize them.
 		if sClient, err := os.NewBlockStorageV3(); err == nil {
-			glog.V(3).Infof("Using Blockstorage API V3")
+			glog.V(3).Info("Using Blockstorage API V3")
 			return &VolumesV3{sClient, os.bsOpts}, nil
 		}
 
 		if sClient, err := os.NewBlockStorageV2(); err == nil {
-			glog.V(3).Infof("Using Blockstorage API V2")
+			glog.V(3).Info("Using Blockstorage API V2")
 			return &VolumesV2{sClient, os.bsOpts}, nil
 		}
 
 		if sClient, err := os.NewBlockStorageV1(); err == nil {
-			glog.V(3).Infof("Using Blockstorage API V1")
+			glog.V(3).Info("Using Blockstorage API V1")
 			return &VolumesV1{sClient, os.bsOpts}, nil
 		}
 

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -162,7 +162,11 @@ func TestReadConfig(t *testing.T) {
 func TestToAuthOptions(t *testing.T) {
 	cfg := Config{}
 	cfg.Global.Username = "user"
-	// etc.
+	cfg.Global.Password = "pass"
+	cfg.Global.DomainId = "2a73b8f597c04551a0fdc8e95544be8a"
+	cfg.Global.DomainName = "local"
+	cfg.Global.AuthUrl = "http://auth.url"
+	cfg.Global.UserId = "user"
 
 	ao := cfg.toAuthOptions()
 
@@ -171,6 +175,24 @@ func TestToAuthOptions(t *testing.T) {
 	}
 	if ao.Username != cfg.Global.Username {
 		t.Errorf("Username %s != %s", ao.Username, cfg.Global.Username)
+	}
+	if ao.Password != cfg.Global.Password {
+		t.Errorf("Password %s != %s", ao.Password, cfg.Global.Password)
+	}
+	if ao.DomainID != cfg.Global.DomainId {
+		t.Errorf("DomainID %s != %s", ao.DomainID, cfg.Global.DomainId)
+	}
+	if ao.IdentityEndpoint != cfg.Global.AuthUrl {
+		t.Errorf("IdentityEndpoint %s != %s", ao.IdentityEndpoint, cfg.Global.AuthUrl)
+	}
+	if ao.UserID != cfg.Global.UserId {
+		t.Errorf("UserID %s != %s", ao.UserID, cfg.Global.UserId)
+	}
+	if ao.DomainName != cfg.Global.DomainName {
+		t.Errorf("DomainName %s != %s", ao.DomainName, cfg.Global.DomainName)
+	}
+	if ao.TenantID != cfg.Global.TenantId {
+		t.Errorf("TenantID %s != %s", ao.TenantID, cfg.Global.TenantId)
 	}
 }
 
@@ -400,7 +422,7 @@ func TestNodeAddresses(t *testing.T) {
 func TestNewOpenStack(t *testing.T) {
 	cfg, ok := configFromEnv()
 	if !ok {
-		t.Skipf("No config found in environment")
+		t.Skip("No config found in environment")
 	}
 
 	_, err := newOpenStack(cfg)
@@ -412,7 +434,7 @@ func TestNewOpenStack(t *testing.T) {
 func TestLoadBalancer(t *testing.T) {
 	cfg, ok := configFromEnv()
 	if !ok {
-		t.Skipf("No config found in environment")
+		t.Skip("No config found in environment")
 	}
 
 	versions := []string{"v2", ""}
@@ -476,7 +498,7 @@ var diskPathRegexp = regexp.MustCompile("/dev/disk/(?:by-id|by-path)/")
 func TestVolumes(t *testing.T) {
 	cfg, ok := configFromEnv()
 	if !ok {
-		t.Skipf("No config found in environment")
+		t.Skip("No config found in environment")
 	}
 
 	os, err := newOpenStack(cfg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
configFromEnv fun miss some para that the type define and add ut to TestToAuthOptions fun
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @dims 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
