### PR TITLE
csi: Remove stale volume path

### DIFF
--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -397,10 +397,17 @@ func removeMountDir(plug *csiPlugin, mountPath string) error {
 			return err
 		}
 		// remove volume data file as well
-		dataFile := path.Join(path.Dir(mountPath), volDataFileName)
+		volPath := path.Dir(mountPath)
+		dataFile := path.Join(volPath, volDataFileName)
 		glog.V(4).Info(log("also deleting volume info data file [%s]", dataFile))
 		if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
 			glog.Error(log("failed to delete volume data file [%s]: %v", dataFile, err))
+			return err
+		}
+		// remove volume path
+		glog.V(4).Info(log("deleting volume path [%s]", volPath))
+		if err := os.Remove(volPath); err != nil && !os.IsNotExist(err) {
+			glog.Error(log("failed to delete volume path [%s]: %v", volPath, err))
 			return err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The CSI mounter creates the following paths during SetUp():

   * .../pods/\<podID\>/volumes/kubernetes.io~csi/\<specVolId\>/mount/
   * .../pods/\<podID\>/volumes/kubernetes.io~csi/\<specVolId\>/volume_data.json

During TearDown(), it does not remove the `.../kubernetes.io~csi/<specVolId>/`
directory, leaving behind orphan volumes: method cleanupOrphanedPodDirs()
complains with 'Orphaned pod found, but volume paths are still present
on disk'.

Fix that by removing the above directory in removeMountDir().

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
