### PR TITLE
Updated the "create-update-delete-deployment" example to use apps/v1 and removed rollback example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/BUILD
+++ b/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/BUILD
@@ -16,7 +16,7 @@ go_library(
     srcs = ["main.go"],
     importpath = "k8s.io/client-go/examples/create-update-delete-deployment",
     deps = [
-        "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

*Waiting for migration to apps/v1*
> The current example at [create-update-delete-deployment/main.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go) was using `RollbackTo` of `v1beta1.DeploymentSpec` which is deprecated.

The current implementation upgrades `create-update-delete-deployment` main.go to use **apps/v1** instead of **extensions/v1beta1** and removed rollback example for now. 

**Which issue(s) this PR fixes**
Helps kubernetes/client-go#346

**Special notes for your reviewer**:
Since it's my first PR dealing with codebase and not a typo fix :xD please let me know my mistakes.
I would love to resolve them.

@nikhita @sttts @jekohk Please review. The other PR #59663  got closed accidentally while changing branch. 