### PR TITLE
Deprecate kubectl scale job

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -270,7 +270,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 			Commands: []*cobra.Command{
 				rollout.NewCmdRollout(f, out, err),
 				NewCmdRollingUpdate(f, out),
-				NewCmdScale(f, out),
+				NewCmdScale(f, out, err),
 				NewCmdAutoscale(f, out),
 			},
 		},

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -32,7 +32,6 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -290,7 +289,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				NewCmdDescribe(f, out, err),
-				NewCmdLogs(f, out),
+				NewCmdLogs(f, out, err),
 				NewCmdAttach(f, in, out, err),
 				NewCmdExec(f, in, out, err),
 				NewCmdPortForward(f, out, err),
@@ -355,8 +354,8 @@ func runHelp(cmd *cobra.Command, args []string) {
 	cmd.Help()
 }
 
-func printDeprecationWarning(command, alias string) {
-	glog.Warningf("%s is DEPRECATED and will be removed in a future version. Use %s instead.", alias, command)
+func printDeprecationWarning(errOut io.Writer, command, alias string) {
+	fmt.Fprintf(errOut, "%s is DEPRECATED and will be removed in a future version. Use %s instead.", alias, command)
 }
 
 // deprecatedAlias is intended to be used to create a "wrapper" command around

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -155,7 +155,7 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 		return cmdutil.UsageErrorf(cmd, execUsageStr)
 	}
 	if len(p.PodName) != 0 {
-		printDeprecationWarning("exec POD_NAME", "-p POD_NAME")
+		printDeprecationWarning(p.Err, "exec POD_NAME", "-p POD_NAME")
 		if len(argsIn) < 1 {
 			return cmdutil.UsageErrorf(cmd, execUsageStr)
 		}

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -138,6 +138,7 @@ func TestPodAndContainer(t *testing.T) {
 
 		cmd := &cobra.Command{}
 		options := test.p
+		options.Err = bytes.NewBuffer([]byte{})
 		err := options.Complete(f, cmd, test.args, test.argsLenAtDash)
 		if test.expectError && err == nil {
 			t.Errorf("%s: unexpected non-error", test.name)

--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -86,7 +86,7 @@ type LogsOptions struct {
 }
 
 // NewCmdLogs creates a new pod logs command
-func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdLogs(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	o := &LogsOptions{}
 	cmd := &cobra.Command{
 		Use: "logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]",
@@ -96,7 +96,7 @@ func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: logsExample,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if len(os.Args) > 1 && os.Args[1] == "log" {
-				printDeprecationWarning("logs", "log")
+				printDeprecationWarning(errOut, "logs", "log")
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -69,7 +69,7 @@ func TestLog(t *testing.T) {
 		tf.ClientConfig = defaultClientConfig()
 		buf := bytes.NewBuffer([]byte{})
 
-		cmd := NewCmdLogs(f, buf)
+		cmd := NewCmdLogs(f, buf, buf)
 		cmd.Flags().Set("namespace", "test")
 		cmd.Run(cmd, []string{"foo"})
 
@@ -124,7 +124,8 @@ func TestValidateLogFlags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cmd := NewCmdLogs(f, bytes.NewBuffer([]byte{}))
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdLogs(f, buf, buf)
 		out := ""
 		for flag, value := range test.flags {
 			cmd.Flags().Set(flag, value)
@@ -183,7 +184,8 @@ func TestLogComplete(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		cmd := NewCmdLogs(f, bytes.NewBuffer([]byte{}))
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdLogs(f, buf, buf)
 		var err error
 		out := ""
 		for flag, value := range test.flags {


### PR DESCRIPTION
**What this PR does / why we need it**:
With the generic scaler (https://github.com/kubernetes/kubernetes/pull/58298) the only problem is job and as discussed in https://github.com/kubernetes/kubernetes/pull/58468#issuecomment-360794229 and during SIG CLI we've agreed that scaling jobs was a mistake we need to revert. 
This PR deprecates scale command for jobs, only. 

/assign @deads2k @pwittrock 

**Release note**:
```release-note
Deprecate kubectl scale jobs (only jobs). 
```
