### PR TITLE
lowercase node name in generated static pod name 

### DIFF
--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -108,6 +108,7 @@ go_test(
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/securitycontext:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -21,6 +21,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +45,7 @@ import (
 
 // Generate a pod name that is unique among nodes by appending the nodeName.
 func generatePodName(name string, nodeName types.NodeName) string {
-	return fmt.Sprintf("%s-%s", name, nodeName)
+	return fmt.Sprintf("%s-%s", name, strings.ToLower(string(nodeName)))
 }
 
 func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName) error {

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -20,12 +20,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/core"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
 
@@ -186,6 +191,62 @@ func TestGetSelfLink(t *testing.T) {
 		selfLink := getSelfLink(testCase.name, testCase.namespace)
 		if testCase.expectedSelfLink != selfLink {
 			t.Errorf("%s: getSelfLink error, expected: %s, got: %s", testCase.desc, testCase.expectedSelfLink, selfLink)
+		}
+	}
+}
+
+func TestStaticPodNameGenerate(t *testing.T) {
+	testCases := []struct {
+		nodeName  types.NodeName
+		podName   string
+		expected  string
+		overwrite string
+		shouldErr bool
+	}{
+		{
+			"node1",
+			"static-pod1",
+			"static-pod1-node1",
+			"",
+			false,
+		},
+		{
+			"Node1",
+			"static-pod1",
+			"static-pod1-node1",
+			"",
+			false,
+		},
+		{
+			"NODE1",
+			"static-pod1",
+			"static-pod1-node1",
+			"static-pod1-NODE1",
+			true,
+		},
+	}
+	for _, c := range testCases {
+		assert.Equal(t, c.expected, generatePodName(c.podName, c.nodeName), "wrong pod name generated")
+		pod := &core.Pod{}
+		pod.Name = c.podName
+		if c.overwrite != "" {
+			pod.Name = c.overwrite
+		}
+		errs := validation.ValidatePod(pod)
+		if c.shouldErr {
+			specNameErrored := false
+			for _, err := range errs {
+				if err.Field == "metadata.name" {
+					specNameErrored = true
+				}
+			}
+			assert.NotEmpty(t, specNameErrored, "expecting error")
+		} else {
+			for _, err := range errs {
+				if err.Field == "metadata.name" {
+					t.Fail()
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cast appended node name to lowercase when generating static pod name on kubelet starting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59801 

**Special notes for your reviewer**:
Not sure about how to deal with other illegal node names e.g. containing invalid no-alphabetic characters. Maybe just let it fail-hard is not a bad idea.
But considering that containing uppercase letter in the hostname is somehow a usual case even in the production environment of some companies, tolerating uppercase and cast it implicitly should be good.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
force node name lowercase on static pod name generating
```
