### PR TITLE
Add GCB config for etcd-empty-dir-cleanup image

### DIFF
--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -14,9 +14,9 @@
 
 .PHONY:	build push
 
-ETCD_VERSION = 3.1.10
-IMAGE = staging-k8s.gcr.io/etcd-empty-dir-cleanup
-TAG = 3.1.10.0
+ETCD_VERSION ?= 3.1.10
+IMAGE ?= staging-k8s.gcr.io/etcd-empty-dir-cleanup
+TAG ?= 3.1.10.0
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
@@ -25,6 +25,8 @@ build: clean
 	curl -L -O https://github.com/coreos/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 	tar xzvf etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 	cp etcd-v$(ETCD_VERSION)-linux-amd64/etcdctl .
+
+container: build
 	docker build --pull -t $(IMAGE):$(TAG) .
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 

--- a/cluster/images/etcd-empty-dir-cleanup/cloudbuild.yaml
+++ b/cluster/images/etcd-empty-dir-cleanup/cloudbuild.yaml
@@ -1,0 +1,35 @@
+timeout: 10800s
+
+substitutions:
+  { "_REGISTRY": "gcr.io/k8s-image-staging",
+    "_TAG": "3.1.10.0" }
+
+steps:
+- name: gcr.io/cloud-builders/git
+  id: git-clone
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -ex
+    mkdir -p /workspace/src/k8s.io
+    cd /workspace/src/k8s.io
+    git clone https://github.com/kubernetes/kubernetes.git
+
+- name: gcr.io/k8s-image-staging/make
+  id: make-build
+  entrypoint: bash
+  dir: "/workspace/src/k8s.io/kubernetes/cluster/images/etcd-empty-dir-cleanup"
+  args:
+  - "-c"
+  - |
+    set -e
+    make build
+
+- name: gcr.io/cloud-builders/docker
+  id: docker-build
+  dir: "/workspace/src/k8s.io/kubernetes/cluster/images/etcd-empty-dir-cleanup"
+  args: ["build", "--pull", "-t", "${_REGISTRY}/etcd-empty-dir-cleanup:${_TAG}", "."]
+
+images:
+- "${_REGISTRY}/etcd-empty-dir-cleanup:${_TAG}"


### PR DESCRIPTION
Adds Google Container Builder config for building the etcd-empty-dir-cleanup addon image.  This is part of a larger effort to automate the build for core addon images.

**What this PR does / why we need it**:
Part of future plans to automate the builds for all core Kubernetes addons.  Provides build provenance by using Google Container Builder to ensure builds are created from checked in source and logs are maintained.  Pushes to the k8s-image-staging registry which will be used for promoting images to eliminate the need for humans to push directly to google-containers.

```release-note
NONE
```
