### PR TITLE
Remove comment from Cluster Autoscaler manifest

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -38,7 +38,6 @@
                         "value": "/var/log/cluster-autoscaler.log"
                     }
                 ],
-                # TODO: Make resource requirements depend on the size of the cluster
                 "resources": {
                     "requests": {
                         "cpu": "10m",


### PR DESCRIPTION
For some reason kubelet stopped to be able to properly handle #. 
```
Feb 03 09:50:35 bootstrap-e2e-master kubelet[1480]: E0203 09:50:35.931999    1480 file.go:149] 
Can't process manifest file "/etc/kubernetes/manifests/cluster-autoscaler.manifest": 
/etc/kubernetes/manifests/cluster-autoscaler.manifest: couldn't parse as pod(couldn't get 
version/kind; json parse error: invalid character '#' looking for beginning of object key string),
please check manifest file.
```
Removing # from manifest to make e2e test green before the release cut.

```release-note
NONE
```
