### PR TITLE
test: e2e: node: add RunAsUser default to image USER test

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -70,6 +70,17 @@ var _ = SIGDescribe("Security Context [Feature:SecurityContext]", func() {
 		f.TestContainerOutput("pod.Spec.SecurityContext.SupplementalGroups", pod, 0, groups)
 	})
 
+	It("RunAsUser should default to image's USER", func() {
+		pod := scTestPod(false, false)
+		// this userID comes from the image's USER 1002
+		userID := int64(1002)
+		pod.Spec.Containers[0].Image = "runcom/imageuser"
+		pod.Spec.Containers[0].Command = []string{"sh", "-c", "id -u"}
+		f.TestContainerOutput("pod.Spec.SecurityContext.RunAsUser", pod, 0, []string{
+			fmt.Sprintf("%v", userID),
+		})
+	})
+
 	It("should support pod.Spec.SecurityContext.RunAsUser", func() {
 		pod := scTestPod(false, false)
 		userID := int64(1001)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We had a bug in CRI-O where ImageStatus wasn't providing the image's
Username, resulting in containers always running as root. This test
ensures we catch such issues in the future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I'm using my own images `runcom/imageuser` which is built from the following Dockerfile:
```
FROM busybox
USER 1002
```
@Random-Liu et all, do you know how to have an official images for tests using that dockrfile?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add RunAsUser default to image USER test
```

@mrunalp @derekwaynecarr PTAL
