### PR TITLE
Fix golint warnings in daemon controller

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -100,7 +100,6 @@ pkg/controller/cloud
 pkg/controller/clusterroleaggregation
 pkg/controller/cronjob
 pkg/controller/daemon
-pkg/controller/daemon/util
 pkg/controller/deployment
 pkg/controller/deployment/util
 pkg/controller/disruption

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -63,13 +63,16 @@ import (
 )
 
 const (
-	// The value of 250 is chosen b/c values that are too high can cause registry DoS issues
+	// BurstReplicas is a rate limiter for booting pods on a lot of pods.
+	// The value of 250 is chosen b/c values that are too high can cause registry DoS issues.
 	BurstReplicas = 250
 
-	// If sending a status update to API server fails, we retry a finite number of times.
+	// StatusUpdateRetries limits the number of retries if sending a status update to API server fails.
 	StatusUpdateRetries = 1
+)
 
-	// Reasons for DaemonSet events
+// Reasons for DaemonSet events
+const (
 	// SelectingAllReason is added to an event when a DaemonSet selects all Pods.
 	SelectingAllReason = "SelectingAll"
 	// FailedPlacementReason is added to an event when a DaemonSet can't schedule a Pod to a specified node.
@@ -130,6 +133,7 @@ type DaemonSetsController struct {
 	suspendedDaemonPods      map[string]sets.String
 }
 
+// NewDaemonSetsController creates a new DaemonSetsController
 func NewDaemonSetsController(daemonSetInformer extensionsinformers.DaemonSetInformer, historyInformer appsinformers.ControllerRevisionInformer, podInformer coreinformers.PodInformer, nodeInformer coreinformers.NodeInformer, kubeClient clientset.Interface) (*DaemonSetsController, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
@@ -1320,6 +1324,7 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *exten
 	return
 }
 
+// NewPod creates a new pod
 func NewPod(ds *extensions.DaemonSet, nodeName string) *v1.Pod {
 	newPod := &v1.Pod{Spec: ds.Spec.Template.Spec, ObjectMeta: ds.Spec.Template.ObjectMeta}
 	newPod.Namespace = ds.Namespace

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -84,12 +84,12 @@ var (
 )
 
 func getKey(ds *extensions.DaemonSet, t *testing.T) string {
-	if key, err := controller.KeyFunc(ds); err != nil {
+	key, err := controller.KeyFunc(ds)
+
+	if err != nil {
 		t.Errorf("Unexpected error getting key for ds %v: %v", ds.Name, err)
-		return ""
-	} else {
-		return key
 	}
+	return key
 }
 
 func newDaemonSet(name string) *extensions.DaemonSet {

--- a/pkg/controller/daemon/util/daemonset_util.go
+++ b/pkg/controller/daemon/util/daemonset_util.go
@@ -94,7 +94,7 @@ func CreatePodTemplate(template v1.PodTemplateSpec, generation int64, hash strin
 	return newTemplate
 }
 
-// IsPodUpdate checks if pod contains label value that either matches templateGeneration or hash
+// IsPodUpdated checks if pod contains label value that either matches templateGeneration or hash
 func IsPodUpdated(dsTemplateGeneration int64, pod *v1.Pod, hash string) bool {
 	// Compare with hash to see if the pod is updated, need to maintain backward compatibility of templateGeneration
 	templateMatches := pod.Labels[extensions.DaemonSetTemplateGenerationKey] == fmt.Sprint(dsTemplateGeneration)


### PR DESCRIPTION
This fixes the golint errors in the daemon controller package.
The only on remaining asks to rename DaemonSetsController, which is a public interface and would need proper deprecation first.

**Special notes for your reviewer**:

**Release note**:
I don't believe a release note is required. It only fixes code comments.

```release-note
NONE
```