### PR TITLE
bazel: update digests for debian-iptables-amd64 and busybox

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -59,7 +59,7 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:a3b936c0fb98a934eecd2cfb91f73658d402b29116084e778ce9ddb68e55383e",
+    digest = "sha256:fb18678f8203ca1bd2fad2671e3ebd80cb408a1baae423d4ad39c05f4caac4e1",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
     tag = "v10",  # ignored, but kept here for documentation

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -75,7 +75,7 @@ docker_pull(
 
 docker_pull(
     name = "official_busybox",
-    digest = "sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642",
+    digest = "sha256:4cee1979ba0bf7db9fc5d28fb7b798ca69ae95a47c5fecf46327720df4ff352d",
     registry = "index.docker.io",
     repository = "library/busybox",
     tag = "latest",  # ignored, but kept here for documentation


### PR DESCRIPTION
**What this PR does / why we need it**: I've pushed updated (rebased) versions of the `debian-base-ARCH:0.3` and `debian-iptables-ARCH:v10` images. Since bazel uses the sha256 digest instead of the tag, we need to update those accordingly.

I also bumped the busybox digest, which hasn't been updated since last summer. This is updating it from v1.26.2 to v1.28.0. Note that the non-bazel build process uses `busybox:latest`, and so has already been using busybox v1.28.0.

**Special notes for your reviewer**:
We will update the hyperkube-base image in #57648.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @tallclair 
/cc @rphillips @rvkubiak