### PR TITLE
Replace nominateNodeName annotation with PodStatus.NominatedNodeName

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1318,8 +1318,7 @@ func TestPreempt(t *testing.T) {
 			// Mark the victims for deletion and record the preemptor's nominated node name.
 			now := metav1.Now()
 			victim.DeletionTimestamp = &now
-			test.pod.Annotations = make(map[string]string)
-			test.pod.Annotations[NominatedNodeAnnotationKey] = node.Name
+			test.pod.Status.NominatedNodeName = node.Name
 		}
 		// Call preempt again and make sure it doesn't preempt any more pods.
 		node, victims, _, err = scheduler.Preempt(test.pod, schedulertesting.FakeNodeLister(makeNodeList(nodeNames)), error(&FitError{Pod: test.pod, FailedPredicates: failedPredMap}))

--- a/pkg/scheduler/core/scheduling_queue.go
+++ b/pkg/scheduler/core/scheduling_queue.go
@@ -397,10 +397,8 @@ func (p *PriorityQueue) WaitingPodsForNode(nodeName string) []*v1.Pod {
 	pods := p.unschedulableQ.GetPodsWaitingForNode(nodeName)
 	for _, obj := range p.activeQ.List() {
 		pod := obj.(*v1.Pod)
-		if pod.Annotations != nil {
-			if n, ok := pod.Annotations[NominatedNodeAnnotationKey]; ok && n == nodeName {
-				pods = append(pods, pod)
-			}
+		if pod.Status.NominatedNodeName == nodeName {
+			pods = append(pods, pod)
 		}
 	}
 	return pods
@@ -420,11 +418,7 @@ type UnschedulablePodsMap struct {
 var _ = UnschedulablePods(&UnschedulablePodsMap{})
 
 func NominatedNodeName(pod *v1.Pod) string {
-	nominatedNodeName, ok := pod.Annotations[NominatedNodeAnnotationKey]
-	if !ok {
-		return ""
-	}
-	return nominatedNodeName
+	return pod.Status.NominatedNodeName
 }
 
 // Add adds a pod to the unschedulable pods.

--- a/pkg/scheduler/core/scheduling_queue_test.go
+++ b/pkg/scheduler/core/scheduling_queue_test.go
@@ -41,11 +41,14 @@ var highPriorityPod, medPriorityPod, unschedulablePod = v1.Pod{
 			Name:      "mpp",
 			Namespace: "ns2",
 			Annotations: map[string]string{
-				NominatedNodeAnnotationKey: "node1", "annot2": "val2",
+				"annot2": "val2",
 			},
 		},
 		Spec: v1.PodSpec{
 			Priority: &mediumPriority,
+		},
+		Status: v1.PodStatus{
+			NominatedNodeName: "node1",
 		},
 	},
 	v1.Pod{
@@ -53,7 +56,7 @@ var highPriorityPod, medPriorityPod, unschedulablePod = v1.Pod{
 			Name:      "up",
 			Namespace: "ns1",
 			Annotations: map[string]string{
-				NominatedNodeAnnotationKey: "node1", "annot2": "val2",
+				"annot2": "val2",
 			},
 		},
 		Spec: v1.PodSpec{
@@ -67,6 +70,7 @@ var highPriorityPod, medPriorityPod, unschedulablePod = v1.Pod{
 					Reason: v1.PodReasonUnschedulable,
 				},
 			},
+			NominatedNodeName: "node1",
 		},
 	}
 
@@ -217,8 +221,11 @@ func TestUnschedulablePodsMap(t *testing.T) {
 				Name:      "p0",
 				Namespace: "ns1",
 				Annotations: map[string]string{
-					NominatedNodeAnnotationKey: "node1", "annot2": "val2",
+					"annot1": "val1",
 				},
+			},
+			Status: v1.PodStatus{
+				NominatedNodeName: "node1",
 			},
 		},
 		{
@@ -235,27 +242,30 @@ func TestUnschedulablePodsMap(t *testing.T) {
 				Name:      "p2",
 				Namespace: "ns2",
 				Annotations: map[string]string{
-					NominatedNodeAnnotationKey: "node3", "annot2": "val2", "annot3": "val3",
+					"annot2": "val2", "annot3": "val3",
 				},
+			},
+			Status: v1.PodStatus{
+				NominatedNodeName: "node3",
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "p3",
 				Namespace: "ns4",
-				Annotations: map[string]string{
-					NominatedNodeAnnotationKey: "node1",
-				},
+			},
+			Status: v1.PodStatus{
+				NominatedNodeName: "node1",
 			},
 		},
 	}
 	var updatedPods = make([]*v1.Pod, len(pods))
 	updatedPods[0] = pods[0].DeepCopy()
