### PR TITLE
Update reviewers for sig-scheduling.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,6 +13,7 @@ aliases:
     - resouer
     - timothysc
     - wojtek-t
+    - aveshagarwal
   sig-cli-maintainers:
     - adohe
     - brendandburns


### PR DESCRIPTION
@bsalamat @timothysc @kubernetes/sig-scheduling-misc 

**Release note**: 
```release-note
None
```
