### PR TITLE
Patch ingress upgrade test to do more robust checking [WIP]

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -224,7 +224,7 @@ func CreateIngressComformanceTests(jig *IngressTestJig, ns string, annotations m
 				})
 				By("Checking that " + pathToFail + " is not exposed by polling for failure")
 				route := fmt.Sprintf("http://%v%v", jig.Address, pathToFail)
-				ExpectNoError(PollURL(route, updateURLMapHost, LoadBalancerCleanupTimeout, jig.PollInterval, &http.Client{Timeout: IngressReqTimeout}, true))
+				ExpectNoError(PollURL(route, updateURLMapHost, LoadBalancerCleanupTimeout, jig.PollInterval, &http.Client{Timeout: IngressReqTimeout}, true, false))
 			},
 			fmt.Sprintf("Waiting for path updates to reflect in L7"),
 		},
@@ -1331,7 +1331,7 @@ func (j *IngressTestJig) pollIngressWithCert(ing *extensions.Ingress, address st
 			}
 			route := fmt.Sprintf("%v://%v%v", proto, address, p.Path)
 			j.Logger.Infof("Testing route %v host %v with simple GET", route, rules.Host)
-			if err := PollURL(route, rules.Host, timeout, j.PollInterval, timeoutClient, false); err != nil {
+			if err := PollURL(route, rules.Host, timeout, j.PollInterval, timeoutClient, false, false); err != nil {
 				return err
 			}
 		}
@@ -1403,7 +1403,7 @@ func (j *IngressTestJig) pollServiceNodePort(ns, name string, port int) error {
 	if err != nil {
 		return err
 	}
-	return PollURL(u, "", 30*time.Second, j.PollInterval, &http.Client{Timeout: IngressReqTimeout}, false)
+	return PollURL(u, "", 30*time.Second, j.PollInterval, &http.Client{Timeout: IngressReqTimeout}, false, false)
 }
 
 func (j *IngressTestJig) GetDefaultBackendNodePort() (int32, error) {

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -80,6 +80,7 @@ const (
 	// On average it takes ~6 minutes for a single backend to come online in GCE.
 	LoadBalancerPollTimeout  = 15 * time.Minute
 	LoadBalancerPollInterval = 30 * time.Second
+	LoadBalancerQuickPollInterval = 500 * time.Millisecond
 
 	LargeClusterMinNodesNumber = 100
 

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -132,10 +132,10 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 
 			By("waiting for Ingress to come up with ip: " + ip)
 			httpClient := framework.BuildInsecureClient(framework.IngressReqTimeout)
-			framework.ExpectNoError(framework.PollURL(fmt.Sprintf("https://%v/", ip), "", framework.LoadBalancerPollTimeout, jig.PollInterval, httpClient, false))
+			framework.ExpectNoError(framework.PollURL(fmt.Sprintf("https://%v/", ip), "", framework.LoadBalancerPollTimeout, jig.PollInterval, httpClient, false, false))
 
 			By("should reject HTTP traffic")
-			framework.ExpectNoError(framework.PollURL(fmt.Sprintf("http://%v/", ip), "", framework.LoadBalancerPollTimeout, jig.PollInterval, httpClient, true))
+			framework.ExpectNoError(framework.PollURL(fmt.Sprintf("http://%v/", ip), "", framework.LoadBalancerPollTimeout, jig.PollInterval, httpClient, true, false))
 
 			By("should have correct firewall rule for ingress")
 			fw := gceController.GetFirewallRule()


### PR DESCRIPTION
**What this PR does / why we need it**:
Hardens the ingress upgrade test. Specifically, we now ping the ingress IP continuously after the upgrade to make sure that there is no downtime for existing paths.

**Release note**:

```release-note
None
```

/cc @nicksardo @MrHohn 
/assign @bowei 


