### PR TITLE
isolate "make test" from local environment

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -172,6 +172,7 @@ define CHECK_TEST_HELP_INFO
 #   make check
 #   make test
 #   make check WHAT=./pkg/kubelet GOFLAGS=-v
+#   make check GOFLAGS='-v -exec "strace -f -e trace=file"'
 endef
 .PHONY: check test
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/59425 by running
test binaries with a temporary HOME and KUBECONFIG unset.

```release-note
NONE
```

/sig testing