### PR TITLE
Use `Int32Ptr` function from utils instead of self-written versions

### DIFF
--- a/pkg/apis/apps/v1/BUILD
+++ b/pkg/apis/apps/v1/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/apis/extensions:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/apps/v1/conversion_test.go
+++ b/pkg/apis/apps/v1/conversion_test.go
@@ -28,10 +28,11 @@ import (
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestV12StatefulSetSpecConversion(t *testing.T) {
-	replicas := newInt32(2)
+	replicas := utilpointer.Int32Ptr(2)
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
 	appsv1Template := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -177,7 +178,7 @@ func TestV1StatefulSetStatusConversion(t *testing.T) {
 }
 
 func TestV1StatefulSetUpdateStrategyConversion(t *testing.T) {
-	partition := newInt32(2)
+	partition := utilpointer.Int32Ptr(2)
 	appsv1rollingUpdate := new(appsv1.RollingUpdateStatefulSetStrategy)
 	appsv1rollingUpdate.Partition = partition
 	appsrollingUpdate := new(apps.RollingUpdateStatefulSetStrategy)
@@ -258,7 +259,7 @@ func TestV1RollingUpdateDaemonSetConversion(t *testing.T) {
 }
 
 func TestV1DeploymentConversion(t *testing.T) {
-	replica := newInt32(2)
+	replica := utilpointer.Int32Ptr(2)
 	rollbackTo := new(extensions.RollbackConfig)
 	rollbackTo.Revision = int64(2)
 	testcases := map[string]struct {
@@ -337,9 +338,9 @@ func TestV1DeploymentConversion(t *testing.T) {
 }
 
 func TestV1DeploymentSpecConversion(t *testing.T) {
-	replica := newInt32(2)
-	revisionHistoryLimit := newInt32(2)
-	progressDeadlineSeconds := newInt32(2)
+	replica := utilpointer.Int32Ptr(2)
+	revisionHistoryLimit := utilpointer.Int32Ptr(2)
+	progressDeadlineSeconds := utilpointer.Int32Ptr(2)
 
 	testcases := map[string]struct {
 		deploymentSpec1 *extensions.DeploymentSpec

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -32,6 +32,7 @@ import (
 	. "k8s.io/kubernetes/pkg/apis/apps/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
@@ -81,7 +82,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 				},
 				Spec: appsv1.DaemonSetSpec{
 					Template:             defaultTemplate,
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 			expected: &appsv1.DaemonSet{
@@ -111,7 +112,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 		},
@@ -130,7 +131,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 						Type: appsv1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -147,7 +148,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -211,7 +212,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -235,7 +236,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.OnDeleteStatefulSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -260,7 +261,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -302,7 +303,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &appsv1.Deployment{},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(1),
+					Replicas: utilpointer.Int32Ptr(1),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -310,8 +311,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -319,7 +320,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -329,7 +330,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -337,8 +338,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -346,7 +347,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1.DeploymentStrategy{
 						Type:          appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: nil,
@@ -355,7 +356,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -363,8 +364,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -372,21 +373,21 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(0),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(0),
 				},
 			},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit:    newInt32(0),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(0),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -394,22 +395,22 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 				},
 			},
 			expected: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 					Template:                defaultTemplate,
 				},
 			},
@@ -466,7 +467,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: appsv1.ReplicaSet{
 				Spec: appsv1.ReplicaSetSpec{
-					Replicas: newInt32(0),
+					Replicas: utilpointer.Int32Ptr(0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -481,7 +482,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: appsv1.ReplicaSet{
 				Spec: appsv1.ReplicaSetSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -524,7 +525,7 @@ func TestDefaultRequestIsNotSetForReplicaSet(t *testing.T) {
 	}
 	rs := &appsv1.ReplicaSet{
 		Spec: appsv1.ReplicaSetSpec{
-			Replicas: newInt32(3),
+			Replicas: utilpointer.Int32Ptr(3),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -562,10 +563,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/apps/v1beta1/BUILD
+++ b/pkg/apis/apps/v1beta1/BUILD
@@ -56,6 +56,7 @@ go_test(
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -31,6 +31,7 @@ import (
 	. "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultDeployment(t *testing.T) {
@@ -54,7 +55,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &appsv1beta1.Deployment{},
 			expected: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(1),
+					Replicas: utilpointer.Int32Ptr(1),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta1.RollingUpdateDeployment{
@@ -62,8 +63,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(2),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -71,7 +72,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						RollingUpdate: &appsv1beta1.RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -81,7 +82,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta1.RollingUpdateDeployment{
@@ -89,8 +90,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(2),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -98,7 +99,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type:          appsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: nil,
@@ -107,7 +108,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta1.RollingUpdateDeployment{
@@ -115,8 +116,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(2),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -124,21 +125,21 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(0),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(0),
 				},
 			},
 			expected: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit:    newInt32(0),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(0),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -146,22 +147,22 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 				},
 			},
 			expected: &appsv1beta1.Deployment{
 				Spec: appsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta1.DeploymentStrategy{
 						Type: appsv1beta1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 					Template:                defaultTemplate,
 				},
 			},
@@ -214,10 +215,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/apps/v1beta2/BUILD
+++ b/pkg/apis/apps/v1beta2/BUILD
@@ -62,6 +62,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/apis/extensions:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/apps/v1beta2/conversion_test.go
+++ b/pkg/apis/apps/v1beta2/conversion_test.go
@@ -30,10 +30,11 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestV1beta2StatefulSetSpecConversion(t *testing.T) {
-	replicas := newInt32(2)
+	replicas := utilpointer.Int32Ptr(2)
 	selector := &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}
 	v1beta2Template := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -104,7 +105,7 @@ func TestV1beta2StatefulSetSpecConversion(t *testing.T) {
 }
 
 func TestV1beta2StatefulSetUpdateStrategyConversion(t *testing.T) {
-	partition := newInt32(2)
+	partition := utilpointer.Int32Ptr(2)
 	v1beta2rollingUpdate := new(v1beta2.RollingUpdateStatefulSetStrategy)
 	v1beta2rollingUpdate.Partition = partition
 	appsrollingUpdate := new(apps.RollingUpdateStatefulSetStrategy)
@@ -260,7 +261,7 @@ func TestV1beta2StatefulSetStatusConversion(t *testing.T) {
 }
 
 func TestV1beta2DeploymentConversion(t *testing.T) {
-	replica := newInt32(2)
+	replica := utilpointer.Int32Ptr(2)
 	rollbackTo := new(extensions.RollbackConfig)
 	rollbackTo.Revision = int64(2)
 	testcases := map[string]struct {
@@ -390,9 +391,9 @@ func TestV1beta2ScaleStatusConversion(t *testing.T) {
 }
 
 func TestV1beta2DeploymentSpecConversion(t *testing.T) {
-	replica := newInt32(2)
-	revisionHistoryLimit := newInt32(2)
-	progressDeadlineSeconds := newInt32(2)
+	replica := utilpointer.Int32Ptr(2)
+	revisionHistoryLimit := utilpointer.Int32Ptr(2)
+	progressDeadlineSeconds := utilpointer.Int32Ptr(2)
 
 	testcases := map[string]struct {
 		deploymentSpec1 *extensions.DeploymentSpec

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -32,6 +32,7 @@ import (
 	. "k8s.io/kubernetes/pkg/apis/apps/v1beta2"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
@@ -81,7 +82,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 				},
 				Spec: appsv1beta2.DaemonSetSpec{
 					Template:             defaultTemplate,
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 			expected: &appsv1beta2.DaemonSet{
@@ -111,7 +112,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 		},
@@ -130,7 +131,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: appsv1beta2.DaemonSetUpdateStrategy{
 						Type: appsv1beta2.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -147,7 +148,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 							MaxUnavailable: &maxUnavailable,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -211,7 +212,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -235,7 +236,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					UpdateStrategy: appsv1beta2.StatefulSetUpdateStrategy{
 						Type: appsv1beta2.OnDeleteStatefulSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -260,7 +261,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 							Partition: &defaultPartition,
 						},
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -302,7 +303,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &appsv1beta2.Deployment{},
 			expected: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(1),
+					Replicas: utilpointer.Int32Ptr(1),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta2.RollingUpdateDeployment{
@@ -310,8 +311,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -319,7 +320,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						RollingUpdate: &appsv1beta2.RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -329,7 +330,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta2.RollingUpdateDeployment{
@@ -337,8 +338,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -346,7 +347,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type:          appsv1beta2.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: nil,
@@ -355,7 +356,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1beta2.RollingUpdateDeployment{
@@ -363,8 +364,8 @@ func TestSetDefaultDeployment(t *testing.T) {
 							MaxUnavailable: &defaultIntOrString,
 						},
 					},
-					RevisionHistoryLimit:    newInt32(10),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(10),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -372,21 +373,21 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(0),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(0),
 				},
 			},
 			expected: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RecreateDeploymentStrategyType,
 					},
-					RevisionHistoryLimit:    newInt32(0),
-					ProgressDeadlineSeconds: newInt32(600),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(0),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(600),
 					Template:                defaultTemplate,
 				},
 			},
@@ -394,22 +395,22 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 				},
 			},
 			expected: &appsv1beta2.Deployment{
 				Spec: appsv1beta2.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: appsv1beta2.DeploymentStrategy{
 						Type: appsv1beta2.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
-					RevisionHistoryLimit:    newInt32(2),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
+					RevisionHistoryLimit:    utilpointer.Int32Ptr(2),
 					Template:                defaultTemplate,
 				},
 			},
@@ -466,7 +467,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: appsv1beta2.ReplicaSet{
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Replicas: newInt32(0),
+					Replicas: utilpointer.Int32Ptr(0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -481,7 +482,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: appsv1beta2.ReplicaSet{
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -524,7 +525,7 @@ func TestDefaultRequestIsNotSetForReplicaSet(t *testing.T) {
 	}
 	rs := &appsv1beta2.ReplicaSet{
 		Spec: appsv1beta2.ReplicaSetSpec{
-			Replicas: newInt32(3),
+			Replicas: utilpointer.Int32Ptr(3),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -562,10 +563,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/autoscaling/v1/BUILD
+++ b/pkg/apis/autoscaling/v1/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/autoscaling/install:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],

--- a/pkg/apis/autoscaling/v1/defaults_test.go
+++ b/pkg/apis/autoscaling/v1/defaults_test.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
@@ -43,7 +44,7 @@ func TestSetDefaultHPA(t *testing.T) {
 		{
 			hpa: autoscalingv1.HorizontalPodAutoscaler{
 				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
-					MinReplicas: newInt32(3),
+					MinReplicas: utilpointer.Int32Ptr(3),
 				},
 			},
 			expectReplicas: 3,
@@ -84,10 +85,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/autoscaling/v2beta1/BUILD
+++ b/pkg/apis/autoscaling/v2beta1/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/autoscaling/install:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v2beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/autoscaling/v2beta1/defaults_test.go
+++ b/pkg/apis/autoscaling/v2beta1/defaults_test.go
@@ -29,11 +29,12 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	. "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultHPA(t *testing.T) {
 	utilizationDefaultVal := int32(autoscaling.DefaultCPUUtilization)
-	defaultReplicas := newInt32(1)
+	defaultReplicas := utilpointer.Int32Ptr(1)
 	defaultTemplate := []autoscalingv2beta1.MetricSpec{
 		{
 			Type: autoscalingv2beta1.ResourceMetricSourceType,
@@ -64,13 +65,13 @@ func TestSetDefaultHPA(t *testing.T) {
 		{ // MinReplicas update
 			original: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: newInt32(3),
+					MinReplicas: utilpointer.Int32Ptr(3),
 					Metrics:     defaultTemplate,
 				},
 			},
 			expected: &autoscalingv2beta1.HorizontalPodAutoscaler{
 				Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-					MinReplicas: newInt32(3),
+					MinReplicas: utilpointer.Int32Ptr(3),
 					Metrics:     defaultTemplate,
 				},
 			},
@@ -122,10 +123,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/autoscaling/validation/BUILD
+++ b/pkg/apis/autoscaling/validation/BUILD
@@ -26,6 +26,7 @@ go_test(
     deps = [
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/pkg/apis/autoscaling/validation/validation_test.go
+++ b/pkg/apis/autoscaling/validation/validation_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestValidateScale(t *testing.T) {
@@ -102,14 +103,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
 						Type: autoscaling.ResourceMetricSourceType,
 						Resource: &autoscaling.ResourceMetricSource{
 							Name: api.ResourceCPU,
-							TargetAverageUtilization: newInt32(70),
+							TargetAverageUtilization: utilpointer.Int32Ptr(70),
 						},
 					},
 				},
@@ -125,7 +126,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 			},
 		},
@@ -139,7 +140,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
@@ -162,7 +163,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
@@ -185,7 +186,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
@@ -212,7 +213,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
@@ -240,7 +241,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 					Kind: "ReplicationController",
 					Name: "myrc",
 				},
-				MinReplicas: newInt32(1),
+				MinReplicas: utilpointer.Int32Ptr(1),
 				MaxReplicas: 5,
 				Metrics: []autoscaling.MetricSpec{
 					{
@@ -274,14 +275,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 							},
 						},
 					},
@@ -294,14 +295,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "..", Name: "myrc"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 							},
 						},
 					},
@@ -314,14 +315,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 							},
 						},
 					},
@@ -334,14 +335,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Kind: "ReplicationController", Name: ".."},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 							},
 						},
 					},
@@ -357,7 +358,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-					MinReplicas:    newInt32(-1),
+					MinReplicas:    utilpointer.Int32Ptr(-1),
 					MaxReplicas:    5,
 				},
 			},
@@ -371,7 +372,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{},
-					MinReplicas:    newInt32(7),
+					MinReplicas:    utilpointer.Int32Ptr(7),
 					MaxReplicas:    5,
 				},
 			},
@@ -385,14 +386,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 								TargetAverageValue:       resource.NewMilliQuantity(300, resource.DecimalSI),
 							},
 						},
