### PR TITLE
Update cadvisor godeps to v0.29.0 and ignore per-cpu metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1454,218 +1454,218 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.28.3-20-g6116f265",
-			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
+			"Comment": "v0.29.0",
+			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -108,7 +108,11 @@ func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
 func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
-	ignoreMetrics := cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}, cadvisormetrics.NetworkUdpUsageMetrics: struct{}{}}
+	ignoreMetrics := cadvisormetrics.MetricSet{
+		cadvisormetrics.NetworkTcpUsageMetrics: struct{}{},
+		cadvisormetrics.NetworkUdpUsageMetrics: struct{}{},
+		cadvisormetrics.PerCpuUsageMetrics:     struct{}{},
+	}
 	if !usingLegacyStats {
 		ignoreMetrics[cadvisormetrics.DiskUsageMetrics] = struct{}{}
 	}

--- a/vendor/github.com/google/cadvisor/container/factory.go
+++ b/vendor/github.com/google/cadvisor/container/factory.go
@@ -42,6 +42,7 @@ type MetricKind string
 
 const (
 	CpuUsageMetrics        MetricKind = "cpu"
+	PerCpuUsageMetrics     MetricKind = "percpu"
 	MemoryUsageMetrics     MetricKind = "memory"
 	CpuLoadMetrics         MetricKind = "cpuLoad"
 	DiskIOMetrics          MetricKind = "diskIO"

--- a/vendor/github.com/google/cadvisor/metrics/prometheus.go
+++ b/vendor/github.com/google/cadvisor/metrics/prometheus.go
@@ -150,10 +150,18 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 				},
 			}, {
 				name:        "container_cpu_usage_seconds_total",
-				help:        "Cumulative cpu time consumed per cpu in seconds.",
+				help:        "Cumulative cpu time consumed in seconds.",
 				valueType:   prometheus.CounterValue,
 				extraLabels: []string{"cpu"},
 				getValues: func(s *info.ContainerStats) metricValues {
+					if len(s.Cpu.Usage.PerCpu) == 0 {
+						if s.Cpu.Usage.Total > 0 {
+							return metricValues{{
+								value:  float64(s.Cpu.Usage.Total) / float64(time.Second),
+								labels: []string{"total"},
+							}}
+						}
+					}
 					values := make(metricValues, 0, len(s.Cpu.Usage.PerCpu))
 					for i, value := range s.Cpu.Usage.PerCpu {
 						if value > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the cAdvisor dependency to the cAdvisor release associated with the kubernetes 1.10 release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60052

**Special notes for your reviewer**:
This PR also adds per-cpu metrics to the ignoreMetrics list.  This is a new metric that can be ignored in the most recent cAdvisor release.
The reason for not collecting per-cpu metrics is that it can cause severe scalability issues.
For example, if using a 128 core machine, and running 100 containers, we have 12800 different streams of metrics just for per-cpu metrics which cAdvisor needs to process and transmit.
Additionally, per-cpu metrics are not used by any kubernetes components, and if a user needs these metrics, they can run cAdvisor as a daemonset. 

**Release note**:
```release-note
Disable per-cpu metrics by default for scalability.
Fix inaccurate disk usage monitoring of overlayFs.
Retry docker connection on startup timeout to avoid permanent loss of metrics.
```

/assign @dchen1107 