### PR TITLE
devicemanager: increase code coverege of endpoint's unit test

### DIFF
--- a/pkg/kubelet/cm/devicemanager/endpoint_test.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint_test.go
@@ -47,11 +47,13 @@ func TestRun(t *testing.T) {
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
 		{ID: "AnotherDeviceId", Health: pluginapi.Healthy},
+		{ID: "AThirdDeviceId", Health: pluginapi.Unhealthy},
 	}
 
 	updated := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Unhealthy},
 		{ID: "AThirdDeviceId", Health: pluginapi.Healthy},
+		{ID: "AFourthDeviceId", Health: pluginapi.Healthy},
 	}
 
 	callbackCount := 0
@@ -65,7 +67,7 @@ func TestRun(t *testing.T) {
 
 		// Check plugin registration
 		if callbackCount == 0 {
-			require.Len(t, a, 2)
+			require.Len(t, a, 3)
 			require.Len(t, u, 0)
 			require.Len(t, r, 0)
 		}
@@ -73,12 +75,14 @@ func TestRun(t *testing.T) {
 		// Check plugin update
 		if callbackCount == 1 {
 			require.Len(t, a, 1)
-			require.Len(t, u, 1)
+			require.Len(t, u, 2)
 			require.Len(t, r, 1)
 
-			require.Equal(t, a[0].ID, updated[1].ID)
+			require.Equal(t, a[0].ID, updated[2].ID)
 			require.Equal(t, u[0].ID, updated[0].ID)
 			require.Equal(t, u[0].Health, updated[0].Health)
+			require.Equal(t, u[1].ID, updated[1].ID)
+			require.Equal(t, u[1].Health, updated[1].Health)
 			require.Equal(t, r[0].ID, devs[1].ID)
 		}
 
@@ -101,7 +105,7 @@ func TestRun(t *testing.T) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	require.Len(t, e.devices, 2)
+	require.Len(t, e.devices, 3)
 	for _, dref := range updated {
 		d, ok := e.devices[dref.ID]
 


### PR DESCRIPTION
Particularly cover the code path when an unhealthy device
becomes healthy.