@@ -406,13 +407,13 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
-								TargetAverageUtilization: newInt32(70),
+								TargetAverageUtilization: utilpointer.Int32Ptr(70),
 							},
 						},
 					},
@@ -425,14 +426,14 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
 							Type: autoscaling.ResourceMetricSourceType,
 							Resource: &autoscaling.ResourceMetricSource{
 								Name: api.ResourceCPU,
-								TargetAverageUtilization: newInt32(-10),
+								TargetAverageUtilization: utilpointer.Int32Ptr(-10),
 							},
 						},
 					},
@@ -445,7 +446,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -464,7 +465,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -483,7 +484,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -502,7 +503,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -525,7 +526,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -548,7 +549,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -572,7 +573,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -596,7 +597,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -621,7 +622,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -646,7 +647,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -672,7 +673,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{},
@@ -686,7 +687,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -702,7 +703,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5,
 					Metrics: []autoscaling.MetricSpec{
 						{
@@ -769,7 +770,7 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "myautoscaler", Namespace: metav1.NamespaceDefault},
 				Spec: autoscaling.HorizontalPodAutoscalerSpec{
 					ScaleTargetRef: autoscaling.CrossVersionObjectReference{Name: "myrc", Kind: "ReplicationController"},
-					MinReplicas:    newInt32(1),
+					MinReplicas:    utilpointer.Int32Ptr(1),
 					MaxReplicas:    5, Metrics: []autoscaling.MetricSpec{spec},
 				},
 			})
