### PR TITLE
kubelet: Make service environment variables optional

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2593,6 +2593,11 @@ type PodSpec struct {
 	// This is an alpha feature and may change in the future.
 	// +optional
 	RuntimeClassName *string
+	// EnableServiceLinks indicates whether information about services should be injected into pod's
+	// environment variables, matching the syntax of Docker links.
+	// Optional: Default to true
+	// +optional
+	EnableServiceLinks *bool
 }
 
 // HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -181,6 +181,10 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 	if obj.SchedulerName == "" {
 		obj.SchedulerName = v1.DefaultSchedulerName
 	}
+	if obj.EnableServiceLinks == nil {
+		enableServiceLinks := v1.DefaultEnableServiceLinks
+		obj.EnableServiceLinks = &enableServiceLinks
+	}
 }
 func SetDefaults_Probe(obj *v1.Probe) {
 	if obj.TimeoutSeconds == 0 {

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -1370,3 +1370,12 @@ func TestSetDefaultHostPathVolumeSource(t *testing.T) {
 		t.Errorf("Expected v1.HostPathVolumeSource default type %v, got %v", expectedType, defaultType)
 	}
 }
+
+func TestSetDefaultEnableServiceLinks(t *testing.T) {
+	pod := &v1.Pod{}
+
+	output := roundTrip(t, runtime.Object(pod)).(*v1.Pod)
+	if *output.Spec.EnableServiceLinks != v1.DefaultEnableServiceLinks {
+		t.Errorf("Expected enableServiceLinks value: %+v\ngot: %+v\n", v1.DefaultEnableServiceLinks, *output.Spec.EnableServiceLinks)
+	}
+}

--- a/pkg/apis/core/v1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1/zz_generated.conversion.go
@@ -5548,6 +5548,7 @@ func autoConvert_v1_PodSpec_To_core_PodSpec(in *v1.PodSpec, out *core.PodSpec, s
 	out.DNSConfig = (*core.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
 	out.ReadinessGates = *(*[]core.PodReadinessGate)(unsafe.Pointer(&in.ReadinessGates))
 	out.RuntimeClassName = (*string)(unsafe.Pointer(in.RuntimeClassName))
+	out.EnableServiceLinks = (*bool)(unsafe.Pointer(in.EnableServiceLinks))
 	return nil
 }
 
@@ -5614,6 +5615,7 @@ func autoConvert_core_PodSpec_To_v1_PodSpec(in *core.PodSpec, out *v1.PodSpec, s
 	out.DNSConfig = (*v1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
 	out.ReadinessGates = *(*[]v1.PodReadinessGate)(unsafe.Pointer(&in.ReadinessGates))
 	out.RuntimeClassName = (*string)(unsafe.Pointer(in.RuntimeClassName))
+	out.EnableServiceLinks = (*bool)(unsafe.Pointer(in.EnableServiceLinks))
 	return nil
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -3551,6 +3551,11 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EnableServiceLinks != nil {
+		in, out := &in.EnableServiceLinks, &out.EnableServiceLinks
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -834,20 +834,22 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name            string                 // the name of the test case
-		ns              string                 // the namespace to generate environment for
-		container       *v1.Container          // the container to use
-		masterServiceNs string                 // the namespace to read master service info from
-		nilLister       bool                   // whether the lister should be nil
-		configMap       *v1.ConfigMap          // an optional ConfigMap to pull from
-		secret          *v1.Secret             // an optional Secret to pull from
-		expectedEnvs    []kubecontainer.EnvVar // a set of expected environment vars
-		expectedError   bool                   // does the test fail
-		expectedEvent   string                 // does the test emit an event
+		name               string                 // the name of the test case
+		ns                 string                 // the namespace to generate environment for
+		enableServiceLinks bool                   // enabling service links
+		container          *v1.Container          // the container to use
+		masterServiceNs    string                 // the namespace to read master service info from
+		nilLister          bool                   // whether the lister should be nil
+		configMap          *v1.ConfigMap          // an optional ConfigMap to pull from
+		secret             *v1.Secret             // an optional Secret to pull from
+		expectedEnvs       []kubecontainer.EnvVar // a set of expected environment vars
+		expectedError      bool                   // does the test fail
+		expectedEvent      string                 // does the test emit an event
 	}{
 		{
-			name: "api server = Y, kubelet = Y",
-			ns:   "test1",
+			name:               "api server = Y, kubelet = Y",
+			ns:                 "test1",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{Name: "FOO", Value: "BAR"},
@@ -881,8 +883,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "api server = Y, kubelet = N",
-			ns:   "test1",
+			name:               "api server = Y, kubelet = N",
+			ns:                 "test1",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{Name: "FOO", Value: "BAR"},
@@ -909,8 +912,31 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "api server = N; kubelet = Y",
-			ns:   "test1",
+			name:               "api server = N; kubelet = Y",
+			ns:                 "test1",
+			enableServiceLinks: false,
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{Name: "FOO", Value: "BAZ"},
+				},
+			},
+			masterServiceNs: metav1.NamespaceDefault,
+			nilLister:       false,
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "FOO", Value: "BAZ"},
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "1.2.3.1"},
+				{Name: "KUBERNETES_SERVICE_PORT", Value: "8081"},
+				{Name: "KUBERNETES_PORT", Value: "tcp://1.2.3.1:8081"},
+				{Name: "KUBERNETES_PORT_8081_TCP", Value: "tcp://1.2.3.1:8081"},
+				{Name: "KUBERNETES_PORT_8081_TCP_PROTO", Value: "tcp"},
+				{Name: "KUBERNETES_PORT_8081_TCP_PORT", Value: "8081"},
+				{Name: "KUBERNETES_PORT_8081_TCP_ADDR", Value: "1.2.3.1"},
+			},
+		},
+		{
+			name:               "api server = N; kubelet = Y; service env vars",
+			ns:                 "test1",
+			enableServiceLinks: true,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{Name: "FOO", Value: "BAZ"},
@@ -937,8 +963,31 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "master service in pod ns",
-			ns:   "test2",
+			name:               "master service in pod ns",
+			ns:                 "test2",
+			enableServiceLinks: false,
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{Name: "FOO", Value: "ZAP"},
+				},
+			},
+			masterServiceNs: "kubernetes",
+			nilLister:       false,
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "FOO", Value: "ZAP"},
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "1.2.3.4"},
+				{Name: "KUBERNETES_SERVICE_PORT", Value: "8084"},
+				{Name: "KUBERNETES_PORT", Value: "tcp://1.2.3.4:8084"},
+				{Name: "KUBERNETES_PORT_8084_TCP", Value: "tcp://1.2.3.4:8084"},
+				{Name: "KUBERNETES_PORT_8084_TCP_PROTO", Value: "tcp"},
+				{Name: "KUBERNETES_PORT_8084_TCP_PORT", Value: "8084"},
+				{Name: "KUBERNETES_PORT_8084_TCP_ADDR", Value: "1.2.3.4"},
+			},
+		},
+		{
+			name:               "master service in pod ns, service env vars",
+			ns:                 "test2",
+			enableServiceLinks: true,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{Name: "FOO", Value: "ZAP"},
@@ -965,11 +1014,29 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name:            "pod in master service ns",
-			ns:              "kubernetes",
-			container:       &v1.Container{},
-			masterServiceNs: "kubernetes",
-			nilLister:       false,
+			name:               "pod in master service ns",
+			ns:                 "kubernetes",
+			enableServiceLinks: false,
+			container:          &v1.Container{},
+			masterServiceNs:    "kubernetes",
+			nilLister:          false,
+			expectedEnvs: []kubecontainer.EnvVar{
+				{Name: "KUBERNETES_SERVICE_HOST", Value: "1.2.3.6"},
+				{Name: "KUBERNETES_SERVICE_PORT", Value: "8086"},
+				{Name: "KUBERNETES_PORT", Value: "tcp://1.2.3.6:8086"},
+				{Name: "KUBERNETES_PORT_8086_TCP", Value: "tcp://1.2.3.6:8086"},
+				{Name: "KUBERNETES_PORT_8086_TCP_PROTO", Value: "tcp"},
+				{Name: "KUBERNETES_PORT_8086_TCP_PORT", Value: "8086"},
+				{Name: "KUBERNETES_PORT_8086_TCP_ADDR", Value: "1.2.3.6"},
+			},
+		},
+		{
+			name:               "pod in master service ns, service env vars",
+			ns:                 "kubernetes",
+			enableServiceLinks: true,
+			container:          &v1.Container{},
+			masterServiceNs:    "kubernetes",
+			nilLister:          false,
 			expectedEnvs: []kubecontainer.EnvVar{
 				{Name: "NOT_SPECIAL_SERVICE_HOST", Value: "1.2.3.8"},
 				{Name: "NOT_SPECIAL_SERVICE_PORT", Value: "8088"},
@@ -988,8 +1055,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "downward api pod",
-			ns:   "downward-api",
+			name:               "downward api pod",
+			ns:                 "downward-api",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1060,8 +1128,105 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "env expansion",
-			ns:   "test1",
+			name:               "env expansion",
+			ns:                 "test1",
+			enableServiceLinks: false,
+			container: &v1.Container{
+				Env: []v1.EnvVar{
+					{
+						Name:  "TEST_LITERAL",
+						Value: "test-test-test",
+					},
+					{
+						Name: "POD_NAME",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "metadata.name",
+							},
+						},
+					},
+					{
+						Name:  "OUT_OF_ORDER_TEST",
+						Value: "$(OUT_OF_ORDER_TARGET)",
+					},
+					{
+						Name:  "OUT_OF_ORDER_TARGET",
+						Value: "FOO",
+					},
+					{
+						Name: "EMPTY_VAR",
+					},
+					{
+						Name:  "EMPTY_TEST",
+						Value: "foo-$(EMPTY_VAR)",
+					},
+					{
+						Name:  "POD_NAME_TEST2",
+						Value: "test2-$(POD_NAME)",
+					},
+					{
+						Name:  "POD_NAME_TEST3",
+						Value: "$(POD_NAME_TEST2)-3",
+					},
+					{
+						Name:  "LITERAL_TEST",
+						Value: "literal-$(TEST_LITERAL)",
+					},
+					{
+						Name:  "TEST_UNDEFINED",
+						Value: "$(UNDEFINED_VAR)",
+					},
+				},
+			},
+			masterServiceNs: "nothing",
+			nilLister:       false,
+			expectedEnvs: []kubecontainer.EnvVar{
+				{
+					Name:  "TEST_LITERAL",
+					Value: "test-test-test",
+				},
+				{
+					Name:  "POD_NAME",
+					Value: "dapi-test-pod-name",
+				},
+				{
+					Name:  "POD_NAME_TEST2",
+					Value: "test2-dapi-test-pod-name",
+				},
+				{
+					Name:  "POD_NAME_TEST3",
+					Value: "test2-dapi-test-pod-name-3",
+				},
+				{
+					Name:  "LITERAL_TEST",
+					Value: "literal-test-test-test",
+				},
+				{
+					Name:  "OUT_OF_ORDER_TEST",
+					Value: "$(OUT_OF_ORDER_TARGET)",
+				},
+				{
+					Name:  "OUT_OF_ORDER_TARGET",
+					Value: "FOO",
+				},
+				{
+					Name:  "TEST_UNDEFINED",
+					Value: "$(UNDEFINED_VAR)",
+				},
+				{
+					Name: "EMPTY_VAR",
+				},
+				{
+					Name:  "EMPTY_TEST",
+					Value: "foo-",
+				},
+			},
+		},
+		{
+			name:               "env expansion, service env vars",
+			ns:                 "test1",
+			enableServiceLinks: true,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1191,8 +1356,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "configmapkeyref_missing_optional",
-			ns:   "test",
+			name:               "configmapkeyref_missing_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1211,8 +1377,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs:    nil,
 		},
 		{
-			name: "configmapkeyref_missing_key_optional",
-			ns:   "test",
+			name:               "configmapkeyref_missing_key_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1241,8 +1408,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs: nil,
 		},
 		{
-			name: "secretkeyref_missing_optional",
-			ns:   "test",
+			name:               "secretkeyref_missing_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1261,8 +1429,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs:    nil,
 		},
 		{
-			name: "secretkeyref_missing_key_optional",
-			ns:   "test",
+			name:               "secretkeyref_missing_key_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				Env: []v1.EnvVar{
 					{
@@ -1291,8 +1460,77 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs: nil,
 		},
 		{
-			name: "configmap",
-			ns:   "test1",
+			name:               "configmap",
+			ns:                 "test1",
+			enableServiceLinks: false,
+			container: &v1.Container{
+				EnvFrom: []v1.EnvFromSource{
+					{
+						ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}},
+					},
+					{
+						Prefix:       "p_",
+						ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}},
+					},
+				},
+				Env: []v1.EnvVar{
+					{
+						Name:  "TEST_LITERAL",
+						Value: "test-test-test",
+					},
+					{
+						Name:  "EXPANSION_TEST",
+						Value: "$(REPLACE_ME)",
+					},
+					{
+						Name:  "DUPE_TEST",
+						Value: "ENV_VAR",
+					},
+				},
+			},
+			masterServiceNs: "nothing",
+			nilLister:       false,
+			configMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test1",
+					Name:      "test-configmap",
+				},
+				Data: map[string]string{
+					"REPLACE_ME": "FROM_CONFIG_MAP",
+					"DUPE_TEST":  "CONFIG_MAP",
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{
+					Name:  "TEST_LITERAL",
+					Value: "test-test-test",
+				},
+				{
+					Name:  "REPLACE_ME",
+					Value: "FROM_CONFIG_MAP",
+				},
+				{
+					Name:  "EXPANSION_TEST",
+					Value: "FROM_CONFIG_MAP",
+				},
+				{
+					Name:  "DUPE_TEST",
+					Value: "ENV_VAR",
+				},
+				{
+					Name:  "p_REPLACE_ME",
+					Value: "FROM_CONFIG_MAP",
+				},
+				{
+					Name:  "p_DUPE_TEST",
+					Value: "CONFIG_MAP",
+				},
+			},
+		},
+		{
+			name:               "configmap, service env vars",
+			ns:                 "test1",
+			enableServiceLinks: true,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{
@@ -1386,8 +1624,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "configmap_missing",
-			ns:   "test1",
+			name:               "configmap_missing",
+			ns:                 "test1",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}}},
@@ -1397,8 +1636,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedError:   true,
 		},
 		{
-			name: "configmap_missing_optional",
-			ns:   "test",
+			name:               "configmap_missing_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{ConfigMapRef: &v1.ConfigMapEnvSource{
@@ -1410,8 +1650,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs:    nil,
 		},
 		{
-			name: "configmap_invalid_keys",
-			ns:   "test",
+			name:               "configmap_invalid_keys",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-config-map"}}},
@@ -1438,8 +1679,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEvent: "Warning InvalidEnvironmentVariableNames Keys [1234, 1z] from the EnvFrom configMap test/test-config-map were skipped since they are considered invalid environment variable names.",
 		},
 		{
-			name: "configmap_invalid_keys_valid",
-			ns:   "test",
+			name:               "configmap_invalid_keys_valid",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{
@@ -1466,8 +1708,77 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "secret",
-			ns:   "test1",
+			name:               "secret",
+			ns:                 "test1",
+			enableServiceLinks: false,
+			container: &v1.Container{
+				EnvFrom: []v1.EnvFromSource{
+					{
+						SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"}},
+					},
+					{
+						Prefix:    "p_",
+						SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"}},
+					},
+				},
+				Env: []v1.EnvVar{
+					{
+						Name:  "TEST_LITERAL",
+						Value: "test-test-test",
+					},
+					{
+						Name:  "EXPANSION_TEST",
+						Value: "$(REPLACE_ME)",
+					},
+					{
+						Name:  "DUPE_TEST",
+						Value: "ENV_VAR",
+					},
+				},
+			},
+			masterServiceNs: "nothing",
+			nilLister:       false,
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test1",
+					Name:      "test-secret",
+				},
+				Data: map[string][]byte{
+					"REPLACE_ME": []byte("FROM_SECRET"),
+					"DUPE_TEST":  []byte("SECRET"),
+				},
+			},
+			expectedEnvs: []kubecontainer.EnvVar{
+				{
+					Name:  "TEST_LITERAL",
+					Value: "test-test-test",
+				},
+				{
+					Name:  "REPLACE_ME",
+					Value: "FROM_SECRET",
+				},
+				{
+					Name:  "EXPANSION_TEST",
+					Value: "FROM_SECRET",
+				},
+				{
+					Name:  "DUPE_TEST",
+					Value: "ENV_VAR",
+				},
+				{
+					Name:  "p_REPLACE_ME",
+					Value: "FROM_SECRET",
+				},
+				{
+					Name:  "p_DUPE_TEST",
+					Value: "SECRET",
+				},
+			},
+		},
+		{
+			name:               "secret, service env vars",
+			ns:                 "test1",
+			enableServiceLinks: true,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{
@@ -1561,8 +1872,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "secret_missing",
-			ns:   "test1",
+			name:               "secret_missing",
+			ns:                 "test1",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"}}},
@@ -1572,8 +1884,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedError:   true,
 		},
 		{
-			name: "secret_missing_optional",
-			ns:   "test",
+			name:               "secret_missing_optional",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{SecretRef: &v1.SecretEnvSource{
@@ -1585,8 +1898,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEnvs:    nil,
 		},
 		{
-			name: "secret_invalid_keys",
-			ns:   "test",
+			name:               "secret_invalid_keys",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: "test-secret"}}},
@@ -1613,8 +1927,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			expectedEvent: "Warning InvalidEnvironmentVariableNames Keys [1234, 1z] from the EnvFrom secret test/test-secret were skipped since they are considered invalid environment variable names.",
 		},
 		{
-			name: "secret_invalid_keys_valid",
-			ns:   "test",
+			name:               "secret_invalid_keys_valid",
+			ns:                 "test",
+			enableServiceLinks: false,
 			container: &v1.Container{
 				EnvFrom: []v1.EnvFromSource{
 					{
@@ -1686,6 +2001,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 			Spec: v1.PodSpec{
 				ServiceAccountName: "special",
 				NodeName:           "node-name",
+				EnableServiceLinks: &tc.enableServiceLinks,
 			},
 		}
 		podIP := "1.2.3.4"

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2887,7 +2887,18 @@ type PodSpec struct {
 	// This is an alpha feature and may change in the future.
 	// +optional
 	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,29,opt,name=runtimeClassName"`
+
+	// EnableServiceLinks indicates whether information about services should be injected into pod's
+	// environment variables, matching the syntax of Docker links.
+	// Optional: Default to true
+	// +optional
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty", protobuf:"varint,30,opt,name=enableServiceLinks"`
 }
+
+const (
+	// The default value for enableServiceLinks attribute.
+	DefaultEnableServiceLinks = true
+)
 
 // HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
 // pod's hosts file.

--- a/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
@@ -3549,6 +3549,11 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EnableServiceLinks != nil {
+		in, out := &in.EnableServiceLinks, &out.EnableServiceLinks
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Services should be accessed by DNS, not by environment variables which are associated with the deprecated --link option in Docker. In this change, those variables can be optionally enabled by setting up the `kubernetes.io/service-environment-variables` annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60099

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make service environment variables optional
```
