### PR TITLE
test: bump timeout on //pkg/master

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -113,6 +113,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "medium",
     srcs = [
         "client_ca_hook_test.go",
         "controller_test.go",


### PR DESCRIPTION
TestValidOpenAPISpec often takes over a minute. This bumps the timeout
from 60 seconds to 300 seconds. On my computer it takes ~73 seconds
consisently. The calls to Validate() take the majority of the time.

some recent failures:

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/59436/pull-kubernetes-bazel-test/29606/
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/59437/pull-kubernetes-bazel-test/29601/
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/59423/pull-kubernetes-bazel-test/29560/
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/59325/pull-kubernetes-bazel-test/29554/

```release-note
NONE
```
