### PR TITLE
e2e tests specific Network/DNS related : add Ipv6 capability

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -79,7 +79,6 @@ func dnsTests(isIPv6 bool) {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	}
 
-	// only IPv4 is conformance for now
 	if isIPv6 {
 		It("should provide DNS for the cluster", testDNSforCluster)
 	} else {
@@ -476,7 +475,7 @@ func dnsTests(isIPv6 bool) {
 			Expect(f.WaitForPodRunning(testUtilsPod.Name)).NotTo(HaveOccurred(), "failed to wait for pod %s to be running", testUtilsPod.Name)
 
 			By("Verifying customized DNS option is configured on pod...")
-			// TODO: Figure out a better way other than checking the actual resolv,conf file.
+			// TODO: Figure out a better way other than checking the actual resolv.conf file.
 			cmd := []string{"cat", "/etc/resolv.conf"}
 			stdout, stderr, err := f.ExecWithOptions(framework.ExecOptions{
 				Command:       cmd,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Support of IPV6 for e2e network/dns tests.

Use the flag "[Feature:Networking-IPv6]" to run in an IPv6 context only
Use the flag "[Feature:Networking-IPv4]" to run in an IPv4 context only

NOTE: the existing [Conformance] still apply to the same IPv4 tests only.


**Which issue(s) this PR fixes** *

None, but is related to : https://github.com/coredns/coredns/issues/1236


**Special notes for your reviewer**

I ran these tests for Ipv6 and for Ipv4 in dedicated environment "Docker-in-Docker" that can propose IPv6 stack.
the IPv4 version is already running part of e2e tests of Kubernetes.

NOTE: I ran the IPv6 ONLY for the "coreDNS" version of DNS.  Which is now BETA for v.1.10 and will be GA for v1.11

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
