### PR TITLE
load ipvs required kernel modules for gce

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -611,6 +611,11 @@ EOF
 KUBELET_TEST_LOG_LEVEL: $(yaml-quote ${KUBELET_TEST_LOG_LEVEL})
 EOF
   fi
+  if [ -n "${KUBEPROXY_MODE:-}" ]; then
+      cat >>$file <<EOF
+KUBEPROXY_MODE: $(yaml-quote ${KUBEPROXY_MDOE})
+EOF
+  fi
   if [ -n "${DOCKER_TEST_LOG_LEVEL:-}" ]; then
       cat >>$file <<EOF
 DOCKER_TEST_LOG_LEVEL: $(yaml-quote ${DOCKER_TEST_LOG_LEVEL})

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -92,6 +92,9 @@ NODE_EXTRA_METADATA=${KUBE_NODE_EXTRA_METADATA:-${KUBE_EXTRA_METADATA:-}}
 # KUBELET_TEST_ARGS are extra arguments passed to kubelet.
 KUBELET_TEST_ARGS=${KUBE_KUBELET_EXTRA_ARGS:-}
 
+# KUBEPROXY_MODE is the proxy mode, ipvs/iptables/userspace
+KUBEPROXY_MODE=${KUBEPROXY_MODE:-iptables}
+
 NETWORK=${KUBE_GCE_NETWORK:-default}
 # Enable network deletion by default (for kube-down), unless we're using 'default' network.
 if [[ "${NETWORK}" == "default" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1298,6 +1298,11 @@ function prepare-kube-proxy-manifest-variables {
   if [[ -n "${FEATURE_GATES:-}" ]]; then
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
+  if [[ "${KUBEPROXY_MODE:-}" == "ipvs" ]]; then
+    # Load kernel modules required by IPVS proxier
+    sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4
+    params+=" --proxy-mode=${KUBEPROXY_TEST_ARGS}"
+  fi
   params+=" --iptables-sync-period=1m --iptables-min-sync-period=10s --ipvs-sync-period=1m --ipvs-min-sync-period=10s"
   if [[ -n "${KUBEPROXY_TEST_ARGS:-}" ]]; then
     params+=" ${KUBEPROXY_TEST_ARGS}"


### PR DESCRIPTION

**What this PR does / why we need it**:

If proxy mode is ipvs, then GCE need load kernel modules in startup scripts. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59402 

**Special notes for your reviewer**:
Use `KUBEPROXY_MODE` as a mark of proxy mode, same as what we do in `local-up-cluster`, if `KUBEPROXY_MODE==ipvs`, then neede load related kernel modules.

**Release note**:
```release-note
NONE
```
