### PR TITLE
Find and run all available kubeadm tests

### DIFF
--- a/hack/make-rules/test-kubeadm-cmd.sh
+++ b/hack/make-rules/test-kubeadm-cmd.sh
@@ -27,6 +27,30 @@ KUBEADM_PATH="${KUBEADM_PATH:=$(kube::realpath "${KUBE_ROOT}")/cluster/kubeadm.s
 # comment this out to save yourself from needlessly building here.
 make -C "${KUBE_ROOT}" WHAT=cmd/kubeadm
 
-make -C "${KUBE_ROOT}" test \
-  WHAT=k8s.io/kubernetes/cmd/kubeadm/test/cmd \
-  KUBE_TEST_ARGS="--kubeadm-path '${KUBEADM_PATH}'"
+pushd .
+
+cd ${KUBE_ROOT}
+
+passed=0
+failed=0
+
+for testdir in $(find ./cmd/kubeadm -name \*_test.go | xargs dirname | sort -u); do
+  kube::log::status "Running tests from $testdir"
+  args=''
+  if [ $testdir == './cmd/kubeadm/test/cmd' ] ; then
+    args="--kubeadm-path ${KUBEADM_PATH}"
+  fi
+  set +e errexit
+  if make -C "${KUBE_ROOT}" test WHAT=$testdir KUBE_TEST_ARGS="$args"; then
+    passed=$((passed+1))
+  else
+    failed=$((failed+1))
+  fi
+  set -o errexit
+done
+
+popd
+
+kube::log::status "Tests passed: $passed, failed: $failed"
+
+[ $failed -eq 0 ] || exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently test-kubeadm-cmd.sh script runs only fraction of
available kubeadm tests.

Changed script code to find all available tests in cmd/kubeadm
source tree and run them. Reported overall test run statistics
at the end.

**Release note**:
```release-note
NONE
```
