### PR TITLE
Change manifest file perms to remove execute

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -172,7 +172,7 @@ func WriteStaticPodToDisk(componentName, manifestDir string, pod v1.Pod) error {
 
 	filename := kubeadmconstants.GetStaticPodFilepath(componentName, manifestDir)
 
-	if err := ioutil.WriteFile(filename, serialized, 0700); err != nil {
+	if err := ioutil.WriteFile(filename, serialized, 0600); err != nil {
 		return fmt.Errorf("failed to write static pod manifest file for %q (%q): %v", componentName, filename, err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the manifests generated by kubeadm have permission 0700. The kubernetes CIS benchmarks state the perms should be 0644 or better, so this change sets the file permissions to 0600, as they are static files, and don't need to be executable.

**Which issue(s) this PR fixes** *: Fixes # https://github.com/kubernetes/kubeadm/issues/678

**Special notes for your reviewer**:
None

**Release note**:
```release-note
NONE
```
