### PR TITLE
Fix bug with profile-gathering waitgroup in scale tests

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -363,6 +363,7 @@ var _ = SIGDescribe("Density", func() {
 		// Stop apiserver CPU profile gatherer and gather memory allocations profile.
 		close(profileGathererStopCh)
 		wg := sync.WaitGroup{}
+		wg.Add(1)
 		framework.GatherApiserverMemoryProfile(&wg, "density")
 		wg.Wait()
 

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -104,6 +104,7 @@ var _ = SIGDescribe("Load capacity", func() {
 		// Stop apiserver CPU profile gatherer and gather memory allocations profile.
 		close(profileGathererStopCh)
 		wg := sync.WaitGroup{}
+		wg.Add(1)
 		framework.GatherApiserverMemoryProfile(&wg, "load")
 		wg.Wait()
 


### PR DESCRIPTION
This bug has caused panic due to:

```
I0208 14:11:52.955]   [91m[1mTest Panicked[0m
I0208 14:11:52.955]   [91msync: negative WaitGroup counter[0m
```

e.g failure - https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-kubemark-500-gce/11818)

/cc @wojtek-t 

```release-note
NONE
```