### PR TITLE
node authorizer sets up access rules for dynamic config

### DIFF
--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -68,12 +68,13 @@ func (config AuthorizationConfig) New() (authorizer.Authorizer, authorizer.RuleR
 	)
 
 	for _, authorizationMode := range config.AuthorizationModes {
-		// Keep cases in sync with constant list above.
+		// Keep cases in sync with constant list in k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes/modes.go.
 		switch authorizationMode {
 		case modes.ModeNode:
 			graph := node.NewGraph()
 			node.AddGraphEventHandlers(
 				graph,
+				config.InformerFactory.Core().InternalVersion().Nodes(),
 				config.InformerFactory.Core().InternalVersion().Pods(),
 				config.InformerFactory.Core().InternalVersion().PersistentVolumes(),
 				config.VersionedInformerFactory.Storage().V1beta1().VolumeAttachments(),

--- a/plugin/pkg/auth/authorizer/node/BUILD
+++ b/plugin/pkg/auth/authorizer/node/BUILD
@@ -8,15 +8,20 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["node_authorizer_test.go"],
+    srcs = [
+        "graph_test.go",
+        "node_authorizer_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/auth/nodeidentifier:go_default_library",
         "//pkg/features:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
@@ -34,12 +35,21 @@ type graphPopulator struct {
 
 func AddGraphEventHandlers(
 	graph *Graph,
+	nodes coreinformers.NodeInformer,
 	pods coreinformers.PodInformer,
 	pvs coreinformers.PersistentVolumeInformer,
 	attachments storageinformers.VolumeAttachmentInformer,
 ) {
 	g := &graphPopulator{
 		graph: graph,
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.DynamicKubeletConfig) {
+		nodes.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    g.addNode,
+			UpdateFunc: g.updateNode,
+			DeleteFunc: g.deleteNode,
+		})
 	}
 
 	pods.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -61,6 +71,57 @@ func AddGraphEventHandlers(
 			DeleteFunc: g.deleteVolumeAttachment,
 		})
 	}
+}
+
+func (g *graphPopulator) addNode(obj interface{}) {
+	g.updateNode(nil, obj)
+}
+
+func (g *graphPopulator) updateNode(oldObj, obj interface{}) {
+	node := obj.(*api.Node)
+	var oldNode *api.Node
+	if oldObj != nil {
+		oldNode = oldObj.(*api.Node)
+	}
+
+	// we only set up rules for ConfigMapRef today, because that is the only reference type
+
+	var name, namespace string
+	if source := node.Spec.ConfigSource; source != nil && source.ConfigMapRef != nil {
+		name = source.ConfigMapRef.Name
+		namespace = source.ConfigMapRef.Namespace
+	}
+
+	var oldName, oldNamespace string
+	if oldNode != nil {
+		if oldSource := oldNode.Spec.ConfigSource; oldSource != nil && oldSource.ConfigMapRef != nil {
+			oldName = oldSource.ConfigMapRef.Name
+			oldNamespace = oldSource.ConfigMapRef.Namespace
+		}
+	}
+
+	// if Node.Spec.ConfigSource wasn't updated, nothing for us to do
+	if name == oldName && namespace == oldNamespace {
+		return
+	}
+
+	path := "nil"
+	if node.Spec.ConfigSource != nil {
+		path = fmt.Sprintf("%s/%s", namespace, name)
+	}
+	glog.V(4).Infof("updateNode configSource reference to %s for node %s", path, node.Name)
+	g.graph.SetNodeConfigMap(node.Name, name, namespace)
+}
+
+func (g *graphPopulator) deleteNode(obj interface{}) {
+	node := obj.(*api.Node)
+
+	// TODO(mtaufen): ensure len(nodeName) > 0 in all cases (would sure be nice to have a dependently-typed language here...)
+
+	// NOTE: We don't remove the node, because if the node is re-created not all pod -> node
+	// links are re-established (we don't get relevant events because the no mutations need
+	// to happen in the API; the state is already there).
+	g.graph.SetNodeConfigMap(node.Name, "", "")
 }
 
 func (g *graphPopulator) addPod(obj interface{}) {

--- a/plugin/pkg/auth/authorizer/node/graph_test.go
+++ b/plugin/pkg/auth/authorizer/node/graph_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteEdges_locked(t *testing.T) {
+	cases := []struct {
+		desc        string
+		fromType    vertexType
+		toType      vertexType
+		toNamespace string
+		toName      string
+		start       *Graph
+		expect      *Graph
+	}{
+		{
+			// single edge from a configmap to a node, will delete edge and orphaned configmap
+			desc:        "edges and source orphans are deleted, destination orphans are preserved",
+			fromType:    configMapVertexType,
+			toType:      nodeVertexType,
+			toNamespace: "",
+			toName:      "node1",
+			start: func() *Graph {
+				g := NewGraph()
+				nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex, nodeVertex))
+				return g
+			}(),
+			expect: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				return g
+			}(),
+		},
+		{
+			// two edges from the same configmap to distinct nodes, will delete one of the edges
+			desc:        "edges are deleted, non-orphans and destination orphans are preserved",
+			fromType:    configMapVertexType,
+			toType:      nodeVertexType,
+			toNamespace: "",
+			toName:      "node2",
+			start: func() *Graph {
+				g := NewGraph()
+				nodeVertex1 := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				nodeVertex2 := g.getOrCreateVertex_locked(nodeVertexType, "", "node2")
+				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
+				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex2, nodeVertex2))
+				return g
+			}(),
+			expect: func() *Graph {
+				g := NewGraph()
+				nodeVertex1 := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node2")
+				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex1, nodeVertex1))
+				return g
+			}(),
+		},
+		{
+			desc:        "no edges to delete",
+			fromType:    configMapVertexType,
+			toType:      nodeVertexType,
+			toNamespace: "",
+			toName:      "node1",
+			start: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				return g
+			}(),
+			expect: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				return g
+			}(),
+		},
+		{
+			desc:        "destination vertex does not exist",
+			fromType:    configMapVertexType,
+			toType:      nodeVertexType,
+			toNamespace: "",
+			toName:      "node1",
+			start: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				return g
+			}(),
+			expect: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
+				return g
+			}(),
+		},
+		{
+			desc:        "source vertex type doesn't exist",
+			fromType:    configMapVertexType,
+			toType:      nodeVertexType,
+			toNamespace: "",
+			toName:      "node1",
+			start: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				return g
+			}(),
+			expect: func() *Graph {
+				g := NewGraph()
+				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
+				return g
+			}(),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			c.start.deleteEdges_locked(c.fromType, c.toType, c.toNamespace, c.toName)
+
+			// Note: We assert on substructures (graph.Nodes(), graph.Edges()) because the graph tracks
+			// freed IDs for reuse, which results in an irrelevant inequality between start and expect.
+
+			// sort the nodes by ID
+			// (the slices we get back are from map iteration, where order is not guaranteed)
+			expectNodes := c.expect.graph.Nodes()
+			sort.Slice(expectNodes, func(i, j int) bool {
+				return expectNodes[i].ID() < expectNodes[j].ID()
+			})
+			startNodes := c.start.graph.Nodes()
+			sort.Slice(expectNodes, func(i, j int) bool {
+				return startNodes[i].ID() < startNodes[j].ID()
+			})
+			assert.Equal(t, expectNodes, startNodes)
+
+			// sort the edges by from ID, then to ID
+			// (the slices we get back are from map iteration, where order is not guaranteed)
+			expectEdges := c.expect.graph.Edges()
+			sort.Slice(expectEdges, func(i, j int) bool {
+				if expectEdges[i].From().ID() == expectEdges[j].From().ID() {
+					return expectEdges[i].To().ID() < expectEdges[j].To().ID()
+				}
+				return expectEdges[i].From().ID() < expectEdges[j].From().ID()
+			})
+			startEdges := c.start.graph.Edges()
+			sort.Slice(expectEdges, func(i, j int) bool {
+				if startEdges[i].From().ID() == startEdges[j].From().ID() {
+					return startEdges[i].To().ID() < startEdges[j].To().ID()
+				}
+				return startEdges[i].From().ID() < startEdges[j].From().ID()
+			})
+			assert.Equal(t, expectEdges, startEdges)
+
+			// vertices is a recursive map, no need to sort
+			assert.Equal(t, c.expect.vertices, c.start.vertices)
+		})
+	}
+}

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -38,6 +38,7 @@ import (
 // 1. If a request is not from a node (NodeIdentity() returns isNode=false), reject
 // 2. If a specific node cannot be identified (NodeIdentity() returns nodeName=""), reject
 // 3. If a request is for a secret, configmap, persistent volume or persistent volume claim, reject unless the verb is get, and the requested object is related to the requesting node:
+//    node <- configmap
 //    node <- pod
 //    node <- pod <- secret
 //    node <- pod <- configmap

--- a/test/e2e/auth/node_authz.go
+++ b/test/e2e/auth/node_authz.go
@@ -74,8 +74,30 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
 	})
 
