### PR TITLE
Create short name for cronjob

### DIFF
--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -60,10 +60,16 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 }
 
 var _ rest.CategoriesProvider = &REST{}
+var _ rest.ShortNamesProvider = &REST{}
 
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (r *REST) Categories() []string {
 	return []string{"all"}
+}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"cj"}
 }
 
 // StatusREST implements the REST endpoint for changing the status of a resourcequota.


### PR DESCRIPTION
**What this PR does / why we need it**:
Following https://github.com/kubernetes/kubernetes/pull/59061 I'm adding short name for cronjob, since I was asked about it several times and was thinking about this for a long.


**Release note**:
```release-note
CronJobs can be accessed through cj alias
```
