### PR TITLE
kubelet: revert the status HostIP behavior

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1382,15 +1382,18 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 		Status: v1.ConditionTrue,
 	})
 
-	hostIP, err := kl.getHostIPAnyWay()
-	if err != nil {
-		glog.V(4).Infof("Cannot get host IP: %v", err)
-		return *s
+	if kl.kubeClient != nil {
+		hostIP, err := kl.getHostIPAnyWay()
+		if err != nil {
+			glog.V(4).Infof("Cannot get host IP: %v", err)
+		} else {
+			s.HostIP = hostIP.String()
+			if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
+				s.PodIP = hostIP.String()
+			}
+		}
 	}
-	s.HostIP = hostIP.String()
-	if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
-		s.PodIP = hostIP.String()
-	}
+
 	return *s
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR partially revert #57106 to fix #59889.

The PR #57106 changed the behavior of `generateAPIPodStatus` when a **kubeClient** is nil.

**Release note**:
```release-note
NONE
```
