### PR TITLE
Add crds as CustomResourceDefinition shortname

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -62,7 +62,7 @@ var _ rest.ShortNamesProvider = &REST{}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
-	return []string{"crd"}
+	return []string{"crd", "crds"}
 }
 
 // Delete adds the CRD finalizer to the list


### PR DESCRIPTION
See https://github.com/kubernetes/apiextensions-apiserver/issues/6#issuecomment-361539766.
Fixes kubernetes/apiextensions-apiserver#6

Before:

```
➜  kubectl get crds
the server doesn't have a resource type "crds"
```

After:

```
➜  kubectl get crds
No resources found.
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 `crds` is added as a shortname for CustomResourceDefinition i.e. `kubectl get crds` can now be used.
```

/cc sttts deads2k soltysh pwittrock 