### PR TITLE
remove f.PrintObjectSpecificMessage

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -213,9 +213,6 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		if len(output) > 0 && !shortOutput {
 			return cmdutil.PrintObject(cmd, info.Object, o.Out)
 		}
-		if !shortOutput {
-			f.PrintObjectSpecificMessage(info.Object, o.Out)
-		}
 
 		cmdutil.PrintSuccess(shortOutput, o.Out, info.Object, dryRun, "created")
 		return nil

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -154,7 +154,6 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		}
 
 		info.Refresh(obj, true)
-		f.PrintObjectSpecificMessage(obj, out)
 		cmdutil.PrintSuccess(shortOutput, out, info.Object, false, "replaced")
 		return nil
 	})
@@ -276,7 +275,6 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 
 		count++
 		info.Refresh(obj, true)
-		f.PrintObjectSpecificMessage(obj, out)
 		cmdutil.PrintSuccess(shortOutput, out, info.Object, false, "replaced")
 		return nil
 	})

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"errors"
 	"fmt"
-	"io"
 	"path/filepath"
 	"time"
 
@@ -458,9 +457,6 @@ func (f *FakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*v1.Pod
 
 func (f *FakeFactory) EditorEnvs() []string {
 	return nil
-}
-
-func (f *FakeFactory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
 }
 
 func (f *FakeFactory) Command(*cobra.Command, bool) string {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -179,9 +178,6 @@ type ClientAccessFactory interface {
 	// can range over in order to determine if the user has specified an editor
 	// of their choice.
 	EditorEnvs() []string
-
-	// PrintObjectSpecificMessage prints object-specific messages on the provided writer
-	PrintObjectSpecificMessage(obj runtime.Object, out io.Writer)
 }
 
 // ObjectMappingFactory holds the second level of factory methods. These functions depend upon ClientAccessFactory methods.

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -674,34 +674,6 @@ func (f *ring0Factory) EditorEnvs() []string {
 	return []string{"KUBE_EDITOR", "EDITOR"}
 }
 
-func (f *ring0Factory) PrintObjectSpecificMessage(obj runtime.Object, out io.Writer) {
-	switch obj := obj.(type) {
-	case *api.Service:
-		if obj.Spec.Type == api.ServiceTypeNodePort {
-			msg := fmt.Sprintf(
-				`You have exposed your service on an external port on all nodes in your
-cluster.  If you want to expose this service to the external internet, you may
-need to set up firewall rules for the service port(s) (%s) to serve traffic.
-
-See http://kubernetes.io/docs/user-guide/services-firewalls for more details.
-`,
-				makePortsString(obj.Spec.Ports, true))
-			out.Write([]byte(msg))
-		}
-
-		if _, ok := obj.Annotations[api.AnnotationLoadBalancerSourceRangesKey]; ok {
-			msg := fmt.Sprintf(
-				`You are using service annotation [service.beta.kubernetes.io/load-balancer-source-ranges].
-It has been promoted to field [loadBalancerSourceRanges] in service spec. This annotation will be deprecated in the future.
-Please use the loadBalancerSourceRanges field instead.
-
-See http://kubernetes.io/docs/user-guide/services-firewalls for more details.
-`)
-			out.Write([]byte(msg))
-		}
-	}
-}
-
 // overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
 var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/\.)]`)
 

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -414,41 +413,6 @@ func TestGetFirstPod(t *testing.T) {
 		}
 		if !apiequality.Semantic.DeepEqual(test.expected, pod) {
 			t.Errorf("%s:\nexpected pod:\n%#v\ngot:\n%#v\n\n", test.name, test.expected, pod)
-		}
-	}
-}
-
-func TestPrintObjectSpecificMessage(t *testing.T) {
-	f := NewFactory(nil)
-	tests := []struct {
-		obj          runtime.Object
-		expectOutput bool
-	}{
-		{
-			obj:          &api.Service{},
-			expectOutput: false,
-		},
-		{
-			obj:          &api.Pod{},
-			expectOutput: false,
-		},
-		{
-			obj:          &api.Service{Spec: api.ServiceSpec{Type: api.ServiceTypeLoadBalancer}},
-			expectOutput: false,
-		},
-		{
-			obj:          &api.Service{Spec: api.ServiceSpec{Type: api.ServiceTypeNodePort}},
-			expectOutput: true,
-		},
-	}
-	for _, test := range tests {
-		buff := &bytes.Buffer{}
-		f.PrintObjectSpecificMessage(test.obj, buff)
-		if test.expectOutput && buff.Len() == 0 {
-			t.Errorf("Expected output, saw none for %v", test.obj)
-		}
-		if !test.expectOutput && buff.Len() > 0 {
-			t.Errorf("Expected no output, saw %s for %v", buff.String(), test.obj)
 		}
 	}
 }


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Mailing list discussion: https://groups.google.com/forum/#!topic/kubernetes-sig-cli/gZWg8Ulo3Ao

Removes the `PrintObjectSpecificMessage` helper in an effort to reduce printing stack complexity, and avoid special-casing resources.