### PR TITLE
Extract instantiation of cloud provider

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -14,6 +14,7 @@ go_library(
         "batch.go",
         "bootstrap.go",
         "certificates.go",
+        "cloudproviders.go",
         "controllermanager.go",
         "core.go",
         "extensions.go",

--- a/cmd/kube-controller-manager/app/cloudproviders.go
+++ b/cmd/kube-controller-manager/app/cloudproviders.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// createCloudProvider helps consolidate what is needed for cloud providers, we explicitly list the things
+// that the cloud providers need as parameters, so we can control
+func createCloudProvider(cloudProvider string, externalCloudVolumePlugin string, cloudConfigFile string,
+	allowUntaggedCloud bool, sharedInformers informers.SharedInformerFactory) (cloudprovider.Interface, ControllerLoopMode, error) {
+	var cloud cloudprovider.Interface
+	var loopMode ControllerLoopMode
+	var err error
+	if cloudprovider.IsExternal(cloudProvider) {
+		loopMode = ExternalLoops
+		if externalCloudVolumePlugin == "" {
+			// externalCloudVolumePlugin is temporary until we split all cloud providers out.
+			// So we just tell the caller that we need to run ExternalLoops without any cloud provider.
+			return nil, loopMode, nil
+		}
+		cloud, err = cloudprovider.InitCloudProvider(externalCloudVolumePlugin, cloudConfigFile)
+	} else {
+		loopMode = IncludeCloudLoops
+		cloud, err = cloudprovider.InitCloudProvider(cloudProvider, cloudConfigFile)
+	}
+	if err != nil {
+		return nil, loopMode, fmt.Errorf("cloud provider could not be initialized: %v", err)
+	}
+
+	if cloud != nil && cloud.HasClusterID() == false {
+		if allowUntaggedCloud == true {
+			glog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")
+		} else {
+			return nil, loopMode, fmt.Errorf("no ClusterID Found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+		}
+	}
+
+	if informerUserCloud, ok := cloud.(cloudprovider.InformerUser); ok {
+		informerUserCloud.SetInformers(sharedInformers)
+	}
+	return cloud, loopMode, err
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add a separate method in a new file for creating cloud providers.
Currently the code is all mixed into the controller manager. We
should actively control what is made available to the cloud provider
so list explicitly the parms needed and move the code out. This will
avoid linkages to sneak in as we will catch it better during reviews.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
