### PR TITLE
Updating kubemci e2e test to not add kubeconfig flag for get-status

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -1142,7 +1142,7 @@ func (j *IngressTestJig) RunCreate(ing *extensions.Ingress) (*extensions.Ingress
 	if err := manifest.IngressToManifest(ing, filePath); err != nil {
 		return nil, err
 	}
-	_, err := RunKubemciCmd("create", ing.Name, fmt.Sprintf("--ingress=%s", filePath))
+	_, err := runKubemciWithKubeconfig("create", ing.Name, fmt.Sprintf("--ingress=%s", filePath))
 	return ing, err
 }
 
@@ -1157,7 +1157,7 @@ func (j *IngressTestJig) RunUpdate(ing *extensions.Ingress) (*extensions.Ingress
 	if err := manifest.IngressToManifest(ing, filePath); err != nil {
 		return nil, err
 	}
-	_, err := RunKubemciCmd("create", ing.Name, fmt.Sprintf("--ingress=%s", filePath), "--force")
+	_, err := runKubemciWithKubeconfig("create", ing.Name, fmt.Sprintf("--ingress=%s", filePath), "--force")
 	return ing, err
 }
 
@@ -1245,14 +1245,14 @@ func (j *IngressTestJig) RunDelete(ing *extensions.Ingress, class string) error 
 	if err := manifest.IngressToManifest(ing, filePath); err != nil {
 		return err
 	}
-	_, err := RunKubemciCmd("delete", ing.Name, fmt.Sprintf("--ingress=%s", filePath))
+	_, err := runKubemciWithKubeconfig("delete", ing.Name, fmt.Sprintf("--ingress=%s", filePath))
 	return err
 }
 
 // getIngressAddressFromKubemci returns the IP address of the given multicluster ingress using kubemci.
 // TODO(nikhiljindal): Update this to be able to return hostname as well.
 func getIngressAddressFromKubemci(name string) ([]string, error) {
-	out, err := RunKubemciCmd("get-status", name)
+	out, err := runKubemciCmd("get-status", name)
 	if err != nil {
 		return []string{}, err
 	}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2192,9 +2192,17 @@ func RunKubectlOrDieInput(data string, args ...string) string {
 	return NewKubectlCommand(args...).WithStdinData(data).ExecOrDie()
 }
 
-// RunKubemciCmd is a convenience wrapper over kubectlBuilder to run kubemci.
+// runKubemciWithKubeconfig is a convenience wrapper over runKubemciCmd
+func runKubemciWithKubeconfig(args ...string) (string, error) {
+	if TestContext.KubeConfig != "" {
+		args = append(args, "--"+clientcmd.RecommendedConfigPathFlag+"="+TestContext.KubeConfig)
+	}
+	return runKubemciCmd(args...)
+}
+
+// runKubemciCmd is a convenience wrapper over kubectlBuilder to run kubemci.
 // It assumes that kubemci exists in PATH.
-func RunKubemciCmd(args ...string) (string, error) {
+func runKubemciCmd(args ...string) (string, error) {
 	// kubemci is assumed to be in PATH.
 	kubemci := "kubemci"
 	b := new(kubectlBuilder)


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/59234

Updating RunKubemciCmd to not add the --kubeconfig flag and adding a RunKubemciWithKubeconfig method that adds the kubeconfig param before calling RunKubemciCmd
And Updating get-status to use RunKubemciCmd instead of RunKubemciWithKubeconfig.

```release-note
NONE
```

cc @MrHohn @G-Harmon @madhusudancs 