### PR TITLE
Marking CSIPersistentVolumeSource as Beta

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -76031,7 +76031,7 @@
     ]
    },
    "io.k8s.api.core.v1.CSIPersistentVolumeSource": {
-    "description": "Represents storage that is managed by an external CSI volume driver",
+    "description": "Represents storage that is managed by an external CSI volume driver (Beta feature)",
     "required": [
      "driver",
      "volumeHandle"
@@ -78556,7 +78556,7 @@
       "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
      },
      "csi": {
-      "description": "CSI represents storage that handled by an external CSI driver",
+      "description": "CSI represents storage that handled by an external CSI driver (Beta feature).",
       "$ref": "#/definitions/io.k8s.api.core.v1.CSIPersistentVolumeSource"
      },
      "fc": {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -20651,7 +20651,7 @@
      },
      "csi": {
       "$ref": "v1.CSIPersistentVolumeSource",
-      "description": "CSI represents storage that handled by an external CSI driver"
+      "description": "CSI represents storage that handled by an external CSI driver (Beta feature)."
      },
      "accessModes": {
       "type": "array",
@@ -21307,7 +21307,7 @@
    },
    "v1.CSIPersistentVolumeSource": {
     "id": "v1.CSIPersistentVolumeSource",
-    "description": "Represents storage that is managed by an external CSI volume driver",
+    "description": "Represents storage that is managed by an external CSI volume driver (Beta feature)",
     "required": [
      "driver",
      "volumeHandle"

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -4164,7 +4164,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">csi</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">CSI represents storage that handled by an external CSI driver</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">CSI represents storage that handled by an external CSI driver (Beta feature).</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_csipersistentvolumesource">v1.CSIPersistentVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7823,7 +7823,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1_csipersistentvolumesource">v1.CSIPersistentVolumeSource</h3>
 <div class="paragraph">
-<p>Represents storage that is managed by an external CSI volume driver</p>
+<p>Represents storage that is managed by an external CSI volume driver (Beta feature)</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -391,7 +391,7 @@ type PersistentVolumeSource struct {
 	// More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md
 	// +optional
 	StorageOS *StorageOSPersistentVolumeSource
-	// CSI (Container Storage Interface) represents storage that handled by an external CSI driver
+	// CSI (Container Storage Interface) represents storage that handled by an external CSI driver (Beta feature).
 	// +optional
 	CSI *CSIPersistentVolumeSource
 }
@@ -1603,7 +1603,7 @@ type LocalVolumeSource struct {
 	Path string
 }
 
-// Represents storage that is managed by an external CSI volume driver
+// Represents storage that is managed by an external CSI volume driver (Beta feature)
 type CSIPersistentVolumeSource struct {
 	// Driver is the name of the driver to use for this volume.
 	// Required.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -170,7 +170,7 @@ message Binding {
   optional ObjectReference target = 2;
 }
 
-// Represents storage that is managed by an external CSI volume driver
+// Represents storage that is managed by an external CSI volume driver (Beta feature)
 message CSIPersistentVolumeSource {
   // Driver is the name of the driver to use for this volume.
   // Required.
@@ -2528,7 +2528,7 @@ message PersistentVolumeSource {
   // +optional
   optional StorageOSPersistentVolumeSource storageos = 21;
 
-  // CSI represents storage that handled by an external CSI driver
+  // CSI represents storage that handled by an external CSI driver (Beta feature).
   // +optional
   optional CSIPersistentVolumeSource csi = 22;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -446,7 +446,7 @@ type PersistentVolumeSource struct {
 	// More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md
 	// +optional
 	StorageOS *StorageOSPersistentVolumeSource `json:"storageos,omitempty" protobuf:"bytes,21,opt,name=storageos"`
-	// CSI represents storage that handled by an external CSI driver
+	// CSI represents storage that handled by an external CSI driver (Beta feature).
 	// +optional
 	CSI *CSIPersistentVolumeSource `json:"csi,omitempty" protobuf:"bytes,22,opt,name=csi"`
 }
@@ -1717,7 +1717,7 @@ type LocalVolumeSource struct {
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
 }
 
-// Represents storage that is managed by an external CSI volume driver
+// Represents storage that is managed by an external CSI volume driver (Beta feature)
 type CSIPersistentVolumeSource struct {
 	// Driver is the name of the driver to use for this volume.
 	// Required.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -117,7 +117,7 @@ func (Binding) SwaggerDoc() map[string]string {
 }
 
 var map_CSIPersistentVolumeSource = map[string]string{
-	"":             "Represents storage that is managed by an external CSI volume driver",
+	"":             "Represents storage that is managed by an external CSI volume driver (Beta feature)",
 	"driver":       "Driver is the name of the driver to use for this volume. Required.",
 	"volumeHandle": "VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
 	"readOnly":     "Optional: The value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).",
@@ -1276,7 +1276,7 @@ var map_PersistentVolumeSource = map[string]string{
 	"scaleIO":              "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
 	"local":                "Local represents directly-attached storage with node affinity",
 	"storageos":            "StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md",
-	"csi":                  "CSI represents storage that handled by an external CSI driver",
+	"csi":                  "CSI represents storage that handled by an external CSI driver (Beta feature).",
 }
 
 func (PersistentVolumeSource) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR marks the `CSIPersistentVolumeSource` type as being `Beta`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58718

```release-note
Move CSI PersistentVolumes to Beta
```