### PR TITLE
[e2e ingress-gce] Enhance cleanup logic for pre-shared-cert test

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -330,7 +330,9 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				// We would not be able to delete the cert until ingress controller
 				// cleans up the target proxy that references it.
 				By("Deleting ingress before deleting ssl certificate")
-				jig.TryDeleteIngress()
+				if jig.Ingress != nil {
+					jig.TryDeleteIngress()
+				}
 				By(fmt.Sprintf("Deleting ssl certificate %q on GCE", preSharedCertName))
 				err := wait.Poll(framework.LoadBalancerPollInterval, framework.LoadBalancerCleanupTimeout, func() (bool, error) {
 					if err := gceCloud.DeleteSslCertificate(preSharedCertName); err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Pre-shared-cert test are flaky (https://k8s-testgrid.appspot.com/sig-network-gce#ingress-gce-e2e&width=5), mostly due to the orphaned ssl cert.

This PR enhances the cleanup logic to continue deleting the orphaned cert for this case (without this test will panic on TryDeleteIngress if no ingress is created).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @rramkumar1 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
