### PR TITLE
should log error when error in parsing device plugin image

### DIFF
--- a/test/e2e/framework/gpu_util.go
+++ b/test/e2e/framework/gpu_util.go
@@ -21,8 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	. "github.com/onsi/gomega"
 	"github.com/golang/glog"
+	. "github.com/onsi/gomega"
 )
 
 const (

--- a/test/e2e/framework/gpu_util.go
+++ b/test/e2e/framework/gpu_util.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
+	"fmt"
 	. "github.com/onsi/gomega"
 )
 
@@ -67,10 +68,16 @@ func NVIDIADevicePlugin(ns string) *v1.Pod {
 	return p
 }
 
-func GetGPUDevicePluginImage() string {
+func GetGPUDevicePluginImage() (string, error) {
 	ds, err := DsFromManifest(GPUDevicePluginDSYAML)
-	if err != nil || ds == nil || len(ds.Spec.Template.Spec.Containers) < 1 {
-		return ""
+	if err != nil {
+		return "", err
 	}
-	return ds.Spec.Template.Spec.Containers[0].Image
+	if ds == nil {
+		return "", fmt.Errorf("empty DaemonSet from DSYAML")
+	}
+	if len(ds.Spec.Template.Spec.Containers) < 1 {
+		return "", fmt.Errorf("no container specified in the DSYAML")
+	}
+	return ds.Spec.Template.Spec.Containers[0].Image, nil
 }

--- a/test/e2e/framework/gpu_util.go
+++ b/test/e2e/framework/gpu_util.go
@@ -21,8 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	"fmt"
 	. "github.com/onsi/gomega"
+	"github.com/golang/glog"
 )
 
 const (
@@ -68,16 +68,19 @@ func NVIDIADevicePlugin(ns string) *v1.Pod {
 	return p
 }
 
-func GetGPUDevicePluginImage() (string, error) {
+func GetGPUDevicePluginImage() string {
 	ds, err := DsFromManifest(GPUDevicePluginDSYAML)
 	if err != nil {
-		return "", err
+		glog.Errorf("Failed to parse the device plugin image: %v", err)
+		return ""
 	}
 	if ds == nil {
-		return "", fmt.Errorf("empty DaemonSet from DSYAML")
+		glog.Errorf("Failed to parse the device plugin image: the extracted DaemonSet is nil")
+		return ""
 	}
 	if len(ds.Spec.Template.Spec.Containers) < 1 {
-		return "", fmt.Errorf("no container specified in the DSYAML")
+		glog.Errorf("Failed to parse the device plugin image: cannot extract the container from YAML")
+		return ""
 	}
-	return ds.Spec.Template.Spec.Containers[0].Image, nil
+	return ds.Spec.Template.Spec.Containers[0].Image
 }

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -52,12 +52,18 @@ var NodeImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Netexec),
 	imageutils.GetE2EImage(imageutils.Nonewprivs),
 	imageutils.GetPauseImageNameForHostArch(),
-	framework.GetGPUDevicePluginImage(),
 )
 
 func init() {
 	// Union NodeImageWhiteList and CommonImageWhiteList into the framework image white list.
 	framework.ImageWhiteList = NodeImageWhiteList.Union(commontest.CommonImageWhiteList)
+
+	// parse the device plugin image from url
+	if image, err := framework.GetGPUDevicePluginImage(); err != nil {
+		glog.Errorf("Failed to parse the device plugin image: %v", err)
+	} else {
+		framework.ImageWhiteList.Insert(image)
+	}
 }
 
 // puller represents a generic image puller

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -52,18 +52,12 @@ var NodeImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Netexec),
 	imageutils.GetE2EImage(imageutils.Nonewprivs),
 	imageutils.GetPauseImageNameForHostArch(),
+	framework.GetGPUDevicePluginImage(),
 )
 
 func init() {
 	// Union NodeImageWhiteList and CommonImageWhiteList into the framework image white list.
 	framework.ImageWhiteList = NodeImageWhiteList.Union(commontest.CommonImageWhiteList)
-
-	// parse the device plugin image from url
-	if image, err := framework.GetGPUDevicePluginImage(); err != nil {
-		glog.Errorf("Failed to parse the device plugin image: %v", err)
-	} else {
-		framework.ImageWhiteList.Insert(image)
-	}
 }
 
 // puller represents a generic image puller


### PR DESCRIPTION
**What this PR does / why we need it**:
add some extra error log in parsing the device plugin image. Error happened in my setup when fetching the yaml from url, but since no error log printed it cost a long time to figure out the reason. So it'd be nice to print the error IMO.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig-node