### PR TITLE
Fixing CSI e2e test

### DIFF
--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -49,6 +49,7 @@ func TestClientAssertSupportedVersion(t *testing.T) {
 		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 0, Patch: 0}},
 		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 1, Patch: 0}},
 		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 1, Patch: 10}},
+		{testName: "supported version", ver: &csipb.Version{Major: 0, Minor: 2, Patch: 0}},
 		{testName: "supported version", ver: &csipb.Version{Major: 1, Minor: 1, Patch: 0}},
 		{testName: "supported version", ver: &csipb.Version{Major: 1, Minor: 0, Patch: 10}},
 		{testName: "unsupported version", ver: &csipb.Version{Major: 10, Minor: 0, Patch: 0}, mustFail: true},

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	// csiVersion supported csi version
-	csiVersion = &csipb.Version{Major: 0, Minor: 1, Patch: 0}
+	csiVersion = &csipb.Version{Major: 0, Minor: 2, Patch: 0}
 )
 
 type csiPlugin struct {

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -53,6 +53,7 @@ func (f *IdentityClient) GetSupportedVersions(ctx grpctx.Context, req *csipb.Get
 		SupportedVersions: []*csipb.Version{
 			{Major: 0, Minor: 0, Patch: 1},
 			{Major: 0, Minor: 1, Patch: 0},
+			{Major: 0, Minor: 2, Patch: 0},
 			{Major: 1, Minor: 0, Patch: 0},
 			{Major: 1, Minor: 0, Patch: 1},
 			{Major: 1, Minor: 1, Patch: 1},

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -39,7 +39,7 @@ const (
 	csiDriverRegistrarImage     string = "quay.io/k8scsi/driver-registrar:v0.2.0"
 )
 
-func externalAttacherServiceAccount(
+func csiServiceAccount(
 	client clientset.Interface,
 	config framework.VolumeTestConfig,
 	teardown bool,
@@ -71,7 +71,7 @@ func externalAttacherServiceAccount(
 	return ret
 }
 
-func externalAttacherClusterRole(
+func csiClusterRole(
 	client clientset.Interface,
 	config framework.VolumeTestConfig,
 	teardown bool,
@@ -89,7 +89,7 @@ func externalAttacherClusterRole(
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"persistentvolumesclaims"},
+				Resources: []string{"persistentvolumeclaims"},
 				Verbs:     []string{"get", "list", "watch", "update"},
 			},
 			{
@@ -129,7 +129,7 @@ func externalAttacherClusterRole(
 	return ret
 }
 
-func externalAttacherClusterRoleBinding(
+func csiClusterRoleBinding(
 	client clientset.Interface,
 	config framework.VolumeTestConfig,
 	teardown bool,
@@ -211,18 +211,18 @@ var _ = utils.SIGDescribe("CSI Volumes [Feature:CSI]", func() {
 
 		BeforeEach(func() {
 			By("deploying csi hostpath driver")
-			clusterRole = externalAttacherClusterRole(cs, config, false)
-			serviceAccount = externalAttacherServiceAccount(cs, config, false)
-			externalAttacherClusterRoleBinding(cs, config, false, serviceAccount, clusterRole)
+			clusterRole = csiClusterRole(cs, config, false)
+			serviceAccount = csiServiceAccount(cs, config, false)
+			csiClusterRoleBinding(cs, config, false, serviceAccount, clusterRole)
 			csiHostPathPod(cs, config, false, f, serviceAccount)
 		})
 
 		AfterEach(func() {
 			By("uninstalling csi hostpath driver")
 			csiHostPathPod(cs, config, true, f, serviceAccount)
-			externalAttacherClusterRoleBinding(cs, config, true, serviceAccount, clusterRole)
-			serviceAccount = externalAttacherServiceAccount(cs, config, true)
-			clusterRole = externalAttacherClusterRole(cs, config, true)
+			csiClusterRoleBinding(cs, config, true, serviceAccount, clusterRole)
+			serviceAccount = csiServiceAccount(cs, config, true)
+			clusterRole = csiClusterRole(cs, config, true)
 		})
 
 		It("should provision storage with a hostPath CSI driver", func() {
@@ -237,6 +237,7 @@ var _ = utils.SIGDescribe("CSI Volumes [Feature:CSI]", func() {
 
 			claim := newClaim(t, ns.GetName(), "")
 			class := newStorageClass(t, ns.GetName(), "")
+			claim.Spec.StorageClassName = &class.ObjectMeta.Name
 			testDynamicProvisioning(t, cs, claim, class)
 		})
 	})


### PR DESCRIPTION
Current e2e test had some inconsistencies which were preventing it from running successfully on the local cluster.
```release-note
Making sure CSI E2E test runs on a local cluster
```
Closes #60016