### PR TITLE
Fix PodPidsLimit and ConfigTrialDuration on internal KubeletConfig type

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -476,7 +476,7 @@ func AddKubeletConfigFlags(fs *pflag.FlagSet, c *kubeletconfig.KubeletConfigurat
 	fs.Int32Var(&c.MaxPods, "max-pods", c.MaxPods, "Number of Pods that can run on this Kubelet.")
 
 	fs.StringVar(&c.PodCIDR, "pod-cidr", c.PodCIDR, "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")
-	fs.Int64Var(c.PodPidsLimit, "pod-max-pids", *c.PodPidsLimit, "<Warning: Alpha feature> Set the maximum number of processes per pod.")
+	fs.Int64Var(&c.PodPidsLimit, "pod-max-pids", c.PodPidsLimit, "<Warning: Alpha feature> Set the maximum number of processes per pod.")
 
 	fs.StringVar(&c.ResolverConfig, "resolv-conf", c.ResolverConfig, "Resolver configuration file used as the basis for the container DNS resolution configuration.")
 	fs.BoolVar(&c.CPUCFSQuota, "cpu-cfs-quota", c.CPUCFSQuota, "Enable CPU CFS quota enforcement for containers that specify CPU limits")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -653,7 +653,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies) (err error) {
 				ExperimentalQOSReserved:               *experimentalQOSReserved,
 				ExperimentalCPUManagerPolicy:          s.CPUManagerPolicy,
 				ExperimentalCPUManagerReconcilePeriod: s.CPUManagerReconcilePeriod.Duration,
-				ExperimentalPodPidsLimit:              *s.PodPidsLimit,
+				ExperimentalPodPidsLimit:              s.PodPidsLimit,
 			},
 			s.FailSwapOn,
 			devicePluginEnabled,

--- a/pkg/apis/apps/v1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1/zz_generated.conversion.go
@@ -890,7 +890,9 @@ func autoConvert_apps_StatefulSetSpec_To_v1_StatefulSetSpec(in *apps.StatefulSet
 }
 
 func autoConvert_v1_StatefulSetStatus_To_apps_StatefulSetStatus(in *v1.StatefulSetStatus, out *apps.StatefulSetStatus, s conversion.Scope) error {
-	// WARNING: in.ObservedGeneration requires manual conversion: inconvertible types (int64 vs *int64)
+	if err := meta_v1.Convert_int64_To_Pointer_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+		return err
+	}
 	out.Replicas = in.Replicas
 	out.ReadyReplicas = in.ReadyReplicas
 	out.CurrentReplicas = in.CurrentReplicas
@@ -903,7 +905,9 @@ func autoConvert_v1_StatefulSetStatus_To_apps_StatefulSetStatus(in *v1.StatefulS
 }
 
 func autoConvert_apps_StatefulSetStatus_To_v1_StatefulSetStatus(in *apps.StatefulSetStatus, out *v1.StatefulSetStatus, s conversion.Scope) error {
-	// WARNING: in.ObservedGeneration requires manual conversion: inconvertible types (*int64 vs int64)
+	if err := meta_v1.Convert_Pointer_int64_To_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+		return err
+	}
 	out.Replicas = in.Replicas
 	out.ReadyReplicas = in.ReadyReplicas
 	out.CurrentReplicas = in.CurrentReplicas

--- a/pkg/apis/apps/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.conversion.go
@@ -962,7 +962,9 @@ func autoConvert_apps_StatefulSetSpec_To_v1beta2_StatefulSetSpec(in *apps.Statef
 }
 
 func autoConvert_v1beta2_StatefulSetStatus_To_apps_StatefulSetStatus(in *v1beta2.StatefulSetStatus, out *apps.StatefulSetStatus, s conversion.Scope) error {
-	// WARNING: in.ObservedGeneration requires manual conversion: inconvertible types (int64 vs *int64)
+	if err := meta_v1.Convert_int64_To_Pointer_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+		return err
+	}
 	out.Replicas = in.Replicas
 	out.ReadyReplicas = in.ReadyReplicas
 	out.CurrentReplicas = in.CurrentReplicas
