### PR TITLE
bazel: support using SOURCE_DATE_EPOCH to override date

### DIFF
--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -43,5 +43,7 @@ gitTreeState ${KUBE_GIT_TREE_STATE-}
 gitVersion ${KUBE_GIT_VERSION-}
 gitMajor ${KUBE_GIT_MAJOR-}
 gitMinor ${KUBE_GIT_MINOR-}
-buildDate $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+buildDate $(date \
+  ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} \
+ -u +'%Y-%m-%dT%H:%M:%SZ')
 EOF


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: ports #48708 to apply to the bazel build as well.
Note that bazel already sets `BUILD_TIMESTAMP` using `SOURCE_DATE_EPOCH`, but we have our own timestamp variable, so we need to fix it too.

We could combine this with something like
```shell
SOURCE_DATE_EPOCH=$(git log -1 --format=%cd --date=format:%s)
```
to get closer to repeatable builds. (This uses the timestamp from the last git commit.)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder @mikedanese 