### PR TITLE
Fixes ci-ingress-gce-upgrade-e2e

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -86,7 +86,6 @@ func ingressUpgradeGCE(isUpgrade bool) error {
 		command = "sudo sed -i -re 's/(image:)(.*)/\\1 gcr.io\\/google_containers\\/glbc:0.9.7/' /etc/kubernetes/manifests/glbc.manifest"
 	}
 	sshResult, err := NodeExec(GetMasterHost(), command)
-	// TODO(rramkumar): Ensure glbc pod is in "Running" state before proceeding.
 	LogSSHResult(sshResult)
 	return err
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4947,6 +4947,7 @@ func PollURL(route, host string, timeout time.Duration, interval time.Duration, 
 			Logf("host %v path %v: %v unreachable", host, route, err)
 			return expectUnreachable, nil
 		}
+		Logf("host %v path %v: reached", host, route)
 		return !expectUnreachable, nil
 	})
 	if pollErr != nil {

--- a/test/e2e/testing-manifests/ingress/static-ip-2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip-2/ing.yaml
@@ -6,6 +6,11 @@ metadata:
   # annotations:
   #  kubernetes.io/ingress.global-static-ip-name: "staticip"
 spec:
-  backend:
-    serviceName: echoheaders-https
-    servicePort: 80
+  rules:
+  - host: ingress.test.com
+    http:
+      paths:
+      - path: /foo
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the broken ci-ingress-gce-upgrade-e2e job. The issue was that the ingress was being deleted by the test framework before the upgraded ingress could properly sync. Therefore, the resources were never cleaned up, which caused test failure. 

```release-note
None
```

cc @MrHohn 
/assign @bowei 
