### PR TITLE
Make grafana root url configurable in Juju deployments

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -41,6 +41,12 @@ options:
     default: ""
     description: |
       Password to be used for admin user (leave empty for random password).
+  grafana-www-root:
+    type: string
+    default: "/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/"
+    description: |
+      Set this to "/" if you plan to expose the grafana used for cluster monitoring.
+      The default value is for accessing the service through kubectl proxy.
   api-extra-args:
     type: string
     default: ""

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -640,12 +640,14 @@ def configure_cdk_addons():
     remove_state('cdk-addons.configured')
     dbEnabled = str(hookenv.config('enable-dashboard-addons')).lower()
     dnsEnabled = str(hookenv.config('enable-kube-dns')).lower()
+    grafanaWwwRoot = str(hookenv.config('grafana-www-root'))
     args = [
         'arch=' + arch(),
         'dns-ip=' + get_deprecated_dns_ip(),
         'dns-domain=' + hookenv.config('dns_domain'),
         'enable-dashboard=' + dbEnabled,
-        'enable-kube-dns=' + dnsEnabled
+        'enable-kube-dns=' + dnsEnabled,
+        'gf-www=' + grafanaWwwRoot,
     ]
     check_call(['snap', 'set', 'cdk-addons'] + args)
     if not addons_ready():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: With this patch we are able to point grafana resources to wherever we need grafana to be available from. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: This PR has to be merged along with https://github.com/juju-solutions/cdk-addons/pull/26

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
