### PR TITLE
dockertools: disable MemorySwap on Linux

### DIFF
--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -104,8 +104,9 @@ func (ds *dockerService) updateCreateConfig(
 		rOpts := lc.GetResources()
 		if rOpts != nil {
 			createConfig.HostConfig.Resources = dockercontainer.Resources{
+				// Memory and MemorySwap are set to the same value, this prevents containers from using any swap.
 				Memory:     rOpts.MemoryLimitInBytes,
-				MemorySwap: DefaultMemorySwap(),
+				MemorySwap: rOpts.MemoryLimitInBytes,
 				CPUShares:  rOpts.CpuShares,
 				CPUQuota:   rOpts.CpuQuota,
 				CPUPeriod:  rOpts.CpuPeriod,


### PR DESCRIPTION
In this commit, set `MemorySwap` the same with `Memory` to prevent using swap on Linux.

**What this PR does / why we need it**:

In #39731, @pires tried to disable swap on Linux by setting `MemorySwap` to 0.
However, according to [Docker's docs](https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details), setting `MemorySwap` to 0 is treated as unset, and its [default behavior](https://github.com/moby/moby/blob/v17.05.0-ce/daemon/daemon_unix.go#L266-L269) is to set to twice the size of `Memory`, which can still cause the container to use the swap.

**Which issue(s) this PR fixes** :

This issue was mentioned in this comment: https://github.com/kubernetes/kubernetes/issues/7294#issuecomment-362722637

**Special notes for your reviewer**:

1. For the case on Windows, we can still use the 0 because [Windows does not support `MemorySwap`](https://github.com/moby/moby/blob/v17.05.0-ce/daemon/daemon_windows.go#L185-L187).
2. There is another place using the `DefaultMemorySwap()` is for [sandbox](https://github.com/kubernetes/kubernetes/blob/v1.9.2/pkg/kubelet/dockershim/docker_sandbox.go#L505).
Maybe setting the sandbox's `MemorySwap` to 0 is fine. I didn't change that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
dockertools: disable memory swap on Linux.
```