@@ -783,10 +784,4 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 			}
 		}
 	}
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/batch/v1/BUILD
+++ b/pkg/apis/batch/v1/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/batch/install:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/apis/batch/v1/defaults_test.go
+++ b/pkg/apis/batch/v1/defaults_test.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	. "k8s.io/kubernetes/pkg/apis/batch/v1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultJob(t *testing.T) {
@@ -48,9 +49,9 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(1),
-					Parallelism:  newInt32(1),
-					BackoffLimit: newInt32(6),
+					Completions:  utilpointer.Int32Ptr(1),
+					Parallelism:  utilpointer.Int32Ptr(1),
+					BackoffLimit: utilpointer.Int32Ptr(6),
 				},
 			},
 			expectLabels: true,
@@ -68,16 +69,16 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(1),
-					Parallelism:  newInt32(1),
-					BackoffLimit: newInt32(6),
+					Completions:  utilpointer.Int32Ptr(1),
+					Parallelism:  utilpointer.Int32Ptr(1),
+					BackoffLimit: utilpointer.Int32Ptr(6),
 				},
 			},
 		},
 		"WQ: Parallelism explicitly 0 and completions unset -> BackoffLimit is defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: newInt32(0),
+					Parallelism: utilpointer.Int32Ptr(0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -85,8 +86,8 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism:  newInt32(0),
-					BackoffLimit: newInt32(6),
+					Parallelism:  utilpointer.Int32Ptr(0),
+					BackoffLimit: utilpointer.Int32Ptr(6),
 				},
 			},
 			expectLabels: true,
