### PR TITLE
Add exit code 1 on not allowed to kubectl auth can-i

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -5219,6 +5219,12 @@ runTests() {
 
     output_message=$(kubectl auth can-i list jobs.batch/bar -n foo --quiet 2>&1 "${kube_flags[@]}")
     kube::test::if_empty_string "${output_message}"
+    
+    output_message=$(kubectl auth can-i get pods --subresource=log 2>&1 "${kube_flags[@]}"; echo $?)
+    kube::test::if_has_string "${output_message}" '0'
+
+    output_message=$(kubectl auth can-i get pods --subresource=log --quiet 2>&1 "${kube_flags[@]}"; echo $?)
+    kube::test::if_has_string "${output_message}" '0'
   fi
 
   # kubectl auth reconcile

--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -97,7 +97,7 @@ func NewCmdCanI(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 
 			allowed, err := o.RunAccessCheck()
 			if err == nil {
-				if o.Quiet && !allowed {
+				if !allowed {
 					os.Exit(1)
 				}
 			}


### PR DESCRIPTION
What this PR does / why we need it:
kubectl auth can-i verb resource always returns 0 status, even if the user can't <verb> <resource>

With this commit, kubectl will return exit code 1 when a verb is not allowed. It doesn't affect quiet option.

Release note:
```release-note
Fix kubectl auth can-i exit code. It will return 1 if the user is not allowed and 0 if it's allowed.
```

