### PR TITLE
Fix incorrect volume plugin name in log, PersistentDisk->EBS

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -328,7 +328,7 @@ func (b *awsElasticBlockStoreMounter) SetUp(fsGroup *int64) error {
 func (b *awsElasticBlockStoreMounter) SetUpAt(dir string, fsGroup *int64) error {
 	// TODO: handle failed mounts here.
 	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
-	glog.V(4).Infof("PersistentDisk set up: %s %v %v", dir, !notMnt, err)
+	glog.V(4).Infof("EBS set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
 		glog.Errorf("cannot validate mount point: %s %v", dir, err)
 		return err


### PR DESCRIPTION
Change a log word that may be confuse people.

**Release note**:
```release-note
None
```