### PR TITLE
Add a label to the cronjob name in their jobs

### DIFF
--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -36,6 +36,10 @@ import (
 
 // Utilities for dealing with Jobs and CronJobs and time.
 
+const (
+	jobLabelName = "cronjob.kubernetes.io/name"
+)
+
 func inActiveList(sj batchv1beta1.CronJob, uid types.UID) bool {
 	for _, j := range sj.Status.Active {
 		if j.UID == uid {
@@ -173,8 +177,8 @@ func getRecentUnmetScheduleTimes(sj batchv1beta1.CronJob, now time.Time) ([]time
 func getJobFromTemplate(sj *batchv1beta1.CronJob, scheduledTime time.Time) (*batchv1.Job, error) {
 	// TODO: consider adding the following labels:
 	// nominal-start-time=$RFC_3339_DATE_OF_INTENDED_START -- for user convenience
-	// scheduled-job-name=$SJ_NAME -- for user convenience
 	labels := copyLabels(&sj.Spec.JobTemplate)
+	labels[jobLabelName] = sj.ObjectMeta.Name
 	annotations := copyAnnotations(&sj.Spec.JobTemplate)
 	// We want job names for a given nominal start time to have a deterministic name to avoid the same job being created twice
 	name := fmt.Sprintf("%s-%d", sj.Name, getTimeHash(scheduledTime))

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -80,8 +80,11 @@ func TestGetJobFromTemplate(t *testing.T) {
 	if !strings.HasPrefix(job.ObjectMeta.Name, "mycronjob-") {
 		t.Errorf("Wrong Name")
 	}
-	if len(job.ObjectMeta.Labels) != 1 {
+	if len(job.ObjectMeta.Labels) != 2 {
 		t.Errorf("Wrong number of labels")
+	}
+	if job.ObjectMeta.Labels[jobLabelName] != "mycronjob" {
+		t.Errorf("Did not expect job label %s", job.ObjectMeta.Labels[jobLabelName])
 	}
 	if len(job.ObjectMeta.Annotations) != 1 {
 		t.Errorf("Wrong number of annotations")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a label to every job created by a cronjob, so they can more easily be found afterwards.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #41633

**Special notes for your reviewer**:

**Release note**:
```release-note
Add 'cronjob-name' label to jobs created by a cronjob
```
