### PR TITLE
Add generic cache for Azure VM/LB/NSG/RouteTable

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -249,29 +249,25 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		az.vmSet = newAvailabilitySet(&az)
 	}
 
-	vmCache, err := az.newVMCache()
+	az.vmCache, err = az.newVMCache()
 	if err != nil {
 		return nil, err
 	}
-	az.vmCache = vmCache
 
-	lbCache, err := az.newLBCache()
+	az.lbCache, err = az.newLBCache()
 	if err != nil {
 		return nil, err
 	}
-	az.lbCache = lbCache
 
-	nsgCache, err := az.newNSGCache()
+	az.nsgCache, err = az.newNSGCache()
 	if err != nil {
 		return nil, err
 	}
-	az.nsgCache = nsgCache
 
-	rtCache, err := az.newRouteTableCache()
+	az.rtCache, err = az.newRouteTableCache()
 	if err != nil {
 		return nil, err
 	}
-	az.rtCache = rtCache
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -138,6 +138,7 @@ type Cloud struct {
 	vmCache  *timedCache
 	lbCache  *timedCache
 	nsgCache *timedCache
+	rtCache  *timedCache
 
 	*BlobDiskController
 	*ManagedDiskController
@@ -265,6 +266,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 	az.nsgCache = nsgCache
+
+	rtCache, err := az.newRouteTableCache()
+	if err != nil {
+		return nil, err
+	}
+	az.rtCache = rtCache
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -136,6 +136,7 @@ type Cloud struct {
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
 	vmCache *timedCache
+	lbCache *timedCache
 
 	*BlobDiskController
 	*ManagedDiskController
@@ -251,6 +252,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 	az.vmCache = vmCache
+
+	lbCache, err := az.newLBCache()
+	if err != nil {
+		return nil, err
+	}
+	az.lbCache = lbCache
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -135,6 +135,8 @@ type Cloud struct {
 	VirtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
+	vmCache *timedCache
+
 	*BlobDiskController
 	*ManagedDiskController
 	*controllerCommon
@@ -243,6 +245,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	} else {
 		az.vmSet = newAvailabilitySet(&az)
 	}
+
+	vmCache, err := az.newVMCache()
+	if err != nil {
+		return nil, err
+	}
+	az.vmCache = vmCache
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -135,8 +135,9 @@ type Cloud struct {
 	VirtualMachineScaleSetsClient   VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetVMsClient VirtualMachineScaleSetVMsClient
 
-	vmCache *timedCache
-	lbCache *timedCache
+	vmCache  *timedCache
+	lbCache  *timedCache
+	nsgCache *timedCache
 
 	*BlobDiskController
 	*ManagedDiskController
@@ -258,6 +259,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 	az.lbCache = lbCache
+
+	nsgCache, err := az.newNSGCache()
+	if err != nil {
+		return nil, err
+	}
+	az.nsgCache = nsgCache
 
 	if err := initDiskControllers(&az); err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -131,7 +131,12 @@ func (az *Cloud) CreateOrUpdateSGWithRetry(sg network.SecurityGroup) error {
 		resp := <-respChan
 		err := <-errChan
 		glog.V(10).Infof("SecurityGroupsClient.CreateOrUpdate(%s): end", *sg.Name)
-		return processRetryResponse(resp.Response, err)
+		done, err := processRetryResponse(resp.Response, err)
+		if done && err == nil {
+			// Invalidate the cache right after updating
+			az.lbCache.Delete(*sg.Name)
+		}
+		return done, err
 	})
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -134,7 +134,7 @@ func (az *Cloud) CreateOrUpdateSGWithRetry(sg network.SecurityGroup) error {
 		done, err := processRetryResponse(resp.Response, err)
 		if done && err == nil {
 			// Invalidate the cache right after updating
-			az.lbCache.Delete(*sg.Name)
+			az.nsgCache.Delete(*sg.Name)
 		}
 		return done, err
 	})

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -142,7 +142,12 @@ func (az *Cloud) CreateOrUpdateLBWithRetry(lb network.LoadBalancer) error {
 		resp := <-respChan
 		err := <-errChan
 		glog.V(10).Infof("LoadBalancerClient.CreateOrUpdate(%s): end", *lb.Name)
-		return processRetryResponse(resp.Response, err)
+		done, err := processRetryResponse(resp.Response, err)
+		if done && err == nil {
+			// Invalidate the cache right after updating
+			az.lbCache.Delete(*lb.Name)
+		}
+		return done, err
 	})
 }
 
