### PR TITLE
examples/podsecuritypolicy: add owners

### DIFF
--- a/examples/podsecuritypolicy/OWNERS
+++ b/examples/podsecuritypolicy/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - deads2k
+  - ericchiang
+  - liggitt
+  - tallclair
+reviewers:
+  - deads2k
+  - ericchiang
+  - liggitt
+  - php-coder
+  - tallclair


### PR DESCRIPTION
When we modify something PSP-related, we need to update examples as well but unfortunately they wasn't belong to us.