### PR TITLE
GCE: Check nodeports are covered by firewall rule with port ranges

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -168,4 +169,11 @@ filegroup(
         "//test/e2e/framework/timer:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["firewall_util_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework",
 )

--- a/test/e2e/framework/firewall_util_test.go
+++ b/test/e2e/framework/firewall_util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "testing"
+
+func TestIsPortsSubset(t *testing.T) {
+	tc := map[string]struct {
+		required  []string
+		coverage  []string
+		expectErr bool
+	}{
+		"Single port coverage": {
+			required: []string{"tcp/50"},
+			coverage: []string{"tcp/50", "tcp/60", "tcp/70"},
+		},
+		"Port range coverage": {
+			required: []string{"tcp/50"},
+			coverage: []string{"tcp/20-30", "tcp/45-60"},
+		},
+		"Multiple Port range coverage": {
+			required: []string{"tcp/50", "tcp/29", "tcp/46"},
+			coverage: []string{"tcp/20-30", "tcp/45-60"},
+		},
+		"Not covered": {
+			required:  []string{"tcp/50"},
+			coverage:  []string{"udp/50", "tcp/49", "tcp/51-60"},
+			expectErr: true,
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			gotErr := isPortsSubset(c.required, c.coverage)
+			if c.expectErr != (gotErr != nil) {
+				t.Errorf("isPortsSubset(%v, %v) = %v, wanted err? %v", c.required, c.coverage, gotErr, c.expectErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When testing firewalls for GCE ingresses, we should assert that particular nodeports are covered by individual ports or port ranges. Currently, port ranges are not acceptable input.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Will fix the currently erroring `ingress-gce-e2e` tests

**Special notes for your reviewer**:
/cc @MrHohn 
/assign @bowei

**Release note**:
```release-note
NONE
```
