### PR TITLE
Increase allowed lag for ssh key sync loop for tunneler

### DIFF
--- a/pkg/master/tunneler/ssh.go
+++ b/pkg/master/tunneler/ssh.go
@@ -60,7 +60,12 @@ func TunnelSyncHealthChecker(tunneler Tunneler) func(req *http.Request) error {
 			return fmt.Errorf("Tunnel sync is taking too long: %d", lag)
 		}
 		sshKeyLag := tunneler.SecondsSinceSSHKeySync()
-		if sshKeyLag > 600 {
+		// Since we are syncing ssh-keys every 5 minutes, the allowed
+		// lag since last sync should be more than 2x higher than that
+		// to allow for single failure, which can always happen.
+		// For now set it to 3x, which is 15 minutes.
+		// For more details see: http://pr.k8s.io/59347
+		if sshKeyLag > 900 {
 			return fmt.Errorf("SSHKey sync is taking too long: %d", sshKeyLag)
 		}
 		return nil


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/59347

```release-note
Increase allowed lag for ssh key sync loop in tunneler to allow for one failure
```