### PR TITLE
Fix instanceID for vmss nodes

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard.go
@@ -60,8 +60,8 @@ const (
 var errNotInVMSet = errors.New("vm is not in the vmset")
 var providerIDRE = regexp.MustCompile(`^` + CloudProviderName + `://(?:.*)/Microsoft.Compute/virtualMachines/(.+)$`)
 
-// returns the full identifier of a machine
-func (az *Cloud) getMachineID(machineName string) string {
+// getStandardMachineID returns the full identifier of a virtual machine.
+func (az *Cloud) getStandardMachineID(machineName string) string {
 	return fmt.Sprintf(
 		machineIDTemplate,
 		az.SubscriptionID,

--- a/pkg/cloudprovider/providers/azure/azure_vmss.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss.go
@@ -39,7 +39,8 @@ var (
 	// ErrorNotVmssInstance indicates an instance is not belongint to any vmss.
 	ErrorNotVmssInstance = errors.New("not a vmss instance")
 
-	scaleSetNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines(?:.*)`)
+	scaleSetNameRE        = regexp.MustCompile(`.*/subscriptions/(?:.*)/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines(?:.*)`)
+	vmssMachineIDTemplate = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s"
 )
 
 // scaleSet implements VMSet interface for Azure scale set.
@@ -734,4 +735,14 @@ func (ss *scaleSet) EnsureBackendPoolDeleted(poolID, vmSetName string) error {
 	}
 
 	return nil
+}
+
+// getVmssMachineID returns the full identifier of a vmss virtual machine.
+func (az *Cloud) getVmssMachineID(scaleSetName, instanceID string) string {
+	return fmt.Sprintf(
+		vmssMachineIDTemplate,
+		az.SubscriptionID,
+		az.ResourceGroup,
+		scaleSetName,
+		instanceID)
 }

--- a/pkg/cloudprovider/providers/azure/azure_vmss_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss_cache.go
@@ -46,7 +46,7 @@ func (ss *scaleSet) makeVmssVMName(scaleSetName, instanceID string) string {
 	return fmt.Sprintf("%s%s%s", scaleSetName, vmssNameSeparator, instanceID)
 }
 
-func (ss *scaleSet) extractVmssVMName(name string) (string, string, error) {
+func extractVmssVMName(name string) (string, string, error) {
 	ret := strings.Split(name, vmssNameSeparator)
 	if len(ret) != 2 {
 		glog.Errorf("Failed to extract vmssVMName %q", name)
@@ -128,7 +128,7 @@ func (ss *scaleSet) newAvailabilitySetNodesCache() (*timedCache, error) {
 func (ss *scaleSet) newVmssVMCache() (*timedCache, error) {
 	getter := func(key string) (interface{}, error) {
 		// vmssVM name's format is 'scaleSetName_instanceID'
-		ssName, instanceID, err := ss.extractVmssVMName(key)
+		ssName, instanceID, err := extractVmssVMName(key)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloudprovider/providers/azure/azure_vmss_cache_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss_cache_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestExtractVmssVMName(t *testing.T) {
-	ss := &scaleSet{}
 	cases := []struct {
 		description        string
 		vmName             string
@@ -50,7 +49,7 @@ func TestExtractVmssVMName(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		ssName, instanceID, err := ss.extractVmssVMName(c.vmName)
+		ssName, instanceID, err := extractVmssVMName(c.vmName)
 		if c.expectError {
 			assert.Error(t, err, c.description)
 			continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When useInstanceMetadata is set to true for vmss nodes, their providerID is wrong.

Their providerID should be in format `azure:///subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.Compute/virtualMachineScaleSets/<scaleset-name>/virtualMachines/<instance-id>`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59855

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix instanceID for vmss nodes.
```
