### PR TITLE
Let client ca post start hook use GET to check if the system namespace exists

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client_ca_hook.go",
+        "client_util.go",
         "controller.go",
         "doc.go",
         "import_known_versions.go",

--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -74,7 +74,7 @@ func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.Pos
 // tryToWriteClientCAs is here for unit testing with a fake client.  This is a wait.ConditionFunc so the bool
 // indicates if the condition was met.  True when its finished, false when it should retry.
 func (h ClientCARegistrationHook) tryToWriteClientCAs(client coreclient.CoreInterface) (bool, error) {
-	if _, err := client.Namespaces().Create(&api.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := createNamespaceIfNeeded(client, metav1.NamespaceSystem); err != nil {
 		utilruntime.HandleError(err)
 		return false, nil
 	}

--- a/pkg/master/client_util.go
+++ b/pkg/master/client_util.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+)
+
+func createNamespaceIfNeeded(c coreclient.NamespacesGetter, ns string) error {
+	if _, err := c.Namespaces().Get(ns, metav1.GetOptions{}); err == nil {
+		// the namespace already exists
+		return nil
+	}
+	newNs := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ns,
+			Namespace: "",
+		},
+	}
+	_, err := c.Namespaces().Create(newNs)
+	if err != nil && errors.IsAlreadyExists(err) {
+		err = nil
+	}
+	return err
+}

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -160,7 +160,7 @@ func (c *Controller) RunKubernetesNamespaces(ch chan struct{}) {
 	wait.Until(func() {
 		// Loop the system namespace list, and create them if they do not exist
 		for _, ns := range c.SystemNamespaces {
-			if err := c.CreateNamespaceIfNeeded(ns); err != nil {
+			if err := createNamespaceIfNeeded(c.NamespaceClient, ns); err != nil {
 				runtime.HandleError(fmt.Errorf("unable to create required kubernetes system namespace %s: %v", ns, err))
 			}
 		}
@@ -185,7 +185,7 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 	// TODO: when it becomes possible to change this stuff,
 	// stop polling and start watching.
 	// TODO: add endpoints of all replicas, not just the elected master.
-	if err := c.CreateNamespaceIfNeeded(metav1.NamespaceDefault); err != nil {
+	if err := createNamespaceIfNeeded(c.NamespaceClient, metav1.NamespaceDefault); err != nil {
 		return err
 	}
 
@@ -198,25 +198,6 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 		return err
 	}
 	return nil
-}
-
-// CreateNamespaceIfNeeded will create a namespace if it doesn't already exist
-func (c *Controller) CreateNamespaceIfNeeded(ns string) error {
-	if _, err := c.NamespaceClient.Namespaces().Get(ns, metav1.GetOptions{}); err == nil {
-		// the namespace already exists
-		return nil
-	}
-	newNs := &api.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ns,
-			Namespace: "",
-		},
-	}
-	_, err := c.NamespaceClient.Namespaces().Create(newNs)
-	if err != nil && errors.IsAlreadyExists(err) {
-		err = nil
-	}
-	return err
 }
 
 // createPortAndServiceSpec creates an array of service ports.


### PR DESCRIPTION
This is a direct fix for #56761.

The original code tried to create a namespace unconditionally, it caused apiserver to fail to reboot if a webhook blocked namespaces creation.

In the long term, we should make the apiserver return 409 instead of 5xx in the case of conflicting POST, even if a webhook fails the POST.

```release-note
Fixed a bug which caused the apiserver reboot failure in the presence of malfunctioning webhooks.
```