### PR TITLE
Extend timeout to deal with pkg/master flake.

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -114,6 +114,7 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "long",
     srcs = [
         "client_ca_hook_test.go",
         "controller_test.go",


### PR DESCRIPTION
**What this PR does / why we need it**:

Workaround for bug #59450.
Related to PR #59441.
Locally test runs about 90 seconds.
However on the bazel-test CI the test frequently runs over 5 minutes.
Extending the timeout as a work-around to ease the rerun problem.
As @mikedanese notes :-

The Validate calls to the vendored go-openapi library are which make the test slow:
https://github.com/kubernetes/kubernetes/blob/master/pkg/master/master_openapi_test.go#L91
We should probably do more perf and send a patch to upstream.

**Special notes for your reviewer**:
This is intended as a work-around to unblock other PRs while someone investigates the timeout issue.

**Release note**:
```release-note
NONE
```
