### PR TITLE
Use `pkg/util/pointer` functions instead of self-written versions

### DIFF
--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -60,6 +60,7 @@ go_test(
         "//pkg/capabilities:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/security/apparmor:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/security/apparmor"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 const (
@@ -1694,7 +1695,7 @@ func TestValidateKeyToPath(t *testing.T) {
 			ok: true,
 		},
 		{
-			kp: core.KeyToPath{Key: "k", Path: "p", Mode: newInt32(0644)},
+			kp: core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(0644)},
 			ok: true,
 		},
 		{
@@ -1728,12 +1729,12 @@ func TestValidateKeyToPath(t *testing.T) {
 			errtype: field.ErrorTypeInvalid,
 		},
 		{
-			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: newInt32(01000)},
+			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(01000)},
 			ok:      false,
 			errtype: field.ErrorTypeInvalid,
 		},
 		{
-			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: newInt32(-1)},
+			kp:      core.KeyToPath{Key: "k", Path: "p", Mode: utilpointer.Int32Ptr(-1)},
 			ok:      false,
 			errtype: field.ErrorTypeInvalid,
 		},
@@ -1970,14 +1971,6 @@ func TestValidateCSIVolumeSource(t *testing.T) {
 		t.Errorf("Failed to disable feature gate for CSIPersistentVolumes: %v", err)
 		return
 	}
-
-}
-
-// helper
-func newInt32(val int) *int32 {
-	p := new(int32)
-	*p = int32(val)
-	return p
 }
 
 // This test is a little too top-to-bottom.  Ideally we would test each volume
@@ -2464,7 +2457,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "my-secret",
-						DefaultMode: newInt32(0644),
+						DefaultMode: utilpointer.Int32Ptr(0644),
 					},
 				},
 			},
@@ -2479,7 +2472,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: newInt32(0644),
+							Mode: utilpointer.Int32Ptr(0644),
 						}},
 					},
 				},
@@ -2549,7 +2542,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: newInt32(01000),
+						DefaultMode: utilpointer.Int32Ptr(01000),
 					},
 				},
 			},
@@ -2563,7 +2556,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					Secret: &core.SecretVolumeSource{
 						SecretName:  "s",
-						DefaultMode: newInt32(-1),
+						DefaultMode: utilpointer.Int32Ptr(-1),
 					},
 				},
 			},
@@ -2593,7 +2586,7 @@ func TestValidateVolumes(t *testing.T) {
 						LocalObjectReference: core.LocalObjectReference{
 							Name: "my-cfgmap",
 						},
-						DefaultMode: newInt32(0644),
+						DefaultMode: utilpointer.Int32Ptr(0644),
 					},
 				},
 			},
@@ -2609,7 +2602,7 @@ func TestValidateVolumes(t *testing.T) {
 						Items: []core.KeyToPath{{
 							Key:  "key",
 							Path: "filename",
-							Mode: newInt32(0644),
+							Mode: utilpointer.Int32Ptr(0644),
 						}},
 					},
 				},
@@ -2680,7 +2673,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          newInt32(01000),
+						DefaultMode:          utilpointer.Int32Ptr(01000),
 					},
 				},
 			},
@@ -2694,7 +2687,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					ConfigMap: &core.ConfigMapVolumeSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "c"},
-						DefaultMode:          newInt32(-1),
+						DefaultMode:          utilpointer.Int32Ptr(-1),
 					},
 				},
 			},
@@ -3023,7 +3016,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: newInt32(0644),
+						DefaultMode: utilpointer.Int32Ptr(0644),
 					},
 				},
 			},
@@ -3035,7 +3028,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: newInt32(0644),
+							Mode: utilpointer.Int32Ptr(0644),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -3053,7 +3046,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: newInt32(01000),
+							Mode: utilpointer.Int32Ptr(01000),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -3073,7 +3066,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
 						Items: []core.DownwardAPIVolumeFile{{
-							Mode: newInt32(-1),
+							Mode: utilpointer.Int32Ptr(-1),
 							Path: "path",
 							FieldRef: &core.ObjectFieldSelector{
 								APIVersion: "v1",
@@ -3214,7 +3207,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: newInt32(01000),
+						DefaultMode: utilpointer.Int32Ptr(01000),
 					},
 				},
 			},
