### PR TITLE
Bump dependencies for build tag fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,7 +11,7 @@
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/bertimus9/systemstat",
-			"Rev": "6edb7bbcb021f6510db33e604f7e18861293a14a"
+			"Rev": "0eeff89b0690611fc32e21f0cd2e4434abf8fe53"
 		},
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",
@@ -442,7 +442,7 @@
 		},
 		{
 			"ImportPath": "github.com/container-storage-interface/spec/lib/go/csi",
-			"Comment": "v0.2.0",
+			"Comment": "v0.1.0-5-g7ab01a9",
 			"Rev": "7ab01a90da87f9fef3ee1de0494962fdefaf7db7"
 		},
 		{
@@ -451,47 +451,47 @@
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/containers/v1",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/tasks/v1",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/services/version/v1",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/types",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/api/types/task",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/containers",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/dialer",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/errdefs",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
 			"ImportPath": "github.com/containerd/containerd/namespaces",
-			"Comment": "v1.0.0-beta.2-159-g27d450a",
+			"Comment": "v1.0.0-beta.2-159-g27d450a0",
 			"Rev": "27d450a01bb533d7ebc5701eb52792565396b084"
 		},
 		{
@@ -980,147 +980,147 @@
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/digestset",
-			"Comment": "v2.6.0-rc.1-209-gedc3ab2",
+			"Comment": "v2.6.0-rc.1-209-gedc3ab29",
 			"Rev": "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/reference",
-			"Comment": "v2.6.0-rc.1-209-gedc3ab2",
+			"Comment": "v2.6.0-rc.1-209-gedc3ab29",
 			"Rev": "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/blkiodev",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/container",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/events",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/filters",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/image",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/mount",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/network",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/registry",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/strslice",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/swarm",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/swarm/runtime",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/time",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/versions",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api/types/volume",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/client",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/ioutils",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/jsonlog",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/jsonmessage",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/longpath",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/mount",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/stdcopy",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/system",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/term/windows",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/tlsconfig",
-			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616f",
+			"Comment": "docs-v1.12.0-rc4-2016-07-15-7401-g4f3616fb1",
 			"Rev": "4f3616fb1c112e206b88cb7a9922bf49067a7756"
 		},
 		{
@@ -1145,7 +1145,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipvs",
-			"Comment": "v0.8.0-dev.2-910-gba46b92",
+			"Comment": "v0.8.0-dev.2-910-gba46b928",
 			"Rev": "ba46b928444931e6865d8618dc03622cac79aa6f"
 		},
 		{
@@ -1272,132 +1272,132 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/gogoproto",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/compare",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/defaultcheck",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/description",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/embedcheck",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/enumstringer",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/equal",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/face",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/gostring",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/marshalto",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/oneofcheck",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/populate",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/size",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/stringer",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/testgen",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/union",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/plugin/unmarshal",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/protoc-gen-gogo/generator",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/protoc-gen-gogo/grpc",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/protoc-gen-gogo/plugin",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/types",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/vanity",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/vanity/command",
-			"Comment": "v0.4-3-gc0656ed",
+			"Comment": "v0.4-3-gc0656edd",
 			"Rev": "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 		},
 		{
@@ -1454,217 +1454,217 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.28.3-20-g6116f26",
+			"Comment": "v0.28.3-20-g6116f265",
 			"Rev": "6116f265302357cbb10f84737af30b1f13ce2d6c"
 		},
 		{
@@ -2631,113 +2631,113 @@
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/find",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/list",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/nfc",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/object",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/methods",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/pbm/types",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/property",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/session",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator/esx",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/simulator/vpx",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/task",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/debug",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/methods",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/mo",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/progress",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/soap",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/types",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/xml",
-			"Comment": "v0.16.0-80-g8174315",
-			"Rev": "81743157fb5ccf548d6bd5088c25ee6156a359ee"
+			"Comment": "v0.16.0-97-g0f82f03",
+			"Rev": "0f82f03a2bbf14037d2331cf02f1d4157bbef6cc"
 		},
 		{
 			"ImportPath": "github.com/vmware/photon-controller-go-sdk/SSPI",

--- a/vendor/bitbucket.org/bertimus9/systemstat/systemstat_ex.go
+++ b/vendor/bitbucket.org/bertimus9/systemstat/systemstat_ex.go
@@ -7,7 +7,6 @@
 package systemstat
 
 import (
-	"syscall"
 	"time"
 )
 
@@ -30,15 +29,8 @@ func getMemSample(procfile string) (samp MemSample) {
 }
 
 func getProcCPUSample() (s ProcCPUSample) {
-	var processInfo syscall.Rusage
-	syscall.Getrusage(syscall.RUSAGE_SELF, &processInfo)
-
+	notImplemented("getProcCPUSample")
 	s.Time = time.Now()
-	s.ProcMemUsedK = int64(processInfo.Maxrss)
-	s.User = float64(processInfo.Utime.Usec)/1000000 + float64(processInfo.Utime.Sec)
-	s.System = float64(processInfo.Stime.Usec)/1000000 + float64(processInfo.Stime.Sec)
-	s.Total = s.User + s.System
-
 	return
 }
 

--- a/vendor/github.com/seccomp/libseccomp-golang/BUILD
+++ b/vendor/github.com/seccomp/libseccomp-golang/BUILD
@@ -13,7 +13,6 @@ go_library(
     clinkopts = select({
         "@io_bazel_rules_go//go/platform:linux": [
             "-lseccomp",
-            "-lseccomp",
         ],
         "//conditions:default": [],
     }),

--- a/vendor/github.com/vmware/govmomi/.travis.yml
+++ b/vendor/github.com/vmware/govmomi/.travis.yml
@@ -10,3 +10,4 @@ before_install:
 
 script:
   - make check test
+  - GOOS=windows make install

--- a/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
@@ -36,7 +37,8 @@ type DatastoreFileManager struct {
 	FileManager        *FileManager
 	VirtualDiskManager *VirtualDiskManager
 
-	Force bool
+	Force            bool
+	DatacenterTarget *Datacenter
 }
 
 // NewFileManager creates a new instance of DatastoreFileManager
@@ -49,9 +51,23 @@ func (d Datastore) NewFileManager(dc *Datacenter, force bool) *DatastoreFileMana
 		FileManager:        NewFileManager(c),
 		VirtualDiskManager: NewVirtualDiskManager(c),
 		Force:              force,
+		DatacenterTarget:   dc,
 	}
 
 	return m
+}
+
+func (m *DatastoreFileManager) WithProgress(ctx context.Context, s progress.Sinker) context.Context {
+	return context.WithValue(ctx, m, s)
+}
+
+func (m *DatastoreFileManager) wait(ctx context.Context, task *Task) error {
+	var logger progress.Sinker
+	if s, ok := ctx.Value(m).(progress.Sinker); ok {
+		logger = s
+	}
+	_, err := task.WaitForResult(ctx, logger)
+	return err
 }
 
 // Delete dispatches to the appropriate Delete method based on file name extension
@@ -73,7 +89,7 @@ func (m *DatastoreFileManager) DeleteFile(ctx context.Context, name string) erro
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
 // DeleteVirtualDisk calls VirtualDiskManager.DeleteVirtualDisk
@@ -94,10 +110,58 @@ func (m *DatastoreFileManager) DeleteVirtualDisk(ctx context.Context, name strin
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
-// Move dispatches to the appropriate Move method based on file name extension
+// CopyFile calls FileManager.CopyDatastoreFile
+func (m *DatastoreFileManager) CopyFile(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	task, err := m.FileManager.CopyDatastoreFile(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// Copy dispatches to the appropriate FileManager or VirtualDiskManager Copy method based on file name extension
+func (m *DatastoreFileManager) Copy(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	f := m.FileManager.CopyDatastoreFile
+
+	if srcp.IsVMDK() {
+		// types.VirtualDiskSpec=nil as it is not implemented by vCenter
+		f = func(ctx context.Context, src string, srcDC *Datacenter, dst string, dstDC *Datacenter, force bool) (*Task, error) {
+			return m.VirtualDiskManager.CopyVirtualDisk(ctx, src, srcDC, dst, dstDC, nil, force)
+		}
+	}
+
+	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// MoveFile calls FileManager.MoveDatastoreFile
+func (m *DatastoreFileManager) MoveFile(ctx context.Context, src string, dst string) error {
+	srcp := m.Path(src)
+	dstp := m.Path(dst)
+
+	task, err := m.FileManager.MoveDatastoreFile(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
+	if err != nil {
+		return err
+	}
+
+	return m.wait(ctx, task)
+}
+
+// Move dispatches to the appropriate FileManager or VirtualDiskManager Move method based on file name extension
 func (m *DatastoreFileManager) Move(ctx context.Context, src string, dst string) error {
 	srcp := m.Path(src)
 	dstp := m.Path(dst)
@@ -108,12 +172,12 @@ func (m *DatastoreFileManager) Move(ctx context.Context, src string, dst string)
 		f = m.VirtualDiskManager.MoveVirtualDisk
 	}
 
-	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.Datacenter, m.Force)
+	task, err := f(ctx, srcp.String(), m.Datacenter, dstp.String(), m.DatacenterTarget, m.Force)
 	if err != nil {
 		return err
 	}
 
-	return task.Wait(ctx)
+	return m.wait(ctx, task)
 }
 
 // Path converts path name to a DatastorePath

--- a/vendor/github.com/vmware/govmomi/object/types.go
+++ b/vendor/github.com/vmware/govmomi/object/types.go
@@ -47,8 +47,10 @@ func NewReference(c *vim25.Client, e types.ManagedObjectReference) Reference {
 		return NewClusterComputeResource(c, e)
 	case "HostSystem":
 		return NewHostSystem(c, e)
-	case "Network", "OpaqueNetwork":
+	case "Network":
 		return NewNetwork(c, e)
+	case "OpaqueNetwork":
+		return NewOpaqueNetwork(c, e)
 	case "ResourcePool":
 		return NewResourcePool(c, e)
 	case "DistributedVirtualSwitch":

--- a/vendor/github.com/vmware/govmomi/simulator/BUILD
+++ b/vendor/github.com/vmware/govmomi/simulator/BUILD
@@ -25,7 +25,6 @@ go_library(
         "license_manager.go",
         "model.go",
         "option_manager.go",
-        "os_unix.go",
         "performance_manager.go",
         "portgroup.go",
         "property_collector.go",
@@ -44,6 +43,36 @@ go_library(
         "virtual_disk_manager.go",
         "virtual_machine.go",
     ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "os_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "os_unix.go",
+        ],
         "@io_bazel_rules_go//go/platform:windows": [
             "os_windows.go",
         ],

--- a/vendor/github.com/vmware/govmomi/simulator/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/simulator/datacenter.go
@@ -20,15 +20,40 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+type Datacenter struct {
+	mo.Datacenter
+
+	isESX bool
+}
+
+// NewDatacenter creates a Datacenter and its child folders.
+func NewDatacenter(f *Folder) *Datacenter {
+	dc := &Datacenter{
+		isESX: f.Self == esx.RootFolder.Self,
+	}
+
+	if dc.isESX {
+		dc.Datacenter = esx.Datacenter
+	}
+
+	f.putChild(dc)
+
+	dc.createFolders()
+
+	return dc
+}
 
 // Create Datacenter Folders.
 // Every Datacenter has 4 inventory Folders: Vm, Host, Datastore and Network.
 // The ESX folder child types are limited to 1 type.
 // The VC folders have additional child types, including nested folders.
-func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
+func (dc *Datacenter) createFolders() {
 	folders := []struct {
 		ref   *types.ManagedObjectReference
 		name  string
@@ -44,7 +69,11 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 		folder := &Folder{}
 		folder.Name = f.name
 
-		if isVC {
+		if dc.isESX {
+			folder.ChildType = f.types[:1]
+			folder.Self = *f.ref
+			Map.PutEntity(dc, folder)
+		} else {
 			folder.ChildType = f.types
 			e := Map.PutEntity(dc, folder)
 
@@ -52,10 +81,6 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 			ref := e.Reference()
 			f.ref.Type = ref.Type
 			f.ref.Value = ref.Value
-		} else {
-			folder.ChildType = f.types[:1]
-			folder.Self = *f.ref
-			Map.PutEntity(dc, folder)
 		}
 	}
 
@@ -67,7 +92,7 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 		network.Self = ref
 		network.Name = strings.Split(ref.Value, "-")[1]
 		network.Entity().Name = network.Name
-		if isVC {
+		if !dc.isESX {
 			network.Self.Value = "" // we want a different moid per-DC
 		}
 
@@ -76,12 +101,35 @@ func createDatacenterFolders(dc *mo.Datacenter, isVC bool) {
 }
 
 func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {
-	dc, ok := obj.(*mo.Datacenter)
+	dc, ok := obj.(*Datacenter)
 	if !ok {
 		dc = Map.getEntityDatacenter(obj)
 	}
 	return &types.DatacenterEventArgument{
 		Datacenter:          dc.Self,
 		EntityEventArgument: types.EntityEventArgument{Name: dc.Name},
+	}
+}
+
+func (dc *Datacenter) PowerOnMultiVMTask(ctx *Context, req *types.PowerOnMultiVM_Task) soap.HasFault {
+	task := CreateTask(dc, "powerOnMultiVM", func(_ *Task) (types.AnyType, types.BaseMethodFault) {
+		if dc.isESX {
+			return nil, new(types.NotImplemented)
+		}
+
+		for _, ref := range req.Vm {
+			vm := Map.Get(ref).(*VirtualMachine)
+			Map.WithLock(vm, func() {
+				vm.PowerOnVMTask(ctx, &types.PowerOnVM_Task{})
+			})
+		}
+
+		return nil, nil
+	})
+
+	return &methods.PowerOnMultiVM_TaskBody{
+		Res: &types.PowerOnMultiVM_TaskResponse{
+			Returnval: task.Run(),
+		},
 	}
 }

--- a/vendor/github.com/vmware/govmomi/simulator/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/file_manager.go
@@ -80,7 +80,7 @@ func (f *FileManager) resolve(dc *types.ManagedObjectReference, name string) (st
 		}
 	}
 
-	folder := Map.Get(*dc).(*mo.Datacenter).DatastoreFolder
+	folder := Map.Get(*dc).(*Datacenter).DatastoreFolder
 
 	ds, fault := f.findDatastore(Map.Get(folder), p.Datastore)
 	if fault != nil {

--- a/vendor/github.com/vmware/govmomi/simulator/folder.go
+++ b/vendor/github.com/vmware/govmomi/simulator/folder.go
@@ -197,13 +197,9 @@ func (f *Folder) CreateDatacenter(ctx *Context, c *types.CreateDatacenter) soap.
 	r := &methods.CreateDatacenterBody{}
 
 	if f.hasChildType("Datacenter") && f.hasChildType("Folder") {
-		dc := &mo.Datacenter{}
+		dc := NewDatacenter(f)
 
 		dc.Name = c.Name
-
-		f.putChild(dc)
-
-		createDatacenterFolders(dc, true)
 
 		r.Res = &types.CreateDatacenterResponse{
 			Returnval: dc.Self,

--- a/vendor/github.com/vmware/govmomi/simulator/host_system.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_system.go
@@ -113,9 +113,7 @@ func addComputeResource(s *types.ComputeResourceSummary, h *HostSystem) {
 // CreateDefaultESX creates a standalone ESX
 // Adds objects of type: Datacenter, Network, ComputeResource, ResourcePool and HostSystem
 func CreateDefaultESX(f *Folder) {
-	dc := &esx.Datacenter
-	f.putChild(dc)
-	createDatacenterFolders(dc, false)
+	dc := NewDatacenter(f)
 
 	host := NewHostSystem(esx.HostSystem)
 

--- a/vendor/github.com/vmware/govmomi/simulator/os_unix.go
+++ b/vendor/github.com/vmware/govmomi/simulator/os_unix.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 /*
 Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 

--- a/vendor/github.com/vmware/govmomi/simulator/registry.go
+++ b/vendor/github.com/vmware/govmomi/simulator/registry.go
@@ -213,8 +213,8 @@ func (r *Registry) getEntityParent(item mo.Entity, kind string) mo.Entity {
 }
 
 // getEntityDatacenter returns the Datacenter containing the given item
-func (r *Registry) getEntityDatacenter(item mo.Entity) *mo.Datacenter {
-	return r.getEntityParent(item, "Datacenter").(*mo.Datacenter)
+func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
+	return r.getEntityParent(item, "Datacenter").(*Datacenter)
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *Folder {

--- a/vendor/github.com/vmware/govmomi/simulator/search_index.go
+++ b/vendor/github.com/vmware/govmomi/simulator/search_index.go
@@ -94,7 +94,7 @@ func (s *SearchIndex) FindChild(req *types.FindChild) soap.HasFault {
 	var children []types.ManagedObjectReference
 
 	switch e := obj.(type) {
-	case *mo.Datacenter:
+	case *Datacenter:
 		children = []types.ManagedObjectReference{e.VmFolder, e.HostFolder, e.DatastoreFolder, e.NetworkFolder}
 	case *Folder:
 		children = e.ChildEntity

--- a/vendor/github.com/vmware/govmomi/simulator/view_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/view_manager.go
@@ -153,7 +153,7 @@ func walk(root mo.Reference, f func(child types.ManagedObjectReference)) {
 	var children []types.ManagedObjectReference
 
 	switch e := root.(type) {
-	case *mo.Datacenter:
+	case *Datacenter:
 		children = []types.ManagedObjectReference{e.VmFolder, e.HostFolder, e.DatastoreFolder, e.NetworkFolder}
 	case *Folder:
 		children = e.ChildEntity

--- a/vendor/github.com/vmware/govmomi/simulator/virtual_disk_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/virtual_disk_manager.go
@@ -152,6 +152,12 @@ func (m *VirtualDiskManager) MoveVirtualDiskTask(req *types.MoveVirtualDisk_Task
 
 func (m *VirtualDiskManager) CopyVirtualDiskTask(req *types.CopyVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "copyVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
+		if req.DestSpec != nil {
+			if Map.IsVPX() {
+				return nil, new(types.NotImplemented)
+			}
+		}
+
 		fm := Map.FileManager()
 
 		dest := m.names(req.DestName)


### PR DESCRIPTION
**What this PR does / why we need it**:
bump github.com/vmware/govmomi to HEAD
bump bitbucket.org/bertimus9/systemstat to HEAD

This should fix build tag issues that @rmmh noticed in https://github.com/kubernetes/kubernetes/pull/59289.

**Release note**:
```release-note
NONE
```
