### PR TITLE
Patch ingress upgrade test to ignore checking certain GCP resources

### DIFF
--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -176,6 +176,15 @@ func (t *IngressUpgradeTest) verify(f *framework.Framework, done <-chan struct{}
 	By("comparing GCP resources post-upgrade")
 	postUpgradeResourceStore := &GCPResourceStore{}
 	t.populateGCPResourceStore(postUpgradeResourceStore)
+
+	// Ignore certain fields in compute.Firewall that we know will change
+	// due to the upgrade/downgrade.
+	// TODO(rramkumar): Remove this once glbc 0.9.8 is released.
+	t.resourceStore.Fw.Allowed = nil
+	t.resourceStore.Fw.SourceRanges = nil
+	postUpgradeResourceStore.Fw.Allowed = nil
+	postUpgradeResourceStore.Fw.SourceRanges = nil
+
 	framework.ExpectNoError(compareGCPResourceStores(t.resourceStore, postUpgradeResourceStore, func(v1 reflect.Value, v2 reflect.Value) error {
 		i1 := v1.Interface()
 		i2 := v2.Interface()


### PR DESCRIPTION
**What this PR does / why we need it**:
In certain situations, GCP resources after an upgrade or downgrade will be different because of semantic changes to the glbc. Therefore in the test, we need to account for this difference and make sure the test does not fail because of it. 


```release-note
None
```

cc @MrHohn 
/assign @bowei 
