### PR TITLE
remove mapper dependency for cmdutil.Factory#PrintSuccess

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -3732,7 +3732,7 @@ run_cmd_with_img_tests() {
 
   # Test that a valid image reference value is provided as the value of --image in `kubectl run <name> --image`
   output_message=$(kubectl run test1 --image=validname)
-  kube::test::if_has_string "${output_message}" 'deployment "test1" created'
+  kube::test::if_has_string "${output_message}" 'deployments "test1" created'
   kubectl delete deployments test1
   # test invalid image name
   output_message=$(! kubectl run test2 --image=InvalidImageName 2>&1)
@@ -4410,7 +4410,7 @@ __EOF__
   kube::test::if_has_string "${response}" 'must provide one or more resources'
   # test=label matches our node
   response=$(kubectl cordon --selector test=label)
-  kube::test::if_has_string "${response}" 'node "127.0.0.1" cordoned'
+  kube::test::if_has_string "${response}" 'nodes "127.0.0.1" cordoned'
   # invalid=label does not match any nodes
   response=$(kubectl cordon --selector invalid=label)
   kube::test::if_has_not_string "${response}" 'cordoned'

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -272,7 +272,7 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 		if len(o.outputFormat) > 0 {
 			return f.PrintObject(cmd, o.local, mapper, outputObj, o.out)
 		}
-		f.PrintSuccess(mapper, false, o.out, info.Mapping.Resource, info.Name, o.dryrun, "annotated")
+		f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, o.dryrun, "annotated")
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -297,7 +297,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			if len(output) > 0 && !shortOutput {
 				return f.PrintResourceInfoForCommand(cmd, info, out)
 			}
-			f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
+			f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
 			return nil
 		}
 
@@ -342,7 +342,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 
 			if string(patchBytes) == "{}" {
 				count++
-				f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "unchanged")
+				f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "unchanged")
 				return nil
 			}
 		}
@@ -350,7 +350,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		if len(output) > 0 && !shortOutput {
 			return f.PrintResourceInfoForCommand(cmd, info, out)
 		}
-		f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "configured")
+		f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "configured")
 		return nil
 	})
 
@@ -517,7 +517,7 @@ func (p *pruner) prune(f cmdutil.Factory, namespace string, mapping *meta.RESTMa
 				return err
 			}
 		}
-		f.PrintSuccess(p.mapper, shortOutput, p.out, mapping.Resource, name, p.dryRun, "pruned")
+		f.PrintSuccess(shortOutput, p.out, mapping.Resource, name, p.dryRun, "pruned")
 	}
 	return nil
 }

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -188,14 +188,14 @@ func (o *SetLastAppliedOptions) RunSetLastApplied(f cmdutil.Factory, cmd *cobra.
 				info.Refresh(patchedObj, false)
 				return f.PrintResourceInfoForCommand(cmd, info, o.Out)
 			}
-			f.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "configured")
+			f.PrintSuccess(o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "configured")
 
 		} else {
 			err := o.formatPrinter(o.Output, patch.Patch, o.Out)
 			if err != nil {
 				return err
 			}
-			f.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "configured")
+			f.PrintSuccess(o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "configured")
 		}
 	}
 	return nil

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -415,7 +415,7 @@ func TestApplyObjectWithoutAnnotation(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	expectRC := "replicationcontroller/" + nameRC + "\n"
+	expectRC := "replicationcontrollers/" + nameRC + "\n"
 	expectWarning := fmt.Sprintf(warningNoLastAppliedConfigAnnotation, "kubectl")
 	if errBuf.String() != expectWarning {
 		t.Fatalf("unexpected non-warning: %s\nexpected: %s", errBuf.String(), expectWarning)
@@ -461,7 +461,7 @@ func TestApplyObject(t *testing.T) {
 		cmd.Run(cmd, []string{})
 
 		// uses the name from the file, not the response
-		expectRC := "replicationcontroller/" + nameRC + "\n"
+		expectRC := "replicationcontrollers/" + nameRC + "\n"
 		if buf.String() != expectRC {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expectRC)
 		}
@@ -586,7 +586,7 @@ func TestApplyRetry(t *testing.T) {
 		}
 
 		// uses the name from the file, not the response
-		expectRC := "replicationcontroller/" + nameRC + "\n"
+		expectRC := "replicationcontrollers/" + nameRC + "\n"
 		if buf.String() != expectRC {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expectRC)
 		}
@@ -630,7 +630,7 @@ func TestApplyNonExistObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	expectRC := "replicationcontroller/" + nameRC + "\n"
+	expectRC := "replicationcontrollers/" + nameRC + "\n"
 	if buf.String() != expectRC {
 		t.Errorf("unexpected output: %s\nexpected: %s", buf.String(), expectRC)
 	}
@@ -683,7 +683,7 @@ func TestApplyEmptyPatch(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	expectRC := "replicationcontroller/" + nameRC + "\n"
+	expectRC := "replicationcontrollers/" + nameRC + "\n"
 	if buf.String() != expectRC {
 		t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expectRC)
 	}
@@ -764,8 +764,8 @@ func testApplyMultipleObjects(t *testing.T, asList bool) {
 		cmd.Run(cmd, []string{})
 
 		// Names should come from the REST response, NOT the files
-		expectRC := "replicationcontroller/" + nameRC + "\n"
-		expectSVC := "service/" + nameSVC + "\n"
+		expectRC := "replicationcontrollers/" + nameRC + "\n"
+		expectSVC := "services/" + nameSVC + "\n"
 		// Test both possible orders since output is non-deterministic.
 		expectOne := expectRC + expectSVC
 		expectTwo := expectSVC + expectRC
@@ -855,7 +855,7 @@ func TestApplyNULLPreservation(t *testing.T) {
 
 		cmd.Run(cmd, []string{})
 
-		expected := "deployment/" + deploymentName + "\n"
+		expected := "deployments/" + deploymentName + "\n"
 		if buf.String() != expected {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expected)
 		}
@@ -918,7 +918,7 @@ func TestUnstructuredApply(t *testing.T) {
 		cmd.Flags().Set("output", "name")
 		cmd.Run(cmd, []string{})
 
-		expected := "widget/" + name + "\n"
+		expected := "widgets/" + name + "\n"
 		if buf.String() != expected {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expected)
 		}
@@ -1009,7 +1009,7 @@ func TestUnstructuredIdempotentApply(t *testing.T) {
 		cmd.Flags().Set("output", "name")
 		cmd.Run(cmd, []string{})
 
-		expected := "widget/widget\n"
+		expected := "widgets/widget\n"
 		if buf.String() != expected {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expected)
 		}
@@ -1040,7 +1040,7 @@ func TestRunApplySetLastApplied(t *testing.T) {
 			name:        "set with exist object",
 			filePath:    filenameRC,
 			expectedErr: "",
-			expectedOut: "replicationcontroller/test-rc\n",
+			expectedOut: "replicationcontrollers/test-rc\n",
 			output:      "name",
 		},
 		{
@@ -1061,14 +1061,14 @@ func TestRunApplySetLastApplied(t *testing.T) {
 			name:        "set with exist object output json",
 			filePath:    filenameRCJSON,
 			expectedErr: "",
-			expectedOut: "replicationcontroller/test-rc\n",
+			expectedOut: "replicationcontrollers/test-rc\n",
 			output:      "name",
 		},
 		{
 			name:        "set test for a directory of files",
 			filePath:    dirName,
 			expectedErr: "",
-			expectedOut: "replicationcontroller/test-rc\nreplicationcontroller/test-rc\n",
+			expectedOut: "replicationcontrollers/test-rc\nreplicationcontrollers/test-rc\n",
 			output:      "name",
 		},
 	}
@@ -1243,7 +1243,7 @@ func TestForceApply(t *testing.T) {
 			}
 		}
 
-		if expected := "replicationcontroller/" + nameRC + "\n"; buf.String() != expected {
+		if expected := "replicationcontrollers/" + nameRC + "\n"; buf.String() != expected {
 			t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expected)
 		}
 		if errBuf.String() != "" {

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -114,7 +114,6 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 	o.RBACClient = client.Rbac()
 	o.NamespaceClient = client.Core().Namespaces()
 
-	mapper, _ := f.Object()
 	dryRun := false
 	output := cmdutil.GetFlagString(cmd, "output")
 	shortOutput := output == "name"
@@ -122,7 +121,7 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 		if len(output) > 0 && !shortOutput {
 			return f.PrintResourceInfoForCommand(cmd, info, o.Out)
 		}
-		f.PrintSuccess(mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, dryRun, "reconciled")
+		f.PrintSuccess(shortOutput, o.Out, info.Mapping.Resource, info.Name, dryRun, "reconciled")
 		return nil
 	}
 

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -173,7 +173,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 			return f.PrintObject(cmd, false, mapper, object, out)
 		}
 
