### PR TITLE
CSI MountDevice/UnmountDevice Implementation

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -20,11 +20,16 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
+	grpctx "golang.org/x/net/context"
 
+	csipb "github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -35,10 +40,17 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 )
 
+const (
+	persistentVolumeInGlobalPath = "pv"
+	globalMountInGlobalPath      = "globalmount"
+)
+
 type csiAttacher struct {
 	plugin        *csiPlugin
 	k8s           kubernetes.Interface
 	waitSleepTime time.Duration
+
+	csiClient csiClient
 }
 
 // volume.Attacher methods
@@ -229,12 +241,125 @@ func (c *csiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.No
 }
 
 func (c *csiAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error) {
-	glog.V(4).Info(log("attacher.GetDeviceMountPath is not implemented"))
-	return "", nil
+	glog.V(4).Info(log("attacher.GetDeviceMountPath(%v)", spec))
+	deviceMountPath, err := makeDeviceMountPath(c.plugin, spec)
+	if err != nil {
+		glog.Error(log("attacher.GetDeviceMountPath failed to make device mount path: %v", err))
+		return "", err
+	}
+	glog.V(4).Infof("attacher.GetDeviceMountPath succeeded, deviceMountPath: %s", deviceMountPath)
+	return deviceMountPath, nil
 }
 
 func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
-	glog.V(4).Info(log("attacher.MountDevice is not implemented"))
+	glog.V(4).Infof(log("attacher.MountDevice(%s, %s)", devicePath, deviceMountPath))
+
+	mounted, err := isDirMounted(c.plugin, deviceMountPath)
+	if err != nil {
+		glog.Error(log("attacher.MountDevice failed while checking mount status for dir [%s]", deviceMountPath))
+		return err
+	}
+
+	if mounted {
+		glog.V(4).Info(log("attacher.MountDevice skipping mount, dir already mounted [%s]", deviceMountPath))
+		return nil
+	}
+
+	// Setup
+	if spec == nil {
+		return fmt.Errorf("attacher.MountDevice failed, spec is nil")
+	}
+	csiSource, err := getCSISourceFromSpec(spec)
+	if err != nil {
+		glog.Error(log("attacher.MountDevice failed to get CSI persistent source: %v", err))
+		return err
+	}
+
+	if c.csiClient == nil {
+		if csiSource.Driver == "" {
+			return fmt.Errorf("attacher.MountDevice failed, driver name is empty")
+		}
+		addr := fmt.Sprintf(csiAddrTemplate, csiSource.Driver)
+		c.csiClient = newCsiDriverClient("unix", addr)
+	}
+	csi := c.csiClient
+
+	ctx, cancel := grpctx.WithTimeout(grpctx.Background(), csiTimeout)
+	defer cancel()
+	// Check whether "STAGE_UNSTAGE_VOLUME" is set
+	stageUnstageSet, err := hasStageUnstageCapability(ctx, csi)
+	if err != nil {
+		glog.Error(log("attacher.MountDevice failed to check STAGE_UNSTAGE_VOLUME: %v", err))
+		return err
+	}
+	if !stageUnstageSet {
+		glog.Infof(log("attacher.MountDevice STAGE_UNSTAGE_VOLUME capability not set. Skipping MountDevice..."))
+		return nil
+	}
+
+	// Start MountDevice
+	if deviceMountPath == "" {
+		return fmt.Errorf("attacher.MountDevice failed, deviceMountPath is empty")
+	}
+
+	nodeName := string(c.plugin.host.GetNodeName())
+	attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
+
+	// search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
+	attachment, err := c.k8s.StorageV1beta1().VolumeAttachments().Get(attachID, meta.GetOptions{})
+	if err != nil {
+		glog.Error(log("attacher.MountDevice failed while getting volume attachment [id=%v]: %v", attachID, err))
+		return err
+	}
+
+	if attachment == nil {
+		glog.Error(log("unable to find VolumeAttachment [id=%s]", attachID))
+		return errors.New("no existing VolumeAttachment found")
+	}
+	publishVolumeInfo := attachment.Status.AttachmentMetadata
+
+	// create target_dir before call to NodeStageVolume
+	if err := os.MkdirAll(deviceMountPath, 0750); err != nil {
+		glog.Error(log("attacher.MountDevice failed to create dir %#v:  %v", deviceMountPath, err))
+		return err
+	}
+	glog.V(4).Info(log("created target path successfully [%s]", deviceMountPath))
+
+	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
+	accessMode := v1.ReadWriteOnce
+	if spec.PersistentVolume.Spec.AccessModes != nil {
+		accessMode = spec.PersistentVolume.Spec.AccessModes[0]
+	}
+
+	fsType := csiSource.FSType
+	if len(fsType) == 0 {
+		fsType = defaultFSType
+	}
+
+	nodeStageSecrets := map[string]string{}
+	if csiSource.NodeStageSecretRef != nil {
+		nodeStageSecrets = getCredentialsFromSecret(c.k8s, csiSource.NodeStageSecretRef)
+	}
+
+	err = csi.NodeStageVolume(ctx,
+		csiSource.VolumeHandle,
+		publishVolumeInfo,
+		deviceMountPath,
+		fsType,
+		accessMode,
+		nodeStageSecrets,
+		csiSource.VolumeAttributes)
+
+	if err != nil {
+		glog.Errorf(log("attacher.MountDevice failed: %v", err))
+		if err := removeMountDir(c.plugin, deviceMountPath); err != nil {
+			glog.Error(log("attacher.MountDevice failed to remove mount dir after a NodeStageVolume() error [%s]: %v", deviceMountPath, err))
+			return err
+		}
+		return err
+	}
+
+	glog.V(4).Infof(log("attacher.MountDevice successfully requested NodeStageVolume [%s]", deviceMountPath))
 	return nil
 }
 
