### PR TITLE
Cleaning up loopback removal process

### DIFF
--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -46,7 +46,6 @@ const (
 
 	ErrDeviceNotFound     = "device not found"
 	ErrDeviceNotSupported = "device not supported"
-	ErrNotAvailable       = "not available"
 )
 
 // IsReady checks for the existence of a regular file


### PR DESCRIPTION
Handling more graceful the process of loopback removal. In case loopback device does not exist any longer, we should not fail the detachment process. 
```release-note

```
