### PR TITLE
Fix kubectl describe output for priority class objects.

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -3370,8 +3370,8 @@ func describePriorityClass(pc *scheduling.PriorityClass, events *api.EventList) 
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pc.Name)
-		w.Write(LEVEL_0, "Value:\t%s\n", pc.Value)
-		w.Write(LEVEL_0, "GlobalDefault:\t%s\n", pc.GlobalDefault)
+		w.Write(LEVEL_0, "Value:\t%v\n", pc.Value)
+		w.Write(LEVEL_0, "GlobalDefault:\t%v\n", pc.GlobalDefault)
 		w.Write(LEVEL_0, "Description:\t%s\n", pc.Description)
 
 		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(pc.Annotations))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `kubectl describe priorityclass`  (try https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#example-priorityclass)  

```
Name:           high-priority
Value:          %!s(int32=1000000)
GlobalDefault:  %!s(bool=false)
Description:    This priority class should be used for XYZ service pods only.
Annotations:    <none>
Events:         <none>

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

@bsalamat @kubernetes/sig-scheduling-bugs  @kubernetes/sig-cli-bugs 
/king bug
/sig scheduling
/sig cli