### PR TITLE
Avoid explicit mention of glusterfs in error strings.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs_util.go
+++ b/pkg/volume/glusterfs/glusterfs_util.go
@@ -34,17 +34,17 @@ func readGlusterLog(path string, podName string) error {
 	var line2 string
 	linecount := 0
 
-	glog.Infof("glusterfs: failure, now attempting to read the gluster log for pod %s", podName)
+	glog.Infof("failure, now attempting to read the gluster log for pod %s", podName)
 
 	// Check and make sure path exists
 	if len(path) == 0 {
-		return fmt.Errorf("glusterfs: log file does not exist for pod: %s", podName)
+		return fmt.Errorf("log file does not exist for pod %s", podName)
 	}
 
 	// open the log file
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("glusterfs: could not open log file for pod: %s", podName)
+		return fmt.Errorf("could not open log file for pod %s", podName)
 	}
 	defer file.Close()
 


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
