### PR TITLE
cmd/controller-manager: add OWNERS for generic controller-manager code

### DIFF
--- a/cmd/controller-manager/OWNERS
+++ b/cmd/controller-manager/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- deads2k
+- cheftako
+- sttts
+reviewers:
+- caesarxuchao
+- cheftako
+- deads2k
+- lavalamp
+- liggitt
+- sttts


### PR DESCRIPTION
This should have the same owners as kube-controller-manager.