### PR TITLE
cluster/images/hyperkube: Fix typo in Dockerfile for aggregator symlink

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -26,7 +26,7 @@ RUN ln -s /hyperkube /apiserver \
  && ln -s /hyperkube /kubelet \
  && ln -s /hyperkube /proxy \
  && ln -s /hyperkube /scheduler \
-  && ln -s /hyperkube /aggerator \
+ && ln -s /hyperkube /aggregator \
  && ln -s /hyperkube /usr/local/bin/kube-apiserver \
  && ln -s /hyperkube /usr/local/bin/kube-controller-manager \
  && ln -s /hyperkube /usr/local/bin/kubectl \


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes typo in the hyperkube Dockerfile for kube-aggregator