### PR TITLE
Cleanup of ipvs utils

### DIFF
--- a/pkg/util/ipvs/ipvs_linux.go
+++ b/pkg/util/ipvs/ipvs_linux.go
@@ -25,83 +25,86 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/docker/libnetwork/ipvs"
+	libipvs "github.com/docker/libnetwork/ipvs"
 	"github.com/golang/glog"
 	utilexec "k8s.io/utils/exec"
 )
 
-// runner implements Interface.
+// runner implements ipvs.Interface.
 type runner struct {
 	exec       utilexec.Interface
-	ipvsHandle *ipvs.Handle
+	ipvsHandle *libipvs.Handle
 }
+
+// Protocol is the IPVS service protocol type
+type Protocol uint16
 
 // New returns a new Interface which will call ipvs APIs.
 func New(exec utilexec.Interface) Interface {
-	ihandle, err := ipvs.New("")
+	handle, err := libipvs.New("")
 	if err != nil {
 		glog.Errorf("IPVS interface can't be initialized, error: %v", err)
 		return nil
 	}
 	return &runner{
 		exec:       exec,
-		ipvsHandle: ihandle,
+		ipvsHandle: handle,
 	}
 }
 
-// AddVirtualServer is part of Interface.
+// AddVirtualServer is part of ipvs.Interface.
 func (runner *runner) AddVirtualServer(vs *VirtualServer) error {
-	eSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return err
 	}
-	return runner.ipvsHandle.NewService(eSvc)
+	return runner.ipvsHandle.NewService(svc)
 }
 
-// UpdateVirtualServer is part of Interface.
+// UpdateVirtualServer is part of ipvs.Interface.
 func (runner *runner) UpdateVirtualServer(vs *VirtualServer) error {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return err
 	}
-	return runner.ipvsHandle.UpdateService(bSvc)
+	return runner.ipvsHandle.UpdateService(svc)
 }
 
-// DeleteVirtualServer is part of Interface.
+// DeleteVirtualServer is part of ipvs.Interface.
 func (runner *runner) DeleteVirtualServer(vs *VirtualServer) error {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return err
 	}
-	return runner.ipvsHandle.DelService(bSvc)
+	return runner.ipvsHandle.DelService(svc)
 }
 
-// GetVirtualServer is part of Interface.
+// GetVirtualServer is part of ipvs.Interface.
 func (runner *runner) GetVirtualServer(vs *VirtualServer) (*VirtualServer, error) {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return nil, err
 	}
-	ipvsService, err := runner.ipvsHandle.GetService(bSvc)
+	ipvsSvc, err := runner.ipvsHandle.GetService(svc)
 	if err != nil {
 		return nil, err
 	}
-	virtualServer, err := toVirtualServer(ipvsService)
+	vServ, err := toVirtualServer(ipvsSvc)
 	if err != nil {
 		return nil, err
 	}
-	return virtualServer, nil
+	return vServ, nil
 }
 
