### PR TITLE
Don't allow shared types as CRD kinds

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -459,6 +459,7 @@ staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informe
 staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
+staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme
 staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
 staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake
 staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation",
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset:go_default_library",
@@ -86,6 +87,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["scheme.go"],
+    importpath = "k8s.io/apiextensions-apiserver/pkg/apiserver/scheme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme/scheme.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/scheme/scheme.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	Scheme = runtime.NewScheme()
+
+	// if you modify this, make sure you update the crEncoder
+	UnversionedVersion = schema.GroupVersion{Group: "", Version: "v1"}
+	UnversionedTypes   = []runtime.Object{
+		&metav1.Status{},
+		&metav1.WatchEvent{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	}
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -821,3 +821,22 @@ func TestNameConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCRDWithTopLevelKind(t *testing.T) {
+	stopCh, apiExtensionClient, clientPool, err := testserver.StartDefaultServerWithClients()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close(stopCh)
+
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	topLevelTypes := []string{"ListOptions", "ExportOptions", "GetOptions", "DeleteOptions", "Status", "APIVersions", "APIGroupList", "APIGroup", "APIResourceList", "WatchEvent"}
+
+	for _, topLevelType := range topLevelTypes {
+		noxuDefinition.Spec.Names.Kind = topLevelType
+		_, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
+		if err == nil {
+			t.Fatalf("unexpected non-error: creation of CRD should fail since it has a top-level type %v as .spec.names.kind", topLevelType)
+		}
+	}
+}


### PR DESCRIPTION
Shared types (meta/v1 and unversioned) are top-level types and exist across all group versions. If a CRD kind is a top-level type, it leads to inconsistent behavior with kubectl.

So we should exclude such types from valid kind names in CRDs.

Fixes kubernetes/kubectl#186

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CustomResourceDefinitions (CRDs) containing the following values for `spec.names.kind` are no longer permitted. Before upgrading, ensure that CRDs do not contain these values.

["ListOptions", "ExportOptions", "GetOptions", "DeleteOptions", "Status", "APIVersions", "APIGroupList", "APIGroup", "APIResourceList", "WatchEvent"]
```

/cc sttts deads2k liggitt adohe 
