### PR TITLE
Automated cherry pick of #59130: Update Calico to version v2.6.7

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: gcr.io/projectcalico-org/node:v2.6.6
+          image: gcr.io/projectcalico-org/node:v2.6.7
           env:
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico
       containers:
-      - image: gcr.io/projectcalico-org/typha:v0.5.5
+      - image: gcr.io/projectcalico-org/typha:v0.5.6
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION
Cherry pick of #59130 on release-1.9.

#59130: Update Calico to version v2.6.7

Includes a relevant bugfix in named ports, see the Calico release notes: https://github.com/projectcalico/calico/releases/tag/v2.6.7

Specifically the following bug fix:
- Fixed bug where Felix would crash when parsing a NetworkPolicy with a named port 