-		f.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, cmdutil.GetDryRunFlag(cmd), "autoscaled")
+		f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, cmdutil.GetDryRunFlag(cmd), "autoscaled")
 		return nil
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -165,7 +165,6 @@ func (options *CertificateOptions) RunCertificateDeny(f cmdutil.Factory, out io.
 
 func (options *CertificateOptions) modifyCertificateCondition(f cmdutil.Factory, out io.Writer, modify func(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, string)) error {
 	var found int
-	mapper, _ := f.Object()
 	c, err := f.ClientSet()
 	if err != nil {
 		return err
@@ -192,7 +191,7 @@ func (options *CertificateOptions) modifyCertificateCondition(f cmdutil.Factory,
 			return err
 		}
 		found++
-		f.PrintSuccess(mapper, options.outputStyle == "name", out, info.Mapping.Resource, info.Name, false, verb)
+		f.PrintSuccess(options.outputStyle == "name", out, info.Mapping.Resource, info.Name, false, verb)
 		return nil
 	})
 	if found == 0 {

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -185,7 +185,6 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	dryRun := cmdutil.GetDryRunFlag(cmd)
 	output := cmdutil.GetFlagString(cmd, "output")
-	mapper := r.Mapper().RESTMapper
 
 	count := 0
 	err = r.Visit(func(info *resource.Info, err error) error {
@@ -218,7 +217,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 			f.PrintObjectSpecificMessage(info.Object, o.Out)
 		}
 
-		f.PrintSuccess(mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, dryRun, "created")
+		f.PrintSuccess(shortOutput, o.Out, info.Mapping.Resource, info.Name, dryRun, "created")
 		return nil
 	})
 	if err != nil {
@@ -357,7 +356,7 @@ func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, o
 	}
 
 	if useShortOutput := options.OutputFormat == "name"; useShortOutput || len(options.OutputFormat) == 0 {
-		f.PrintSuccess(mapper, useShortOutput, out, mapping.Resource, info.Name, options.DryRun, "created")
+		f.PrintSuccess(useShortOutput, out, mapping.Resource, info.Name, options.DryRun, "created")
 		return nil
 	}
 

--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -173,7 +173,7 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 	}
 
 	if useShortOutput := c.OutputFormat == "name"; useShortOutput || len(c.OutputFormat) == 0 {
-		c.PrintSuccess(c.Mapper, useShortOutput, c.Out, "clusterroles", c.Name, c.DryRun, "created")
+		c.PrintSuccess(useShortOutput, c.Out, "clusterroles", c.Name, c.DryRun, "created")
 		return nil
 	}
 

--- a/pkg/kubectl/cmd/create_clusterrolebinding_test.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding_test.go
@@ -107,7 +107,7 @@ func TestCreateClusterRoleBinding(t *testing.T) {
 		},
 	}
 
-	expectedOutput := "clusterrolebinding/" + expectBinding.Name + "\n"
+	expectedOutput := "clusterrolebindings/" + expectBinding.Name + "\n"
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateClusterRoleBinding(f, buf)
 	cmd.Flags().Set("clusterrole", "fake-clusterrole")

