### PR TITLE
Fix getting pool size in autoscaling e2e tests

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1326,7 +1326,7 @@ func getPoolInitialSize(poolName string) int {
 	// get initial node count
 	args := []string{"container", "node-pools", "describe", poolName, "--quiet",
 		"--cluster=" + framework.TestContext.CloudConfig.Cluster,
-		"--format=value(initialNodeCount)"}
+		"--format=\"value(initialNodeCount)\""}
 	output, err := execCmd(getGcloudCommand(args)...).CombinedOutput()
 	glog.Infof("Node-pool initial size: %s", output)
 	framework.ExpectNoError(err)
@@ -1338,7 +1338,7 @@ func getPoolInitialSize(poolName string) int {
 	// get number of node pools
 	args = []string{"container", "node-pools", "describe", poolName, "--quiet",
 		"--cluster=" + framework.TestContext.CloudConfig.Cluster,
-		"--format=value(instanceGroupUrls)"}
+		"--format=\"value(instanceGroupUrls)\""}
 	output, err = execCmd(getGcloudCommand(args)...).CombinedOutput()
 	framework.ExpectNoError(err)
 	nodeGroupCount := len(strings.Split(string(output), ";"))


### PR DESCRIPTION
Command fails due to missing quotation marks, causing tests to fail:

```I0221 01:01:09.140] I0221 01:01:09.138464    1873 cluster_size_autoscaling.go:956] Executing: gcloud container node-pools describe extra-pool --quiet --cluster=e2e-5481 --format=value(initialNodeCount) --zone=us-central1-f --project=k8s-e2e-gci-gke-autoscaling
I0221 01:01:09.842] I0221 01:01:09.842393    1873 cluster_size_autoscaling.go:1331] Node-pool initial size: 
I0221 01:01:09.843] [AfterEach] [sig-autoscaling] Cluster size autoscaling [Slow]
```

```release-note
NONE
```