### PR TITLE
Enable HPA tests on large clusters

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -66,8 +66,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 		})
 	})
 
-	// TODO: Get rid of [DisabledForLargeClusters] tag when issue #54637 is fixed.
-	SIGDescribe("[DisabledForLargeClusters] ReplicationController light", func() {
+	SIGDescribe("ReplicationController light", func() {
 		It("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/55887
After https://github.com/kubernetes/test-infra/pull/6667 was able to run HPA tests 3 times successfully on 2k node cluster.
/cc @shyamjvs @wojtek-t

```release-note

```
