### PR TITLE
GCE: Bump GLBC version to 0.9.8-alpha.1

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.7
+  name: l7-lb-controller-v0.9.8-alpha.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v0.9.7
+    version: v0.9.8-alpha.1
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/glbc:0.9.7
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:0.9.8-alpha.1
     livenessProbe:
       httpGet:
         path: /healthz
@@ -44,7 +44,7 @@ spec:
     # TODO: split this out into args when we no longer need to pipe stdout to a file #6428
     - sh
     - -c
-    - 'exec /glbc --verbose=true --apiserver-host=http://localhost:8080 --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=false --use-real-cloud=true --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1'
+    - 'exec /glbc -v=3 --apiserver-host=http://localhost:8080 --default-backend-service=kube-system/default-http-backend --sync-period=600s --running-in-cluster=false --use-real-cloud=true --config-file-path=/etc/gce.conf --healthz-port=8086 1>>/var/log/glbc.log 2>&1'
   volumes:
   - hostPath:
       path: /etc/gce.conf


### PR DESCRIPTION
**What this PR does / why we need it**:
Soak on an alpha version of GLBC 0.9.8


**Special notes for your reviewer**:
/assign @bowei 
/cc @bowei 

**Release note**:
Release note will be set when we update this to stable 0.9.8. 
```release-note
NONE
```
