### PR TITLE
Fix grammar in resource error message

### DIFF
--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -684,13 +684,13 @@ func TestResourceErrors(t *testing.T) {
 		"resources but no selectors": {
 			args: []string{"pods"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "resources were provided, but no name, label selector, or --all flag specified")
 			},
 		},
 		"multiple resources but no selectors": {
 			args: []string{"pods,deployments"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "resources were provided, but no name, label selector, or --all flag specified")
 			},
 		},
 	}

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -307,13 +307,13 @@ func TestLabelErrors(t *testing.T) {
 		"resources but no selectors": {
 			args: []string{"pods", "app=bar"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "resources were provided, but no name, label selector, or --all flag specified")
 			},
 		},
 		"multiple resources but no selectors": {
 			args: []string{"pods,deployments", "app=bar"},
 			errFn: func(err error) bool {
-				return strings.Contains(err.Error(), "resource(s) were provided, but no name, label selector, or --all flag specified")
+				return strings.Contains(err.Error(), "resources were provided, but no name, label selector, or --all flag specified")
 			},
 		},
 	}

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -692,7 +692,7 @@ func (b *Builder) visitorResult() *Result {
 	}
 
 	if len(b.resources) != 0 {
-		return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
+		return &Result{err: fmt.Errorf("resources were provided, but no name, label selector, or --all flag specified")}
 	}
 	return &Result{err: missingResourceError}
 }


### PR DESCRIPTION
Simplified error message.

It uses the plural "were" so using the singular
form "resource" is wrong.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cleanup, usability

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
