### PR TITLE
Check ErrorNotFound for IPVS in netlink.go to fix windows cross build error

### DIFF
--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -93,7 +93,6 @@ go_library(
         "//pkg/util/sysctl:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
@@ -103,6 +102,7 @@ go_library(
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/vishvananda/netlink:go_default_library",
+            "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -57,7 +57,7 @@ func (h *netlinkHandle) EnsureAddressBind(address, devName string) (exist bool, 
 	return false, nil
 }
 
-// UnbindAddress unbind address from the interface
+// UnbindAddress makes sure IP address is unbound from the network interface.
 func (h *netlinkHandle) UnbindAddress(address, devName string) error {
 	dev, err := h.LinkByName(devName)
 	if err != nil {
@@ -68,7 +68,9 @@ func (h *netlinkHandle) UnbindAddress(address, devName string) error {
 		return fmt.Errorf("error parse ip address: %s", address)
 	}
 	if err := h.AddrDel(dev, &netlink.Addr{IPNet: netlink.NewIPNet(addr)}); err != nil {
-		return fmt.Errorf("error unbind address: %s from interface: %s, err: %v", address, devName, err)
+		if err != unix.ENXIO {
+			return fmt.Errorf("error unbind address: %s from interface: %s, err: %v", address, devName, err)
+		}
 	}
 	return nil
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -51,8 +51,6 @@ import (
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilexec "k8s.io/utils/exec"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -1705,7 +1703,7 @@ func (proxier *Proxier) cleanLegacyService(atciveServices map[string]bool, curre
 	for _, addr := range unbindIPAddr.UnsortedList() {
 		err := proxier.netlinkHandle.UnbindAddress(addr, DefaultDummyDevice)
 		// Ignore no such address error when try to unbind address
-		if err != nil && err != unix.ENXIO {
+		if err != nil {
 			glog.Errorf("Failed to unbind service addr %s from dummy interface %s: %v", addr, DefaultDummyDevice, err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Check IPVS unbind address ErrorNotFound in `netlink.go` which is only compiled in Linux platform to fix windows cross build error.

**Which issue(s) this PR fixes**:
Fixes #59223

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