@@ -975,7 +977,9 @@ func autoConvert_v1beta2_StatefulSetStatus_To_apps_StatefulSetStatus(in *v1beta2
 }
 
 func autoConvert_apps_StatefulSetStatus_To_v1beta2_StatefulSetStatus(in *apps.StatefulSetStatus, out *v1beta2.StatefulSetStatus, s conversion.Scope) error {
-	// WARNING: in.ObservedGeneration requires manual conversion: inconvertible types (*int64 vs int64)
+	if err := meta_v1.Convert_Pointer_int64_To_int64(&in.ObservedGeneration, &out.ObservedGeneration, s); err != nil {
+		return err
+	}
 	out.Replicas = in.Replicas
 	out.ReadyReplicas = in.ReadyReplicas
 	out.CurrentReplicas = in.CurrentReplicas

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -36,7 +36,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 		// provide non-empty values for fields with defaults, so the defaulter doesn't change values during round-trip
 		func(obj *kubeletconfig.KubeletConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
-			obj.ConfigTrialDuration = &metav1.Duration{Duration: 10 * time.Minute}
 			obj.Authentication.Anonymous.Enabled = true
 			obj.Authentication.Webhook.Enabled = false
 			obj.Authentication.Webhook.CacheTTL = metav1.Duration{Duration: 2 * time.Minute}
@@ -62,8 +61,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ImageGCLowThresholdPercent = 80
 			obj.MaxOpenFiles = 1000000
 			obj.MaxPods = 110
-			temp := int64(-1)
-			obj.PodPidsLimit = &temp
+			obj.PodPidsLimit = -1
 			obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 10 * time.Second}
 			obj.CPUManagerPolicy = "none"
 			obj.CPUManagerReconcilePeriod = obj.NodeStatusUpdateFrequency

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -49,7 +49,7 @@ type KubeletConfiguration struct {
 
 	// Only used for dynamic configuration.
 	// The length of the trial period for this configuration. This configuration will become the last-known-good after this duration.
-	ConfigTrialDuration *metav1.Duration
+	ConfigTrialDuration metav1.Duration
 	// podManifestPath is the path to the directory containing pod manifests to
 	// run, or the path to a single manifest file
 	PodManifestPath string
@@ -194,7 +194,7 @@ type KubeletConfiguration struct {
 	// In cluster mode, this is obtained from the master.
 	PodCIDR string
 	// PodPidsLimit is the maximum number of pids in any pod.
-	PodPidsLimit *int64
+	PodPidsLimit int64
 	// ResolverConfig is the resolver configuration file used as the basis
 	// for the container DNS resolution configuration.
 	ResolverConfig string

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -141,7 +141,9 @@ func Convert_kubeletconfig_KubeletAuthorization_To_v1alpha1_KubeletAuthorization
 }
 
 func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(in *KubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
-	out.ConfigTrialDuration = (*v1.Duration)(unsafe.Pointer(in.ConfigTrialDuration))
+	if err := v1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.ConfigTrialDuration, &out.ConfigTrialDuration, s); err != nil {
+		return err
+	}
 	out.PodManifestPath = in.PodManifestPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
@@ -213,7 +215,9 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfigura
 	out.HairpinMode = in.HairpinMode
 	out.MaxPods = in.MaxPods
 	out.PodCIDR = in.PodCIDR
-	out.PodPidsLimit = (*int64)(unsafe.Pointer(in.PodPidsLimit))
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodPidsLimit, &out.PodPidsLimit, s); err != nil {
+		return err
+	}
 	out.ResolverConfig = in.ResolverConfig
 	if err := v1.Convert_Pointer_bool_To_bool(&in.CPUCFSQuota, &out.CPUCFSQuota, s); err != nil {
 		return err
@@ -265,7 +269,9 @@ func Convert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration
 }
 
 func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfiguration(in *kubeletconfig.KubeletConfiguration, out *KubeletConfiguration, s conversion.Scope) error {
-	out.ConfigTrialDuration = (*v1.Duration)(unsafe.Pointer(in.ConfigTrialDuration))
+	if err := v1.Convert_v1_Duration_To_Pointer_v1_Duration(&in.ConfigTrialDuration, &out.ConfigTrialDuration, s); err != nil {
+		return err
+	}
 	out.PodManifestPath = in.PodManifestPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
@@ -337,7 +343,9 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	out.HairpinMode = in.HairpinMode
 	out.MaxPods = in.MaxPods
 	out.PodCIDR = in.PodCIDR
-	out.PodPidsLimit = (*int64)(unsafe.Pointer(in.PodPidsLimit))
+	if err := v1.Convert_int64_To_Pointer_int64(&in.PodPidsLimit, &out.PodPidsLimit, s); err != nil {
+		return err
+	}
 	out.ResolverConfig = in.ResolverConfig
 	if err := v1.Convert_bool_To_Pointer_bool(&in.CPUCFSQuota, &out.CPUCFSQuota, s); err != nil {
 		return err

--- a/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package kubeletconfig
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -81,15 +80,7 @@ func (in *KubeletAuthorization) DeepCopy() *KubeletAuthorization {
 func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.ConfigTrialDuration != nil {
-		in, out := &in.ConfigTrialDuration, &out.ConfigTrialDuration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
-	}
+	out.ConfigTrialDuration = in.ConfigTrialDuration
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
 	out.HTTPCheckFrequency = in.HTTPCheckFrequency
@@ -123,15 +114,6 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	out.CPUManagerReconcilePeriod = in.CPUManagerReconcilePeriod
 	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
-	if in.PodPidsLimit != nil {
-		in, out := &in.PodPidsLimit, &out.PodPidsLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
-	}
 	if in.EvictionHard != nil {
 		in, out := &in.EvictionHard, &out.EvictionHard
 		*out = make(map[string]string, len(*in))

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
@@ -65,6 +65,9 @@ func AddConversionFuncs(scheme *runtime.Scheme) error {
 		Convert_Pointer_int32_To_int32,
 		Convert_int32_To_Pointer_int32,
 
+		Convert_Pointer_int64_To_int64,
+		Convert_int64_To_Pointer_int64,
+
 		Convert_Pointer_float64_To_float64,
 		Convert_float64_To_Pointer_float64,
 
@@ -101,6 +104,21 @@ func Convert_Pointer_int32_To_int32(in **int32, out *int32, s conversion.Scope) 
 
 func Convert_int32_To_Pointer_int32(in *int32, out **int32, s conversion.Scope) error {
 	temp := int32(*in)
+	*out = &temp
+	return nil
+}
+
+func Convert_Pointer_int64_To_int64(in **int64, out *int64, s conversion.Scope) error {
+	if *in == nil {
+		*out = 0
+		return nil
+	}
+	*out = int64(**in)
+	return nil
+}
+
+func Convert_int64_To_Pointer_int64(in *int64, out **int64, s conversion.Scope) error {
+	temp := int64(*in)
 	*out = &temp
 	return nil
 }

--- a/test/e2e_node/dynamic_kubelet_config_test.go
+++ b/test/e2e_node/dynamic_kubelet_config_test.go
@@ -98,7 +98,7 @@ var _ = framework.KubeDescribe("DynamicKubeletConfiguration [Feature:DynamicKube
 				// we base the "correct" configmap off of the current configuration,
 				// but we also set the trial duration very high to prevent changing the last-known-good
 				correctKC := originalKC.DeepCopy()
-				correctKC.ConfigTrialDuration = &metav1.Duration{Duration: time.Hour}
+				correctKC.ConfigTrialDuration = metav1.Duration{Duration: time.Hour}
 				correctConfigMap := newKubeletConfigMap("dynamic-kubelet-config-test-correct", correctKC)
 				correctConfigMap, err = f.ClientSet.CoreV1().ConfigMaps("kube-system").Create(correctConfigMap)
 				framework.ExpectNoError(err)
@@ -221,7 +221,7 @@ var _ = framework.KubeDescribe("DynamicKubeletConfiguration [Feature:DynamicKube
 				// we base the "lkg" configmap off of the current configuration, but set the trial
 				// duration very low so that it quickly becomes the last-known-good
 				lkgKC := originalKC.DeepCopy()
-				lkgKC.ConfigTrialDuration = &metav1.Duration{Duration: time.Nanosecond}
+				lkgKC.ConfigTrialDuration = metav1.Duration{Duration: time.Nanosecond}
 				lkgConfigMap := newKubeletConfigMap("dynamic-kubelet-config-test-intended-lkg", lkgKC)
 				lkgConfigMap, err = f.ClientSet.CoreV1().ConfigMaps("kube-system").Create(lkgConfigMap)
 				framework.ExpectNoError(err)


### PR DESCRIPTION
They should both follow the convention of not being a pointer on the internal type. 

This required adding a conversion function between `int64` and `*int64`. A side effect is this removes a warning in the generated code for the apps API group.

@dims

```release-note
NONE
```