### PR TITLE
Automated cherry pick of #59217: Increase RSS limit for runtime from 300MB to 350MB on test

### DIFF
--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -257,7 +257,7 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 				podsPerNode: 100,
 				memLimits: framework.ResourceUsagePerContainer{
 					stats.SystemContainerKubelet: &framework.ContainerResourceUsage{MemoryRSSInBytes: 300 * 1024 * 1024},
-					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 300 * 1024 * 1024},
+					stats.SystemContainerRuntime: &framework.ContainerResourceUsage{MemoryRSSInBytes: 350 * 1024 * 1024},
 				},
 			},
 		}


### PR DESCRIPTION
Cherry pick of #59217 on release-1.9.

#59217: Increase RSS limit for runtime from 300MB to 350MB on test