### PR TITLE
Update cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -31,7 +31,7 @@ COPY Gemfile /Gemfile
 # 2. Install fluentd via ruby.
 # 3. Remove build dependencies.
 # 4. Cleanup leftover caches & files.
-RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev" \
+RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev autoconf automake libtool libltdl-dev" \
     && clean-install $BUILD_DEPS \
                      ca-certificates \
                      libjemalloc1 \


### PR DESCRIPTION
Fix BUILD_DEPS packages

**What this PR does / why we need it**:
Docker image fluentd-elsticsearch do not build without added packages. 
Build crash with multiple errors