--- a/pkg/kubectl/cmd/create_configmap_test.go
+++ b/pkg/kubectl/cmd/create_configmap_test.go
@@ -50,7 +50,7 @@ func TestCreateConfigMap(t *testing.T) {
 	cmd := NewCmdCreateConfigMap(f, buf)
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{configMap.Name})
-	expectedOutput := "configmap/" + configMap.Name + "\n"
+	expectedOutput := "configmaps/" + configMap.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_deployment_test.go
+++ b/pkg/kubectl/cmd/create_deployment_test.go
@@ -93,7 +93,7 @@ func TestCreateDeployment(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("image", "hollywood/jonny.depp:v2")
 	cmd.Run(cmd, []string{depName})
-	expectedOutput := "deployment/" + depName + "\n"
+	expectedOutput := "deployments/" + depName + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_namespace_test.go
+++ b/pkg/kubectl/cmd/create_namespace_test.go
@@ -49,7 +49,7 @@ func TestCreateNamespace(t *testing.T) {
 	cmd := NewCmdCreateNamespace(f, buf)
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{namespaceObject.Name})
-	expectedOutput := "namespace/" + namespaceObject.Name + "\n"
+	expectedOutput := "namespaces/" + namespaceObject.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_pdb_test.go
+++ b/pkg/kubectl/cmd/create_pdb_test.go
@@ -52,7 +52,7 @@ func TestCreatePdb(t *testing.T) {
 	cmd.Flags().Set("dry-run", "true")
 	cmd.Flags().Set("output", "name")
 	CreatePodDisruptionBudget(f, buf, cmd, []string{pdbName})
-	expectedOutput := "poddisruptionbudget/" + pdbName + "\n"
+	expectedOutput := "poddisruptionbudgets/" + pdbName + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_priorityclass_test.go
+++ b/pkg/kubectl/cmd/create_priorityclass_test.go
@@ -52,7 +52,7 @@ func TestCreatePriorityClass(t *testing.T) {
 	cmd.Flags().Set("dry-run", "true")
 	cmd.Flags().Set("output", "name")
 	CreatePriorityClass(f, buf, cmd, []string{pcName})
-	expectedOutput := "priorityclass/" + pcName + "\n"
+	expectedOutput := "priorityclasses/" + pcName + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_quota_test.go
+++ b/pkg/kubectl/cmd/create_quota_test.go
@@ -53,19 +53,19 @@ func TestCreateQuota(t *testing.T) {
 	}{
 		"single resource": {
 			flags:          []string{"--hard=cpu=1"},
-			expectedOutput: "resourcequota/" + resourceQuotaObject.Name + "\n",
+			expectedOutput: "resourcequotas/" + resourceQuotaObject.Name + "\n",
 		},
 		"single resource with a scope": {
 			flags:          []string{"--hard=cpu=1", "--scopes=BestEffort"},
-			expectedOutput: "resourcequota/" + resourceQuotaObject.Name + "\n",
+			expectedOutput: "resourcequotas/" + resourceQuotaObject.Name + "\n",
 		},
 		"multiple resources": {
 			flags:          []string{"--hard=cpu=1,pods=42", "--scopes=BestEffort"},
-			expectedOutput: "resourcequota/" + resourceQuotaObject.Name + "\n",
+			expectedOutput: "resourcequotas/" + resourceQuotaObject.Name + "\n",
 		},
 		"single resource with multiple scopes": {
 			flags:          []string{"--hard=cpu=1", "--scopes=BestEffort,NotTerminating"},
-			expectedOutput: "resourcequota/" + resourceQuotaObject.Name + "\n",
+			expectedOutput: "resourcequotas/" + resourceQuotaObject.Name + "\n",
 		},
 	}
 	for name, test := range tests {

--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -112,7 +112,7 @@ type CreateRoleOptions struct {
 	Mapper       meta.RESTMapper
 	Out          io.Writer
 	PrintObject  func(obj runtime.Object) error
-	PrintSuccess func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 }
 
 // Role is a command to ease creating Roles.
@@ -295,7 +295,7 @@ func (c *CreateRoleOptions) RunCreateRole() error {
 	}
 
 	if useShortOutput := c.OutputFormat == "name"; useShortOutput || len(c.OutputFormat) == 0 {
-		c.PrintSuccess(c.Mapper, useShortOutput, c.Out, "roles", c.Name, c.DryRun, "created")
+		c.PrintSuccess(useShortOutput, c.Out, "roles", c.Name, c.DryRun, "created")
 		return nil
 	}
 

--- a/pkg/kubectl/cmd/create_secret_test.go
+++ b/pkg/kubectl/cmd/create_secret_test.go
@@ -57,7 +57,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 	cmd.Flags().Set("from-literal", "password=includes,comma")
 	cmd.Flags().Set("from-literal", "username=test_user")
 	cmd.Run(cmd, []string{secretObject.Name})
-	expectedOutput := "secret/" + secretObject.Name + "\n"
+	expectedOutput := "secrets/" + secretObject.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
@@ -89,7 +89,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 	cmd.Flags().Set("docker-email", "test-email")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{secretObject.Name})
-	expectedOutput := "secret/" + secretObject.Name + "\n"
+	expectedOutput := "secrets/" + secretObject.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", buf.String(), expectedOutput)
 	}

--- a/pkg/kubectl/cmd/create_service_test.go
+++ b/pkg/kubectl/cmd/create_service_test.go
@@ -51,7 +51,7 @@ func TestCreateService(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("tcp", "8080:8000")
 	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
+	expectedOutput := "services/" + service.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
@@ -81,7 +81,7 @@ func TestCreateServiceNodePort(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("tcp", "30000:8000")
 	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
+	expectedOutput := "services/" + service.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
@@ -111,7 +111,7 @@ func TestCreateServiceExternalName(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("external-name", "name")
 	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
+	expectedOutput := "services/" + service.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/create_serviceaccount_test.go
@@ -50,7 +50,7 @@ func TestCreateServiceAccount(t *testing.T) {
 	cmd := NewCmdCreateServiceAccount(f, buf)
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{serviceAccountObject.Name})
-	expectedOutput := "serviceaccount/" + serviceAccountObject.Name + "\n"
+	expectedOutput := "serviceaccounts/" + serviceAccountObject.Name + "\n"
 	if buf.String() != expectedOutput {
 		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}

--- a/pkg/kubectl/cmd/create_test.go
+++ b/pkg/kubectl/cmd/create_test.go
@@ -69,7 +69,7 @@ func TestCreateObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "replicationcontroller/redis-master-controller\n" {
+	if buf.String() != "replicationcontrollers/redis-master-controller\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -106,7 +106,7 @@ func TestCreateMultipleObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// Names should come from the REST response, NOT the files
-	if buf.String() != "replicationcontroller/rc1\nservice/baz\n" {
+	if buf.String() != "replicationcontrollers/rc1\nservices/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -140,7 +140,7 @@ func TestCreateDirectory(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/name\nreplicationcontroller/name\nreplicationcontroller/name\n" {
+	if buf.String() != "replicationcontrollers/name\nreplicationcontrollers/name\nreplicationcontrollers/name\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -259,7 +259,7 @@ func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultD
 			}
 		}
 		if !quiet {
-			f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
+			f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
 		}
 		return nil
 	})
@@ -311,7 +311,7 @@ func deleteResource(info *resource.Info, f cmdutil.Factory, out io.Writer, short
 	if err := resource.NewHelper(info.Client, info.Mapping).DeleteWithOptions(info.Namespace, info.Name, deleteOptions); err != nil {
 		return cmdutil.AddSourceToErr("deleting", info.Source, err)
 	}
-	f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
+	f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
 	return nil
 }
 

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -84,7 +84,7 @@ func TestDeleteObjectByTuple(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"replicationcontrollers/redis-master-controller"})
-	if buf.String() != "replicationcontroller/redis-master-controller\n" {
+	if buf.String() != "replicationcontrollers/redis-master-controller\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -94,7 +94,7 @@ func TestDeleteObjectByTuple(t *testing.T) {
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets/mysecret"})
-	if buf.String() != "secret/mysecret\n" {
+	if buf.String() != "secrets/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -143,7 +143,7 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets/mysecret"})
-	if buf.String() != "secret/mysecret\n" {
+	if buf.String() != "secrets/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -156,7 +156,7 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets/mysecret"})
-	if buf.String() != "secret/mysecret\n" {
+	if buf.String() != "secrets/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -196,7 +196,7 @@ func TestDeleteNamedObject(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"replicationcontrollers", "redis-master-controller"})
-	if buf.String() != "replicationcontroller/redis-master-controller\n" {
+	if buf.String() != "replicationcontrollers/redis-master-controller\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -207,7 +207,7 @@ func TestDeleteNamedObject(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"secrets", "mysecret"})
-	if buf.String() != "secret/mysecret\n" {
+	if buf.String() != "secrets/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -240,7 +240,7 @@ func TestDeleteObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "replicationcontroller/redis-master\n" {
+	if buf.String() != "replicationcontrollers/redis-master\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -310,7 +310,7 @@ func TestDeleteObjectGraceZero(t *testing.T) {
 	cmd.Run(cmd, []string{"pod/nginx"})
 
 	// uses the name from the file, not the response
-	if buf.String() != "pod/nginx\n" {
+	if buf.String() != "pods/nginx\n" {
 		t.Errorf("unexpected output: %s\n---\n%s", buf.String(), errBuf.String())
 	}
 	if reaper.deleteOptions == nil || reaper.deleteOptions.GracePeriodSeconds == nil || *reaper.deleteOptions.GracePeriodSeconds != 1 {
@@ -473,7 +473,7 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"services"})
 
-	if buf.String() != "service/baz\n" {
+	if buf.String() != "services/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -508,7 +508,7 @@ func TestDeleteMultipleObject(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/redis-master\nservice/frontend\n" {
+	if buf.String() != "replicationcontrollers/redis-master\nservices/frontend\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -553,7 +553,7 @@ func TestDeleteMultipleObjectContinueOnMissing(t *testing.T) {
 		t.Errorf("unexpected error: expected NotFound, got %v", err)
 	}
 
-	if buf.String() != "service/frontend\n" {
+	if buf.String() != "services/frontend\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -590,7 +590,7 @@ func TestDeleteMultipleResourcesWithTheSameName(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"replicationcontrollers,services", "baz", "foo"})
-	if buf.String() != "replicationcontroller/baz\nreplicationcontroller/foo\nservice/baz\nservice/foo\n" {
+	if buf.String() != "replicationcontrollers/baz\nreplicationcontrollers/foo\nservices/baz\nservices/foo\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -622,7 +622,7 @@ func TestDeleteDirectory(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/frontend\nreplicationcontroller/redis-master\nreplicationcontroller/redis-slave\n" {
+	if buf.String() != "replicationcontrollers/frontend\nreplicationcontrollers/redis-master\nreplicationcontrollers/redis-slave\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -666,7 +666,7 @@ func TestDeleteMultipleSelector(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	if buf.String() != "pod/foo\npod/bar\nservice/baz\n" {
+	if buf.String() != "pods/foo\npods/bar\nservices/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -242,7 +242,6 @@ func (o *DrainOptions) SetupDrain(cmd *cobra.Command, args []string) error {
 	}
 
 	o.nodeInfos = []*resource.Info{}
-	o.mapper, o.typer = o.Factory.Object()
 
 	cmdNamespace, _, err := o.Factory.DefaultNamespace()
 	if err != nil {
@@ -296,7 +295,7 @@ func (o *DrainOptions) RunDrain() error {
 		}
 		if err == nil || o.DryRun {
 			drainedNodes.Insert(info.Name)
-			o.Factory.PrintSuccess(o.mapper, false, o.Out, "node", info.Name, o.DryRun, "drained")
+			o.Factory.PrintSuccess(false, o.Out, "node", info.Name, o.DryRun, "drained")
 		} else {
 			fmt.Fprintf(o.ErrOut, "error: unable to drain node %q, aborting command...\n\n", info.Name)
 			remainingNodes := []string{}
@@ -617,7 +616,7 @@ func (o *DrainOptions) waitForDelete(pods []corev1.Pod, interval, timeout time.D
 		for i, pod := range pods {
 			p, err := getPodFn(pod.Namespace, pod.Name)
 			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
-				o.Factory.PrintSuccess(o.mapper, false, o.Out, "pod", pod.Name, false, verbStr)
+				o.Factory.PrintSuccess(false, o.Out, "pod", pod.Name, false, verbStr)
 				continue
 			} else if err != nil {
 				return false, err
@@ -698,7 +697,7 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 			}
 			unsched := node.Spec.Unschedulable
 			if unsched == desired {
-				o.Factory.PrintSuccess(o.mapper, false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, already(desired))
+				o.Factory.PrintSuccess(false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, already(desired))
 			} else {
 				if !o.DryRun {
 					helper := resource.NewHelper(o.restClient, nodeInfo.Mapping)
@@ -719,10 +718,10 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 						continue
 					}
 				}
-				o.Factory.PrintSuccess(o.mapper, false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, changed(desired))
+				o.Factory.PrintSuccess(false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, changed(desired))
 			}
 		} else {
-			o.Factory.PrintSuccess(o.mapper, false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, "skipped")
+			o.Factory.PrintSuccess(false, o.Out, nodeInfo.Mapping.Resource, nodeInfo.Name, o.DryRun, "skipped")
 		}
 	}
 

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -257,7 +257,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
 				return f.PrintObject(cmd, false, mapper, object, out)
 			}
-			f.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, true, "exposed")
+			f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, true, "exposed")
 			return nil
 		}
 		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, f.JSONEncoder()); err != nil {
@@ -274,7 +274,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			return f.PrintObject(cmd, false, mapper, object, out)
 		}
 
-		f.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, false, "exposed")
+		f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, false, "exposed")
 		return nil
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -79,7 +79,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"app": "go"},
 				},
 			},
