### PR TITLE
[e2e ingress-gce] Retrieve the correct health check resource

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -256,29 +256,27 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			// Get cluster UID.
 			clusterID, err := framework.GetClusterID(f.ClientSet)
 			Expect(err).NotTo(HaveOccurred())
-			// Get default backend nodeport.
-			defaultBackendNodePort, err := jig.GetDefaultBackendNodePort()
-			Expect(err).NotTo(HaveOccurred())
+			// Get the related nodeports.
+			nodePorts := jig.GetIngressNodePorts(false)
+			Expect(len(nodePorts)).ToNot(Equal(0))
 
 			// Filter health check using cluster UID as the suffix.
 			By("Retrieving relevant health check resources from GCE.")
 			gceCloud := gceController.Cloud.Provider.(*gcecloud.GCECloud)
 			hcs, err := gceCloud.ListHealthChecks()
 			Expect(err).NotTo(HaveOccurred())
-			ingressHCs := []*compute.HealthCheck{}
+			var hcToChange *compute.HealthCheck
 			for _, hc := range hcs {
 				if strings.HasSuffix(hc.Name, clusterID) {
-					Expect(hc.HttpHealthCheck).ToNot(Equal(nil))
-					// Skip the default backend healthcheck as that shouldn't be customized.
-					if hc.HttpHealthCheck.Port == int64(defaultBackendNodePort) {
-						continue
+					Expect(hc.HttpHealthCheck).NotTo(BeNil())
+					if fmt.Sprintf("%d", hc.HttpHealthCheck.Port) == nodePorts[0] {
+						hcToChange = hc
+						break
 					}
-					ingressHCs = append(ingressHCs, hc)
 				}
 			}
+			Expect(hcToChange).NotTo(BeNil())
 
-			Expect(len(ingressHCs)).ToNot(Equal(0))
-			hcToChange := ingressHCs[0]
 			By(fmt.Sprintf("Modifying health check %v without involving ingress.", hcToChange.Name))
 			// Change timeout from 60s to 25s.
 			hcToChange.TimeoutSec = 25


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the test retrieves a random health check resource and assumes it belongs to the test ingress, which is wrong when multiple ingress tests are running simultaneously.

Example failure: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-ingress-gce-e2e/533

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @rramkumar1 @nicksardo 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
