### PR TITLE
Standardize on KUBE_PROXY_MODE (not KUBEPROXY_MODE)

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -121,7 +121,7 @@ if [ "${CLOUD_PROVIDER}" == "openstack" ]; then
 fi
 
 # set feature gates if using ipvs mode
-if [ "${KUBEPROXY_MODE}" == "ipvs" ]; then
+if [ "${KUBE_PROXY_MODE}" == "ipvs" ]; then
     FEATURE_GATES="$FEATURE_GATES,SupportIPVSProxyMode=true"
 fi
 
@@ -811,9 +811,9 @@ clientConnection:
   kubeconfig: ${CERT_DIR}/kube-proxy.kubeconfig
 hostnameOverride: ${HOSTNAME_OVERRIDE}
 featureGates: ${FEATURE_GATES}
-mode: ${KUBEPROXY_MODE}
+mode: ${KUBE_PROXY_MODE}
 EOF
-    if [ "${KUBEPROXY_MODE}" == "ipvs" ]; then
+    if [ "${KUBE_PROXY_MODE}" == "ipvs" ]; then
 	# Load kernel modules required by IPVS proxier
         sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4
     fi

--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -18,7 +18,7 @@ Currently, local-up scripts and kubeadm support switching IPVS proxy mode via ex
 
 Kube-proxy will run in iptables mode by default in a [local-up cluster](https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md). 
 
-Users should export the env `KUBEPROXY_MODE=ipvs` to specify the ipvs mode before deploying the cluster if want to run kube-proxy in ipvs mode.
+Users should export the env `KUBE_PROXY_MODE=ipvs` to specify the ipvs mode before deploying the cluster if want to run kube-proxy in ipvs mode.
 
 ### Cluster Created by Kubeadm
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

There's a disconnect between 12d4eac0383db9d952a4b96ebfc0e8bfa9fb1952
and the earlier a6af82789833322d47fe52be6b038eb4b4387744. One says
KUBEPROXY_MODE and another says KUBE_PROXY_MODE. Let's just pick one.
Currently we fail with the following error:

hack/local-up-cluster.sh: line 808: KUBEPROXY_MODE: unbound variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