-			expected: "service \"foo\" exposed",
+			expected: "services \"foo\" exposed",
 			status:   200,
 		},
 		{
@@ -110,7 +110,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"func": "stream"},
 				},
 			},
-			expected: "service \"foo\" exposed",
+			expected: "services \"foo\" exposed",
 			status:   200,
 		},
 		{
@@ -142,7 +142,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"run": "this"},
 				},
 			},
-			expected: "service \"mayor\" exposed",
+			expected: "services \"mayor\" exposed",
 			status:   200,
 		},
 		{
@@ -237,7 +237,7 @@ func TestRunExposeService(t *testing.T) {
 					ClusterIP: "10.10.10.10",
 				},
 			},
-			expected: "service \"foo\" exposed",
+			expected: "services \"foo\" exposed",
 			status:   200,
 		},
 		{
@@ -269,7 +269,7 @@ func TestRunExposeService(t *testing.T) {
 					ClusterIP: api.ClusterIPNone,
 				},
 			},
-			expected: "service \"foo\" exposed",
+			expected: "services \"foo\" exposed",
 			status:   200,
 		},
 		{
@@ -295,7 +295,7 @@ func TestRunExposeService(t *testing.T) {
 					ClusterIP: api.ClusterIPNone,
 				},
 			},
-			expected: "service \"foo\" exposed",
+			expected: "services \"foo\" exposed",
 			status:   200,
 		},
 		{
@@ -353,7 +353,7 @@ func TestRunExposeService(t *testing.T) {
 					Selector: map[string]string{"svc": "frompod"},
 				},
 			},
