### PR TITLE
e2e tests for local-volume plugin block devices

### DIFF
--- a/pkg/volume/util/util_linux.go
+++ b/pkg/volume/util/util_linux.go
@@ -61,7 +61,7 @@ func (v VolumePathHandler) GetLoopDevice(path string) (string, error) {
 	cmd := exec.Command(losetupPath, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		glog.V(2).Infof("Failed device discover command for path %s: %v", path, err)
+		glog.V(2).Infof("Failed device discover command for path %s: %v %s", path, err, out)
 		return "", err
 	}
 	return parseLosetupOutputForDevice(out)
@@ -72,7 +72,7 @@ func makeLoopDevice(path string) (string, error) {
 	cmd := exec.Command(losetupPath, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		glog.V(2).Infof("Failed device create command for path %s: %v", path, err)
+		glog.V(2).Infof("Failed device create command for path: %s %v %s ", path, err, out)
 		return "", err
 	}
 	return parseLosetupOutputForDevice(out)

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -81,6 +81,7 @@ type PersistentVolumeConfig struct {
 	Labels           labels.Set
 	StorageClassName string
 	NodeAffinity     *v1.VolumeNodeAffinity
+	VolumeMode       *v1.PersistentVolumeMode
 }
 
 // PersistentVolumeClaimConfig is consumed by MakePersistentVolumeClaim() to generate a PVC object.
@@ -92,6 +93,7 @@ type PersistentVolumeClaimConfig struct {
 	Annotations      map[string]string
 	Selector         *metav1.LabelSelector
 	StorageClassName *string
+	VolumeMode       *v1.PersistentVolumeMode
 }
 
 // Clean up a pv and pvc in a single pv/pvc test case.
@@ -581,7 +583,7 @@ func MakePersistentVolume(pvConfig PersistentVolumeConfig) *v1.PersistentVolume 
 			Namespace: pvConfig.Prebind.Namespace,
 		}
 	}
-	pv := &v1.PersistentVolume{
+	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: pvConfig.NamePrefix,
 			Labels:       pvConfig.Labels,
@@ -603,9 +605,9 @@ func MakePersistentVolume(pvConfig PersistentVolumeConfig) *v1.PersistentVolume 
 			ClaimRef:         claimRef,
 			StorageClassName: pvConfig.StorageClassName,
 			NodeAffinity:     pvConfig.NodeAffinity,
+			VolumeMode:       pvConfig.VolumeMode,
 		},
 	}
-	return pv
 }
 
 // Returns a PVC definition based on the namespace.
@@ -635,6 +637,7 @@ func MakePersistentVolumeClaim(cfg PersistentVolumeClaimConfig, ns string) *v1.P
 				},
 			},
 			StorageClassName: cfg.StorageClassName,
+			VolumeMode:       cfg.VolumeMode,
 		},
 	}
 }
@@ -868,14 +871,21 @@ func MakeSecPod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bo
 			RestartPolicy: v1.RestartPolicyOnFailure,
 		},
 	}
-	var volumeMounts = make([]v1.VolumeMount, len(pvclaims))
+	var volumeMounts = make([]v1.VolumeMount, 0)
+	var volumeDevices = make([]v1.VolumeDevice, 0)
 	var volumes = make([]v1.Volume, len(pvclaims))
 	for index, pvclaim := range pvclaims {
 		volumename := fmt.Sprintf("volume%v", index+1)
-		volumeMounts[index] = v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename}
+		if pvclaim.Spec.VolumeMode != nil && *pvclaim.Spec.VolumeMode == v1.PersistentVolumeBlock {
+			volumeDevices = append(volumeDevices, v1.VolumeDevice{Name: volumename, DevicePath: "/mnt/" + volumename})
+		} else {
+			volumeMounts = append(volumeMounts, v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename})
+		}
+
 		volumes[index] = v1.Volume{Name: volumename, VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: false}}}
 	}
 	podSpec.Spec.Containers[0].VolumeMounts = volumeMounts
+	podSpec.Spec.Containers[0].VolumeDevices = volumeDevices
 	podSpec.Spec.Volumes = volumes
 	podSpec.Spec.SecurityContext.SELinuxOptions = seLinuxLabel
 	return podSpec


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR contains e2e tests for local block devices, and it leverages the `BlockVolume` feature-gate.

This PR can help us avoid regressions for local block volumes. For example, #60025.

**Which issue(s) this PR fixes** :
Fixes https://github.com/kubernetes/kubernetes/issues/60141

**Special notes for your reviewer**:

These tests can be run with the following commands:
```
KUBE_FEATURE_GATES="MountPropagation=true,BlockVolume=true" NUM_NODES=1 go run hack/e2e.go -- --up

go run hack/e2e.go -- -v --test --test_args="--ginkgo.focus=PersistentVolumes-local.*block”
```

**Release note**:
```release-note
NONE
```
