### PR TITLE
return error if New-SmbGlobalMapping failed when mounting azure file on Windows

### DIFF
--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -89,10 +89,7 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 		cmdLine += fmt.Sprintf(";New-SmbGlobalMapping -RemotePath %s -Credential $Credential", source)
 
 		if output, err := exec.Command("powershell", "/c", cmdLine).CombinedOutput(); err != nil {
-			// we don't return error here, even though New-SmbGlobalMapping failed, we still make it successful,
-			// will return error when Windows 2016 RS3 is ready on azure
-			glog.Errorf("azureMount: SmbGlobalMapping failed: %v, only SMB mount is supported now, output: %q", err, string(output))
-			return os.MkdirAll(target, 0755)
+			return fmt.Errorf("azureMount: SmbGlobalMapping failed: %v, only SMB mount is supported now, output: %q", err, string(output))
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR will return error if New-SmbGlobalMapping failed when mounting azure file on Windows.
User wants to create a pod moutning with azure file pvc using static provisioning([doc](https://github.com/andyzhangx/Demo/tree/master/windows/azurefile#static-provisioning-for-azure-file-on-windows-server-version-1709support-from-v17x])) and user uses a wrong storage account name or key, current behavior is if mount azure file on Windows, it will create an empty directory, and user would not know actually it fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59538 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
return error if New-SmbGlobalMapping failed when mounting azure file on Windows
```