### PR TITLE
update admissionregistration v1alpha1 to v1beta1

### DIFF
--- a/examples/cloud-controller-manager/persistent-volume-label-initializer-config.yaml
+++ b/examples/cloud-controller-manager/persistent-volume-label-initializer-config.yaml
@@ -1,5 +1,5 @@
 kind: InitializerConfiguration
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 metadata:
   name: pvlabel.kubernetes.io
 initializers:

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -477,7 +477,7 @@ function start_apiserver {
         if [[ -n "${RUNTIME_CONFIG}" ]]; then
           RUNTIME_CONFIG+=","
         fi
-        RUNTIME_CONFIG+="admissionregistration.k8s.io/v1alpha1"
+        RUNTIME_CONFIG+="admissionregistration.k8s.io/v1beta1"
     fi
 
     if [[ ${ENABLE_ADMISSION_PLUGINS} == *"PodPreset"* ]]; then


### PR DESCRIPTION

**What this PR does / why we need it**: 
admissionregistration v1beta1 has been enabled by default (#56687)

**Which issue(s) this PR fixes** 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
