### PR TITLE
Add call to addCredentialProviderFlags

### DIFF
--- a/cmd/kubelet/app/options/globalflags.go
+++ b/cmd/kubelet/app/options/globalflags.go
@@ -40,6 +40,7 @@ import (
 func AddGlobalFlags(fs *pflag.FlagSet) {
 	addGlogFlags(fs)
 	addCadvisorFlags(fs)
+	addCredentialProviderFlags(fs)
 	verflag.AddFlags(fs)
 	logs.AddFlags(fs)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Credential flags such as 'azure-container-registry-config' are still in use, call addCredentialProviderFlags to hook it up.

See:
https://github.com/kubernetes/kubernetes/pull/56995#issuecomment-361483382

**Which issue(s) this PR fixes**
Follow up of #56995 

**Special notes for your reviewer**:
/assign  @mtaufen @liggitt

**Release note**:
```release-note
NONE
```
