### PR TITLE
remove conversion from printers

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -266,9 +266,8 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 			}
 		}
 
-		mapper := r.Mapper().RESTMapper
 		if len(o.outputFormat) > 0 {
-			return f.PrintObject(cmd, o.local, mapper, outputObj, o.out)
+			return f.PrintObject(cmd, o.local, outputObj, o.out)
 		}
 		f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, o.dryrun, "annotated")
 		return nil

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -156,7 +156,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 			object = hpa.Object
 		}
 		if cmdutil.GetDryRunFlag(cmd) {
-			return f.PrintObject(cmd, false, mapper, object, out)
+			return f.PrintObject(cmd, false, object, out)
 		}
 
 		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), hpa, f.JSONEncoder()); err != nil {
@@ -170,7 +170,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 
 		count++
 		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-			return f.PrintObject(cmd, false, mapper, object, out)
+			return f.PrintObject(cmd, false, object, out)
 		}
 
 		f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, cmdutil.GetDryRunFlag(cmd), "autoscaled")

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -237,8 +237,7 @@ func Example_printReplicationControllerWithNamespace() {
 			ReadyReplicas: 1,
 		},
 	}
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, ctrl, os.Stdout)
+	err := f.PrintObject(cmd, false, ctrl, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -291,8 +290,7 @@ func Example_printMultiContainersReplicationControllerWithWide() {
 			Replicas: 1,
 		},
 	}
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, ctrl, os.Stdout)
+	err := f.PrintObject(cmd, false, ctrl, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -344,8 +342,7 @@ func Example_printReplicationController() {
 			Replicas: 1,
 		},
 	}
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, ctrl, os.Stdout)
+	err := f.PrintObject(cmd, false, ctrl, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -386,8 +383,7 @@ func Example_printPodWithWideFormat() {
 			PodIP: "10.1.1.3",
 		},
 	}
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, pod, os.Stdout)
+	err := f.PrintObject(cmd, false, pod, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -431,8 +427,7 @@ func Example_printPodWithShowLabels() {
 			},
 		},
 	}
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, pod, os.Stdout)
+	err := f.PrintObject(cmd, false, pod, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -554,8 +549,7 @@ func Example_printPodHideTerminated() {
 		fmt.Printf("Unexpected filter error: %v\n", errs)
 	}
 	for _, pod := range filteredPodList {
-		mapper, _ := f.Object()
-		err := f.PrintObject(cmd, false, mapper, pod, os.Stdout)
+		err := f.PrintObject(cmd, false, pod, os.Stdout)
 		if err != nil {
 			fmt.Printf("Unexpected error: %v", err)
 		}
@@ -581,8 +575,7 @@ func Example_printPodShowAll() {
 	}
 	cmd := NewCmdRun(f, os.Stdin, os.Stdout, os.Stderr)
 	podList := newAllPhasePodList()
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, podList, os.Stdout)
+	err := f.PrintObject(cmd, false, podList, os.Stdout)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}
@@ -657,8 +650,7 @@ func Example_printServiceWithNamespacesAndLabels() {
 	}
 	ld := strings.NewLineDelimiter(os.Stdout, "|")
 	defer ld.Flush()
-	mapper, _ := f.Object()
-	err := f.PrintObject(cmd, false, mapper, svc, ld)
+	err := f.PrintObject(cmd, false, svc, ld)
 	if err != nil {
 		fmt.Printf("Unexpected error: %v", err)
 	}

--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -206,7 +206,7 @@ func (c *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 	}
 
 	c.PrintObject = func(obj runtime.Object) error {
-		return f.PrintObject(cmd, false, c.Mapper, obj, c.Out)
+		return f.PrintObject(cmd, false, obj, c.Out)
 	}
 
 	clientset, err := f.KubernetesClientSet()

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -255,7 +255,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 		info.Refresh(object, true)
 		if cmdutil.GetDryRunFlag(cmd) {
 			if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-				return f.PrintObject(cmd, false, mapper, object, out)
+				return f.PrintObject(cmd, false, object, out)
 			}
 			f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, true, "exposed")
 			return nil
