### PR TITLE
GCE: sort firewall parameters

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_util.go
+++ b/pkg/cloudprovider/providers/gce/gce_util.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -98,8 +99,13 @@ func firewallToGcloudArgs(fw *compute.Firewall, projectID string) string {
 			allPorts = append(allPorts, fmt.Sprintf("%v:%v", a.IPProtocol, p))
 		}
 	}
+
+	// Sort all slices to prevent the event from being duped
+	sort.Strings(allPorts)
 	allow := strings.Join(allPorts, ",")
+	sort.Strings(fw.SourceRanges)
 	srcRngs := strings.Join(fw.SourceRanges, ",")
+	sort.Strings(fw.TargetTags)
 	targets := strings.Join(fw.TargetTags, ",")
 	return fmt.Sprintf("--description %q --allow %v --source-ranges %v --target-tags %v --project %v", fw.Description, allow, srcRngs, targets, projectID)
 }

--- a/pkg/cloudprovider/providers/gce/gce_util_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_util_test.go
@@ -88,3 +88,27 @@ func TestSubnetsInCIDR(t *testing.T) {
 		t.Errorf("autoSubnetInList() = %v, expected: %v", gotNames, expectedNames)
 	}
 }
+
+func TestFirewallToGcloudArgs(t *testing.T) {
+	firewall := compute.Firewall{
+		Description:  "Last Line of Defense",
+		TargetTags:   []string{"jock-nodes", "band-nodes"},
+		SourceRanges: []string{"3.3.3.3/20", "1.1.1.1/20", "2.2.2.2/20"},
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "udp",
+				Ports:      []string{"321", "123-456", "123"},
+			},
+			{
+				IPProtocol: "tcp",
+				Ports:      []string{"321", "123-456", "123"},
+			},
+		},
+	}
+	got := firewallToGcloudArgs(&firewall, "my-project")
+
+	var e = `--description "Last Line of Defense" --allow tcp:123,tcp:123-456,tcp:321,udp:123,udp:123-456,udp:321 --source-ranges 1.1.1.1/20,2.2.2.2/20,3.3.3.3/20 --target-tags band-nodes,jock-nodes --project my-project`
+	if got != e {
+		t.Errorf("%q does not equal %q", got, e)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the firewall arguments deterministic.
Fixes #59294 

**Release note**:
```release-note
NONE
```