-			expected: "service \"a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand\" exposed",
+			expected: "services \"a-name-that-is-toooo-big-for-a-service-because-it-can-only-hand\" exposed",
 			status:   200,
 		},
 		{
@@ -501,7 +501,7 @@ func TestRunExposeService(t *testing.T) {
 				continue
 			}
 
-			test.expected = fmt.Sprintf("service %q exposed (dry run)", test.flags["name"])
+			test.expected = fmt.Sprintf("services %q exposed (dry run)", test.flags["name"])
 		}
 
 		if !strings.Contains(out, test.expected) {

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -293,7 +293,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		if o.outputFormat != "" {
 			return f.PrintObject(cmd, o.local, r.Mapper().RESTMapper, outputObj, o.out)
 		}
-		f.PrintSuccess(r.Mapper().RESTMapper, false, o.out, info.Mapping.Resource, info.Name, o.dryrun, dataChangeMsg)
+		f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, o.dryrun, dataChangeMsg)
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -212,7 +212,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			if len(options.OutputFormat) > 0 && options.OutputFormat != "name" {
 				return f.PrintResourceInfoForCommand(cmd, info, out)
 			}
-			f.PrintSuccess(r.Mapper().RESTMapper, options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
+			f.PrintSuccess(options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
 
 			// if object was not successfully patched, exit with error code 1
 			if !didPatch {

--- a/pkg/kubectl/cmd/patch_test.go
+++ b/pkg/kubectl/cmd/patch_test.go
@@ -60,7 +60,7 @@ func TestPatchObject(t *testing.T) {
 	cmd.Run(cmd, []string{"services/frontend"})
 
 	// uses the name from the response
-	if buf.String() != "service/baz\n" {
+	if buf.String() != "services/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -92,7 +92,7 @@ func TestPatchObjectFromFile(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the response
-	if buf.String() != "service/baz\n" {
+	if buf.String() != "services/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -131,7 +131,7 @@ func TestPatchNoop(t *testing.T) {
 		cmd.Flags().Set("namespace", "test")
 		cmd.Flags().Set("patch", `{"metadata":{"annotations":{"foo":"bar"}}}`)
 		cmd.Run(cmd, []string{"services", "frontend"})
-		if buf.String() != "service \"baz\" patched\n" {
+		if buf.String() != "services \"baz\" patched\n" {
 			t.Errorf("unexpected output: %s", buf.String())
 		}
 	}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -132,8 +132,6 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		return err
 	}
 
-	mapper := r.Mapper().RESTMapper
-
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
@@ -157,7 +155,7 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 
 		info.Refresh(obj, true)
 		f.PrintObjectSpecificMessage(obj, out)
-		f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "replaced")
+		f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "replaced")
 		return nil
 	})
 }
@@ -281,7 +279,7 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		count++
 		info.Refresh(obj, true)
 		f.PrintObjectSpecificMessage(obj, out)
