### PR TITLE
KeyMutex: added TryLockKey()

### DIFF
--- a/pkg/util/keymutex/keymutex.go
+++ b/pkg/util/keymutex/keymutex.go
@@ -48,7 +48,7 @@ func (tm *tryMutex) Unlock() {
 	case <-tm.ch:
 		return
 	default:
-		glog.Fatalln("unlock of unlocked mutex")
+		panic("unlock of unlocked mutex")
 	}
 }
 

--- a/pkg/util/keymutex/keymutex.go
+++ b/pkg/util/keymutex/keymutex.go
@@ -44,7 +44,12 @@ func (tm *tryMutex) TryLock() bool {
 }
 
 func (tm *tryMutex) Unlock() {
-	<-tm.ch
+	select {
+	case <-tm.ch:
+		return
+	default:
+		glog.Fatalln("unlock of unlocked mutex")
+	}
 }
 
 // KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.


### PR DESCRIPTION
**What this PR does / why we need it:**
Adds try-lock functionality to KeyMutex. It's now possible to either acquire the lock on a KeyMutex, or fail immediately.

**Release note:**

NONE