### PR TITLE
[GCE] Unit test ExternalLoadBalancer

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -107,6 +107,7 @@ go_test(
     deps = [
         "//pkg/cloudprovider:go_default_library",
         "//pkg/cloudprovider/providers/gce/cloud:go_default_library",
+        "//pkg/cloudprovider/providers/gce/cloud/mock:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -106,6 +106,7 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
     deps = [
         "//pkg/cloudprovider:go_default_library",
+        "//pkg/cloudprovider/providers/gce/cloud:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/pkg/cloudprovider/providers/gce/cloud/BUILD
+++ b/pkg/cloudprovider/providers/gce/cloud/BUILD
@@ -57,6 +57,7 @@ filegroup(
         "//pkg/cloudprovider/providers/gce/cloud/filter:all-srcs",
         "//pkg/cloudprovider/providers/gce/cloud/gen:all-srcs",
         "//pkg/cloudprovider/providers/gce/cloud/meta:all-srcs",
+        "//pkg/cloudprovider/providers/gce/cloud/mock:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/cloudprovider/providers/gce/cloud/gen.go
+++ b/pkg/cloudprovider/providers/gce/cloud/gen.go
@@ -1222,10 +1222,10 @@ type MockAddresses struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAddresses, ctx context.Context, key *meta.Key) (bool, *ga.Address, error)
-	ListHook   func(m *MockAddresses, ctx context.Context, region string, fl *filter.F) (bool, []*ga.Address, error)
-	InsertHook func(m *MockAddresses, ctx context.Context, key *meta.Key, obj *ga.Address) (bool, error)
-	DeleteHook func(m *MockAddresses, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAddresses) (bool, *ga.Address, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockAddresses) (bool, []*ga.Address, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.Address, m *MockAddresses) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAddresses) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -1235,7 +1235,7 @@ type MockAddresses struct {
 // Get returns the object from the mock.
 func (m *MockAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Address, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAddresses.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -1268,7 +1268,7 @@ func (m *MockAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Address, er
 // List all of the objects in the mock in the given region.
 func (m *MockAddresses) List(ctx context.Context, region string, fl *filter.F) ([]*ga.Address, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockAddresses.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -1302,7 +1302,7 @@ func (m *MockAddresses) List(ctx context.Context, region string, fl *filter.F) (
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga.Address) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAddresses.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -1340,7 +1340,7 @@ func (m *MockAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga.Addre
 // Delete is a mock for deleting the object.
 func (m *MockAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAddresses.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -1553,10 +1553,10 @@ type MockAlphaAddresses struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaAddresses, ctx context.Context, key *meta.Key) (bool, *alpha.Address, error)
-	ListHook   func(m *MockAlphaAddresses, ctx context.Context, region string, fl *filter.F) (bool, []*alpha.Address, error)
-	InsertHook func(m *MockAlphaAddresses, ctx context.Context, key *meta.Key, obj *alpha.Address) (bool, error)
-	DeleteHook func(m *MockAlphaAddresses, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaAddresses) (bool, *alpha.Address, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockAlphaAddresses) (bool, []*alpha.Address, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.Address, m *MockAlphaAddresses) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaAddresses) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -1566,7 +1566,7 @@ type MockAlphaAddresses struct {
 // Get returns the object from the mock.
 func (m *MockAlphaAddresses) Get(ctx context.Context, key *meta.Key) (*alpha.Address, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaAddresses.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -1599,7 +1599,7 @@ func (m *MockAlphaAddresses) Get(ctx context.Context, key *meta.Key) (*alpha.Add
 // List all of the objects in the mock in the given region.
 func (m *MockAlphaAddresses) List(ctx context.Context, region string, fl *filter.F) ([]*alpha.Address, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaAddresses.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -1633,7 +1633,7 @@ func (m *MockAlphaAddresses) List(ctx context.Context, region string, fl *filter
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaAddresses) Insert(ctx context.Context, key *meta.Key, obj *alpha.Address) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaAddresses.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -1671,7 +1671,7 @@ func (m *MockAlphaAddresses) Insert(ctx context.Context, key *meta.Key, obj *alp
 // Delete is a mock for deleting the object.
 func (m *MockAlphaAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaAddresses.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -1884,10 +1884,10 @@ type MockBetaAddresses struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockBetaAddresses, ctx context.Context, key *meta.Key) (bool, *beta.Address, error)
-	ListHook   func(m *MockBetaAddresses, ctx context.Context, region string, fl *filter.F) (bool, []*beta.Address, error)
-	InsertHook func(m *MockBetaAddresses, ctx context.Context, key *meta.Key, obj *beta.Address) (bool, error)
-	DeleteHook func(m *MockBetaAddresses, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockBetaAddresses) (bool, *beta.Address, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockBetaAddresses) (bool, []*beta.Address, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *beta.Address, m *MockBetaAddresses) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockBetaAddresses) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -1897,7 +1897,7 @@ type MockBetaAddresses struct {
 // Get returns the object from the mock.
 func (m *MockBetaAddresses) Get(ctx context.Context, key *meta.Key) (*beta.Address, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBetaAddresses.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -1930,7 +1930,7 @@ func (m *MockBetaAddresses) Get(ctx context.Context, key *meta.Key) (*beta.Addre
 // List all of the objects in the mock in the given region.
 func (m *MockBetaAddresses) List(ctx context.Context, region string, fl *filter.F) ([]*beta.Address, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockBetaAddresses.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -1964,7 +1964,7 @@ func (m *MockBetaAddresses) List(ctx context.Context, region string, fl *filter.
 // Insert is a mock for inserting/creating a new object.
 func (m *MockBetaAddresses) Insert(ctx context.Context, key *meta.Key, obj *beta.Address) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockBetaAddresses.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -2002,7 +2002,7 @@ func (m *MockBetaAddresses) Insert(ctx context.Context, key *meta.Key, obj *beta
 // Delete is a mock for deleting the object.
 func (m *MockBetaAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBetaAddresses.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -2215,10 +2215,10 @@ type MockGlobalAddresses struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockGlobalAddresses, ctx context.Context, key *meta.Key) (bool, *ga.Address, error)
-	ListHook   func(m *MockGlobalAddresses, ctx context.Context, fl *filter.F) (bool, []*ga.Address, error)
-	InsertHook func(m *MockGlobalAddresses, ctx context.Context, key *meta.Key, obj *ga.Address) (bool, error)
-	DeleteHook func(m *MockGlobalAddresses, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockGlobalAddresses) (bool, *ga.Address, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockGlobalAddresses) (bool, []*ga.Address, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.Address, m *MockGlobalAddresses) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockGlobalAddresses) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -2228,7 +2228,7 @@ type MockGlobalAddresses struct {
 // Get returns the object from the mock.
 func (m *MockGlobalAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Address, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockGlobalAddresses.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -2261,7 +2261,7 @@ func (m *MockGlobalAddresses) Get(ctx context.Context, key *meta.Key) (*ga.Addre
 // List all of the objects in the mock.
 func (m *MockGlobalAddresses) List(ctx context.Context, fl *filter.F) ([]*ga.Address, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockGlobalAddresses.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -2292,7 +2292,7 @@ func (m *MockGlobalAddresses) List(ctx context.Context, fl *filter.F) ([]*ga.Add
 // Insert is a mock for inserting/creating a new object.
 func (m *MockGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga.Address) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockGlobalAddresses.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -2330,7 +2330,7 @@ func (m *MockGlobalAddresses) Insert(ctx context.Context, key *meta.Key, obj *ga
 // Delete is a mock for deleting the object.
 func (m *MockGlobalAddresses) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockGlobalAddresses.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -2546,12 +2546,12 @@ type MockBackendServices struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook       func(m *MockBackendServices, ctx context.Context, key *meta.Key) (bool, *ga.BackendService, error)
-	ListHook      func(m *MockBackendServices, ctx context.Context, fl *filter.F) (bool, []*ga.BackendService, error)
-	InsertHook    func(m *MockBackendServices, ctx context.Context, key *meta.Key, obj *ga.BackendService) (bool, error)
-	DeleteHook    func(m *MockBackendServices, ctx context.Context, key *meta.Key) (bool, error)
-	GetHealthHook func(*MockBackendServices, context.Context, *meta.Key, *ga.ResourceGroupReference) (*ga.BackendServiceGroupHealth, error)
-	UpdateHook    func(*MockBackendServices, context.Context, *meta.Key, *ga.BackendService) error
+	GetHook       func(ctx context.Context, key *meta.Key, m *MockBackendServices) (bool, *ga.BackendService, error)
+	ListHook      func(ctx context.Context, fl *filter.F, m *MockBackendServices) (bool, []*ga.BackendService, error)
+	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.BackendService, m *MockBackendServices) (bool, error)
+	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockBackendServices) (bool, error)
+	GetHealthHook func(context.Context, *meta.Key, *ga.ResourceGroupReference, *MockBackendServices) (*ga.BackendServiceGroupHealth, error)
+	UpdateHook    func(context.Context, *meta.Key, *ga.BackendService, *MockBackendServices) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -2561,7 +2561,7 @@ type MockBackendServices struct {
 // Get returns the object from the mock.
 func (m *MockBackendServices) Get(ctx context.Context, key *meta.Key) (*ga.BackendService, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBackendServices.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -2594,7 +2594,7 @@ func (m *MockBackendServices) Get(ctx context.Context, key *meta.Key) (*ga.Backe
 // List all of the objects in the mock.
 func (m *MockBackendServices) List(ctx context.Context, fl *filter.F) ([]*ga.BackendService, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockBackendServices.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -2625,7 +2625,7 @@ func (m *MockBackendServices) List(ctx context.Context, fl *filter.F) ([]*ga.Bac
 // Insert is a mock for inserting/creating a new object.
 func (m *MockBackendServices) Insert(ctx context.Context, key *meta.Key, obj *ga.BackendService) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockBackendServices.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -2663,7 +2663,7 @@ func (m *MockBackendServices) Insert(ctx context.Context, key *meta.Key, obj *ga
 // Delete is a mock for deleting the object.
 func (m *MockBackendServices) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -2701,7 +2701,7 @@ func (m *MockBackendServices) Obj(o *ga.BackendService) *MockBackendServicesObj 
 // GetHealth is a mock for the corresponding method.
 func (m *MockBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0 *ga.ResourceGroupReference) (*ga.BackendServiceGroupHealth, error) {
 	if m.GetHealthHook != nil {
-		return m.GetHealthHook(m, ctx, key, arg0)
+		return m.GetHealthHook(ctx, key, arg0, m)
 	}
 	return nil, fmt.Errorf("GetHealthHook must be set")
 }
@@ -2709,7 +2709,7 @@ func (m *MockBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0
 // Update is a mock for the corresponding method.
 func (m *MockBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *ga.BackendService) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -2955,11 +2955,11 @@ type MockAlphaBackendServices struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaBackendServices, ctx context.Context, key *meta.Key) (bool, *alpha.BackendService, error)
-	ListHook   func(m *MockAlphaBackendServices, ctx context.Context, fl *filter.F) (bool, []*alpha.BackendService, error)
-	InsertHook func(m *MockAlphaBackendServices, ctx context.Context, key *meta.Key, obj *alpha.BackendService) (bool, error)
-	DeleteHook func(m *MockAlphaBackendServices, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockAlphaBackendServices, context.Context, *meta.Key, *alpha.BackendService) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaBackendServices) (bool, *alpha.BackendService, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockAlphaBackendServices) (bool, []*alpha.BackendService, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.BackendService, m *MockAlphaBackendServices) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaBackendServices) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *alpha.BackendService, *MockAlphaBackendServices) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -2969,7 +2969,7 @@ type MockAlphaBackendServices struct {
 // Get returns the object from the mock.
 func (m *MockAlphaBackendServices) Get(ctx context.Context, key *meta.Key) (*alpha.BackendService, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaBackendServices.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -3002,7 +3002,7 @@ func (m *MockAlphaBackendServices) Get(ctx context.Context, key *meta.Key) (*alp
 // List all of the objects in the mock.
 func (m *MockAlphaBackendServices) List(ctx context.Context, fl *filter.F) ([]*alpha.BackendService, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaBackendServices.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -3033,7 +3033,7 @@ func (m *MockAlphaBackendServices) List(ctx context.Context, fl *filter.F) ([]*a
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaBackendServices) Insert(ctx context.Context, key *meta.Key, obj *alpha.BackendService) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaBackendServices.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -3071,7 +3071,7 @@ func (m *MockAlphaBackendServices) Insert(ctx context.Context, key *meta.Key, ob
 // Delete is a mock for deleting the object.
 func (m *MockAlphaBackendServices) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -3109,7 +3109,7 @@ func (m *MockAlphaBackendServices) Obj(o *alpha.BackendService) *MockBackendServ
 // Update is a mock for the corresponding method.
 func (m *MockAlphaBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *alpha.BackendService) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -3328,12 +3328,12 @@ type MockRegionBackendServices struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook       func(m *MockRegionBackendServices, ctx context.Context, key *meta.Key) (bool, *ga.BackendService, error)
-	ListHook      func(m *MockRegionBackendServices, ctx context.Context, region string, fl *filter.F) (bool, []*ga.BackendService, error)
-	InsertHook    func(m *MockRegionBackendServices, ctx context.Context, key *meta.Key, obj *ga.BackendService) (bool, error)
-	DeleteHook    func(m *MockRegionBackendServices, ctx context.Context, key *meta.Key) (bool, error)
-	GetHealthHook func(*MockRegionBackendServices, context.Context, *meta.Key, *ga.ResourceGroupReference) (*ga.BackendServiceGroupHealth, error)
-	UpdateHook    func(*MockRegionBackendServices, context.Context, *meta.Key, *ga.BackendService) error
+	GetHook       func(ctx context.Context, key *meta.Key, m *MockRegionBackendServices) (bool, *ga.BackendService, error)
+	ListHook      func(ctx context.Context, region string, fl *filter.F, m *MockRegionBackendServices) (bool, []*ga.BackendService, error)
+	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.BackendService, m *MockRegionBackendServices) (bool, error)
+	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockRegionBackendServices) (bool, error)
+	GetHealthHook func(context.Context, *meta.Key, *ga.ResourceGroupReference, *MockRegionBackendServices) (*ga.BackendServiceGroupHealth, error)
+	UpdateHook    func(context.Context, *meta.Key, *ga.BackendService, *MockRegionBackendServices) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -3343,7 +3343,7 @@ type MockRegionBackendServices struct {
 // Get returns the object from the mock.
 func (m *MockRegionBackendServices) Get(ctx context.Context, key *meta.Key) (*ga.BackendService, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockRegionBackendServices.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -3376,7 +3376,7 @@ func (m *MockRegionBackendServices) Get(ctx context.Context, key *meta.Key) (*ga
 // List all of the objects in the mock in the given region.
 func (m *MockRegionBackendServices) List(ctx context.Context, region string, fl *filter.F) ([]*ga.BackendService, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockRegionBackendServices.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -3410,7 +3410,7 @@ func (m *MockRegionBackendServices) List(ctx context.Context, region string, fl 
 // Insert is a mock for inserting/creating a new object.
 func (m *MockRegionBackendServices) Insert(ctx context.Context, key *meta.Key, obj *ga.BackendService) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockRegionBackendServices.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -3448,7 +3448,7 @@ func (m *MockRegionBackendServices) Insert(ctx context.Context, key *meta.Key, o
 // Delete is a mock for deleting the object.
 func (m *MockRegionBackendServices) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockRegionBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -3486,7 +3486,7 @@ func (m *MockRegionBackendServices) Obj(o *ga.BackendService) *MockRegionBackend
 // GetHealth is a mock for the corresponding method.
 func (m *MockRegionBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0 *ga.ResourceGroupReference) (*ga.BackendServiceGroupHealth, error) {
 	if m.GetHealthHook != nil {
-		return m.GetHealthHook(m, ctx, key, arg0)
+		return m.GetHealthHook(ctx, key, arg0, m)
 	}
 	return nil, fmt.Errorf("GetHealthHook must be set")
 }
@@ -3494,7 +3494,7 @@ func (m *MockRegionBackendServices) GetHealth(ctx context.Context, key *meta.Key
 // Update is a mock for the corresponding method.
 func (m *MockRegionBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *ga.BackendService) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -3740,12 +3740,12 @@ type MockAlphaRegionBackendServices struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook       func(m *MockAlphaRegionBackendServices, ctx context.Context, key *meta.Key) (bool, *alpha.BackendService, error)
-	ListHook      func(m *MockAlphaRegionBackendServices, ctx context.Context, region string, fl *filter.F) (bool, []*alpha.BackendService, error)
-	InsertHook    func(m *MockAlphaRegionBackendServices, ctx context.Context, key *meta.Key, obj *alpha.BackendService) (bool, error)
-	DeleteHook    func(m *MockAlphaRegionBackendServices, ctx context.Context, key *meta.Key) (bool, error)
-	GetHealthHook func(*MockAlphaRegionBackendServices, context.Context, *meta.Key, *alpha.ResourceGroupReference) (*alpha.BackendServiceGroupHealth, error)
-	UpdateHook    func(*MockAlphaRegionBackendServices, context.Context, *meta.Key, *alpha.BackendService) error
+	GetHook       func(ctx context.Context, key *meta.Key, m *MockAlphaRegionBackendServices) (bool, *alpha.BackendService, error)
+	ListHook      func(ctx context.Context, region string, fl *filter.F, m *MockAlphaRegionBackendServices) (bool, []*alpha.BackendService, error)
+	InsertHook    func(ctx context.Context, key *meta.Key, obj *alpha.BackendService, m *MockAlphaRegionBackendServices) (bool, error)
+	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockAlphaRegionBackendServices) (bool, error)
+	GetHealthHook func(context.Context, *meta.Key, *alpha.ResourceGroupReference, *MockAlphaRegionBackendServices) (*alpha.BackendServiceGroupHealth, error)
+	UpdateHook    func(context.Context, *meta.Key, *alpha.BackendService, *MockAlphaRegionBackendServices) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -3755,7 +3755,7 @@ type MockAlphaRegionBackendServices struct {
 // Get returns the object from the mock.
 func (m *MockAlphaRegionBackendServices) Get(ctx context.Context, key *meta.Key) (*alpha.BackendService, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionBackendServices.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -3788,7 +3788,7 @@ func (m *MockAlphaRegionBackendServices) Get(ctx context.Context, key *meta.Key)
 // List all of the objects in the mock in the given region.
 func (m *MockAlphaRegionBackendServices) List(ctx context.Context, region string, fl *filter.F) ([]*alpha.BackendService, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionBackendServices.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -3822,7 +3822,7 @@ func (m *MockAlphaRegionBackendServices) List(ctx context.Context, region string
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaRegionBackendServices) Insert(ctx context.Context, key *meta.Key, obj *alpha.BackendService) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionBackendServices.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -3860,7 +3860,7 @@ func (m *MockAlphaRegionBackendServices) Insert(ctx context.Context, key *meta.K
 // Delete is a mock for deleting the object.
 func (m *MockAlphaRegionBackendServices) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionBackendServices.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -3898,7 +3898,7 @@ func (m *MockAlphaRegionBackendServices) Obj(o *alpha.BackendService) *MockRegio
 // GetHealth is a mock for the corresponding method.
 func (m *MockAlphaRegionBackendServices) GetHealth(ctx context.Context, key *meta.Key, arg0 *alpha.ResourceGroupReference) (*alpha.BackendServiceGroupHealth, error) {
 	if m.GetHealthHook != nil {
-		return m.GetHealthHook(m, ctx, key, arg0)
+		return m.GetHealthHook(ctx, key, arg0, m)
 	}
 	return nil, fmt.Errorf("GetHealthHook must be set")
 }
@@ -3906,7 +3906,7 @@ func (m *MockAlphaRegionBackendServices) GetHealth(ctx context.Context, key *met
 // Update is a mock for the corresponding method.
 func (m *MockAlphaRegionBackendServices) Update(ctx context.Context, key *meta.Key, arg0 *alpha.BackendService) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -4150,10 +4150,10 @@ type MockDisks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockDisks, ctx context.Context, key *meta.Key) (bool, *ga.Disk, error)
-	ListHook   func(m *MockDisks, ctx context.Context, zone string, fl *filter.F) (bool, []*ga.Disk, error)
-	InsertHook func(m *MockDisks, ctx context.Context, key *meta.Key, obj *ga.Disk) (bool, error)
-	DeleteHook func(m *MockDisks, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockDisks) (bool, *ga.Disk, error)
+	ListHook   func(ctx context.Context, zone string, fl *filter.F, m *MockDisks) (bool, []*ga.Disk, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.Disk, m *MockDisks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockDisks) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -4163,7 +4163,7 @@ type MockDisks struct {
 // Get returns the object from the mock.
 func (m *MockDisks) Get(ctx context.Context, key *meta.Key) (*ga.Disk, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockDisks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -4196,7 +4196,7 @@ func (m *MockDisks) Get(ctx context.Context, key *meta.Key) (*ga.Disk, error) {
 // List all of the objects in the mock in the given zone.
 func (m *MockDisks) List(ctx context.Context, zone string, fl *filter.F) ([]*ga.Disk, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockDisks.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -4230,7 +4230,7 @@ func (m *MockDisks) List(ctx context.Context, zone string, fl *filter.F) ([]*ga.
 // Insert is a mock for inserting/creating a new object.
 func (m *MockDisks) Insert(ctx context.Context, key *meta.Key, obj *ga.Disk) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockDisks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -4268,7 +4268,7 @@ func (m *MockDisks) Insert(ctx context.Context, key *meta.Key, obj *ga.Disk) err
 // Delete is a mock for deleting the object.
 func (m *MockDisks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockDisks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -4481,10 +4481,10 @@ type MockAlphaDisks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaDisks, ctx context.Context, key *meta.Key) (bool, *alpha.Disk, error)
-	ListHook   func(m *MockAlphaDisks, ctx context.Context, zone string, fl *filter.F) (bool, []*alpha.Disk, error)
-	InsertHook func(m *MockAlphaDisks, ctx context.Context, key *meta.Key, obj *alpha.Disk) (bool, error)
-	DeleteHook func(m *MockAlphaDisks, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaDisks) (bool, *alpha.Disk, error)
+	ListHook   func(ctx context.Context, zone string, fl *filter.F, m *MockAlphaDisks) (bool, []*alpha.Disk, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.Disk, m *MockAlphaDisks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaDisks) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -4494,7 +4494,7 @@ type MockAlphaDisks struct {
 // Get returns the object from the mock.
 func (m *MockAlphaDisks) Get(ctx context.Context, key *meta.Key) (*alpha.Disk, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaDisks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -4527,7 +4527,7 @@ func (m *MockAlphaDisks) Get(ctx context.Context, key *meta.Key) (*alpha.Disk, e
 // List all of the objects in the mock in the given zone.
 func (m *MockAlphaDisks) List(ctx context.Context, zone string, fl *filter.F) ([]*alpha.Disk, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaDisks.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -4561,7 +4561,7 @@ func (m *MockAlphaDisks) List(ctx context.Context, zone string, fl *filter.F) ([
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaDisks) Insert(ctx context.Context, key *meta.Key, obj *alpha.Disk) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaDisks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -4599,7 +4599,7 @@ func (m *MockAlphaDisks) Insert(ctx context.Context, key *meta.Key, obj *alpha.D
 // Delete is a mock for deleting the object.
 func (m *MockAlphaDisks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaDisks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -4812,10 +4812,10 @@ type MockAlphaRegionDisks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaRegionDisks, ctx context.Context, key *meta.Key) (bool, *alpha.Disk, error)
-	ListHook   func(m *MockAlphaRegionDisks, ctx context.Context, region string, fl *filter.F) (bool, []*alpha.Disk, error)
-	InsertHook func(m *MockAlphaRegionDisks, ctx context.Context, key *meta.Key, obj *alpha.Disk) (bool, error)
-	DeleteHook func(m *MockAlphaRegionDisks, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaRegionDisks) (bool, *alpha.Disk, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockAlphaRegionDisks) (bool, []*alpha.Disk, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.Disk, m *MockAlphaRegionDisks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaRegionDisks) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -4825,7 +4825,7 @@ type MockAlphaRegionDisks struct {
 // Get returns the object from the mock.
 func (m *MockAlphaRegionDisks) Get(ctx context.Context, key *meta.Key) (*alpha.Disk, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionDisks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -4858,7 +4858,7 @@ func (m *MockAlphaRegionDisks) Get(ctx context.Context, key *meta.Key) (*alpha.D
 // List all of the objects in the mock in the given region.
 func (m *MockAlphaRegionDisks) List(ctx context.Context, region string, fl *filter.F) ([]*alpha.Disk, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionDisks.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -4892,7 +4892,7 @@ func (m *MockAlphaRegionDisks) List(ctx context.Context, region string, fl *filt
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaRegionDisks) Insert(ctx context.Context, key *meta.Key, obj *alpha.Disk) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionDisks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -4930,7 +4930,7 @@ func (m *MockAlphaRegionDisks) Insert(ctx context.Context, key *meta.Key, obj *a
 // Delete is a mock for deleting the object.
 func (m *MockAlphaRegionDisks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaRegionDisks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -5144,11 +5144,11 @@ type MockFirewalls struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockFirewalls, ctx context.Context, key *meta.Key) (bool, *ga.Firewall, error)
-	ListHook   func(m *MockFirewalls, ctx context.Context, fl *filter.F) (bool, []*ga.Firewall, error)
-	InsertHook func(m *MockFirewalls, ctx context.Context, key *meta.Key, obj *ga.Firewall) (bool, error)
-	DeleteHook func(m *MockFirewalls, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockFirewalls, context.Context, *meta.Key, *ga.Firewall) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockFirewalls) (bool, *ga.Firewall, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockFirewalls) (bool, []*ga.Firewall, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.Firewall, m *MockFirewalls) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockFirewalls) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *ga.Firewall, *MockFirewalls) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -5158,7 +5158,7 @@ type MockFirewalls struct {
 // Get returns the object from the mock.
 func (m *MockFirewalls) Get(ctx context.Context, key *meta.Key) (*ga.Firewall, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockFirewalls.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -5191,7 +5191,7 @@ func (m *MockFirewalls) Get(ctx context.Context, key *meta.Key) (*ga.Firewall, e
 // List all of the objects in the mock.
 func (m *MockFirewalls) List(ctx context.Context, fl *filter.F) ([]*ga.Firewall, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockFirewalls.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -5222,7 +5222,7 @@ func (m *MockFirewalls) List(ctx context.Context, fl *filter.F) ([]*ga.Firewall,
 // Insert is a mock for inserting/creating a new object.
 func (m *MockFirewalls) Insert(ctx context.Context, key *meta.Key, obj *ga.Firewall) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockFirewalls.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -5260,7 +5260,7 @@ func (m *MockFirewalls) Insert(ctx context.Context, key *meta.Key, obj *ga.Firew
 // Delete is a mock for deleting the object.
 func (m *MockFirewalls) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockFirewalls.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -5298,7 +5298,7 @@ func (m *MockFirewalls) Obj(o *ga.Firewall) *MockFirewallsObj {
 // Update is a mock for the corresponding method.
 func (m *MockFirewalls) Update(ctx context.Context, key *meta.Key, arg0 *ga.Firewall) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -5515,10 +5515,10 @@ type MockForwardingRules struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockForwardingRules, ctx context.Context, key *meta.Key) (bool, *ga.ForwardingRule, error)
-	ListHook   func(m *MockForwardingRules, ctx context.Context, region string, fl *filter.F) (bool, []*ga.ForwardingRule, error)
-	InsertHook func(m *MockForwardingRules, ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) (bool, error)
-	DeleteHook func(m *MockForwardingRules, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockForwardingRules) (bool, *ga.ForwardingRule, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockForwardingRules) (bool, []*ga.ForwardingRule, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *MockForwardingRules) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockForwardingRules) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -5528,7 +5528,7 @@ type MockForwardingRules struct {
 // Get returns the object from the mock.
 func (m *MockForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga.ForwardingRule, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockForwardingRules.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -5561,7 +5561,7 @@ func (m *MockForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga.Forwa
 // List all of the objects in the mock in the given region.
 func (m *MockForwardingRules) List(ctx context.Context, region string, fl *filter.F) ([]*ga.ForwardingRule, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockForwardingRules.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -5595,7 +5595,7 @@ func (m *MockForwardingRules) List(ctx context.Context, region string, fl *filte
 // Insert is a mock for inserting/creating a new object.
 func (m *MockForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockForwardingRules.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -5633,7 +5633,7 @@ func (m *MockForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *ga
 // Delete is a mock for deleting the object.
 func (m *MockForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -5846,10 +5846,10 @@ type MockAlphaForwardingRules struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaForwardingRules, ctx context.Context, key *meta.Key) (bool, *alpha.ForwardingRule, error)
-	ListHook   func(m *MockAlphaForwardingRules, ctx context.Context, region string, fl *filter.F) (bool, []*alpha.ForwardingRule, error)
-	InsertHook func(m *MockAlphaForwardingRules, ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule) (bool, error)
-	DeleteHook func(m *MockAlphaForwardingRules, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaForwardingRules) (bool, *alpha.ForwardingRule, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *MockAlphaForwardingRules) (bool, []*alpha.ForwardingRule, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule, m *MockAlphaForwardingRules) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaForwardingRules) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -5859,7 +5859,7 @@ type MockAlphaForwardingRules struct {
 // Get returns the object from the mock.
 func (m *MockAlphaForwardingRules) Get(ctx context.Context, key *meta.Key) (*alpha.ForwardingRule, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaForwardingRules.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -5892,7 +5892,7 @@ func (m *MockAlphaForwardingRules) Get(ctx context.Context, key *meta.Key) (*alp
 // List all of the objects in the mock in the given region.
 func (m *MockAlphaForwardingRules) List(ctx context.Context, region string, fl *filter.F) ([]*alpha.ForwardingRule, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaForwardingRules.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -5926,7 +5926,7 @@ func (m *MockAlphaForwardingRules) List(ctx context.Context, region string, fl *
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaForwardingRules.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -5964,7 +5964,7 @@ func (m *MockAlphaForwardingRules) Insert(ctx context.Context, key *meta.Key, ob
 // Delete is a mock for deleting the object.
 func (m *MockAlphaForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -6178,11 +6178,11 @@ type MockGlobalForwardingRules struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook       func(m *MockGlobalForwardingRules, ctx context.Context, key *meta.Key) (bool, *ga.ForwardingRule, error)
-	ListHook      func(m *MockGlobalForwardingRules, ctx context.Context, fl *filter.F) (bool, []*ga.ForwardingRule, error)
-	InsertHook    func(m *MockGlobalForwardingRules, ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) (bool, error)
-	DeleteHook    func(m *MockGlobalForwardingRules, ctx context.Context, key *meta.Key) (bool, error)
-	SetTargetHook func(*MockGlobalForwardingRules, context.Context, *meta.Key, *ga.TargetReference) error
+	GetHook       func(ctx context.Context, key *meta.Key, m *MockGlobalForwardingRules) (bool, *ga.ForwardingRule, error)
+	ListHook      func(ctx context.Context, fl *filter.F, m *MockGlobalForwardingRules) (bool, []*ga.ForwardingRule, error)
+	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *MockGlobalForwardingRules) (bool, error)
+	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockGlobalForwardingRules) (bool, error)
+	SetTargetHook func(context.Context, *meta.Key, *ga.TargetReference, *MockGlobalForwardingRules) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -6192,7 +6192,7 @@ type MockGlobalForwardingRules struct {
 // Get returns the object from the mock.
 func (m *MockGlobalForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga.ForwardingRule, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockGlobalForwardingRules.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -6225,7 +6225,7 @@ func (m *MockGlobalForwardingRules) Get(ctx context.Context, key *meta.Key) (*ga
 // List all of the objects in the mock.
 func (m *MockGlobalForwardingRules) List(ctx context.Context, fl *filter.F) ([]*ga.ForwardingRule, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockGlobalForwardingRules.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -6256,7 +6256,7 @@ func (m *MockGlobalForwardingRules) List(ctx context.Context, fl *filter.F) ([]*
 // Insert is a mock for inserting/creating a new object.
 func (m *MockGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockGlobalForwardingRules.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -6294,7 +6294,7 @@ func (m *MockGlobalForwardingRules) Insert(ctx context.Context, key *meta.Key, o
 // Delete is a mock for deleting the object.
 func (m *MockGlobalForwardingRules) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockGlobalForwardingRules.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -6332,7 +6332,7 @@ func (m *MockGlobalForwardingRules) Obj(o *ga.ForwardingRule) *MockGlobalForward
 // SetTarget is a mock for the corresponding method.
 func (m *MockGlobalForwardingRules) SetTarget(ctx context.Context, key *meta.Key, arg0 *ga.TargetReference) error {
 	if m.SetTargetHook != nil {
-		return m.SetTargetHook(m, ctx, key, arg0)
+		return m.SetTargetHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -6550,11 +6550,11 @@ type MockHealthChecks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockHealthChecks, ctx context.Context, key *meta.Key) (bool, *ga.HealthCheck, error)
-	ListHook   func(m *MockHealthChecks, ctx context.Context, fl *filter.F) (bool, []*ga.HealthCheck, error)
-	InsertHook func(m *MockHealthChecks, ctx context.Context, key *meta.Key, obj *ga.HealthCheck) (bool, error)
-	DeleteHook func(m *MockHealthChecks, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockHealthChecks, context.Context, *meta.Key, *ga.HealthCheck) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockHealthChecks) (bool, *ga.HealthCheck, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockHealthChecks) (bool, []*ga.HealthCheck, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.HealthCheck, m *MockHealthChecks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockHealthChecks) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *ga.HealthCheck, *MockHealthChecks) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -6564,7 +6564,7 @@ type MockHealthChecks struct {
 // Get returns the object from the mock.
 func (m *MockHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HealthCheck, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHealthChecks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -6597,7 +6597,7 @@ func (m *MockHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HealthCh
 // List all of the objects in the mock.
 func (m *MockHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.HealthCheck, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockHealthChecks.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -6628,7 +6628,7 @@ func (m *MockHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.Health
 // Insert is a mock for inserting/creating a new object.
 func (m *MockHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga.HealthCheck) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockHealthChecks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -6666,7 +6666,7 @@ func (m *MockHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga.He
 // Delete is a mock for deleting the object.
 func (m *MockHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -6704,7 +6704,7 @@ func (m *MockHealthChecks) Obj(o *ga.HealthCheck) *MockHealthChecksObj {
 // Update is a mock for the corresponding method.
 func (m *MockHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *ga.HealthCheck) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -6922,11 +6922,11 @@ type MockAlphaHealthChecks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockAlphaHealthChecks, ctx context.Context, key *meta.Key) (bool, *alpha.HealthCheck, error)
-	ListHook   func(m *MockAlphaHealthChecks, ctx context.Context, fl *filter.F) (bool, []*alpha.HealthCheck, error)
-	InsertHook func(m *MockAlphaHealthChecks, ctx context.Context, key *meta.Key, obj *alpha.HealthCheck) (bool, error)
-	DeleteHook func(m *MockAlphaHealthChecks, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockAlphaHealthChecks, context.Context, *meta.Key, *alpha.HealthCheck) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockAlphaHealthChecks) (bool, *alpha.HealthCheck, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockAlphaHealthChecks) (bool, []*alpha.HealthCheck, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *alpha.HealthCheck, m *MockAlphaHealthChecks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockAlphaHealthChecks) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *alpha.HealthCheck, *MockAlphaHealthChecks) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -6936,7 +6936,7 @@ type MockAlphaHealthChecks struct {
 // Get returns the object from the mock.
 func (m *MockAlphaHealthChecks) Get(ctx context.Context, key *meta.Key) (*alpha.HealthCheck, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaHealthChecks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -6969,7 +6969,7 @@ func (m *MockAlphaHealthChecks) Get(ctx context.Context, key *meta.Key) (*alpha.
 // List all of the objects in the mock.
 func (m *MockAlphaHealthChecks) List(ctx context.Context, fl *filter.F) ([]*alpha.HealthCheck, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaHealthChecks.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -7000,7 +7000,7 @@ func (m *MockAlphaHealthChecks) List(ctx context.Context, fl *filter.F) ([]*alph
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *alpha.HealthCheck) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaHealthChecks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -7038,7 +7038,7 @@ func (m *MockAlphaHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *
 // Delete is a mock for deleting the object.
 func (m *MockAlphaHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -7076,7 +7076,7 @@ func (m *MockAlphaHealthChecks) Obj(o *alpha.HealthCheck) *MockHealthChecksObj {
 // Update is a mock for the corresponding method.
 func (m *MockAlphaHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *alpha.HealthCheck) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -7294,11 +7294,11 @@ type MockHttpHealthChecks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockHttpHealthChecks, ctx context.Context, key *meta.Key) (bool, *ga.HttpHealthCheck, error)
-	ListHook   func(m *MockHttpHealthChecks, ctx context.Context, fl *filter.F) (bool, []*ga.HttpHealthCheck, error)
-	InsertHook func(m *MockHttpHealthChecks, ctx context.Context, key *meta.Key, obj *ga.HttpHealthCheck) (bool, error)
-	DeleteHook func(m *MockHttpHealthChecks, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockHttpHealthChecks, context.Context, *meta.Key, *ga.HttpHealthCheck) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockHttpHealthChecks) (bool, *ga.HttpHealthCheck, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockHttpHealthChecks) (bool, []*ga.HttpHealthCheck, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.HttpHealthCheck, m *MockHttpHealthChecks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockHttpHealthChecks) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *ga.HttpHealthCheck, *MockHttpHealthChecks) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -7308,7 +7308,7 @@ type MockHttpHealthChecks struct {
 // Get returns the object from the mock.
 func (m *MockHttpHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HttpHealthCheck, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHttpHealthChecks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -7341,7 +7341,7 @@ func (m *MockHttpHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.Http
 // List all of the objects in the mock.
 func (m *MockHttpHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.HttpHealthCheck, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockHttpHealthChecks.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -7372,7 +7372,7 @@ func (m *MockHttpHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.Ht
 // Insert is a mock for inserting/creating a new object.
 func (m *MockHttpHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga.HttpHealthCheck) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockHttpHealthChecks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -7410,7 +7410,7 @@ func (m *MockHttpHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *g
 // Delete is a mock for deleting the object.
 func (m *MockHttpHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHttpHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -7448,7 +7448,7 @@ func (m *MockHttpHealthChecks) Obj(o *ga.HttpHealthCheck) *MockHttpHealthChecksO
 // Update is a mock for the corresponding method.
 func (m *MockHttpHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *ga.HttpHealthCheck) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -7666,11 +7666,11 @@ type MockHttpsHealthChecks struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockHttpsHealthChecks, ctx context.Context, key *meta.Key) (bool, *ga.HttpsHealthCheck, error)
-	ListHook   func(m *MockHttpsHealthChecks, ctx context.Context, fl *filter.F) (bool, []*ga.HttpsHealthCheck, error)
-	InsertHook func(m *MockHttpsHealthChecks, ctx context.Context, key *meta.Key, obj *ga.HttpsHealthCheck) (bool, error)
-	DeleteHook func(m *MockHttpsHealthChecks, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockHttpsHealthChecks, context.Context, *meta.Key, *ga.HttpsHealthCheck) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockHttpsHealthChecks) (bool, *ga.HttpsHealthCheck, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockHttpsHealthChecks) (bool, []*ga.HttpsHealthCheck, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.HttpsHealthCheck, m *MockHttpsHealthChecks) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockHttpsHealthChecks) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *ga.HttpsHealthCheck, *MockHttpsHealthChecks) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -7680,7 +7680,7 @@ type MockHttpsHealthChecks struct {
 // Get returns the object from the mock.
 func (m *MockHttpsHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.HttpsHealthCheck, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHttpsHealthChecks.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -7713,7 +7713,7 @@ func (m *MockHttpsHealthChecks) Get(ctx context.Context, key *meta.Key) (*ga.Htt
 // List all of the objects in the mock.
 func (m *MockHttpsHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.HttpsHealthCheck, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockHttpsHealthChecks.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -7744,7 +7744,7 @@ func (m *MockHttpsHealthChecks) List(ctx context.Context, fl *filter.F) ([]*ga.H
 // Insert is a mock for inserting/creating a new object.
 func (m *MockHttpsHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *ga.HttpsHealthCheck) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockHttpsHealthChecks.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -7782,7 +7782,7 @@ func (m *MockHttpsHealthChecks) Insert(ctx context.Context, key *meta.Key, obj *
 // Delete is a mock for deleting the object.
 func (m *MockHttpsHealthChecks) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockHttpsHealthChecks.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -7820,7 +7820,7 @@ func (m *MockHttpsHealthChecks) Obj(o *ga.HttpsHealthCheck) *MockHttpsHealthChec
 // Update is a mock for the corresponding method.
 func (m *MockHttpsHealthChecks) Update(ctx context.Context, key *meta.Key, arg0 *ga.HttpsHealthCheck) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8041,14 +8041,14 @@ type MockInstanceGroups struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook             func(m *MockInstanceGroups, ctx context.Context, key *meta.Key) (bool, *ga.InstanceGroup, error)
-	ListHook            func(m *MockInstanceGroups, ctx context.Context, zone string, fl *filter.F) (bool, []*ga.InstanceGroup, error)
-	InsertHook          func(m *MockInstanceGroups, ctx context.Context, key *meta.Key, obj *ga.InstanceGroup) (bool, error)
-	DeleteHook          func(m *MockInstanceGroups, ctx context.Context, key *meta.Key) (bool, error)
-	AddInstancesHook    func(*MockInstanceGroups, context.Context, *meta.Key, *ga.InstanceGroupsAddInstancesRequest) error
-	ListInstancesHook   func(*MockInstanceGroups, context.Context, *meta.Key, *ga.InstanceGroupsListInstancesRequest, *filter.F) ([]*ga.InstanceWithNamedPorts, error)
-	RemoveInstancesHook func(*MockInstanceGroups, context.Context, *meta.Key, *ga.InstanceGroupsRemoveInstancesRequest) error
-	SetNamedPortsHook   func(*MockInstanceGroups, context.Context, *meta.Key, *ga.InstanceGroupsSetNamedPortsRequest) error
+	GetHook             func(ctx context.Context, key *meta.Key, m *MockInstanceGroups) (bool, *ga.InstanceGroup, error)
+	ListHook            func(ctx context.Context, zone string, fl *filter.F, m *MockInstanceGroups) (bool, []*ga.InstanceGroup, error)
+	InsertHook          func(ctx context.Context, key *meta.Key, obj *ga.InstanceGroup, m *MockInstanceGroups) (bool, error)
+	DeleteHook          func(ctx context.Context, key *meta.Key, m *MockInstanceGroups) (bool, error)
+	AddInstancesHook    func(context.Context, *meta.Key, *ga.InstanceGroupsAddInstancesRequest, *MockInstanceGroups) error
+	ListInstancesHook   func(context.Context, *meta.Key, *ga.InstanceGroupsListInstancesRequest, *filter.F, *MockInstanceGroups) ([]*ga.InstanceWithNamedPorts, error)
+	RemoveInstancesHook func(context.Context, *meta.Key, *ga.InstanceGroupsRemoveInstancesRequest, *MockInstanceGroups) error
+	SetNamedPortsHook   func(context.Context, *meta.Key, *ga.InstanceGroupsSetNamedPortsRequest, *MockInstanceGroups) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -8058,7 +8058,7 @@ type MockInstanceGroups struct {
 // Get returns the object from the mock.
 func (m *MockInstanceGroups) Get(ctx context.Context, key *meta.Key) (*ga.InstanceGroup, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockInstanceGroups.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -8091,7 +8091,7 @@ func (m *MockInstanceGroups) Get(ctx context.Context, key *meta.Key) (*ga.Instan
 // List all of the objects in the mock in the given zone.
 func (m *MockInstanceGroups) List(ctx context.Context, zone string, fl *filter.F) ([]*ga.InstanceGroup, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockInstanceGroups.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -8125,7 +8125,7 @@ func (m *MockInstanceGroups) List(ctx context.Context, zone string, fl *filter.F
 // Insert is a mock for inserting/creating a new object.
 func (m *MockInstanceGroups) Insert(ctx context.Context, key *meta.Key, obj *ga.InstanceGroup) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockInstanceGroups.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -8163,7 +8163,7 @@ func (m *MockInstanceGroups) Insert(ctx context.Context, key *meta.Key, obj *ga.
 // Delete is a mock for deleting the object.
 func (m *MockInstanceGroups) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockInstanceGroups.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -8201,7 +8201,7 @@ func (m *MockInstanceGroups) Obj(o *ga.InstanceGroup) *MockInstanceGroupsObj {
 // AddInstances is a mock for the corresponding method.
 func (m *MockInstanceGroups) AddInstances(ctx context.Context, key *meta.Key, arg0 *ga.InstanceGroupsAddInstancesRequest) error {
 	if m.AddInstancesHook != nil {
-		return m.AddInstancesHook(m, ctx, key, arg0)
+		return m.AddInstancesHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8209,7 +8209,7 @@ func (m *MockInstanceGroups) AddInstances(ctx context.Context, key *meta.Key, ar
 // ListInstances is a mock for the corresponding method.
 func (m *MockInstanceGroups) ListInstances(ctx context.Context, key *meta.Key, arg0 *ga.InstanceGroupsListInstancesRequest, fl *filter.F) ([]*ga.InstanceWithNamedPorts, error) {
 	if m.ListInstancesHook != nil {
-		return m.ListInstancesHook(m, ctx, key, arg0, fl)
+		return m.ListInstancesHook(ctx, key, arg0, fl, m)
 	}
 	return nil, nil
 }
@@ -8217,7 +8217,7 @@ func (m *MockInstanceGroups) ListInstances(ctx context.Context, key *meta.Key, a
 // RemoveInstances is a mock for the corresponding method.
 func (m *MockInstanceGroups) RemoveInstances(ctx context.Context, key *meta.Key, arg0 *ga.InstanceGroupsRemoveInstancesRequest) error {
 	if m.RemoveInstancesHook != nil {
-		return m.RemoveInstancesHook(m, ctx, key, arg0)
+		return m.RemoveInstancesHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8225,7 +8225,7 @@ func (m *MockInstanceGroups) RemoveInstances(ctx context.Context, key *meta.Key,
 // SetNamedPorts is a mock for the corresponding method.
 func (m *MockInstanceGroups) SetNamedPorts(ctx context.Context, key *meta.Key, arg0 *ga.InstanceGroupsSetNamedPortsRequest) error {
 	if m.SetNamedPortsHook != nil {
-		return m.SetNamedPortsHook(m, ctx, key, arg0)
+		return m.SetNamedPortsHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8553,12 +8553,12 @@ type MockInstances struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook        func(m *MockInstances, ctx context.Context, key *meta.Key) (bool, *ga.Instance, error)
-	ListHook       func(m *MockInstances, ctx context.Context, zone string, fl *filter.F) (bool, []*ga.Instance, error)
-	InsertHook     func(m *MockInstances, ctx context.Context, key *meta.Key, obj *ga.Instance) (bool, error)
-	DeleteHook     func(m *MockInstances, ctx context.Context, key *meta.Key) (bool, error)
-	AttachDiskHook func(*MockInstances, context.Context, *meta.Key, *ga.AttachedDisk) error
-	DetachDiskHook func(*MockInstances, context.Context, *meta.Key, string) error
+	GetHook        func(ctx context.Context, key *meta.Key, m *MockInstances) (bool, *ga.Instance, error)
+	ListHook       func(ctx context.Context, zone string, fl *filter.F, m *MockInstances) (bool, []*ga.Instance, error)
+	InsertHook     func(ctx context.Context, key *meta.Key, obj *ga.Instance, m *MockInstances) (bool, error)
+	DeleteHook     func(ctx context.Context, key *meta.Key, m *MockInstances) (bool, error)
+	AttachDiskHook func(context.Context, *meta.Key, *ga.AttachedDisk, *MockInstances) error
+	DetachDiskHook func(context.Context, *meta.Key, string, *MockInstances) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -8568,7 +8568,7 @@ type MockInstances struct {
 // Get returns the object from the mock.
 func (m *MockInstances) Get(ctx context.Context, key *meta.Key) (*ga.Instance, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockInstances.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -8601,7 +8601,7 @@ func (m *MockInstances) Get(ctx context.Context, key *meta.Key) (*ga.Instance, e
 // List all of the objects in the mock in the given zone.
 func (m *MockInstances) List(ctx context.Context, zone string, fl *filter.F) ([]*ga.Instance, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockInstances.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -8635,7 +8635,7 @@ func (m *MockInstances) List(ctx context.Context, zone string, fl *filter.F) ([]
 // Insert is a mock for inserting/creating a new object.
 func (m *MockInstances) Insert(ctx context.Context, key *meta.Key, obj *ga.Instance) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockInstances.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -8673,7 +8673,7 @@ func (m *MockInstances) Insert(ctx context.Context, key *meta.Key, obj *ga.Insta
 // Delete is a mock for deleting the object.
 func (m *MockInstances) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockInstances.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -8711,7 +8711,7 @@ func (m *MockInstances) Obj(o *ga.Instance) *MockInstancesObj {
 // AttachDisk is a mock for the corresponding method.
 func (m *MockInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *ga.AttachedDisk) error {
 	if m.AttachDiskHook != nil {
-		return m.AttachDiskHook(m, ctx, key, arg0)
+		return m.AttachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8719,7 +8719,7 @@ func (m *MockInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *ga.
 // DetachDisk is a mock for the corresponding method.
 func (m *MockInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 string) error {
 	if m.DetachDiskHook != nil {
-		return m.DetachDiskHook(m, ctx, key, arg0)
+		return m.DetachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -8971,13 +8971,13 @@ type MockBetaInstances struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook                    func(m *MockBetaInstances, ctx context.Context, key *meta.Key) (bool, *beta.Instance, error)
-	ListHook                   func(m *MockBetaInstances, ctx context.Context, zone string, fl *filter.F) (bool, []*beta.Instance, error)
-	InsertHook                 func(m *MockBetaInstances, ctx context.Context, key *meta.Key, obj *beta.Instance) (bool, error)
-	DeleteHook                 func(m *MockBetaInstances, ctx context.Context, key *meta.Key) (bool, error)
-	AttachDiskHook             func(*MockBetaInstances, context.Context, *meta.Key, *beta.AttachedDisk) error
-	DetachDiskHook             func(*MockBetaInstances, context.Context, *meta.Key, string) error
-	UpdateNetworkInterfaceHook func(*MockBetaInstances, context.Context, *meta.Key, string, *beta.NetworkInterface) error
+	GetHook                    func(ctx context.Context, key *meta.Key, m *MockBetaInstances) (bool, *beta.Instance, error)
+	ListHook                   func(ctx context.Context, zone string, fl *filter.F, m *MockBetaInstances) (bool, []*beta.Instance, error)
+	InsertHook                 func(ctx context.Context, key *meta.Key, obj *beta.Instance, m *MockBetaInstances) (bool, error)
+	DeleteHook                 func(ctx context.Context, key *meta.Key, m *MockBetaInstances) (bool, error)
+	AttachDiskHook             func(context.Context, *meta.Key, *beta.AttachedDisk, *MockBetaInstances) error
+	DetachDiskHook             func(context.Context, *meta.Key, string, *MockBetaInstances) error
+	UpdateNetworkInterfaceHook func(context.Context, *meta.Key, string, *beta.NetworkInterface, *MockBetaInstances) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -8987,7 +8987,7 @@ type MockBetaInstances struct {
 // Get returns the object from the mock.
 func (m *MockBetaInstances) Get(ctx context.Context, key *meta.Key) (*beta.Instance, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBetaInstances.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -9020,7 +9020,7 @@ func (m *MockBetaInstances) Get(ctx context.Context, key *meta.Key) (*beta.Insta
 // List all of the objects in the mock in the given zone.
 func (m *MockBetaInstances) List(ctx context.Context, zone string, fl *filter.F) ([]*beta.Instance, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockBetaInstances.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -9054,7 +9054,7 @@ func (m *MockBetaInstances) List(ctx context.Context, zone string, fl *filter.F)
 // Insert is a mock for inserting/creating a new object.
 func (m *MockBetaInstances) Insert(ctx context.Context, key *meta.Key, obj *beta.Instance) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockBetaInstances.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -9092,7 +9092,7 @@ func (m *MockBetaInstances) Insert(ctx context.Context, key *meta.Key, obj *beta
 // Delete is a mock for deleting the object.
 func (m *MockBetaInstances) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockBetaInstances.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -9130,7 +9130,7 @@ func (m *MockBetaInstances) Obj(o *beta.Instance) *MockInstancesObj {
 // AttachDisk is a mock for the corresponding method.
 func (m *MockBetaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *beta.AttachedDisk) error {
 	if m.AttachDiskHook != nil {
-		return m.AttachDiskHook(m, ctx, key, arg0)
+		return m.AttachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -9138,7 +9138,7 @@ func (m *MockBetaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 
 // DetachDisk is a mock for the corresponding method.
 func (m *MockBetaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 string) error {
 	if m.DetachDiskHook != nil {
-		return m.DetachDiskHook(m, ctx, key, arg0)
+		return m.DetachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -9146,7 +9146,7 @@ func (m *MockBetaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 
 // UpdateNetworkInterface is a mock for the corresponding method.
 func (m *MockBetaInstances) UpdateNetworkInterface(ctx context.Context, key *meta.Key, arg0 string, arg1 *beta.NetworkInterface) error {
 	if m.UpdateNetworkInterfaceHook != nil {
-		return m.UpdateNetworkInterfaceHook(m, ctx, key, arg0, arg1)
+		return m.UpdateNetworkInterfaceHook(ctx, key, arg0, arg1, m)
 	}
 	return nil
 }
@@ -9431,13 +9431,13 @@ type MockAlphaInstances struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook                    func(m *MockAlphaInstances, ctx context.Context, key *meta.Key) (bool, *alpha.Instance, error)
-	ListHook                   func(m *MockAlphaInstances, ctx context.Context, zone string, fl *filter.F) (bool, []*alpha.Instance, error)
-	InsertHook                 func(m *MockAlphaInstances, ctx context.Context, key *meta.Key, obj *alpha.Instance) (bool, error)
-	DeleteHook                 func(m *MockAlphaInstances, ctx context.Context, key *meta.Key) (bool, error)
-	AttachDiskHook             func(*MockAlphaInstances, context.Context, *meta.Key, *alpha.AttachedDisk) error
-	DetachDiskHook             func(*MockAlphaInstances, context.Context, *meta.Key, string) error
-	UpdateNetworkInterfaceHook func(*MockAlphaInstances, context.Context, *meta.Key, string, *alpha.NetworkInterface) error
+	GetHook                    func(ctx context.Context, key *meta.Key, m *MockAlphaInstances) (bool, *alpha.Instance, error)
+	ListHook                   func(ctx context.Context, zone string, fl *filter.F, m *MockAlphaInstances) (bool, []*alpha.Instance, error)
+	InsertHook                 func(ctx context.Context, key *meta.Key, obj *alpha.Instance, m *MockAlphaInstances) (bool, error)
+	DeleteHook                 func(ctx context.Context, key *meta.Key, m *MockAlphaInstances) (bool, error)
+	AttachDiskHook             func(context.Context, *meta.Key, *alpha.AttachedDisk, *MockAlphaInstances) error
+	DetachDiskHook             func(context.Context, *meta.Key, string, *MockAlphaInstances) error
+	UpdateNetworkInterfaceHook func(context.Context, *meta.Key, string, *alpha.NetworkInterface, *MockAlphaInstances) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -9447,7 +9447,7 @@ type MockAlphaInstances struct {
 // Get returns the object from the mock.
 func (m *MockAlphaInstances) Get(ctx context.Context, key *meta.Key) (*alpha.Instance, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaInstances.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -9480,7 +9480,7 @@ func (m *MockAlphaInstances) Get(ctx context.Context, key *meta.Key) (*alpha.Ins
 // List all of the objects in the mock in the given zone.
 func (m *MockAlphaInstances) List(ctx context.Context, zone string, fl *filter.F) ([]*alpha.Instance, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaInstances.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -9514,7 +9514,7 @@ func (m *MockAlphaInstances) List(ctx context.Context, zone string, fl *filter.F
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaInstances) Insert(ctx context.Context, key *meta.Key, obj *alpha.Instance) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaInstances.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -9552,7 +9552,7 @@ func (m *MockAlphaInstances) Insert(ctx context.Context, key *meta.Key, obj *alp
 // Delete is a mock for deleting the object.
 func (m *MockAlphaInstances) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaInstances.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -9590,7 +9590,7 @@ func (m *MockAlphaInstances) Obj(o *alpha.Instance) *MockInstancesObj {
 // AttachDisk is a mock for the corresponding method.
 func (m *MockAlphaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0 *alpha.AttachedDisk) error {
 	if m.AttachDiskHook != nil {
-		return m.AttachDiskHook(m, ctx, key, arg0)
+		return m.AttachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -9598,7 +9598,7 @@ func (m *MockAlphaInstances) AttachDisk(ctx context.Context, key *meta.Key, arg0
 // DetachDisk is a mock for the corresponding method.
 func (m *MockAlphaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0 string) error {
 	if m.DetachDiskHook != nil {
-		return m.DetachDiskHook(m, ctx, key, arg0)
+		return m.DetachDiskHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -9606,7 +9606,7 @@ func (m *MockAlphaInstances) DetachDisk(ctx context.Context, key *meta.Key, arg0
 // UpdateNetworkInterface is a mock for the corresponding method.
 func (m *MockAlphaInstances) UpdateNetworkInterface(ctx context.Context, key *meta.Key, arg0 string, arg1 *alpha.NetworkInterface) error {
 	if m.UpdateNetworkInterfaceHook != nil {
-		return m.UpdateNetworkInterfaceHook(m, ctx, key, arg0, arg1)
+		return m.UpdateNetworkInterfaceHook(ctx, key, arg0, arg1, m)
 	}
 	return nil
 }
@@ -9893,14 +9893,14 @@ type MockAlphaNetworkEndpointGroups struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook                    func(m *MockAlphaNetworkEndpointGroups, ctx context.Context, key *meta.Key) (bool, *alpha.NetworkEndpointGroup, error)
-	ListHook                   func(m *MockAlphaNetworkEndpointGroups, ctx context.Context, zone string, fl *filter.F) (bool, []*alpha.NetworkEndpointGroup, error)
-	InsertHook                 func(m *MockAlphaNetworkEndpointGroups, ctx context.Context, key *meta.Key, obj *alpha.NetworkEndpointGroup) (bool, error)
-	DeleteHook                 func(m *MockAlphaNetworkEndpointGroups, ctx context.Context, key *meta.Key) (bool, error)
-	AggregatedListHook         func(m *MockAlphaNetworkEndpointGroups, ctx context.Context, fl *filter.F) (bool, map[string][]*alpha.NetworkEndpointGroup, error)
-	AttachNetworkEndpointsHook func(*MockAlphaNetworkEndpointGroups, context.Context, *meta.Key, *alpha.NetworkEndpointGroupsAttachEndpointsRequest) error
-	DetachNetworkEndpointsHook func(*MockAlphaNetworkEndpointGroups, context.Context, *meta.Key, *alpha.NetworkEndpointGroupsDetachEndpointsRequest) error
-	ListNetworkEndpointsHook   func(*MockAlphaNetworkEndpointGroups, context.Context, *meta.Key, *alpha.NetworkEndpointGroupsListEndpointsRequest, *filter.F) ([]*alpha.NetworkEndpointWithHealthStatus, error)
+	GetHook                    func(ctx context.Context, key *meta.Key, m *MockAlphaNetworkEndpointGroups) (bool, *alpha.NetworkEndpointGroup, error)
+	ListHook                   func(ctx context.Context, zone string, fl *filter.F, m *MockAlphaNetworkEndpointGroups) (bool, []*alpha.NetworkEndpointGroup, error)
+	InsertHook                 func(ctx context.Context, key *meta.Key, obj *alpha.NetworkEndpointGroup, m *MockAlphaNetworkEndpointGroups) (bool, error)
+	DeleteHook                 func(ctx context.Context, key *meta.Key, m *MockAlphaNetworkEndpointGroups) (bool, error)
+	AggregatedListHook         func(ctx context.Context, fl *filter.F, m *MockAlphaNetworkEndpointGroups) (bool, map[string][]*alpha.NetworkEndpointGroup, error)
+	AttachNetworkEndpointsHook func(context.Context, *meta.Key, *alpha.NetworkEndpointGroupsAttachEndpointsRequest, *MockAlphaNetworkEndpointGroups) error
+	DetachNetworkEndpointsHook func(context.Context, *meta.Key, *alpha.NetworkEndpointGroupsDetachEndpointsRequest, *MockAlphaNetworkEndpointGroups) error
+	ListNetworkEndpointsHook   func(context.Context, *meta.Key, *alpha.NetworkEndpointGroupsListEndpointsRequest, *filter.F, *MockAlphaNetworkEndpointGroups) ([]*alpha.NetworkEndpointWithHealthStatus, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -9910,7 +9910,7 @@ type MockAlphaNetworkEndpointGroups struct {
 // Get returns the object from the mock.
 func (m *MockAlphaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key) (*alpha.NetworkEndpointGroup, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaNetworkEndpointGroups.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -9943,7 +9943,7 @@ func (m *MockAlphaNetworkEndpointGroups) Get(ctx context.Context, key *meta.Key)
 // List all of the objects in the mock in the given zone.
 func (m *MockAlphaNetworkEndpointGroups) List(ctx context.Context, zone string, fl *filter.F) ([]*alpha.NetworkEndpointGroup, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaNetworkEndpointGroups.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 			return objs, err
 		}
@@ -9977,7 +9977,7 @@ func (m *MockAlphaNetworkEndpointGroups) List(ctx context.Context, zone string, 
 // Insert is a mock for inserting/creating a new object.
 func (m *MockAlphaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.Key, obj *alpha.NetworkEndpointGroup) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockAlphaNetworkEndpointGroups.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -10015,7 +10015,7 @@ func (m *MockAlphaNetworkEndpointGroups) Insert(ctx context.Context, key *meta.K
 // Delete is a mock for deleting the object.
 func (m *MockAlphaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockAlphaNetworkEndpointGroups.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -10048,7 +10048,7 @@ func (m *MockAlphaNetworkEndpointGroups) Delete(ctx context.Context, key *meta.K
 // AggregatedList is a mock for AggregatedList.
 func (m *MockAlphaNetworkEndpointGroups) AggregatedList(ctx context.Context, fl *filter.F) (map[string][]*alpha.NetworkEndpointGroup, error) {
 	if m.AggregatedListHook != nil {
-		if intercept, objs, err := m.AggregatedListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.AggregatedListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockAlphaNetworkEndpointGroups.AggregatedList(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -10088,7 +10088,7 @@ func (m *MockAlphaNetworkEndpointGroups) Obj(o *alpha.NetworkEndpointGroup) *Moc
 // AttachNetworkEndpoints is a mock for the corresponding method.
 func (m *MockAlphaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Context, key *meta.Key, arg0 *alpha.NetworkEndpointGroupsAttachEndpointsRequest) error {
 	if m.AttachNetworkEndpointsHook != nil {
-		return m.AttachNetworkEndpointsHook(m, ctx, key, arg0)
+		return m.AttachNetworkEndpointsHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -10096,7 +10096,7 @@ func (m *MockAlphaNetworkEndpointGroups) AttachNetworkEndpoints(ctx context.Cont
 // DetachNetworkEndpoints is a mock for the corresponding method.
 func (m *MockAlphaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Context, key *meta.Key, arg0 *alpha.NetworkEndpointGroupsDetachEndpointsRequest) error {
 	if m.DetachNetworkEndpointsHook != nil {
-		return m.DetachNetworkEndpointsHook(m, ctx, key, arg0)
+		return m.DetachNetworkEndpointsHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -10104,7 +10104,7 @@ func (m *MockAlphaNetworkEndpointGroups) DetachNetworkEndpoints(ctx context.Cont
 // ListNetworkEndpoints is a mock for the corresponding method.
 func (m *MockAlphaNetworkEndpointGroups) ListNetworkEndpoints(ctx context.Context, key *meta.Key, arg0 *alpha.NetworkEndpointGroupsListEndpointsRequest, fl *filter.F) ([]*alpha.NetworkEndpointWithHealthStatus, error) {
 	if m.ListNetworkEndpointsHook != nil {
-		return m.ListNetworkEndpointsHook(m, ctx, key, arg0, fl)
+		return m.ListNetworkEndpointsHook(ctx, key, arg0, fl, m)
 	}
 	return nil, nil
 }
@@ -10484,8 +10484,8 @@ type MockRegions struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook  func(m *MockRegions, ctx context.Context, key *meta.Key) (bool, *ga.Region, error)
-	ListHook func(m *MockRegions, ctx context.Context, fl *filter.F) (bool, []*ga.Region, error)
+	GetHook  func(ctx context.Context, key *meta.Key, m *MockRegions) (bool, *ga.Region, error)
+	ListHook func(ctx context.Context, fl *filter.F, m *MockRegions) (bool, []*ga.Region, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -10495,7 +10495,7 @@ type MockRegions struct {
 // Get returns the object from the mock.
 func (m *MockRegions) Get(ctx context.Context, key *meta.Key) (*ga.Region, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockRegions.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -10528,7 +10528,7 @@ func (m *MockRegions) Get(ctx context.Context, key *meta.Key) (*ga.Region, error
 // List all of the objects in the mock.
 func (m *MockRegions) List(ctx context.Context, fl *filter.F) ([]*ga.Region, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockRegions.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -10672,10 +10672,10 @@ type MockRoutes struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockRoutes, ctx context.Context, key *meta.Key) (bool, *ga.Route, error)
-	ListHook   func(m *MockRoutes, ctx context.Context, fl *filter.F) (bool, []*ga.Route, error)
-	InsertHook func(m *MockRoutes, ctx context.Context, key *meta.Key, obj *ga.Route) (bool, error)
-	DeleteHook func(m *MockRoutes, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockRoutes) (bool, *ga.Route, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockRoutes) (bool, []*ga.Route, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.Route, m *MockRoutes) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockRoutes) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -10685,7 +10685,7 @@ type MockRoutes struct {
 // Get returns the object from the mock.
 func (m *MockRoutes) Get(ctx context.Context, key *meta.Key) (*ga.Route, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockRoutes.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -10718,7 +10718,7 @@ func (m *MockRoutes) Get(ctx context.Context, key *meta.Key) (*ga.Route, error) 
 // List all of the objects in the mock.
 func (m *MockRoutes) List(ctx context.Context, fl *filter.F) ([]*ga.Route, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockRoutes.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -10749,7 +10749,7 @@ func (m *MockRoutes) List(ctx context.Context, fl *filter.F) ([]*ga.Route, error
 // Insert is a mock for inserting/creating a new object.
 func (m *MockRoutes) Insert(ctx context.Context, key *meta.Key, obj *ga.Route) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockRoutes.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -10787,7 +10787,7 @@ func (m *MockRoutes) Insert(ctx context.Context, key *meta.Key, obj *ga.Route) e
 // Delete is a mock for deleting the object.
 func (m *MockRoutes) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockRoutes.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -11001,10 +11001,10 @@ type MockSslCertificates struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockSslCertificates, ctx context.Context, key *meta.Key) (bool, *ga.SslCertificate, error)
-	ListHook   func(m *MockSslCertificates, ctx context.Context, fl *filter.F) (bool, []*ga.SslCertificate, error)
-	InsertHook func(m *MockSslCertificates, ctx context.Context, key *meta.Key, obj *ga.SslCertificate) (bool, error)
-	DeleteHook func(m *MockSslCertificates, ctx context.Context, key *meta.Key) (bool, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockSslCertificates) (bool, *ga.SslCertificate, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockSslCertificates) (bool, []*ga.SslCertificate, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.SslCertificate, m *MockSslCertificates) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockSslCertificates) (bool, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -11014,7 +11014,7 @@ type MockSslCertificates struct {
 // Get returns the object from the mock.
 func (m *MockSslCertificates) Get(ctx context.Context, key *meta.Key) (*ga.SslCertificate, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockSslCertificates.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -11047,7 +11047,7 @@ func (m *MockSslCertificates) Get(ctx context.Context, key *meta.Key) (*ga.SslCe
 // List all of the objects in the mock.
 func (m *MockSslCertificates) List(ctx context.Context, fl *filter.F) ([]*ga.SslCertificate, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockSslCertificates.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -11078,7 +11078,7 @@ func (m *MockSslCertificates) List(ctx context.Context, fl *filter.F) ([]*ga.Ssl
 // Insert is a mock for inserting/creating a new object.
 func (m *MockSslCertificates) Insert(ctx context.Context, key *meta.Key, obj *ga.SslCertificate) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockSslCertificates.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -11116,7 +11116,7 @@ func (m *MockSslCertificates) Insert(ctx context.Context, key *meta.Key, obj *ga
 // Delete is a mock for deleting the object.
 func (m *MockSslCertificates) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockSslCertificates.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -11331,11 +11331,11 @@ type MockTargetHttpProxies struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook       func(m *MockTargetHttpProxies, ctx context.Context, key *meta.Key) (bool, *ga.TargetHttpProxy, error)
-	ListHook      func(m *MockTargetHttpProxies, ctx context.Context, fl *filter.F) (bool, []*ga.TargetHttpProxy, error)
-	InsertHook    func(m *MockTargetHttpProxies, ctx context.Context, key *meta.Key, obj *ga.TargetHttpProxy) (bool, error)
-	DeleteHook    func(m *MockTargetHttpProxies, ctx context.Context, key *meta.Key) (bool, error)
-	SetUrlMapHook func(*MockTargetHttpProxies, context.Context, *meta.Key, *ga.UrlMapReference) error
+	GetHook       func(ctx context.Context, key *meta.Key, m *MockTargetHttpProxies) (bool, *ga.TargetHttpProxy, error)
+	ListHook      func(ctx context.Context, fl *filter.F, m *MockTargetHttpProxies) (bool, []*ga.TargetHttpProxy, error)
+	InsertHook    func(ctx context.Context, key *meta.Key, obj *ga.TargetHttpProxy, m *MockTargetHttpProxies) (bool, error)
+	DeleteHook    func(ctx context.Context, key *meta.Key, m *MockTargetHttpProxies) (bool, error)
+	SetUrlMapHook func(context.Context, *meta.Key, *ga.UrlMapReference, *MockTargetHttpProxies) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -11345,7 +11345,7 @@ type MockTargetHttpProxies struct {
 // Get returns the object from the mock.
 func (m *MockTargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*ga.TargetHttpProxy, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetHttpProxies.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -11378,7 +11378,7 @@ func (m *MockTargetHttpProxies) Get(ctx context.Context, key *meta.Key) (*ga.Tar
 // List all of the objects in the mock.
 func (m *MockTargetHttpProxies) List(ctx context.Context, fl *filter.F) ([]*ga.TargetHttpProxy, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockTargetHttpProxies.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -11409,7 +11409,7 @@ func (m *MockTargetHttpProxies) List(ctx context.Context, fl *filter.F) ([]*ga.T
 // Insert is a mock for inserting/creating a new object.
 func (m *MockTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, obj *ga.TargetHttpProxy) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockTargetHttpProxies.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -11447,7 +11447,7 @@ func (m *MockTargetHttpProxies) Insert(ctx context.Context, key *meta.Key, obj *
 // Delete is a mock for deleting the object.
 func (m *MockTargetHttpProxies) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetHttpProxies.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -11485,7 +11485,7 @@ func (m *MockTargetHttpProxies) Obj(o *ga.TargetHttpProxy) *MockTargetHttpProxie
 // SetUrlMap is a mock for the corresponding method.
 func (m *MockTargetHttpProxies) SetUrlMap(ctx context.Context, key *meta.Key, arg0 *ga.UrlMapReference) error {
 	if m.SetUrlMapHook != nil {
-		return m.SetUrlMapHook(m, ctx, key, arg0)
+		return m.SetUrlMapHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -11704,12 +11704,12 @@ type MockTargetHttpsProxies struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook                func(m *MockTargetHttpsProxies, ctx context.Context, key *meta.Key) (bool, *ga.TargetHttpsProxy, error)
-	ListHook               func(m *MockTargetHttpsProxies, ctx context.Context, fl *filter.F) (bool, []*ga.TargetHttpsProxy, error)
-	InsertHook             func(m *MockTargetHttpsProxies, ctx context.Context, key *meta.Key, obj *ga.TargetHttpsProxy) (bool, error)
-	DeleteHook             func(m *MockTargetHttpsProxies, ctx context.Context, key *meta.Key) (bool, error)
-	SetSslCertificatesHook func(*MockTargetHttpsProxies, context.Context, *meta.Key, *ga.TargetHttpsProxiesSetSslCertificatesRequest) error
-	SetUrlMapHook          func(*MockTargetHttpsProxies, context.Context, *meta.Key, *ga.UrlMapReference) error
+	GetHook                func(ctx context.Context, key *meta.Key, m *MockTargetHttpsProxies) (bool, *ga.TargetHttpsProxy, error)
+	ListHook               func(ctx context.Context, fl *filter.F, m *MockTargetHttpsProxies) (bool, []*ga.TargetHttpsProxy, error)
+	InsertHook             func(ctx context.Context, key *meta.Key, obj *ga.TargetHttpsProxy, m *MockTargetHttpsProxies) (bool, error)
+	DeleteHook             func(ctx context.Context, key *meta.Key, m *MockTargetHttpsProxies) (bool, error)
+	SetSslCertificatesHook func(context.Context, *meta.Key, *ga.TargetHttpsProxiesSetSslCertificatesRequest, *MockTargetHttpsProxies) error
+	SetUrlMapHook          func(context.Context, *meta.Key, *ga.UrlMapReference, *MockTargetHttpsProxies) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -11719,7 +11719,7 @@ type MockTargetHttpsProxies struct {
 // Get returns the object from the mock.
 func (m *MockTargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*ga.TargetHttpsProxy, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetHttpsProxies.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -11752,7 +11752,7 @@ func (m *MockTargetHttpsProxies) Get(ctx context.Context, key *meta.Key) (*ga.Ta
 // List all of the objects in the mock.
 func (m *MockTargetHttpsProxies) List(ctx context.Context, fl *filter.F) ([]*ga.TargetHttpsProxy, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockTargetHttpsProxies.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -11783,7 +11783,7 @@ func (m *MockTargetHttpsProxies) List(ctx context.Context, fl *filter.F) ([]*ga.
 // Insert is a mock for inserting/creating a new object.
 func (m *MockTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, obj *ga.TargetHttpsProxy) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockTargetHttpsProxies.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -11821,7 +11821,7 @@ func (m *MockTargetHttpsProxies) Insert(ctx context.Context, key *meta.Key, obj 
 // Delete is a mock for deleting the object.
 func (m *MockTargetHttpsProxies) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetHttpsProxies.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -11859,7 +11859,7 @@ func (m *MockTargetHttpsProxies) Obj(o *ga.TargetHttpsProxy) *MockTargetHttpsPro
 // SetSslCertificates is a mock for the corresponding method.
 func (m *MockTargetHttpsProxies) SetSslCertificates(ctx context.Context, key *meta.Key, arg0 *ga.TargetHttpsProxiesSetSslCertificatesRequest) error {
 	if m.SetSslCertificatesHook != nil {
-		return m.SetSslCertificatesHook(m, ctx, key, arg0)
+		return m.SetSslCertificatesHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -11867,7 +11867,7 @@ func (m *MockTargetHttpsProxies) SetSslCertificates(ctx context.Context, key *me
 // SetUrlMap is a mock for the corresponding method.
 func (m *MockTargetHttpsProxies) SetUrlMap(ctx context.Context, key *meta.Key, arg0 *ga.UrlMapReference) error {
 	if m.SetUrlMapHook != nil {
-		return m.SetUrlMapHook(m, ctx, key, arg0)
+		return m.SetUrlMapHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -12119,12 +12119,12 @@ type MockTargetPools struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook            func(m *MockTargetPools, ctx context.Context, key *meta.Key) (bool, *ga.TargetPool, error)
-	ListHook           func(m *MockTargetPools, ctx context.Context, region string, fl *filter.F) (bool, []*ga.TargetPool, error)
-	InsertHook         func(m *MockTargetPools, ctx context.Context, key *meta.Key, obj *ga.TargetPool) (bool, error)
-	DeleteHook         func(m *MockTargetPools, ctx context.Context, key *meta.Key) (bool, error)
-	AddInstanceHook    func(*MockTargetPools, context.Context, *meta.Key, *ga.TargetPoolsAddInstanceRequest) error
-	RemoveInstanceHook func(*MockTargetPools, context.Context, *meta.Key, *ga.TargetPoolsRemoveInstanceRequest) error
+	GetHook            func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, *ga.TargetPool, error)
+	ListHook           func(ctx context.Context, region string, fl *filter.F, m *MockTargetPools) (bool, []*ga.TargetPool, error)
+	InsertHook         func(ctx context.Context, key *meta.Key, obj *ga.TargetPool, m *MockTargetPools) (bool, error)
+	DeleteHook         func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, error)
+	AddInstanceHook    func(context.Context, *meta.Key, *ga.TargetPoolsAddInstanceRequest, *MockTargetPools) error
+	RemoveInstanceHook func(context.Context, *meta.Key, *ga.TargetPoolsRemoveInstanceRequest, *MockTargetPools) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -12134,7 +12134,7 @@ type MockTargetPools struct {
 // Get returns the object from the mock.
 func (m *MockTargetPools) Get(ctx context.Context, key *meta.Key) (*ga.TargetPool, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetPools.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -12167,7 +12167,7 @@ func (m *MockTargetPools) Get(ctx context.Context, key *meta.Key) (*ga.TargetPoo
 // List all of the objects in the mock in the given region.
 func (m *MockTargetPools) List(ctx context.Context, region string, fl *filter.F) ([]*ga.TargetPool, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m); intercept {
 			glog.V(5).Infof("MockTargetPools.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 			return objs, err
 		}
@@ -12201,7 +12201,7 @@ func (m *MockTargetPools) List(ctx context.Context, region string, fl *filter.F)
 // Insert is a mock for inserting/creating a new object.
 func (m *MockTargetPools) Insert(ctx context.Context, key *meta.Key, obj *ga.TargetPool) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockTargetPools.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -12239,7 +12239,7 @@ func (m *MockTargetPools) Insert(ctx context.Context, key *meta.Key, obj *ga.Tar
 // Delete is a mock for deleting the object.
 func (m *MockTargetPools) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockTargetPools.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -12277,7 +12277,7 @@ func (m *MockTargetPools) Obj(o *ga.TargetPool) *MockTargetPoolsObj {
 // AddInstance is a mock for the corresponding method.
 func (m *MockTargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsAddInstanceRequest) error {
 	if m.AddInstanceHook != nil {
-		return m.AddInstanceHook(m, ctx, key, arg0)
+		return m.AddInstanceHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -12285,7 +12285,7 @@ func (m *MockTargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *
 // RemoveInstance is a mock for the corresponding method.
 func (m *MockTargetPools) RemoveInstance(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsRemoveInstanceRequest) error {
 	if m.RemoveInstanceHook != nil {
-		return m.RemoveInstanceHook(m, ctx, key, arg0)
+		return m.RemoveInstanceHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -12535,11 +12535,11 @@ type MockUrlMaps struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook    func(m *MockUrlMaps, ctx context.Context, key *meta.Key) (bool, *ga.UrlMap, error)
-	ListHook   func(m *MockUrlMaps, ctx context.Context, fl *filter.F) (bool, []*ga.UrlMap, error)
-	InsertHook func(m *MockUrlMaps, ctx context.Context, key *meta.Key, obj *ga.UrlMap) (bool, error)
-	DeleteHook func(m *MockUrlMaps, ctx context.Context, key *meta.Key) (bool, error)
-	UpdateHook func(*MockUrlMaps, context.Context, *meta.Key, *ga.UrlMap) error
+	GetHook    func(ctx context.Context, key *meta.Key, m *MockUrlMaps) (bool, *ga.UrlMap, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *MockUrlMaps) (bool, []*ga.UrlMap, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *ga.UrlMap, m *MockUrlMaps) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *MockUrlMaps) (bool, error)
+	UpdateHook func(context.Context, *meta.Key, *ga.UrlMap, *MockUrlMaps) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -12549,7 +12549,7 @@ type MockUrlMaps struct {
 // Get returns the object from the mock.
 func (m *MockUrlMaps) Get(ctx context.Context, key *meta.Key) (*ga.UrlMap, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockUrlMaps.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -12582,7 +12582,7 @@ func (m *MockUrlMaps) Get(ctx context.Context, key *meta.Key) (*ga.UrlMap, error
 // List all of the objects in the mock.
 func (m *MockUrlMaps) List(ctx context.Context, fl *filter.F) ([]*ga.UrlMap, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockUrlMaps.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -12613,7 +12613,7 @@ func (m *MockUrlMaps) List(ctx context.Context, fl *filter.F) ([]*ga.UrlMap, err
 // Insert is a mock for inserting/creating a new object.
 func (m *MockUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *ga.UrlMap) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj); intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m); intercept {
 			glog.V(5).Infof("MockUrlMaps.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -12651,7 +12651,7 @@ func (m *MockUrlMaps) Insert(ctx context.Context, key *meta.Key, obj *ga.UrlMap)
 // Delete is a mock for deleting the object.
 func (m *MockUrlMaps) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key); intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockUrlMaps.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -12689,7 +12689,7 @@ func (m *MockUrlMaps) Obj(o *ga.UrlMap) *MockUrlMapsObj {
 // Update is a mock for the corresponding method.
 func (m *MockUrlMaps) Update(ctx context.Context, key *meta.Key, arg0 *ga.UrlMap) error {
 	if m.UpdateHook != nil {
-		return m.UpdateHook(m, ctx, key, arg0)
+		return m.UpdateHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -12900,8 +12900,8 @@ type MockZones struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook  func(m *MockZones, ctx context.Context, key *meta.Key) (bool, *ga.Zone, error)
-	ListHook func(m *MockZones, ctx context.Context, fl *filter.F) (bool, []*ga.Zone, error)
+	GetHook  func(ctx context.Context, key *meta.Key, m *MockZones) (bool, *ga.Zone, error)
+	ListHook func(ctx context.Context, fl *filter.F, m *MockZones) (bool, []*ga.Zone, error)
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -12911,7 +12911,7 @@ type MockZones struct {
 // Get returns the object from the mock.
 func (m *MockZones) Get(ctx context.Context, key *meta.Key) (*ga.Zone, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key); intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m); intercept {
 			glog.V(5).Infof("MockZones.Get(%v, %s) = %+v, %v", ctx, key, obj, err)
 			return obj, err
 		}
@@ -12944,7 +12944,7 @@ func (m *MockZones) Get(ctx context.Context, key *meta.Key) (*ga.Zone, error) {
 // List all of the objects in the mock.
 func (m *MockZones) List(ctx context.Context, fl *filter.F) ([]*ga.Zone, error) {
 	if m.ListHook != nil {
-		if intercept, objs, err := m.ListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("MockZones.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}

--- a/pkg/cloudprovider/providers/gce/cloud/gen/main.go
+++ b/pkg/cloudprovider/providers/gce/cloud/gen/main.go
@@ -352,27 +352,27 @@ type {{.MockWrapType}} struct {
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
 	{{- if .GenerateGet}}
-	GetHook    func(m *{{.MockWrapType}}, ctx context.Context, key *meta.Key) (bool, *{{.FQObjectType}}, error)
+	GetHook    func(ctx context.Context, key *meta.Key, m *{{.MockWrapType}}) (bool, *{{.FQObjectType}}, error)
 	{{- end -}}
 	{{- if .GenerateList}}
 	{{- if .KeyIsGlobal}}
-	ListHook   func(m *{{.MockWrapType}}, ctx context.Context, fl *filter.F) (bool, []*{{.FQObjectType}}, error)
+	ListHook   func(ctx context.Context, fl *filter.F, m *{{.MockWrapType}}) (bool, []*{{.FQObjectType}}, error)
 	{{- end -}}
 	{{- if .KeyIsRegional}}
-	ListHook   func(m *{{.MockWrapType}}, ctx context.Context, region string, fl *filter.F) (bool, []*{{.FQObjectType}}, error)
+	ListHook   func(ctx context.Context, region string, fl *filter.F, m *{{.MockWrapType}}) (bool, []*{{.FQObjectType}}, error)
 	{{- end -}}
 	{{- if .KeyIsZonal}}
-	ListHook   func(m *{{.MockWrapType}}, ctx context.Context, zone string, fl *filter.F) (bool, []*{{.FQObjectType}}, error)
+	ListHook   func(ctx context.Context, zone string, fl *filter.F, m *{{.MockWrapType}}) (bool, []*{{.FQObjectType}}, error)
 	{{- end}}
 	{{- end -}}
 	{{- if .GenerateInsert}}
-	InsertHook func(m *{{.MockWrapType}}, ctx context.Context, key *meta.Key, obj *{{.FQObjectType}}) (bool, error)
+	InsertHook func(ctx context.Context, key *meta.Key, obj *{{.FQObjectType}}, m *{{.MockWrapType}}) (bool, error)
 	{{- end -}}
 	{{- if .GenerateDelete}}
-	DeleteHook func(m *{{.MockWrapType}}, ctx context.Context, key *meta.Key) (bool, error)
+	DeleteHook func(ctx context.Context, key *meta.Key, m *{{.MockWrapType}}) (bool, error)
 	{{- end -}}
 	{{- if .AggregatedList}}
-	AggregatedListHook func(m *{{.MockWrapType}}, ctx context.Context, fl *filter.F) (bool, map[string][]*{{.FQObjectType}}, error)
+	AggregatedListHook func(ctx context.Context, fl *filter.F, m *{{.MockWrapType}}) (bool, map[string][]*{{.FQObjectType}}, error)
 	{{- end}}
 
 {{- with .Methods -}}
@@ -390,7 +390,7 @@ type {{.MockWrapType}} struct {
 // Get returns the object from the mock.
 func (m *{{.MockWrapType}}) Get(ctx context.Context, key *meta.Key) (*{{.FQObjectType}}, error) {
 	if m.GetHook != nil {
-		if intercept, obj, err := m.GetHook(m, ctx, key);  intercept {
+		if intercept, obj, err := m.GetHook(ctx, key, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.Get(%v, %s) = %+v, %v", ctx, key, obj ,err)
 			return obj, err
 		}
@@ -436,15 +436,15 @@ func (m *{{.MockWrapType}}) List(ctx context.Context, zone string, fl *filter.F)
 {{- end}}
 	if m.ListHook != nil {
 		{{if .KeyIsGlobal -}}
-		if intercept, objs, err := m.ListHook(m, ctx, fl);  intercept {
+		if intercept, objs, err := m.ListHook(ctx, fl, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.List(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 		{{- end -}}
 		{{- if .KeyIsRegional -}}
-		if intercept, objs, err := m.ListHook(m, ctx, region, fl);  intercept {
+		if intercept, objs, err := m.ListHook(ctx, region, fl, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.List(%v, %q, %v) = [%v items], %v", ctx, region, fl, len(objs), err)
 		{{- end -}}
 		{{- if .KeyIsZonal -}}
-		if intercept, objs, err := m.ListHook(m, ctx, zone, fl);  intercept {
+		if intercept, objs, err := m.ListHook(ctx, zone, fl, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.List(%v, %q, %v) = [%v items], %v", ctx, zone, fl, len(objs), err)
 		{{- end}}
 			return objs, err
@@ -508,7 +508,7 @@ func (m *{{.MockWrapType}}) List(ctx context.Context, zone string, fl *filter.F)
 // Insert is a mock for inserting/creating a new object.
 func (m *{{.MockWrapType}}) Insert(ctx context.Context, key *meta.Key, obj *{{.FQObjectType}}) error {
 	if m.InsertHook != nil {
-		if intercept, err := m.InsertHook(m, ctx, key, obj);  intercept {
+		if intercept, err := m.InsertHook(ctx, key, obj, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.Insert(%v, %v, %+v) = %v", ctx, key, obj, err)
 			return err
 		}
@@ -548,7 +548,7 @@ func (m *{{.MockWrapType}}) Insert(ctx context.Context, key *meta.Key, obj *{{.F
 // Delete is a mock for deleting the object.
 func (m *{{.MockWrapType}}) Delete(ctx context.Context, key *meta.Key) error {
 	if m.DeleteHook != nil {
-		if intercept, err := m.DeleteHook(m, ctx, key);  intercept {
+		if intercept, err := m.DeleteHook(ctx, key, m);  intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.Delete(%v, %v) = %v", ctx, key, err)
 			return err
 		}
@@ -583,7 +583,7 @@ func (m *{{.MockWrapType}}) Delete(ctx context.Context, key *meta.Key) error {
 // AggregatedList is a mock for AggregatedList.
 func (m *{{.MockWrapType}}) AggregatedList(ctx context.Context, fl *filter.F) (map[string][]*{{.FQObjectType}}, error) {
 	if m.AggregatedListHook != nil {
-		if intercept, objs, err := m.AggregatedListHook(m, ctx, fl); intercept {
+		if intercept, objs, err := m.AggregatedListHook(ctx, fl, m); intercept {
 			glog.V(5).Infof("{{.MockWrapType}}.AggregatedList(%v, %v) = [%v items], %v", ctx, fl, len(objs), err)
 			return objs, err
 		}
@@ -632,17 +632,17 @@ func (m *{{.MockWrapType}}) Obj(o *{{.FQObjectType}}) *Mock{{.Service}}Obj {
 func (m *{{.MockWrapType}}) {{.FcnArgs}} {
 {{- if .IsOperation }}
 	if m.{{.MockHookName}} != nil {
-		return m.{{.MockHookName}}(m, ctx, key {{.CallArgs}})
+		return m.{{.MockHookName}}(ctx, key {{.CallArgs}}, m)
 	}
 	return nil
 {{- else if .IsGet}}
 	if m.{{.MockHookName}} != nil {
-		return m.{{.MockHookName}}(m, ctx, key {{.CallArgs}})
+		return m.{{.MockHookName}}(ctx, key {{.CallArgs}}, m)
 	}
 	return nil, fmt.Errorf("{{.MockHookName}} must be set")
 {{- else if .IsPaged}}
 	if m.{{.MockHookName}} != nil {
-		return m.{{.MockHookName}}(m, ctx, key {{.CallArgs}}, fl)
+		return m.{{.MockHookName}}(ctx, key {{.CallArgs}}, fl, m)
 	}
 	return nil, nil
 {{- end}}

--- a/pkg/cloudprovider/providers/gce/cloud/meta/method.go
+++ b/pkg/cloudprovider/providers/gce/cloud/meta/method.go
@@ -270,13 +270,14 @@ func (m *Method) MockHookName() string {
 // MockHook is the definition of the hook function.
 func (m *Method) MockHook() string {
 	args := m.args(m.argsSkip(), false, []string{
-		fmt.Sprintf("*%s", m.MockWrapType()),
 		"context.Context",
 		"*meta.Key",
 	})
 	if m.kind == MethodPaged {
 		args = append(args, "*filter.F")
 	}
+
+	args = append(args, fmt.Sprintf("*%s", m.MockWrapType()))
 
 	switch m.kind {
 	case MethodOperation:

--- a/pkg/cloudprovider/providers/gce/cloud/mock/BUILD
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/mock",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloudprovider/providers/gce/cloud:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/cloudprovider/providers/gce/cloud/mock/BUILD
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/BUILD
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cloudprovider/providers/gce/cloud:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//pkg/cloudprovider/providers/gce/cloud/meta:go_default_library",
+        "//vendor/google.golang.org/api/compute/v1:go_default_library",
+        "//vendor/google.golang.org/api/googleapi:go_default_library",
     ],
 )
 

--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -50,3 +50,26 @@ func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Ke
 
 	return nil
 }
+
+func RemoveInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsRemoveInstanceRequest) error {
+	pool, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in TargetPools", key.String()),
+		}
+	}
+
+	for _, instanceToRemove := range req.Instances {
+		for i, instance := range pool.Instances {
+			if instanceToRemove.Instance == instance {
+				// Delete instance from pool.Instances without preserving order
+				pool.Instances[i] = pool.Instances[len(pool.Instances)-1]
+				pool.Instances = pool.Instances[:len(pool.Instances)-1]
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -21,7 +21,6 @@ limitations under the License.
 //  // Example usage:
 // cloud := cloud.NewMockGCE()
 // cloud.MockTargetPools.AddInstanceHook = mock.AddInstanceHook
-
 package mock
 
 import (
@@ -35,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 )
 
+// AddInstanceHook mocks adding a Instance to MockTargetPools
 func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsAddInstanceRequest) error {
 	pool, err := m.Get(ctx, key)
 	if err != nil {
@@ -51,6 +51,7 @@ func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Ke
 	return nil
 }
 
+// AddInstanceHook mocks removing a Instance from MockTargetPools
 func RemoveInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsRemoveInstanceRequest) error {
 	pool, err := m.Get(ctx, key)
 	if err != nil {

--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mock encapsulates mocks for testing GCE provider functionality.
+// These methods are used to override the mock objects' methods in order to
+// intercept the standard processing and to add custom logic for test purposes.
+//
+//  // Example usage:
+// cloud := cloud.NewMockGCE()
+// cloud.MockTargetPools.AddInstanceHook = mock.AddInstanceHook
+
+package mock
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	ga "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	cloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
+)
+
+func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsAddInstanceRequest) error {
+	pool, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in TargetPools", key.String()),
+		}
+	}
+
+	for _, instance := range req.Instances {
+		pool.Instances = append(pool.Instances, instance.Instance)
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -35,7 +35,7 @@ import (
 )
 
 // AddInstanceHook mocks adding a Instance to MockTargetPools
-func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsAddInstanceRequest) error {
+func AddInstanceHook(ctx context.Context, key *meta.Key, req *ga.TargetPoolsAddInstanceRequest, m *cloud.MockTargetPools) error {
 	pool, err := m.Get(ctx, key)
 	if err != nil {
 		return &googleapi.Error{
@@ -51,8 +51,8 @@ func AddInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Ke
 	return nil
 }
 
-// AddInstanceHook mocks removing a Instance from MockTargetPools
-func RemoveInstanceHook(m *cloud.MockTargetPools, ctx context.Context, key *meta.Key, req *ga.TargetPoolsRemoveInstanceRequest) error {
+// RemoveInstanceHook mocks removing a Instance from MockTargetPools
+func RemoveInstanceHook(ctx context.Context, key *meta.Key, req *ga.TargetPoolsRemoveInstanceRequest, m *cloud.MockTargetPools) error {
 	pool, err := m.Get(ctx, key)
 	if err != nil {
 		return &googleapi.Error{

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -321,7 +321,6 @@ func createAndInsertNodes(gce *GCECloud, nodeNames []string) ([]*v1.Node, error)
 					},
 				},
 			)
-
 			if err != nil {
 				return nodes, err
 			}
@@ -351,20 +350,17 @@ func createAndInsertNodes(gce *GCECloud, nodeNames []string) ([]*v1.Node, error)
 
 func createExternalLoadBalancer(gce *GCECloud) (*v1.LoadBalancerStatus, error) {
 	nodes, err := createAndInsertNodes(gce, []string{nodeName})
-
 	if err != nil {
 		return nil, err
 	}
 
-	status, err := gce.ensureExternalLoadBalancer(
+	return gce.ensureExternalLoadBalancer(
 		clusterName,
 		clusterID,
 		apiService,
 		nil,
 		nodes,
 	)
-
-	return status, err
 }
 
 func TestEnsureExternalLoadBalancer(t *testing.T) {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -356,6 +356,12 @@ func TestEnsureExternalLoadBalancer(t *testing.T) {
 	assert.NotEmpty(t, pool.HealthChecks)
 	assert.NotEmpty(t, pool.Instances)
 
+	// Check that HealthCheck is created
+	hcName := MakeNodesHealthCheckName(clusterID)
+	healthcheck, err := gce.GetHttpHealthCheck(hcName)
+	require.NoError(t, err)
+	assert.Equal(t, hcName, healthcheck.Name)
+
 	// Check that ForwardingRule is created
 	fwdRule, err := gce.GetRegionForwardingRule(lbName, gceRegion)
 	require.NoError(t, err)
@@ -392,6 +398,12 @@ func TestEnsureExternalLoadBalancerDeleted(t *testing.T) {
 	pool, err := gce.GetTargetPool(lbName, gceRegion)
 	require.Error(t, err)
 	assert.Nil(t, pool)
+
+	// Check that HealthCheck is deleted
+	hcName := MakeNodesHealthCheckName(clusterID)
+	healthcheck, err := gce.GetHttpHealthCheck(hcName)
+	require.Error(t, err)
+	assert.Nil(t, healthcheck)
 
 	// Check forwarding rule is deleted
 	fwdRule, err := gce.GetRegionForwardingRule(lbName, gceRegion)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Unit tests for `pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go`
- Tests creating, updating, and deleting an external LoadBalancer

**Future Improvements**
In order to further test `gce_loadbalancer_external.go`, we should add tests for the following cases:

- Network Tiers - when the current/desired network tier doesn't match, existing resources with the wrong tier should be torn down
- Expect an error when the TargetPool does not exist
- Expect an error when the LoadBalancer Firewall does not exist
- Case when TargetPool needs to be recreated 
- Case when IP needs to be released (calls gce.DeleteRegionAddress)
```release-note
NONE
```

