### PR TITLE
Store labels and fields with object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
@@ -61,12 +61,16 @@ type watchCacheEvent struct {
 }
 
 // Computing a key of an object is generally non-trivial (it performs
-// e.g. validation underneath). To avoid computing it multiple times
-// (to serve the event in different List/Watch requests), in the
-// underlying store we are keeping pair (key, object).
+// e.g. validation underneath). Similarly computing object fields and
+// labels. To avoid computing them multiple times (to serve the event
+// in different List/Watch requests), in the underlying store we are
+// keeping structs (key, object, labels, fields, uninitialized).
 type storeElement struct {
-	Key    string
-	Object runtime.Object
+	Key           string
+	Object        runtime.Object
+	Labels        labels.Set
+	Fields        fields.Set
+	Uninitialized bool
 }
 
 func storeElementKey(obj interface{}) (string, error) {
@@ -220,6 +224,20 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		return fmt.Errorf("couldn't compute key: %v", err)
 	}
 	elem := &storeElement{Key: key, Object: event.Object}
+	elem.Labels, elem.Fields, elem.Uninitialized, err = w.getAttrsFunc(event.Object)
+	if err != nil {
+		return err
+	}
+
+	watchCacheEvent := &watchCacheEvent{
+		Type:             event.Type,
+		Object:           elem.Object,
+		ObjLabels:        elem.Labels,
+		ObjFields:        elem.Fields,
+		ObjUninitialized: elem.Uninitialized,
+		Key:              key,
+		ResourceVersion:  resourceVersion,
+	}
 
 	// TODO: We should consider moving this lock below after the watchCacheEvent
 	// is created. In such situation, the only problematic scenario is Replace(
@@ -231,34 +249,14 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 	if err != nil {
 		return err
 	}
-	objLabels, objFields, objUninitialized, err := w.getAttrsFunc(event.Object)
-	if err != nil {
-		return err
-	}
-	var prevObject runtime.Object
-	var prevObjLabels labels.Set
-	var prevObjFields fields.Set
-	var prevObjUninitialized bool
 	if exists {
-		prevObject = previous.(*storeElement).Object
-		prevObjLabels, prevObjFields, prevObjUninitialized, err = w.getAttrsFunc(prevObject)
-		if err != nil {
-			return err
-		}
+		previousElem := previous.(*storeElement)
+		watchCacheEvent.PrevObject = previousElem.Object
+		watchCacheEvent.PrevObjLabels = previousElem.Labels
+		watchCacheEvent.PrevObjFields = previousElem.Fields
+		watchCacheEvent.PrevObjUninitialized = previousElem.Uninitialized
 	}
-	watchCacheEvent := &watchCacheEvent{
-		Type:                 event.Type,
-		Object:               event.Object,
-		ObjLabels:            objLabels,
-		ObjFields:            objFields,
-		ObjUninitialized:     objUninitialized,
-		PrevObject:           prevObject,
-		PrevObjLabels:        prevObjLabels,
-		PrevObjFields:        prevObjFields,
-		PrevObjUninitialized: prevObjUninitialized,
-		Key:                  key,
-		ResourceVersion:      resourceVersion,
-	}
+
 	if w.onEvent != nil {
 		w.onEvent(watchCacheEvent)
 	}


### PR DESCRIPTION
We are already computing labels and fields before putting objects in watchcache.
And my tests show this is `PodToSelectableFields` is responsible for ~10% of memory allocations.
This PR is supposed to fix that - let's double check by running kubemark-big on it.