### PR TITLE
WIP: Validate metadata for custom resources

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -307,8 +307,8 @@ type LineReader struct {
 // An error is returned iff there is an error with the underlying reader.
 func (r *LineReader) Read() ([]byte, error) {
 	var (
-		isPrefix bool  = true
-		err      error = nil
+		isPrefix = true
+		err      error
 		line     []byte
 		buffer   bytes.Buffer
 	)


### PR DESCRIPTION
Validates the following by converting the metadata subtree of custom resources from `Unstructured` to a metadata struct and back:

1. null/nil values for labels and annotations are marshalled as empty strings `""`.
2. Validates metadata to make sure there are no unknown fields.
3. Validates invalid values (numbers, booleans, structured values, etc) for labels, annotations, etc.

Fixes #59451

TODO:

- [ ] Decide how to proceed with existing bad data

**Release note**:

(This probably deserves a release note but will update after the TODO is done)
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts liggitt deads2k ash2k jennybuckley 