### PR TITLE
Remove plain text username and password, since they are kept encoded

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -262,7 +262,7 @@ func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 }
 
 func (ident DockerConfigEntry) MarshalJSON() ([]byte, error) {
-	toEncode := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, ""}
+	toEncode := dockerConfigEntryWithAuth{}
 	toEncode.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)
 
 	return json.Marshal(toEncode)

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -244,7 +244,7 @@ func TestDockerConfigEntryJSONCompatibleEncode(t *testing.T) {
 	}{
 		// simple case, just decode the fields
 		{
-			expect: []byte(`{"username":"foo","password":"bar","email":"foo@example.com","auth":"Zm9vOmJhcg=="}`),
+			expect: []byte(`{"auth":"Zm9vOmJhcg=="}`),
 			input: DockerConfigEntry{
 				Username: "foo",
 				Password: "bar",

--- a/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/pkg/kubectl/secret_for_docker_registry_test.go
@@ -70,7 +70,7 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expected: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-548cm7fgdh",
+					Name: "foo-td6m9k5td8",
 				},
 				Data: map[string][]byte{
 					v1.DockerConfigJsonKey: secretData,
@@ -109,16 +109,18 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 	}
 
 	generator := SecretForDockerRegistryGeneratorV1{}
-	for _, test := range tests {
-		obj, err := generator.Generate(test.params)
-		if !test.expectErr && err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if test.expectErr && err != nil {
-			continue
-		}
-		if !reflect.DeepEqual(obj.(*v1.Secret), test.expected) {
-			t.Errorf("\nexpected:\n%#v\nsaw:\n%#v", test.expected, obj.(*v1.Secret))
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			obj, err := generator.Generate(test.params)
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if test.expectErr && err != nil {
+				return
+			}
+			if !reflect.DeepEqual(obj.(*v1.Secret), test.expected) {
+				t.Errorf("\nexpected:\n%#v\nsaw:\n%#v", test.expected, obj.(*v1.Secret))
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`docker login` produces a file which looks like this:
```
{
  "auths": {
    "https://index.docker.io/v1/": {
      "auth": "xyzabc12345..."
    }
  }
}
```
but our `kubectl create secret` will keep the username and password in plain text in the generated secret as well. This PR removes the two bits, since they are already there encoded in auth field.

/assign @liggitt @deads2k 
@kubernetes/sig-auth-pr-reviews fyi

**Release note**:
```release-note
NONE
```
