### PR TITLE
 hack: update bazel-gazelle to 0.9

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -32,7 +32,7 @@ kube::util::go_install_from_commit \
     ae4e9a3906ace4ba657b7a09242610c6266e832c
 kube::util::go_install_from_commit \
     github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
-    31ce76e3acc34a22434d1a783bb9b3cae790d108  # 0.8.0
+    2f186389e2d9a91ee64007914f9b9d0ecae1d8e9  # 0.9.0
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 

--- a/staging/src/k8s.io/api/admission/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/admission/v1beta1/BUILD
@@ -10,7 +10,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/admission/v1beta1",
+    importpath = "v1beta1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/admissionregistration/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/admissionregistration/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/apps/v1/BUILD
+++ b/staging/src/k8s.io/api/apps/v1/BUILD
@@ -10,7 +10,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/apps/v1",
+    importpath = "v1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/api/apps/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/apps/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/apps/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/apps/v1beta2/BUILD
+++ b/staging/src/k8s.io/api/apps/v1beta2/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/apps/v1beta2",
+    importpath = "v1beta2",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/authentication/v1/BUILD
+++ b/staging/src/k8s.io/api/authentication/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/authentication/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/authentication/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/authentication/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/authentication/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/authorization/v1/BUILD
+++ b/staging/src/k8s.io/api/authorization/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/authorization/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/authorization/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/authorization/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/authorization/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/autoscaling/v1/BUILD
+++ b/staging/src/k8s.io/api/autoscaling/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/autoscaling/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/api/autoscaling/v2beta1/BUILD
+++ b/staging/src/k8s.io/api/autoscaling/v2beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/autoscaling/v2beta1",
+    importpath = "v2beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/api/batch/v1/BUILD
+++ b/staging/src/k8s.io/api/batch/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/batch/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/api/batch/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/batch/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/batch/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",

--- a/staging/src/k8s.io/api/batch/v2alpha1/BUILD
+++ b/staging/src/k8s.io/api/batch/v2alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/batch/v2alpha1",
+    importpath = "v2alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",