@@ -3227,7 +3220,7 @@ func TestValidateVolumes(t *testing.T) {
 				Name: "downapi",
 				VolumeSource: core.VolumeSource{
 					DownwardAPI: &core.DownwardAPIVolumeSource{
-						DefaultMode: newInt32(-1),
+						DefaultMode: utilpointer.Int32Ptr(-1),
 					},
 				},
 			},
@@ -3242,7 +3235,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        newInt32(1),
+						Lun:        utilpointer.Int32Ptr(1),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -3269,7 +3262,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{},
-						Lun:        newInt32(1),
+						Lun:        utilpointer.Int32Ptr(1),
 						WWIDs:      []string{},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -3287,7 +3280,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"some_wwn"},
-						Lun:        newInt32(1),
+						Lun:        utilpointer.Int32Ptr(1),
 						WWIDs:      []string{"some_wwid"},
 						FSType:     "ext4",
 						ReadOnly:   false,
@@ -3322,7 +3315,7 @@ func TestValidateVolumes(t *testing.T) {
 				VolumeSource: core.VolumeSource{
 					FC: &core.FCVolumeSource{
 						TargetWWNs: []string{"wwn"},
-						Lun:        newInt32(256),
+						Lun:        utilpointer.Int32Ptr(256),
 						FSType:     "ext4",
 						ReadOnly:   false,
 					},
@@ -8826,7 +8819,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.SessionAffinity = core.ServiceAffinityClientIP
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: newInt32(-1),
+						TimeoutSeconds: utilpointer.Int32Ptr(-1),
 					},
 				}
 			},
@@ -8839,7 +8832,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.SessionAffinity = core.ServiceAffinityNone
 				s.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: newInt32(90),
+						TimeoutSeconds: utilpointer.Int32Ptr(90),
 					},
 				}
 			},
@@ -10334,7 +10327,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.SessionAffinity = "ClientIP"
 				newSvc.Spec.SessionAffinityConfig = &core.SessionAffinityConfig{
 					ClientIP: &core.ClientIPConfig{
-						TimeoutSeconds: newInt32(90),
+						TimeoutSeconds: utilpointer.Int32Ptr(90),
 					},
 				}
 			},
@@ -12628,17 +12621,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 	successCases := map[string]*core.SessionAffinityConfig{
 		"non-empty config, valid timeout: 1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(1),
+				TimeoutSeconds: utilpointer.Int32Ptr(1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds-1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(int(core.MaxClientIPServiceAffinitySeconds - 1)),
+				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds - 1),
 			},
 		},
 		"non-empty config, valid timeout: core.MaxClientIPServiceAffinitySeconds": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(int(core.MaxClientIPServiceAffinitySeconds)),
+				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds),
 			},
 		},
 	}
@@ -12661,17 +12654,17 @@ func TestValidateOrSetClientIPAffinityConfig(t *testing.T) {
 		},
 		"non-empty config, invalid timeout: core.MaxClientIPServiceAffinitySeconds+1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(int(core.MaxClientIPServiceAffinitySeconds + 1)),
+				TimeoutSeconds: utilpointer.Int32Ptr(core.MaxClientIPServiceAffinitySeconds + 1),
 			},
 		},
 		"non-empty config, invalid timeout: -1": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(-1),
+				TimeoutSeconds: utilpointer.Int32Ptr(-1),
 			},
 		},
 		"non-empty config, invalid timeout: 0": {
 			ClientIP: &core.ClientIPConfig{
-				TimeoutSeconds: newInt32(0),
+				TimeoutSeconds: utilpointer.Int32Ptr(0),
 			},
 		},
 	}

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -48,6 +48,7 @@ go_test(
         "//pkg/client/clientset_generated/internalclientset/typed/batch/internalversion:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//pkg/kubectl/util:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",

--- a/pkg/kubectl/autoscale_test.go
+++ b/pkg/kubectl/autoscale_test.go
@@ -22,6 +22,7 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 func TestHPAGenerate(t *testing.T) {
@@ -51,14 +52,14 @@ func TestHPAGenerate(t *testing.T) {
 					Name: "foo",
 				},
 				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
-					TargetCPUUtilizationPercentage: newInt32(80),
+					TargetCPUUtilizationPercentage: utilpointer.Int32Ptr(80),
 					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 						Kind:       "kind",
 						Name:       "name",
 						APIVersion: "apiVersion",
 					},
 					MaxReplicas: int32(10),
-					MinReplicas: newInt32(1),
+					MinReplicas: utilpointer.Int32Ptr(1),
 				},
 			},
 			expectErr: false,
