### PR TITLE
WIP: apiextensions: add transitional version alias support for CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
@@ -24,6 +24,11 @@ type CustomResourceDefinitionSpec struct {
 	Group string
 	// Version is the version this resource belongs in
 	Version string
+	// TransitionalVersionAlias is a version alias of the main version. The CustomResources will be available
+	// under both version, without any conversion being performed and with the same validations being applied.
+	// This can be used to transition an alpha to a beta or beta to a GA version.
+	// +optional
+	TransitionalVersionAlias string
 	// Names are the names used to describe this custom resource
 	Names CustomResourceDefinitionNames
 	// Scope indicates whether this resource is cluster or namespace scoped.  Default is namespaced

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -24,6 +24,11 @@ type CustomResourceDefinitionSpec struct {
 	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	// Version is the version this resource belongs in
 	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`
+	// TransitionalVersionAlias is a version alias of the main version. The CustomResources will be available
+	// under both version, without any conversion being performed and with the same validations being applied.
+	// This can be used to transition an alpha to a beta or beta to a GA version.
+	// +optional
+	TransitionalVersionAlias string `json:"transitional-version-alias,omitempty" protobuf:"bytes,6,opt,name=transitionalVersionAlias"`
 	// Names are the names used to describe this custom resource
 	Names CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
 	// Scope indicates whether this resource is cluster or namespace scoped.  Default is namespaced

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -79,6 +79,13 @@ func ValidateCustomResourceDefinitionSpec(spec *apiextensions.CustomResourceDefi
 	} else if errs := validationutil.IsDNS1035Label(spec.Version); len(errs) > 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("version"), spec.Version, strings.Join(errs, ",")))
 	}
+	if len(spec.TransitionalVersionAlias) > 0 {
+		if errs := validationutil.IsDNS1035Label(spec.TransitionalVersionAlias); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("transitional-version-alias"), spec.TransitionalVersionAlias, strings.Join(errs, ",")))
+		} else if spec.Version == spec.TransitionalVersionAlias {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("transitional-version-alias"), spec.TransitionalVersionAlias, "should be different than version"))
+		}
+	}
 
 	switch spec.Scope {
 	case "":
@@ -119,7 +126,6 @@ func ValidateCustomResourceDefinitionSpecUpdate(spec, oldSpec *apiextensions.Cus
 
 	if established {
 		// these effect the storage and cannot be changed therefore
-		allErrs = append(allErrs, genericvalidation.ValidateImmutableField(spec.Version, oldSpec.Version, fldPath.Child("version"))...)
 		allErrs = append(allErrs, genericvalidation.ValidateImmutableField(spec.Scope, oldSpec.Scope, fldPath.Child("scope"))...)
 		allErrs = append(allErrs, genericvalidation.ValidateImmutableField(spec.Names.Kind, oldSpec.Names.Kind, fldPath.Child("names", "kind"))...)
 	}


### PR DESCRIPTION
Prototype of a minimal CRD feature to allow graceful version promotion of CRDs without dataloss, but clearly separate from full featured multi-version support with conversion.

TODO:
- [ ] add validation tests
- [ ] add integration tests