--- a/staging/src/k8s.io/api/certificates/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/certificates/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/certificates/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/core/v1/BUILD
+++ b/staging/src/k8s.io/api/core/v1/BUILD
@@ -32,7 +32,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/core/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/events/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/events/v1beta1/BUILD
@@ -16,7 +16,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/events/v1beta1",
+    importpath = "v1beta1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/api/extensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/extensions/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/extensions/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/imagepolicy/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/networking/v1/BUILD
+++ b/staging/src/k8s.io/api/networking/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/networking/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/api/policy/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/policy/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/policy/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/api/rbac/v1/BUILD
+++ b/staging/src/k8s.io/api/rbac/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/rbac/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/rbac/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/rbac/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/rbac/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/rbac/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/rbac/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/scheduling/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/api/settings/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/settings/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/settings/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/api/storage/v1/BUILD
+++ b/staging/src/k8s.io/api/storage/v1/BUILD
@@ -10,7 +10,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/storage/v1",
+    importpath = "v1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/api/storage/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/storage/v1alpha1/BUILD
@@ -16,7 +16,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/storage/v1alpha1",
+    importpath = "v1alpha1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/api/storage/v1beta1/BUILD
+++ b/staging/src/k8s.io/api/storage/v1beta1/BUILD
@@ -10,7 +10,7 @@ go_library(
         "types_swagger_doc_generated.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/api/storage/v1beta1",
+    importpath = "v1beta1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/BUILD
@@ -22,7 +22,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/BUILD
@@ -36,7 +36,7 @@ go_library(
         "suffix.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/api/resource",
+    importpath = "resource",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -51,7 +51,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/apis/meta/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/BUILD
@@ -19,7 +19,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
+    importpath = "v1beta1",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/BUILD
@@ -19,7 +19,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/apis/testapigroup/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
@@ -35,7 +35,7 @@ go_library(
         "types_proto.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/runtime",
+    importpath = "runtime",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/BUILD
@@ -20,7 +20,7 @@ go_library(
         "group_version.go",
         "interfaces.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/runtime/schema",
+    importpath = "schema",
     deps = ["//vendor/github.com/gogo/protobuf/proto:go_default_library"],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/BUILD
@@ -20,7 +20,7 @@ go_library(
         "generated.pb.go",
         "intstr.go",
     ],
-    importpath = "k8s.io/apimachinery/pkg/util/intstr",
+    importpath = "intstr",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/BUILD
@@ -18,7 +18,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apiserver/pkg/apis/audit/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/BUILD
@@ -18,7 +18,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apiserver/pkg/apis/audit/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/BUILD
@@ -19,7 +19,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apiserver/pkg/apis/example/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/BUILD
@@ -19,7 +19,7 @@ go_library(
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
     ],
-    importpath = "k8s.io/apiserver/pkg/apis/example2/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1",
+    importpath = "v1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/metrics/pkg/apis/custom_metrics/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/metrics/pkg/apis/metrics/v1alpha1",
+    importpath = "v1alpha1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/BUILD
@@ -15,7 +15,7 @@ go_library(
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
     ],
-    importpath = "k8s.io/metrics/pkg/apis/metrics/v1beta1",
+    importpath = "v1beta1",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/vendor/github.com/grpc-ecosystem/grpc-gateway/runtime/internal/BUILD
+++ b/vendor/github.com/grpc-ecosystem/grpc-gateway/runtime/internal/BUILD
@@ -9,7 +9,7 @@ filegroup(
 go_library(
     name = "go_default_library",
     srcs = ["stream_chunk.pb.go"],
-    importpath = "github.com/grpc-ecosystem/grpc-gateway/runtime/internal",
+    importpath = "internal",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )

--- a/vendor/github.com/libopenstorage/openstorage/api/BUILD
+++ b/vendor/github.com/libopenstorage/openstorage/api/BUILD
@@ -13,7 +13,7 @@ go_library(
         "api.pb.go",
         "status.go",
     ],
-    importpath = "github.com/libopenstorage/openstorage/api",
+    importpath = "api",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD
+++ b/vendor/github.com/opencontainers/runc/libcontainer/system/BUILD
@@ -92,7 +92,37 @@ go_library(
     importpath = "github.com/opencontainers/runc/libcontainer/system",
     visibility = ["//visibility:public"],
     deps = select({
-        "@io_bazel_rules_go//go/platform:linux": [
+        "@io_bazel_rules_go//go/platform:linux_386": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_arm": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_arm64": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_mips": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_mips64": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_mips64le": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_mipsle": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_ppc64": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_s390x": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
         "//conditions:default": [],

--- a/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages/BUILD
+++ b/vendor/google.golang.org/grpc/grpclb/grpc_lb_v1/messages/BUILD
@@ -9,7 +9,7 @@ filegroup(
 go_library(
     name = "go_default_library",
     srcs = ["messages.pb.go"],
-    importpath = "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
+    importpath = "messages",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )


### PR DESCRIPTION
I was attempting to vendor https://github.com/mattn/go-isatty for https://github.com/kubernetes/kubernetes/pull/59495 and hit https://github.com/bazelbuild/bazel-gazelle/issues/28.

This resulted in failures:

```
$ bazel build //vendor/github.com/mattn/go-isatty:go_default_library
ERROR: /home/eric/src/k8s.io/kubernetes/vendor/github.com/mattn/go-isatty/BUILD:3:1: Label '//vendor/golang.org/x/sys/unix:go_default_library' is duplicated in the 'deps' attribute of rule 'go_default_library'
ERROR: error loading package 'vendor/github.com/mattn/go-isatty': Package 'vendor/github.com/mattn/go-isatty' contains errors
INFO: Elapsed time: 0.463s
FAILED: Build did NOT complete successfully (1 packages loaded)
```

Updating bazel to 0.9 includes the fix

```
$ bazel build //vendor/github.com/mattn/go-isatty:go_default_library          
INFO: Analysed target //vendor/github.com/mattn/go-isatty:go_default_library (0 packages loaded).        
INFO: Found 1 target...                                                                                  
Target //vendor/github.com/mattn/go-isatty:go_default_library up-to-date:                                                                                                                                         
  bazel-bin/vendor/github.com/mattn/go-isatty/linux_amd64_stripped/go_default_library~/github.com/mattn/go-isatty.a                                                                                               
INFO: Elapsed time: 26.368s, Critical Path: 25.64s                                                                                                                                                                
INFO: Build completed successfully, 3 total actions
```

cc @mikedanese @ixdy 

```release-note
NONE
```
