### PR TITLE
e2e: Add pre-check before rolling-update

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1222,6 +1222,7 @@ metadata:
 				framework.Failf("Failed creating rc %s for 1 pod with expected image %s", rcName, nginxImage)
 			}
 			framework.WaitForRCToStabilize(c, ns, rcName, framework.PodStartTimeout)
+			framework.ValidateController(c, nginxImage, 1, rcName, "run="+rcName, noOpValidatorFn, ns)
 
 			By("rolling-update to same image controller")
 


### PR DESCRIPTION
This commit adds the same check of ValidateController before
rolling-update to distinguish rolling-update affects the test
result or not.

**What this PR does / why we need it**:

As https://github.com/kubernetes/kubernetes/issues/59833, "should support rolling-update to same image" the e2e fails due to the difference between the specified image and the rolling-upgraded image.
However, this image check(ValidateController()) is not used for nginx image at the other places.
So we need to distinguish the rolling-upgrade affects the test result or not.

**Release note**: "NONE"
