### PR TITLE
Rename StorageProtection to StorageObjectInUseProtection

### DIFF
--- a/cluster/centos/config-default.sh
+++ b/cluster/centos/config-default.sh
@@ -124,7 +124,7 @@ export FLANNEL_NET=${FLANNEL_NET:-"172.16.0.0/16"}
 # modification is overwritten.
 # If we included ResourceQuota, we should keep it at the end of the list to
 # prevent incrementing quota usage prematurely.
-export ADMISSION_CONTROL=${ADMISSION_CONTROL:-"Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeClaimResize,DefaultTolerationSeconds,Priority,StorageProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"}
+export ADMISSION_CONTROL=${ADMISSION_CONTROL:-"Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeClaimResize,DefaultTolerationSeconds,Priority,StorageObjectInUseProtection,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"}
 
 # Extra options to set on the Docker command line.
 # This is useful for setting --insecure-registry for local registries.

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -295,7 +295,7 @@ if [[ -n "${GCE_GLBC_IMAGE:-}" ]]; then
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageProtection
+ADMISSION_CONTROL=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection
 
 if [[ "${ENABLE_POD_SECURITY_POLICY:-}" == "true" ]]; then
   ADMISSION_CONTROL="${ADMISSION_CONTROL},PodSecurityPolicy"

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -395,7 +395,7 @@ func startGarbageCollectorController(ctx ControllerContext) (bool, error) {
 }
 
 func startPVCProtectionController(ctx ControllerContext) (bool, error) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		go pvcprotection.NewPVCProtectionController(
 			ctx.InformerFactory.Core().V1().PersistentVolumeClaims(),
 			ctx.InformerFactory.Core().V1().Pods(),
@@ -407,7 +407,7 @@ func startPVCProtectionController(ctx ControllerContext) (bool, error) {
 }
 
 func startPVProtectionController(ctx ControllerContext) (bool, error) {
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		go pvprotection.NewPVProtectionController(
 			ctx.InformerFactory.Core().V1().PersistentVolumes(),
 			ctx.ClientBuilder.ClientOrDie("pv-protection-controller"),

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -170,7 +170,7 @@ func findMatchingVolume(
 		}
 
 		// check if PV's DeletionTimeStamp is set, if so, skip this volume.
-		if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 			if volume.ObjectMeta.DeletionTimestamp != nil {
 				continue
 			}

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -1043,7 +1043,7 @@ func TestAlphaFilteringVolumeModes(t *testing.T) {
 	toggleFeature(false, "BlockVolume", t)
 }
 
-func TestAlphaStorageProtectionFiltering(t *testing.T) {
+func TestAlphaStorageObjectInUseProtectionFiltering(t *testing.T) {
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pv1",
@@ -1072,39 +1072,39 @@ func TestAlphaStorageProtectionFiltering(t *testing.T) {
 	}
 
 	satisfyingTestCases := map[string]struct {
-		isExpectedMatch         bool
-		vol                     *v1.PersistentVolume
-		pvc                     *v1.PersistentVolumeClaim
-		enableStorageProtection bool
+		isExpectedMatch                    bool
+		vol                                *v1.PersistentVolume
+		pvc                                *v1.PersistentVolumeClaim
+		enableStorageObjectInUseProtection bool
 	}{
 		"feature enabled - pv deletionTimeStamp not set": {
 			isExpectedMatch: true,
 			vol:             pv,
 			pvc:             pvc,
-			enableStorageProtection: true,
+			enableStorageObjectInUseProtection: true,
 		},
 		"feature enabled - pv deletionTimeStamp set": {
 			isExpectedMatch: false,
 			vol:             pvToDelete,
 			pvc:             pvc,
-			enableStorageProtection: true,
+			enableStorageObjectInUseProtection: true,
 		},
 		"feature disabled - pv deletionTimeStamp not set": {
 			isExpectedMatch: true,
 			vol:             pv,
 			pvc:             pvc,
-			enableStorageProtection: false,
+			enableStorageObjectInUseProtection: false,
 		},
 		"feature disabled - pv deletionTimeStamp set": {
 			isExpectedMatch: true,
 			vol:             pvToDelete,
 			pvc:             pvc,
-			enableStorageProtection: false,
+			enableStorageObjectInUseProtection: false,
 		},
 	}
 
 	for name, testCase := range satisfyingTestCases {
-		toggleFeature(testCase.enableStorageProtection, "StorageProtection", t)
+		toggleFeature(testCase.enableStorageObjectInUseProtection, "StorageObjectInUseProtection", t)
 		err := checkVolumeSatisfyClaim(testCase.vol, testCase.pvc)
 		// expected to match but got an error
 		if err != nil && testCase.isExpectedMatch {
@@ -1118,38 +1118,38 @@ func TestAlphaStorageProtectionFiltering(t *testing.T) {
 	}
 
 	filteringTestCases := map[string]struct {
-		isExpectedMatch         bool
-		vol                     persistentVolumeOrderedIndex
-		pvc                     *v1.PersistentVolumeClaim
-		enableStorageProtection bool
+		isExpectedMatch                    bool
+		vol                                persistentVolumeOrderedIndex
+		pvc                                *v1.PersistentVolumeClaim
+		enableStorageObjectInUseProtection bool
 	}{
 		"feature enabled - pv deletionTimeStamp not set": {
 			isExpectedMatch: true,
 			vol:             createTestVolOrderedIndex(pv),
 			pvc:             pvc,
-			enableStorageProtection: true,
+			enableStorageObjectInUseProtection: true,
 		},
 		"feature enabled - pv deletionTimeStamp set": {
 			isExpectedMatch: false,
 			vol:             createTestVolOrderedIndex(pvToDelete),
 			pvc:             pvc,
-			enableStorageProtection: true,
+			enableStorageObjectInUseProtection: true,
 		},
 		"feature disabled - pv deletionTimeStamp not set": {
 			isExpectedMatch: true,
 			vol:             createTestVolOrderedIndex(pv),
 			pvc:             pvc,
-			enableStorageProtection: false,
+			enableStorageObjectInUseProtection: false,
 		},
 		"feature disabled - pv deletionTimeStamp set": {
 			isExpectedMatch: true,
 			vol:             createTestVolOrderedIndex(pvToDelete),
 			pvc:             pvc,
-			enableStorageProtection: false,
+			enableStorageObjectInUseProtection: false,
 		},
 	}
 	for name, testCase := range filteringTestCases {
-		toggleFeature(testCase.enableStorageProtection, "StorageProtection", t)
+		toggleFeature(testCase.enableStorageObjectInUseProtection, "StorageObjectInUseProtection", t)
 		pvmatch, err := testCase.vol.findBestMatchForClaim(testCase.pvc, false)
 		// expected to match but either got an error or no returned pvmatch
 		if pvmatch == nil && testCase.isExpectedMatch {
@@ -1168,7 +1168,7 @@ func TestAlphaStorageProtectionFiltering(t *testing.T) {
 	}
 
 	// make sure feature gate is turned off
-	toggleFeature(false, "StorageProtection", t)
+	toggleFeature(false, "StorageObjectInUseProtection", t)
 }
 
 func TestFindingPreboundVolumes(t *testing.T) {

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -240,7 +240,7 @@ func checkVolumeSatisfyClaim(volume *v1.PersistentVolume, claim *v1.PersistentVo
 	requestedSize := requestedQty.Value()
 
 	// check if PV's DeletionTimeStamp is set, if so, return error.
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		if volume.ObjectMeta.DeletionTimestamp != nil {
 			return fmt.Errorf("the volume is marked for deletion")
 		}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -206,7 +206,7 @@ const (
 	// alpha: v1.9
 	//
 	// Postpone deletion of a PV or a PVC when they are being used
-	StorageProtection utilfeature.Feature = "StorageProtection"
+	StorageObjectInUseProtection utilfeature.Feature = "StorageObjectInUseProtection"
 
 	// owner: @aveshagarwal
 	// alpha: v1.9
@@ -280,7 +280,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	CSIPersistentVolume:                         {Default: true, PreRelease: utilfeature.Beta},
 	CustomPodDNS:                                {Default: false, PreRelease: utilfeature.Alpha},
 	BlockVolume:                                 {Default: false, PreRelease: utilfeature.Alpha},
-	StorageProtection:                           {Default: false, PreRelease: utilfeature.Alpha},
+	StorageObjectInUseProtection:                {Default: false, PreRelease: utilfeature.Alpha},
 	ResourceLimitsPriorityFunction:              {Default: false, PreRelease: utilfeature.Alpha},
 	SupportIPVSProxyMode:                        {Default: false, PreRelease: utilfeature.Beta},
 	SupportPodPidsLimit:                         {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -52,7 +52,7 @@ go_library(
         "//plugin/pkg/admission/security/podsecuritypolicy:go_default_library",
         "//plugin/pkg/admission/securitycontext/scdeny:go_default_library",
         "//plugin/pkg/admission/serviceaccount:go_default_library",
-        "//plugin/pkg/admission/storage/storageprotection:go_default_library",
+        "//plugin/pkg/admission/storage/storageobjectinuseprotection:go_default_library",
         "//plugin/pkg/admission/storageclass/setdefault:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -49,7 +49,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy"
 	"k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
-	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageprotection"
+	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageobjectinuseprotection"
 	"k8s.io/kubernetes/plugin/pkg/admission/storageclass/setdefault"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -62,38 +62,38 @@ import (
 
 // AllOrderedPlugins is the list of all the plugins in order.
 var AllOrderedPlugins = []string{
-	admit.PluginName,                      // AlwaysAdmit
-	autoprovision.PluginName,              // NamespaceAutoProvision
-	lifecycle.PluginName,                  // NamespaceLifecycle
-	exists.PluginName,                     // NamespaceExists
-	scdeny.PluginName,                     // SecurityContextDeny
-	antiaffinity.PluginName,               // LimitPodHardAntiAffinityTopology
-	initialresources.PluginName,           // InitialResources
-	podpreset.PluginName,                  // PodPreset
-	limitranger.PluginName,                // LimitRanger
-	serviceaccount.PluginName,             // ServiceAccount
-	noderestriction.PluginName,            // NodeRestriction
-	alwayspullimages.PluginName,           // AlwaysPullImages
-	imagepolicy.PluginName,                // ImagePolicyWebhook
-	podsecuritypolicy.PluginName,          // PodSecurityPolicy
-	podnodeselector.PluginName,            // PodNodeSelector
-	podpriority.PluginName,                // Priority
-	defaulttolerationseconds.PluginName,   // DefaultTolerationSeconds
-	podtolerationrestriction.PluginName,   // PodTolerationRestriction
-	exec.DenyEscalatingExec,               // DenyEscalatingExec
-	exec.DenyExecOnPrivileged,             // DenyExecOnPrivileged
-	eventratelimit.PluginName,             // EventRateLimit
-	extendedresourcetoleration.PluginName, // ExtendedResourceToleration
-	label.PluginName,                      // PersistentVolumeLabel
-	setdefault.PluginName,                 // DefaultStorageClass
-	storageprotection.PluginName,          // StorageProtection
-	gc.PluginName,                         // OwnerReferencesPermissionEnforcement
-	resize.PluginName,                     // PersistentVolumeClaimResize
-	mutatingwebhook.PluginName,            // MutatingAdmissionWebhook
-	initialization.PluginName,             // Initializers
-	validatingwebhook.PluginName,          // ValidatingAdmissionWebhook
-	resourcequota.PluginName,              // ResourceQuota
-	deny.PluginName,                       // AlwaysDeny
+	admit.PluginName,                        // AlwaysAdmit
+	autoprovision.PluginName,                // NamespaceAutoProvision
+	lifecycle.PluginName,                    // NamespaceLifecycle
+	exists.PluginName,                       // NamespaceExists
+	scdeny.PluginName,                       // SecurityContextDeny
+	antiaffinity.PluginName,                 // LimitPodHardAntiAffinityTopology
+	initialresources.PluginName,             // InitialResources
+	podpreset.PluginName,                    // PodPreset
+	limitranger.PluginName,                  // LimitRanger
+	serviceaccount.PluginName,               // ServiceAccount
+	noderestriction.PluginName,              // NodeRestriction
+	alwayspullimages.PluginName,             // AlwaysPullImages
+	imagepolicy.PluginName,                  // ImagePolicyWebhook
+	podsecuritypolicy.PluginName,            // PodSecurityPolicy
+	podnodeselector.PluginName,              // PodNodeSelector
+	podpriority.PluginName,                  // Priority
+	defaulttolerationseconds.PluginName,     // DefaultTolerationSeconds
+	podtolerationrestriction.PluginName,     // PodTolerationRestriction
+	exec.DenyEscalatingExec,                 // DenyEscalatingExec
+	exec.DenyExecOnPrivileged,               // DenyExecOnPrivileged
+	eventratelimit.PluginName,               // EventRateLimit
+	extendedresourcetoleration.PluginName,   // ExtendedResourceToleration
+	label.PluginName,                        // PersistentVolumeLabel
+	setdefault.PluginName,                   // DefaultStorageClass
+	storageobjectinuseprotection.PluginName, // StorageObjectInUseProtection
+	gc.PluginName,                           // OwnerReferencesPermissionEnforcement
+	resize.PluginName,                       // PersistentVolumeClaimResize
+	mutatingwebhook.PluginName,              // MutatingAdmissionWebhook
+	initialization.PluginName,               // Initializers
+	validatingwebhook.PluginName,            // ValidatingAdmissionWebhook
+	resourcequota.PluginName,                // ResourceQuota
+	deny.PluginName,                         // AlwaysDeny
 }
 
 // RegisterAllAdmissionPlugins registers all admission plugins and
@@ -125,7 +125,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	serviceaccount.Register(plugins)
 	setdefault.Register(plugins)
 	resize.Register(plugins)
-	storageprotection.Register(plugins)
+	storageobjectinuseprotection.Register(plugins)
 }
 
 // DefaultOffAdmissionPlugins get admission plugins off by default for kube-apiserver.

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -441,7 +441,7 @@ func (dswp *desiredStateOfWorldPopulator) getPVCExtractPV(
 			err)
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		// Pods that uses a PVC that is being deleted must not be started.
 		//
 		// In case an old kubelet is running without this check or some kubelets

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -36,7 +36,7 @@ filegroup(
         "//plugin/pkg/admission/security:all-srcs",
         "//plugin/pkg/admission/securitycontext/scdeny:all-srcs",
         "//plugin/pkg/admission/serviceaccount:all-srcs",
-        "//plugin/pkg/admission/storage/storageprotection:all-srcs",
+        "//plugin/pkg/admission/storage/storageobjectinuseprotection:all-srcs",
         "//plugin/pkg/admission/storageclass/setdefault:all-srcs",
         "//plugin/pkg/auth:all-srcs",
     ],

--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/BUILD
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["admission.go"],
-    importpath = "k8s.io/kubernetes/plugin/pkg/admission/storage/storageprotection",
+    importpath = "k8s.io/kubernetes/plugin/pkg/admission/storage/storageobjectinuseprotection",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/core:go_default_library",

--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/admission.go
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/admission.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package storageprotection
+package storageobjectinuseprotection
 
 import (
 	"fmt"
@@ -34,7 +34,7 @@ import (
 
 const (
 	// PluginName is the name of this admission controller plugin
-	PluginName = "StorageProtection"
+	PluginName = "StorageObjectInUseProtection"
 )
 
 // Register registers a plugin
@@ -95,7 +95,7 @@ var (
 // This prevents users from deleting a PVC that's used by a running pod.
 // This also prevents admin from deleting a PV that's bound by a PVC
 func (c *storageProtectionPlugin) Admit(a admission.Attributes) error {
-	if !feature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if !feature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		return nil
 	}
 

--- a/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
+++ b/plugin/pkg/admission/storage/storageobjectinuseprotection/admission_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package storageprotection
+package storageobjectinuseprotection
 
 import (
 	"fmt"
@@ -122,7 +122,7 @@ func TestAdmit(t *testing.T) {
 	ctrl.SetInternalKubeInformerFactory(informerFactory)
 
 	for _, test := range tests {
-		feature.DefaultFeatureGate.Set(fmt.Sprintf("StorageProtection=%v", test.featureEnabled))
+		feature.DefaultFeatureGate.Set(fmt.Sprintf("StorageObjectInUseProtection=%v", test.featureEnabled))
 		obj := test.object.DeepCopyObject()
 		attrs := admission.NewAttributesRecord(
 			obj,                  // new object
@@ -147,5 +147,5 @@ func TestAdmit(t *testing.T) {
 
 	// Disable the feature for rest of the tests.
 	// TODO: remove after alpha
-	feature.DefaultFeatureGate.Set("StorageProtection=false")
+	feature.DefaultFeatureGate.Set("StorageObjectInUseProtection=false")
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -324,7 +324,7 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 			eventsRule(),
 		},
 	})
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbac.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "pvc-protection-controller"},
 			Rules: []rbac.PolicyRule{
@@ -334,7 +334,7 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 			},
 		})
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.StorageProtection) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageObjectInUseProtection) {
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbac.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "pv-protection-controller"},
 			Rules: []rbac.PolicyRule{

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
-var _ = utils.SIGDescribe("PV Protection [Feature:StorageProtection]", func() {
+var _ = utils.SIGDescribe("PV Protection [Feature:StorageObjectInUseProtection]", func() {
 	var (
 		client    clientset.Interface
 		nameSpace string

--- a/test/e2e/storage/pvc_protection.go
+++ b/test/e2e/storage/pvc_protection.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
-var _ = utils.SIGDescribe("PVC Protection [Feature:StorageProtection]", func() {
+var _ = utils.SIGDescribe("PVC Protection [Feature:StorageObjectInUseProtection]", func() {
 	var (
 		client                  clientset.Interface
 		nameSpace               string


### PR DESCRIPTION
Rename StorageProtection to StorageObjectInUseProtection

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59639

**Special notes for your reviewer**:

**Release note**:
```release-note
Rename StorageProtection to StorageObjectInUseProtection
```
