### PR TITLE
Make kubeadm config imageRepository can implement coredns

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -169,12 +169,14 @@ func coreDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interfac
 	}
 
 	// Get the config file for CoreDNS
-	coreDNSConfigMapBytes, err := kubeadmutil.ParseTemplate(CoreDNSConfigMap, struct{ DNSDomain, UpstreamNameserver, Federation, StubDomain string }{
-		DNSDomain:          coreDNSDomain,
-		UpstreamNameserver: upstreamNameserver,
-		Federation:         federations,
-		StubDomain:         stubDomain,
-	})
+	coreDNSConfigMapBytes, err := kubeadmutil.ParseTemplate(CoreDNSConfigMap,
+		struct{ ImageRepository, DNSDomain, UpstreamNameserver, Federation, StubDomain string }{
+			ImageRepository:    cfg.ImageRepository,
+			DNSDomain:          coreDNSDomain,
+			UpstreamNameserver: upstreamNameserver,
+			Federation:         federations,
+			StubDomain:         stubDomain,
+		})
 	if err != nil {
 		return fmt.Errorf("error when parsing CoreDNS configMap template: %v", err)
 	}

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -115,9 +115,10 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: CoreDNSDeployment,
-			data: struct{ MasterTaintKey, Version string }{
-				MasterTaintKey: "foo",
-				Version:        "foo",
+			data: struct{ ImageRepository, MasterTaintKey, Version string }{
+				ImageRepository: "foo",
+				MasterTaintKey:  "foo",
+				Version:         "foo",
 			},
 			expected: true,
 		},

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -245,7 +245,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns
-        image: coredns/coredns:{{ .Version }}
+        image: {{ .ImageRepository }}/coredns:{{ .Version }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make the kubeadm's config `imageRepository` can implement on `coredns`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I know coredns images configuration for the Deployment are using index.docker.io as a registry, and I think we should support overwriting the registry just like other repositories. There are occasions or places where access to grc.io or index.docker.io registry is restricted, therefore there should be a way to set a mirror as a fallback. The only downside from this implementation would be to add an external process to sync coredns images to the default registry. I am aware that this could add complexity to the process, and I am open to discuss further a solution to this problem, including changing this pull-request to satisfy both needs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
      Kubeadm's coredns deployment configuration using imageRepository just like other images
```
