### PR TITLE
Add cluster-location to GCE instance attributes

### DIFF
--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -108,6 +108,7 @@ function create-master-instance-internal() {
   local metadata="kube-env=${KUBE_TEMP}/master-kube-env.yaml"
   metadata="${metadata},user-data=${KUBE_ROOT}/cluster/gce/gci/master.yaml"
   metadata="${metadata},configure-sh=${KUBE_ROOT}/cluster/gce/gci/configure.sh"
+  metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},cluster-name=${KUBE_TEMP}/cluster-name.txt"
   metadata="${metadata},gci-update-strategy=${KUBE_TEMP}/gci-update.txt"
   metadata="${metadata},gci-ensure-gke-docker=${KUBE_TEMP}/gci-ensure-gke-docker.txt"

--- a/cluster/gce/gci/node-helper.sh
+++ b/cluster/gce/gci/node-helper.sh
@@ -22,6 +22,7 @@ function get-node-instance-metadata {
   metadata+="kube-env=${KUBE_TEMP}/node-kube-env.yaml,"
   metadata+="user-data=${KUBE_ROOT}/cluster/gce/gci/node.yaml,"
   metadata+="configure-sh=${KUBE_ROOT}/cluster/gce/gci/configure.sh,"
+  metadata+="cluster-location=${KUBE_TEMP}/cluster-location.txt,"
   metadata+="cluster-name=${KUBE_TEMP}/cluster-name.txt,"
   metadata+="gci-update-strategy=${KUBE_TEMP}/gci-update.txt,"
   metadata+="gci-ensure-gke-docker=${KUBE_TEMP}/gci-ensure-gke-docker.txt,"

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -151,6 +151,7 @@ function prepare-upgrade() {
   detect-project
   detect-subnetworks
   detect-node-names # sets INSTANCE_GROUPS
+  write-cluster-location
   write-cluster-name
   tars_from_version
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -472,6 +472,15 @@ function yaml-quote {
   echo "'$(echo "${@:-}" | sed -e "s/'/''/g")'"
 }
 
+# Writes the cluster location into a temporary file.
+# Assumed vars
+#   ZONE
+function write-cluster-location {
+  cat >"${KUBE_TEMP}/cluster-location.txt" << EOF
+${ZONE}
+EOF
+}
+
 # Writes the cluster name into a temporary file.
 # Assumed vars
 #   CLUSTER_NAME
@@ -1499,6 +1508,7 @@ function kube-up() {
     create-network
     create-subnetworks
     detect-subnetworks
+    write-cluster-location
     write-cluster-name
     create-autoscaler-config
     create-master


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes cluster location on GCP as instance attribute. In particular, this metadata is useful for exposing metrics to Stackdriver monitoring system and is necessary for some Stackdriver integration components, i.e. Stackdriver Metadata Agent

**Release note**:
```release-note
NONE
```
