### PR TITLE
Add exit code 1 on not allowed to kubectl auth can-i

### DIFF
--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -99,7 +99,7 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 
 			allowed, err := o.RunAccessCheck()
 			if err == nil {
-				if o.Quiet && !allowed {
+				if (o.Quiet || !o.Quiet) && !allowed {
 					os.Exit(1)
 				}
 			}


### PR DESCRIPTION
kubectl auth can-i verb resource always returns 0 status, even if the user canot run the action.

With this commit, kubectl will return exit code 1 when a verb is not allowed for the user.