@@ -283,7 +288,12 @@ func (az *Cloud) DeleteLBWithRetry(lbName string) error {
 		respChan, errChan := az.LoadBalancerClient.Delete(az.ResourceGroup, lbName, nil)
 		resp := <-respChan
 		err := <-errChan
-		return processRetryResponse(resp, err)
+		done, err := processRetryResponse(resp, err)
+		if done && err == nil {
+			// Invalidate the cache right after deleting
+			az.lbCache.Delete(lbName)
+		}
+		return done, err
 	})
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_cache.go
@@ -38,11 +38,7 @@ type cacheEntry struct {
 
 // cacheKeyFunc defines the key function required in TTLStore.
 func cacheKeyFunc(obj interface{}) (string, error) {
-	if entry, ok := obj.(*cacheEntry); ok {
-		return entry.key, nil
-	}
-
-	return "", fmt.Errorf("obj %q is not an object of cacheEntry", obj)
+	return obj.(*cacheEntry).key, nil
 }
 
 // timedCache is a cache with TTL.
@@ -107,23 +103,17 @@ func (t *timedCache) Get(key string) (interface{}, error) {
 		entry.lock.Lock()
 		defer entry.lock.Unlock()
 
-		data, err := t.getter(key)
-		if err != nil {
-			return nil, err
-		}
+		if entry.data == nil {
+			data, err := t.getter(key)
+			if err != nil {
+				return nil, err
+			}
 
-		entry.data = data
+			entry.data = data
+		}
 	}
 
 	return entry.data, nil
-}
-
-// Update sets an item in the cache to its updated state.
-func (t *timedCache) Update(key string, data interface{}) error {
-	return t.store.Update(&cacheEntry{
-		key:  key,
-		data: data,
-	})
 }
 
 // Delete removes an item from the cache.

--- a/pkg/cloudprovider/providers/azure/azure_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_cache.go
@@ -17,40 +17,62 @@ limitations under the License.
 package azure
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"k8s.io/client-go/tools/cache"
 )
 
