### PR TITLE
libffi-dev dependency added in fluentd-es-image Dockerfile to solve the docker build error

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -31,7 +31,7 @@ COPY Gemfile /Gemfile
 # 2. Install fluentd via ruby.
 # 3. Remove build dependencies.
 # 4. Cleanup leftover caches & files.
-RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev" \
+RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev libffi-dev" \
     && clean-install $BUILD_DEPS \
                      ca-certificates \
                      libjemalloc1 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Not able to build the docker images for fluentd-es-image. The docker build shows the error like below

```
Installing fluent-plugin-elasticsearch (2.4.1)
Installing ffi (1.9.21)
Building native extensions.  This could take a while...
ERROR:  While executing gem ... (Gem::Ext::BuildError)
    ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c
/usr/bin/ruby2.3 -r ./siteconf20180209-4127-3e9tjv.rb extconf.rb
checking for ffi.h... no
checking for ffi.h in /usr/local/include,/usr/include/ffi... no
checking for shlwapi.h... no
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_with_gvl()... yes
checking for rb_thread_call_without_gvl()... yes
creating extconf.h
creating Makefile

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/ffi-1.9.21/mkmf.log

current directory: /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR=" clean

current directory: /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR="
Running autoreconf for libffi
/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi/autogen.sh: 2: exec: autoreconf: not found
libffi.mk:6: recipe for target '"/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a' failed
make: *** ["/var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a] Error 127

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/2.3.0/gems/ffi-1.9.21 for inspection.
Results logged to /var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/ffi-1.9.21/gem_make.out
The command '/bin/sh -c BUILD_DEPS="make gcc g++ libc6-dev ruby-dev"     && clean-install $BUILD_DEPS                      ca-certificates                      libjemalloc1                      ruby     && echo 'gem: --no-document' >> /etc/gemrc     && gem install --file Gemfile     && apt-get purge -y --auto-remove                      -o APT::AutoRemove::RecommendsImportant=false                      $BUILD_DEPS     && clean-apt     && ulimit -n 65536' returned a non-zero code: 1
```
added the libffi-dev dependency solves the build error.

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```