### PR TITLE
patch cmd/kubeadm/test/cmd/BUILD for bazel 0.10

### DIFF
--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -22,10 +22,11 @@ go_test(
         "token_test.go",
         "version_test.go",
     ],
-    args = ["--kubeadm-path=../../kubeadm"],
+    args = ["--kubeadm-path=$(location //cmd/kubeadm:kubeadm)"],
     data = ["//cmd/kubeadm"],
     embed = [":go_default_library"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/test/cmd",
+    rundir = ".",
     tags = [
         "integration",
         "skip",


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes `//cmd/kubeadm/test/cmd:go_default_test` failure with Bazel `0.10.0` (just released). 

This should be enough to let us upgrade to Bazel `0.10.0` which has some very useful improvements.

**Special notes for your reviewer**: Example failure when canary testing `0.10.0`: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-bazel-test-canary/124/#cmdkubeadmtestcmdgo_default_test 

**Release note**:
```release-note
NONE
```
