### PR TITLE
Fix running with no eviction thresholds

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -222,7 +222,7 @@ func startMemoryThresholdNotifier(thresholds []evictionapi.Threshold, observatio
 func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc ActivePodsFunc) []*v1.Pod {
 	// if we have nothing to do, just return
 	thresholds := m.config.Thresholds
-	if len(thresholds) == 0 {
+	if len(thresholds) == 0 && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After https://github.com/kubernetes/kubernetes/pull/57802, [LocalStorageCapacityIsolationEviction tests](https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-serial-gce-e2e&include-filter-by-regex=LocalStorageCapacityIsolationEviction) started failing.  They failed because the eviction manager was not running its synchronization loops when we have no thresholds.  We should still perform the eviction manager synchronization loop even when we have no thresholds if the LocalStorageCapacityIsolation feature gate is enabled.  The reason we didn't see this before is that we added a threshold for node allocatable even when there was no corresponding eviction threshold.   https://github.com/kubernetes/kubernetes/pull/57802 changed this to only add a memory allocatable threshold when we have a memory eviction threshold specified.

**Release note**:
```release-note
NONE
```

/kind bug
/priority critical-urgent
/sig node
/assign @Random-Liu 
cc @kubernetes/sig-node-test-failures 