### PR TITLE
Disallow PriorityClass names with 'system-' prefix for user defined priority classes

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -23,6 +23,9 @@ const (
 	// that do not specify any priority class and there is no priority class
 	// marked as default.
 	DefaultPriorityWhenNoDefaultClassExists = 0
+	// SystemPriorityClassPrefix is the prefix reserved for system priority class names. Other priority
+	// classes are not allowed to start with this prefix.
+	SystemPriorityClassPrefix = "system-"
 )
 
 // +genclient

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -17,14 +17,22 @@ limitations under the License.
 package validation
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
-// ValidatePriorityClassName can be used to check whether the given priority
-// class name is valid.
-var ValidatePriorityClassName = apivalidation.NameIsDNSSubdomain
+// ValidatePriorityClassName checks whether the given priority class name is valid.
+func ValidatePriorityClassName(name string, prefix bool) []string {
+	var allErrs []string
+	if strings.HasPrefix(name, scheduling.SystemPriorityClassPrefix) {
+		allErrs = append(allErrs, "priority class names with '"+scheduling.SystemPriorityClassPrefix+"' prefix are reserved for system use only")
+	}
+	allErrs = append(allErrs, apivalidation.NameIsDNSSubdomain(name, prefix)...)
+	return allErrs
+}
 
 // ValidatePriorityClass tests whether required fields in the PriorityClass are
 // set correctly.

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -53,6 +53,10 @@ func TestValidatePriorityClass(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "tier&1", Namespace: ""},
 			Value:      100,
 		},
+		"invalid system name": {
+			ObjectMeta: metav1.ObjectMeta{Name: scheduling.SystemPriorityClassPrefix + "test"},
+			Value:      100,
+		},
 	}
 
 	for k, v := range errorCases {

--- a/plugin/pkg/admission/priority/admission_test.go
+++ b/plugin/pkg/admission/priority/admission_test.go
@@ -127,21 +127,6 @@ func TestPriorityClassAdmission(t *testing.T) {
 			systemClass,
 			true,
 		},
-		{
-			"forbidden system name prefix",
-			[]*scheduling.PriorityClass{},
-			&scheduling.PriorityClass{
-				TypeMeta: metav1.TypeMeta{
-					Kind: "PriorityClass",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "system-something",
-				},
-				Value:       5,
-				Description: "Name with 'system-' prefix is reserved for system use",
-			},
-			true,
-		},
 	}
 
 	for _, test := range tests {

--- a/plugin/pkg/admission/priority/admission_test.go
+++ b/plugin/pkg/admission/priority/admission_test.go
@@ -127,6 +127,21 @@ func TestPriorityClassAdmission(t *testing.T) {
 			systemClass,
 			true,
 		},
+		{
+			"forbidden system name prefix",
+			[]*scheduling.PriorityClass{},
+			&scheduling.PriorityClass{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "PriorityClass",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "system-something",
+				},
+				Value:       5,
+				Description: "Name with 'system-' prefix is reserved for system use",
+			},
+			true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes our Priority admission controller to disallow PriorityClass names with 'system-' prefix for user defined priority classes. Please refer to #59381 for reasons why we need this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59381

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disallow PriorityClass names with 'system-' prefix for user defined priority classes.
```

ref #57471
/sig scheduling
/assign @liggitt 