### PR TITLE
bumping timeouts for apiserver communication.

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -975,7 +975,7 @@ def get_node_name():
     # Get all the nodes in the cluster
     cmd = 'kubectl --kubeconfig={} get no -o=json'.format(kubeconfig_path)
     cmd = cmd.split()
-    deadline = time.time() + 60
+    deadline = time.time() + 180
     while time.time() < deadline:
         try:
             raw = check_output(cmd)
@@ -1028,7 +1028,7 @@ def _apply_node_label(label, delete=False, overwrite=False):
             cmd = '{} --overwrite'.format(cmd)
     cmd = cmd.split()
 
-    deadline = time.time() + 60
+    deadline = time.time() + 180
     while time.time() < deadline:
         code = subprocess.call(cmd)
         if code == 0:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Our CI is failing due to timeouts. The times we set node names intersects with apiserver restarts, which can sometimes get caught up for longer than one minute. This is a temporary fix until we can decide on the best long-term solution.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upped the timeout for apiserver communication in the juju kubernetes-worker charm.
```
