### PR TITLE
Implement subresource for Node.Spec.ConfigSource

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4049,6 +4049,9 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
 
 	// Allow updates to Node.Spec.ConfigSource if DynamicKubeletConfig feature gate is enabled
 	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicKubeletConfig) {
+		if node.Spec.ConfigSource != nil {
+			allErrs = append(allErrs, validateNodeConfigSource(node.Spec.ConfigSource, field.NewPath("spec", "configSource"))...)
+		}
 		oldNode.Spec.ConfigSource = node.Spec.ConfigSource
 	}
 
@@ -4059,6 +4062,25 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "node updates may only change labels, taints, or capacity (or configSource, if the DynamicKubeletConfig feature gate is enabled)"))
 	}
 
+	return allErrs
+}
+
+func validateNodeConfigSource(source *core.NodeConfigSource, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	count := int(0)
+	if ref := source.ConfigMapRef; ref != nil {
+		count++
+		// name, namespace, and UID must all be non-empty for ConfigMapRef
+		if ref.Name == "" || ref.Namespace == "" || string(ref.UID) == "" {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("configMapRef"), ref, "name, namespace, and UID must all be non-empty"))
+		}
+	}
+	// add more subfields here in the future as they are added to NodeConfigSource
+
+	// exactly one reference subfield must be non-nil
+	if count != 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath, source, "exactly one reference subfield must be non-nil"))
+	}
 	return allErrs
 }
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -238,6 +238,9 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	if serviceAccountStorage.Token != nil {
 		restStorageMap["serviceaccounts/token"] = serviceAccountStorage.Token
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicKubeletConfig) {
+		restStorageMap["nodes/configsource"] = nodeStorage.ConfigSource
+	}
 	apiGroupInfo.VersionedResourcesStorageMap["v1"] = restStorageMap
 
 	return restStorage, apiGroupInfo, nil

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4062,6 +4062,7 @@ type ResourceList map[ResourceName]resource.Quantity
 
 // +genclient
 // +genclient:nonNamespaced
+// +genclient:method=UpdateConfigSource,verb=update,subresource=configsource
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Node is a worker node in Kubernetes.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -127,3 +127,13 @@ func (c *FakeNodes) Patch(name string, pt types.PatchType, data []byte, subresou
 	}
 	return obj.(*core_v1.Node), err
 }
+
+// UpdateConfigSource takes the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
+func (c *FakeNodes) UpdateConfigSource(nodeName string, node *core_v1.Node) (result *core_v1.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(nodesResource, node), &core_v1.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Node), err
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -42,6 +42,8 @@ type NodeInterface interface {
 	List(opts meta_v1.ListOptions) (*v1.NodeList, error)
 	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Node, err error)
+	UpdateConfigSource(nodeName string, node *v1.Node) (*v1.Node, error)
+
 	NodeExpansion
 }
 
