### PR TITLE
Fix to register priority function ResourceLimitsPriority correctly.

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -107,10 +107,6 @@ func init() {
 	factory.RegisterPriorityFunction2("ImageLocalityPriority", priorities.ImageLocalityPriorityMap, nil, 1)
 	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
 	factory.RegisterPriorityFunction2("MostRequestedPriority", priorities.MostRequestedPriorityMap, nil, 1)
-	// Prioritizes nodes that satisfy pod's resource limits
-	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceLimitsPriorityFunction) {
-		factory.RegisterPriorityFunction2("ResourceLimitsPriority", priorities.ResourceLimitsPriorityMap, nil, 1)
-	}
 }
 
 func defaultPredicates() sets.String {
@@ -182,7 +178,6 @@ func defaultPredicates() sets.String {
 
 // ApplyFeatureGates applies algorithm by feature gates.
 func ApplyFeatureGates() {
-
 	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
 		// Remove "CheckNodeCondition" predicate
 		factory.RemoveFitPredicate(predicates.CheckNodeConditionPred)
@@ -200,6 +195,12 @@ func ApplyFeatureGates() {
 
 		glog.Warningf("TaintNodesByCondition is enabled, PodToleratesNodeTaints predicate is mandatory")
 	}
+
+	// Prioritizes nodes that satisfy pod's resource limits
+	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceLimitsPriorityFunction) {
+		factory.RegisterPriorityFunction2("ResourceLimitsPriority", priorities.ResourceLimitsPriorityMap, nil, 1)
+	}
+
 }
 
 func registerAlgorithmProvider(predSet, priSet sets.String) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes registration of priority function ResourceLimitsPriority.  Previously this function was being registered inside `init()`. Since this priority function ResourceLimitsPriority is behind feature gate `ResourceLimitsPriorityFunction` and if the feature is enabled, it was not visible in `init()` function. So now the registration of this priority function is moved inside `ApplyFeatureGates()` in scheduler where it can be correctly registered after the feature has been enabled.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

None
```

@kubernetes/sig-scheduling-pr-reviews @bsalamat @ravisantoshgudimetla 
