### PR TITLE
Prevent IPv6 addresses to be v1.NodeInternalIP

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -452,8 +452,9 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 	addrs := []v1.NodeAddress{}
 
 	type Address struct {
-		IPType string `mapstructure:"OS-EXT-IPS:type"`
-		Addr   string
+		IPType    string `mapstructure:"OS-EXT-IPS:type"`
+		Addr      string
+		IPVersion int `mapstructure:"version"`
 	}
 
 	var addresses map[string][]Address
@@ -465,7 +466,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 	for network, addrList := range addresses {
 		for _, props := range addrList {
 			var addressType v1.NodeAddressType
-			if props.IPType == "floating" || network == "public" {
+			if props.IPType == "floating" || network == "public" || props.IPVersion == 6 {
 				addressType = v1.NodeExternalIP
 			} else {
 				addressType = v1.NodeInternalIP


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR makes sure IPv6 address are set as v1.NodeExternalIP
We need it because setting IPv6 addresses as v1.NodeInternalIP breaks the current Kubernetes Neutron networking as described in issue #59421

**Which issue(s) this PR fixes**:
Fixes #59421
Fixes #55202
**Special notes for your reviewer**:

please note that already here https://github.com/zioproto/kubernetes/commit/60ab7cad665241684fc07bbb14ddd9f633d399cb#diff-694c675fe77b09923cc453e7228f8fa8R494 there is the assumption IPv6 = External IP

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
