### PR TITLE
Use overlay2 for testing on COS serial node-e2e

### DIFF
--- a/test/e2e_node/jenkins/gci-init-gpu.yaml
+++ b/test/e2e_node/jenkins/gci-init-gpu.yaml
@@ -1,6 +1,11 @@
 #cloud-config
 
 runcmd:
+  - cp /usr/lib/systemd/system/docker.service /etc/systemd/system/
+  - sed -i -e 's/-s overlay/-s overlay2/g' /etc/systemd/system/docker.service
+  - systemctl daemon-reload
+  - echo '{"live-restore":true}' > /etc/docker/daemon.json
+  - systemctl restart docker
   - modprobe configs
   - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e BASE_DIR=/rootfs/nvidia --privileged gcr.io/google_containers/cos-nvidia-driver-install@sha256:cb55c7971c337fece62f2bfe858662522a01e43ac9984a2dd1dd5c71487d225c
   - mount /tmp /tmp -o remount,exec,suid


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR configures the node-e2e serial tests which utilize GPUs to use overlay2.  It is taken from https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/cos-init-disable-live-restore.yaml#L6, which we use for other serial tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Issue: #59155
This will fix the failing tests, but does not explain the underlying issue.  I will continue to test to figure out what is causing it.

**Release note**:
```release-note
NONE
```

/assign @yujuhong @Random-Liu 