-		f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "replaced")
+		f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "replaced")
 		return nil
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/replace_test.go
+++ b/pkg/kubectl/cmd/replace_test.go
@@ -67,7 +67,7 @@ func TestReplaceObject(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "replicationcontroller/rc1\n" {
+	if buf.String() != "replicationcontrollers/rc1\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -77,7 +77,7 @@ func TestReplaceObject(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/redis-master\nreplicationcontroller/rc1\n" {
+	if buf.String() != "replicationcontrollers/redis-master\nreplicationcontrollers/rc1\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -136,7 +136,7 @@ func TestReplaceMultipleObject(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/rc1\nservice/baz\n" {
+	if buf.String() != "replicationcontrollers/rc1\nservices/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -146,7 +146,7 @@ func TestReplaceMultipleObject(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/redis-master\nservice/frontend\nreplicationcontroller/rc1\nservice/baz\n" {
+	if buf.String() != "replicationcontrollers/redis-master\nservices/frontend\nreplicationcontrollers/rc1\nservices/baz\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -192,7 +192,7 @@ func TestReplaceDirectory(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/rc1\nreplicationcontroller/rc1\nreplicationcontroller/rc1\n" {
+	if buf.String() != "replicationcontrollers/rc1\nreplicationcontrollers/rc1\nreplicationcontrollers/rc1\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
@@ -201,8 +201,8 @@ func TestReplaceDirectory(t *testing.T) {
 	cmd.Flags().Set("cascade", "false")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/frontend\nreplicationcontroller/redis-master\nreplicationcontroller/redis-slave\n"+
-		"replicationcontroller/rc1\nreplicationcontroller/rc1\nreplicationcontroller/rc1\n" {
+	if buf.String() != "replicationcontrollers/frontend\nreplicationcontrollers/redis-master\nreplicationcontrollers/redis-slave\n"+
+		"replicationcontrollers/rc1\nreplicationcontrollers/rc1\nreplicationcontrollers/rc1\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -238,7 +238,7 @@ func TestForceReplaceObjectNotFound(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	if buf.String() != "replicationcontroller/rc1\n" {
+	if buf.String() != "replicationcontrollers/rc1\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -372,7 +372,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 	if outputFormat != "" {
 		return f.PrintObject(cmd, false, mapper, newRc, out)
 	}
-	f.PrintSuccess(mapper, false, out, "replicationcontrollers", oldName, dryrun, message)
+	f.PrintSuccess(false, out, "replicationcontrollers", oldName, dryrun, message)
 	return nil
 }
 

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -45,7 +45,7 @@ type PauseConfig struct {
 	Encoder runtime.Encoder
 	Infos   []*resource.Info
 
-	PrintSuccess func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	Out          io.Writer
 }
 
@@ -145,7 +145,7 @@ func (o PauseConfig) RunPause() error {
 		}
 
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			o.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "already paused")
+			o.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "already paused")
 			continue
 		}
 
@@ -156,7 +156,7 @@ func (o PauseConfig) RunPause() error {
 		}
 
 		info.Refresh(obj, true)
-		o.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "paused")
+		o.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "paused")
 	}
 
 	return utilerrors.NewAggregate(allErrs)

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -45,7 +45,7 @@ type ResumeConfig struct {
 	Encoder runtime.Encoder
 	Infos   []*resource.Info
 
-	PrintSuccess func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	Out          io.Writer
 }
 
@@ -150,7 +150,7 @@ func (o ResumeConfig) RunResume() error {
 		}
 
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			o.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "already resumed")
+			o.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "already resumed")
 			continue
 		}
 
@@ -161,7 +161,7 @@ func (o ResumeConfig) RunResume() error {
 		}
 
 		info.Refresh(obj, true)
-		o.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "resumed")
+		o.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "resumed")
 	}
 
 	return utilerrors.NewAggregate(allErrs)

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -43,7 +43,7 @@ type UndoOptions struct {
 	ToRevision  int64
 	DryRun      bool
 
-	PrintSuccess func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	Out          io.Writer
 }
 
@@ -150,7 +150,7 @@ func (o *UndoOptions) RunUndo() error {
 			allErrs = append(allErrs, cmdutil.AddSourceToErr("undoing", info.Source, err))
 			continue
 		}
-		o.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, result)
+		o.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, result)
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -406,7 +406,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 	if outputFormat != "" || cmdutil.GetDryRunFlag(cmd) {
 		return f.PrintObject(cmd, false, runObject.Mapper, runObject.Object, cmdOut)
 	}
-	f.PrintSuccess(runObject.Mapper, false, cmdOut, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
+	f.PrintSuccess(false, cmdOut, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
 	return nil
 }
 
@@ -561,7 +561,7 @@ func generateService(f cmdutil.Factory, cmd *cobra.Command, args []string, servi
 		}
 		return runObject, nil
 	}
-	f.PrintSuccess(runObject.Mapper, false, out, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
+	f.PrintSuccess(false, out, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
 
 	return runObject, nil
 }

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -104,7 +104,6 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 	selector := cmdutil.GetFlagString(cmd, "selector")
 	all := cmdutil.GetFlagBool(cmd, "all")
 
-	mapper, _ := f.Object()
 	r := f.NewBuilder().
 		Internal().
 		ContinueOnError().
@@ -181,7 +180,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			}
 		}
 		counter++
-		f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "scaled")
+		f.PrintSuccess(shortOutput, out, info.Mapping.Resource, info.Name, false, "scaled")
 		return nil
 	})
 	if err != nil {

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -440,7 +440,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 			continue
 		}
 
-		f.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, false, "env updated")
+		f.PrintSuccess(o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, false, "env updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -54,7 +54,7 @@ type ImageOptions struct {
 	Cmd          *cobra.Command
 	ResolveImage func(in string) (string, error)
 
-	PrintSuccess           func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
@@ -278,7 +278,7 @@ func (o *ImageOptions) Run() error {
 			}
 			continue
 		}
-		o.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "image updated")
+		o.PrintSuccess(o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, o.DryRun, "image updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -80,7 +80,7 @@ type ResourcesOptions struct {
 	Requests             string
 	ResourceRequirements v1.ResourceRequirements
 
-	PrintSuccess           func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
@@ -269,7 +269,7 @@ func (o *ResourcesOptions) Run() error {
 			}
 			continue
 		}
