### PR TITLE
Require boilerplate on Bazel Skylark source files

### DIFF
--- a/hack/boilerplate/boilerplate.bzl.txt
+++ b/hack/boilerplate/boilerplate.bzl.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors.
+# Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A project wanting to generate openapi code for vendored
-# k8s.io/kubernetes will need to set the following variables in
-# //build/openapi.bzl in their project and customize the go prefix:
-#
-# openapi_go_prefix = "k8s.io/myproject/"
-# openapi_vendor_prefix = "vendor/k8s.io/kubernetes/"
-
-openapi_go_prefix = "k8s.io/kubernetes/"
-
-openapi_vendor_prefix = ""

--- a/pkg/generated/openapi/def.bzl
+++ b/pkg/generated/openapi/def.bzl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_kubernetes_build//defs:go.bzl", "go_genrule")
 

--- a/pkg/version/def.bzl
+++ b/pkg/version/def.bzl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Implements hack/lib/version.sh's kube::version::ldflags() for Bazel.
 def version_x_defs():
   # This should match the list of packages in kube::version::ldflag

--- a/staging/src/k8s.io/client-go/pkg/version/def.bzl
+++ b/staging/src/k8s.io/client-go/pkg/version/def.bzl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Implements hack/lib/version.sh's kube::version::ldflags() for Bazel.
 def version_x_defs():
   # This should match the list of packages in kube::version::ldflag


### PR DESCRIPTION
**What this PR does / why we need it**: `.bzl` files are also source code, so they should probably have the boilerplate text too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
