### PR TITLE
Admit upgrading storage class of pv from beta annotation to spec field

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1770,6 +1770,21 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume) field.E
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "persistentvolumesource"), "is immutable after creation"))
 	}
 
+	var oldSCName, newSCName *string
+	if len(oldPv.Spec.StorageClassName) > 0 {
+		oldSCName = &oldPv.Spec.StorageClassName
+	}
+	if len(newPv.Spec.StorageClassName) > 0 {
+		newSCName = &newPv.Spec.StorageClassName
+	}
+	if !validateStorageClassUpgrade(oldPv.Annotations, newPv.Annotations, oldSCName, newSCName) {
+		// Not a valid upgrade from beta storage class annotation to storage class name field,
+		// so both the beta storage class annotation and storage class name field should be immutable.
+		allErrs = append(allErrs, ValidateImmutableAnnotation(newPv.Annotations[v1.BetaStorageClassAnnotation],
+			oldPv.Annotations[v1.BetaStorageClassAnnotation], v1.BetaStorageClassAnnotation, field.NewPath("metadata"))...)
+		allErrs = append(allErrs, ValidateImmutableField(newPv.Spec.StorageClassName, oldPv.Spec.StorageClassName, field.NewPath("storageClassName"))...)
+	}
+
 	newPv.Status = oldPv.Status
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) {
@@ -1896,10 +1911,10 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 // Provide an upgrade path from PVC with storage class specified in beta
 // annotation to storage class specified in attribute. We allow update of
 // StorageClassName only if following four conditions are met at the same time:
-// 1. The old pvc's StorageClassAnnotation is set
-// 2. The old pvc's StorageClassName is not set
-// 3. The new pvc's StorageClassName is set and equal to the old value in annotation
-// 4. If the new pvc's StorageClassAnnotation is set,it must be equal to the old pv/pvc's StorageClassAnnotation
+// 1. The old pv/pvc's StorageClassAnnotation is set
+// 2. The old pv/pvc's StorageClassName is not set
+// 3. The new pv/pvc's StorageClassName is set and equal to the old value in annotation
+// 4. If the new pv/pvc's StorageClassAnnotation is set,it must be equal to the old pv/pvc's StorageClassAnnotation
 func validateStorageClassUpgrade(oldAnnotations, newAnnotations map[string]string, oldScName, newScName *string) bool {
 	oldSc, oldAnnotationExist := oldAnnotations[core.BetaStorageClassAnnotation]
 	newScInAnnotation, newAnnotationExist := newAnnotations[core.BetaStorageClassAnnotation]

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -507,6 +507,101 @@ func testLocalVolume(path string, affinity *core.VolumeNodeAffinity) core.Persis
 	}
 }
 
+func TestValidatePersistentVolumeStorageClassUpdate(t *testing.T) {
+	volume := testVolume("foo", "", core.PersistentVolumeSpec{
+		Capacity: core.ResourceList{
+			core.ResourceName(core.ResourceStorage): resource.MustParse("1G"),
+		},
+		AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+		PersistentVolumeSource: core.PersistentVolumeSource{
+			HostPath: &core.HostPathVolumeSource{
+				Path: "/foo",
+				Type: newHostPathType(string(core.HostPathDirectory)),
+			},
+		},
+	})
+	volumeWithAnnotation := volume.DeepCopy()
+	volumeWithAnnotation.Annotations = map[string]string{v1.BetaStorageClassAnnotation: "valid"}
+
+	volumeWithStorageClass := volume.DeepCopy()
+	volumeWithStorageClass.Spec.StorageClassName = "valid"
+
+	volumeWithAnnAndSC := volume.DeepCopy()
+	volumeWithAnnAndSC.Annotations = map[string]string{v1.BetaStorageClassAnnotation: "valid"}
+	volumeWithAnnAndSC.Spec.StorageClassName = "valid"
+
+	invalidVolumeWithAnnotation := volume.DeepCopy()
+	invalidVolumeWithAnnotation.Annotations = map[string]string{v1.BetaStorageClassAnnotation: "invalid"}
+
+	invalidVolumeWithStorageClass := volume.DeepCopy()
+	invalidVolumeWithStorageClass.Spec.StorageClassName = "invalid"
+
+	volumeWithAnnAndInvalidSC := volume.DeepCopy()
+	volumeWithAnnAndInvalidSC.Annotations = map[string]string{v1.BetaStorageClassAnnotation: "valid"}
+	volumeWithAnnAndInvalidSC.Spec.StorageClassName = "invalid"
+
+	volumeWithSCAndInvalidAnn := volume.DeepCopy()
+	volumeWithSCAndInvalidAnn.Annotations = map[string]string{v1.BetaStorageClassAnnotation: "invalid"}
+	volumeWithSCAndInvalidAnn.Spec.StorageClassName = "valid"
+
+	scenarios := map[string]struct {
+		isExpectedFailure bool
+		oldVolume         *core.PersistentVolume
+		newVolume         *core.PersistentVolume
+	}{
+		"invalid-no-sc-to-annotation": {
+			isExpectedFailure: true,
+			oldVolume:         volume,
+			newVolume:         volumeWithAnnotation,
+		},
+		"invalid-no-sc-to-storage-class": {
+			isExpectedFailure: true,
+			oldVolume:         volume,
+			newVolume:         volumeWithStorageClass,
+		},
+		"valid-annotation-to-storage-class": {
+			isExpectedFailure: false,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         volumeWithStorageClass,
+		},
+		"valid-ann-to-ann-and-sc": {
+			isExpectedFailure: false,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         volumeWithAnnAndSC,
+		},
+		"invalid-annotation-to-storage-class": {
+			isExpectedFailure: true,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         invalidVolumeWithStorageClass,
+		},
+		"invalid-update-annotation": {
+			isExpectedFailure: true,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         invalidVolumeWithAnnotation,
+		},
+		"ann-to-ann-and-invalid-sc": {
+			isExpectedFailure: true,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         volumeWithAnnAndInvalidSC,
+		},
+		"ann-to-sc-and-invalid-ann": {
+			isExpectedFailure: true,
+			oldVolume:         volumeWithAnnotation,
+			newVolume:         volumeWithSCAndInvalidAnn,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		errs := ValidatePersistentVolumeUpdate(scenario.newVolume, scenario.oldVolume)
+		if len(errs) == 0 && scenario.isExpectedFailure {
+			t.Errorf("Unexpected success for scenario: %s", name)
+		}
+		if len(errs) > 0 && !scenario.isExpectedFailure {
+			t.Errorf("Unexpected failure for scenario: %s - %+v", name, errs)
+		}
+	}
+}
+
 func TestValidateLocalVolumes(t *testing.T) {
 	scenarios := map[string]struct {
 		isExpectedFailure bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`BetaStorageClassAnnotation` is marked as deprecated so we need to provide an upgrade path from PV with storage class specified in beta annotation to storage class specified in attribute.

ref: #58147

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
