### PR TITLE
Fixing diskIsAttached function

### DIFF
--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -719,11 +719,10 @@ func diskIsAttached(volPath string, nodeName string) (bool, error) {
 			nodeName)
 		return false, err
 	}
-	if device != nil {
-		framework.Logf("diskIsAttached found the disk %q attached on node %q",
-			volPath,
-			nodeName)
+	if device == nil {
+		return false, nil
 	}
+	framework.Logf("diskIsAttached found the disk %q attached on node %q", volPath, nodeName)
 	return true, nil
 }
 

--- a/test/e2e/storage/vsphere/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_fstype.go
@@ -73,7 +73,7 @@ var _ = utils.SIGDescribe("Volume FStype [Feature:vsphere]", func() {
 		Bootstrap(f)
 		client = f.ClientSet
 		namespace = f.Namespace.Name
-		Expect(GetReadySchedulableNodeInfos).NotTo(BeEmpty())
+		Expect(GetReadySchedulableNodeInfos()).NotTo(BeEmpty())
 	})
 
 	It("verify fstype - ext3 formatted volume", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the `diskIsAttached` function. 
When disk is detached from the Node, this function was returning true, which results into time out for some vsphere e2e test cases.

**Which issue(s) this PR fixes**
Fixes #

**Special notes for your reviewer**:
Executed E2E test to verify failures are resolved with this change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
