### PR TITLE
juju: Fix broken ingress after upgrade-charm

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -953,15 +953,14 @@ def catch_change_in_creds(kube_control):
     """Request a service restart in case credential updates were detected."""
     nodeuser = 'system:node:{}'.format(get_node_name().lower())
     creds = kube_control.get_auth_credentials(nodeuser)
-    if creds \
-            and data_changed('kube-control.creds', creds) \
-            and creds['user'] == nodeuser:
+    if creds and creds['user'] == nodeuser:
         # We need to cache the credentials here because if the
         # master changes (master leader dies and replaced by a new one)
         # the new master will have no recollection of our certs.
         db.set('credentials', creds)
         set_state('worker.auth.bootstrapped')
-        set_state('kubernetes-worker.restart-needed')
+        if data_changed('kube-control.creds', creds):
+            set_state('kubernetes-worker.restart-needed')
 
 
 @when_not('kube-control.connected')


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a bug that prevents the ingress controller from being deployed after doing an `upgrade-charm`.

Essentially, `worker.auth.bootstrapped` gets cleared during `upgrade-charm`, and it never gets set again. This prevents the `start_worker` and `render_and_launch_ingress` handlers from running, among other things.

This PR fixes that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
