### PR TITLE
Remove method NewCronJobControllerFromClient

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -89,14 +89,6 @@ func NewCronJobController(kubeClient clientset.Interface) (*CronJobController, e
 	return jm, nil
 }
 
-func NewCronJobControllerFromClient(kubeClient clientset.Interface) (*CronJobController, error) {
-	jm, err := NewCronJobController(kubeClient)
-	if err != nil {
-		return nil, err
-	}
-	return jm, nil
-}
-
 // Run the main goroutine responsible for watching and syncing jobs.
 func (jm *CronJobController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()


### PR DESCRIPTION
**What this PR does / why we need it**:

This method was originally introduced when cronjob was still called scheduledjob: https://github.com/kubernetes/kubernetes/commit/7a34347f7f7503dea787c6cb0f27c5e97b1c49d2
Back then, both init methods had different signatures.

Since the rename to cronjob (https://github.com/kubernetes/kubernetes/commit/41d88d30ddbec0f06bc82bf087a85dfcc030db79), this method is an alias to the normal initializer, have the same signature and is not used anywhere in the codebase.

Since this method was never actually used for cronjobs, it doesn't seem removing it would need any deprecation notice.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Remove never used NewCronJobControllerFromClient method
```
