### PR TITLE
Use SeekStart, SeekCurrent, and SeekEnd repalace of deprecated constant

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -278,7 +278,7 @@ func ReadLogs(path, containerID string, opts *LogOptions, runtimeService interna
 	if err != nil {
 		return fmt.Errorf("failed to tail %d lines of log file %q: %v", opts.tail, path, err)
 	}
-	if _, err := f.Seek(start, os.SEEK_SET); err != nil {
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
 		return fmt.Errorf("failed to seek %d in log file %q: %v", start, path, err)
 	}
 
@@ -303,7 +303,7 @@ func ReadLogs(path, containerID string, opts *LogOptions, runtimeService interna
 			if opts.follow {
 				// Reset seek so that if this is an incomplete line,
 				// it will be read again.
-				if _, err := f.Seek(-int64(len(l)), os.SEEK_CUR); err != nil {
+				if _, err := f.Seek(-int64(len(l)), io.SeekCurrent); err != nil {
 					return fmt.Errorf("failed to reset seek in log file %q: %v", path, err)
 				}
 				if watcher == nil {

--- a/pkg/util/tail/tail.go
+++ b/pkg/util/tail/tail.go
@@ -53,7 +53,7 @@ func ReadAtMost(path string, max int64) ([]byte, bool, error) {
 	if size < max {
 		max = size
 	}
-	offset, err := f.Seek(-max, os.SEEK_END)
+	offset, err := f.Seek(-max, io.SeekEnd)
 	if err != nil {
 		return nil, false, err
 	}
@@ -70,7 +70,7 @@ func FindTailLineStartIndex(f io.ReadSeeker, n int64) (int64, error) {
 	if n < 0 {
 		return 0, nil
 	}
-	size, err := f.Seek(0, os.SEEK_END)
+	size, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return 0, err
 	}
@@ -82,7 +82,7 @@ func FindTailLineStartIndex(f io.ReadSeeker, n int64) (int64, error) {
 			left = 0
 			buf = make([]byte, right)
 		}
-		if _, err := f.Seek(left, os.SEEK_SET); err != nil {
+		if _, err := f.Seek(left, io.SeekStart); err != nil {
 			return 0, err
 		}
 		if _, err := f.Read(buf); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use SeekStart, SeekCurrent, and SeekEnd repalace of deprecated constant.
'''
// Deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.
const (
	SEEK_SET int = 0 // seek relative to the origin of the file
	SEEK_CUR int = 1 // seek relative to the current offset
	SEEK_END int = 2 // seek relative to the end
)

'''
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
