### PR TITLE
Adding kubemci e2e test for ingress spec conformance

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2177,6 +2177,21 @@ func RunKubectlOrDieInput(data string, args ...string) string {
 	return NewKubectlCommand(args...).WithStdinData(data).ExecOrDie()
 }
 
+// RunKubemciCmd is a convenience wrapper over kubectlBuilder to run kubemci.
+// It assumes that kubemci exists in PATH.
+func RunKubemciCmd(args ...string) (string, error) {
+	// kubemci is assumed to be in PATH.
+	kubemci := "kubemci"
+	b := new(kubectlBuilder)
+	if TestContext.KubeConfig != "" {
+		args = append(args, "--"+clientcmd.RecommendedConfigPathFlag+"="+TestContext.KubeConfig)
+	}
+	args = append(args, "--gcp-project="+TestContext.CloudConfig.ProjectID)
+
+	b.cmd = exec.Command(kubemci, args...)
+	return b.Exec()
+}
+
 func StartCmdAndStreamOutput(cmd *exec.Cmd) (stdout, stderr io.ReadCloser, err error) {
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {

--- a/test/e2e/manifest/BUILD
+++ b/test/e2e/manifest/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -10,6 +11,7 @@ go_library(
     srcs = ["manifest.go"],
     importpath = "k8s.io/kubernetes/test/e2e/manifest",
     deps = [
+        "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//test/e2e/generated:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
@@ -32,4 +34,12 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["manifest_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/kubernetes/test/e2e/manifest",
+    deps = ["//vendor/k8s.io/api/extensions/v1beta1:go_default_library"],
 )

--- a/test/e2e/manifest/manifest.go
+++ b/test/e2e/manifest/manifest.go
@@ -17,12 +17,16 @@ limitations under the License.
 package manifest
 
 import (
+	"fmt"
+	"io/ioutil"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/test/e2e/generated"
 )
@@ -85,6 +89,20 @@ func IngressFromManifest(fileName string) (*extensions.Ingress, error) {
 		return nil, err
 	}
 	return &ing, nil
+}
+
+// IngressToManifest generates a yaml file in the given path with the given ingress.
+// Returns the file name and error, if there was any.
+func IngressToManifest(ing *extensions.Ingress, path string) error {
+	serialized, err := util.MarshalToYaml(ing, extensions.SchemeGroupVersion)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ingress %v to YAML: %v", ing, err)
+	}
+
+	if err := ioutil.WriteFile(path, serialized, 0600); err != nil {
+		return fmt.Errorf("error in writing ingress to file: %s", err)
+	}
+	return nil
 }
 
 // StatefulSetFromManifest returns a StatefulSet from a manifest stored in fileName in the Namespace indicated by ns.

--- a/test/e2e/manifest/manifest_test.go
+++ b/test/e2e/manifest/manifest_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"testing"
+
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+func TestIngressToManifest(t *testing.T) {
+	ing := &extensions.Ingress{}
+	// Write the ingress to a file and ensure that there is no error.
+	if err := IngressToManifest(ing, "/tmp/ing.yaml"); err != nil {
+		t.Fatalf("Error in creating file: %s", err)
+	}
+	// Writing it again should not return an error.
+	if err := IngressToManifest(ing, "/tmp/ing.yaml"); err != nil {
+		t.Fatalf("Error in creating file: %s", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an e2e test case for kubemci to verify that it conforms to the ingress spec.
Not all tests will pass right now, but adding it will enable us to track the latest status.

```release-note
NONE
```
