### PR TITLE
Serve OpenAPI spec with single /openapi/v2 endpoint

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3265,35 +3265,35 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto/validation",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/utils/clock",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -175,6 +175,7 @@ func ClusterRoles() []rbac.ClusterRole {
 					// do not expand this pattern for openapi discovery docs
 					// move to a single openapi endpoint that takes accept/accept-encoding headers
 					"/swagger.json", "/swagger-2.0.0.pb-v1",
+					"/openapi", "/openapi/*",
 					"/api", "/api/*",
 					"/apis", "/apis/*",
 				).RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -635,6 +635,8 @@ items:
     - /apis
     - /apis/*
     - /healthz
+    - /openapi
+    - /openapi/*
     - /swagger-2.0.0.pb-v1
     - /swagger.json
     - /swaggerapi

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1640,23 +1640,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -172,7 +172,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1736,23 +1736,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -17,7 +17,7 @@ limitations under the License.
 package routes
 
 import (
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/golang/glog"
 
 	"k8s.io/apiserver/pkg/server/mux"
@@ -32,8 +32,15 @@ type OpenAPI struct {
 
 // Install adds the SwaggerUI webservice to the given mux.
 func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) {
+	// NOTE: [DEPRECATION] We will announce deprecation for format-separated endpoints for OpenAPI spec,
+	// and switch to a single /openapi/v2 endpoint in Kubernetes 1.10. The design doc and deprecation process
+	// are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU.
 	_, err := handler.BuildAndRegisterOpenAPIService("/swagger.json", c.RegisteredWebServices(), oa.Config, mux)
 	if err != nil {
 		glog.Fatalf("Failed to register open api spec for root: %v", err)
+	}
+	_, err = handler.BuildAndRegisterOpenAPIVersionedService("/openapi/v2", c.RegisteredWebServices(), oa.Config, mux)
+	if err != nil {
+		glog.Fatalf("Failed to register versioned open api spec for root: %v", err)
 	}
 }

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -612,7 +612,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -36,8 +36,12 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-// defaultRetries is the number of times a resource discovery is repeated if an api group disappears on the fly (e.g. ThirdPartyResources).
-const defaultRetries = 2
+const (
+	// defaultRetries is the number of times a resource discovery is repeated if an api group disappears on the fly (e.g. ThirdPartyResources).
+	defaultRetries = 2
+	// protobuf mime type
+	mimePb = "application/com.github.proto-openapi.spec.v2@v1.0+protobuf"
+)
 
 // DiscoveryInterface holds the methods that discover server-supported API groups,
 // versions and resources.
@@ -329,9 +333,18 @@ func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
 
 // OpenAPISchema fetches the open api schema using a rest client and parses the proto.
 func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
-	data, err := d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()
+	data, err := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do().Raw()
 	if err != nil {
-		return nil, err
+		if errors.IsForbidden(err) || errors.IsNotFound(err) {
+			// single endpoint not found/registered in old server, try to fetch old endpoint
+			// TODO(roycaihw): remove this in 1.11
+			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 	document := &openapi_v2.Document{}
 	err = proto.Unmarshal(data, document)

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -326,9 +326,14 @@ var returnedOpenAPI = openapi_v2.Document{
 	},
 }
 
-func openapiSchemaFakeServer() (*httptest.Server, error) {
+func openapiSchemaDeprecatedFakeServer() (*httptest.Server, error) {
 	var sErr error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// old server returns 403 on new endpoint request
+		if req.URL.Path == "/openapi/v2" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
 		if req.URL.Path != "/swagger-2.0.0.pb-v1" {
 			sErr = fmt.Errorf("Unexpected url %v", req.URL)
 		}
@@ -349,8 +354,52 @@ func openapiSchemaFakeServer() (*httptest.Server, error) {
 	return server, sErr
 }
 
+func openapiSchemaFakeServer() (*httptest.Server, error) {
+	var sErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/openapi/v2" {
+			sErr = fmt.Errorf("Unexpected url %v", req.URL)
+		}
+		if req.Method != "GET" {
+			sErr = fmt.Errorf("Unexpected method %v", req.Method)
+		}
+		decipherableFormat := req.Header.Get("Accept")
+		if decipherableFormat != "application/com.github.proto-openapi.spec.v2@v1.0+protobuf" {
+			sErr = fmt.Errorf("Unexpected accept mime type %v", decipherableFormat)
+		}
+
+		mime.AddExtensionType(".pb-v1", "application/com.github.googleapis.gnostic.OpenAPIv2@68f4ded+protobuf")
+
+		output, err := proto.Marshal(&returnedOpenAPI)
+		if err != nil {
+			sErr = err
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	return server, sErr
+}
+
 func TestGetOpenAPISchema(t *testing.T) {
 	server, err := openapiSchemaFakeServer()
+	if err != nil {
+		t.Errorf("unexpected error starting fake server: %v", err)
+	}
+	defer server.Close()
+
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.OpenAPISchema()
+	if err != nil {
+		t.Fatalf("unexpected error getting openapi: %v", err)
+	}
+	if e, a := returnedOpenAPI, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetOpenAPISchemaFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer()
 	if err != nil {
 		t.Errorf("unexpected error starting fake server: %v", err)
 	}

--- a/staging/src/k8s.io/code-generator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/code-generator/Godeps/Godeps.json
@@ -260,11 +260,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1628,27 +1628,27 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
@@ -93,6 +93,32 @@ func (h handlerTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(h.data)
 }
 
+type handlerDeprecatedTest struct {
+	etag string
+	data []byte
+}
+
+var _ http.Handler = handlerDeprecatedTest{}
+
+func (h handlerDeprecatedTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// old server returns 403 on new endpoint
+	if r.URL.Path == "/openapi/v2" {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	if len(h.etag) > 0 {
+		w.Header().Add("Etag", h.etag)
+	}
+	ifNoneMatches := r.Header["If-None-Match"]
+	for _, match := range ifNoneMatches {
+		if match == h.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+	w.Write(h.data)
+}
+
 func assertDownloadedSpec(actualSpec *spec.Swagger, actualEtag string, err error,
 	expectedSpecID string, expectedEtag string) error {
 	if err != nil {
@@ -132,4 +158,9 @@ func TestDownloadOpenAPISpec(t *testing.T) {
 	actualSpec, actualEtag, _, err = s.Download(
 		handlerTest{data: []byte("{\"id\": \"test\"}"), etag: "etag_test1"}, "etag_test2")
 	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "etag_test1"))
+
+	// Test old server fallback path
+	actualSpec, actualEtag, _, err = s.Download(handlerDeprecatedTest{data: []byte("{\"id\": \"test\"}")}, "")
+	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "\"6E8F849B434D4B98A569B9D7718876E9-356ECAB19D7FBE1336BABB1E70F8F3025050DE218BE78256BE81620681CFC9A268508E542B8B55974E17B2184BBFC8FFFAA577E51BE195D32B3CA2547818ABE4\""))
+
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
@@ -99,10 +99,11 @@ func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *sp
 	handler = request.WithRequestContext(handler, s.contextMapper)
 	handler = http.TimeoutHandler(handler, specDownloadTimeout, "request timed out")
 
-	req, err := http.NewRequest("GET", "/swagger.json", nil)
+	req, err := http.NewRequest("GET", "/openapi/v2", nil)
 	if err != nil {
 		return nil, "", 0, err
 	}
+	req.Header.Add("Accept", "application/json")
 
 	// Only pass eTag if it is not generated locally
 	if len(etag) > 0 && !strings.HasPrefix(etag, locallyGeneratedEtagPrefix) {
@@ -111,6 +112,23 @@ func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *sp
 
 	writer := newInMemoryResponseWriter()
 	handler.ServeHTTP(writer, req)
+
+	// single endpoint not found/registered in old server, try to fetch old endpoint
+	// TODO(roycaihw): remove this in 1.11
+	if writer.respCode == http.StatusForbidden || writer.respCode == http.StatusNotFound {
+		req, err = http.NewRequest("GET", "/swagger.json", nil)
+		if err != nil {
+			return nil, "", 0, err
+		}
+
+		// Only pass eTag if it is not generated locally
+		if len(etag) > 0 && !strings.HasPrefix(etag, locallyGeneratedEtagPrefix) {
+			req.Header.Add("If-None-Match", etag)
+		}
+
+		writer = newInMemoryResponseWriter()
+		handler.ServeHTTP(writer, req)
+	}
 
 	switch writer.respCode {
 	case http.StatusNotModified:

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1616,23 +1616,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -900,7 +900,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "a07b7bbb58e7fdc5144f8d7046331d29fc9ad3b3"
+			"Rev": "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 		}
 	]
 }

--- a/vendor/k8s.io/kube-openapi/pkg/aggregator/aggregator.go
+++ b/vendor/k8s.io/kube-openapi/pkg/aggregator/aggregator.go
@@ -58,8 +58,10 @@ func (s *referenceWalker) walkRef(ref spec.Ref) spec.Ref {
 	// We do not support external references yet.
 	if !s.alreadyVisited[refStr] && strings.HasPrefix(refStr, definitionPrefix) {
 		s.alreadyVisited[refStr] = true
-		def := s.root.Definitions[refStr[len(definitionPrefix):]]
+		k := refStr[len(definitionPrefix):]
+		def := s.root.Definitions[k]
 		s.walkSchema(&def)
+		s.root.Definitions[k] = def
 	}
 	return s.walkRefCallback(ref)
 }
@@ -69,23 +71,26 @@ func (s *referenceWalker) walkSchema(schema *spec.Schema) {
 		return
 	}
 	schema.Ref = s.walkRef(schema.Ref)
-	for _, v := range schema.Definitions {
+	for k, v := range schema.Definitions {
 		s.walkSchema(&v)
+		schema.Definitions[k] = v
 	}
-	for _, v := range schema.Properties {
+	for k, v := range schema.Properties {
 		s.walkSchema(&v)
+		schema.Properties[k] = v
 	}
-	for _, v := range schema.PatternProperties {
+	for k, v := range schema.PatternProperties {
 		s.walkSchema(&v)
+		schema.PatternProperties[k] = v
 	}
-	for _, v := range schema.AllOf {
-		s.walkSchema(&v)
+	for i, _ := range schema.AllOf {
+		s.walkSchema(&schema.AllOf[i])
 	}
-	for _, v := range schema.AnyOf {
-		s.walkSchema(&v)
+	for i, _ := range schema.AnyOf {
+		s.walkSchema(&schema.AnyOf[i])
 	}
-	for _, v := range schema.OneOf {
-		s.walkSchema(&v)
+	for i, _ := range schema.OneOf {
+		s.walkSchema(&schema.OneOf[i])
 	}
 	if schema.Not != nil {
 		s.walkSchema(schema.Not)
@@ -100,8 +105,8 @@ func (s *referenceWalker) walkSchema(schema *spec.Schema) {
 		if schema.Items.Schema != nil {
 			s.walkSchema(schema.Items.Schema)
 		}
-		for _, v := range schema.Items.Schemas {
-			s.walkSchema(&v)
+		for i, _ := range schema.Items.Schemas {
+			s.walkSchema(&schema.Items.Schemas[i])
 		}
 	}
 }
@@ -291,15 +296,29 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 			from, to string
 		}
 		renames := []Rename{}
+
+	OUTERLOOP:
 		for k, v := range source.Definitions {
 			if usedNames[k] {
 				v2, found := dest.Definitions[k]
-				// Reuse model iff they are exactly the same.
+				// Reuse model if they are exactly the same.
 				if found && reflect.DeepEqual(v, v2) {
 					continue
 				}
-				i := 2
-				newName := fmt.Sprintf("%s_v%d", k, i)
+
+				// Reuse previously renamed model if one exists
+				var newName string
+				i := 1
+				for found {
+					i++
+					newName = fmt.Sprintf("%s_v%d", k, i)
+					v2, found = dest.Definitions[newName]
+					if found && reflect.DeepEqual(v, v2) {
+						renames = append(renames, Rename{from: k, to: newName})
+						continue OUTERLOOP
+					}
+				}
+
 				_, foundInSource := source.Definitions[newName]
 				for usedNames[newName] || foundInSource {
 					i++

--- a/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
@@ -634,6 +634,8 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function", elemType)
 	case types.Struct:
 		g.generateReferenceProperty(elemType)
+	case types.Slice, types.Array:
+		g.generateSliceProperty(elemType)
 	default:
 		return fmt.Errorf("slice Element kind %v is not supported in %v", elemType.Kind, t)
 	}

--- a/vendor/k8s.io/kube-openapi/pkg/handler/BUILD
+++ b/vendor/k8s.io/kube-openapi/pkg/handler/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kube-openapi/pkg/handler",
     visibility = ["//visibility:public"],
     deps = [
+        "//vendor/bitbucket.org/ww/goautoneg:go_default_library",
         "//vendor/github.com/NYTimes/gziphandler:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We are deprecating format-separated endpoints (`/swagger.json`, `/swagger-2.0.0.json`, `/swagger-2.0.0.pb-v1`, `/swagger-2.0.0.pb-v1.gz`) for OpenAPI spec, and switching to a single `/openapi/v2` endpoint in Kubernetes 1.10. The design doc and deprecation process are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU

Requested format is specified by setting HTTP headers

header | possible values
-- | --
Accept | `application/json`, `application/com.github.proto-openapi.spec.v2@v1.0+protobuf`
Accept-Encoding | `gzip`

This PR changes dynamic_client (and kubectl as a result) to use the new endpoint. The old endpoints will remain in 1.10, 1.11, 1.12 and 1.13, and get removed in 1.14. 

**Examples**:

previous | now
-- | --
GET /swagger.json | GET /openapi/v2 **Accept**: application/json
GET /swagger-2.0.0.pb-v1 | GET /openapi/v2 **Accept**: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
GET /swagger-2.0.0.pb-v1.gz | GET /openapi/v2 **Accept**: application/com.github.proto-openapi.spec.v2@v1.0+protobuf **Accept-Encoding**: gzip


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required: Deprecate format-separated endpoints for OpenAPI spec. Please use single `/openapi/v2` endpoint instead.
```

/sig api-machinery