### PR TITLE
[WIP] Improve fake.RESTClient test cases by eliminating mixed api prefix use

### DIFF
--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -178,25 +178,23 @@ func TestPodAndContainerAttach(t *testing.T) {
 func TestAttach(t *testing.T) {
 	version := legacyscheme.Registry.GroupOrDie(api.GroupName).GroupVersion.Version
 	tests := []struct {
-		name, version, podPath, fetchPodPath, attachPath, container string
-		pod                                                         *api.Pod
-		remoteAttachErr                                             bool
-		exepctedErr                                                 string
+		name, version, podPath, attachPath, container string
+		pod                                           *api.Pod
+		remoteAttachErr                               bool
+		exepctedErr                                   string
 	}{
 		{
-			name:         "pod attach",
-			version:      version,
-			podPath:      "/api/" + version + "/namespaces/test/pods/foo",
-			fetchPodPath: "/namespaces/test/pods/foo",
-			attachPath:   "/api/" + version + "/namespaces/test/pods/foo/attach",
-			pod:          attachPod(),
-			container:    "bar",
+			name:       "pod attach",
+			version:    version,
+			podPath:    "/api/" + version + "/namespaces/test/pods/foo",
+			attachPath: "/api/" + version + "/namespaces/test/pods/foo/attach",
+			pod:        attachPod(),
+			container:  "bar",
 		},
 		{
 			name:            "pod attach error",
 			version:         version,
 			podPath:         "/api/" + version + "/namespaces/test/pods/foo",
-			fetchPodPath:    "/namespaces/test/pods/foo",
 			attachPath:      "/api/" + version + "/namespaces/test/pods/foo/attach",
 			pod:             attachPod(),
 			remoteAttachErr: true,
@@ -204,27 +202,24 @@ func TestAttach(t *testing.T) {
 			exepctedErr:     "attach error",
 		},
 		{
-			name:         "container not found error",
-			version:      version,
-			podPath:      "/api/" + version + "/namespaces/test/pods/foo",
-			fetchPodPath: "/namespaces/test/pods/foo",
-			attachPath:   "/api/" + version + "/namespaces/test/pods/foo/attach",
-			pod:          attachPod(),
-			container:    "foo",
-			exepctedErr:  "cannot attach to the container: container not found (foo)",
+			name:        "container not found error",
+			version:     version,
+			podPath:     "/api/" + version + "/namespaces/test/pods/foo",
+			attachPath:  "/api/" + version + "/namespaces/test/pods/foo/attach",
+			pod:         attachPod(),
+			container:   "foo",
+			exepctedErr: "cannot attach to the container: container not found (foo)",
 		},
 	}
 	for _, test := range tests {
 		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
+			VersionedAPIPath:     "/api/v1",
 			GroupVersion:         legacyscheme.Registry.GroupOrDie(api.GroupName).GroupVersion,
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
 				case p == test.podPath && m == "GET":
-					body := objBody(codec, test.pod)
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
-				case p == test.fetchPodPath && m == "GET":
 					body := objBody(codec, test.pod)
 					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 				default:
@@ -286,32 +281,29 @@ func TestAttach(t *testing.T) {
 func TestAttachWarnings(t *testing.T) {
 	version := legacyscheme.Registry.GroupOrDie(api.GroupName).GroupVersion.Version
 	tests := []struct {
-		name, container, version, podPath, fetchPodPath, expectedErr string
-		pod                                                          *api.Pod
-		stdin, tty                                                   bool
+		name, container, version, podPath, expectedErr string
+		pod                                            *api.Pod
+		stdin, tty                                     bool
 	}{
 		{
-			name:         "fallback tty if not supported",
-			version:      version,
-			podPath:      "/api/" + version + "/namespaces/test/pods/foo",
-			fetchPodPath: "/namespaces/test/pods/foo",
-			pod:          attachPod(),
-			stdin:        true,
-			tty:          true,
-			expectedErr:  "Unable to use a TTY - container bar did not allocate one",
+			name:        "fallback tty if not supported",
+			version:     version,
+			podPath:     "/api/" + version + "/namespaces/test/pods/foo",
+			pod:         attachPod(),
+			stdin:       true,
+			tty:         true,
+			expectedErr: "Unable to use a TTY - container bar did not allocate one",
 		},
 	}
 	for _, test := range tests {
 		f, tf, codec, ns := cmdtesting.NewAPIFactory()
 		tf.Client = &fake.RESTClient{
+			VersionedAPIPath:     "/api/v1",
 			GroupVersion:         legacyscheme.Registry.GroupOrDie(api.GroupName).GroupVersion,
 			NegotiatedSerializer: ns,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
 				case p == test.podPath && m == "GET":
-					body := objBody(codec, test.pod)
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
-				case p == test.fetchPodPath && m == "GET":
 					body := objBody(codec, test.pod)
 					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 				default:


### PR DESCRIPTION

**What this PR does / why we need it**:

In #59705, a suboptimal test client construction was discussed, and a better method is implemented.  This PR tries to identify similar cases and update them.

**Which issue(s) this PR fixes**
Fixes #59765

**Special notes for your reviewer**:

So far I have only found one, where the construction was copied from, but there are numerous other cases where req.paths are declared with and without api prefix in the same test client set up with different paths, see an example in #59765.

**Release note**:

```release-note
NONE
```

/cc @liggitt 
/sig cli