### PR TITLE
add illegal verb check for clusterrole creation

### DIFF
--- a/pkg/apis/rbac/validation/BUILD
+++ b/pkg/apis/rbac/validation/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/validation/path:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/apis/rbac/validation/validation_test.go
+++ b/pkg/apis/rbac/validation/validation_test.go
@@ -453,6 +453,25 @@ func TestValidateRoleNonResourceURLNoVerbs(t *testing.T) {
 	}.test(t)
 }
 
+func TestValidateRoleNonResourceURLIllegalVerbs(t *testing.T) {
+	ValidateClusterRoleTest{
+		role: rbac.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+			Rules: []rbac.PolicyRule{
+				{
+					Verbs:           []string{"illegalVerb"},
+					NonResourceURLs: []string{"/*"},
+				},
+			},
+		},
+		wantErr: true,
+		errType: field.ErrorTypeInvalid,
+		field:   "rules[0].verbs",
+	}.test(t)
+}
+
 func TestValidateRoleMixedNonResourceAndResource(t *testing.T) {
 	ValidateRoleTest{
 		role: rbac.Role{


### PR DESCRIPTION
`kubectl create clusterrole `command will check  if the verbs are legal when creating object is noResourceURL clusterrole.
However,` kubectl create -f `will not do this check.
So, user could create bad clusterrole which contains illegal verbs.
This patch fix this.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
