### PR TITLE
apiextensions: optimize customresource discovery using atomic.Value

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/apiserver/pkg/endpoints/discovery"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -172,13 +171,15 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	versionDiscoveryHandler := &versionDiscoveryHandler{
-		discovery: map[schema.GroupVersion]*discovery.APIVersionHandler{},
-		delegate:  delegateHandler,
+		delegate: delegateHandler,
 	}
+	versionDiscoveryHandler.discoveryStorage.Store(versionDiscoveryMap{})
+
 	groupDiscoveryHandler := &groupDiscoveryHandler{
-		discovery: map[string]*discovery.APIGroupHandler{},
-		delegate:  delegateHandler,
+		delegate: delegateHandler,
 	}
+	groupDiscoveryHandler.discoveryStorage.Store(groupDiscoveryMap{})
+
 	crdHandler := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,
 		groupDiscoveryHandler,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -263,7 +263,7 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 
 	// Copy because we cannot write to storageMap without a race
 	// as it is used without locking elsewhere.
-	storageMap2 := storageMap.clone()
+	storageMap2 := clone(storageMap).(crdStorageMap)
 	if oldInfo, ok := storageMap2[types.UID(oldCRD.UID)]; ok {
 		oldInfo.storage.DestroyFunc()
 		delete(storageMap2, types.UID(oldCRD.UID))
@@ -286,7 +286,7 @@ func (r *crdHandler) removeDeadStorage() {
 	storageMap := r.customStorage.Load().(crdStorageMap)
 	// Copy because we cannot write to storageMap without a race
 	// as it is used without locking elsewhere
-	storageMap2 := storageMap.clone()
+	storageMap2 := clone(storageMap).(crdStorageMap)
 	for uid, s := range storageMap2 {
 		found := false
 		for _, crd := range allCustomResourceDefinitions {
@@ -417,7 +417,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensions.CustomResource
 
 	// Copy because we cannot write to storageMap without a race
 	// as it is used without locking elsewhere.
-	storageMap2 := storageMap.clone()
+	storageMap2 := clone(storageMap).(crdStorageMap)
 
 	storageMap2[crd.UID] = ret
 	r.customStorage.Store(storageMap2)
@@ -534,17 +534,4 @@ func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (gen
 		ret.Decorator = genericregistry.StorageWithCacher(t.DefaultWatchCacheSize)
 	}
 	return ret, nil
-}
-
-// clone returns a clone of the provided crdStorageMap.
-// The clone is a shallow copy of the map.
-func (in crdStorageMap) clone() crdStorageMap {
-	if in == nil {
-		return nil
-	}
-	out := make(crdStorageMap, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
-	return out
 }


### PR DESCRIPTION
Fixes TODO: optimize customresource discovery using `atomic.Value` since writing is infrequent.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts liggitt hzxuzhonghu 