-// GetVirtualServers is part of Interface.
+// GetVirtualServers is part of ipvs.Interface.
 func (runner *runner) GetVirtualServers() ([]*VirtualServer, error) {
-	ipvsServices, err := runner.ipvsHandle.GetServices()
+	ipvsSvcs, err := runner.ipvsHandle.GetServices()
 	if err != nil {
 		return nil, err
 	}
 	vss := make([]*VirtualServer, 0)
-	for _, ipvsService := range ipvsServices {
-		vs, err := toVirtualServer(ipvsService)
+	for _, ipvsSvc := range ipvsSvcs {
+		vs, err := toVirtualServer(ipvsSvc)
 		if err != nil {
 			return nil, err
 		}
@@ -110,61 +113,61 @@ func (runner *runner) GetVirtualServers() ([]*VirtualServer, error) {
 	return vss, nil
 }
 
-// Flush is part of Interface.  Currently we delete IPVS services one by one
+// Flush is part of ipvs.Interface. Currently we delete IPVS services one by one
 func (runner *runner) Flush() error {
 	return runner.ipvsHandle.Flush()
 }
 
-// AddRealServer is part of Interface.
+// AddRealServer is part of ipvs.Interface.
 func (runner *runner) AddRealServer(vs *VirtualServer, rs *RealServer) error {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return err
 	}
-	bDst, err := toBackendDestination(rs)
+	dst, err := toIPVSDestination(rs)
 	if err != nil {
 		return err
 	}
-	return runner.ipvsHandle.NewDestination(bSvc, bDst)
+	return runner.ipvsHandle.NewDestination(svc, dst)
 }
 
-// DeleteRealServer is part of Interface.
+// DeleteRealServer is part of ipvs.Interface.
 func (runner *runner) DeleteRealServer(vs *VirtualServer, rs *RealServer) error {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return err
 	}
-	bDst, err := toBackendDestination(rs)
+	dst, err := toIPVSDestination(rs)
 	if err != nil {
 		return err
 	}
-	return runner.ipvsHandle.DelDestination(bSvc, bDst)
+	return runner.ipvsHandle.DelDestination(svc, dst)
 }
 
-// GetRealServers is part of Interface.
+// GetRealServers is part of ipvs.Interface.
 func (runner *runner) GetRealServers(vs *VirtualServer) ([]*RealServer, error) {
-	bSvc, err := toBackendService(vs)
+	svc, err := toIPVSService(vs)
 	if err != nil {
 		return nil, err
 	}
-	bDestinations, err := runner.ipvsHandle.GetDestinations(bSvc)
+	dsts, err := runner.ipvsHandle.GetDestinations(svc)
 	if err != nil {
 		return nil, err
 	}
-	realServers := make([]*RealServer, 0)
-	for _, dest := range bDestinations {
-		dst, err := toRealServer(dest)
+	rss := make([]*RealServer, 0)
+	for _, dst := range dsts {
+		dst, err := toRealServer(dst)
 		// TODO: aggregate errors?
 		if err != nil {
 			return nil, err
 		}
-		realServers = append(realServers, dst)
+		rss = append(rss, dst)
 	}
-	return realServers, nil
+	return rss, nil
 }
 
-// toVirtualServer converts an IPVS service representation to the equivalent virtual server structure.
-func toVirtualServer(svc *ipvs.Service) (*VirtualServer, error) {
+// toVirtualServer converts an IPVS Service to the equivalent VirtualServer structure.
+func toVirtualServer(svc *libipvs.Service) (*VirtualServer, error) {
 	if svc == nil {
 		return nil, errors.New("ipvs svc should not be empty")
 	}
@@ -172,7 +175,7 @@ func toVirtualServer(svc *ipvs.Service) (*VirtualServer, error) {
 		Address:   svc.Address,
 		Port:      svc.Port,
 		Scheduler: svc.SchedName,
-		Protocol:  protocolNumbeToString(ProtoType(svc.Protocol)),
+		Protocol:  protocolToString(Protocol(svc.Protocol)),
 		Timeout:   svc.Timeout,
 	}
 
@@ -194,8 +197,8 @@ func toVirtualServer(svc *ipvs.Service) (*VirtualServer, error) {
 	return vs, nil
 }
 
-// toRealServer converts an IPVS destination representation to the equivalent real server structure.
-func toRealServer(dst *ipvs.Destination) (*RealServer, error) {
+// toRealServer converts an IPVS Destination to the equivalent RealServer structure.
+func toRealServer(dst *libipvs.Destination) (*RealServer, error) {
 	if dst == nil {
 		return nil, errors.New("ipvs destination should not be empty")
 	}
@@ -206,14 +209,14 @@ func toRealServer(dst *ipvs.Destination) (*RealServer, error) {
 	}, nil
 }
 
-// toBackendService converts an IPVS real server representation to the equivalent "backend" service structure.
-func toBackendService(vs *VirtualServer) (*ipvs.Service, error) {
+// toIPVSService converts a VirtualServer to the equivalent IPVS Service structure.
+func toIPVSService(vs *VirtualServer) (*libipvs.Service, error) {
 	if vs == nil {
 		return nil, errors.New("virtual server should not be empty")
 	}
-	bakSvc := &ipvs.Service{
+	ipvsSvc := &libipvs.Service{
 		Address:   vs.Address,
-		Protocol:  stringToProtocolNumber(vs.Protocol),
+		Protocol:  stringToProtocol(vs.Protocol),
 		Port:      vs.Port,
 		SchedName: vs.Scheduler,
 		Flags:     uint32(vs.Flags),
@@ -221,29 +224,29 @@ func toBackendService(vs *VirtualServer) (*ipvs.Service, error) {
 	}
 
 	if ip4 := vs.Address.To4(); ip4 != nil {
-		bakSvc.AddressFamily = syscall.AF_INET
-		bakSvc.Netmask = 0xffffffff
+		ipvsSvc.AddressFamily = syscall.AF_INET
+		ipvsSvc.Netmask = 0xffffffff
 	} else {
-		bakSvc.AddressFamily = syscall.AF_INET6
-		bakSvc.Netmask = 128
+		ipvsSvc.AddressFamily = syscall.AF_INET6
+		ipvsSvc.Netmask = 128
 	}
-	return bakSvc, nil
+	return ipvsSvc, nil
 }
 
-// toBackendDestination converts an IPVS real server representation to the equivalent "backend" destination structure.
-func toBackendDestination(rs *RealServer) (*ipvs.Destination, error) {
+// toIPVSDestination converts a RealServer to the equivalent IPVS Destination structure.
+func toIPVSDestination(rs *RealServer) (*libipvs.Destination, error) {
 	if rs == nil {
 		return nil, errors.New("real server should not be empty")
 	}
-	return &ipvs.Destination{
+	return &libipvs.Destination{
 		Address: rs.Address,
 		Port:    rs.Port,
 		Weight:  rs.Weight,
 	}, nil
 }
 
-// stringToProtocolNumber returns the protocol value for the given name
-func stringToProtocolNumber(protocol string) uint16 {
+// stringToProtocolType returns the protocol type for the given name
+func stringToProtocol(protocol string) uint16 {
 	switch strings.ToLower(protocol) {
 	case "tcp":
 		return uint16(syscall.IPPROTO_TCP)
@@ -253,8 +256,8 @@ func stringToProtocolNumber(protocol string) uint16 {
 	return uint16(0)
 }
 
-// protocolNumbeToString returns the name for the given protocol value.
-func protocolNumbeToString(proto ProtoType) string {
+// protocolTypeToString returns the name for the given protocol.
+func protocolToString(proto Protocol) string {
 	switch proto {
 	case syscall.IPPROTO_TCP:
 		return "TCP"
@@ -263,6 +266,3 @@ func protocolNumbeToString(proto ProtoType) string {
 	}
 	return ""
 }
-
-// ProtoType is IPVS service protocol type
-type ProtoType uint16


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a small cleanup of pkg/util/ipvs.

The changes are as follows:

1. Rename toBackendService -> toIPVSService and toBackendDestination -> toIPVSDestination. The use of the term 'backend' makes things really confusing and this renamig makes it more explicit about what we are doing.

2. Give the libnetwork/ipvs package the name libipvs. This makes it less confusing since the package these files are in is also ipvs.

3. Some variable naming cleanup to make things easier to read.

/assign @m1093782566 

**Release note**:

```release-note
None
```
