### PR TITLE
Add etcd 3.x minor version rollback support to migrate-if-needed.sh

### DIFF
--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -33,6 +33,9 @@
       },
       { "name": "DATA_DIRECTORY",
         "value": "/var/etcd/data{{ suffix }}"
+      },
+      { "name": "INITIAL_CLUSTER",
+        "value": "{{ etcd_cluster }}"
       }
         ],
     "livenessProbe": {

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -16,4 +16,4 @@ FROM BASEIMAGE
 
 EXPOSE 2379 2380 4001 7001
 COPY etcd* etcdctl* /usr/local/bin/
-COPY migrate-if-needed.sh attachlease rollback /usr/local/bin/
+COPY migrate-if-needed.sh start-stop-etcd.sh attachlease rollback /usr/local/bin/

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -28,6 +28,8 @@
 # That binary will be set to the last tag from $(TAGS).
 TAGS?=2.2.1 2.3.7 3.0.17 3.1.11 3.2.14
 REGISTRY_TAG?=3.2.14
+# ROLLBACK_REGISTRY_TAG specified the tag that REGISTRY_TAG may be rolled back to.
+ROLLBACK_REGISTRY_TAG?=3.1.11
 ARCH?=amd64
 REGISTRY?=k8s.gcr.io
 # golang version should match the golang version from https://github.com/coreos/etcd/releases for REGISTRY_TAG version of etcd.
@@ -57,10 +59,10 @@ build:
 	find ./ -maxdepth 1 -type f | xargs -I {} cp {} $(TEMP_DIR)
 
 	# Compile attachlease
-	docker run -i -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
 		/bin/bash -c "CGO_ENABLED=0 go build -o /build/attachlease k8s.io/kubernetes/cluster/images/etcd/attachlease"
 	# Compile rollback
-	docker run -i -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
+	docker run --interactive -v $(shell pwd)/../../../:/go/src/k8s.io/kubernetes -v $(TEMP_DIR):/build -e GOARCH=$(ARCH) golang:$(GOLANG_VERSION) \
 		/bin/bash -c "CGO_ENABLED=0 go build -o /build/rollback k8s.io/kubernetes/cluster/images/etcd/rollback"
 
 
@@ -81,7 +83,7 @@ else
 	# For each release create a tmp dir 'etcd_release_tmp_dir' and unpack the release tar there.
 	for tag in $(TAGS); do \
 		etcd_release_tmp_dir=$(shell mktemp -d); \
-		docker run -i -v $$etcd_release_tmp_dir:/etcdbin golang:$(GOLANG_VERSION) /bin/bash -c \
+		docker run --interactive -v $$etcd_release_tmp_dir:/etcdbin golang:$(GOLANG_VERSION) /bin/bash -c \
 			"git clone https://github.com/coreos/etcd /go/src/github.com/coreos/etcd \
 			&& cd /go/src/github.com/coreos/etcd \
 			&& git checkout v$$tag \
@@ -114,5 +116,127 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push $(REGISTRY)/etcd:$(REGISTRY_TAG)
 endif
 
-all: build
-.PHONY:	build push
+ETCD2_ROLLBACK_NEW_TAG=3.0.17
+ETCD2_ROLLBACK_OLD_TAG=2.2.1
+
+# Test a rollback to etcd2 from the earliest etcd3 version.
+test-rollback-etcd2:
+	mkdir -p $(TEMP_DIR)/rollback-etcd2
+	cd $(TEMP_DIR)/rollback-etcd2
+
+	@echo "Starting $(ETCD2_ROLLBACK_NEW_TAG) etcd and writing some sample data."
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
+		-e "TARGET_STORAGE=etcd3" \
+		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_NEW_TAG)" \
+		-e "DATA_DIRECTORY=/var/etcd/data" \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
+			/usr/local/bin/migrate-if-needed.sh && \
+			source /usr/local/bin/start-stop-etcd.sh && \
+			START_STORAGE=etcd3 START_VERSION=$(ETCD2_ROLLBACK_NEW_TAG) start_etcd && \
+			ETCDCTL_API=3 /usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_NEW_TAG) --endpoints http://127.0.0.1:$${ETCD_PORT} put /registry/k1 value1 && \
+			stop_etcd && \
+			[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_NEW_TAG)/etcd3 ]'
+
+	@echo "Rolling back to the previous version of etcd and recording keyspace to a flat file."
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
+		-e "TARGET_STORAGE=etcd2" \
+		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_OLD_TAG)" \
+		-e "DATA_DIRECTORY=/var/etcd/data" \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
+			/usr/local/bin/migrate-if-needed.sh && \
+			source /usr/local/bin/start-stop-etcd.sh && \
+			START_STORAGE=etcd2 START_VERSION=$(ETCD2_ROLLBACK_OLD_TAG) start_etcd && \
+			/usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_OLD_TAG) --endpoint 127.0.0.1:$${ETCD_PORT} get /registry/k1 > /var/etcd/keyspace.txt && \
+			stop_etcd'
+
+	@echo "Checking if rollback successfully downgraded etcd to $(ETCD2_ROLLBACK_OLD_TAG)"
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_OLD_TAG)/etcd2 ] && \
+			 grep -q value1 /var/etcd/keyspace.txt'
+
+# Test a rollback from the latest version to the previous version.
+test-rollback:
+	mkdir -p $(TEMP_DIR)/rollback-test
+	cd $(TEMP_DIR)/rollback-test
+
+	@echo "Starting $(REGISTRY_TAG) etcd and writing some sample data."
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
+		-e "TARGET_STORAGE=etcd3" \
+		-e "TARGET_VERSION=$(REGISTRY_TAG)" \
+		-e "DATA_DIRECTORY=/var/etcd/data" \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
+			/usr/local/bin/migrate-if-needed.sh && \
+			source /usr/local/bin/start-stop-etcd.sh && \
+			START_STORAGE=etcd3 START_VERSION=$(REGISTRY_TAG) start_etcd && \
+			ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} put /registry/k1 value1 && \
+			stop_etcd'
+
+	@echo "Rolling back to the previous version of etcd and recording keyspace to a flat file."
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
+		-e "TARGET_STORAGE=etcd3" \
+		-e "TARGET_VERSION=$(ROLLBACK_REGISTRY_TAG)" \
+		-e "DATA_DIRECTORY=/var/etcd/data" \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
+			/usr/local/bin/migrate-if-needed.sh && \
+			source /usr/local/bin/start-stop-etcd.sh && \
+			START_STORAGE=etcd3 START_VERSION=$(ROLLBACK_REGISTRY_TAG) start_etcd && \
+			ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} get --prefix / > /var/etcd/keyspace.txt && \
+			stop_etcd'
+
+	@echo "Checking if rollback successfully downgraded etcd to $(ROLLBACK_REGISTRY_TAG)"
+	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
+		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+			'[ $$(cat /var/etcd/data/version.txt) = $(ROLLBACK_REGISTRY_TAG)/etcd3 ] && \
+			 grep -q value1 /var/etcd/keyspace.txt'
+
+# Test migrating from each supported versions to the latest version.
+test-migrate:
+	for tag in $(TAGS); do \
+		echo "Testing migration from $${tag} to $(REGISTRY_TAG)" && \
+		mkdir -p $(TEMP_DIR)/migrate-$${tag} && \
+		cd $(TEMP_DIR)/migrate-$${tag} && \
+		MAJOR_VERSION=$$(echo $${tag} | cut -c 1) && \
+		echo "Starting etcd $${tag} and writing sample data to keyspace" && \
+		docker run --tty --interactive -v $(TEMP_DIR)/migrate-$${tag}:/var/etcd \
+			-e "TARGET_STORAGE=etcd$${MAJOR_VERSION}" \
+			-e "TARGET_VERSION=$${tag}" \
+			-e "DATA_DIRECTORY=/var/etcd/data" \
+			gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+				"INITIAL_CLUSTER=etcd-\$$(hostname)=http://localhost:2380 \
+				/usr/local/bin/migrate-if-needed.sh && \
+				source /usr/local/bin/start-stop-etcd.sh && \
+				START_STORAGE=etcd$${MAJOR_VERSION} START_VERSION=$${tag} start_etcd && \
+				if [ $${MAJOR_VERSION} == 2 ]; then \
+				  /usr/local/bin/etcdctl --endpoint http://127.0.0.1:\$${ETCD_PORT} set /registry/k1 value1; \
+				else \
+				  ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:\$${ETCD_PORT} put /registry/k1 value1; \
+				fi && \
+				stop_etcd" && \
+		echo " Migrating from $${tag} to $(REGISTRY_TAG) and capturing keyspace" && \
+		docker run --tty --interactive -v $(TEMP_DIR)/migrate-$${tag}:/var/etcd \
+			-e "TARGET_STORAGE=etcd3" \
+			-e "TARGET_VERSION=$(REGISTRY_TAG)" \
+			-e "DATA_DIRECTORY=/var/etcd/data" \
+			gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+				'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
+				/usr/local/bin/migrate-if-needed.sh && \
+				source /usr/local/bin/start-stop-etcd.sh && \
+				START_STORAGE=etcd3 START_VERSION=$(REGISTRY_TAG) start_etcd && \
+				ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} get --prefix / > /var/etcd/keyspace.txt && \
+				stop_etcd'  && \
+		echo "Checking if migrate from $${tag} successfully upgraded etcd to $(REGISTRY_TAG)" && \
+		docker run --tty --interactive -v $(TEMP_DIR)/migrate-$${tag}:/var/etcd \
+			gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
+				'[ $$(cat /var/etcd/data/version.txt) = $(REGISTRY_TAG)/etcd3 ] && \
+				 grep -q value1 /var/etcd/keyspace.txt'; \
+	done
+
+test: test-rollback test-rollback-etcd2 test-migrate
+
+all: build test
+.PHONY:	build push test-rollback test-rollback-etcd2 test-migrate test

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -7,6 +7,14 @@ For other architectures, `etcd` is cross-compiled from source. Arch-specific `bu
 
 #### How to release
 
+First, run the migration and rollback tests.
+
+```console
+$ make build test
+```
+
+Next, build and push the docker images for all supported architectures.
+
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64

--- a/cluster/images/etcd/start-stop-etcd.sh
+++ b/cluster/images/etcd/start-stop-etcd.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Starts 'etcd' version ${START_VERSION} and writes to it:
+# 'etcd_version' -> "${START_VERSION}"
+# Successful write confirms that etcd is up and running.
+# Sets ETCD_PID at the end.
+# Returns 0 if etcd was successfully started, non-0 otherwise.
+start_etcd() {
+  # Use random ports, so that apiserver cannot connect to etcd.
+  ETCD_PORT=18629
+  ETCD_PEER_PORT=2380
+  # Avoid collisions between etcd and event-etcd.
+  case "${DATA_DIRECTORY}" in
+    *event*)
+      ETCD_PORT=18631
+      ETCD_PEER_PORT=2381
+      ;;
+  esac
+  local ETCD_CMD="${ETCD:-/usr/local/bin/etcd-${START_VERSION}}"
+  local ETCDCTL_CMD="${ETCDCTL:-/usr/local/bin/etcdctl-${START_VERSION}}"
+  local API_VERSION="$(echo ${START_STORAGE} | cut -c5-5)"
+  if [ "${API_VERSION}" = "2" ]; then
+    ETCDCTL_CMD="${ETCDCTL_CMD} --debug --endpoint=http://127.0.0.1:${ETCD_PORT} set"
+  else
+    ETCDCTL_CMD="${ETCDCTL_CMD} --endpoints=http://127.0.0.1:${ETCD_PORT} put"
+  fi
+  ${ETCD_CMD} \
+    --name="etcd-$(hostname)" \
+    --initial-cluster="etcd-$(hostname)=http://127.0.0.1:${ETCD_PEER_PORT}" \
+    --debug \
+    --data-dir=${DATA_DIRECTORY} \
+    --listen-client-urls http://127.0.0.1:${ETCD_PORT} \
+    --advertise-client-urls http://127.0.0.1:${ETCD_PORT} \
+    --listen-peer-urls http://127.0.0.1:${ETCD_PEER_PORT} \
+    --initial-advertise-peer-urls http://127.0.0.1:${ETCD_PEER_PORT} &
+  ETCD_PID=$!
+  # Wait until we can write to etcd.
+  for i in $(seq 240); do
+    sleep 0.5
+    ETCDCTL_API="${API_VERSION}" ${ETCDCTL_CMD} 'etcd_version' ${START_VERSION}
+    if [ "$?" -eq "0" ]; then
+      echo "Etcd on port ${ETCD_PORT} is up."
+      return 0
+    fi
+  done
+  echo "Timeout while waiting for etcd on port ${ETCD_PORT}"
+  return 1
+}
+
+# Stops etcd with ${ETCD_PID} pid.
+stop_etcd() {
+  kill "${ETCD_PID-}" >/dev/null 2>&1 || :
+  wait "${ETCD_PID-}" >/dev/null 2>&1 || :
+}


### PR DESCRIPTION
Provide automatic etcd 3.x minor version downgrade when using the gcr.io/google_containers/etcd docker images to operate etcd.

Uses `etcdctl snapshot save` and `etcdctl snapshot restore` to safely downgrade etcd from 3.2->3.1 or 3.1->3.0. This is safe because the data storage file formats used by etcd have not changed between these versions.

Intended as a stop-gap until we can introduce more comprehensive downgrade support in etcd. The main limitation of this approach is that it is not able to perform zero downtime downgrades for HA clusters.   For HA clusters, all members must be stopped and downgraded before the cluster may be restarted at the downgraded version.

Example usage:
- Initially the [etcd.manifest](https://github.com/kubernetes/kubernetes/blob/58547ebd72bf314cba26e8d9148db282751e34f2/cluster/gce/manifests/etcd.manifest#L43) is set to gcr.io/google_containers/etcd:3.0.17, TARGET_VERSION=3.0.17
- A upgrade to 3.1.11 is initiated.
- etcd.manifest is updated to gcr.io/google_containers/etcd:3.1.11, TARGET_VERSION=3.1.11
- etcd restarts and establishes 3.1 as it's "cluster version"
- For whatever reason, a downgrade is initiated
- etcd.manifest is updated gcr.io/google_containers/etcd:3.1.11, TARGET_VERSION=3.0.17
- migrate-if-needed.sh detects that the current version (3.1.11) is newer than the target version, so it:
  - creates a snapshot using etcd & etcdctl 3.1.11
  - backs up the data dir
  - restores the snapshot using etcdctl 3.0.17 to create a replacement data dir
  - starts etcd 3.0.17

Note that while this will rollback to an earlier etcd version, the newer etcd gcr.io image version must continue to be used throughout the downgrade. Only TARGET_VERSION is downgraded.

Test coverage was lacking for `migrate-if-needed.sh` so this adds some container level testing to the `Makefile` for migrating and rolling back. This surfaced a couple bugs that are fixed by this PR as well.

cc @mml @lavalamp @wenjiaswe

```release-note
Add automatic etcd 3.2->3.1 and 3.1->3.0 minor version rollback support to gcr.io/google_container/etcd images. For HA clusters, all members must be stopped before performing a rollback.
```
