### PR TITLE
Automated cherry pick of #59073: Client ca post start hook now checks if the system namespace

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client_ca_hook.go",
+        "client_util.go",
         "controller.go",
         "doc.go",
         "import_known_versions.go",

--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -74,7 +74,7 @@ func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.Pos
 // tryToWriteClientCAs is here for unit testing with a fake client.  This is a wait.ConditionFunc so the bool
 // indicates if the condition was met.  True when its finished, false when it should retry.
 func (h ClientCARegistrationHook) tryToWriteClientCAs(client coreclient.CoreInterface) (bool, error) {
-	if _, err := client.Namespaces().Create(&api.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := createNamespaceIfNeeded(client, metav1.NamespaceSystem); err != nil {
 		utilruntime.HandleError(err)
 		return false, nil
 	}

--- a/pkg/master/client_util.go
+++ b/pkg/master/client_util.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+)
+
+func createNamespaceIfNeeded(c coreclient.NamespacesGetter, ns string) error {
+	if _, err := c.Namespaces().Get(ns, metav1.GetOptions{}); err == nil {
+		// the namespace already exists
+		return nil
+	}
+	newNs := &api.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ns,
+			Namespace: "",
+		},
+	}
+	_, err := c.Namespaces().Create(newNs)
+	if err != nil && errors.IsAlreadyExists(err) {
+		err = nil
+	}
+	return err
+}


### PR DESCRIPTION
Cherry pick of #59073 on release-1.9.

#59073: Client ca post start hook now checks if the system namespace