### PR TITLE
sample-controller: document minimum kubernetes version

### DIFF
--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -29,6 +29,8 @@ This is an example of how to build a kube-like controller with a single type.
 
 ## Running
 
+**Prerequisite**: Since the sample-controller uses `apps/v1` deployments, the Kubernetes cluster version should be greater than 1.9.
+
 ```sh
 # assumes you have a working kubeconfig, not required if operating in-cluster
 $ go run *.go -kubeconfig=$HOME/.kube/config


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/58446, the sample-controller started using `apps/v1` deployments since they became GA in 1.9.

This means that sample-controller does not support versions below 1.9.

Fixes kubernetes/sample-controller#9

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts munnerz 