### PR TITLE
Re-enable Dashboard's use of secret for cert/key pair

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.0
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.3
         resources:
           limits:
             cpu: 100m
@@ -56,7 +56,8 @@ spec:
           timeoutSeconds: 30
       volumes:
       - name: kubernetes-dashboard-certs
-        emptyDir: {}
+        secret:
+          secretName: kubernetes-dashboard-certs
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a partial revert of 66b061da from https://github.com/kubernetes/kubernetes/pull/58720

It re-enables the old behavior.

**Which issue(s) this PR fixes**:
Fixes #59354

**Special notes for your reviewer**:

This PR will fail E2E tests until a new build of Dashboard is published that includes https://github.com/kubernetes/dashboard/pull/2795

This PR should not be merged until that new build is available and the E2E tests are again passing.

**Release note**:
```release-note
NONE

```