### PR TITLE
document that kubectl --help can have more levels

### DIFF
--- a/pkg/kubectl/cmd/templates/templates.go
+++ b/pkg/kubectl/cmd/templates/templates.go
@@ -60,7 +60,7 @@ const (
 {{end}}`
 
 	// SectionTipsHelp is the help template section that displays the '--help' hint.
-	SectionTipsHelp = `{{if .HasSubCommands}}Use "{{$rootCmd}} <command> --help" for more information about a given command.
+	SectionTipsHelp = `{{if .HasSubCommands}}Use "{{$rootCmd}} <command> [<subcommand>] --help" for details about a given (sub)command.
 {{end}}`
 
 	// SectionTipsGlobalOptions is the help template section that displays the 'options' hint for displaying global flags.


### PR DESCRIPTION
I searched for documentation about the invocation of `kubectl top node $NODE` and thought the help for `kubectl top` was insufficient since it contained no details.
Only much later I understood that I could run `kubectl help top node` to get more information on the `node` subcommand.