### PR TITLE
Cluster Autoscaler 0.6.3

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
CA 0.6.3 contains tiny fixes around metrics.

```release-note
Bump Cluster Autoscaler to 0.6.3 version
```
