### PR TITLE
handle disabled clientmapper w no connection to server

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -606,7 +606,12 @@ func UpdateObjectNamespace(info *Info, err error) error {
 		return err
 	}
 	if info.Object != nil {
-		return info.Mapping.MetadataAccessor.SetNamespace(info.Object, info.Namespace)
+		metadata, err := meta.Accessor(info.Object)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve metadata: %v", err)
+		}
+		metadata.SetNamespace(info.Namespace)
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Handles cases where a resource builder is instantiated with the `LocalParam()`,
there is no connection to a server, and we are not using internal types.

cc @deads2k 