### PR TITLE
Return information about which int tests failed in the summary - followup

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -5108,7 +5108,7 @@ runTests() {
 
   kube::test::clear_all
 
-  if [ ! -z "${foundError}" ]; then
+  if [[ -n "${foundError}" ]]; then
     echo "FAILED TESTS: ""${foundError}"
     exit 1
   fi


### PR DESCRIPTION
@stevekuznetsov you asked about it in https://github.com/kubernetes/kubernetes/pull/59486#discussion_r169351176

/assign @stevekuznetsov 


**Release note**:
```release-note
NONE
```
