### PR TITLE
do not delete node in openstack, if those still exist in cloudprovider

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -415,12 +415,9 @@ func foreachServer(client *gophercloud.ServiceClient, opts servers.ListOptsBuild
 	return err
 }
 
-func getServerByName(client *gophercloud.ServiceClient, name types.NodeName, showOnlyActive bool) (*servers.Server, error) {
+func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*servers.Server, error) {
 	opts := servers.ListOpts{
 		Name: fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
-	}
-	if showOnlyActive {
-		opts.Status = "ACTIVE"
 	}
 
 	pager := servers.List(client, opts)
@@ -504,7 +501,7 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 }
 
 func getAddressesByName(client *gophercloud.ServiceClient, name types.NodeName) ([]v1.NodeAddress, error) {
-	srv, err := getServerByName(client, name, true)
+	srv, err := getServerByName(client, name)
 	if err != nil {
 		return nil, err
 	}
@@ -666,7 +663,7 @@ func (os *OpenStack) GetZoneByNodeName(ctx context.Context, nodeName types.NodeN
 		return cloudprovider.Zone{}, err
 	}
 
-	srv, err := getServerByName(compute, nodeName, true)
+	srv, err := getServerByName(compute, nodeName)
 	if err != nil {
 		if err == ErrNotFound {
 			return cloudprovider.Zone{}, cloudprovider.InstanceNotFound

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -107,7 +107,7 @@ func (i *Instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 
 // ExternalID returns the cloud provider ID of the specified instance (deprecated).
 func (i *Instances) ExternalID(ctx context.Context, name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name, true)
+	srv, err := getServerByName(i.compute, name)
 	if err != nil {
 		if err == ErrNotFound {
 			return "", cloudprovider.InstanceNotFound
@@ -155,7 +155,7 @@ func (os *OpenStack) InstanceID() (string, error) {
 
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name, true)
+	srv, err := getServerByName(i.compute, name)
 	if err != nil {
 		if err == ErrNotFound {
 			return "", cloudprovider.InstanceNotFound
@@ -188,7 +188,7 @@ func (i *Instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 
 // InstanceType returns the type of the specified instance.
 func (i *Instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	srv, err := getServerByName(i.compute, name, true)
+	srv, err := getServerByName(i.compute, name)
 
 	if err != nil {
 		return "", err

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -552,7 +552,7 @@ func getNodeSecurityGroupIDForLB(compute *gophercloud.ServiceClient, nodes []*v1
 
 	for _, node := range nodes {
 		nodeName := types.NodeName(node.Name)
-		srv, err := getServerByName(compute, nodeName, true)
+		srv, err := getServerByName(compute, nodeName)
 		if err != nil {
 			return nodeSecurityGroupIDs.List(), err
 		}

--- a/pkg/cloudprovider/providers/openstack/openstack_routes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes.go
@@ -297,7 +297,7 @@ func (r *Routes) DeleteRoute(ctx context.Context, clusterName string, route *clo
 }
 
 func getPortIDByIP(compute *gophercloud.ServiceClient, targetNode types.NodeName, ipAddress string) (string, error) {
-	srv, err := getServerByName(compute, targetNode, true)
+	srv, err := getServerByName(compute, targetNode)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -622,7 +622,7 @@ func (os *OpenStack) DiskIsAttachedByName(nodeName types.NodeName, volumeID stri
 	if err != nil {
 		return false, "", err
 	}
-	srv, err := getServerByName(cClient, nodeName, false)
+	srv, err := getServerByName(cClient, nodeName)
 	if err != nil {
 		if err == ErrNotFound {
 			// instance not found anymore in cloudprovider, assume that cinder is detached
@@ -659,7 +659,7 @@ func (os *OpenStack) DisksAreAttachedByName(nodeName types.NodeName, volumeIDs [
 	if err != nil {
 		return attached, err
 	}
-	srv, err := getServerByName(cClient, nodeName, false)
+	srv, err := getServerByName(cClient, nodeName)
 	if err != nil {
 		if err == ErrNotFound {
 			// instance not found anymore, mark all volumes as detached


### PR DESCRIPTION
**What this PR does / why we need it**: Deleting nodes in kubernetes cluster causes problems. It will lead to situations like labels and taints are missing from nodes when node will return online.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

```release-note
Nodes are not deleted from kubernetes anymore if node is shutdown in Openstack.
```
