### PR TITLE
read openstack auth config from client config

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/BUILD
@@ -18,6 +18,7 @@ go_library(
     importpath = "k8s.io/client-go/plugin/pkg/client/auth/openstack",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 
 	"k8s.io/apimachinery/pkg/util/net"
@@ -42,8 +43,7 @@ const DefaultTTLDuration = 10 * time.Minute
 // the environment variables to determine the client identity, and generates a
 // token which will be inserted into the request header later.
 type openstackAuthProvider struct {
-	ttl time.Duration
-
+	ttl         time.Duration
 	tokenGetter TokenGetter
 }
 
@@ -52,13 +52,23 @@ type TokenGetter interface {
 	Token() (string, error)
 }
 
-type tokenGetter struct{}
+type tokenGetter struct {
+	authOpt *gophercloud.AuthOptions
+}
 
 // Token creates a token by authenticate with keystone.
-func (*tokenGetter) Token() (string, error) {
-	options, err := openstack.AuthOptionsFromEnv()
-	if err != nil {
-		return "", fmt.Errorf("failed to read openstack env vars: %s", err)
+func (t *tokenGetter) Token() (string, error) {
+	var options gophercloud.AuthOptions
+	var err error
+	if t.authOpt == nil {
+		// reads the config from the environment
+		glog.V(4).Info("reading openstack config from the environment variables")
+		options, err = openstack.AuthOptionsFromEnv()
+		if err != nil {
+			return "", fmt.Errorf("failed to read openstack env vars: %s", err)
+		}
+	} else {
+		options = *t.authOpt
 	}
 	client, err := openstack.AuthenticatedClient(options)
 	if err != nil {
@@ -126,7 +136,7 @@ func (t *tokenRoundTripper) WrappedRoundTripper() http.RoundTripper { return t.R
 
 // newOpenstackAuthProvider creates an auth provider which works with openstack
 // environment.
-func newOpenstackAuthProvider(clusterAddress string, config map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+func newOpenstackAuthProvider(_ string, config map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
 	var ttlDuration time.Duration
 	var err error
 
@@ -145,11 +155,27 @@ func newOpenstackAuthProvider(clusterAddress string, config map[string]string, p
 		}
 	}
 
-	// TODO: read/persist client configuration(OS_XXX env vars) in config
+	authOpt := gophercloud.AuthOptions{
+		IdentityEndpoint: config["identityEndpoint"],
+		Username:         config["username"],
+		Password:         config["password"],
+		DomainName:       config["name"],
+		TenantID:         config["tenantId"],
+		TenantName:       config["tenantName"],
+	}
+
+	getter := tokenGetter{}
+	// not empty
+	if (authOpt != gophercloud.AuthOptions{}) {
+		if len(authOpt.IdentityEndpoint) == 0 {
+			return nil, fmt.Errorf("empty %q in the config for openstack auth provider", "identityEndpoint")
+		}
+		getter.authOpt = &authOpt
+	}
 
 	return &openstackAuthProvider{
 		ttl:         ttlDuration,
-		tokenGetter: &tokenGetter{},
+		tokenGetter: &getter,
 	}, nil
 }
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack_test.go
@@ -114,3 +114,60 @@ func TestOpenstackAuthProvider(t *testing.T) {
 	}
 
 }
+
+type fakePersister struct{}
+
+func (i *fakePersister) Persist(map[string]string) error {
+	return nil
+}
+
+func TestNewOpenstackAuthProvider(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]string
+		expectError bool
+	}{
+		{
+			name: "normal config without openstack configurations",
+			config: map[string]string{
+				"ttl": "1s",
+				"foo": "bar",
+			},
+		},
+		{
+			name: "openstack auth provider: missing identityEndpoint",
+			config: map[string]string{
+				"ttl":        "1s",
+				"foo":        "bar",
+				"username":   "xyz",
+				"password":   "123",
+				"tenantName": "admin",
+			},
+			expectError: true,
+		},
+		{
+			name: "openstack auth provider",
+			config: map[string]string{
+				"ttl":              "1s",
+				"foo":              "bar",
+				"identityEndpoint": "http://controller:35357/v3",
+				"username":         "xyz",
+				"password":         "123",
+				"tenantName":       "admin",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		_, err := newOpenstackAuthProvider("test", test.config, &fakePersister{})
+		if err != nil {
+			if !test.expectError {
+				t.Errorf("unexpected error: %v", err)
+			}
+		} else {
+			if test.expectError {
+				t.Error("expect error, but nil")
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
> // TODO: read/persist client configuration(OS_XXX env vars) in config

/sig openstack

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @dims
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
try to read openstack auth config from client config and fall back to read from the environment variables if not available
```
