### PR TITLE
Skip TestRoutes when there are no vm(s)

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -40,9 +40,17 @@ func TestRoutes(t *testing.T) {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 
+	vms := getServers(os)
+	_, err = os.InstanceID()
+	if err != nil || len(vms) == 0 {
+		t.Skipf("Please run this test in an OpenStack vm or create at least one VM in OpenStack before you run this test.")
+	}
+
+	// We know we have at least one vm.
+	servername := vms[0].Name
+
 	// Pick the first router and server to try a test with
 	os.routeOpts.RouterID = getRouters(os)[0].ID
-	servername := getServers(os)[0].Name
 
 	r, ok := os.Routes()
 	if !ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

TestRoutes assumes that there is at least one vm in the OpenStack it
is connecting to. So let's limit this test to run properly only when
we are running in a VM or one was created already outside of the
test harness


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Please see https://github.com/dims/openstack-cloud-controller-manager/issues/73 for some more context

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