@@ -124,9 +125,4 @@ func TestHPAGenerate(t *testing.T) {
 			t.Errorf("[%s] want:\n%#v\ngot:\n%#v", test.name, test.expected, obj.(*autoscalingv1.HorizontalPodAutoscaler))
 		}
 	}
-}
-
-func newInt32(value int) *int32 {
-	v := int32(value)
-	return &v
 }

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -48,8 +48,12 @@ func AllPtrFieldsNil(obj interface{}) bool {
 
 // Int32Ptr returns a pointer to an int32
 func Int32Ptr(i int32) *int32 {
-	o := i
-	return &o
+	return &i
+}
+
+// Int64Ptr returns a pointer to an int64
+func Int64Ptr(i int64) *int64 {
+	return &i
 }
 
 // Int32PtrDerefOr dereference the int32 ptr and returns it i not nil,
@@ -63,6 +67,5 @@ func Int32PtrDerefOr(ptr *int32, def int32) int32 {
 
 // BoolPtr returns a pointer to a bool
 func BoolPtr(b bool) *bool {
-	o := b
-	return &o
+	return &b
 }

--- a/plugin/pkg/admission/security/podsecuritypolicy/BUILD
+++ b/plugin/pkg/admission/security/podsecuritypolicy/BUILD
@@ -48,6 +48,7 @@ go_test(
         "//pkg/security/podsecuritypolicy:go_default_library",
         "//pkg/security/podsecuritypolicy/seccomp:go_default_library",
         "//pkg/security/podsecuritypolicy/util:go_default_library",
+        "//pkg/util/pointer:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -44,6 +44,7 @@ import (
 	kpsp "k8s.io/kubernetes/pkg/security/podsecuritypolicy"
 	"k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp"
 	psputil "k8s.io/kubernetes/pkg/security/podsecuritypolicy/util"
+	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
 
 const defaultContainerName = "test-c"
@@ -1223,39 +1224,39 @@ func TestAdmitRunAsUser(t *testing.T) {
 			expectedPSP:         runAsAny.Name,
 		},
 		"runAsAny pod request": {
-			pod:                 createPodWithSecurityContexts(podSC(userIDPtr(1)), nil),
+			pod:                 createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(1)), nil),
 			psps:                []*extensions.PodSecurityPolicy{runAsAny},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
-			expectedPodSC:       podSC(userIDPtr(1)),
+			expectedPodSC:       podSC(utilpointer.Int64Ptr(1)),
 			expectedContainerSC: nil,
 			expectedPSP:         runAsAny.Name,
 		},
 		"runAsAny container request": {
-			pod:                 createPodWithSecurityContexts(nil, containerSC(userIDPtr(1))),
+			pod:                 createPodWithSecurityContexts(nil, containerSC(utilpointer.Int64Ptr(1))),
 			psps:                []*extensions.PodSecurityPolicy{runAsAny},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
 			expectedPodSC:       nil,
-			expectedContainerSC: containerSC(userIDPtr(1)),
+			expectedContainerSC: containerSC(utilpointer.Int64Ptr(1)),
 			expectedPSP:         runAsAny.Name,
 		},
 
 		"mustRunAs pod request out of range": {
-			pod:                createPodWithSecurityContexts(podSC(userIDPtr(1)), nil),
+			pod:                createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(1)), nil),
 			psps:               []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:    false,
 			shouldPassValidate: false,
 		},
 		"mustRunAs container request out of range": {
-			pod:                createPodWithSecurityContexts(podSC(userIDPtr(999)), containerSC(userIDPtr(1))),
+			pod:                createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(999)), containerSC(utilpointer.Int64Ptr(1))),
 			psps:               []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:    false,
 			shouldPassValidate: false,
 		},
 
 		"mustRunAs pod request in range": {
-			pod:                 createPodWithSecurityContexts(podSC(userIDPtr(999)), nil),
+			pod:                 createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(999)), nil),
 			psps:                []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
