### PR TITLE
Do not allow duplicate environment variable definitions

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1904,6 +1904,7 @@ func validateContainerPorts(ports []core.ContainerPort, fldPath *field.Path) fie
 func ValidateEnv(vars []core.EnvVar, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	allNames := sets.String{}
 	for i, ev := range vars {
 		idxPath := fldPath.Index(i)
 		if len(ev.Name) == 0 {
@@ -1911,6 +1912,11 @@ func ValidateEnv(vars []core.EnvVar, fldPath *field.Path) field.ErrorList {
 		} else {
 			for _, msg := range validation.IsEnvVarName(ev.Name) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), ev.Name, msg))
+			}
+			if allNames.Has(ev.Name) {
+				allErrs = append(allErrs, field.Duplicate(idxPath.Child("name"), ev.Name))
+			} else {
+				allNames.Insert(ev.Name)
 			}
 		}
 		allErrs = append(allErrs, validateEnvVarValueFrom(ev, idxPath.Child("valueFrom"))...)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3988,15 +3988,20 @@ func TestLocalStorageEnvWithFeatureGate(t *testing.T) {
 }
 
 func TestValidateEnv(t *testing.T) {
+	counter := 0
+	makeName := func(prefix string) string {
+		counter = counter + 1
+		return fmt.Sprintf("%s%v", prefix, counter)
+	}
 	successCase := []core.EnvVar{
-		{Name: "abc", Value: "value"},
+		{Name: makeName("abc"), Value: "value"},
 		{Name: "ABC", Value: "value"},
 		{Name: "AbC_123", Value: "value"},
-		{Name: "abc", Value: ""},
+		{Name: makeName("abc"), Value: ""},
 		{Name: "a.b.c", Value: "value"},
 		{Name: "a-b-c", Value: "value"},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4005,7 +4010,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4014,7 +4019,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4023,7 +4028,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4032,7 +4037,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4041,7 +4046,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4050,7 +4055,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4059,7 +4064,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
@@ -4068,7 +4073,7 @@ func TestValidateEnv(t *testing.T) {
 			},
 		},
 		{
-			Name: "abc",
+			Name: makeName("abc"),
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -19,6 +19,7 @@ package apps
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -660,7 +661,7 @@ func testIterativeDeployments(f *framework.Framework) {
 			// trigger a new deployment
 			framework.Logf("%02d: triggering a new rollout for deployment %q", i, deployment.Name)
 			deployment, err = framework.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *extensions.Deployment) {
-				newEnv := v1.EnvVar{Name: "A", Value: fmt.Sprintf("%d", i)}
+				newEnv := v1.EnvVar{Name: fmt.Sprintf("A%s", strings.Repeat("B", i)), Value: fmt.Sprintf("%d", i)}
 				update.Spec.Template.Spec.Containers[0].Env = append(update.Spec.Template.Spec.Containers[0].Env, newEnv)
 				randomScale(update, i)
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
According to [this comment](https://github.com/kubernetes/kubernetes/issues/58477#issuecomment-358802050) by @liggitt, "the envvar name is supposed to be the unique key of items in the list" but our validation does not currently prevent this. This causes issues because name field is the patchMergeKey, so when someone tries to remove just one of two duplicate envvars, the both are actually removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58477

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug which allowed Container.EnvVar to contain multiple EnvVars with the same name. Environment variables should not be defined multiple times.
```
