### PR TITLE
Add generic cache for Azure VM/LB/NSG 

### DIFF
--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -56,7 +56,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -128,6 +128,8 @@ type Cloud struct {
 	VirtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
+	vmCache *timedCache
+
 	*BlobDiskController
 	*ManagedDiskController
 	*controllerCommon
@@ -234,6 +236,8 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	} else {
 		az.vmSet = newAvailabilitySet(&az)
 	}
+
+	az.vmCache = az.newVMCache()
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -129,6 +129,7 @@ type Cloud struct {
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
 	vmCache *timedCache
+	lbCache *timedCache
 
 	*BlobDiskController
 	*ManagedDiskController
@@ -238,6 +239,7 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	}
 
 	az.vmCache = az.newVMCache()
+	az.lbCache = az.newLBCache()
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -128,8 +128,9 @@ type Cloud struct {
 	VirtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
-	vmCache *timedCache
-	lbCache *timedCache
+	vmCache  *timedCache
+	lbCache  *timedCache
+	nsgCache *timedCache
 
 	*BlobDiskController
 	*ManagedDiskController
@@ -240,6 +241,7 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 
 	az.vmCache = az.newVMCache()
 	az.lbCache = az.newLBCache()
+	az.nsgCache = az.newNSGCache()
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -80,7 +80,12 @@ func (az *Cloud) CreateOrUpdateSGWithRetry(sg network.SecurityGroup) error {
 		resp := <-respChan
 		err := <-errChan
 		glog.V(10).Infof("SecurityGroupsClient.CreateOrUpdate(%s): end", *sg.Name)
-		return processRetryResponse(resp.Response, err)
+		done, err := processRetryResponse(resp.Response, err)
+		if done && err == nil {
+			// Update the cache right after updating.
+			az.nsgCache.AddOrUpdate(*sg.Name, &sg)
+		}
+		return done, err
 	})
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_cache.go
@@ -19,63 +19,138 @@ package azure
 import (
 	"sync"
 	"time"
-
-	"k8s.io/client-go/tools/cache"
 )
 
