### PR TITLE
[WIP] kubelet should look for files in /etc/kuberenetes/pods

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -162,6 +162,9 @@ const (
 
 	// Minimum number of dead containers to keep in a pod
 	minDeadContainerInPod = 1
+
+	// Path to look for static pod manifest files
+	staticPodManifestPath = "/etc/kubernetes/pods"
 )
 
 // SyncHandler is an interface implemented by Kubelet, for testability
@@ -264,7 +267,22 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 	// source of all configuration
 	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder)
 
-	// define file config source
+	// define file config sources, where two sources are considered
+
+	// The first one is the path defined by staticPodManifestPath
+	statInfo, err := os.Stat(staticPodManifestPath)
+	if err != nil {
+		glog.Infof("Static pod manifest path %v does not exist, skipping", staticPodManifestPath)
+	} else {
+		if statInfo.IsDir() {
+			glog.Infof("Adding static pod manifest path: %v", staticPodManifestPath)
+			config.NewSourceFile(staticPodManifestPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
+		} else {
+			glog.Infof("Static pod manifest path %v is not a directory, skipping", staticPodManifestPath)
+		}
+	}
+
+	// The second one is the path supplied via PodManifestPath
 	if kubeCfg.PodManifestPath != "" {
 		glog.Infof("Adding manifest path: %v", kubeCfg.PodManifestPath)
 		config.NewSourceFile(kubeCfg.PodManifestPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adding support for kubelet to look for files in /etc/kuberenetes/pods, with background in #10091.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10091

**Special notes for your reviewer**:

This is a quick implementation to demonstrate the approach, and to verify that it works as expected.  There will be other work involved including update documentation such as https://kubernetes.io/docs/tasks/administer-cluster/static-pod/ to reflect the change.

No need to test before this approach is confirmed to meet expectations.

**Release note**:
```release-note
kubelet now also looks for static pod manifest files in /etc/kuberenetes/pods, in addition to the path specified via --pod-manifest-path
```

@thockin 