### PR TITLE
Fix typo: constucts -> constructs

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
@@ -69,7 +69,7 @@ func NewForConfigOrDie(c *rest.Config) CustomMetricsClient {
 	return client
 }
 
-// NewForMapper constucts the client with a RESTMapper, which allows more
+// NewForMapper constructs the client with a RESTMapper, which allows more
 // accurate translation from GroupVersionKind to GroupVersionResource.
 func NewForMapper(client rest.Interface, mapper meta.RESTMapper) CustomMetricsClient {
 	return &customMetricsClient{


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix doc typo

**Release note**:
```release-note
NONE
```
