### PR TITLE
Use SetInformers method to register for Node events. (#449)

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -211,21 +210,23 @@ func init() {
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {
+}
+
+// Initialize Node Informers
+func (vs *VSphere) SetInformers(informerFactory informers.SharedInformerFactory) {
 	if vs.cfg == nil {
 		return
 	}
 
 	// Only on controller node it is required to register listeners.
 	// Register callbacks for node updates
-	client := clientBuilder.ClientOrDie("vsphere-cloud-provider")
-	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
-	nodeInformer := factory.Core().V1().Nodes()
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	glog.V(4).Infof("Setting up node informers for vSphere Cloud Provider")
+	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    vs.NodeAdded,
 		DeleteFunc: vs.NodeDeleted,
 	})
-	go nodeInformer.Informer().Run(wait.NeverStop)
-	glog.V(4).Infof("vSphere cloud provider initialized")
+	glog.V(4).Infof("Node informers in vSphere cloud provider initialized")
 }
 
 // Creates new worker node interface and returns


### PR DESCRIPTION
Till 1.9.2 Kubernetes release vSphere Cloud Provider needs a separate service account which is not needed.

**What this PR does / why we need it**: 
In this fix, vSphere CLoud Provider is now implementing SetInformer API to get the required NodeInformer. With this change vSphere Cloud Provider no more requires separate service account for listening NodeEvents.

**Which issue(s) this PR fixes** 
Fixes #58747

**Special notes for your reviewer**:
VMware vSphere Cloud Provide internal change

old release note: Till 1.9.3 vSphere Cloud Provider (VCP) need a separate service account for internal purpose. With this fix VCP is not need any special service account for functioning.

**Release note**:
```release-note
Bugfix: vSphere Cloud Provider (VCP) does not need any special service account anymore.
```
