### PR TITLE
Fix installation and use of vendored godep

### DIFF
--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -20,7 +20,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-source "${KUBE_ROOT}/hack/lib/util.sh"
 
 kube::log::status "Restoring kubernetes godeps"
 

--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -33,7 +33,6 @@ retry() {
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-retry go get github.com/tools/godep && godep version
 retry go get github.com/jstemmer/go-junit-report
 retry go get github.com/cespare/prettybench
 

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -33,7 +33,6 @@ retry() {
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 
-retry go get github.com/tools/godep && godep version
 retry go get github.com/jstemmer/go-junit-report
 
 # Enable the Go race detector.

--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -36,8 +36,6 @@ export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
 # Set artifacts directory
 export ARTIFACTS_DIR=${WORKSPACE}/artifacts
 
-retry go get github.com/tools/godep && godep version
-
 export LOG_LEVEL=4
 
 cd /go/src/k8s.io/kubernetes

--- a/hack/jenkins/verify.sh
+++ b/hack/jenkins/verify.sh
@@ -32,6 +32,5 @@ export PATH=${GOPATH}/bin:${HOME}/third_party/etcd:/usr/local/go/bin:$PATH
 
 # Install a few things needed by the verification tests.
 command -v etcd &>/dev/null || ./hack/install-etcd.sh
-go get -u github.com/tools/godep
 
 make verify

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -446,6 +446,9 @@ kube::util::ensure_godep_version() {
 
   kube::log::status "Installing godep version ${GODEP_VERSION}"
   go install ./vendor/github.com/tools/godep/
+  GP="$(echo $GOPATH | cut -f1 -d:)"
+  hash -r # force bash to clear PATH cache
+  PATH="${GP}/bin:${PATH}"
 
   if [[ "$(godep version 2>/dev/null)" != *"godep ${GODEP_VERSION}"* ]]; then
     kube::log::error "Expected godep ${GODEP_VERSION}, got $(godep version)"

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -29,6 +29,9 @@ if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   exit 0
 fi
 
+# Ensure we have the right godep version available
+kube::util::ensure_godep_version
+
 if [[ -z ${TMP_GOPATH:-} ]]; then
   # Create a nice clean place to put our new godeps
   _tmpdir="$(mktemp -d -t gopath.XXXXXX)"

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -18,30 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# As of go 1.6, the vendor experiment is enabled by default.
-export GO15VENDOREXPERIMENT=1
-
-#### HACK ####
-# Sometimes godep just can't handle things. This lets use manually put
-# some deps in place first, so godep won't fall over.
-preload-dep() {
-  org="$1"
-  project="$2"
-  sha="$3"
-  # project_dir ($4) is optional, if unset we will generate it
-  if [[ -z ${4:-} ]]; then
-    project_dir="${GOPATH}/src/${org}/${project}.git"
-  else
-    project_dir="${4}"
-  fi
-
-  echo "**HACK** preloading dep for ${org} ${project} at ${sha} into ${project_dir}"
-  git clone "https://${org}/${project}" "${project_dir}" > /dev/null 2>&1
-  pushd "${project_dir}" > /dev/null
-    git checkout "${sha}"
-  popd > /dev/null
-}
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the installation of the vendored godep to ensure that the binary ends up in the path when it's done.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58975

**Special notes for your reviewer**:
It looks like this broke in https://github.com/kubernetes/kubernetes/pull/51766, but didn't matter because our pinned version was the same as the latest version (so we didn't notice). This fixes it in my local env -- hopefully it will in CI too.

**Release note**:
```release-note
NONE
```
