### PR TITLE
Unset CDPATH in build script to fix path generation

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Unset CDPATH so that path interpolation can work correctly
+# https://github.com/kubernetes/kubernetes/issues/52255
+unset CDPATH
+
 # The root of the build/dist directory
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE}")/../.." && pwd -P)"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In #52255, it was determined that if the user has set the `CDPATH` environment variable, running `make` will fail. This is because using the `KUBE_ROOT` variable results in invalid paths when the CDPATH environment variable is set.

Fixes #52255

**Release note**:

```release-note
NONE
```

/area build-release
/sig testing