-		o.PrintSuccess(o.Mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "resource requirements updated")
+		o.PrintSuccess(shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "resource requirements updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -49,7 +49,7 @@ type SelectorOptions struct {
 	selector  *metav1.LabelSelector
 
 	out              io.Writer
-	PrintSuccess     func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess     func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	PrintObject      func(obj runtime.Object) error
 	ClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 
@@ -218,7 +218,7 @@ func (o *SelectorOptions) RunSelector() error {
 		if len(o.output) > 0 && !shortOutput {
 			return o.PrintObject(patched)
 		}
-		o.PrintSuccess(o.mapper, shortOutput, o.out, info.Mapping.Resource, info.Name, o.dryrun, "selector updated")
+		o.PrintSuccess(shortOutput, o.out, info.Mapping.Resource, info.Name, o.dryrun, "selector updated")
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -70,7 +70,7 @@ type serviceAccountConfig struct {
 	local                  bool
 	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
 	updatePodSpecForObject func(runtime.Object, func(*v1.PodSpec) error) (bool, error)
-	printSuccess           func(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	printSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	infos                  []*resource.Info
 	serviceAccountName     string
 }
@@ -192,7 +192,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			}
 			continue
 		}
-		saConfig.printSuccess(saConfig.mapper, saConfig.shortOutput, saConfig.out, info.Mapping.Resource, info.Name, saConfig.dryRun, "serviceaccount updated")
+		saConfig.printSuccess(saConfig.shortOutput, saConfig.out, info.Mapping.Resource, info.Name, saConfig.dryRun, "serviceaccount updated")
 	}
 	return utilerrors.NewAggregate(patchErrs)
 }

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -257,7 +257,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		if len(o.Output) > 0 && !shortOutput {
 			return o.PrintObject(o.Mapper, info.AsVersioned(), o.Out)
 		}
