### PR TITLE
Fix passing gcloud command output to error check

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1298,7 +1298,7 @@ func addNodePool(name string, machineType string, numNodes int) {
 		"--cluster=" + framework.TestContext.CloudConfig.Cluster}
 	output, err := execCmd(getGcloudCommand(args)...).CombinedOutput()
 	glog.Infof("Creating node-pool %s: %s", name, output)
-	framework.ExpectNoError(err, output)
+	framework.ExpectNoError(err, string(output))
 }
 
 func deleteNodePool(name string) {


### PR DESCRIPTION
Fix passing gcloud command output to error check. Underlying function from testing library expects interface{} and then type asserts that it's a string, so passing []byte results in errors:

```interface conversion: interface {} is []uint8, not string```

```release-note
NONE
```