-	updatedPods[0].Annotations[NominatedNodeAnnotationKey] = "node3"
+	updatedPods[0].Status.NominatedNodeName = "node3"
 	updatedPods[1] = pods[1].DeepCopy()
-	updatedPods[1].Annotations[NominatedNodeAnnotationKey] = "node3"
+	updatedPods[1].Status.NominatedNodeName = "node3"
 	updatedPods[3] = pods[3].DeepCopy()
-	delete(updatedPods[3].Annotations, NominatedNodeAnnotationKey)
+	updatedPods[3].Status.NominatedNodeName = ""
 
 	tests := []struct {
 		podsToAdd                    []*v1.Pod

--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -33,7 +33,6 @@ go_library(
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -19,7 +19,6 @@ limitations under the License.
 package factory
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -30,7 +29,6 @@ import (
 	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1313,41 +1311,16 @@ func (p *podPreemptor) DeletePod(pod *v1.Pod) error {
 	return p.Client.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 }
 
-func (p *podPreemptor) UpdatePodAnnotations(pod *v1.Pod, annotations map[string]string) error {
+func (p *podPreemptor) SetNominatedNodeName(pod *v1.Pod, nominatedNodeName string) error {
 	podCopy := pod.DeepCopy()
-	if podCopy.Annotations == nil {
-		podCopy.Annotations = map[string]string{}
-	}
-	for k, v := range annotations {
-		podCopy.Annotations[k] = v
-	}
-	ret := &unstructured.Unstructured{}
-	ret.SetAnnotations(podCopy.Annotations)
-	patchData, err := json.Marshal(ret)
-	if err != nil {
-		return err
-	}
-	_, error := p.Client.CoreV1().Pods(podCopy.Namespace).Patch(podCopy.Name, types.MergePatchType, patchData, "status")
-	return error
+	podCopy.Status.NominatedNodeName = nominatedNodeName
+	_, err := p.Client.CoreV1().Pods(pod.Namespace).UpdateStatus(podCopy)
+	return err
 }
 
-func (p *podPreemptor) RemoveNominatedNodeAnnotation(pod *v1.Pod) error {
-	podCopy := pod.DeepCopy()
-	if podCopy.Annotations == nil {
+func (p *podPreemptor) RemoveNominatedNodeName(pod *v1.Pod) error {
+	if len(pod.Status.NominatedNodeName) == 0 {
 		return nil
 	}
-	if _, exists := podCopy.Annotations[core.NominatedNodeAnnotationKey]; !exists {
-		return nil
-	}
-	// Note: Deleting the entry from the annotations and passing it to Patch() will
-	// not remove the annotation. That's why we set it to empty string.
-	podCopy.Annotations[core.NominatedNodeAnnotationKey] = ""
-	ret := &unstructured.Unstructured{}
-	ret.SetAnnotations(podCopy.Annotations)
-	patchData, err := json.Marshal(ret)
-	if err != nil {
-		return err
-	}
-	_, error := p.Client.CoreV1().Pods(podCopy.Namespace).Patch(podCopy.Name, types.MergePatchType, patchData, "status")
-	return error
+	return p.SetNominatedNodeName(pod, "")
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -65,11 +65,11 @@ func (fp fakePodPreemptor) DeletePod(pod *v1.Pod) error {
 	return nil
 }
 
-func (fp fakePodPreemptor) UpdatePodAnnotations(pod *v1.Pod, annots map[string]string) error {
+func (fp fakePodPreemptor) SetNominatedNodeName(pod *v1.Pod, nomNodeName string) error {
 	return nil
 }
 
-func (fp fakePodPreemptor) RemoveNominatedNodeAnnotation(pod *v1.Pod) error {
+func (fp fakePodPreemptor) RemoveNominatedNodeName(pod *v1.Pod) error {
 	return nil
 }
 

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -39,7 +39,6 @@ go_test(
         "//pkg/scheduler/algorithm:go_default_library",
         "//pkg/scheduler/algorithmprovider:go_default_library",
         "//pkg/scheduler/api:go_default_library",
-        "//pkg/scheduler/core:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
         "//pkg/scheduler/schedulercache:go_default_library",
         "//plugin/pkg/admission/podtolerationrestriction:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces nominateNodeName annotation with PodStatus.NominatedNodeName in scheudler's logic. We don't expect any logic/behavior changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

ref #57471

/sig scheduling
cc: @k82cn @aveshagarwal @resouer 