### PR TITLE
add ${KUBE-ROOT} for file directory

### DIFF
--- a/hack/test-update-storage-objects.sh
+++ b/hack/test-update-storage-objects.sh
@@ -130,7 +130,7 @@ for test in ${tests[@]}; do
   source_file=${test_data[0]}
 
   kube::log::status "Creating ${source_file}"
-  ${KUBECTL} create -f "${source_file}"
+  ${KUBECTL} create -f "${KUBE_ROOT}/${source_file}"
 
   # Verify that the storage version is the old version
   resource=${test_data[1]}


### PR DESCRIPTION
**What this PR does / why we need it**:
If we using following command
```shell
cd hack
./test-update-storage-objects.sh
```
it would throw err about unable find file `examples\persistent-volume-provisioning\rbd\rbd-storage-class.yaml`.
I think we should add `${KUBE-ROOT} `for file directory, so that we can run command in relative directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
