### PR TITLE
deprecate Kubelet cadvisor housekeeping_interval flag

### DIFF
--- a/cmd/kubelet/app/options/globalflags_linux.go
+++ b/cmd/kubelet/app/options/globalflags_linux.go
@@ -43,8 +43,6 @@ func addCadvisorFlags(fs *pflag.FlagSet) {
 	// These flags were also implicit from cadvisor, but are actually used by something in the core repo:
 	// TODO(mtaufen): This one is stil used by our salt, but for heaven's sake it's even deprecated in cadvisor
 	register(global, local, "docker_root")
-	// e2e node tests rely on this
-	register(global, local, "housekeeping_interval")
 
 	// These flags were implicit from cadvisor, and are mistakes that should be registered deprecated:
 	const deprecated = "This is a cadvisor flag that was mistakenly registered with the Kubelet. Due to legacy concerns, it will follow the standard CLI deprecation timeline before being removed."
@@ -64,6 +62,7 @@ func addCadvisorFlags(fs *pflag.FlagSet) {
 	registerDeprecated(global, local, "event_storage_age_limit", deprecated)
 	registerDeprecated(global, local, "event_storage_event_limit", deprecated)
 	registerDeprecated(global, local, "global_housekeeping_interval", deprecated)
+	registerDeprecated(global, local, "housekeeping_interval", deprecated)
 	registerDeprecated(global, local, "log_cadvisor_usage", deprecated)
 	registerDeprecated(global, local, "machine_id_file", deprecated)
 	registerDeprecated(global, local, "storage_driver_user", deprecated)


### PR DESCRIPTION
I thought e2e node tests were relying on this, but it's actually just
set in a Pod spec that runs a cadvisor image directly, so deprecating
and eventually removing from Kubelet shouldn't affect this.

```release-note
NONE
```

@gyliu513 you've mentioned a few times that you want to set this, can you explain your use case here so we can discuss deprecation and removal of this flag?