### PR TITLE
GCE: Modify address manager to handle external lb

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_address_manager_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_address_manager_test.go
@@ -19,119 +19,245 @@ package gce
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	compute "google.golang.org/api/compute/v1"
 )
 
 const testSvcName = "my-service"
 const testRegion = "us-central1"
 const testSubnet = "/projects/x/testRegions/us-central1/testSubnetworks/customsub"
-const testLBName = "a111111111111111"
+const testLBName = "a1234"
 
-// TestAddressManagerNoRequestedIP tests the typical case of passing in no requested IP
-func TestAddressManagerNoRequestedIP(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	targetIP := ""
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	testHoldAddress(t, mgr, svc, testLBName, testRegion, targetIP, string(schemeInternal))
-	testReleaseAddress(t, mgr, svc, testLBName, testRegion)
-}
-
-// TestAddressManagerBasic tests the typical case of reserving and unreserving an address.
-func TestAddressManagerBasic(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	targetIP := "1.1.1.1"
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	testHoldAddress(t, mgr, svc, testLBName, testRegion, targetIP, string(schemeInternal))
-	testReleaseAddress(t, mgr, svc, testLBName, testRegion)
-}
-
-// TestAddressManagerOrphaned tests the case where the address exists with the IP being equal
-// to the requested address (forwarding rule or loadbalancer IP).
-func TestAddressManagerOrphaned(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	targetIP := "1.1.1.1"
-
-	addr := &compute.Address{Name: testLBName, Address: targetIP, AddressType: string(schemeInternal)}
-	err := svc.ReserveRegionAddress(addr, testRegion)
-	require.NoError(t, err)
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	testHoldAddress(t, mgr, svc, testLBName, testRegion, targetIP, string(schemeInternal))
-	testReleaseAddress(t, mgr, svc, testLBName, testRegion)
-}
-
-// TestAddressManagerOutdatedOrphan tests the case where an address exists but points to
-// an IP other than the forwarding rule or loadbalancer IP.
-func TestAddressManagerOutdatedOrphan(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	previousAddress := "1.1.0.0"
-	targetIP := "1.1.1.1"
-
-	addr := &compute.Address{Name: testLBName, Address: previousAddress, AddressType: string(schemeExternal)}
-	err := svc.ReserveRegionAddress(addr, testRegion)
-	require.NoError(t, err)
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	testHoldAddress(t, mgr, svc, testLBName, testRegion, targetIP, string(schemeInternal))
-	testReleaseAddress(t, mgr, svc, testLBName, testRegion)
-}
-
-// TestAddressManagerExternallyOwned tests the case where the address exists but isn't
-// owned by the controller.
-func TestAddressManagerExternallyOwned(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	targetIP := "1.1.1.1"
-
-	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeInternal)}
-	err := svc.ReserveRegionAddress(addr, testRegion)
-	require.NoError(t, err)
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	ipToUse, err := mgr.HoldAddress()
-	require.NoError(t, err)
-	assert.NotEmpty(t, ipToUse)
-
-	_, err = svc.GetRegionAddress(testLBName, testRegion)
-	assert.True(t, isNotFound(err))
-
-	testReleaseAddress(t, mgr, svc, testLBName, testRegion)
-}
-
-// TestAddressManagerExternallyOwned tests the case where the address exists but isn't
-// owned by the controller. However, this address has the wrong type.
-func TestAddressManagerBadExternallyOwned(t *testing.T) {
-	svc := NewFakeCloudAddressService()
-	targetIP := "1.1.1.1"
-
-	addr := &compute.Address{Name: "my-important-address", Address: targetIP, AddressType: string(schemeExternal)}
-	err := svc.ReserveRegionAddress(addr, testRegion)
-	require.NoError(t, err)
-
-	mgr := newAddressManager(svc, testSvcName, testRegion, testSubnet, testLBName, targetIP, schemeInternal)
-	_, err = mgr.HoldAddress()
-	assert.NotNil(t, err)
-}
-
-func testHoldAddress(t *testing.T, mgr *addressManager, svc CloudAddressService, name, region, targetIP, scheme string) {
-	ipToUse, err := mgr.HoldAddress()
-	require.NoError(t, err)
-	assert.NotEmpty(t, ipToUse)
-
-	addr, err := svc.GetRegionAddress(name, region)
-	require.NoError(t, err)
-	if targetIP != "" {
-		assert.EqualValues(t, targetIP, addr.Address)
+func newInternalAddr(requestedIP, currentIP string) addressParams {
+	return addressParams{
+		name:        testLBName,
+		requestedIP: requestedIP,
+		currentIP:   currentIP,
+		addressType: schemeInternal,
 	}
-	assert.EqualValues(t, scheme, addr.AddressType)
 }
 
-func testReleaseAddress(t *testing.T, mgr *addressManager, svc CloudAddressService, name, region string) {
-	err := mgr.ReleaseAddress()
+func newExternalAddr(requestedIP, currentIP string, tier NetworkTier) addressParams {
+	return addressParams{
+		name:        testLBName,
+		requestedIP: requestedIP,
+		currentIP:   currentIP,
+		addressType: schemeExternal,
+		netTier:     tier,
+	}
+}
+
+func TestAddressManager(t *testing.T) {
+	t.Parallel()
+
+	alphaFeatureGate, err := NewAlphaFeatureGate([]string{AlphaFeatureNetworkTiers})
 	require.NoError(t, err)
-	_, err = svc.GetRegionAddress(name, region)
-	assert.True(t, isNotFound(err))
+
+	tc := map[string]struct {
+		params             addressParams
+		existingAddrs      []compute.Address
+		existingAlphaAddrs []computealpha.Address
+
+		expectedIP   string
+		expectedType lbScheme
+		expectedErr  bool
+	}{
+		// Internal Addresses
+		"create ILB": {
+			params:       newInternalAddr("", ""),
+			expectedIP:   "", // whatever is assigned
+			expectedType: schemeInternal,
+		},
+		"sync ILB": {
+			params:       newInternalAddr("", "1.1.2.1"),
+			expectedIP:   "1.1.2.1",
+			expectedType: schemeInternal,
+		},
+		"create ILB - requested IP": {
+			params:       newInternalAddr("1.1.1.1", ""),
+			expectedIP:   "1.1.1.1",
+			expectedType: schemeInternal,
+		},
+		"sync ILB - requested IP": {
+			params:       newInternalAddr("1.1.1.1", "1.1.1.1"),
+			expectedIP:   "1.1.1.1",
+			expectedType: schemeInternal,
+		},
+		"sync ILB - change requested IP": {
+			params:       newInternalAddr("2.2.2.2", "1.1.1.1"),
+			expectedIP:   "2.2.2.2",
+			expectedType: schemeInternal,
+		},
+
+		// External Addresses
+		"create ELB": {
+			params:       newExternalAddr("", "", NetworkTierDefault),
+			expectedType: schemeExternal,
+		},
+		"create ELB - Standard": {
+			params:       newExternalAddr("", "", NetworkTierStandard),
+			expectedType: schemeExternal,
+		},
+		"sync ELB": {
+			params:       newExternalAddr("", "35.35.35.35", NetworkTierDefault),
+			expectedIP:   "35.35.35.35",
+			expectedType: schemeExternal,
+		},
+		"sync ELB - requested IP": {
+			params:       newExternalAddr("35.35.35.35", "35.35.35.35", NetworkTierStandard),
+			expectedIP:   "35.35.35.35",
+			expectedType: schemeExternal,
+		},
+
+		// Controller owned orphan cases
+		"sync ILB - controller owned addr exists": {
+			params:        newInternalAddr("", "1.1.2.1"),
+			existingAddrs: []compute.Address{{Name: testLBName, Address: "1.1.2.1", AddressType: string(schemeInternal)}},
+			expectedIP:    "1.1.2.1",
+			expectedType:  schemeInternal,
+		},
+		"sync ILB - controller owned addr exists with wrong IP": {
+			params:        newInternalAddr("", "1.1.2.1"),
+			existingAddrs: []compute.Address{{Name: testLBName, Address: "3.3.3.3", AddressType: string(schemeInternal)}},
+			expectedIP:    "1.1.2.1",
+			expectedType:  schemeInternal,
+		},
+		"sync ILB - controller owned addr exists with wrong scheme": {
+			params:        newInternalAddr("", "1.1.2.1"),
+			existingAddrs: []compute.Address{{Name: testLBName, Address: "35.35.35.35", AddressType: string(schemeExternal)}},
+			expectedIP:    "1.1.2.1",
+			expectedType:  schemeInternal,
+		},
+
+		// User owned address case
+		"create ILB - user owned addr exists": {
+			params:        newInternalAddr("1.2.3.4", ""),
+			existingAddrs: []compute.Address{{Name: "my-addr", Address: "1.2.3.4", AddressType: string(schemeInternal)}},
+			expectedIP:    "1.2.3.4",
+			expectedType:  schemeInternal,
+		},
+		"sync ILB - user owned addr exists": {
+			params:        newInternalAddr("", "1.2.3.4"),
+			existingAddrs: []compute.Address{{Name: "my-addr", Address: "1.2.3.4", AddressType: string(schemeInternal)}},
+			expectedIP:    "1.2.3.4",
+			expectedType:  schemeInternal,
+		},
+
+		"create ELB - user owned addr requested": {
+			params:        newExternalAddr("35.35.35.35", "", NetworkTierDefault),
+			existingAddrs: []compute.Address{{Name: "my-addr", Address: "35.35.35.35", AddressType: string(schemeExternal)}},
+			expectedIP:    "35.35.35.35",
+			expectedType:  schemeExternal,
+		},
+		"sync ELB - user owned addr requested": {
+			params:        newExternalAddr("35.35.35.35", "35.35.35.35", NetworkTierDefault),
+			existingAddrs: []compute.Address{{Name: "my-addr", Address: "35.35.35.35", AddressType: string(schemeExternal)}},
+			expectedIP:    "35.35.35.35",
+			expectedType:  schemeExternal,
+		},
+
+		"sync ELB - user owned addr exists": {
+			params:        newExternalAddr("", "35.35.35.35", NetworkTierDefault),
+			existingAddrs: []compute.Address{{Name: "my-addr", Address: "35.35.35.35", AddressType: string(schemeExternal)}},
+			expectedIP:    "35.35.35.35",
+			expectedType:  schemeExternal,
+		},
+
+		"create ELB - user requested addr exists with wrong tier": {
+			params:             newExternalAddr("35.35.35.35", "", NetworkTierDefault),
+			existingAlphaAddrs: []computealpha.Address{{Name: "my-addr", Address: "35.35.35.35", AddressType: string(schemeExternal), NetworkTier: NetworkTierStandard.ToGCEValue()}},
+			expectedErr:        true,
+		},
+	}
+
+	for name, c := range tc {
+		t.Run(name, func(t *testing.T) {
+			svc := NewFakeCloudAddressService()
+
+			// Reserve existing addresses
+			for _, a := range c.existingAddrs {
+				x := a
+				err := svc.ReserveRegionAddress(&x, testRegion)
+				require.NoError(t, err)
+			}
+			for _, a := range c.existingAlphaAddrs {
+				x := a
+				err := svc.ReserveAlphaRegionAddress(&x, testRegion)
+				require.NoError(t, err)
+			}
+
+			// Hold address
+			mgr := newAddressManager(svc, testRegion, testSubnet, c.params, alphaFeatureGate)
+			gotIP, err := mgr.HoldAddress()
+
+			if c.expectedErr != (err != nil) {
+				t.Fatal(err)
+			}
+
+			if c.expectedErr {
+				return
+			}
+
+			// Assert IP exists and is as expected
+			require.NotEmpty(t, gotIP)
+			if c.expectedIP != "" {
+				require.Equal(t, c.expectedIP, gotIP)
+			}
+
+			// Check something is reserving the IP
+			addr, err := svc.GetRegionAddressByIP(testRegion, gotIP)
+			require.NoError(t, err)
+			require.EqualValues(t, string(c.expectedType), addr.AddressType)
+
+			expectedNetTier := c.params.netTier.ToGCEValue()
+			if c.params.addressType == schemeExternal && expectedNetTier == "" {
+				expectedNetTier = NetworkTierDefault.ToGCEValue()
+			}
+
+			// Assert network tier
+			alphaAddr, _ := svc.GetAlphaRegionAddress(addr.Name, testRegion)
+			require.EqualValues(t, expectedNetTier, alphaAddr.NetworkTier)
+
+			// Release address (this is a no-op if user-owned)
+			err = mgr.ReleaseAddress()
+			require.NoError(t, err)
+
+			// Check controller no longer owns an address.
+			_, err = svc.GetRegionAddress(testLBName, testRegion)
+			require.True(t, isNotFound(err))
+
+			// Assert that existing addresses (that aren't owned by the controller)
+			// continue to exist.
+			for _, a := range c.existingAddrs {
+				if a.Name == testLBName {
+					continue
+				}
+				_, err := svc.GetRegionAddress(a.Name, testRegion)
+				require.NoError(t, err)
+			}
+			for _, a := range c.existingAlphaAddrs {
+				if a.Name == testLBName {
+					continue
+				}
+				_, err := svc.GetRegionAddress(a.Name, testRegion)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestAddressManagerRequestWrongType tests the case where the requestedIP is reserved by the user
+// but is the wrong type.
+func TestAddressManagerRequestWrongType(t *testing.T) {
+	svc := NewFakeCloudAddressService()
+	requestedIP := "35.35.35.35"
+
+	addr := &compute.Address{Name: "my-addr", Address: requestedIP, AddressType: string(schemeExternal)}
+	err := svc.ReserveRegionAddress(addr, testRegion)
+	require.NoError(t, err)
+
+	mgr := newAddressManager(svc, testRegion, testSubnet, newInternalAddr(requestedIP, ""), nil)
+	_, err = mgr.HoldAddress()
+	require.Error(t, err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_addresses_fakes.go
+++ b/pkg/cloudprovider/providers/gce/gce_addresses_fakes.go
@@ -71,6 +71,12 @@ func (cas *FakeCloudAddressService) ReserveAlphaRegionAddress(addr *computealpha
 		addr.AddressType = string(schemeExternal)
 	}
 
+	// Set the default NetworkTier for external IPs.
+	// Internal IPs have empty-string value
+	if addr.AddressType == string(schemeExternal) && addr.NetworkTier == "" {
+		addr.NetworkTier = NetworkTierDefault.ToGCEValue()
+	}
+
 	if cas.reservedAddrs[addr.Address] {
 		msg := "IP in use"
 		// When the IP is already in use, this call returns an error code based
@@ -208,8 +214,7 @@ func convertToAlphaAddress(object gceObject) *computealpha.Address {
 	if err := json.Unmarshal(enc, &addr); err != nil {
 		panic(fmt.Sprintf("Failed to convert GCE apiObject %v to alpha address: %v", object, err))
 	}
-	// Set the default values for the Alpha fields.
-	addr.NetworkTier = NetworkTierDefault.ToGCEValue()
+
 	return &addr
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring of GCE address manager to be usable by external load balancers. It includes desired behavior that would stop issues like #53475. 

This PR only changes the internal LB behavior; a separate PR will be made to utilize the address manager for external LBs.

**Special notes for your reviewer**:
/assign @bowei
/cc @MrHohn  
/cc @yujuhong 

**Release note**:
```release-note
NONE
```
