### PR TITLE
Do not add kubeconfig flag while running kubemci unless explicitly requested

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2206,9 +2206,6 @@ func runKubemciCmd(args ...string) (string, error) {
 	// kubemci is assumed to be in PATH.
 	kubemci := "kubemci"
 	b := new(kubectlBuilder)
-	if TestContext.KubeConfig != "" {
-		args = append(args, "--"+clientcmd.RecommendedConfigPathFlag+"="+TestContext.KubeConfig)
-	}
 	args = append(args, "--gcp-project="+TestContext.CloudConfig.ProjectID)
 
 	b.cmd = exec.Command(kubemci, args...)


### PR DESCRIPTION
Follow up to 
https://github.com/kubernetes/kubernetes/pull/59955

Now that we have runKubemciWithKubeconfig, runKubemciCmd should not be adding kubeconfig flag.

```release-note
NONE
```
