### PR TITLE
fix package name error

### DIFF
--- a/plugin/pkg/admission/priority/admission.go
+++ b/plugin/pkg/admission/priority/admission.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package admission
+package priority
 
 import (
 	"fmt"
@@ -52,12 +52,12 @@ var SystemPriorityClasses = map[string]int32{
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewPlugin(), nil
+		return newPlugin(), nil
 	})
 }
 
-// PriorityPlugin is an implementation of admission.Interface.
-type PriorityPlugin struct {
+// priorityPlugin is an implementation of admission.Interface.
+type priorityPlugin struct {
 	*admission.Handler
 	client internalclientset.Interface
 	lister schedulinglisters.PriorityClassLister
@@ -65,20 +65,20 @@ type PriorityPlugin struct {
 	globalDefaultPriority *int32
 }
 
-var _ admission.MutationInterface = &PriorityPlugin{}
-var _ admission.ValidationInterface = &PriorityPlugin{}
-var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&PriorityPlugin{})
-var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&PriorityPlugin{})
+var _ admission.MutationInterface = &priorityPlugin{}
+var _ admission.ValidationInterface = &priorityPlugin{}
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&priorityPlugin{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&priorityPlugin{})
 
 // NewPlugin creates a new priority admission plugin.
-func NewPlugin() *PriorityPlugin {
-	return &PriorityPlugin{
+func newPlugin() *priorityPlugin {
+	return &priorityPlugin{
 		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 	}
 }
 
 // ValidateInitialization implements the InitializationValidator interface.
-func (p *PriorityPlugin) ValidateInitialization() error {
+func (p *priorityPlugin) ValidateInitialization() error {
 	if p.client == nil {
 		return fmt.Errorf("%s requires a client", PluginName)
 	}
@@ -89,12 +89,12 @@ func (p *PriorityPlugin) ValidateInitialization() error {
 }
 
 // SetInternalKubeClientSet implements the WantsInternalKubeClientSet interface.
-func (p *PriorityPlugin) SetInternalKubeClientSet(client internalclientset.Interface) {
+func (p *priorityPlugin) SetInternalKubeClientSet(client internalclientset.Interface) {
 	p.client = client
 }
 
 // SetInternalKubeInformerFactory implements the WantsInternalKubeInformerFactory interface.
-func (p *PriorityPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
+func (p *priorityPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	priorityInformer := f.Scheduling().InternalVersion().PriorityClasses()
 	p.lister = priorityInformer.Lister()
 	p.SetReadyFunc(priorityInformer.Informer().HasSynced)
@@ -107,7 +107,7 @@ var (
 
 // Admit checks Pods and admits or rejects them. It also resolves the priority of pods based on their PriorityClass.
 // Note that pod validation mechanism prevents update of a pod priority.
-func (p *PriorityPlugin) Admit(a admission.Attributes) error {
+func (p *priorityPlugin) Admit(a admission.Attributes) error {
 	operation := a.GetOperation()
 	// Ignore all calls to subresources
 	if len(a.GetSubresource()) != 0 {
@@ -127,7 +127,7 @@ func (p *PriorityPlugin) Admit(a admission.Attributes) error {
 }
 
 // Validate checks PriorityClasses and admits or rejects them.
-func (p *PriorityPlugin) Validate(a admission.Attributes) error {
+func (p *priorityPlugin) Validate(a admission.Attributes) error {
 	operation := a.GetOperation()
 	// Ignore all calls to subresources
 	if len(a.GetSubresource()) != 0 {
@@ -151,7 +151,7 @@ func (p *PriorityPlugin) Validate(a admission.Attributes) error {
 }
 
 // admitPod makes sure a new pod does not set spec.Priority field. It also makes sure that the PriorityClassName exists if it is provided and resolves the pod priority from the PriorityClassName.
-func (p *PriorityPlugin) admitPod(a admission.Attributes) error {
+func (p *priorityPlugin) admitPod(a admission.Attributes) error {
 	operation := a.GetOperation()
 	pod, ok := a.GetObject().(*api.Pod)
 	if !ok {
@@ -194,7 +194,7 @@ func (p *PriorityPlugin) admitPod(a admission.Attributes) error {
 }
 
 // validatePriorityClass ensures that the value field is not larger than the highest user definable priority. If the GlobalDefault is set, it ensures that there is no other PriorityClass whose GlobalDefault is set.
-func (p *PriorityPlugin) validatePriorityClass(a admission.Attributes) error {
+func (p *priorityPlugin) validatePriorityClass(a admission.Attributes) error {
 	operation := a.GetOperation()
 	pc, ok := a.GetObject().(*scheduling.PriorityClass)
 	if !ok {
@@ -224,7 +224,7 @@ func (p *PriorityPlugin) validatePriorityClass(a admission.Attributes) error {
 	return nil
 }
 
-func (p *PriorityPlugin) getDefaultPriorityClass() (*scheduling.PriorityClass, error) {
+func (p *priorityPlugin) getDefaultPriorityClass() (*scheduling.PriorityClass, error) {
 	list, err := p.lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -237,7 +237,7 @@ func (p *PriorityPlugin) getDefaultPriorityClass() (*scheduling.PriorityClass, e
 	return nil, nil
 }
 
-func (p *PriorityPlugin) getDefaultPriority() (int32, error) {
+func (p *priorityPlugin) getDefaultPriority() (int32, error) {
 	// If global default priority is cached, return it.
 	if p.globalDefaultPriority != nil {
 		return *p.globalDefaultPriority, nil
@@ -256,6 +256,6 @@ func (p *PriorityPlugin) getDefaultPriority() (int32, error) {
 }
 
 // invalidateCachedDefaultPriority sets global default priority to nil to indicate that it should be looked up again.
-func (p *PriorityPlugin) invalidateCachedDefaultPriority() {
+func (p *priorityPlugin) invalidateCachedDefaultPriority() {
 	p.globalDefaultPriority = nil
 }

--- a/plugin/pkg/admission/priority/admission_test.go
+++ b/plugin/pkg/admission/priority/admission_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package admission
+package priority
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-func addPriorityClasses(ctrl *PriorityPlugin, priorityClasses []*scheduling.PriorityClass) {
+func addPriorityClasses(ctrl *priorityPlugin, priorityClasses []*scheduling.PriorityClass) {
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
 	ctrl.SetInternalKubeInformerFactory(informerFactory)
 	// First add the existing classes to the cache.
@@ -132,7 +132,7 @@ func TestPriorityClassAdmission(t *testing.T) {
 	for _, test := range tests {
 		glog.V(4).Infof("starting test %q", test.name)
 
-		ctrl := NewPlugin()
+		ctrl := newPlugin()
 		// Add existing priority classes.
 		addPriorityClasses(ctrl, test.existingClasses)
 		// Now add the new class.
@@ -209,7 +209,7 @@ func TestDefaultPriority(t *testing.T) {
 
 	for _, test := range tests {
 		glog.V(4).Infof("starting test %q", test.name)
-		ctrl := NewPlugin()
+		ctrl := newPlugin()
 		addPriorityClasses(ctrl, test.classesBefore)
 		defaultPriority, err := ctrl.getDefaultPriority()
 		if err != nil {
@@ -430,7 +430,7 @@ func TestPodAdmission(t *testing.T) {
 	for _, test := range tests {
 		glog.V(4).Infof("starting test %q", test.name)
 
-		ctrl := NewPlugin()
+		ctrl := newPlugin()
 		// Add existing priority classes.
 		addPriorityClasses(ctrl, test.existingClasses)
 


### PR DESCRIPTION
1.priority admission file got wrong package name
2.PriorityPlugin struct should not be public as well as its construct function. 
this patch fix this.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
