### PR TITLE
Start deprecation of role for `cloud-provider` service account in rbac boostrap

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
@@ -87,6 +87,7 @@ func init() {
 	})
 	addNamespaceRole(metav1.NamespaceSystem, rbac.Role{
 		// role for the cloud providers to access/create kube-system configmaps
+		// Deprecated starting Kubernetes 1.10 and will be deleted according to GA deprecation policy.
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "cloud-provider"},
 		Rules: []rbac.PolicyRule{
 			rbac.NewRule("create", "get", "list", "watch").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
@@ -123,6 +124,7 @@ func init() {
 		rbac.NewRoleBinding("system::leader-locking-kube-scheduler", metav1.NamespaceSystem).SAs(metav1.NamespaceSystem, "kube-scheduler").BindingOrDie())
 	addNamespaceRoleBinding(metav1.NamespaceSystem,
 		rbac.NewRoleBinding(saRolePrefix+"bootstrap-signer", metav1.NamespaceSystem).SAs(metav1.NamespaceSystem, "bootstrap-signer").BindingOrDie())
+	// cloud-provider is deprecated starting Kubernetes 1.10 and will be deleted according to GA deprecation policy.
 	addNamespaceRoleBinding(metav1.NamespaceSystem,
 		rbac.NewRoleBinding(saRolePrefix+"cloud-provider", metav1.NamespaceSystem).SAs(metav1.NamespaceSystem, "cloud-provider").BindingOrDie())
 	addNamespaceRoleBinding(metav1.NamespaceSystem,


### PR DESCRIPTION
**What this PR does / why we need it**:
See #59686 for reference

**Special notes for your reviewer**:
/assign @tallclair 

**Release note**:
```release-note
Action Required: The boostrapped RBAC role and rolebinding for the `cloud-provider` service account is now deprecated. If you're currently using this service account, you must create and apply your own RBAC policy for new clusters.
```
