### PR TITLE
Reset DeferredDiscoveryRESTMapper before use

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -183,6 +183,7 @@ func (f *Framework) BeforeEach() {
 		Expect(err).NotTo(HaveOccurred())
 		cachedDiscoClient := cacheddiscovery.NewMemCacheClient(discoClient)
 		restMapper := discovery.NewDeferredDiscoveryRESTMapper(cachedDiscoClient, meta.InterfacesForUnstructured)
+		restMapper.Reset()
 		resolver := scaleclient.NewDiscoveryScaleKindResolver(cachedDiscoClient)
 		f.ScalesGetter = scaleclient.New(restClient, restMapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -384,6 +384,7 @@ func createClients(numberOfClients int) ([]clientset.Interface, []internalclient
 		}
 		cachedDiscoClient := cacheddiscovery.NewMemCacheClient(discoClient)
 		restMapper := discovery.NewDeferredDiscoveryRESTMapper(cachedDiscoClient, meta.InterfacesForUnstructured)
+		restMapper.Reset()
 		resolver := scaleclient.NewDiscoveryScaleKindResolver(cachedDiscoClient)
 		scalesClients[i] = scaleclient.New(restClient, restMapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 	}


### PR DESCRIPTION
DeferredDiscoveryRESTMapper won't automatically `Reset` itself before its
initial use, since actually trying to construct the delegate will error
out before it gets a chance to `Reset` itself.  Ergo, we have to
manually call `Reset` before use.

Fixes #59043 

```release-note
NONE
```
