### PR TITLE
bump debian-base for updates

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10
+  debian_iptables_version=v11
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.3
+TAG ?= 0.4
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,11 +19,11 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=debian-hyperkube-base
-TAG=0.8
+TAG=0.9
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10
+TAG=v11
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.9.1
@@ -34,7 +34,7 @@ ifeq ($(ARCH),s390x)
 	QEMUARCH=s390x
 endif
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -62,7 +62,7 @@ docker_pull(
     digest = "sha256:a3b936c0fb98a934eecd2cfb91f73658d402b29116084e778ce9ddb68e55383e",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10",  # ignored, but kept here for documentation
+    tag = "v11",  # ignored, but kept here for documentation
 )
 
 docker_pull(
@@ -70,7 +70,7 @@ docker_pull(
     digest = "sha256:fc1b461367730660ac5a40c1eb2d1b23221829acf8a892981c12361383b3742b",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.8",  # ignored, but kept here for documentation
+    tag = "0.9",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.8
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.9
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.4
+arm=k8s.gcr.io/debian-base-arm:0.4
+arm64=k8s.gcr.io/debian-base-arm64:0.4
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.4
+arm=k8s.gcr.io/debian-base-arm:0.4
+arm64=k8s.gcr.io/debian-base-arm64:0.4
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.4
+arm=k8s.gcr.io/debian-base-arm:0.4
+arm64=k8s.gcr.io/debian-base-arm64:0.4
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.4
+arm=k8s.gcr.io/debian-base-arm:0.4
+arm64=k8s.gcr.io/debian-base-arm64:0.4
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4


### PR DESCRIPTION
**What this PR does / why we need it**: Bumps the debian base image to include updated packages. This is a manual bump until automated base packages get put into the tree, and (https://github.com/kubernetes/kubernetes/issues/58012) can be fixed.

An automated proof of concept using Google Container Builder is here https://github.com/rphillips/kubernetes-base-image-builder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

/cc @ixdy  

```release-note
NONE
```

/cc @kubernetes/sig-node-pr-reviews 