### PR TITLE
fix markdown formatting for test image doc

### DIFF
--- a/test/images/resource-consumer/README.md
+++ b/test/images/resource-consumer/README.md
@@ -21,7 +21,7 @@ The container consumes specified amount of resources:
 - Memory in megabytes,
 - Fake custom metrics.
 
-###Consume CPU http request
+### Consume CPU http request
 - suffix "ConsumeCPU",
 - parameters "millicores" and "durationSec".
 
@@ -31,7 +31,7 @@ When CPU consumption is too low this binary uses cpu by calculating math.sqrt(0)
 and if consumption is too high binary sleeps for 10 millisecond.
 One replica of Resource Consumer cannot consume more that 1 cpu.
 
-###Consume Memory http request
+### Consume Memory http request
 - suffix "ConsumeMem",
 - parameters "megabytes" and "durationSec".
 
@@ -39,14 +39,14 @@ Consumes specified amount of megabytes for durationSec seconds.
 Consume Memory uses stress tool (stress -m 1 --vm-bytes megabytes --vm-hang 0 -t durationSec).
 Request leading to consuming more memory then container limit will be ignored.
 
-###Bump value of a fake custom metric
+### Bump value of a fake custom metric
 - suffix "BumpMetric",
 - parameters "metric", "delta" and "durationSec".
 
 Bumps metric with given name by delta for durationSec seconds.
 Custom metrics in Prometheus format are exposed on "/metrics" endpoint.
 
-###CURL example
+### CURL example
 ```console
 $ kubectl run resource-consumer --image=k8s.gcr.io/resource_consumer:beta --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080
 $ kubectl get services resource-consumer
@@ -66,20 +66,18 @@ Docker image of Resource Consumer can be found in Google Container Registry as k
 
 ## Use cases
 
-###Cluster size autoscaling
+### Cluster size autoscaling
 1. Consume more resources on each node that is specified for autoscaler
 2. Observe that cluster size increased
 
-###Horizontal autoscaling of pod
+### Horizontal autoscaling of pod
 1. Create consuming RC and start consuming appropriate amount of resources
 2. Observe that RC has been resized
 3. Observe that usage on each replica decreased
 
-###Vertical autoscaling of pod
+### Vertical autoscaling of pod
 1. Create consuming pod and start consuming appropriate amount of resources
 2. Observed that limits has been increased
-
-
 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/images/resource-consumer/README.md?pixel)]()


### PR DESCRIPTION
subtitles were not rendering correctly due to lack of spaces after octothorps.

**Release note**:

None.