### PR TITLE
Fix broken systemd detection in containerized kubelet

### DIFF
--- a/pkg/util/nsenter/nsenter.go
+++ b/pkg/util/nsenter/nsenter.go
@@ -119,6 +119,6 @@ func (ne *Nsenter) AbsHostPath(command string) string {
 
 // SupportsSystemd checks whether command systemd-run exists
 func (ne *Nsenter) SupportsSystemd() (string, bool) {
-	systemdRunPath, hasSystemd := ne.paths["systemd-run"]
-	return systemdRunPath, hasSystemd
+	systemdRunPath := ne.paths["systemd-run"]
+	return systemdRunPath, systemdRunPath != ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It appears that detection of whether the host has systemd is broken in the containerized kubelet code. The code returns true if the `systemd-run` entry is present in the `paths` map, but the entry is always present in the paths map, so it always returns true even if the host doesn't have the `systemd-run` binary.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE

```