### PR TITLE
Set instanceID to azure resource ID format while useInstanceMetadata is enabled

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -112,10 +112,8 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 			return "", err
 		}
 		if isLocalInstance {
-			externalInstanceID, err := az.metadata.Text("instance/compute/vmId")
-			if err == nil {
-				return externalInstanceID, nil
-			}
+			nodeName := mapNodeNameToVMName(name)
+			return az.getMachineID(nodeName), nil
 		}
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR sets instanceID to azure resource ID format while useInstanceMetadata is enabled.

Before this PR, it is `azure://d84a1c30-0c9f-11e8-8a34-000d3a919531`.

With this PR, it becomes `azure:///subscriptions/<id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/<node-name>`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR is only for vmas and could be cherry-picked to old releases. There will be another PR for vmss after this.

Should cherry-pick to release 1.8 and 1.9.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Node's providerID is following Azure resource ID format now when useInstanceMetadata is enabled
```
