### PR TITLE
Automated cherry pick of #59747: Map correct vmset name for internal load balancers

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -228,7 +228,7 @@ func (az *Cloud) getAgentPoolAvailabiliySets(nodes []*v1.Node) (agentPoolAvailab
 
 func (az *Cloud) mapLoadBalancerNameToAvailabilitySet(lbName string, clusterName string) (availabilitySetName string) {
 	availabilitySetName = strings.TrimSuffix(lbName, InternalLoadBalancerNameSuffix)
-	if strings.EqualFold(clusterName, lbName) {
+	if strings.EqualFold(clusterName, availabilitySetName) {
 		availabilitySetName = az.Config.PrimaryAvailabilitySetName
 	}
 

--- a/pkg/cloudprovider/providers/azure/azure_util_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_util_test.go
@@ -51,3 +51,45 @@ func TestGetVmssInstanceID(t *testing.T) {
 		}
 	}
 }
+
+func TestMapLoadBalancerNameToAvailabilitySet(t *testing.T) {
+	az := getTestCloud()
+	az.PrimaryAvailabilitySetName = "primary"
+
+	cases := []struct {
+		description   string
+		lbName        string
+		clusterName   string
+		expectedVMSet string
+	}{
+		{
+			description:   "default external LB should map to primary vmset",
+			lbName:        "azure",
+			clusterName:   "azure",
+			expectedVMSet: "primary",
+		},
+		{
+			description:   "default internal LB should map to primary vmset",
+			lbName:        "azure-internal",
+			clusterName:   "azure",
+			expectedVMSet: "primary",
+		},
+		{
+			description:   "non-default external LB should map to its own vmset",
+			lbName:        "azuretest",
+			clusterName:   "azure",
+			expectedVMSet: "azuretest",
+		},
+		{
+			description:   "non-default internal LB should map to its own vmset",
+			lbName:        "azuretest-internal",
+			clusterName:   "azure",
+			expectedVMSet: "azuretest",
+		},
+	}
+
+	for _, c := range cases {
+		vmset := az.mapLoadBalancerNameToAvailabilitySet(c.lbName, c.clusterName)
+		assert.Equal(t, c.expectedVMSet, vmset, c.description)
+	}
+}


### PR DESCRIPTION
Cherry pick of #59747 on release-1.9.

#59747: Map correct vmset name for internal load balancers