### PR TITLE
svcacct: move claim generation out of TokenGenerator

### DIFF
--- a/pkg/controller/serviceaccount/BUILD
+++ b/pkg/controller/serviceaccount/BUILD
@@ -58,6 +58,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/gopkg.in/square/go-jose.v2/jwt:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -395,7 +395,7 @@ func (e *TokensController) ensureReferencedToken(serviceAccount *v1.ServiceAccou
 	}
 
 	// Generate the token
-	token, err := e.token.GenerateToken(*serviceAccount, *secret)
+	token, err := e.token.GenerateToken(serviceaccount.LegacyClaims(*serviceAccount, *secret))
 	if err != nil {
 		// retriable error
 		return true, err
@@ -551,7 +551,7 @@ func (e *TokensController) generateTokenIfNeeded(serviceAccount *v1.ServiceAccou
 
 	// Generate the token
 	if needsToken {
-		token, err := e.token.GenerateToken(*serviceAccount, *liveSecret)
+		token, err := e.token.GenerateToken(serviceaccount.LegacyClaims(*serviceAccount, *liveSecret))
 		if err != nil {
 			return false, err
 		}

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
+	"gopkg.in/square/go-jose.v2/jwt"
 
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,15 +40,11 @@ import (
 )
 
 type testGenerator struct {
-	GeneratedServiceAccounts []v1.ServiceAccount
-	GeneratedSecrets         []v1.Secret
-	Token                    string
-	Err                      error
+	Token string
+	Err   error
 }
 
-func (t *testGenerator) GenerateToken(serviceAccount v1.ServiceAccount, secret v1.Secret) (string, error) {
-	t.GeneratedSecrets = append(t.GeneratedSecrets, secret)
-	t.GeneratedServiceAccounts = append(t.GeneratedServiceAccounts, serviceAccount)
+func (t *testGenerator) GenerateToken(sc *jwt.Claims, pc interface{}) (string, error) {
 	return t.Token, t.Err
 }
 

--- a/pkg/serviceaccount/BUILD
+++ b/pkg/serviceaccount/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "jwt.go",
+        "legacy.go",
         "util.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/serviceaccount",

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -129,7 +129,7 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 
 	// Generate the RSA token
 	rsaGenerator := serviceaccount.JWTTokenGenerator(serviceaccount.LegacyIssuer, getPrivateKey(rsaPrivateKey))
-	rsaToken, err := rsaGenerator.GenerateToken(*serviceAccount, *rsaSecret)
+	rsaToken, err := rsaGenerator.GenerateToken(serviceaccount.LegacyClaims(*serviceAccount, *rsaSecret))
 	if err != nil {
 		t.Fatalf("error generating token: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 
 	// Generate the ECDSA token
 	ecdsaGenerator := serviceaccount.JWTTokenGenerator(serviceaccount.LegacyIssuer, getPrivateKey(ecdsaPrivateKey))
-	ecdsaToken, err := ecdsaGenerator.GenerateToken(*serviceAccount, *ecdsaSecret)
+	ecdsaToken, err := ecdsaGenerator.GenerateToken(serviceaccount.LegacyClaims(*serviceAccount, *ecdsaSecret))
 	if err != nil {
 		t.Fatalf("error generating token: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 
 	// Generate signer with same keys as RSA signer but different issuer
 	badIssuerGenerator := serviceaccount.JWTTokenGenerator("foo", getPrivateKey(rsaPrivateKey))
-	badIssuerToken, err := badIssuerGenerator.GenerateToken(*serviceAccount, *rsaSecret)
+	badIssuerToken, err := badIssuerGenerator.GenerateToken(serviceaccount.LegacyClaims(*serviceAccount, *rsaSecret))
 	if err != nil {
 		t.Fatalf("error generating token: %v", err)
 	}

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"k8s.io/api/core/v1"
+	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+func LegacyClaims(serviceAccount v1.ServiceAccount, secret v1.Secret) (*jwt.Claims, interface{}) {
+	return &jwt.Claims{
+			Subject: apiserverserviceaccount.MakeUsername(serviceAccount.Namespace, serviceAccount.Name),
+		}, &legacyPrivateClaims{
+			Namespace:          serviceAccount.Namespace,
+			ServiceAccountName: serviceAccount.Name,
+			ServiceAccountUID:  string(serviceAccount.UID),
+			SecretName:         secret.Name,
+		}
+}
+
+const LegacyIssuer = "kubernetes/serviceaccount"
+
+type legacyPrivateClaims struct {
+	ServiceAccountName string `json:"kubernetes.io/serviceaccount/service-account.name"`
+	ServiceAccountUID  string `json:"kubernetes.io/serviceaccount/service-account.uid"`
+	SecretName         string `json:"kubernetes.io/serviceaccount/secret.name"`
+	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
+}


### PR DESCRIPTION
More no-op refactoring.

https://github.com/kubernetes/kubernetes/issues/58790

```release-note
NONE
```
