### PR TITLE
Pipe error message from openapi/swaggerspec verify checks to stderr

### DIFF
--- a/hack/verify-openapi-spec.sh
+++ b/hack/verify-openapi-spec.sh
@@ -35,7 +35,7 @@ mkdir -p "${_tmp}"
 cp -a "${SPECROOT}" "${TMP_SPECROOT}"
 trap "cp -a ${TMP_SPECROOT} ${SPECROOT}/..; rm -rf ${_tmp}" EXIT SIGINT
 rm ${SPECROOT}/*
-cp ${TMP_SPECROOT}/BUILD ${SPECROOT}/BUILD 
+cp ${TMP_SPECROOT}/BUILD ${SPECROOT}/BUILD
 cp ${TMP_SPECROOT}/README.md ${SPECROOT}/README.md
 
 "${KUBE_ROOT}/hack/update-openapi-spec.sh"
@@ -46,7 +46,7 @@ if [[ $ret -eq 0 ]]
 then
   echo "${SPECROOT} up to date."
 else
-  echo "${SPECROOT} is out of date. Please run hack/update-openapi-spec.sh"
+  echo "${SPECROOT} is out of date. Please run hack/update-openapi-spec.sh" >&2
   exit 1
 fi
 

--- a/hack/verify-swagger-spec.sh
+++ b/hack/verify-swagger-spec.sh
@@ -44,7 +44,7 @@ if [[ $ret -eq 0 ]]
 then
   echo "${SPECROOT} up to date."
 else
-  echo "${SPECROOT} is out of date. Please run hack/update-swagger-spec.sh"
+  echo "${SPECROOT} is out of date. Please run hack/update-swagger-spec.sh" >&2
   exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pipes the error messages from openapi and swagger spec verify jobs to stderr so they show up in junit reports.

**Release note**:
```release-note
NONE
```
