### PR TITLE
hack/lib: Download cfssl only once if not present in PATH

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -713,58 +713,17 @@ function kube::util::join {
 
 # Downloads cfssl/cfssljson into $1 directory if they do not already exist in PATH
 #
-# Assumed vars:
-#   $1 (cfssl directory) (optional)
-#
 # Sets:
 #  CFSSL_BIN: The path of the installed cfssl binary
 #  CFSSLJSON_BIN: The path of the installed cfssljson binary
 #
 function kube::util::ensure-cfssl {
-  if command -v cfssl &>/dev/null && command -v cfssljson &>/dev/null; then
-    CFSSL_BIN=$(command -v cfssl)
-    CFSSLJSON_BIN=$(command -v cfssljson)
-    return 0
+  if ! command -v cfssl &>/dev/null || ! command -v cfssljson &>/dev/null; then
+    echo "Failed to find 'cfssl'. Downloading and installing..."
+    go get -u github.com/cloudflare/cfssl/cmd/...
   fi
-
-  # Create a temp dir for cfssl if no directory was given
-  local cfssldir=${1:-}
-  if [[ -z "${cfssldir}" ]]; then
-    kube::util::ensure-temp-dir
-    cfssldir="${KUBE_TEMP}/cfssl"
-  fi
-
-  mkdir -p "${cfssldir}"
-  pushd "${cfssldir}" > /dev/null
-
-    echo "Unable to successfully run 'cfssl' from $PATH; downloading instead..."
-    kernel=$(uname -s)
-    case "${kernel}" in
-      Linux)
-        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
-        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
-        ;;
-      Darwin)
-        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
-        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
-        ;;
-      *)
-        echo "Unknown, unsupported platform: ${kernel}." >&2
-        echo "Supported platforms: Linux, Darwin." >&2
-        exit 2
-    esac
-
-    chmod +x cfssl || true
-    chmod +x cfssljson || true
-
-    CFSSL_BIN="${cfssldir}/cfssl"
-    CFSSLJSON_BIN="${cfssldir}/cfssljson"
-    if [[ ! -x ${CFSSL_BIN} || ! -x ${CFSSLJSON_BIN} ]]; then
-      echo "Failed to download 'cfssl'. Please install cfssl and cfssljson and verify they are in \$PATH."
-      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
-      exit 1
-    fi
-  popd > /dev/null
+  CFSSL_BIN=$(command -v cfssl)
+  CFSSLJSON_BIN=$(command -v cfssljson)
 }
 
 # kube::util::ensure_dockerized


### PR DESCRIPTION
Before this change, if cfssl was not present in PATH, it was
downloaded by local-up-cluster.sh script on every execution.
Now it will be installed only once.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It makes `local-up-cluster.sh` execution faster if someone doesn't have `cfssl` installed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60070

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
