### PR TITLE
Replace deprecated ubuntu-slim image with debian-base from k8s

### DIFF
--- a/examples/storage/cassandra/image/Dockerfile
+++ b/examples/storage/cassandra/image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/ubuntu-slim:0.9
+FROM k8s.gcr.io/debian-base-amd64:0.3
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -34,90 +34,13 @@ ENV CASSANDRA_HOME=/usr/local/apache-cassandra-${CASSANDRA_VERSION} \
     CASSANDRA_DATA=/cassandra_data \
     CASSANDRA_LOGS=/var/log/cassandra \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
-    PATH=${PATH}:/usr/lib/jvm/java-8-openjdk-amd64/bin:/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin  \
-    DI_VERSION=1.2.0 \
-    DI_SHA=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363
+    PATH=${PATH}:/usr/lib/jvm/java-8-openjdk-amd64/bin:/usr/local/apache-cassandra-${CASSANDRA_VERSION}/bin
 
 ADD files /
 
-RUN set -e && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
-  && apt-get update && apt-get -qq -y --force-yes install --no-install-recommends \
-    openjdk-8-jre-headless \
-    libjemalloc1 \
-    localepurge \
-    wget && \
-  mirror_url=$( wget -q -O - http://www.apache.org/dyn/closer.cgi/cassandra/ \
-        | sed -n 's#.*href="\(http://.*/cassandra\/[^"]*\)".*#\1#p' \
-        | head -n 1 \
-    ) \
-    && wget -q -O - ${mirror_url}/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz \
-        | tar -xzf - -C /usr/local \
-    && wget -q -O - https://github.com/Yelp/dumb-init/releases/download/v${DI_VERSION}/dumb-init_${DI_VERSION}_amd64 > /sbin/dumb-init \
-    && echo "$DI_SHA  /sbin/dumb-init" | sha256sum -c - \
-    && chmod +x /sbin/dumb-init \
-    && chmod +x /ready-probe.sh \
-    && mkdir -p /cassandra_data/data \
-    && mkdir -p /etc/cassandra \
-    && mv /logback.xml /cassandra.yaml /jvm.options /etc/cassandra/ \
-    && mv /usr/local/apache-cassandra-${CASSANDRA_VERSION}/conf/cassandra-env.sh /etc/cassandra/ \
-    && adduser --disabled-password --no-create-home --gecos '' --disabled-login cassandra \
-    && chown cassandra: /ready-probe.sh \
-    && if [ -n "$DEV_CONTAINER" ]; then apt-get -y --no-install-recommends install python; else rm -rf  $CASSANDRA_HOME/pylib; fi \
-    && apt-get -y purge wget localepurge \
-    && apt-get -y autoremove \
-    && apt-get clean \
-    && rm -rf \
-        $CASSANDRA_HOME/*.txt \
-        $CASSANDRA_HOME/doc \
-        $CASSANDRA_HOME/javadoc \
-        $CASSANDRA_HOME/tools/*.yaml \
-        $CASSANDRA_HOME/tools/bin/*.bat \
-        $CASSANDRA_HOME/bin/*.bat \
-    doc \
-    man \
-    info \
-    locale \
-    common-licenses \
-    ~/.bashrc \
-        /var/lib/apt/lists/* \
-        /var/log/* \
-        /var/cache/debconf/* \
-        /etc/systemd \
-        /lib/lsb \
-        /lib/udev \
-        /usr/share/doc/ \
-        /usr/share/doc-base/ \
-        /usr/share/man/ \
-        /tmp/* \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/plugin \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/javaws \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/jjs \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/orbd \
-        /usr/lib/jvm/java-8-openjdk-amd64/bin/pack200 \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/policytool \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmiregistry \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/servertool \
-        /usr/lib/jvm/java-8-openjdk-amd64/bin/tnameserv \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/unpack200 \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/javaws.jar \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/deploy* \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/desktop \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/*javafx* \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/*jfx* \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libdecora_sse.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libprism_*.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libfxplugins.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libglass.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libgstreamer-lite.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libjavafx*.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libjfx*.so \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/jfxrt.jar \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/oblique-fonts \
-        /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/plugin.jar \
-        /usr/lib/jvm/java-8-openjdk-amd64/man
-
+RUN clean-install bash \
+    && /build.sh \
+    && rm /build.sh
 
 VOLUME ["/$CASSANDRA_DATA"]
 
@@ -128,4 +51,4 @@ VOLUME ["/$CASSANDRA_DATA"]
 # 9160: thrift service
 EXPOSE 7000 7001 7199 9042 9160
 
-CMD ["/sbin/dumb-init", "/bin/bash", "/run.sh"]
+CMD ["/usr/bin/dumb-init", "/bin/bash", "/run.sh"]

--- a/examples/storage/cassandra/image/Makefile
+++ b/examples/storage/cassandra/image/Makefile
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 # build the cassandra image.
-VERSION=v12
+VERSION=v13
 PROJECT_ID?=google_samples
 PROJECT=gcr.io/${PROJECT_ID}
-CASSANDRA_VERSION=3.10
+CASSANDRA_VERSION=3.11.2
 
 all: kubernetes-cassandra.jar build
 

--- a/examples/storage/cassandra/image/files/build.sh
+++ b/examples/storage/cassandra/image/files/build.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+apt-get update && apt-get dist-upgrade -y
+
+clean-install \
+    openjdk-8-jre-headless \
+    libjemalloc1 \
+    localepurge \
+    dumb-init \
+    wget
+
+CASSANDRA_PATH="cassandra/${CASSANDRA_VERSION}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
+CASSANDRA_DOWNLOAD="http://www.apache.org/dyn/closer.cgi?path=/${CASSANDRA_PATH}&as_json=1"
+CASSANDRA_MIRROR=`wget -q -O - ${CASSANDRA_DOWNLOAD} | grep -oP "(?<=\"preferred\": \")[^\"]+"`
+
+echo "Downloading Apache Cassandra from $CASSANDRA_MIRROR$CASSANDRA_PATH..."
+wget -q -O - $CASSANDRA_MIRROR$CASSANDRA_PATH \
+    | tar -xzf - -C /usr/local
+
+mkdir -p /cassandra_data/data
+mkdir -p /etc/cassandra
+
+mv /logback.xml /cassandra.yaml /jvm.options /etc/cassandra/
+mv /usr/local/apache-cassandra-${CASSANDRA_VERSION}/conf/cassandra-env.sh /etc/cassandra/
+
+adduser --disabled-password --no-create-home --gecos '' --disabled-login cassandra
+chmod +x /ready-probe.sh
+chown cassandra: /ready-probe.sh
+
+DEV_IMAGE=${DEV_CONTAINER:-}
+if [ ! -z "$DEV_IMAGE" ]; then
+    clean-install python;
+else
+    rm -rf  $CASSANDRA_HOME/pylib;
+fi
+
+apt-get -y purge localepurge
+apt-get -y autoremove
+apt-get clean
+
+rm -rf \
+    $CASSANDRA_HOME/*.txt \
+    $CASSANDRA_HOME/doc \
+    $CASSANDRA_HOME/javadoc \
+    $CASSANDRA_HOME/tools/*.yaml \
+    $CASSANDRA_HOME/tools/bin/*.bat \
+    $CASSANDRA_HOME/bin/*.bat \
+    doc \
+    man \
+    info \
+    locale \
+    common-licenses \
+    ~/.bashrc \
+    /var/lib/apt/lists/* \
+    /var/log/* \
+    /var/cache/debconf/* \
+    /etc/systemd \
+    /lib/lsb \
+    /lib/udev \
+    /usr/share/doc/ \
+    /usr/share/doc-base/ \
+    /usr/share/man/ \
+    /tmp/* \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/plugin \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/javaws \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/jjs \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/orbd \
+    /usr/lib/jvm/java-8-openjdk-amd64/bin/pack200 \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/policytool \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmiregistry \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/servertool \
+    /usr/lib/jvm/java-8-openjdk-amd64/bin/tnameserv \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/unpack200 \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/javaws.jar \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/deploy* \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/desktop \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/*javafx* \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/*jfx* \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libdecora_sse.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libprism_*.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libfxplugins.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libglass.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libgstreamer-lite.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libjavafx*.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/libjfx*.so \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/jfxrt.jar \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/oblique-fonts \
+    /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/plugin.jar \
+    /usr/lib/jvm/java-8-openjdk-amd64/man


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the deprecated ubuntu-slim image with ` k8s.gcr.io/debian-base-amd64:0.3`.
Also adds a script for the build process to improve the legibility of the process and better error messages.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