-	It("Getting an existent secret should exit with the Forbidden error", func() {
+	It("Getting an existing secret should exit with the Forbidden error", func() {
 		_, err := c.CoreV1().Secrets(ns).Get(defaultSaSecret, metav1.GetOptions{})
+		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
+	})
+
+	It("Getting a non-existent configmap should exit with the Forbidden error, not a NotFound error", func() {
+		_, err := c.CoreV1().ConfigMaps(ns).Get("foo", metav1.GetOptions{})
+		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
+	})
+
+	It("Getting an existing configmap should exit with the Forbidden error", func() {
+		By("Create a configmap for testing")
+		configmap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      "node-auth-configmap",
+			},
+			Data: map[string]string{
+				"data": "content",
+			},
+		}
+		_, err := f.ClientSet.CoreV1().ConfigMaps(ns).Create(configmap)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = c.CoreV1().ConfigMaps(ns).Get(configmap.Name, metav1.GetOptions{})
 		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
 	})
 
@@ -138,7 +160,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("A node shouldn't be able to create an other node", func() {
+	It("A node shouldn't be able to create another node", func() {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			TypeMeta: metav1.TypeMeta{
@@ -151,7 +173,7 @@ var _ = SIGDescribe("[Feature:NodeAuthorizer]", func() {
 		Expect(apierrors.IsForbidden(err)).Should(Equal(true))
 	})
 
-	It("A node shouldn't be able to delete an other node", func() {
+	It("A node shouldn't be able to delete another node", func() {
 		By(fmt.Sprintf("Create node foo by user: %v", asUser))
 		err := c.CoreV1().Nodes().Delete("foo", &metav1.DeleteOptions{})
 		Expect(apierrors.IsForbidden(err)).Should(Equal(true))


### PR DESCRIPTION
This PR makes the node authorizer automatically set up access rules for
dynamic Kubelet config.

I also added some validation to the node strategy, which I discovered we
were missing while writing this.

This PR is based on another WIP from @liggitt.

```release-note
The node authorizer now automatically sets up rules for Node.Spec.ConfigSource when the DynamicKubeletConfig feature gate is enabled.
```
