### PR TITLE
Return information about which int tests failed in the summary

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -106,7 +106,7 @@ function record_command() {
     juLog -output="${output}" -class="test-cmd" -name="${name}" "$@"
     if [[ $? -ne 0 ]]; then
       echo "Error when running ${name}"
-      foundError="True"
+      foundError="${foundError}""${name}"", "
     fi
 
     set -o nounset
@@ -4537,7 +4537,7 @@ run_impersonation_tests() {
 # Requires an env var SUPPORTED_RESOURCES which is a comma separated list of
 # resources for which tests should be run.
 runTests() {
-  foundError="False"
+  foundError=""
 
   if [ -z "${SUPPORTED_RESOURCES:-}" ]; then
     echo "Need to set SUPPORTED_RESOURCES env var. It is a list of resources that are supported and hence should be tested. Set it to (*) to test all resources"
@@ -5035,8 +5035,8 @@ runTests() {
 
   kube::test::clear_all
 
-  if [ "$foundError" == "True" ]; then
-    echo "TEST FAILED"
+  if [ ! -z "${foundError}" ]; then
+    echo "FAILED TESTS: ""${foundError}"
     exit 1
   fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if integration tests fail they will print the name of the failing tests as it goes, but the summary only tells that it failed. You need to know what to look for to be able to find all these occurrences. This PR provides a summary next to the failure information, eg:
```
FAILED TESTS: run_cluster_management_tests, run_plugins_tests, 
```
Which should greatly simplify developers integration debugging. 

**Release note**:
```release-note
NONE
```
