### PR TITLE
call utilflag.InitFlags all over this repo

### DIFF
--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/version/prometheus:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -20,7 +20,6 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -34,8 +33,6 @@ import (
 	// implementing an out-of-tree cloud-provider.
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
-
-	"github.com/spf13/pflag"
 )
 
 func main() {
@@ -43,12 +40,7 @@ func main() {
 
 	command := app.NewCloudControllerManagerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/hyperkube/BUILD
+++ b/cmd/hyperkube/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//pkg/kubectl/cmd:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"errors"
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -30,7 +29,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -50,12 +48,7 @@ func main() {
 
 	hyperkubeCommand, allCommandFns := NewHyperKubeCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//cmd/kube-apiserver/app:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -19,13 +19,10 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -39,12 +36,7 @@ func main() {
 
 	command := app.NewAPIServerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-controller-manager/BUILD
+++ b/cmd/kube-controller-manager/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//pkg/util/reflector/prometheus:go_default_library",
         "//pkg/util/workqueue/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -21,13 +21,10 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -43,12 +40,7 @@ func main() {
 
 	command := app.NewControllerManagerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-proxy/BUILD
+++ b/cmd/kube-proxy/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//cmd/kube-proxy/app:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -17,13 +17,10 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -37,12 +34,7 @@ func main() {
 
 	command := app.NewProxyCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kube-scheduler/BUILD
+++ b/cmd/kube-scheduler/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//cmd/kube-scheduler/app:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -17,13 +17,11 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
-	"github.com/spf13/pflag"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
@@ -36,12 +34,7 @@ func main() {
 
 	command := app.NewSchedulerCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -20,7 +20,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/kubectl/cmd:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -17,13 +17,10 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -35,12 +32,7 @@ func main() {
 
 	command := cmd.NewDefaultKubectlCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -99,12 +98,7 @@ func main() {
 
 	command := newHollowNodeCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
@@ -47,7 +47,6 @@ func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedNam
 func InitFlags() {
 	pflag.CommandLine.SetNormalizeFunc(WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	pflag.Parse()
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		glog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})

--- a/test/images/no-snat-test-proxy/BUILD
+++ b/test/images/no-snat-test-proxy/BUILD
@@ -16,6 +16,8 @@ go_library(
     srcs = ["main.go"],
     importpath = "k8s.io/kubernetes/test/images/no-snat-test-proxy",
     deps = [
+        "//pkg/version/verflag:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",

--- a/test/images/no-snat-test-proxy/main.go
+++ b/test/images/no-snat-test-proxy/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -68,12 +67,7 @@ func main() {
 
 	command := NewTestProxyCommand()
 
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/test/images/no-snat-test-proxy/main.go
+++ b/test/images/no-snat-test-proxy/main.go
@@ -17,15 +17,19 @@ limitations under the License.
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
-	"strings"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apiserver/pkg/util/flag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
+	"k8s.io/kubernetes/pkg/version/verflag"
 )
 
 // This Pod's /checknosnat takes `target` and `ips` arguments, and queries {target}/checknosnat?ips={ips}
@@ -40,20 +44,41 @@ func NewMasqTestProxy() *MasqTestProxy {
 	}
 }
 
+// NewTestProxyCommand creates a *cobra.Command object with default parameters
+func NewTestProxyCommand() *cobra.Command {
+	m := NewMasqTestProxy()
+	cmd := &cobra.Command{
+		Use:  "MasqTestProxy",
+		Long: `MasqTestProxy`,
+		Run: func(cmd *cobra.Command, args []string) {
+			verflag.PrintAndExitIfRequested()
+			m.Run()
+		},
+	}
+	m.AddFlags(cmd.Flags())
+
+	return cmd
+}
 func (m *MasqTestProxy) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&m.Port, "port", m.Port, "The port to serve /checknosnat endpoint on.")
 }
 
 func main() {
-	m := NewMasqTestProxy()
-	m.AddFlags(pflag.CommandLine)
+	rand.Seed(time.Now().UTC().UnixNano())
 
-	flag.InitFlags()
+	command := NewTestProxyCommand()
+
+	// TODO: once we switch everything over to Cobra commands, we can go back to calling
+	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
+	// normalize func and add the go flag set by hand.
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if err := m.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -64,16 +89,6 @@ func (m *MasqTestProxy) Run() error {
 
 	// spin up the server
 	return http.ListenAndServe(":"+m.Port, nil)
-}
-
-type handler func(http.ResponseWriter, *http.Request)
-
-func joinErrors(errs []error, sep string) string {
-	strs := make([]string, len(errs))
-	for i, err := range errs {
-		strs[i] = err.Error()
-	}
-	return strings.Join(strs, sep)
 }
 
 func checknosnatURL(pip, ips string) string {

--- a/test/images/no-snat-test/BUILD
+++ b/test/images/no-snat-test/BUILD
@@ -16,6 +16,8 @@ go_library(
     srcs = ["main.go"],
     importpath = "k8s.io/kubernetes/test/images/no-snat-test",
     deps = [
+        "//pkg/version/verflag:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",

--- a/test/images/no-snat-test/main.go
+++ b/test/images/no-snat-test/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -72,12 +71,8 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	command := NewMasqCommand()
-	// TODO: once we switch everything over to Cobra commands, we can go back to calling
-	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
-	// normalize func and add the go flag set by hand.
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	// utilflag.InitFlags()
+
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/test/images/no-snat-test/main.go
+++ b/test/images/no-snat-test/main.go
@@ -17,16 +17,21 @@ limitations under the License.
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apiserver/pkg/util/flag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
+	"k8s.io/kubernetes/pkg/version/verflag"
 )
 
 // ip = target for /whoami query
@@ -48,16 +53,36 @@ func (m *MasqTester) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&m.Port, "port", m.Port, "The port to serve /checknosnat and /whoami endpoints on.")
 }
 
-func main() {
+// NewMasqCommand creates a *cobra.Command object with default parameters
+func NewMasqCommand() *cobra.Command {
 	m := NewMasqTester()
-	m.AddFlags(pflag.CommandLine)
+	cmd := &cobra.Command{
+		Use:  "MasqTest",
+		Long: `MasqTest`,
+		Run: func(cmd *cobra.Command, args []string) {
+			verflag.PrintAndExitIfRequested()
+			m.Run()
+		},
+	}
+	m.AddFlags(cmd.Flags())
 
-	flag.InitFlags()
+	return cmd
+}
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	command := NewMasqCommand()
+	// TODO: once we switch everything over to Cobra commands, we can go back to calling
+	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
+	// normalize func and add the go flag set by hand.
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	if err := m.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

follow up #59718 ,
we switch everything over to Cobra commands, we can go back to calling	`utilflag.InitFlags()`
// utilflag.InitFlags() (by removing its pflag.Parse() call)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
