### PR TITLE
Improve etcd-version-monitor etcd 3.0-3.1 compatibility

### DIFF
--- a/cluster/images/etcd-version-monitor/BUILD
+++ b/cluster/images/etcd-version-monitor/BUILD
@@ -17,6 +17,7 @@ go_library(
     srcs = ["etcd-version-monitor.go"],
     importpath = "k8s.io/kubernetes/cluster/images/etcd-version-monitor",
     deps = [
+        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",

--- a/cluster/images/etcd-version-monitor/Makefile
+++ b/cluster/images/etcd-version-monitor/Makefile
@@ -20,7 +20,7 @@
 ARCH:=amd64
 GOLANG_VERSION?=1.8.3
 REGISTRY?=staging-k8s.gcr.io
-TAG?=0.1.1
+TAG?=0.1.2
 IMAGE:=$(REGISTRY)/etcd-version-monitor:$(TAG)
 CURRENT_DIR:=$(pwd)
 TEMP_DIR:=$(shell mktemp -d)

--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   hostNetwork: true
   containers:
   - name: etcd-version-monitor
-    image: k8s.gcr.io/etcd-version-monitor:0.1.0
+    image: k8s.gcr.io/etcd-version-monitor:0.1.2
     command:
     - /etcd-version-monitor
     - --logtostderr


### PR DESCRIPTION
In etcd-version-monitor, this remove grpc labels used only in etcd 3.1+ format when translating metric back to 3.0 format
