### PR TITLE
Client for external metrics

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -730,6 +730,8 @@ staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1
 staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1
 staging/src/k8s.io/metrics/pkg/client/custom_metrics
 staging/src/k8s.io/metrics/pkg/client/custom_metrics/fake
+staging/src/k8s.io/metrics/pkg/client/external_metrics
+staging/src/k8s.io/metrics/pkg/client/external_metrics/fake
 staging/src/k8s.io/sample-apiserver/pkg/apis/wardle
 staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
 staging/src/k8s.io/sample-apiserver/pkg/apiserver

--- a/staging/BUILD
+++ b/staging/BUILD
@@ -215,6 +215,7 @@ filegroup(
         "//staging/src/k8s.io/metrics/pkg/apis/metrics:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset:all-srcs",
         "//staging/src/k8s.io/metrics/pkg/client/custom_metrics:all-srcs",
+        "//staging/src/k8s.io/metrics/pkg/client/external_metrics:all-srcs",
         "//staging/src/k8s.io/sample-apiserver:all-srcs",
         "//staging/src/k8s.io/sample-controller:all-srcs",
     ],

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/BUILD
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "interfaces.go",
+    ],
+    importpath = "k8s.io/metrics/pkg/client/external_metrics",
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/apis/external_metrics/v1beta1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//staging/src/k8s.io/metrics/pkg/client/external_metrics/fake:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external_metrics
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+)
+
+type externalMetricsClient struct {
+	client rest.Interface
+}
+
+func New(client rest.Interface) ExternalMetricsClient {
+	return &externalMetricsClient{
+		client: client,
+	}
+}
+
+func NewForConfig(c *rest.Config) (ExternalMetricsClient, error) {
+	configShallowCopy := *c
+	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
+		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	configShallowCopy.APIPath = "/apis"
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	configShallowCopy.GroupVersion = &v1beta1.SchemeGroupVersion
+	configShallowCopy.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+
+	client, err := rest.RESTClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(client), nil
+}
+
+func NewForConfigOrDie(c *rest.Config) ExternalMetricsClient {
+	client, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func (c *externalMetricsClient) NamespacedMetrics(namespace string) MetricsInterface {
+	return &namespacedMetrics{
+		client:    c,
+		namespace: namespace,
+	}
+}
+
+type namespacedMetrics struct {
+	client    *externalMetricsClient
+	namespace string
+}
+
+func (m *namespacedMetrics) List(metricName string, metricSelector labels.Selector) (*v1beta1.ExternalMetricValueList, error) {
+	res := &v1beta1.ExternalMetricValueList{}
+	err := m.client.client.Get().
+		Namespace(m.namespace).
+		Resource(metricName).
+		VersionedParams(&metav1.ListOptions{
+			LabelSelector: metricSelector.String(),
+		}, metav1.ParameterCodec).
+		Do().
+		Into(res)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/fake/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/fake/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fake_client.go"],
+    importpath = "k8s.io/metrics/pkg/client/external_metrics/fake",
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/apis/external_metrics/v1beta1:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/external_metrics:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/fake/fake_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/fake/fake_client.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/testing"
+	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+	eclient "k8s.io/metrics/pkg/client/external_metrics"
+)
+
+type FakeExternalMetricsClient struct {
+	testing.Fake
+}
+
+func (c *FakeExternalMetricsClient) NamespacedMetrics(namespace string) eclient.MetricsInterface {
+	return &fakeNamespacedMetrics{
+		Fake: c,
+		ns:   namespace,
+	}
+}
+
+type fakeNamespacedMetrics struct {
+	Fake *FakeExternalMetricsClient
+	ns   string
+}
+
+func (m *fakeNamespacedMetrics) List(metricName string, metricSelector labels.Selector) (*v1beta1.ExternalMetricValueList, error) {
+	resource := schema.GroupResource{
+		Group:    v1beta1.SchemeGroupVersion.Group,
+		Resource: metricName,
+	}
+	kind := schema.GroupKind{
+		Group: v1beta1.SchemeGroupVersion.Group,
+		Kind:  "ExternalMetricValue",
+	}
+	action := testing.NewListAction(resource.WithVersion(""), kind.WithVersion(""), m.ns, metav1.ListOptions{LabelSelector: metricSelector.String()})
+	obj, err := m.Fake.
+		Invokes(action, &v1beta1.ExternalMetricValueList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*v1beta1.ExternalMetricValueList), err
+}

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/interfaces.go
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/interfaces.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external_metrics
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+)
+
+// ExternalMetricsClient is a client for fetching external metrics.
+type ExternalMetricsClient interface {
+	NamespacedMetricsGetter
+}
+
+// NamespacedMetricsGetter provides access to an interface for fetching
+// metrics in a particular namespace.
+type NamespacedMetricsGetter interface {
+	NamespacedMetrics(namespace string) MetricsInterface
+}
+
+// MetricsInterface provides access to external metrics.
+type MetricsInterface interface {
+	// Get fetches the metric for the given namespace that maches the given
+	// metricSelector.
+	List(metricName string, metricSelector labels.Selector) (*v1beta1.ExternalMetricValueList, error)
+}


### PR DESCRIPTION
Add client for External Metrics API introduced in https://github.com/kubernetes/kubernetes/pull/60079.

This PR is just client all the API changes are included from https://github.com/kubernetes/kubernetes/pull/60079.