### PR TITLE
Do not log unchanged message if a format other than 'name' is specified

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -274,6 +274,9 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving modified configuration from:\n%v\nfor:", info), info.Source, err)
 		}
 
+		// Print object only if output format other than "name" is specified
+		printObject := len(output) > 0 && !shortOutput
+
 		if err := info.Get(); err != nil {
 			if !errors.IsNotFound(err) {
 				return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%v\nfrom server for:", info), info.Source, err)
@@ -297,7 +300,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			}
 
 			count++
-			if len(output) > 0 && !shortOutput {
+			if printObject {
 				return cmdutil.PrintObject(cmd, info.Object, out)
 			}
 			cmdutil.PrintSuccess(shortOutput, out, info.Object, dryRun, "created")
@@ -343,14 +346,14 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 				visitedUids.Insert(string(uid))
 			}
 
-			if string(patchBytes) == "{}" {
+			if string(patchBytes) == "{}" && !printObject {
 				count++
 				cmdutil.PrintSuccess(shortOutput, out, info.Object, false, "unchanged")
 				return nil
 			}
 		}
 		count++
-		if len(output) > 0 && !shortOutput {
+		if printObject {
 			return cmdutil.PrintObject(cmd, info.Object, out)
 		}
 		cmdutil.PrintSuccess(shortOutput, out, info.Object, dryRun, "configured")


### PR DESCRIPTION
**What this PR does / why we need it**:
When specifying an output format, the "unchanged" message screws up the output format.

**Which issue(s) this PR fixes**:
Fixes #58836

**Special notes for your reviewer**: N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
