### PR TITLE
Automated cherry pick of #59398: fix invalid match rules for advanced audit policy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -76,14 +76,18 @@ func (p *policyChecker) LevelAndStages(attrs authorizer.Attributes) (audit.Level
 
 // Check whether the rule matches the request attrs.
 func ruleMatches(r *audit.PolicyRule, attrs authorizer.Attributes) bool {
-	if len(r.Users) > 0 && attrs.GetUser() != nil {
-		if !hasString(r.Users, attrs.GetUser().GetName()) {
+	user := attrs.GetUser()
+	if len(r.Users) > 0 {
+		if user == nil || !hasString(r.Users, user.GetName()) {
 			return false
 		}
 	}
-	if len(r.UserGroups) > 0 && attrs.GetUser() != nil {
+	if len(r.UserGroups) > 0 {
+		if user == nil {
+			return false
+		}
 		matched := false
-		for _, group := range attrs.GetUser().GetGroups() {
+		for _, group := range user.GetGroups() {
 			if hasString(r.UserGroups, group) {
 				matched = true
 				break

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -73,6 +73,16 @@ var (
 			ResourceRequest: true,
 			Path:            "/api/v1/namespaces/default/pods/busybox",
 		},
+		"Unauthorized": &authorizer.AttributesRecord{
+			Verb:            "get",
+			Namespace:       "default",
+			APIGroup:        "", // Core
+			APIVersion:      "v1",
+			Resource:        "pods",
+			Name:            "busybox",
+			ResourceRequest: true,
+			Path:            "/api/v1/namespaces/default/pods/busybox",
+		},
 	}
 
 	rules = map[string]audit.PolicyRule{
@@ -209,6 +219,10 @@ func testAuditLevel(t *testing.T, stages []audit.Stage) {
 
 	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodLogs", "getPods")
 
+	test(t, "Unauthorized", audit.LevelNone, stages, stages, "tims")
+	test(t, "Unauthorized", audit.LevelMetadata, stages, stages, "tims", "default")
+	test(t, "Unauthorized", audit.LevelNone, stages, stages, "humans")
+	test(t, "Unauthorized", audit.LevelMetadata, stages, stages, "humans", "default")
 }
 
 func TestChecker(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #59398 on release-1.9.

#59398: fix invalid match rules for advanced audit policy