### PR TITLE
Remove duplicated definition of ResourceList in Metrics API

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/BUILD
@@ -15,7 +15,7 @@ go_library(
     ],
     importpath = "k8s.io/metrics/pkg/apis/metrics",
     deps = [
-        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metrics
 
 import (
-	"k8s.io/apimachinery/pkg/api/resource"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +38,7 @@ type NodeMetrics struct {
 	Window    metav1.Duration
 
 	// The memory usage is the memory working set.
-	Usage ResourceList
+	Usage corev1.ResourceList
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -91,19 +91,5 @@ type ContainerMetrics struct {
 	// Container name corresponding to the one from pod.spec.containers.
 	Name string
 	// The memory usage is the memory working set.
-	Usage ResourceList
+	Usage corev1.ResourceList
 }
-
-// NOTE: ResourceName and ResourceList are copied from
-// k8s.io/kubernetes/pkg/api/types.go. We cannot depend on
-// k8s.io/kubernetes/pkg/api because that creates cyclic dependency between
-// k8s.io/metrics and k8s.io/kubernetes. We cannot depend on
-// k8s.io/client-go/pkg/api because the package is going to be deprecated soon.
-// There is no need to keep them exact copies. Each repo can define its own
-// internal objects.
-
-// ResourceList is a set of (resource name, quantity) pairs.
-type ResourceList map[ResourceName]resource.Quantity
-
-// ResourceName is the name identifying various resources in a ResourceList.
-type ResourceName string

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
@@ -52,7 +52,7 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_ContainerMetrics_To_metrics_ContainerMetrics(in *ContainerMetrics, out *metrics.ContainerMetrics, s conversion.Scope) error {
 	out.Name = in.Name
-	out.Usage = *(*metrics.ResourceList)(unsafe.Pointer(&in.Usage))
+	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
 	return nil
 }
 
@@ -76,7 +76,7 @@ func autoConvert_v1alpha1_NodeMetrics_To_metrics_NodeMetrics(in *NodeMetrics, ou
 	out.ObjectMeta = in.ObjectMeta
 	out.Timestamp = in.Timestamp
 	out.Window = in.Window
-	out.Usage = *(*metrics.ResourceList)(unsafe.Pointer(&in.Usage))
+	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/zz_generated.conversion.go
@@ -52,7 +52,7 @@ func RegisterConversions(scheme *runtime.Scheme) error {
 
 func autoConvert_v1beta1_ContainerMetrics_To_metrics_ContainerMetrics(in *ContainerMetrics, out *metrics.ContainerMetrics, s conversion.Scope) error {
 	out.Name = in.Name
-	out.Usage = *(*metrics.ResourceList)(unsafe.Pointer(&in.Usage))
+	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
 	return nil
 }
 
@@ -76,7 +76,7 @@ func autoConvert_v1beta1_NodeMetrics_To_metrics_NodeMetrics(in *NodeMetrics, out
 	out.ObjectMeta = in.ObjectMeta
 	out.Timestamp = in.Timestamp
 	out.Window = in.Window
-	out.Usage = *(*metrics.ResourceList)(unsafe.Pointer(&in.Usage))
+	out.Usage = *(*v1.ResourceList)(unsafe.Pointer(&in.Usage))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package metrics
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -29,7 +30,7 @@ func (in *ContainerMetrics) DeepCopyInto(out *ContainerMetrics) {
 	*out = *in
 	if in.Usage != nil {
 		in, out := &in.Usage, &out.Usage
-		*out = make(ResourceList, len(*in))
+		*out = make(v1.ResourceList, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val.DeepCopy()
 		}
@@ -56,7 +57,7 @@ func (in *NodeMetrics) DeepCopyInto(out *NodeMetrics) {
 	out.Window = in.Window
 	if in.Usage != nil {
 		in, out := &in.Usage, &out.Usage
-		*out = make(ResourceList, len(*in))
+		*out = make(v1.ResourceList, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val.DeepCopy()
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove duplicated definition of ResourceList in Metrics API

**Release note**:
```release-note
NONE
```