@@ -335,12 +460,111 @@ func (c *csiAttacher) waitForVolumeDetachmentInternal(volumeHandle, attachID str
 }
 
 func (c *csiAttacher) UnmountDevice(deviceMountPath string) error {
-	glog.V(4).Info(log("detacher.UnmountDevice is not implemented"))
+	glog.V(4).Info(log("attacher.UnmountDevice(%s)", deviceMountPath))
+
+	// Setup
+	driverName, volID, err := getDriverAndVolNameFromDeviceMountPath(c.k8s, deviceMountPath)
+	if err != nil {
+		glog.Errorf(log("attacher.UnmountDevice failed to get driver and volume name from device mount path: %v", err))
+		return err
+	}
+
+	if c.csiClient == nil {
+		addr := fmt.Sprintf(csiAddrTemplate, driverName)
+		c.csiClient = newCsiDriverClient("unix", addr)
+	}
+	csi := c.csiClient
+
+	ctx, cancel := grpctx.WithTimeout(grpctx.Background(), csiTimeout)
+	defer cancel()
+	// Check whether "STAGE_UNSTAGE_VOLUME" is set
+	stageUnstageSet, err := hasStageUnstageCapability(ctx, csi)
+	if err != nil {
+		glog.Errorf(log("attacher.UnmountDevice failed to check whether STAGE_UNSTAGE_VOLUME set: %v", err))
+		return err
+	}
+	if !stageUnstageSet {
+		glog.Infof(log("attacher.UnmountDevice STAGE_UNSTAGE_VOLUME capability not set. Skipping UnmountDevice..."))
+		return nil
+	}
+
+	// Start UnmountDevice
+	err = csi.NodeUnstageVolume(ctx,
+		volID,
+		deviceMountPath)
+
+	if err != nil {
+		glog.Errorf(log("attacher.UnmountDevice failed: %v", err))
+		return err
+	}
+
+	glog.V(4).Infof(log("attacher.UnmountDevice successfully requested NodeStageVolume [%s]", deviceMountPath))
 	return nil
+}
+
+func hasStageUnstageCapability(ctx grpctx.Context, csi csiClient) (bool, error) {
+	capabilities, err := csi.NodeGetCapabilities(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	stageUnstageSet := false
+	if capabilities == nil {
+		return false, nil
+	}
+	for _, capability := range capabilities {
+		if capability.GetRpc().GetType() == csipb.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME {
+			stageUnstageSet = true
+		}
+	}
+	return stageUnstageSet, nil
 }
 
 // getAttachmentName returns csi-<sha252(volName,csiDriverName,NodeName>
 func getAttachmentName(volName, csiDriverName, nodeName string) string {
 	result := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", volName, csiDriverName, nodeName)))
 	return fmt.Sprintf("csi-%x", result)
+}
+
+func makeDeviceMountPath(plugin *csiPlugin, spec *volume.Spec) (string, error) {
+	if spec == nil {
+		return "", fmt.Errorf("makeDeviceMountPath failed, spec is nil")
+	}
+
+	pvName := spec.PersistentVolume.Name
+	if pvName == "" {
+		return "", fmt.Errorf("makeDeviceMountPath failed, pv name empty")
+	}
+
+	return path.Join(plugin.host.GetPluginDir(plugin.GetPluginName()), persistentVolumeInGlobalPath, pvName, globalMountInGlobalPath), nil
+}
+
+func getDriverAndVolNameFromDeviceMountPath(k8s kubernetes.Interface, deviceMountPath string) (string, string, error) {
+	// deviceMountPath structure: /var/lib/kubelet/plugins/kubernetes.io/csi/pv/{pvname}/globalmount
+	dir := filepath.Dir(deviceMountPath)
+	if file := filepath.Base(deviceMountPath); file != globalMountInGlobalPath {
+		return "", "", fmt.Errorf("getDriverAndVolNameFromDeviceMountPath failed, path did not end in %s", globalMountInGlobalPath)
+	}
+	// dir is now /var/lib/kubelet/plugins/kubernetes.io/csi/pv/{pvname}
+	pvName := filepath.Base(dir)
+
+	// Get PV and check for errors
+	pv, err := k8s.CoreV1().PersistentVolumes().Get(pvName, meta.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	if pv == nil || pv.Spec.CSI == nil {
+		return "", "", fmt.Errorf("getDriverAndVolNameFromDeviceMountPath could not find CSI Persistent Volume Source for pv: %s", pvName)
+	}
+
+	// Get VolumeHandle and PluginName from pv
+	csiSource := pv.Spec.CSI
+	if csiSource.Driver == "" {
+		return "", "", fmt.Errorf("getDriverAndVolNameFromDeviceMountPath failed, driver name empty")
+	}
+	if csiSource.VolumeHandle == "" {
+		return "", "", fmt.Errorf("getDriverAndVolNameFromDeviceMountPath failed, VolumeHandle empty")
+	}
+
+	return csiSource.Driver, csiSource.VolumeHandle, nil
 }

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -26,13 +26,13 @@ import (
 	"k8s.io/kubernetes/pkg/volume/csi/fake"
 )
 
-func setupClient(t *testing.T) *csiDriverClient {
+func setupClient(t *testing.T, stageUnstageSet bool) *csiDriverClient {
 	client := newCsiDriverClient("unix", "/tmp/test.sock")
 	client.conn = new(grpc.ClientConn) //avoids creating conn object
 
 	// setup mock grpc clients
 	client.idClient = fake.NewIdentityClient()
-	client.nodeClient = fake.NewNodeClient()
+	client.nodeClient = fake.NewNodeClient(stageUnstageSet)
 	client.ctrlClient = fake.NewControllerClient()
 
 	return client
@@ -54,7 +54,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 		{name: "grpc error", volID: "vol-test", targetPath: "/test/path", mustFail: true, err: errors.New("grpc error")},
 	}
 
-	client := setupClient(t)
+	client := setupClient(t, false)
 
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
@@ -63,6 +63,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 			grpctx.Background(),
 			tc.volID,
 			false,
+			"",
 			tc.targetPath,
 			api.ReadWriteOnce,
 			map[string]string{"device": "/dev/null"},
@@ -91,12 +92,80 @@ func TestClientNodeUnpublishVolume(t *testing.T) {
 		{name: "grpc error", volID: "vol-test", targetPath: "/test/path", mustFail: true, err: errors.New("grpc error")},
 	}
 
-	client := setupClient(t)
+	client := setupClient(t, false)
 
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
 		client.nodeClient.(*fake.NodeClient).SetNextError(tc.err)
 		err := client.NodeUnpublishVolume(grpctx.Background(), tc.volID, tc.targetPath)
+		if tc.mustFail && err == nil {
+			t.Error("test must fail, but err is nil")
+		}
+	}
+}
+
+func TestClientNodeStageVolume(t *testing.T) {
+	testCases := []struct {
+		name              string
+		volID             string
+		stagingTargetPath string
+		fsType            string
+		secret            map[string]string
+		mustFail          bool
+		err               error
+	}{
+		{name: "test ok", volID: "vol-test", stagingTargetPath: "/test/path", fsType: "ext4"},
+		{name: "missing volID", stagingTargetPath: "/test/path", mustFail: true},
+		{name: "missing target path", volID: "vol-test", mustFail: true},
+		{name: "bad fs", volID: "vol-test", stagingTargetPath: "/test/path", fsType: "badfs", mustFail: true},
+		{name: "grpc error", volID: "vol-test", stagingTargetPath: "/test/path", mustFail: true, err: errors.New("grpc error")},
+	}
+
+	client := setupClient(t, false)
+
+	for _, tc := range testCases {
+		t.Logf("Running test case: %s", tc.name)
+		client.nodeClient.(*fake.NodeClient).SetNextError(tc.err)
+		err := client.NodeStageVolume(
+			grpctx.Background(),
+			tc.volID,
+			map[string]string{"device": "/dev/null"},
+			tc.stagingTargetPath,
+			tc.fsType,
+			api.ReadWriteOnce,
+			tc.secret,
+			map[string]string{"attr0": "val0"},
+		)
+
+		if tc.mustFail && err == nil {
+			t.Error("test must fail, but err is nil")
+		}
+	}
+}
+
+func TestClientNodeUnstageVolume(t *testing.T) {
+	testCases := []struct {
+		name              string
+		volID             string
+		stagingTargetPath string
+		mustFail          bool
+		err               error
+	}{
+		{name: "test ok", volID: "vol-test", stagingTargetPath: "/test/path"},
+		{name: "missing volID", stagingTargetPath: "/test/path", mustFail: true},
+		{name: "missing target path", volID: "vol-test", mustFail: true},
+		{name: "grpc error", volID: "vol-test", stagingTargetPath: "/test/path", mustFail: true, err: errors.New("grpc error")},
+	}
+
+	client := setupClient(t, false)
+
+	for _, tc := range testCases {
+		t.Logf("Running test case: %s", tc.name)
+		client.nodeClient.(*fake.NodeClient).SetNextError(tc.err)
+		err := client.NodeUnstageVolume(
+			grpctx.Background(),
+			tc.volID, tc.stagingTargetPath,
+		)
 		if tc.mustFail && err == nil {
 			t.Error("test must fail, but err is nil")
 		}

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -114,7 +114,7 @@ func TestMounterSetUp(t *testing.T) {
 	}
 
 	csiMounter := mounter.(*csiMountMgr)
-	csiMounter.csiClient = setupClient(t)
+	csiMounter.csiClient = setupClient(t, false)
 
 	attachID := getAttachmentName(csiMounter.volumeID, csiMounter.driverName, string(plug.host.GetNodeName()))
 
@@ -172,7 +172,7 @@ func TestUnmounterTeardown(t *testing.T) {
 	}
 
 	csiUnmounter := unmounter.(*csiMountMgr)
-	csiUnmounter.csiClient = setupClient(t)
+	csiUnmounter.csiClient = setupClient(t, false)
 
 	dir := csiUnmounter.GetPath()
 

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -64,8 +64,7 @@ func newTestPlugin(t *testing.T) (*csiPlugin, string) {
 func makeTestPV(name string, sizeGig int, driverName, volID string) *api.PersistentVolume {
 	return &api.PersistentVolume{
 		ObjectMeta: meta.ObjectMeta{
-			Name:      name,
-			Namespace: testns,
+			Name: name,
 		},
 		Spec: api.PersistentVolumeSpec{
 			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -60,12 +60,18 @@ func (f *IdentityClient) Probe(ctx context.Context, in *csipb.ProbeRequest, opts
 // NodeClient returns CSI node client
 type NodeClient struct {
 	nodePublishedVolumes map[string]string
+	nodeStagedVolumes    map[string]string
+	stageUnstageSet      bool
 	nextErr              error
 }
 
 // NewNodeClient returns fake node client
-func NewNodeClient() *NodeClient {
-	return &NodeClient{nodePublishedVolumes: make(map[string]string)}
+func NewNodeClient(stageUnstageSet bool) *NodeClient {
+	return &NodeClient{
+		nodePublishedVolumes: make(map[string]string),
+		nodeStagedVolumes:    make(map[string]string),
+		stageUnstageSet:      stageUnstageSet,
+	}
 }
 
 // SetNextError injects next expected error
@@ -76,6 +82,15 @@ func (f *NodeClient) SetNextError(err error) {
 // GetNodePublishedVolumes returns node published volumes
 func (f *NodeClient) GetNodePublishedVolumes() map[string]string {
 	return f.nodePublishedVolumes
+}
+
+// GetNodeStagedVolumes returns node staged volumes
+func (f *NodeClient) GetNodeStagedVolumes() map[string]string {
+	return f.nodeStagedVolumes
+}
+
+func (f *NodeClient) AddNodeStagedVolume(volID, deviceMountPath string) {
+	f.nodeStagedVolumes[volID] = deviceMountPath
 }
 
 // NodePublishVolume implements CSI NodePublishVolume
@@ -116,6 +131,50 @@ func (f *NodeClient) NodeUnpublishVolume(ctx context.Context, req *csipb.NodeUnp
 	return &csipb.NodeUnpublishVolumeResponse{}, nil
 }
 
+// NodeStagevolume implements csi method
+func (f *NodeClient) NodeStageVolume(ctx context.Context, req *csipb.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipb.NodeStageVolumeResponse, error) {
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
+
+	if req.GetVolumeId() == "" {
+		return nil, errors.New("missing volume id")
+	}
+	if req.GetStagingTargetPath() == "" {
+		return nil, errors.New("missing staging target path")
+	}
+
+	fsType := ""
+	fsTypes := "ext4|xfs|zfs"
+	mounted := req.GetVolumeCapability().GetMount()
+	if mounted != nil {
+		fsType = mounted.GetFsType()
+	}
+	if !strings.Contains(fsTypes, fsType) {
+		return nil, errors.New("invalid fstype")
+	}
+
+	f.nodeStagedVolumes[req.GetVolumeId()] = req.GetStagingTargetPath()
+	return &csipb.NodeStageVolumeResponse{}, nil
+}
+
+// NodeUnstageVolume implements csi method
+func (f *NodeClient) NodeUnstageVolume(ctx context.Context, req *csipb.NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*csipb.NodeUnstageVolumeResponse, error) {
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
+
+	if req.GetVolumeId() == "" {
+		return nil, errors.New("missing volume id")
+	}
+	if req.GetStagingTargetPath() == "" {
+		return nil, errors.New("missing staging target path")
+	}
+
+	delete(f.nodeStagedVolumes, req.GetVolumeId())
+	return &csipb.NodeUnstageVolumeResponse{}, nil
+}
+
 // NodeGetId implements method
 func (f *NodeClient) NodeGetId(ctx context.Context, in *csipb.NodeGetIdRequest, opts ...grpc.CallOption) (*csipb.NodeGetIdResponse, error) {
 	return nil, nil
@@ -123,16 +182,20 @@ func (f *NodeClient) NodeGetId(ctx context.Context, in *csipb.NodeGetIdRequest, 
 
 // NodeGetCapabilities implements csi method
 func (f *NodeClient) NodeGetCapabilities(ctx context.Context, in *csipb.NodeGetCapabilitiesRequest, opts ...grpc.CallOption) (*csipb.NodeGetCapabilitiesResponse, error) {
-	return nil, nil
-}
-
-// NodeStageVolume implements csi method
-func (f *NodeClient) NodeStageVolume(ctx context.Context, in *csipb.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipb.NodeStageVolumeResponse, error) {
-	return nil, nil
-}
-
-// NodeUnstageVolume implements csi method
-func (f *NodeClient) NodeUnstageVolume(ctx context.Context, in *csipb.NodeUnstageVolumeRequest, opts ...grpc.CallOption) (*csipb.NodeUnstageVolumeResponse, error) {
+	resp := &csipb.NodeGetCapabilitiesResponse{
+		Capabilities: []*csipb.NodeServiceCapability{
+			{
+				Type: &csipb.NodeServiceCapability_Rpc{
+					Rpc: &csipb.NodeServiceCapability_RPC{
+						Type: csipb.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+					},
+				},
+			},
+		},
+	}
+	if f.stageUnstageSet {
+		return resp, nil
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes #60114

**What this PR does / why we need it**:
This PR Implements MountDevice and UnmountDevice for the CSI Plugin, the functions will call through to NodeStageVolume/NodeUnstageVolume for CSI plugins.

/sig storage

```release-note
Implements MountDevice and UnmountDevice for the CSI Plugin, the functions will call through to NodeStageVolume/NodeUnstageVolume for CSI plugins.
```
