### PR TITLE
Move ipvs module loading logic in local-cluster-up.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -122,7 +122,14 @@ fi
 
 # set feature gates if using ipvs mode
 if [ "${KUBE_PROXY_MODE}" == "ipvs" ]; then
-    FEATURE_GATES="$FEATURE_GATES,SupportIPVSProxyMode=true"
+    # If required kernel modules are not available, fall back to iptables.
+    sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4
+    if [[ $? -eq 0 ]]; then
+      FEATURE_GATES="${FEATURE_GATES},SupportIPVSProxyMode=true"
+    else
+      echo "Required kernel modules for ipvs not found. Falling back to iptables mode."
+      KUBE_PROXY_MODE=iptables
+    fi
 fi
 
 # set feature gates if enable Pod priority and preemption
@@ -813,10 +820,6 @@ hostnameOverride: ${HOSTNAME_OVERRIDE}
 featureGates: ${FEATURE_GATES}
 mode: ${KUBE_PROXY_MODE}
 EOF
-    if [ "${KUBE_PROXY_MODE}" == "ipvs" ]; then
-	# Load kernel modules required by IPVS proxier
-        sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4
-    fi
 
     sudo "${GO_OUT}/hyperkube" proxy \
       --config=/tmp/kube-proxy.yaml \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the module loading logic for ipvs kube-proxy a little more robust. Previously we were attempting to load the modules and not checking that it succeeded. Now we make sure the loading was successful before proceeding with using ipvs as the proxier.

/assign @cblecker 

Release Note
```release-note
None
```