@@ -94,7 +95,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"WQ: Parallelism explicitly 2 and completions unset -> BackoffLimit is defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: newInt32(2),
+					Parallelism: utilpointer.Int32Ptr(2),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -102,8 +103,8 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Parallelism:  newInt32(2),
-					BackoffLimit: newInt32(6),
+					Parallelism:  utilpointer.Int32Ptr(2),
+					BackoffLimit: utilpointer.Int32Ptr(6),
 				},
 			},
 			expectLabels: true,
@@ -111,7 +112,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"Completions explicitly 2 and others unset -> parallelism and BackoffLimit are defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions: newInt32(2),
+					Completions: utilpointer.Int32Ptr(2),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -119,9 +120,9 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(2),
-					Parallelism:  newInt32(1),
-					BackoffLimit: newInt32(6),
+					Completions:  utilpointer.Int32Ptr(2),
+					Parallelism:  utilpointer.Int32Ptr(1),
+					BackoffLimit: utilpointer.Int32Ptr(6),
 				},
 			},
 			expectLabels: true,
@@ -129,7 +130,7 @@ func TestSetDefaultJob(t *testing.T) {
 		"BackoffLimit explicitly 5 and others unset -> parallelism and completions are defaulted": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					BackoffLimit: newInt32(5),
+					BackoffLimit: utilpointer.Int32Ptr(5),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -137,9 +138,9 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(1),
-					Parallelism:  newInt32(1),
-					BackoffLimit: newInt32(5),
+					Completions:  utilpointer.Int32Ptr(1),
+					Parallelism:  utilpointer.Int32Ptr(1),
+					BackoffLimit: utilpointer.Int32Ptr(5),
 				},
 			},
 			expectLabels: true,