@@ -1264,7 +1265,7 @@ func TestAdmitRunAsUser(t *testing.T) {
 			expectedPSP:         mustRunAs.Name,
 		},
 		"mustRunAs container request in range": {
-			pod:                 createPodWithSecurityContexts(nil, containerSC(userIDPtr(999))),
+			pod:                 createPodWithSecurityContexts(nil, containerSC(utilpointer.Int64Ptr(999))),
 			psps:                []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
@@ -1273,12 +1274,12 @@ func TestAdmitRunAsUser(t *testing.T) {
 			expectedPSP:         mustRunAs.Name,
 		},
 		"mustRunAs pod and container request in range": {
-			pod:                 createPodWithSecurityContexts(podSC(userIDPtr(999)), containerSC(userIDPtr(1000))),
+			pod:                 createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(999)), containerSC(utilpointer.Int64Ptr(1000))),
 			psps:                []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
-			expectedPodSC:       podSC(userIDPtr(999)),
-			expectedContainerSC: containerSC(userIDPtr(1000)),
+			expectedPodSC:       podSC(utilpointer.Int64Ptr(999)),
+			expectedContainerSC: containerSC(utilpointer.Int64Ptr(1000)),
 			expectedPSP:         mustRunAs.Name,
 		},
 		"mustRunAs no request": {
@@ -1301,32 +1302,32 @@ func TestAdmitRunAsUser(t *testing.T) {
 			expectedPSP:         runAsNonRoot.Name,
 		},
 		"runAsNonRoot pod request root": {
-			pod:                createPodWithSecurityContexts(podSC(userIDPtr(0)), nil),
+			pod:                createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(0)), nil),
 			psps:               []*extensions.PodSecurityPolicy{runAsNonRoot},
 			shouldPassAdmit:    false,
 			shouldPassValidate: false,
 		},
 		"runAsNonRoot pod request non-root": {
-			pod:                createPodWithSecurityContexts(podSC(userIDPtr(1)), nil),
+			pod:                createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(1)), nil),
 			psps:               []*extensions.PodSecurityPolicy{runAsNonRoot},
 			shouldPassAdmit:    true,
 			shouldPassValidate: true,
-			expectedPodSC:      podSC(userIDPtr(1)),
+			expectedPodSC:      podSC(utilpointer.Int64Ptr(1)),
 			expectedPSP:        runAsNonRoot.Name,
 		},
 		"runAsNonRoot container request root": {
-			pod:                createPodWithSecurityContexts(podSC(userIDPtr(1)), containerSC(userIDPtr(0))),
+			pod:                createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(1)), containerSC(utilpointer.Int64Ptr(0))),
 			psps:               []*extensions.PodSecurityPolicy{runAsNonRoot},
 			shouldPassAdmit:    false,
 			shouldPassValidate: false,
 		},
 		"runAsNonRoot container request non-root": {
-			pod:                 createPodWithSecurityContexts(podSC(userIDPtr(1)), containerSC(userIDPtr(2))),
+			pod:                 createPodWithSecurityContexts(podSC(utilpointer.Int64Ptr(1)), containerSC(utilpointer.Int64Ptr(2))),
 			psps:                []*extensions.PodSecurityPolicy{runAsNonRoot},
 			shouldPassAdmit:     true,
 			shouldPassValidate:  true,
-			expectedPodSC:       podSC(userIDPtr(1)),
-			expectedContainerSC: containerSC(userIDPtr(2)),
+			expectedPodSC:       podSC(utilpointer.Int64Ptr(1)),
+			expectedContainerSC: containerSC(utilpointer.Int64Ptr(2)),
 			expectedPSP:         runAsNonRoot.Name,
 		},
 	}
