### PR TITLE
Change HAIRPIN_MODE to hairpin-veth as default

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -324,7 +324,7 @@ NETWORK_POLICY_PROVIDER="${NETWORK_POLICY_PROVIDER:-none}" # calico
 NON_MASQUERADE_CIDR="0.0.0.0/0"
 
 # How should the kubelet configure hairpin mode?
-HAIRPIN_MODE="${HAIRPIN_MODE:-promiscuous-bridge}" # promiscuous-bridge, hairpin-veth, none
+HAIRPIN_MODE="${HAIRPIN_MODE:-hairpin-veth}" # promiscuous-bridge, hairpin-veth, none
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT="${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}"
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -349,7 +349,7 @@ NETWORK_POLICY_PROVIDER="${NETWORK_POLICY_PROVIDER:-none}" # calico
 NON_MASQUERADE_CIDR="0.0.0.0/0"
 
 # How should the kubelet configure hairpin mode?
-HAIRPIN_MODE="${HAIRPIN_MODE:-promiscuous-bridge}" # promiscuous-bridge, hairpin-veth, none
+HAIRPIN_MODE="${HAIRPIN_MODE:-hairpin-veth}" # promiscuous-bridge, hairpin-veth, none
 
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the default HAIRPIN_MODE back to "hairpin-veth".

It was previously "promiscuous-bridge" in order to workaround a kernel bug which deadlocked the machine when hairpin-veth was used. (#27498)

After some thorough manual testing on ubuntu clusters, we feel confident now that the kernel bug is fixed so we should switch back to using hairpin-veth. This will allow us to clean up some ebtables rules that were put in place to make "promiscuous-bridge" work properly.

Once this change goes in, we need to carefully monitor our e2e tests to make sure the bug has not resurfaced.

**Release note**:
```release-note
In a GCE cluster, the default HAIRPIN_MODE is now "hairpin-veth".
```

/cc @freehan @prameshj 
/assign @roberthbailey 