@@ -147,9 +148,9 @@ func TestSetDefaultJob(t *testing.T) {
 		"All set -> no change": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(8),
-					Parallelism:  newInt32(9),
-					BackoffLimit: newInt32(10),
+					Completions:  utilpointer.Int32Ptr(8),
+					Parallelism:  utilpointer.Int32Ptr(9),
+					BackoffLimit: utilpointer.Int32Ptr(10),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -157,9 +158,9 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(8),
-					Parallelism:  newInt32(9),
-					BackoffLimit: newInt32(10),
+					Completions:  utilpointer.Int32Ptr(8),
+					Parallelism:  utilpointer.Int32Ptr(9),
+					BackoffLimit: utilpointer.Int32Ptr(10),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -170,9 +171,9 @@ func TestSetDefaultJob(t *testing.T) {
 		"All set, flipped -> no change": {
 			original: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(11),
-					Parallelism:  newInt32(10),
-					BackoffLimit: newInt32(9),
+					Completions:  utilpointer.Int32Ptr(11),
+					Parallelism:  utilpointer.Int32Ptr(10),
+					BackoffLimit: utilpointer.Int32Ptr(9),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{Labels: defaultLabels},
 					},
@@ -180,9 +181,9 @@ func TestSetDefaultJob(t *testing.T) {
 			},
 			expected: &batchv1.Job{
 				Spec: batchv1.JobSpec{
-					Completions:  newInt32(11),
-					Parallelism:  newInt32(10),
-					BackoffLimit: newInt32(9),
+					Completions:  utilpointer.Int32Ptr(11),
+					Parallelism:  utilpointer.Int32Ptr(10),
+					BackoffLimit: utilpointer.Int32Ptr(9),
 				},
 			},
 			expectLabels: true,
@@ -243,10 +244,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }

--- a/pkg/apis/batch/v1beta1/BUILD
+++ b/pkg/apis/batch/v1beta1/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/batch/install:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/batch/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],

