### PR TITLE
Conversion from typed to unstructured should set GVK

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -431,6 +431,7 @@ func (s *Scheme) Convert(in, out interface{}, context interface{}) error {
 				return err
 			}
 			unstructuredOut.SetUnstructuredContent(content)
+			unstructuredOut.GetObjectKind().SetGroupVersionKind(gvk)
 			return nil
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
@@ -315,6 +315,9 @@ func (u *Unstructured) GroupVersionKind() schema.GroupVersionKind {
 }
 
 func (u *Unstructured) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	if u.Object == nil {
+		u.Object = make(map[string]interface{})
+	}
 	u.Object["apiVersion"] = gvk.GroupVersion().String()
 	u.Object["kind"] = gvk.Kind
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
By convention typed objects do not have `TypeMeta` information filled. When the scheme converts a typed object into Unstructured it should set type meta information explicitly otherwise Unstructured object is not recognizable.

**Special notes for your reviewer**:
Bug was not visible to tests because tests were working with a typed object with `TypeMeta` information filled. It was filled by previous tests. I have refactored tests for better isolation. Also fixed some other issues in tests.

Add `?w=1` to the PR's URL to see the diff with whitespace changes ignored.

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery
/cc @smarterclayton @deads2k 