### PR TITLE
Route verify script output to stderr

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -21,9 +21,9 @@ export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 if [[ ! -f "${KUBE_ROOT}/vendor/BUILD" ]]; then
-  echo "${KUBE_ROOT}/vendor/BUILD does not exist."
-  echo
-  echo "Run ./hack/update-bazel.sh"
+  echo "${KUBE_ROOT}/vendor/BUILD does not exist." >&2
+  echo >&2
+  echo "Run ./hack/update-bazel.sh" >&2
   exit 1
 fi
 
@@ -45,8 +45,8 @@ GOPATH="${_tmp_gopath}" ./hack/update-bazel.sh
 diff=$(diff -Naupr "${KUBE_ROOT}" "${_tmp_kuberoot}" || true)
 
 if [[ -n "${diff}" ]]; then
-  echo "${diff}"
-  echo
-  echo "Run ./hack/update-bazel.sh"
+  echo "${diff}" >&2
+  echo >&2
+  echo "Run ./hack/update-bazel.sh" >&2
   exit 1
 fi

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -28,7 +28,7 @@ files_need_boilerplate=($(${boiler} "$@"))
 # Run boilerplate check
 if [[ ${#files_need_boilerplate[@]} -gt 0 ]]; then
   for file in "${files_need_boilerplate[@]}"; do
-    echo "Boilerplate header is wrong for: ${file}"
+    echo "Boilerplate header is wrong for: ${file}" >&2
   done
 
   exit 1

--- a/hack/verify-godep-licenses.sh
+++ b/hack/verify-godep-licenses.sh
@@ -49,7 +49,7 @@ LICENSE_ROOT="${_tmpdir}" "${KUBE_ROOT}/hack/update-godep-licenses.sh"
 
 # Compare Godep Licenses
 if ! _out="$(diff -Naupr ${KUBE_ROOT}/Godeps/LICENSES ${_tmpdir}/Godeps/LICENSES)"; then
-  echo "Your godep licenses file is out of date. Run hack/update-godep-licenses.sh and commit the results."
-  echo "${_out}"
+  echo "Your godep licenses file is out of date. Run hack/update-godep-licenses.sh and commit the results." >&2
+  echo "${_out}" >&2
   exit 1
 fi

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -85,14 +85,14 @@ ret=0
 pushd "${KUBE_ROOT}" 2>&1 > /dev/null
   # Test for diffs
   if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-line='^\s*\"GodepVersion\":' --ignore-matching-lines='^\s*\"Comment\":' Godeps/Godeps.json ${_kubetmp}/Godeps/Godeps.json)"; then
-    echo "Your Godeps.json is different:"
-    echo "${_out}"
-    echo "Godeps Verify failed."
+    echo "Your Godeps.json is different:" >&2
+    echo "${_out}" >&2
+    echo "Godeps Verify failed." >&2
     echo "${_out}" > godepdiff.patch
-    echo "If you're seeing this locally, run the below command to fix your Godeps.json:"
-    echo "patch -p0 < godepdiff.patch"
-    echo "(The above output can be saved as godepdiff.patch if you're not running this locally)"
-    echo "(The patch file should also be exported as a build artifact if run through CI)"
+    echo "If you're seeing this locally, run the below command to fix your Godeps.json:" >&2
+    echo "patch -p0 < godepdiff.patch" >&2
+    echo "(The above output can be saved as godepdiff.patch if you're not running this locally)" >&2
+    echo "(The patch file should also be exported as a build artifact if run through CI)" >&2
     KEEP_TMP=true
     if [[ -f godepdiff.patch && -d "${ARTIFACTS_DIR:-}" ]]; then
       echo "Copying patch to artifacts.."
@@ -102,14 +102,14 @@ pushd "${KUBE_ROOT}" 2>&1 > /dev/null
   fi
 
   if ! _out="$(diff -Naupr -x "BUILD" -x "OWNERS" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor ${_kubetmp}/vendor)"; then
-    echo "Your vendored results are different:"
-    echo "${_out}"
-    echo "Godeps Verify failed."
+    echo "Your vendored results are different:" >&2
+    echo "${_out}" >&2
+    echo "Godeps Verify failed." >&2
     echo "${_out}" > vendordiff.patch
-    echo "If you're seeing this locally, run the below command to fix your directories:"
-    echo "patch -p0 < vendordiff.patch"
-    echo "(The above output can be saved as godepdiff.patch if you're not running this locally)"
-    echo "(The patch file should also be exported as a build artifact if run through CI)"
+    echo "If you're seeing this locally, run the below command to fix your directories:" >&2
+    echo "patch -p0 < vendordiff.patch" >&2
+    echo "(The above output can be saved as godepdiff.patch if you're not running this locally)" >&2
+    echo "(The patch file should also be exported as a build artifact if run through CI)" >&2
     KEEP_TMP=true
     if [[ -f vendordiff.patch && -d "${ARTIFACTS_DIR:-}" ]]; then
       echo "Copying patch to artifacts.."

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -54,6 +54,8 @@ find_files() {
 # have failed before getting to the "echo" in the block below.
 diff=$(find_files | xargs ${gofmt} -d -s 2>&1) || true
 if [[ -n "${diff}" ]]; then
-  echo "${diff}"
+  echo "${diff}" >&2
+  echo >&2
+  echo "Run ./hack/update-gofmt.sh" >&2
   exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes a few of the review scripts that weren't routing their output to stderr, to route there error output there. This allows the junit report to pick up on the error message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
sort of fixes #59518

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