@@ -155,6 +157,19 @@ func (c *nodes) Patch(name string, pt types.PatchType, data []byte, subresources
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateConfigSource takes the top resource name and the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
+func (c *nodes) UpdateConfigSource(nodeName string, node *v1.Node) (result *v1.Node, err error) {
+	result = &v1.Node{}
+	err = c.client.Put().
+		Resource("nodes").
+		Name(nodeName).
+		SubResource("configsource").
+		Body(node).
 		Do().
 		Into(result)
 	return

--- a/test/e2e_node/dynamic_kubelet_config_test.go
+++ b/test/e2e_node/dynamic_kubelet_config_test.go
@@ -19,6 +19,7 @@ package e2e_node
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -40,6 +41,8 @@ type configState struct {
 	configSource   *apiv1.NodeConfigSource
 	expectConfigOk *apiv1.NodeCondition
 	expectConfig   *kubeletconfig.KubeletConfiguration
+	// whether to expect this substring in an error returned from the API server when updating the config source
+	apierr string
 	// whether the state would cause a config change event as a result of the update to Node.Spec.ConfigSource,
 	// assuming that the current source would have also caused a config change event.
 	// for example, some malformed references may result in a download failure, in which case the Kubelet
@@ -132,25 +135,16 @@ var _ = framework.KubeDescribe("DynamicKubeletConfiguration [Feature:DynamicKube
 
 					// Node.Spec.ConfigSource has all nil subfields
 					{desc: "Node.Spec.ConfigSource has all nil subfields",
-						configSource: &apiv1.NodeConfigSource{ConfigMapRef: nil},
-						expectConfigOk: &apiv1.NodeCondition{Type: apiv1.NodeKubeletConfigOk, Status: apiv1.ConditionFalse,
-							Message: "",
-							Reason:  fmt.Sprintf(status.FailSyncReasonFmt, status.FailSyncReasonAllNilSubfields)},
-						expectConfig: nil,
-						event:        false,
+						configSource: &apiv1.NodeConfigSource{},
+						apierr:       "exactly one reference subfield must be non-nil",
 					},
 
 					// Node.Spec.ConfigSource.ConfigMapRef is partial
 					{desc: "Node.Spec.ConfigSource.ConfigMapRef is partial",
-						// TODO(mtaufen): check the other 7 partials in a unit test
 						configSource: &apiv1.NodeConfigSource{ConfigMapRef: &apiv1.ObjectReference{
 							UID:  "foo",
 							Name: "bar"}}, // missing Namespace
-						expectConfigOk: &apiv1.NodeCondition{Type: apiv1.NodeKubeletConfigOk, Status: apiv1.ConditionFalse,
-							Message: "",
-							Reason:  fmt.Sprintf(status.FailSyncReasonFmt, status.FailSyncReasonPartialObjectReference)},
-						expectConfig: nil,
-						event:        false,
+						apierr: "name, namespace, and UID must all be non-empty",
 					},
 
 					// Node.Spec.ConfigSource's UID does not align with namespace/name
@@ -348,10 +342,20 @@ func setAndTestKubeletConfigState(f *framework.Framework, state *configState, ex
 	// set the desired state, retry a few times in case we are competing with other editors
 	Eventually(func() error {
 		if err := setNodeConfigSource(f, state.configSource); err != nil {
-			return fmt.Errorf("case %s: error setting Node.Spec.ConfigSource", err)
+			if len(state.apierr) == 0 {
+				return fmt.Errorf("case %s: expect nil error but got %q", state.desc, err.Error())
+			} else if !strings.Contains(err.Error(), state.apierr) {
+				return fmt.Errorf("case %s: expect error to contain %q but got %q", state.desc, state.apierr, err.Error())
+			}
+		} else if len(state.apierr) > 0 {
+			return fmt.Errorf("case %s: expect error to contain %q but got nil error", state.desc, state.apierr)
 		}
 		return nil
 	}, time.Minute, time.Second).Should(BeNil())
+	// skip further checks if we expected an API error
+	if len(state.apierr) > 0 {
+		return
+	}
 	// check that config source actually got set to what we expect
 	checkNodeConfigSource(f, state.desc, state.configSource)
 	// check condition

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -197,12 +197,10 @@ func setKubeletConfiguration(f *framework.Framework, kubeCfg *kubeletconfig.Kube
 
 // sets the current node's configSource, this should only be called from Serial tests
 func setNodeConfigSource(f *framework.Framework, source *apiv1.NodeConfigSource) error {
-	// since this is a serial test, we just get the node, change the source, and then update it
-	// this prevents any issues with the patch API from affecting the test results
-	nodeclient := f.ClientSet.CoreV1().Nodes()
+	c := f.ClientSet.CoreV1().Nodes()
 
 	// get the node
-	node, err := nodeclient.Get(framework.TestContext.NodeName, metav1.GetOptions{})
+	node, err := c.Get(framework.TestContext.NodeName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -211,7 +209,7 @@ func setNodeConfigSource(f *framework.Framework, source *apiv1.NodeConfigSource)
 	node.Spec.ConfigSource = source
 
 	// update to the new source
-	_, err = nodeclient.Update(node)
+	_, err = c.UpdateConfigSource(node.Name, node)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements a "nodes/configsource" subresource, which must be
used to update Node.Spec.ConfigSource instead of a standard Node update.

This allows us to write separate access control rules for managing
Node.Spec.ConfigSource vs updating other parts of the Node object.

See: https://github.com/kubernetes/kubernetes/issues/58362

```release-note
Updates to Node.Spec.ConfigSource should now be performed via the "nodes/configsource" subresource.
```

Please sanity check this, it's the first time I've implemented a subresource and I'm not sure if this is the right way to do it (just following in the footsteps of preexisting code).