-type timedcacheEntry struct {
-	key  string
-	data interface{}
+type getFunc func(key string) (interface{}, error)
+type listFunc func() (map[string]interface{}, error)
+
+// timedCache is a cache with TTL.
+type timedCache struct {
+	store       map[string]interface{}
+	lock        sync.Mutex
+	ttl         time.Duration
+	lastRefresh time.Time
+
+	getter getFunc
+	lister listFunc
 }
 
-type timedcache struct {
-	store cache.Store
-	lock  sync.Mutex
-}
-
-// ttl time.Duration
-func newTimedcache(ttl time.Duration) timedcache {
-	return timedcache{
-		store: cache.NewTTLStore(cacheKeyFunc, ttl),
+// newTimedcache creates a new timedCache with TTL.
+func newTimedcache(ttl time.Duration, getFunc getFunc, listFunc listFunc) *timedCache {
+	return &timedCache{
+		ttl:    ttl,
+		getter: getFunc,
+		lister: listFunc,
+		store:  make(map[string]interface{}),
 	}
 }
 
-func cacheKeyFunc(obj interface{}) (string, error) {
-	return obj.(*timedcacheEntry).key, nil
+// expired returns true if the cache is expired.
+func (t *timedCache) expired() bool {
+	return t.lastRefresh.Add(t.ttl).Before(time.Now())
 }
 
-func (t *timedcache) GetOrCreate(key string, createFunc func() interface{}) (interface{}, error) {
-	entry, exists, err := t.store.GetByKey(key)
-	if err != nil {
-		return nil, err
-	}
-	if exists {
-		return (entry.(*timedcacheEntry)).data, nil
-	}
-
+// Get gets data by key. It returns nil if data not found.
+func (t *timedCache) Get(key string) (interface{}, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	entry, exists, err = t.store.GetByKey(key)
-	if err != nil {
+
+	if t.expired() {
+		if err := t.refresh(""); err != nil {
+			return nil, err
+		}
+	}
+
+	entry, ok := t.store[key]
+	if ok {
+		return entry, nil
+	}
+
+	// not cache this vm yet, refresh by key
+	if err := t.refresh(key); err != nil {
 		return nil, err
 	}
-	if exists {
-		return (entry.(*timedcacheEntry)).data, nil
+	entry, ok = t.store[key]
+	if ok {
+		return entry, nil
 	}
 
-	if createFunc == nil {
-		return nil, nil
-	}
-	created := createFunc()
-	t.store.Add(&timedcacheEntry{
-		key:  key,
-		data: created,
-	})
-	return created, nil
+	// Key still not found, set it to nil. This is required to avoid
+	// relisting nonexist objects.
+	t.store[key] = nil
+	return nil, nil
 }
 
-func (t *timedcache) Delete(key string) {
-	_ = t.store.Delete(&timedcacheEntry{
-		key: key,
-	})
+// refresh updates cache by getter or lister. If key is an empty string,
+// then lister is used to update cache.
+// It should be only called under a lock.
+func (t *timedCache) refresh(key string) error {
+	// Refresh cache by getter.
+	if key != "" && t.getter != nil {
+		data, err := t.getter(key)
+		if err != nil {
+			return err
+		}
+
+		t.store[key] = data
+		return nil
+	}
+
+	// Refresh cache by lister.
+	dataList, err := t.lister()
+	if err != nil {
+		return err
+	}
+	t.store = make(map[string]interface{})
+	for key, data := range dataList {
+		t.store[key] = data
+	}
+
+	t.lastRefresh = time.Now()
+	return nil
+}
+
+// Delete removes data from cache by key.
+func (t *timedCache) Delete(key string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// mark data as nil to avoid invoking APIs later.
+	t.store[key] = nil
+}
+
+// List gets a list of data from cache.
+func (t *timedCache) List() ([]interface{}, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.expired() {
+		if err := t.refresh(""); err != nil {
+			return nil, err
+		}
+	}
+
+	result := make([]interface{}, 0)
+	for _, data := range t.store {
+		if data == nil {
+			continue
+		}
+
+		result = append(result, data)
+	}
+	return result, nil
+}
+
+// AddOrUpdate adds new data or updates existing data in the cache.
+// If the data is nil, then it updates cache from getter.
+func (t *timedCache) AddOrUpdate(key string, data interface{}) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if data != nil {
+		t.store[key] = data
+		return nil
+	}
+
+	return t.refresh(key)
 }

--- a/pkg/cloudprovider/providers/azure/azure_cache_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_cache_test.go
@@ -17,80 +17,148 @@ limitations under the License.
 package azure
 
 import (
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestCacheReturnsSameObject(t *testing.T) {
-	type cacheTestingStruct struct{}
-	c := newTimedcache(1 * time.Minute)
-	o1 := cacheTestingStruct{}
-	get1, _ := c.GetOrCreate("b1", func() interface{} {
-		return o1
-	})
-	o2 := cacheTestingStruct{}
-	get2, _ := c.GetOrCreate("b1", func() interface{} {
-		return o2
-	})
-	if get1 != get2 {
-		t.Error("Get not equal")
+var (
+	fakeCacheTTL = 2 * time.Second
+)
+
+type fakeDataObj struct{}
+
+type fakeDataSource struct {
+	data map[string]*fakeDataObj
+	lock sync.Mutex
+}
+
+func (fake *fakeDataSource) get(key string) (interface{}, error) {
+	fake.lock.Lock()
+	defer fake.lock.Unlock()
+
+	if v, ok := fake.data[key]; ok {
+		return v, nil
+	}
+
+	return nil, nil
+}
+
+func (fake *fakeDataSource) list() (map[string]interface{}, error) {
+	fake.lock.Lock()
+	defer fake.lock.Unlock()
+
+	result := make(map[string]interface{})
+	for k, v := range fake.data {
+		result[k] = v
+	}
+	return result, nil
+}
+
+func (fake *fakeDataSource) set(data map[string]*fakeDataObj) {
+	fake.lock.Lock()
+	defer fake.lock.Unlock()
+
+	fake.data = data
+}
+
+func newFakeCache() (*fakeDataSource, *timedCache) {
+	dataSource := &fakeDataSource{
+		data: make(map[string]*fakeDataObj),
+	}
+	getter := dataSource.get
+	lister := dataSource.list
+	return dataSource, newTimedcache(fakeCacheTTL, getter, lister)
+}
+
+func TestCacheGet(t *testing.T) {
+	val := &fakeDataObj{}
+	cases := []struct {
+		name     string
+		data     map[string]*fakeDataObj
+		key      string
+		expected interface{}
+	}{
+		{
+			name:     "cache should return nil for empty data source",
+			key:      "key1",
+			expected: nil,
+		},
+		{
+			name:     "cache should return nil for non exist key",
+			data:     map[string]*fakeDataObj{"key2": val},
+			key:      "key1",
+			expected: nil,
+		},
+		{
+			name:     "cache should return data for existing key",
+			data:     map[string]*fakeDataObj{"key1": val},
+			key:      "key1",
+			expected: val,
+		},
+	}
+
+	for _, c := range cases {
+		dataSource, cache := newFakeCache()
+		dataSource.set(c.data)
+		val, err := cache.Get(c.key)
+		assert.NoError(t, err, c.name)
+		assert.Equal(t, c.expected, val, c.name)
 	}
 }
 
-func TestCacheCallsCreateFuncOnce(t *testing.T) {
-	var callsCount uint32
-	f1 := func() interface{} {
-		atomic.AddUint32(&callsCount, 1)
-		return 1
-	}
-	c := newTimedcache(500 * time.Millisecond)
-	for index := 0; index < 20; index++ {
-		_, _ = c.GetOrCreate("b1", f1)
+func TestCacheList(t *testing.T) {
+	val := &fakeDataObj{}
+	cases := []struct {
+		name     string
+		data     map[string]*fakeDataObj
+		expected []interface{}
+	}{
+		{
+			name:     "cache should get empty result with empty data source",
+			expected: []interface{}{},
+		},
+		{
+			name:     "cache should get same data with provided data source",
+			data:     map[string]*fakeDataObj{"key1": val},
+			expected: []interface{}{val},
+		},
 	}
 
-	if callsCount != 1 {
-		t.Error("Count not match")
-	}
-	time.Sleep(500 * time.Millisecond)
-	c.GetOrCreate("b1", f1)
-	if callsCount != 2 {
-		t.Error("Count not match")
+	for _, c := range cases {
+		dataSource, cache := newFakeCache()
+		dataSource.set(c.data)
+		val, err := cache.List()
+		assert.NoError(t, err, c.name)
+		assert.Equal(t, c.expected, val, c.name)
 	}
 }
 
-func TestCacheExpires(t *testing.T) {
-	f1 := func() interface{} {
-		return 1
+func TestCacheExpired(t *testing.T) {
+	key := "key1"
+	val := &fakeDataObj{}
+	data := map[string]*fakeDataObj{
+		key: val,
 	}
-	c := newTimedcache(500 * time.Millisecond)
-	get1, _ := c.GetOrCreate("b1", f1)
-	if get1 != 1 {
-		t.Error("Value not equal")
-	}
-	time.Sleep(500 * time.Millisecond)
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != nil {
-		t.Error("value not expired")
-	}
-}
+	dataSource, cache := newFakeCache()
+	dataSource.set(data)
 
-func TestCacheDelete(t *testing.T) {
-	f1 := func() interface{} {
-		return 1
-	}
-	c := newTimedcache(500 * time.Millisecond)
-	get1, _ := c.GetOrCreate("b1", f1)
-	if get1 != 1 {
-		t.Error("Value not equal")
-	}
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != 1 {
-		t.Error("Value not equal")
-	}
-	c.Delete("b1")
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != nil {
-		t.Error("value not deleted")
-	}
+	v, err := cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v, "cache should get correct data")
+
+	cache.Delete(key)
+	v, err = cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, v, "cache should get nil after data is removed")
+	valList, err := cache.List()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(valList), "cache should get empty list after data is removed")
+
+	time.Sleep(fakeCacheTTL)
+	v, err = cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v, "cache should get correct data even after expired")
 }

--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -123,8 +123,8 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 		}
 	} else {
 		glog.V(4).Info("azureDisk - azure attach succeeded")
-		// Invalidate the cache right after updating
-		vmCache.Delete(vmName)
+		// Update the cache right after updating.
+		c.cloud.vmCache.AddOrUpdate(vmName, nil)
 	}
 	return err
 }
@@ -182,8 +182,8 @@ func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName t
 		glog.Errorf("azureDisk - azure disk detach failed, err: %v", err)
 	} else {
 		glog.V(4).Info("azureDisk - azure disk detach succeeded")
-		// Invalidate the cache right after updating
-		vmCache.Delete(vmName)
+		// Update the cache right after updating.
+		c.cloud.vmCache.AddOrUpdate(vmName, nil)
 	}
 	return err
 }

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -803,7 +803,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		ports = []v1.ServicePort{}
 	}
 
-	sg, err := az.SecurityGroupsClient.Get(az.ResourceGroup, az.SecurityGroupName, "")
+	sg, err := az.getSecurityGroup()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -181,7 +181,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 	primaryVMSetName := az.vmSet.GetPrimaryVMSetName()
 	defaultLBName := az.getLoadBalancerName(clusterName, primaryVMSetName, isInternal)
 
-	existingLBs, err := az.ListLBWithRetry()
+	existingLBs, err := az.ListLoadBalancers()
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -874,6 +874,8 @@ func getTestCloud() (az *Cloud) {
 	az.VirtualMachinesClient = newFakeAzureVirtualMachinesClient()
 	az.vmSet = newAvailabilitySet(az)
 
+	az.vmCache = az.newVMCache()
+
 	return az
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -875,6 +875,7 @@ func getTestCloud() (az *Cloud) {
 	az.vmSet = newAvailabilitySet(az)
 
 	az.vmCache = az.newVMCache()
+	az.lbCache = az.newLBCache()
 
 	return az
 }

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -876,6 +876,7 @@ func getTestCloud() (az *Cloud) {
 
 	az.vmCache = az.newVMCache()
 	az.lbCache = az.newLBCache()
+	az.nsgCache = az.newNSGCache()
 
 	return az
 }

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -18,16 +18,18 @@ package azure
 
 import (
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+var (
+	vmCacheTTL = 30 * time.Second
 )
 
 // checkExistsFromError inspects an error and returns a true if err is nil,
@@ -60,59 +62,21 @@ func ignoreStatusNotFoundFromError(err error) error {
 	return err
 }
 
-// cache used by getVirtualMachine
-// 15s for expiration duration
-var vmCache = newTimedcache(15 * time.Second)
-
-type vmRequest struct {
-	lock *sync.Mutex
-	vm   *compute.VirtualMachine
-}
-
 /// getVirtualMachine calls 'VirtualMachinesClient.Get' with a timed cache
 /// The service side has throttling control that delays responses if there're multiple requests onto certain vm
 /// resource request in short period.
 func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachine, err error) {
 	vmName := string(nodeName)
-
-	cachedRequest, err := vmCache.GetOrCreate(vmName, func() interface{} {
-		return &vmRequest{
-			lock: &sync.Mutex{},
-			vm:   nil,
-		}
-	})
+	cachedVM, err := az.vmCache.Get(vmName)
 	if err != nil {
-		return compute.VirtualMachine{}, err
-	}
-	request := cachedRequest.(*vmRequest)
-
-	if request.vm == nil {
-		request.lock.Lock()
-		defer request.lock.Unlock()
-		if request.vm == nil {
-			// Currently InstanceView request are used by azure_zones, while the calls come after non-InstanceView
-			// request. If we first send an InstanceView request and then a non InstanceView request, the second
-			// request will still hit throttling. This is what happens now for cloud controller manager: In this
-			// case we do get instance view every time to fulfill the azure_zones requirement without hitting
-			// throttling.
-			// Consider adding separate parameter for controlling 'InstanceView' once node update issue #56276 is fixed
-			vm, err = az.VirtualMachinesClient.Get(az.ResourceGroup, vmName, compute.InstanceView)
-			exists, realErr := checkResourceExistsFromError(err)
-			if realErr != nil {
-				return vm, realErr
-			}
-
-			if !exists {
-				return vm, cloudprovider.InstanceNotFound
-			}
-
-			request.vm = &vm
-		}
-		return *request.vm, nil
+		return vm, err
 	}
 
-	glog.V(6).Infof("getVirtualMachine hits cache for(%s)", vmName)
-	return *request.vm, nil
+	if cachedVM == nil {
+		return vm, cloudprovider.InstanceNotFound
+	}
+
+	return *(cachedVM.(*compute.VirtualMachine)), nil
 }
 
 func (az *Cloud) getRouteTable() (routeTable network.RouteTable, exists bool, err error) {
@@ -172,4 +136,46 @@ func (az *Cloud) getSubnet(virtualNetworkName string, subnetName string) (subnet
 	}
 
 	return subnet, exists, err
+}
+
+func (az *Cloud) newVMCache() *timedCache {
+	getter := func(key string) (interface{}, error) {
+		vm, err := az.VirtualMachinesClient.Get(az.ResourceGroup, key, compute.InstanceView)
+		exists, realErr := checkResourceExistsFromError(err)
+		if realErr != nil {
+			return nil, realErr
+		}
+
+		if !exists {
+			return nil, nil
+		}
+
+		return &vm, nil
+	}
+
+	lister := func() (map[string]interface{}, error) {
+		allNodes := map[string]interface{}{}
+
+		result, err := az.VirtualMachinesClient.List(az.ResourceGroup)
+		if err != nil {
+			return nil, err
+		}
+		moreResults := (result.Value != nil && len(*result.Value) > 0)
+		if moreResults {
+			for idx := range *result.Value {
+				vm := (*result.Value)[idx]
+				allNodes[*vm.Name] = &vm
+			}
+			moreResults = false
+			result, err = az.VirtualMachinesClient.ListNextResults(az.ResourceGroup, result)
+			if err != nil {
+				return nil, err
+			}
+			moreResults = (result.Value != nil && len(*result.Value) > 0)
+		}
+
+		return allNodes, nil
+	}
+
+	return newTimedcache(vmCacheTTL, getter, lister)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Part of #58770. This PR adds a generic cache of Azure VM/LB/NSG for reducing ARM calls. Basically,

- The new cache relies on `listFunc` for refreshing when the cached data is expired
- It will try to use `getFunc` to refresh a single object if the cache is not expired yet and the object is not cached yet
- To avoid additional ARM calls (e.g. get after delete), the cache also stores deleted objects (value is nil) within a TTL period

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of #58770.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