-		f.PrintSuccess(o.Mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
+		f.PrintSuccess(shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -280,7 +280,7 @@ func (o TaintOptions) RunTaint() error {
 			return o.f.PrintObject(o.cmd, false, mapper, outputObj, o.out)
 		}
 
-		o.f.PrintSuccess(mapper, false, o.out, info.Mapping.Resource, info.Name, false, operation)
+		o.f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, false, operation)
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list-fail/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list-fail/test.yaml
@@ -5,8 +5,8 @@ args:
 - service/svc1
 namespace: "myproject"
 expectedStdout:
-- configmap "cm1" edited
-- service "svc1" edited
+- configmaps "cm1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list/test.yaml
@@ -5,8 +5,8 @@ args:
 - service/svc1
 namespace: "myproject"
 expectedStdout:
-- configmap "cm1" edited
-- service "svc1" edited
+- configmaps "cm1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-syntax-error/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-syntax-error/test.yaml
@@ -4,7 +4,7 @@ args:
 - service/svc1
 namespace: myproject
 expectedStdout:
-- "service \"svc1\" edited"
+- "services \"svc1\" edited"
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied/test.yaml
@@ -6,7 +6,7 @@ args:
 outputFormat: yaml
 namespace: myproject
 expectedStdout:
-- service "svc1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-create-list-error/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-create-list-error/test.yaml
@@ -3,7 +3,7 @@ mode: create
 filename: "svc.yaml"
 namespace: "edit-test"
 expectedStdout:
-- "service \"svc1\" created"
+- "services \"svc1\" created"
 expectedStderr:
 - "\"svc2\" is invalid"
 expectedExitCode: 1

--- a/pkg/kubectl/cmd/testdata/edit/testcase-create-list/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-create-list/test.yaml
@@ -3,8 +3,8 @@ mode: create
 filename: "svc.yaml"
 namespace: "edit-test"
 expectedStdout:
-- service "svc1" created
-- service "svc2" created
+- services "svc1" created
+- services "svc2" created
 expectedExitCode: 0
 steps:
 - type: edit

--- a/pkg/kubectl/cmd/testdata/edit/testcase-edit-error-reedit/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-edit-error-reedit/test.yaml
@@ -5,7 +5,7 @@ args:
 - svc1
 namespace: edit-test
 expectedStdout:
-- service "svc1" edited
+- services "svc1" edited
 expectedStderr:
 - "error: services \"svc1\" is invalid"
 expectedExitCode: 0

--- a/pkg/kubectl/cmd/testdata/edit/testcase-edit-output-patch/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-edit-output-patch/test.yaml
@@ -11,7 +11,7 @@ outputPatch: "true"
 namespace: edit-test
 expectedStdout:
 - 'Patch: {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2017-02-27T19:40:53Z\",\"labels\":{\"app\":\"svc1\",\"new-label\":\"new-value\"},\"name\":\"svc1\",\"namespace\":\"edit-test\",\"resourceVersion\":\"670\",\"selfLink\":\"/api/v1/namespaces/edit-test/services/svc1\",\"uid\":\"a6c11186-fd24-11e6-b53c-480fcf4a5275\"},\"spec\":{\"clusterIP\":\"10.0.0.204\",\"ports\":[{\"name\":\"80\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"svc1\"},\"sessionAffinity\":\"None\",\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}\n"},"labels":{"new-label":"new-value"}}}'
-- service "svc1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-list-errors/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-list-errors/test.yaml
@@ -4,8 +4,8 @@ args:
 - configmaps,services
 namespace: "edit-test"
 expectedStdout:
-- configmap "cm1" edited
-- service "svc1" edited
+- configmaps "cm1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-list-record/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-list-record/test.yaml
@@ -5,8 +5,8 @@ args:
 - service/svc1
 namespace: "edit-test"
 expectedStdout:
-- configmap "cm1" edited
-- service "svc1" edited
+- configmaps "cm1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-list/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-list/test.yaml
@@ -5,8 +5,8 @@ args:
 - service/svc1
 namespace: "edit-test"
 expectedStdout:
-- configmap "cm1" edited
-- service "svc1" edited
+- configmaps "cm1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-not-update-annotation/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-not-update-annotation/test.yaml
@@ -9,7 +9,7 @@ args:
 saveConfig: "false"
 namespace: edit-test
 expectedStdout:
-- service "svc1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-schemaless-list/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-schemaless-list/test.yaml
@@ -6,9 +6,9 @@ args:
 - bars/test2
 namespace: default
 expectedStdout:
-- "service \"kubernetes\" edited"
-- "bar \"test\" edited"
-- "bar \"test2\" edited"
+- "services \"kubernetes\" edited"
+- "bars \"test\" edited"
+- "bars \"test2\" edited"
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-single-service/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-single-service/test.yaml
@@ -8,7 +8,7 @@ args:
 - svc1
 namespace: edit-test
 expectedStdout:
-- service "svc1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-syntax-error/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-syntax-error/test.yaml
@@ -4,7 +4,7 @@ args:
 - service/kubernetes
 namespace: default
 expectedStdout:
-- "service \"kubernetes\" edited"
+- "services \"kubernetes\" edited"
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/test.yaml
@@ -4,7 +4,7 @@ args:
 - storageclasses.v1beta1.storage.k8s.io/foo
 namespace: default
 expectedStdout:
-- "storageclass \"foo\" edited"
+- "storageclasses \"foo\" edited"
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-version-known-group-kind/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-version-known-group-kind/test.yaml
@@ -4,7 +4,7 @@ args:
 - storageclasses.v0.storage.k8s.io/foo
 namespace: default
 expectedStdout:
-- "storageclass \"foo\" edited"
+- "storageclasses \"foo\" edited"
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testdata/edit/testcase-update-annotation/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-update-annotation/test.yaml
@@ -9,7 +9,7 @@ args:
 saveConfig: "true"
 namespace: edit-test
 expectedStdout:
-- service "svc1" edited
+- services "svc1" edited
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -376,8 +376,7 @@ func (f *FakeFactory) PrintResourceInfoForCommand(cmd *cobra.Command, info *reso
 	return printer.PrintObj(info.Object, out)
 }
 
-func (f *FakeFactory) PrintSuccess(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
-	resource, _ = mapper.ResourceSingularizer(resource)
+func (f *FakeFactory) PrintSuccess(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
 	dryRunMsg := ""
 	if dryRun {
 		dryRunMsg = " (dry run)"
@@ -772,8 +771,7 @@ func (f *fakeAPIFactory) PrintResourceInfoForCommand(cmd *cobra.Command, info *r
 	return printer.PrintObj(info.Object, out)
 }
 
-func (f *fakeAPIFactory) PrintSuccess(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
-	resource, _ = mapper.ResourceSingularizer(resource)
+func (f *fakeAPIFactory) PrintSuccess(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
 	dryRunMsg := ""
 	if dryRun {
 		dryRunMsg = " (dry run)"

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -60,7 +60,6 @@ type EditOptions struct {
 
 	cmdutil.ValidateOptions
 
-	Mapper         meta.RESTMapper
 	ResourceMapper *resource.Mapper
 	OriginalResult *resource.Result
 	Encoder        runtime.Encoder
@@ -107,7 +106,6 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 	if err != nil {
 		return err
 	}
-	mapper, _ := f.Object()
 	b := f.NewBuilder().
 		Unstructured()
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
@@ -138,7 +136,6 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 			Do()
 	}
 
-	o.Mapper = mapper
 	o.CmdNamespace = cmdNamespace
 	o.Encoder = f.JSONEncoder()
 	o.f = f
@@ -408,14 +405,14 @@ func (o *EditOptions) visitToApplyEditPatch(originalInfos []*resource.Info, patc
 		}
 
 		if reflect.DeepEqual(originalJS, editedJS) {
-			o.f.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "skipped")
+			o.f.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "skipped")
 			return nil
 		} else {
 			err := o.annotationPatch(info)
 			if err != nil {
 				return err
 			}
-			o.f.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "edited")
+			o.f.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "edited")
 			return nil
 		}
 	})
@@ -534,7 +531,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 
 		if reflect.DeepEqual(originalJS, editedJS) {
 			// no edit, so just skip it.
-			o.f.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "skipped")
+			o.f.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "skipped")
 			return nil
 		}
 
@@ -588,7 +585,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 			return nil
 		}
 		info.Refresh(patched, true)
-		o.f.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "edited")
+		o.f.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "edited")
 		return nil
 	})
 	return err
@@ -599,7 +596,7 @@ func (o *EditOptions) visitToCreate(createVisitor resource.Visitor) error {
 		if err := resource.CreateAndRefresh(info); err != nil {
 			return err
 		}
-		o.f.PrintSuccess(o.Mapper, false, o.Out, info.Mapping.Resource, info.Name, false, "created")
+		o.f.PrintSuccess(false, o.Out, info.Mapping.Resource, info.Name, false, "created")
 		return nil
 	})
 	return err

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -248,7 +248,7 @@ type BuilderFactory interface {
 	// Requires that printer flags have been added to cmd (see AddPrinterFlags).
 	PrintResourceInfoForCommand(cmd *cobra.Command, info *resource.Info, out io.Writer) error
 	// PrintSuccess prints message after finishing mutating operations
-	PrintSuccess(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
+	PrintSuccess(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	// NewBuilder returns an object that assists in loading objects from both disk and the server
 	// and which implements the common patterns for CLI interactions with generic resources.
 	NewBuilder() *resource.Builder

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -82,8 +82,7 @@ func (f *ring2Factory) PrinterForMapping(options *printers.PrintOptions, mapping
 	return printer, nil
 }
 
-func (f *ring2Factory) PrintSuccess(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
-	resource, _ = mapper.ResourceSingularizer(resource)
+func (f *ring2Factory) PrintSuccess(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string) {
 	dryRunMsg := ""
 	if dryRun {
 		dryRunMsg = " (dry run)"


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Part of a series of patches removing printing stack dependency on mappings the rest mapper

**Before**
```
$ kubectl label pod/my-pod label=label
pod "my-pod" labeled
```

**After**
```
$ kubectl label pod/my-pod label=label
pods "my-pod" labeled
```

cc @deads2k 