### PR TITLE
Automated cherry pick of #58221: Bump metadata proxy to v1.9

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google-containers/metadata-proxy:0.1.3
+        image: gcr.io/google-containers/metadata-proxy:0.1.9
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Cherry pick of #58221 on release-1.7.

#58221: Bump metadata proxy to v1.9