### PR TITLE
busybox image: add symlink for /bin/mkfifo

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -34,6 +34,8 @@ docker_build(
         # tee & mkfifo are used to send logs to /var/log and stdout, e.g. by kops
         "/bin/tee": "/bin/busybox",
         "/bin/mkfifo": "/bin/busybox",
+        # Force creation of /tmp
+        "/tmp/hostname": "/etc/hostname",
     },
 )
 

--- a/build/BUILD
+++ b/build/BUILD
@@ -31,8 +31,9 @@ docker_build(
         "/usr/bin/busybox": "/bin/busybox",
         "/usr/sbin/busybox": "/bin/busybox",
         "/sbin/busybox": "/bin/busybox",
-        # tee is used to send logs to /var/log and stdout, e.g. by kops
+        # tee & mkfifo are used to send logs to /var/log and stdout, e.g. by kops
         "/bin/tee": "/bin/busybox",
+        "/bin/mkfifo": "/bin/busybox",
     },
 )
 


### PR DESCRIPTION
This makes the bazel image more similar to the bash build, which uses
the image from the docker registry.

mkfifo is used by e.g. kops to send logs to both a /var/log file and to
stdout (which is then captured by docker).

```release-note
Add /bin/mkfifo symlink to bazel build for busybox, so that CI builds have /bin/tee
```
