### PR TITLE
Add instructions on how to debug a crashed pod

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -104,12 +104,13 @@ var (
 			- 'systemctl status kubelet'
 			- 'journalctl -xeu kubelet'
 		
-		Additionally a service may not have come up in docker. If that's the case, you can enumerate all docker
-		containers that have been started (including ones that have crashed and exited) by running the following commands:
+		Additionally a control plane component may not have come up in docker. If that's the case, you can enumerate 
+		all docker containers that have been started (including ones that have crashed and exited) by running the
+		following commands:
 			- 'docker ps -a'
 		
-		Once you have that list, you can inspect the logs for any job with:
-			- 'docker logs $INSTANCEID'
+		Once you have that list, you can inspect the logs for any pod with:
+			- 'docker logs $CONTAINERID'
 		`)))
 )
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -103,6 +103,13 @@ var (
 		If you are on a systemd-powered system, you can try to troubleshoot the error with the following commands:
 			- 'systemctl status kubelet'
 			- 'journalctl -xeu kubelet'
+		
+		Additionally a service may not have come up in docker. If that's the case, you can enumerate all docker
+		containers that have been started (including ones that have crashed and exited) by running the following commands:
+			- 'docker ps -a'
+		
+		Once you have that list, you can inspect the logs for any job with:
+			- 'docker logs $INSTANCEID'
 		`)))
 )
 


### PR DESCRIPTION
When I was using `kubeadm init`, I ran into an issue where I had passed an
invalid flag through the kubeadm config file. The flag was being passed into
apiserver and preventing it from launching with a "unknown flag" error.

The flag in question is (other flags elided for clarity):

```
admission-control: ...,GenericAdmissionWebhook,...
```

Since this prevented the apiserver from coming up, the setup timed out
and gave me the error message I just modified.

It would be better if the config was vetted more thoroughly, but I think
documenting the backup strategy for viewing logs in case of failure is
also valuable.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR extends an error message in kubeadm to make it clear a potential step forward for new cluster users.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59731 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
