### PR TITLE
Automated cherry pick of #59749: Detect CIDR IPv4 or IPv6 version to select nexthop

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_routes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"errors"
+	"net"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -145,7 +146,10 @@ func (r *Routes) CreateRoute(clusterName string, nameHint string, route *cloudpr
 
 	onFailure := NewCaller()
 
-	addr, err := getAddressByName(r.compute, route.TargetNode)
+	ip, _, _ := net.ParseCIDR(route.DestinationCIDR)
+	isCIDRv6 := ip.To4() == nil
+	addr, err := getAddressByName(r.compute, route.TargetNode, isCIDRv6)
+
 	if err != nil {
 		return err
 	}
@@ -217,7 +221,10 @@ func (r *Routes) DeleteRoute(clusterName string, route *cloudprovider.Route) err
 
 	onFailure := NewCaller()
 
-	addr, err := getAddressByName(r.compute, route.TargetNode)
+	ip, _, _ := net.ParseCIDR(route.DestinationCIDR)
+	isCIDRv6 := ip.To4() == nil
+	addr, err := getAddressByName(r.compute, route.TargetNode, isCIDRv6)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #59749 on release-1.9.

#59749: Detect CIDR IPv4 or IPv6 version to select nexthop

```release-note
Fixing a bug in OpenStack cloud provider, where dual stack deployments (IPv4 and IPv6) did not work well when using kubenet as the network plugin.
```