### PR TITLE
Scheduler - not able to read from config file if configmap is not found

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -214,7 +214,7 @@ func (o *Options) applyDeprecatedHealthzPortToConfig() {
 // 3. --algorithm-provider to use a named algorithm provider.
 func (o *Options) applyDeprecatedAlgorithmSourceOptionsToConfig() {
 	switch {
-	case o.useLegacyPolicyConfig:
+	case o.useLegacyPolicyConfig || (len(o.policyConfigFile) > 0 && o.policyConfigMapName == ""):
 		o.config.AlgorithmSource = componentconfig.SchedulerAlgorithmSource{
 			Policy: &componentconfig.SchedulerPolicySource{
 				File: &componentconfig.SchedulerPolicyFileSource{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
As of now, we are not able to read config file if configmap is not present.  The only way to make it work is to enable legacy mode which should not be the case.
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1540785
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Scheduler should be able to read from config file if configmap is not present.
```
/cc @bsalamat @ironcladlou 