### PR TITLE
Bump addon-manager to v8.6

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 8.6  (Tue February 20 2018 Zihong Zheng <zihongz@google.com>)
+ - Allow reconcile/ensure loop to work with resource under non-kube-system namespace.
+ - Update kubectl to v1.9.3.
+
 ### Version 8.4  (Thu November 30 2017 zou nengren @zouyee)
  - Update kubectl to v1.8.4.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v8.5
-KUBECTL_VERSION?=v1.8.4
+VERSION=v8.6
+KUBECTL_VERSION?=v1.9.3
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -21,7 +21,6 @@ In future release (after one year), Addon Manager may not respect it anymore. Ad
 have this label but without `addonmanager.kubernetes.io/mode=EnsureExists` will be
 treated as "reconcile class addons" for now.
 - Resources under `$ADDON_PATH` need to have either one of these two labels.
-Meanwhile namespaced resources need to be in `kube-system` namespace.
 Otherwise it will be omitted.
 - The above label and namespace rule does not stand for `/opt/namespace.yaml` and
 resources under `/etc/kubernetes/admission-controls/`. addon-manager will attempt to

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -107,7 +107,7 @@ function create_resource_from_string() {
   local -r config_name=$4;
   local -r namespace=$5;
   while [ ${tries} -gt 0 ]; do
-    echo "${config_string}" | ${KUBECTL} ${KUBECTL_OPTS} apply -f - && \
+    echo "${config_string}" | ${KUBECTL} ${KUBECTL_OPTS} --namespace="${namespace}" apply -f - && \
       log INFO "== Successfully started ${config_name} in namespace ${namespace} at $(date -Is)" && \
       return 0;
     let tries=tries-1;

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.5
+    image: k8s.gcr.io/kube-addon-manager:v8.6
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.5
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.6
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes/kubernetes/pull/59378, build & push a new addon-manager image to pick up the namespace change to support istio addon.

Pushed images for {amd64, arm, arm64, ppc64le, s390x}.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @mikedanese @ostromart 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
