### PR TITLE
deprecate --show-all

### DIFF
--- a/pkg/kubectl/cmd/resource/get_test.go
+++ b/pkg/kubectl/cmd/resource/get_test.go
@@ -386,14 +386,14 @@ func TestGetObjectsFiltered(t *testing.T) {
 		flags  map[string]string
 		expect string
 	}{
+		{args: []string{"pods", "foo"}, flags: map[string]string{"show-all": "true"}, resp: first, expect: "pod/foo\n"},
 		{args: []string{"pods", "foo"}, resp: first, expect: "pod/foo\n"},
-		{args: []string{"pods", "foo"}, flags: map[string]string{"show-all": "false"}, resp: first, expect: "pod/foo\n"},
-		{args: []string{"pods"}, flags: map[string]string{"show-all": "true"}, resp: pods, expect: "pod/foo\npod/bar\n"},
-		{args: []string{"pods/foo"}, resp: first, expect: "pod/foo\n"},
-		{args: []string{"pods"}, flags: map[string]string{"output": "yaml"}, resp: pods, expect: "pod/bar\n"},
-		{args: []string{}, flags: map[string]string{"filename": "../../../../examples/storage/cassandra/cassandra-controller.yaml"}, resp: pods, expect: "pod/foo\npod/bar\n"},
+		{args: []string{"pods"}, resp: pods, expect: "pod/foo\npod/bar\n"},
+		{args: []string{"pods/foo"}, flags: map[string]string{"show-all": "false"}, resp: first, expect: "pod/foo\n"},
+		{args: []string{"pods"}, flags: map[string]string{"show-all": "false", "output": "yaml"}, resp: pods, expect: "pod/bar\n"},
+		{args: []string{}, flags: map[string]string{"show-all": "false", "filename": "../../../../examples/storage/cassandra/cassandra-controller.yaml"}, resp: pods, expect: "pod/foo\npod/bar\n"},
 
-		{args: []string{"pods"}, resp: pods, expect: "pod/bar\n"},
+		{args: []string{"pods"}, flags: map[string]string{"show-all": "false"}, resp: pods, expect: "pod/bar\n"},
 		{args: []string{"pods"}, flags: map[string]string{"show-all": "true", "output": "yaml"}, resp: pods, expect: "pod/foo\npod/bar\n"},
 		{args: []string{"pods"}, flags: map[string]string{"show-all": "false"}, resp: pods, expect: "pod/bar\n"},
 	}
@@ -991,6 +991,7 @@ func TestGetByFormatForcesFlag(t *testing.T) {
 	cmd := NewCmdGet(f, buf, errBuf)
 	cmd.SetOutput(buf)
 	cmd.Flags().Lookup("output").Value.Set("yaml")
+	cmd.Flags().Set("show-all", "false")
 	cmd.Run(cmd, []string{"pods"})
 
 	showAllFlag, _ := cmd.Flags().GetBool("show-all")

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -52,7 +52,8 @@ func AddNonDeprecatedPrinterFlags(cmd *cobra.Command) {
 	cmd.Flags().String("template", "", "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
 	cmd.MarkFlagFilename("template")
 	cmd.Flags().String("sort-by", "", "If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string.")
-	cmd.Flags().BoolP("show-all", "a", false, "When printing, show all resources (default hide terminated pods.)")
+	cmd.Flags().BoolP("show-all", "a", true, "When printing, show all resources (default hide terminated pods.)")
+	cmd.Flags().MarkDeprecated("show-all", "will be removed in an upcoming release")
 }
 
 // AddOutputFlagsForMutation adds output related flags to a command. Used by mutations only.


### PR DESCRIPTION
`--show-all` is a pod-only filter that only affects human-readable printing of pods and only from `kubectl get`.  It hides pods which are in a terminal state.  Even at the beginning this was questionable, since you often (usually?) want to see the pods that have failed: all happy pods are alike, but every unhappy pod is unhappy in its own way.  In addition, it only worked on human-readable printers.  Doing a `-o name` or `-o yaml` showed a different set of results!

Per the mailing list discussion here: https://groups.google.com/forum/#!topic/kubernetes-sig-cli/0SxgDxObxD0

```release-note
`--show-all` (which only affected pods and only for human readable/non-API printers) is now defaulted to true and deprecated.  It will be inert in 1.11 and removed in a future release.
```

/assign @adohe 
/assign @pwittrock 
/assign @soltysh 

@kubernetes/sig-cli-maintainers 