### PR TITLE
Introduce some plumbing which makes it possible to specify which ingress image to upgrade to for the upgrade test

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -61,6 +61,7 @@ type TestContextType struct {
 	UpgradeTarget               string
 	EtcdUpgradeStorage          string
 	EtcdUpgradeVersion          string
+	IngressUpgradeImage         string
 	UpgradeImage                string
 	GCEUpgradeScript            string
 	ContainerRuntime            string
@@ -260,6 +261,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.EtcdUpgradeStorage, "etcd-upgrade-storage", "", "The storage version to upgrade to (either 'etcdv2' or 'etcdv3') if doing an etcd upgrade test.")
 	flag.StringVar(&TestContext.EtcdUpgradeVersion, "etcd-upgrade-version", "", "The etcd binary version to upgrade to (e.g., '3.0.14', '2.3.7') if doing an etcd upgrade test.")
 	flag.StringVar(&TestContext.UpgradeImage, "upgrade-image", "", "Image to upgrade to (e.g. 'container_vm' or 'gci') if doing an upgrade test.")
+	flag.StringVar(&TestContext.IngressUpgradeImage, "ingress-upgrade-image", "", "Image to upgrade to if doing an upgrade test for ingress.")
 	flag.StringVar(&TestContext.GCEUpgradeScript, "gce-upgrade-script", "", "Script to use to upgrade a GCE cluster.")
 	flag.BoolVar(&TestContext.CleanStart, "clean-start", false, "If true, purge all namespaces except default and system before running tests. This serves to Cleanup test namespaces from failed/interrupted e2e runs in a long-lived cluster.")
 	flag.BoolVar(&TestContext.GarbageCollectorEnabled, "garbage-collector-enabled", true, "Set to true if the garbage collector is enabled in the kube-apiserver and kube-controller-manager, then some tests will rely on the garbage collector to delete dependent resources.")


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a new flag which allows the user to run the ingress upgrade test with a specific image they are targeting for the upgrade. Before, it was only possible to run an upgrade test which upgraded to the latest image built from HEAD.

cc @MrHohn 
/assign @bowei 

**Release note**:

```release-note
None
```
