### PR TITLE
Use previous phase if current phase is unknown

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1401,6 +1401,7 @@ func podWithUIDNameNs(uid types.UID, name, namespace string) *v1.Pod {
 func podWithUIDNameNsSpec(uid types.UID, name, namespace string, spec v1.PodSpec) *v1.Pod {
 	pod := podWithUIDNameNs(uid, name, namespace)
 	pod.Spec = spec
+	pod.Status = v1.PodStatus{Phase: v1.PodPending}
 	return pod
 }
 
@@ -1953,6 +1954,7 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 				Name:      "podA",
 				Namespace: "foo",
 			},
+			Status: v1.PodStatus{Phase: v1.PodPending},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1960,6 +1962,7 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 				Name:      "podB",
 				Namespace: "foo",
 			},
+			Status: v1.PodStatus{Phase: v1.PodPending},
 		},
 	}
 	podToReject := pods[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
Try using a previous phase when we don't have container statuses.  This should eliminate some invalid phase transitions where the kubelet uses the default "Pending" phase after containers have been removed.

**Special notes for your reviewer**:
This is just a test right now.  Associated issue: https://github.com/kubernetes/kubernetes/issues/58711

**Release note**:
```release-note
Fixes a bug where pods could transition from succeeded -> pending.
```
