### PR TITLE
Add conflict detection to apply merge strategy

### DIFF
--- a/pkg/kubectl/apply/BUILD
+++ b/pkg/kubectl/apply/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "compare.go",
         "doc.go",
         "element.go",
         "empty_element.go",

--- a/pkg/kubectl/apply/compare.go
+++ b/pkg/kubectl/apply/compare.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+// Compare implements a strategy for comparing elements for comflicts
+// Follows visitor pattern
+type Compare interface {
+	CompareList(ListElement) bool
+	CompareMap(MapElement) bool
+	CompareEmpty(EmptyElement) bool
+	ComparePrimitive(PrimitiveElement) bool
+	CompareType(TypeElement) bool
+}

--- a/pkg/kubectl/apply/element.go
+++ b/pkg/kubectl/apply/element.go
@@ -36,6 +36,9 @@ type Element interface {
 	// Returns the Result of the merged elements
 	Merge(Strategy) (Result, error)
 
+	// Compare detects conflicts between recorded and remote values.
+	Compare(Compare) bool
+
 	// HasRecorded returns true if the field was explicitly
 	// present in the recorded source.  This is to differentiate between
 	// undefined and set to null

--- a/pkg/kubectl/apply/empty_element.go
+++ b/pkg/kubectl/apply/empty_element.go
@@ -27,6 +27,11 @@ func (e EmptyElement) Merge(v Strategy) (Result, error) {
 	return v.MergeEmpty(e)
 }
 
+// Compare detect conflicts in merging empty elements of remote and recorded values
+func (e EmptyElement) Compare(v Compare) bool {
+	return v.CompareEmpty(e)
+}
+
 // IsAdd implements Element.IsAdd
 func (e EmptyElement) IsAdd() bool {
 	return false

--- a/pkg/kubectl/apply/list_element.go
+++ b/pkg/kubectl/apply/list_element.go
@@ -36,6 +36,11 @@ func (e ListElement) Merge(v Strategy) (Result, error) {
 	return v.MergeList(e)
 }
 
+// Compare implements Element.Compare, detect conflicts of recorded and remote list elements
+func (e ListElement) Compare(v Compare) bool {
+	return v.CompareList(e)
+}
+
 var _ Element = &ListElement{}
 
 // ListElementData contains the recorded, local and remote data for a list

--- a/pkg/kubectl/apply/map_element.go
+++ b/pkg/kubectl/apply/map_element.go
@@ -41,6 +41,11 @@ func (e MapElement) GetValues() map[string]Element {
 	return e.Values
 }
 
+// Compare implements Element.Compare, detects conflicts between remote and record in mapElement
+func (e MapElement) Compare(v Compare) bool {
+	return v.CompareMap(e)
+}
+
 var _ Element = &MapElement{}
 
 // MapElementData contains the recorded, local and remote data for a map or type

--- a/pkg/kubectl/apply/primitive_element.go
+++ b/pkg/kubectl/apply/primitive_element.go
@@ -31,4 +31,9 @@ func (e PrimitiveElement) Merge(v Strategy) (Result, error) {
 	return v.MergePrimitive(e)
 }
 
+// Compare implements Element.Compare, detects conflicts between remote and record in primitiveElement
+func (e PrimitiveElement) Compare(v Compare) bool {
+	return v.ComparePrimitive(e)
+}
+
 var _ Element = &PrimitiveElement{}

--- a/pkg/kubectl/apply/strategy/BUILD
+++ b/pkg/kubectl/apply/strategy/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "compare_visitor.go",
         "doc.go",
         "merge.go",
         "merge_visitor.go",
@@ -18,6 +19,7 @@ go_library(
 go_test(
     name = "go_default_xtest",
     srcs = [
+        "compare_visitor_test.go",
         "merge_map_list_test.go",
         "merge_map_test.go",
         "merge_primitive_list_test.go",

--- a/pkg/kubectl/apply/strategy/compare_visitor.go
+++ b/pkg/kubectl/apply/strategy/compare_visitor.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"reflect"
+
+	"k8s.io/kubernetes/pkg/kubectl/apply"
+)
+
+// CreateCompareStrategy return compare strategy instance
+func CreateCompareStrategy() apply.Compare {
+	return compareStrategy{}
+}
+
+type compareStrategy struct {
+}
+
+// CompareMap recursively detects conflicts between recorded and remote in MapElement.
+// Return false if conflicts detected.
+func (v compareStrategy) CompareMap(e apply.MapElement) bool {
+	if e.HasRecorded() && e.HasRemote() {
+		record := e.GetRecordedMap()
+		remote := e.GetRemoteMap()
+		for key, value := range record {
+			if val, ok := remote[key]; ok {
+				if !v.hasNext(value, val) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// CompareList recursively detects conflicts between recorded and remote in ListElement.
+// Return false if conflicts detected.
+func (v compareStrategy) CompareList(e apply.ListElement) bool {
+	if e.HasRecorded() && e.HasRemote() {
+		record := e.GetRecordedList()
+		remote := e.GetRemoteList()
+		if keys := e.GetFieldMergeKeys(); keys != nil {
+			return v.compareMapList(record, remote, keys)
+		}
+		return v.comparePrimitiveList(record, remote)
+	}
+	return true
+}
+
+// compareList compares list in which element is object, like map, list, etc.
+func (v compareStrategy) compareMapList(record, remote []interface{}, keys apply.MergeKeys) bool {
+	if len(record) == 0 || len(remote) == 0 {
+		return true
+	}
+	list1, list2 := sort(record, remote)
+	var found bool
+	for _, l2 := range list2 {
+		found = false
+		for _, l1 := range list1 {
+			mergeKeyValueRecord, _ := keys.GetMergeKeyValue(l1)
+			mergeKeyValueRemote, _ := keys.GetMergeKeyValue(l2)
+			if mergeKeyValueRecord.Equal(mergeKeyValueRemote) {
+				if v.hasNext(l1, l2) {
+					found = true
+					break
+				}
+			}
+		}
+	}
+	return found
+}
+
+// comparePrimitiveList compare list in which elements are treated as primitive
+func (v compareStrategy) comparePrimitiveList(record, remote []interface{}) bool {
+	if len(record) == 0 || len(remote) == 0 {
+		return true
+	}
+	list1, list2 := sort(record, remote)
+	var found bool
+	for _, value := range list2 {
+		found = false
+		for _, val := range list1 {
+			if reflect.DeepEqual(value, val) {
+				found = true
+				break
+			}
+		}
+	}
+	return found
+}
+
+// hasNext recursively compare two values based on their type
+func (v compareStrategy) hasNext(value, val interface{}) bool {
+	if reflect.TypeOf(value).Kind() != reflect.TypeOf(val).Kind() {
+		return false
+	}
+	switch value.(type) {
+	case apply.ListElement:
+		return value.(apply.ListElement).Compare(v) && val.(apply.ListElement).Compare(v)
+	case apply.MapElement:
+		return value.(apply.MapElement).Compare(v) && val.(apply.MapElement).Compare(v)
+	case apply.TypeElement:
+		return value.(apply.TypeElement).Compare(v) && val.(apply.TypeElement).Compare(v)
+	case apply.PrimitiveElement:
+		return value.(apply.PrimitiveElement).Compare(v) && val.(apply.PrimitiveElement).Compare(v)
+	}
+	return reflect.DeepEqual(value, val)
+}
+
+// CompareEmpty compares emptyElement and return true always
+func (v compareStrategy) CompareEmpty(e apply.EmptyElement) bool {
+	// Always return true, because empty element has no conflicts
+	return true
+}
+
+// ComparePrimitive compares PrimitiveElement
+func (v compareStrategy) ComparePrimitive(e apply.PrimitiveElement) bool {
+	return reflect.DeepEqual(e.GetRecorded(), e.GetRemote())
+}
+
+// CompareType compares TypeElement
+func (v compareStrategy) CompareType(e apply.TypeElement) bool {
+	m := apply.MapElement{
+		FieldMetaImpl:  e.FieldMetaImpl,
+		MapElementData: e.MapElementData,
+		Values:         e.Values,
+	}
+	return v.CompareMap(m)
+}
+
+// sort two lists by length
+func sort(arg1, arg2 []interface{}) (l1, l2 []interface{}) {
+	l1 = arg1
+	l2 = arg2
+	if len(arg2) > len(arg1) {
+		l1 = arg2
+		l2 = arg1
+	}
+	return l1, l2
+}
+
+func lookUpList(index int, list []interface{}) (interface{}, bool) {
+	if list != nil && len(list) > index {
+		return list[index], true
+	}
+	return nil, false
+}

--- a/pkg/kubectl/apply/strategy/compare_visitor_test.go
+++ b/pkg/kubectl/apply/strategy/compare_visitor_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy_test
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
+)
+
+var _ = Describe("Comparing fields of remote and recorded ", func() {
+	Context("Test conflict in map fields of remote and recorded", func() {
+		It("If conflicts found, expected return false", func() {
+			recorded := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo1: "key1"
+`)
+			local := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo2: "baz2-1"
+`)
+			remote := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo1: "baz1-0"
+`)
+			expected := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo2: "baz2-1"
+`)
+			res := false
+			runTest(strategy.CreateCompareStrategy(), recorded, local, remote, expected, res)
+		})
+	})
+
+	Context("Test conflict in list fields of remote and recorded ", func() {
+		It("If conflicts found, expected return false", func() {
+			recorded := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  finalizers:
+  - "a"
+  - "b"
+  - "c"
+`)
+			local := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  finalizers:
+  - "a"
+  - "b"
+`)
+			remote := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  finalizers:
+  - "a"
+  - "b"
+  - "d"
+`)
+			expected := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  finalizers:
+  - "a"
+  - "c"
+`)
+			res := false
+			runTest(strategy.CreateCompareStrategy(), recorded, local, remote, expected, res)
+		})
+	})
+
+	Context("Test conflict in Map-List-Map nested fields of remote and recorded ", func() {
+		It("If conflicts found, expected return false", func() {
+			recorded := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  containers:
+  - finalizers: "bar1"
+  - docker: "tst"
+`)
+			local := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  containers:
+  - finalizers: "bar2"
+`)
+			remote := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  containers:
+  - finalizers: "bar1"
+  - docker: "test"
+`)
+			expected := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  - containers: "docker"
+`)
+			res := false
+			runTest(strategy.CreateCompareStrategy(), recorded, local, remote, expected, res)
+		})
+	})
+
+	Context("Test conflicts in nested map field", func() {
+		It("If conflicts found, expected return false", func() {
+			recorded := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo1:
+    name: "key1"
+`)
+			local := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo2:
+    name: "baz2-1"
+`)
+			remote := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo1:
+    name: "baz1-0"
+`)
+			expected := create(`
+apiVersion: apps/v1beta1
+kind: Deployment
+spec:
+  foo2: "baz2-1"
+`)
+			res := false
+			runTest(strategy.CreateCompareStrategy(), recorded, local, remote, expected, res)
+		})
+	})
+
+})

--- a/pkg/kubectl/apply/strategy/retain_keys_visitor.go
+++ b/pkg/kubectl/apply/strategy/retain_keys_visitor.go
@@ -18,12 +18,13 @@ package strategy
 
 import (
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/kubectl/apply"
 )
 
 func createRetainKeysStrategy(options Options, strategic *delegatingStrategy) retainKeysStrategy {
 	return retainKeysStrategy{
-		&mergeStrategy{strategic, options},
+		&mergeStrategy{strategic, options, CreateCompareStrategy()},
 		strategic,
 		options,
 	}

--- a/pkg/kubectl/apply/strategy/utils_test.go
+++ b/pkg/kubectl/apply/strategy/utils_test.go
@@ -64,3 +64,15 @@ func create(config string) map[string]interface{} {
 
 	return result
 }
+
+// run compare test
+func runTest(instance apply.Compare, recorded, local, remote, expected map[string]interface{}, res bool) {
+	runCompare(instance, recorded, local, remote, expected, res, fakeResources)
+}
+
+func runCompare(instance apply.Compare, recorded, local, remote, expected map[string]interface{}, res bool, resources openapi.Resources) {
+	parseFactory := parse.Factory{Resources: resources}
+	parsed, err := parseFactory.CreateElement(recorded, local, remote)
+	Expect(err).Should(Not(HaveOccurred()))
+	Expect(parsed.Compare(instance)).Should(Equal(res), fmt.Sprintf("RESULT: %v\n", parsed.Compare(instance)))
+}

--- a/pkg/kubectl/apply/type_element.go
+++ b/pkg/kubectl/apply/type_element.go
@@ -35,6 +35,11 @@ func (e TypeElement) Merge(v Strategy) (Result, error) {
 	return v.MergeType(e)
 }
 
+// Compare implements Element.Compare
+func (e TypeElement) Compare(v Compare) bool {
+	return v.CompareType(e)
+}
+
 // GetValues implements Element.GetValues
 func (e TypeElement) GetValues() map[string]Element {
 	return e.Values


### PR DESCRIPTION
- Add IsConflict func for Element interface
- Add conflict detection check when option is enabled in merge visitor

**What this PR does / why we need it**:
Apply is being rewritten under pkg/kubectl/apply/strategy. The new merge and replace code should check for conflicts between the last seen value and the current value, and optionally return an error if they do not match with the field and details.

**Which issue(s) this PR fixes** 
https://github.com/kubernetes/kubectl/issues/97

**Special notes for your reviewer**:
Split the issue tasks in three subtasks. This PR focus on implement a conflict detection function for Element interface, and apply to merge visitor when FailOnConflicts option enabled.

