### PR TITLE
move csi assert support version inside client

### DIFF
--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -60,7 +60,7 @@ func TestClientAssertSupportedVersion(t *testing.T) {
 		t.Logf("test case: %s", tc.testName)
 		client := setupClient(t)
 		client.idClient.(*fake.IdentityClient).SetNextError(tc.err)
-		err := client.AssertSupportedVersion(grpctx.Background(), tc.ver)
+		err := client.assertSupportedVersion(grpctx.Background(), tc.ver)
 		if tc.mustFail && err == nil {
 			t.Error("test must fail, but err = nil")
 		}

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -123,12 +123,6 @@ func (c *csiMountMgr) SetUpAt(dir string, fsGroup *int64) error {
 	nodeName := string(c.plugin.host.GetNodeName())
 	attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 
-	// ensure version is supported
-	if err := csi.AssertSupportedVersion(ctx, csiVersion); err != nil {
-		glog.Error(log("mounter.SetUpAt failed to assert version: %v", err))
-		return err
-	}
-
 	// probe driver
 	// TODO (vladimirvivien) move probe call where it is done only when it is needed.
 	if err := csi.NodeProbe(ctx, csiVersion); err != nil {
@@ -273,12 +267,6 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 	defer cancel()
 
 	csi := c.csiClient
-
-	// TODO make all assertion calls private within the client itself
-	if err := csi.AssertSupportedVersion(ctx, csiVersion); err != nil {
-		glog.Errorf(log("mounter.TearDownAt failed to assert version: %v", err))
-		return err
-	}
 
 	if err := csi.NodeUnpublishVolume(ctx, volID, dir); err != nil {
 		glog.Errorf(log("mounter.TearDownAt failed: %v", err))


### PR DESCRIPTION

**What this PR does / why we need it**:

Move csi assert support version inside client, so method don't have to call `AssertSupportedVersion()`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58633

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