@@ -271,7 +271,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 		}
 
 		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-			return f.PrintObject(cmd, false, mapper, object, out)
+			return f.PrintObject(cmd, false, object, out)
 		}
 
 		f.PrintSuccess(false, out, info.Mapping.Resource, info.Name, false, "exposed")

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -288,7 +288,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		}
 
 		if len(o.outputFormat) > 0 {
-			return f.PrintObject(cmd, o.local, r.Mapper().RESTMapper, outputObj, o.out)
+			return f.PrintObject(cmd, o.local, outputObj, o.out)
 		}
 		f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, o.dryrun, dataChangeMsg)
 		return nil

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -191,8 +191,6 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 	var keepOldName bool
 	var replicasDefaulted bool
 
-	mapper, _ := f.Object()
-
 	if len(filename) != 0 {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 		if err != nil {
@@ -322,10 +320,10 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 			oldRcData.WriteString(oldRc.Name)
 			newRcData.WriteString(newRc.Name)
 		} else {
-			if err := f.PrintObject(cmd, false, mapper, oldRc, oldRcData); err != nil {
+			if err := f.PrintObject(cmd, false, oldRc, oldRcData); err != nil {
 				return err
 			}
-			if err := f.PrintObject(cmd, false, mapper, newRc, newRcData); err != nil {
+			if err := f.PrintObject(cmd, false, newRc, newRcData); err != nil {
 				return err
 			}
 		}
@@ -370,7 +368,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 		return err
 	}
 	if outputFormat != "" {
-		return f.PrintObject(cmd, false, mapper, newRc, out)
+		return f.PrintObject(cmd, false, newRc, out)
 	}
 	f.PrintSuccess(false, out, "replicationcontrollers", oldName, dryrun, message)
 	return nil

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -407,7 +407,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 	if runObject != nil {
 		outputFormat := cmdutil.GetFlagString(cmd, "output")
 		if outputFormat != "" || cmdutil.GetDryRunFlag(cmd) {
-			return f.PrintObject(cmd, false, runObject.Mapper, runObject.Object, cmdOut)
+			return ensurePrintVersionedObject(f, cmd, runObject.Object, cmdOut)
 		}
 		f.PrintSuccess(false, cmdOut, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
 	}
@@ -557,7 +557,7 @@ func generateService(f cmdutil.Factory, cmd *cobra.Command, args []string, servi
 	}
 
 	if cmdutil.GetFlagString(cmd, "output") != "" || cmdutil.GetDryRunFlag(cmd) {
-		err := f.PrintObject(cmd, false, runObject.Mapper, runObject.Object, out)
+		err := f.PrintObject(cmd, false, runObject.Object, out)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -116,7 +115,6 @@ type EnvOptions struct {
 	From              string
 	Prefix            string
 
-	Mapper  meta.RESTMapper
 	Builder *resource.Builder
 	Infos   []*resource.Info
 	Encoder runtime.Encoder
@@ -124,7 +122,7 @@ type EnvOptions struct {
 	Cmd *cobra.Command
 
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
-	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject            func(cmd *cobra.Command, isLocal bool, obj runtime.Object, out io.Writer) error
 }
 
 // NewCmdEnv implements the OpenShift cli env command
@@ -189,7 +187,6 @@ func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		return cmdutil.UsageErrorf(cmd, "one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
 
-	o.Mapper, _ = f.Object()
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
 	o.Encoder = f.JSONEncoder()
 	o.ContainerSelector = cmdutil.GetFlagString(cmd, "containers")
@@ -417,7 +414,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 		}
 
 		if o.PrintObject != nil && (o.Local || o.DryRun) {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, patch.Info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -437,7 +434,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 		}
 
 		if len(o.Output) > 0 {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -37,7 +36,6 @@ import (
 type ImageOptions struct {
 	resource.FilenameOptions
 
-	Mapper       meta.RESTMapper
 	Infos        []*resource.Info
 	Encoder      runtime.Encoder
 	Decoder      runtime.Decoder
@@ -55,7 +53,7 @@ type ImageOptions struct {
 	ResolveImage func(in string) (string, error)
 
 	PrintSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
-	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject            func(cmd *cobra.Command, isLocal bool, obj runtime.Object, out io.Writer) error
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
 	ContainerImages        map[string]string
@@ -117,7 +115,6 @@ func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 }
 
 func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	o.Mapper, _ = f.Object()
 	o.PrintSuccess = f.PrintSuccess
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
 	o.Encoder = f.JSONEncoder()
@@ -249,7 +246,7 @@ func (o *ImageOptions) Run() error {
 		}
 
 		if o.PrintObject != nil && (o.Local || o.DryRun) {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, patch.Info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -275,7 +272,7 @@ func (o *ImageOptions) Run() error {
 		info.Refresh(obj, true)
 
 		if len(o.Output) > 0 {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -62,7 +61,6 @@ var (
 type ResourcesOptions struct {
 	resource.FilenameOptions
 
-	Mapper            meta.RESTMapper
 	Infos             []*resource.Info
 	Encoder           runtime.Encoder
 	Out               io.Writer
@@ -81,7 +79,7 @@ type ResourcesOptions struct {
 	ResourceRequirements v1.ResourceRequirements
 
 	PrintSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
-	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject            func(cmd *cobra.Command, isLocal bool, obj runtime.Object, out io.Writer) error
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
 }
@@ -128,7 +126,6 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 }
 
 func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	o.Mapper, _ = f.Object()
 	o.PrintSuccess = f.PrintSuccess
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
 	o.Encoder = f.JSONEncoder()
@@ -241,7 +238,7 @@ func (o *ResourcesOptions) Run() error {
 		}
 
 		if o.Local || cmdutil.GetDryRunFlag(o.Cmd) {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, patch.Info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -266,7 +263,7 @@ func (o *ResourcesOptions) Run() error {
 
 		shortOutput := o.Output == "name"
 		if len(o.Output) > 0 && !shortOutput {
-			if err := o.PrintObject(o.Cmd, o.Local, o.Mapper, info.AsVersioned(), o.Out); err != nil {
+			if err := o.PrintObject(o.Cmd, o.Local, info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -152,7 +152,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	}
 
 	o.PrintObject = func(obj runtime.Object) error {
-		return f.PrintObject(cmd, o.local, mapper, obj, o.out)
+		return f.PrintObject(cmd, o.local, obj, o.out)
 	}
 	o.ClientForMapping = func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
 		return f.ClientForMapping(mapping)

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -56,7 +55,6 @@ var (
 // serviceAccountConfig encapsulates the data required to perform the operation.
 type serviceAccountConfig struct {
 	fileNameOptions        resource.FilenameOptions
-	mapper                 meta.RESTMapper
 	encoder                runtime.Encoder
 	out                    io.Writer
 	err                    io.Writer
@@ -68,7 +66,7 @@ type serviceAccountConfig struct {
 	output                 string
 	changeCause            string
 	local                  bool
-	PrintObject            func(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject            func(cmd *cobra.Command, isLocal bool, obj runtime.Object, out io.Writer) error
 	updatePodSpecForObject func(runtime.Object, func(*v1.PodSpec) error) (bool, error)
 	printSuccess           func(shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
 	infos                  []*resource.Info
@@ -108,7 +106,6 @@ func NewCmdServiceAccount(f cmdutil.Factory, out, err io.Writer) *cobra.Command 
 
 // Complete configures serviceAccountConfig from command line args.
 func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	saConfig.mapper, _ = f.Object()
 	saConfig.encoder = f.JSONEncoder()
 	saConfig.shortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
 	saConfig.record = cmdutil.GetRecordFlag(cmd)
@@ -168,7 +165,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			continue
 		}
 		if saConfig.local || saConfig.dryRun {
-			if err := saConfig.PrintObject(saConfig.cmd, saConfig.local, saConfig.mapper, patch.Info.AsVersioned(), saConfig.out); err != nil {
+			if err := saConfig.PrintObject(saConfig.cmd, saConfig.local, patch.Info.AsVersioned(), saConfig.out); err != nil {
 				return err
 			}
 			continue
@@ -187,7 +184,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			}
 		}
 		if len(saConfig.output) > 0 {
-			if err := saConfig.PrintObject(saConfig.cmd, saConfig.local, saConfig.mapper, info.AsVersioned(), saConfig.out); err != nil {
+			if err := saConfig.PrintObject(saConfig.cmd, saConfig.local, info.AsVersioned(), saConfig.out); err != nil {
 				return err
 			}
 			continue

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -57,7 +56,6 @@ type updateSubjects func(existings []rbac.Subject, targets []rbac.Subject) (bool
 type SubjectOptions struct {
 	resource.FilenameOptions
 
-	Mapper            meta.RESTMapper
 	Typer             runtime.ObjectTyper
 	Infos             []*resource.Info
 	Encoder           runtime.Encoder
@@ -74,7 +72,7 @@ type SubjectOptions struct {
 	Groups          []string
 	ServiceAccounts []string
 
-	PrintObject func(mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject func(obj runtime.Object, out io.Writer) error
 }
 
 func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
@@ -111,12 +109,11 @@ func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 }
 
 func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	o.Mapper, o.Typer = f.Object()
 	o.Encoder = f.JSONEncoder()
 	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
-	o.PrintObject = func(mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
-		return f.PrintObject(cmd, o.Local, mapper, obj, out)
+	o.PrintObject = func(obj runtime.Object, out io.Writer) error {
+		return f.PrintObject(cmd, o.Local, obj, out)
 	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
@@ -242,7 +239,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObject(o.Mapper, info.Object, o.Out); err != nil {
+			if err := o.PrintObject(info.Object, o.Out); err != nil {
 				return err
 			}
 			continue
@@ -257,7 +254,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 
 		shortOutput := o.Output == "name"
 		if len(o.Output) > 0 && !shortOutput {
-			return o.PrintObject(o.Mapper, info.AsVersioned(), o.Out)
+			return o.PrintObject(info.AsVersioned(), o.Out)
 		}
 		f.PrintSuccess(shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
 	}

--- a/pkg/kubectl/cmd/set/set_subject_test.go
+++ b/pkg/kubectl/cmd/set/set_subject_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	f, tf, _, _ := cmdtesting.NewAPIFactory()
+	_, tf, _, _ := cmdtesting.NewAPIFactory()
 	tf.Namespace = "test"
 
 	tests := map[string]struct {
@@ -107,7 +107,6 @@ func TestValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test.options.Mapper, _ = f.Object()
 		err := test.options.Validate()
 		if test.expectErr && err != nil {
 			continue

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -274,10 +274,9 @@ func (o TaintOptions) RunTaint() error {
 			return err
 		}
 
-		mapper, _ := o.f.Object()
 		outputFormat := cmdutil.GetFlagString(o.cmd, "output")
 		if outputFormat != "" {
-			return o.f.PrintObject(o.cmd, false, mapper, outputObj, o.out)
+			return o.f.PrintObject(o.cmd, false, outputObj, o.out)
 		}
 
 		o.f.PrintSuccess(false, o.out, info.Mapping.Resource, info.Name, false, operation)

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -241,7 +241,7 @@ type BuilderFactory interface {
 	// an error if a printer could not be found.
 	PrinterForMapping(options *printers.PrintOptions, mapping *meta.RESTMapping) (printers.ResourcePrinter, error)
 	// PrintObject prints an api object given command line flags to modify the output format
-	PrintObject(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
+	PrintObject(cmd *cobra.Command, isLocal bool, obj runtime.Object, out io.Writer) error
 	// PrintResourceInfoForCommand receives a *cobra.Command and a *resource.Info and
 	// attempts to print an info object based on the specified output format. If the
 	// object passed is non-generic, it attempts to print the object using a HumanReadablePrinter.


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Begin removing conversion and RESTMapper usage from the printing stack.
For now, just seeing which commands break.
Ideally, will remove the entire `PrintObject` method from the cmdutil.Factory as it is no longer needed if this works.

Next steps would look into removing the `PrinterForMapper` method. It only does conversion on generic prints, which should be handled at the command level where needed.

Followup to https://github.com/kubernetes/kubernetes/pull/59353
Depends on https://github.com/kubernetes/kubernetes/pull/60057

cc @deads2k @soltysh 