-type timedcacheEntry struct {
+// getFunc defines a getter function for timedCache.
+type getFunc func(key string) (interface{}, error)
+
+// cacheEntry is the internal structure stores inside TTLStore.
+type cacheEntry struct {
 	key  string
 	data interface{}
+
+	// The lock to ensure not updating same entry simultaneously.
+	lock sync.Mutex
 }
 
-type timedcache struct {
-	store cache.Store
-	lock  sync.Mutex
-}
-
-// ttl time.Duration
-func newTimedcache(ttl time.Duration) timedcache {
-	return timedcache{
-		store: cache.NewTTLStore(cacheKeyFunc, ttl),
-	}
-}
-
+// cacheKeyFunc defines the key function required in TTLStore.
 func cacheKeyFunc(obj interface{}) (string, error) {
-	return obj.(*timedcacheEntry).key, nil
+	if entry, ok := obj.(*cacheEntry); ok {
+		return entry.key, nil
+	}
+
+	return "", fmt.Errorf("obj %q is not an object of cacheEntry", obj)
 }
 
-func (t *timedcache) GetOrCreate(key string, createFunc func() interface{}) (interface{}, error) {
+// timedCache is a cache with TTL.
+type timedCache struct {
+	store  cache.Store
+	lock   sync.Mutex
+	getter getFunc
+}
+
+// newTimedcache creates a new timedCache.
+func newTimedcache(ttl time.Duration, getter getFunc) (*timedCache, error) {
+	if getter == nil {
+		return nil, fmt.Errorf("getter is not provided")
+	}
+
+	return &timedCache{
+		getter: getter,
+		store:  cache.NewTTLStore(cacheKeyFunc, ttl),
+	}, nil
+}
+
+// getInternal returns cacheEntry by key. If the key is not cached yet,
+// it returns a cacheEntry with nil data.
+func (t *timedCache) getInternal(key string) (*cacheEntry, error) {
 	entry, exists, err := t.store.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	if exists {
-		return (entry.(*timedcacheEntry)).data, nil
+		return entry.(*cacheEntry), nil
 	}
 
 	t.lock.Lock()
@@ -60,22 +82,53 @@ func (t *timedcache) GetOrCreate(key string, createFunc func() interface{}) (int
 		return nil, err
 	}
 	if exists {
-		return (entry.(*timedcacheEntry)).data, nil
+		return entry.(*cacheEntry), nil
 	}
 
-	if createFunc == nil {
-		return nil, nil
-	}
-	created := createFunc()
-	t.store.Add(&timedcacheEntry{
+	// Still not found, add new entry with nil data.
+	// Note the data will be filled later by getter.
+	newEntry := &cacheEntry{
 		key:  key,
-		data: created,
-	})
-	return created, nil
+		data: nil,
+	}
+	t.store.Add(newEntry)
+	return newEntry, nil
 }
 
-func (t *timedcache) Delete(key string) {
-	_ = t.store.Delete(&timedcacheEntry{
+// Get returns the requested item by key.
+func (t *timedCache) Get(key string) (interface{}, error) {
+	entry, err := t.getInternal(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Data is still not cached yet, cache it by getter.
+	if entry.data == nil {
+		entry.lock.Lock()
+		defer entry.lock.Unlock()
+
+		data, err := t.getter(key)
+		if err != nil {
+			return nil, err
+		}
+
+		entry.data = data
+	}
+
+	return entry.data, nil
+}
+
+// Update sets an item in the cache to its updated state.
+func (t *timedCache) Update(key string, data interface{}) error {
+	return t.store.Update(&cacheEntry{
+		key:  key,
+		data: data,
+	})
+}
+
+// Delete removes an item from the cache.
+func (t *timedCache) Delete(key string) error {
+	return t.store.Delete(&cacheEntry{
 		key: key,
 	})
 }

--- a/pkg/cloudprovider/providers/azure/azure_cache_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_cache_test.go
@@ -17,80 +17,123 @@ limitations under the License.
 package azure
 
 import (
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestCacheReturnsSameObject(t *testing.T) {
-	type cacheTestingStruct struct{}
-	c := newTimedcache(1 * time.Minute)
-	o1 := cacheTestingStruct{}
-	get1, _ := c.GetOrCreate("b1", func() interface{} {
-		return o1
-	})
-	o2 := cacheTestingStruct{}
-	get2, _ := c.GetOrCreate("b1", func() interface{} {
-		return o2
-	})
-	if get1 != get2 {
-		t.Error("Get not equal")
-	}
+var (
+	fakeCacheTTL = 2 * time.Second
+)
+
+type fakeDataObj struct{}
+
+type fakeDataSource struct {
+	data map[string]*fakeDataObj
+	lock sync.Mutex
 }
 
-func TestCacheCallsCreateFuncOnce(t *testing.T) {
-	var callsCount uint32
-	f1 := func() interface{} {
-		atomic.AddUint32(&callsCount, 1)
-		return 1
-	}
-	c := newTimedcache(500 * time.Millisecond)
-	for index := 0; index < 20; index++ {
-		_, _ = c.GetOrCreate("b1", f1)
+func (fake *fakeDataSource) get(key string) (interface{}, error) {
+	fake.lock.Lock()
+	defer fake.lock.Unlock()
+
+	if v, ok := fake.data[key]; ok {
+		return v, nil
 	}
 
-	if callsCount != 1 {
-		t.Error("Count not match")
-	}
-	time.Sleep(500 * time.Millisecond)
-	c.GetOrCreate("b1", f1)
-	if callsCount != 2 {
-		t.Error("Count not match")
-	}
+	return nil, nil
 }
 
-func TestCacheExpires(t *testing.T) {
-	f1 := func() interface{} {
-		return 1
+func (fake *fakeDataSource) set(data map[string]*fakeDataObj) {
+	fake.lock.Lock()
+	defer fake.lock.Unlock()
+
+	fake.data = data
+}
+
+func newFakeCache(t *testing.T) (*fakeDataSource, *timedCache) {
+	dataSource := &fakeDataSource{
+		data: make(map[string]*fakeDataObj),
 	}
-	c := newTimedcache(500 * time.Millisecond)
-	get1, _ := c.GetOrCreate("b1", f1)
-	if get1 != 1 {
-		t.Error("Value not equal")
+	getter := dataSource.get
+	cache, err := newTimedcache(fakeCacheTTL, getter)
+	assert.NoError(t, err)
+	return dataSource, cache
+}
+
+func TestCacheGet(t *testing.T) {
+	val := &fakeDataObj{}
+	cases := []struct {
+		name     string
+		data     map[string]*fakeDataObj
+		key      string
+		expected interface{}
+	}{
+		{
+			name:     "cache should return nil for empty data source",
+			key:      "key1",
+			expected: nil,
+		},
+		{
+			name:     "cache should return nil for non exist key",
+			data:     map[string]*fakeDataObj{"key2": val},
+			key:      "key1",
+			expected: nil,
+		},
+		{
+			name:     "cache should return data for existing key",
+			data:     map[string]*fakeDataObj{"key1": val},
+			key:      "key1",
+			expected: val,
+		},
 	}
-	time.Sleep(500 * time.Millisecond)
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != nil {
-		t.Error("value not expired")
+
+	for _, c := range cases {
+		dataSource, cache := newFakeCache(t)
+		dataSource.set(c.data)
+		val, err := cache.Get(c.key)
+		assert.NoError(t, err, c.name)
+		assert.Equal(t, c.expected, val, c.name)
 	}
 }
 
 func TestCacheDelete(t *testing.T) {
-	f1 := func() interface{} {
-		return 1
+	key := "key1"
+	val := &fakeDataObj{}
+	data := map[string]*fakeDataObj{
+		key: val,
 	}
-	c := newTimedcache(500 * time.Millisecond)
-	get1, _ := c.GetOrCreate("b1", f1)
-	if get1 != 1 {
-		t.Error("Value not equal")
+	dataSource, cache := newFakeCache(t)
+	dataSource.set(data)
+
+	v, err := cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v, "cache should get correct data")
+
+	dataSource.set(nil)
+	cache.Delete(key)
+	v, err = cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, v, "cache should get nil after data is removed")
+}
+
+func TestCacheExpired(t *testing.T) {
+	key := "key1"
+	val := &fakeDataObj{}
+	data := map[string]*fakeDataObj{
+		key: val,
 	}
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != 1 {
-		t.Error("Value not equal")
-	}
-	c.Delete("b1")
-	get1, _ = c.GetOrCreate("b1", nil)
-	if get1 != nil {
-		t.Error("value not deleted")
-	}
+	dataSource, cache := newFakeCache(t)
+	dataSource.set(data)
+
+	v, err := cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v, "cache should get correct data")
+
+	time.Sleep(fakeCacheTTL)
+	v, err = cache.Get(key)
+	assert.NoError(t, err)
+	assert.Equal(t, val, v, "cache should get correct data even after expired")
 }

--- a/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
+++ b/pkg/cloudprovider/providers/azure/azure_controllerCommon.go
@@ -124,7 +124,7 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	} else {
 		glog.V(4).Info("azureDisk - azure attach succeeded")
 		// Invalidate the cache right after updating
-		vmCache.Delete(vmName)
+		c.cloud.vmCache.Delete(vmName)
 	}
 	return err
 }
@@ -183,7 +183,7 @@ func (c *controllerCommon) DetachDiskByName(diskName, diskURI string, nodeName t
 	} else {
 		glog.V(4).Info("azureDisk - azure disk detach succeeded")
 		// Invalidate the cache right after updating
-		vmCache.Delete(vmName)
+		c.cloud.vmCache.Delete(vmName)
 	}
 	return err
 }

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -819,7 +819,7 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 		ports = []v1.ServicePort{}
 	}
 
-	sg, err := az.SecurityGroupsClient.Get(az.ResourceGroup, az.SecurityGroupName, "")
+	sg, err := az.getSecurityGroup()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/azure/azure_routes.go
+++ b/pkg/cloudprovider/providers/azure/azure_routes.go
@@ -98,10 +98,9 @@ func (az *Cloud) createRouteTable() error {
 		return err
 	}
 
-	glog.V(10).Infof("RouteTablesClient.Get(%q): start", az.RouteTableName)
-	_, err = az.RouteTablesClient.Get(az.ResourceGroup, az.RouteTableName, "")
-	glog.V(10).Infof("RouteTablesClient.Get(%q): end", az.RouteTableName)
-	return err
+	// Invalidate the cache right after updating
+	az.rtCache.Delete(az.RouteTableName)
+	return nil
 }
 
 // CreateRoute creates the described managed route

--- a/pkg/cloudprovider/providers/azure/azure_routes_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_routes_test.go
@@ -37,6 +37,7 @@ func TestCreateRoute(t *testing.T) {
 			Location:       "location",
 		},
 	}
+	cloud.rtCache, _ = cloud.newRouteTableCache()
 	expectedTable := network.RouteTable{
 		Name:     &cloud.RouteTableName,
 		Location: &cloud.Location,

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -880,6 +880,7 @@ func getTestCloud() (az *Cloud) {
 	az.vmSet = newAvailabilitySet(az)
 	az.vmCache, _ = az.newVMCache()
 	az.lbCache, _ = az.newLBCache()
+	az.nsgCache, _ = az.newNSGCache()
 
 	return az
 }

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -879,6 +879,7 @@ func getTestCloud() (az *Cloud) {
 	az.VirtualMachinesClient = newFakeAzureVirtualMachinesClient()
 	az.vmSet = newAvailabilitySet(az)
 	az.vmCache, _ = az.newVMCache()
+	az.lbCache, _ = az.newLBCache()
 
 	return az
 }

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -881,6 +881,7 @@ func getTestCloud() (az *Cloud) {
 	az.vmCache, _ = az.newVMCache()
 	az.lbCache, _ = az.newLBCache()
 	az.nsgCache, _ = az.newNSGCache()
+	az.rtCache, _ = az.newRouteTableCache()
 
 	return az
 }

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -878,6 +878,7 @@ func getTestCloud() (az *Cloud) {
 	az.VirtualMachineScaleSetVMsClient = newFakeVirtualMachineScaleSetVMsClient()
 	az.VirtualMachinesClient = newFakeAzureVirtualMachinesClient()
 	az.vmSet = newAvailabilitySet(az)
+	az.vmCache, _ = az.newVMCache()
 
 	return az
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Part of #58770. This PR adds a generic cache of Azure VM/LB/NSG/RouteTable for reducing ARM calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #58770

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add generic cache for Azure VM/LB/NSG/RouteTable
```