--- a/pkg/apis/batch/v1beta1/defaults_test.go
+++ b/pkg/apis/batch/v1beta1/defaults_test.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	. "k8s.io/kubernetes/pkg/apis/batch/v1beta1"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultCronJob(t *testing.T) {
@@ -40,8 +41,8 @@ func TestSetDefaultCronJob(t *testing.T) {
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.AllowConcurrent,
 					Suspend:                    newBool(false),
-					SuccessfulJobsHistoryLimit: newInt32(3),
-					FailedJobsHistoryLimit:     newInt32(1),
+					SuccessfulJobsHistoryLimit: utilpointer.Int32Ptr(3),
+					FailedJobsHistoryLimit:     utilpointer.Int32Ptr(1),
 				},
 			},
 		},
@@ -50,16 +51,16 @@ func TestSetDefaultCronJob(t *testing.T) {
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 					Suspend:                    newBool(true),
-					SuccessfulJobsHistoryLimit: newInt32(5),
-					FailedJobsHistoryLimit:     newInt32(5),
+					SuccessfulJobsHistoryLimit: utilpointer.Int32Ptr(5),
+					FailedJobsHistoryLimit:     utilpointer.Int32Ptr(5),
 				},
 			},
 			expected: &batchv1beta1.CronJob{
 				Spec: batchv1beta1.CronJobSpec{
 					ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
 					Suspend:                    newBool(true),
-					SuccessfulJobsHistoryLimit: newInt32(5),
-					FailedJobsHistoryLimit:     newInt32(5),
+					SuccessfulJobsHistoryLimit: utilpointer.Int32Ptr(5),
+					FailedJobsHistoryLimit:     utilpointer.Int32Ptr(5),
 				},
 			},
 		},
@@ -111,12 +112,6 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 
 func newBool(val bool) *bool {
 	p := new(bool)
-	*p = val
-	return p
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
 	*p = val
 	return p
 }

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -29,6 +29,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 
 	// enforce that all types are installed
 	_ "k8s.io/kubernetes/pkg/api/testapi"
@@ -164,12 +165,6 @@ func TestSetDefaultReplicationController(t *testing.T) {
 	}
 }
 
