### PR TITLE
kubeadm: use localhost for API server liveness probe

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/BUILD
+++ b/cmd/kubeadm/app/util/staticpod/BUILD
@@ -13,6 +13,7 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//cmd/kubeadm/app/features:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
@@ -26,6 +27,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -53,6 +54,22 @@ func TestComponentProbe(t *testing.T) {
 			cfg: &kubeadmapi.MasterConfiguration{
 				API: kubeadmapi.API{
 					AdvertiseAddress: "",
+				},
+			},
+			component: kubeadmconstants.KubeAPIServer,
+			port:      1,
+			path:      "foo",
+			scheme:    v1.URISchemeHTTP,
+			expected:  "127.0.0.1",
+		},
+		{
+			name: "default apiserver advertise address with http",
+			cfg: &kubeadmapi.MasterConfiguration{
+				API: kubeadmapi.API{
+					AdvertiseAddress: "1.2.3.4",
+				},
+				FeatureGates: map[string]bool{
+					features.SelfHosting: true,
 				},
 			},
 			component: kubeadmconstants.KubeAPIServer,


### PR DESCRIPTION
**What this PR does / why we need it**:
The current liveness probe does not work with an HA cluster created with kubeadm. The probe's `host` value will be set to the IP address of the machine where `kubeadm --init` is run. For other master nodes, the IP address will be wrong.

**Special notes for your reviewer**:
None
**Release note**:
```release-note
NONE
```

/cc @timothysc 