### PR TITLE
staging: add boilerplate header

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
@@ -53,7 +53,7 @@ INPUT="--input ${INPUT_APIS[@]}"
 CLIENTSET_PATH="--output-package k8s.io/apiextensions-apiserver/pkg/client/clientset"
 
 ${CLIENTGEN} ${INPUT_BASE} ${INPUT} ${CLIENTSET_PATH} --output-base ${SCRIPT_BASE}
-${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input apiextensions/v1beta1 ${CLIENTSET_PATH}  --output-base ${SCRIPT_BASE}
+${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input apiextensions/v1beta1 ${CLIENTSET_PATH}  --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
 
 echo "Building lister-gen"
@@ -62,7 +62,7 @@ go build -o "${listergen}" ${CODEGEN_PKG}/cmd/lister-gen
 
 LISTER_INPUT="--input-dirs k8s.io/apiextensions-apiserver/pkg/apis/apiextensions --input-dirs k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 LISTER_PATH="--output-package k8s.io/apiextensions-apiserver/pkg/client/listers"
-${listergen} ${LISTER_INPUT} ${LISTER_PATH} --output-base ${SCRIPT_BASE}
+${listergen} ${LISTER_INPUT} ${LISTER_PATH} --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
 
 echo "Building informer-gen"
@@ -75,5 +75,6 @@ ${informergen} \
   --versioned-clientset-package k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset \
   --internal-clientset-package k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset \
   --listers-package k8s.io/apiextensions-apiserver/pkg/client/listers \
-  --output-package k8s.io/apiextensions-apiserver/pkg/client/informers
+  --output-package k8s.io/apiextensions-apiserver/pkg/client/informers \
+  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
   "$@"

--- a/staging/src/k8s.io/kube-aggregator/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/kube-aggregator/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -55,7 +55,7 @@ INPUT="--input ${INPUT_APIS[@]}"
 CLIENTSET_PATH="--output-package k8s.io/kube-aggregator/pkg/client/clientset_generated"
 
 ${CLIENTGEN} ${INPUT_BASE} ${INPUT} ${CLIENTSET_PATH} --output-base ${SCRIPT_BASE}
-${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input apiregistration/v1beta1,apiregistration/v1 ${CLIENTSET_PATH}  --output-base ${SCRIPT_BASE}
+${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input apiregistration/v1beta1,apiregistration/v1 ${CLIENTSET_PATH}  --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
 
 echo "Building lister-gen"
@@ -64,7 +64,7 @@ go build -o "${listergen}" ${CODEGEN_PKG}/cmd/lister-gen
 
 LISTER_INPUT="--input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration --input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1,k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 LISTER_PATH="--output-package k8s.io/kube-aggregator/pkg/client/listers"
-${listergen} ${LISTER_INPUT} ${LISTER_PATH} --output-base ${SCRIPT_BASE}
+${listergen} ${LISTER_INPUT} ${LISTER_PATH} --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
 
 echo "Building informer-gen"
@@ -77,5 +77,6 @@ ${informergen} \
   --versioned-clientset-package k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset \
   --internal-clientset-package k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset \
   --listers-package k8s.io/kube-aggregator/pkg/client/listers \
-  --output-package k8s.io/kube-aggregator/pkg/client/informers
+  --output-package k8s.io/kube-aggregator/pkg/client/informers \
+  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
   "$@"

--- a/staging/src/k8s.io/metrics/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/metrics/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/metrics/hack/update-codegen.sh
+++ b/staging/src/k8s.io/metrics/hack/update-codegen.sh
@@ -36,7 +36,7 @@ PREFIX=k8s.io/metrics/pkg/apis
 INPUT_BASE="--input-base ${PREFIX}"
 CLIENTSET_PATH="--output-package k8s.io/metrics/pkg/client/clientset_generated"
 
-${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input metrics/v1alpha1 --input metrics/v1beta1 ${CLIENTSET_PATH} --output-base ${SCRIPT_BASE}
+${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input metrics/v1alpha1 --input metrics/v1beta1 ${CLIENTSET_PATH} --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
 # we skip informers and listers for metrics, because we don't quite support the requisite operations yet
 # we skip generating the internal clientset as it's not really needed

--- a/staging/src/k8s.io/sample-apiserver/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/sample-apiserver/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-apiserver/hack/update-codegen.sh
@@ -28,7 +28,8 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
 ${CODEGEN_PKG}/generate-internal-groups.sh all \
   k8s.io/sample-apiserver/pkg/client k8s.io/sample-apiserver/pkg/apis k8s.io/sample-apiserver/pkg/apis \
   wardle:v1alpha1 \
-  --output-base "$(dirname ${BASH_SOURCE})/../../.."
+  --output-base "$(dirname ${BASH_SOURCE})/../../.." \
+  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
-# To use your own boilerplate text append:
+# To use your own boilerplate text use:
 #   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt

--- a/staging/src/k8s.io/sample-controller/hack/boilerplate.go.txt
+++ b/staging/src/k8s.io/sample-controller/hack/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
+++ b/staging/src/k8s.io/sample-controller/hack/update-codegen.sh
@@ -28,7 +28,8 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
 ${CODEGEN_PKG}/generate-groups.sh "deepcopy,client,informer,lister" \
   k8s.io/sample-controller/pkg/client k8s.io/sample-controller/pkg/apis \
   samplecontroller:v1alpha1 \
-  --output-base "$(dirname ${BASH_SOURCE})/../../.."
+  --output-base "$(dirname ${BASH_SOURCE})/../../.." \
+  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
 
-# To use your own boilerplate text append:
+# To use your own boilerplate text use:
 #   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/kubernetes/pull/57656.

Adds boilerplate in the relevant staging repos so that they don't need to depend on code-generator's boilerplate.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts fisherxu 
