### PR TITLE
Increase RSS limit for runtime from 300MB to 350MB on test creating 100 pods per node.

### DIFF
--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -257,7 +257,7 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 				podsPerNode: 100,
 				memLimits: framework.ResourceUsagePerContainer{
 					stats.SystemContainerKubelet: &framework.ContainerResourceUsage{MemoryRSSInBytes: 300 * 1024 * 1024},
-					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 300 * 1024 * 1024},
+					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 350 * 1024 * 1024},
 				},
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

In recent COS image (cos-dev-65), the typical RSS increased a bit. It seems it was already close to the limit and now surpassed it.

I looked at some samples of failures of the test... In [some cases](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial/1270) it seems very close (<1%), a [more representative example](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial/1266)  goes up about ~5% but in [some](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial/1269) [cases](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial/1267) it did go up to close or above 340MB.

I did some tests using just "docker" on the machines, creating 100 "pause" containers. I didn't really see much difference in RSS, though after killing the containers RSS was a bit higher on the host running cos-dev.

I looked at some possible reasons that would explain that:
- Transparent huge pages: confirmed they were disabled;
- Version of docker: same on cos-65, cos-64 and cos-63;
- Version of Go: same, 1.9.2 on cos-64 and cos-65, while 1.9.1 on cos-63 but 64 was already using same as current version;
- Version of systemd (maybe due to systemd libraries linked into Docker?): same on the three images.

I don't really know what can explain this increase... So cc @adityakali in case he has something to add here. Also cc @yguo0905 with whom I discussed the testgrid.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
