### PR TITLE
Fix the wrong comment in cri constants.

### DIFF
--- a/pkg/kubelet/apis/cri/v1alpha1/runtime/constants.go
+++ b/pkg/kubelet/apis/cri/v1alpha1/runtime/constants.go
@@ -38,7 +38,7 @@ const (
 
 // LogTag is the tag of a log line in CRI container log.
 // Currently defined log tags:
-// * First tag: Partial/End - P/E.
+// * First tag: Partial/Full - P/F.
 // The field in the container log format can be extended to include multiple
 // tags by using a delimiter, but changes should be rare. If it becomes clear
 // that better extensibility is desired, a more extensible format (e.g., json)


### PR DESCRIPTION
The comment is wrong in cri constants.go.
Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