@@ -1435,12 +1436,12 @@ func TestAdmitSupplementalGroups(t *testing.T) {
 }
 
 func TestAdmitFSGroup(t *testing.T) {
-	createPodWithFSGroup := func(group int) *kapi.Pod {
+	createPodWithFSGroup := func(group int64) *kapi.Pod {
 		pod := goodPod()
 		// doesn't matter if we set it here or on the container, the
 		// admission controller uses DetermineEffectiveSC to get the defaulting
 		// behavior so it can validate what will be applied at runtime
-		pod.Spec.SecurityContext.FSGroup = groupIDPtr(group)
+		pod.Spec.SecurityContext.FSGroup = utilpointer.Int64Ptr(group)
 		return pod
 	}
 
@@ -1472,7 +1473,7 @@ func TestAdmitFSGroup(t *testing.T) {
 			psps:               []*extensions.PodSecurityPolicy{runAsAny},
 			shouldPassAdmit:    true,
 			shouldPassValidate: true,
-			expectedFSGroup:    groupIDPtr(1),
+			expectedFSGroup:    utilpointer.Int64Ptr(1),
 			expectedPSP:        runAsAny.Name,
 		},
 		"mustRunAs no pod request": {
@@ -1494,7 +1495,7 @@ func TestAdmitFSGroup(t *testing.T) {
 			psps:               []*extensions.PodSecurityPolicy{mustRunAs},
 			shouldPassAdmit:    true,
 			shouldPassValidate: true,
-			expectedFSGroup:    groupIDPtr(999),
+			expectedFSGroup:    utilpointer.Int64Ptr(999),
 			expectedPSP:        mustRunAs.Name,
 		},
 	}
@@ -2431,14 +2432,4 @@ func goodPod() *kapi.Pod {
 			},
 		},
 	}
-}
-
-func userIDPtr(i int) *int64 {
-	userID := int64(i)
-	return &userID
-}
-
-func groupIDPtr(i int) *int64 {
-	groupID := int64(i)
-	return &groupID
 }

--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -325,7 +325,7 @@ func restrictedPod(f *framework.Framework, name string) *v1.Pod {
 				Image: framework.GetPauseImageName(f.ClientSet),
 				SecurityContext: &v1.SecurityContext{
 					AllowPrivilegeEscalation: boolPtr(false),
-					RunAsUser:                intPtr(65534),
+					RunAsUser:                utilpointer.Int64Ptr(65534),
 				},
 			}},
 		},
@@ -479,8 +479,4 @@ func restrictedPSP(name string) *extensionsv1beta1.PodSecurityPolicy {
 
 func boolPtr(b bool) *bool {
 	return &b
-}
-
-func intPtr(i int64) *int64 {
-	return &i
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Replaces instances of module-written `int(32|64)? --> *int(32|64)?` functions with functions from k8s.io/kubernetes/pkg/util/pointer

**Special notes for your reviewer**:

Here's the grep used, based on the comments in:
* https://github.com/kubernetes/kubernetes/pull/59924#issuecomment-366119396
* https://github.com/kubernetes/kubernetes/issues/59971#issue-297766556

```bash
$ git grep -E 'func\ [^ (]+\([^ ]+\ int(32|64)?\)\ \*int(32|64)?' !(vendor|staging) | grep -v pkg/util/pointer

pkg/apis/apps/v1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/apps/v1beta1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/apps/v1beta2/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/autoscaling/v1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/autoscaling/v2beta1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/autoscaling/validation/validation_test.go:func newInt32(val int32) *int32 {
pkg/apis/batch/v1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/batch/v1beta1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/apis/core/v1/defaults_test.go:func newInt(val int32) *int32 {
pkg/apis/core/validation/validation_test.go:func newInt32(val int) *int32 {
pkg/apis/extensions/v1beta1/defaults_test.go:func newInt32(val int32) *int32 {
pkg/controller/deployment/sync_test.go:func intOrStrP(val int) *intstr.IntOrString {
pkg/kubectl/autoscale_test.go:func newInt32(value int) *int32 {
plugin/pkg/admission/security/podsecuritypolicy/admission_test.go:func userIDPtr(i int) *int64 {
plugin/pkg/admission/security/podsecuritypolicy/admission_test.go:func groupIDPtr(i int) *int64 {
test/e2e/apps/deployment.go:func intOrStrP(num int) *intstr.IntOrString {
test/e2e/auth/pod_security_policy.go:func intPtr(i int64) *int64 {
test/integration/deployment/util.go:func intOrStrP(num int) *intstr.IntOrString {
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind cleanup
/cc @php-coder 
/assign @tallclair 