### PR TITLE
Added support for colon (':') in environment variable name

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3884,6 +3884,7 @@ func TestValidateEnv(t *testing.T) {
 		{Name: "abc", Value: ""},
 		{Name: "a.b.c", Value: "value"},
 		{Name: "a-b-c", Value: "value"},
+		{Name: "a:b:c", Value: "value"},
 		{
 			Name: "abc",
 			ValueFrom: &core.EnvVarSource{
@@ -4285,6 +4286,12 @@ func TestValidateEnvFrom(t *testing.T) {
 			},
 		},
 		{
+			Prefix: "a:b",
+			ConfigMapRef: &core.ConfigMapEnvSource{
+				LocalObjectReference: core.LocalObjectReference{Name: "abc"},
+			},
+		},
+		{
 			SecretRef: &core.SecretEnvSource{
 				LocalObjectReference: core.LocalObjectReference{Name: "abc"},
 			},
@@ -4297,6 +4304,12 @@ func TestValidateEnvFrom(t *testing.T) {
 		},
 		{
 			Prefix: "a.b",
+			SecretRef: &core.SecretEnvSource{
+				LocalObjectReference: core.LocalObjectReference{Name: "abc"},
+			},
+		},
+		{
+			Prefix: "a:b",
 			SecretRef: &core.SecretEnvSource{
 				LocalObjectReference: core.LocalObjectReference{Name: "abc"},
 			},

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -1130,6 +1130,7 @@ func TestParseEnv(t *testing.T) {
 			envArray: []string{
 				"THIS_ENV=isOK",
 				"this.dotted.env=isOKToo",
+				"this:colon:env=isAlsoOk",
 				"HAS_COMMAS=foo,bar",
 				"HAS_EQUALS=jJnro54iUu75xNy==",
 			},
@@ -1141,6 +1142,10 @@ func TestParseEnv(t *testing.T) {
 				{
 					Name:  "this.dotted.env",
 					Value: "isOKToo",
+				},
+				{
+					Name:  "this:colon:env",
+					Value: "isAlsoOk",
 				},
 				{
 					Name:  "HAS_COMMAS",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1585,12 +1585,17 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					"1234":  []byte("abc"),
 					"1z":    []byte("abc"),
 					"key.1": []byte("value"),
+					"key:2": []byte("value2"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
 					Name:  "key.1",
 					Value: "value",
+				},
+				{
+					Name:  "key:2",
+					Value: "value2",
 				},
 			},
 			expectedEvent: "Warning InvalidEnvironmentVariableNames Keys [1234, 1z] from the EnvFrom secret test/test-secret were skipped since they are considered invalid environment variable names.",
@@ -1614,12 +1619,17 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"1234.name": []byte("abc"),
+					"5678:name": []byte("def"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
 					Name:  "p_1234.name",
 					Value: "abc",
+				},
+				{
+					Name:  "p_5678:name",
+					Value: "def",
 				},
 			},
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -302,7 +302,7 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
-const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
+const envVarNameFmt = "[-:._a-zA-Z][-:._a-zA-Z0-9]*"
 const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
 
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -303,7 +303,7 @@ func IsHTTPHeaderName(value string) []string {
 }
 
 const envVarNameFmt = "[-:._a-zA-Z][-:._a-zA-Z0-9]*"
-const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
+const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', ':', or '.', and must not start with a digit"
 
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds support for including a colon `:` in environment variable names.  A number of .Net applications/libraries use `:` in their environment variable names.  
**Which issue(s) this PR fixes**:
Fixes #53201 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for `:` character in environment variable names.
```
