### PR TITLE
Index PVs by StorageClass in assume cache

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_assume_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_assume_cache.go
@@ -43,7 +43,7 @@ type AssumeCache interface {
 	Get(objName string) (interface{}, error)
 
 	// List all the objects in the cache
-	List() []interface{}
+	List(indexObj interface{}) []interface{}
 }
 
 type errWrongType struct {
@@ -89,7 +89,11 @@ type assumeCache struct {
 	description string
 
 	// Stores objInfo pointers
-	store cache.Store
+	store cache.Indexer
+
+	// Index function for object
+	indexFunc cache.IndexFunc
+	indexName string
 }
 
 type objInfo struct {
@@ -111,9 +115,21 @@ func objInfoKeyFunc(obj interface{}) (string, error) {
 	return objInfo.name, nil
 }
 
-func NewAssumeCache(informer cache.SharedIndexInformer, description string) *assumeCache {
-	// TODO: index by storageclass
-	c := &assumeCache{store: cache.NewStore(objInfoKeyFunc), description: description}
+func (c *assumeCache) objInfoIndexFunc(obj interface{}) ([]string, error) {
+	objInfo, ok := obj.(*objInfo)
+	if !ok {
+		return []string{""}, &errWrongType{"objInfo", obj}
+	}
+	return c.indexFunc(objInfo.latestObj)
+}
+
+func NewAssumeCache(informer cache.SharedIndexInformer, description, indexName string, indexFunc cache.IndexFunc) *assumeCache {
+	c := &assumeCache{
+		description: description,
+		indexFunc:   indexFunc,
+		indexName:   indexName,
+	}
+	c.store = cache.NewIndexer(objInfoKeyFunc, cache.Indexers{indexName: c.objInfoIndexFunc})
 
 	// Unit tests don't use informers
 	if informer != nil {
@@ -211,12 +227,18 @@ func (c *assumeCache) Get(objName string) (interface{}, error) {
 	return objInfo.latestObj, nil
 }
 
-func (c *assumeCache) List() []interface{} {
+func (c *assumeCache) List(indexObj interface{}) []interface{} {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	allObjs := []interface{}{}
-	for _, obj := range c.store.List() {
+	objs, err := c.store.Index(c.indexName, &objInfo{latestObj: indexObj})
+	if err != nil {
+		glog.Errorf("list index error: %v", err)
+		return nil
+	}
+
+	for _, obj := range objs {
 		objInfo, ok := obj.(*objInfo)
 		if !ok {
 			glog.Errorf("list error: %v", &errWrongType{"objInfo", obj})
@@ -280,15 +302,22 @@ type PVAssumeCache interface {
 	AssumeCache
 
 	GetPV(pvName string) (*v1.PersistentVolume, error)
-	ListPVs() []*v1.PersistentVolume
+	ListPVs(storageClassName string) []*v1.PersistentVolume
 }
 
 type pvAssumeCache struct {
 	*assumeCache
 }
 
+func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
+	if pv, ok := obj.(*v1.PersistentVolume); ok {
+		return []string{pv.Spec.StorageClassName}, nil
+	}
+	return []string{""}, fmt.Errorf("object is not a v1.PersistentVolume: %v", obj)
+}
+
 func NewPVAssumeCache(informer cache.SharedIndexInformer) PVAssumeCache {
-	return &pvAssumeCache{assumeCache: NewAssumeCache(informer, "v1.PersistentVolume")}
+	return &pvAssumeCache{assumeCache: NewAssumeCache(informer, "v1.PersistentVolume", "storageclass", pvStorageClassIndexFunc)}
 }
 
 func (c *pvAssumeCache) GetPV(pvName string) (*v1.PersistentVolume, error) {
@@ -304,8 +333,12 @@ func (c *pvAssumeCache) GetPV(pvName string) (*v1.PersistentVolume, error) {
 	return pv, nil
 }
 
-func (c *pvAssumeCache) ListPVs() []*v1.PersistentVolume {
-	objs := c.List()
+func (c *pvAssumeCache) ListPVs(storageClassName string) []*v1.PersistentVolume {
+	objs := c.List(&v1.PersistentVolume{
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: storageClassName,
+		},
+	})
 	pvs := []*v1.PersistentVolume{}
 	for _, obj := range objs {
 		pv, ok := obj.(*v1.PersistentVolume)

--- a/pkg/controller/volume/persistentvolume/scheduler_binder.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder.go
@@ -350,10 +350,17 @@ func (b *volumeBinder) findMatchingVolumes(pod *v1.Pod, claimsToBind []*bindingI
 	// Sort all the claims by increasing size request to get the smallest fits
 	sort.Sort(byPVCSize(claimsToBind))
 
-	allPVs := b.pvCache.ListPVs()
 	chosenPVs := map[string]*v1.PersistentVolume{}
 
 	for _, bindingInfo := range claimsToBind {
+		// Get storage class name from each PVC
+		storageClassName := ""
+		storageClass := bindingInfo.pvc.Spec.StorageClassName
+		if storageClass != nil {
+			storageClassName = *storageClass
+		}
+		allPVs := b.pvCache.ListPVs(storageClassName)
+
 		// Find a matching PV
 		bindingInfo.pv, err = findMatchingVolume(bindingInfo.pvc, allPVs, node, chosenPVs, true)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Performance optimization for delayed binding in the scheduler to only search for PVs with a matching StorageClass name.  This means that if you prebind the PV to a PVC, the PV must have a matching StorageClass name.  This behavior is different from when you prebind with immediate binding, which doesn't care about StorageClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56102

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```