### PR TITLE
Add events permission to cloud-provider cluster-role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -296,6 +296,12 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 		},
 	})
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "cloud-provider"},
+		Rules: []rbac.PolicyRule{
+			eventsRule(),
+		},
+	})
+	addControllerRole(&controllerRoles, &controllerRoleBindings, rbac.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "statefulset-controller"},
 		Rules: []rbac.PolicyRule{
 			rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the `cloud-provider` service account to create events for all namespaces. This will be used by cloud-providers to raise warning events. This service account will go be removed after cloud-specific controllers have been removed from kubernetes core. 

**Release note**:
```release-note
NONE
```

/assign @bowei 
