### PR TITLE
kubelet: revert the get pod with updated status

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -142,15 +142,7 @@ func (kl *Kubelet) getPodContainerDir(podUID types.UID, ctrName string) string {
 // GetPods returns all pods bound to the kubelet and their spec, and the mirror
 // pods.
 func (kl *Kubelet) GetPods() []*v1.Pod {
-	pods := kl.podManager.GetPods()
-	// a kubelet running without apiserver requires an additional
-	// update of the static pod status. See #57106
-	for _, p := range pods {
-		if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
-			p.Status = status
-		}
-	}
-	return pods
+	return kl.podManager.GetPods()
 }
 
 // GetRunningPods returns all pods running on kubelet from looking at the


### PR DESCRIPTION
**What this PR does / why we need it**:

Following #59892 this PR finish to revert #57106 

The first revert didn't solve the reboot test in the [test grid](https://k8s-testgrid.appspot.com/google-gce#gci-gce-reboot).


**Special notes for your reviewer**:

cc @dashpole  @Random-Liu 

**Release note**:
```release-note
None
```
