### PR TITLE
Enable mount propagation tests by default

### DIFF
--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -74,7 +74,7 @@ func preparePod(name string, node *v1.Node, propagation v1.MountPropagationMode,
 	return pod
 }
 
-var _ = SIGDescribe("Mount propagation [Feature:MountPropagation]", func() {
+var _ = SIGDescribe("Mount propagation", func() {
 	f := framework.NewDefaultFramework("mount-propagation")
 
 	It("should propagate mounts to the host", func() {


### PR DESCRIPTION
MountPropagation is enabled by default now, so should be the test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
