### PR TITLE
kube-scheduler: Use default predicates/prioritizers if they are unspecified in the policy config

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -37,9 +37,14 @@ const (
 
 type Policy struct {
 	metav1.TypeMeta
-	// Holds the information to configure the fit predicate functions
+	// Holds the information to configure the fit predicate functions.
+	// If unspecified, the default predicate functions will be applied.
+	// If empty list, all predicates (except the mandatory ones) will be
+	// bypassed.
 	Predicates []PredicatePolicy
-	// Holds the information to configure the priority functions
+	// Holds the information to configure the priority functions.
+	// If unspecified, the default priority functions will be applied.
+	// If empty list, all priority functions will be bypassed.
 	Priorities []PriorityPolicy
 	// Holds the information to communicate with the extender(s)
 	ExtenderConfigs []ExtenderConfig

--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -67,6 +67,7 @@ go_test(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testing:go_default_library",
+        "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/algorithm:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/api/latest:go_default_library",
@@ -77,6 +78,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -892,15 +892,33 @@ func (f *configFactory) CreateFromConfig(policy schedulerapi.Policy) (*scheduler
 	}
 
 	predicateKeys := sets.NewString()
-	for _, predicate := range policy.Predicates {
-		glog.V(2).Infof("Registering predicate: %s", predicate.Name)
-		predicateKeys.Insert(RegisterCustomFitPredicate(predicate))
+	if policy.Predicates == nil {
+		glog.V(2).Infof("Using predicates from algorithm provider '%v'", DefaultProvider)
+		provider, err := GetAlgorithmProvider(DefaultProvider)
+		if err != nil {
+			return nil, err
+		}
+		predicateKeys = provider.FitPredicateKeys
+	} else {
+		for _, predicate := range policy.Predicates {
+			glog.V(2).Infof("Registering predicate: %s", predicate.Name)
+			predicateKeys.Insert(RegisterCustomFitPredicate(predicate))
+		}
 	}
 
 	priorityKeys := sets.NewString()
-	for _, priority := range policy.Priorities {
-		glog.V(2).Infof("Registering priority: %s", priority.Name)
-		priorityKeys.Insert(RegisterCustomPriorityFunction(priority))
+	if policy.Priorities == nil {
+		glog.V(2).Infof("Using priorities from algorithm provider '%v'", DefaultProvider)
+		provider, err := GetAlgorithmProvider(DefaultProvider)
+		if err != nil {
+			return nil, err
+		}
+		priorityKeys = provider.PriorityFunctionKeys
+	} else {
+		for _, priority := range policy.Priorities {
+			glog.V(2).Infof("Registering priority: %s", priority.Name)
+			priorityKeys.Insert(RegisterCustomPriorityFunction(priority))
+		}
 	}
 
 	extenders := make([]algorithm.SchedulerExtender, 0)

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The scheduler has built-in default sets of predicate/prioritizer that are applied on pod scheduling. It can also take a policy config file where predicate/prioritizer and extender settings can be specified. The current behavior is that if we want to configure an extender using the policy config, we have to also provide the default predicate/prioritizer settings. Otherwise, the empty predicate/prioritizer sets will be used.

This is inconvenient, and it's hard to keep the policy config up to date with the scheduler's defaults. This PR changes the scheduler to use the default predicate/prioritizer sets if they are unspecified in the policy config. But an empty list would bypass non-mandatory predicates/prioritizers.

This will change the behavior of a policy config that does not specify (but not empty list) predicate/prioritizer, but it's unlike someone is using such config in practice.

**Special notes for your reviewer**:

I think it makes sense to have this in 1.9 as well because
- It's safe, given the scope of this change and the fact that it's very unlikely that someone is using a policy config with empty predicates/prioritizers.
- Compared with the risk, asking users to provide the default predicate/prioritizer sets for is error-prone and may cause other issues.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kube-scheduler: Use default predicates/prioritizers if they are unspecified in the policy config
```

/sig scheduling
/assign @bsalamat
/cc @vishh 