### PR TITLE
[fluentd-gcp addon] Update event-exporter in k8s 1.8

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.1.7
+  name: event-exporter-v0.1.8
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.1.7
+    version: v0.1.8
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -42,12 +42,12 @@ spec:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.1.7
+        version: v0.1.8
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.7
+        image: gcr.io/google-containers/event-exporter:v0.1.8
         command:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD


### PR DESCRIPTION
Update to new version of event-exporter which includes bugfix for metrics

```release-note
NONE
```