### PR TITLE
Automated cherry pick of #60068 upstream release 1.8 

### DIFF
--- a/pkg/master/tunneler/ssh.go
+++ b/pkg/master/tunneler/ssh.go
@@ -59,7 +59,12 @@ func TunnelSyncHealthChecker(tunneler Tunneler) func(req *http.Request) error {
 			return fmt.Errorf("Tunnel sync is taking too long: %d", lag)
 		}
 		sshKeyLag := tunneler.SecondsSinceSSHKeySync()
-		if sshKeyLag > 600 {
+		// Since we are syncing ssh-keys every 5 minutes, the allowed
+		// lag since last sync should be more than 2x higher than that
+		// to allow for single failure, which can always happen.
+		// For now set it to 3x, which is 15 minutes.
+		// For more details see: http://pr.k8s.io/59347
+		if sshKeyLag > 900 {
 			return fmt.Errorf("SSHKey sync is taking too long: %d", sshKeyLag)
 		}
 		return nil


### PR DESCRIPTION
Cherry pick of #60068 on release-1.8.

#60068 : Increase allowed lag for ssh key sync loop for tunneler