### PR TITLE
increase timeout for downward api volume test

### DIFF
--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -373,7 +373,7 @@ func downwardAPIVolumePodForUpdateTest(name string, labels, annotations map[stri
 		{
 			Name:    "client-container",
 			Image:   mountImage,
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",


### PR DESCRIPTION
This increases timeout for downward api volume test (similar increase was done in #56432). This is to prevent flakes (currently this is number one flake in openshift/origin).