### PR TITLE
Support cluster level resources in the node

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -53,6 +53,9 @@ type predicateMetadata struct {
 	serviceAffinityInUse               bool
 	serviceAffinityMatchingPodList     []*v1.Pod
 	serviceAffinityMatchingPodServices []*v1.Service
+	// Extended resources can be cluster level or node level.
+	// When set to true, resource fit predicates will ignore absence of extended resources.
+	ignoreMissingExtendedResources bool
 }
 
 // Ensure that predicateMetadata implements algorithm.PredicateMetadata.
@@ -185,4 +188,12 @@ func (meta *predicateMetadata) ShallowCopy() algorithm.PredicateMetadata {
 	newPredMeta.serviceAffinityMatchingPodList = append([]*v1.Pod(nil),
 		meta.serviceAffinityMatchingPodList...)
 	return (algorithm.PredicateMetadata)(newPredMeta)
+}
+
+// RegisterPodFitsResourcesPredicateMetadataProducer registers additional metadata that are specific to
+// PodFitsResources scheduling predicate.
+func RegisterPodFitsResourcesPredicateMetadataProducer(ignoreMissingExtendedResources bool) {
+	RegisterPredicateMetadataProducer("PodFitsResources", func(pm *predicateMetadata) {
+		pm.ignoreMissingExtendedResources = ignoreMissingExtendedResources
+	})
 }

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -93,11 +93,12 @@ func PredicateMetadata(p *v1.Pod, nodeInfo map[string]*schedulercache.NodeInfo) 
 
 func TestPodFitsResources(t *testing.T) {
 	enoughPodsTests := []struct {
-		pod      *v1.Pod
-		nodeInfo *schedulercache.NodeInfo
-		fits     bool
-		test     string
-		reasons  []algorithm.PredicateFailureReason
+		pod                            *v1.Pod
+		nodeInfo                       *schedulercache.NodeInfo
+		fits                           bool
+		test                           string
+		reasons                        []algorithm.PredicateFailureReason
+		ignoreMissingExtendedResources bool
 	}{
 		{
 			pod: &v1.Pod{},
@@ -323,12 +324,24 @@ func TestPodFitsResources(t *testing.T) {
 			test:    "hugepages resource allocatable enforced for multiple containers",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(hugePageResourceA, 6, 2, 5)},
 		},
+		{
+			pod: newResourcePod(
+				schedulercache.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{"extended.com/foo": 3}},
+				schedulercache.Resource{MilliCPU: 1, Memory: 1, ScalarResources: map[v1.ResourceName]int64{"hello.com/bar": 3}}),
+			nodeInfo: schedulercache.NewNodeInfo(
+				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
+			fits: true,
+			ignoreMissingExtendedResources: true,
+			test: "missing extended resources are ignored",
+		},
 	}
 
 	for _, test := range enoughPodsTests {
 		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 0, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 0, 32, 5, 20, 5)}}
 		test.nodeInfo.SetNode(&node)
-		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+		RegisterPodFitsResourcesPredicateMetadataProducer(test.ignoreMissingExtendedResources)
+		meta := PredicateMetadata(test.pod, nil)
+		fits, reasons, err := PodFitsResources(test.pod, meta, test.nodeInfo)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.test, err)
 		}


### PR DESCRIPTION
Ignore missing extended resources as part of Node Predicate Check Pod admission handles.
This is done to ensure that node supports cluster level resources.

As an unfortunate side-effect, kubelet will run pods that request extended resources advertized by local device plugins that have dynamically unregistered (or gone offline for any reason). This scenario is unexpected and operators are expected to mark nodes unhealthy when device plugins fail in production.

If hotplugging of device plugins is necessary, it can be achieved by the introduction of better compute resource APIs which can include the scope (node or cluster) for each resource. New resource APIs are already being designed. 

```release-note
Kubelet supports extended cluster level resources exposed via scheduler extenders
```

For #53616
This PR and #58851 together fix #53616 