### PR TITLE
bzl: use --local_test_jobs

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -19,6 +19,5 @@ test:unit --features=race
 test:unit --test_tag_filters=-e2e,-integration
 test:unit --flaky_test_attempts=3
 
-build:integration --build_tag_filters=integration
-test:integration --jobs 4
+test:integration --local_test_jobs 4
 test:integration --test_tag_filters=integration

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -562,7 +562,6 @@ bazel-test-integration:
 	@echo "$$BAZEL_TEST_INTEGRATION_HELP_INFO"
 else
 bazel-test-integration:
-	bazel build --config integration //test/integration/...
 	bazel test --config integration //test/integration/...
 endif
 


### PR DESCRIPTION
We originally seperated build and test so that only 4 integration tests
would be run at a time, but we didn't want to slow down build, however
we didn't know --local_test_jobs existed. This achieves the same result
but more efficiently.

```release-note
NONE
```