-func newInt(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
-}
-
 func TestSetDefaultReplicationControllerReplicas(t *testing.T) {
 	tests := []struct {
 		rc             v1.ReplicationController
@@ -192,7 +187,7 @@ func TestSetDefaultReplicationControllerReplicas(t *testing.T) {
 		{
 			rc: v1.ReplicationController{
 				Spec: v1.ReplicationControllerSpec{
-					Replicas: newInt(0),
+					Replicas: utilpointer.Int32Ptr(0),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -207,7 +202,7 @@ func TestSetDefaultReplicationControllerReplicas(t *testing.T) {
 		{
 			rc: v1.ReplicationController{
 				Spec: v1.ReplicationControllerSpec{
-					Replicas: newInt(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -1274,7 +1269,7 @@ func TestDefaultRequestIsNotSetForReplicationController(t *testing.T) {
 	}
 	rc := &v1.ReplicationController{
 		Spec: v1.ReplicationControllerSpec{
-			Replicas: newInt(3),
+			Replicas: utilpointer.Int32Ptr(3),
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/apis/extensions/v1beta1/BUILD
+++ b/pkg/apis/extensions/v1beta1/BUILD
@@ -43,6 +43,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
 	. "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestSetDefaultDaemonSetSpec(t *testing.T) {
@@ -81,7 +82,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 				},
 				Spec: extensionsv1beta1.DaemonSetSpec{
 					Template:             defaultTemplate,
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 			expected: &extensionsv1beta1.DaemonSet{
@@ -111,7 +112,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(1),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(1),
 				},
 			},
 		},
@@ -123,7 +124,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -137,7 +138,7 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					UpdateStrategy: extensionsv1beta1.DaemonSetUpdateStrategy{
 						Type: extensionsv1beta1.OnDeleteDaemonSetStrategyType,
 					},
-					RevisionHistoryLimit: newInt32(10),
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
 				},
 			},
 		},
@@ -179,7 +180,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			original: &extensionsv1beta1.Deployment{},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(1),
+					Replicas: utilpointer.Int32Ptr(1),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -194,7 +195,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
 							MaxSurge: &differentIntOrString,
@@ -204,7 +205,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -219,7 +220,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type:          extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: nil,
@@ -228,7 +229,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &extensionsv1beta1.RollingUpdateDeployment{
@@ -243,7 +244,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
@@ -251,7 +252,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
@@ -262,21 +263,21 @@ func TestSetDefaultDeployment(t *testing.T) {
 		{
 			original: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
-					ProgressDeadlineSeconds: newInt32(30),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
 				},
 			},
 			expected: &extensionsv1beta1.Deployment{
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Replicas: newInt32(5),
+					Replicas: utilpointer.Int32Ptr(5),
 					Strategy: extensionsv1beta1.DeploymentStrategy{
 						Type: extensionsv1beta1.RecreateDeploymentStrategyType,
 					},
 					Template:                defaultTemplate,
-					ProgressDeadlineSeconds: newInt32(30),
+					ProgressDeadlineSeconds: utilpointer.Int32Ptr(30),
 				},
 			},
 		},
@@ -432,7 +433,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: extensionsv1beta1.ReplicaSet{
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Replicas: newInt32(0),
+					Replicas: utilpointer.Int32Ptr(0),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -447,7 +448,7 @@ func TestSetDefaultReplicaSetReplicas(t *testing.T) {
 		{
 			rs: extensionsv1beta1.ReplicaSet{
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Replicas: newInt32(3),
+					Replicas: utilpointer.Int32Ptr(3),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -490,7 +491,7 @@ func TestDefaultRequestIsNotSetForReplicaSet(t *testing.T) {
 	}
 	rs := &extensionsv1beta1.ReplicaSet{
 		Spec: extensionsv1beta1.ReplicaSetSpec{
-			Replicas: newInt32(3),
+			Replicas: utilpointer.Int32Ptr(3),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -741,10 +742,4 @@ func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
 		return nil
 	}
 	return obj3
-}
-
-func newInt32(val int32) *int32 {
-	p := new(int32)
-	*p = val
-	return p
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces instances of newInt{,32} with `Int32Ptr` function from `k8s.io/kubernetes/pkg/util/pointer`

**Which issue(s) this PR fixes**:
Fixes #59971

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
