### PR TITLE
apiserver: add flag that disable the proxy handlers

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -53,8 +53,10 @@ type ServerRunOptions struct {
 	StorageSerialization    *kubeoptions.StorageSerializationOptions
 	APIEnablement           *genericoptions.APIEnablementOptions
 
-	AllowPrivileged           bool
-	EnableLogsHandler         bool
+	AllowPrivileged     bool
+	EnableProxyHandlers bool
+	EnableLogsHandler   bool
+
 	EventTTL                  time.Duration
 	KubeletConfig             kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort int
@@ -92,6 +94,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		APIEnablement:        genericoptions.NewAPIEnablementOptions(),
 
 		EnableLogsHandler:      true,
+		EnableProxyHandlers:    true,
 		EventTTL:               1 * time.Hour,
 		MasterCount:            1,
 		EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
@@ -149,6 +152,9 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
 		"If true, install a /logs handler for the apiserver logs.")
+
+	fs.BoolVar(&s.EnableProxyHandlers, "enable-proxy-handlers", s.EnableProxyHandlers,
+		"If true, install a /proxy handler on resources that support proxying.")
 
 	// Deprecated in release 1.9
 	fs.StringVar(&s.SSHUser, "ssh-user", s.SSHUser,

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -103,6 +103,7 @@ func TestAddFlags(t *testing.T) {
 		MasterCount:            5,
 		EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
 		AllowPrivileged:        false,
+		EnableProxyHandlers:    true,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -358,6 +358,7 @@ func CreateKubeAPIServerConfig(s *options.ServerRunOptions, nodeTunneler tunnele
 			EventTTL:                s.EventTTL,
 			KubeletClientConfig:     s.KubeletConfig,
 			EnableLogsSupport:       s.EnableLogsHandler,
+			EnableProxyHandlers:     s.EnableProxyHandlers,
 			ProxyTransport:          proxyTransport,
 
 			Tunneler: nodeTunneler,

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -106,6 +106,7 @@ type ExtraConfig struct {
 	EnableCoreControllers    bool
 	EndpointReconcilerConfig EndpointReconcilerConfig
 	EventTTL                 time.Duration
+	EnableProxyHandlers      bool
 	KubeletClientConfig      kubeletclient.KubeletClientConfig
 
 	// Used to start and monitor tunneling
@@ -315,6 +316,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	if c.ExtraConfig.APIResourceConfigSource.VersionEnabled(apiv1.SchemeGroupVersion) {
 		legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
 			StorageFactory:       c.ExtraConfig.StorageFactory,
+			EnableProxyHandlers:  c.ExtraConfig.EnableProxyHandlers,
 			ProxyTransport:       c.ExtraConfig.ProxyTransport,
 			KubeletClientConfig:  c.ExtraConfig.KubeletClientConfig,
 			EventTTL:             c.ExtraConfig.EventTTL,

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -73,6 +73,7 @@ import (
 type LegacyRESTStorageProvider struct {
 	StorageFactory serverstorage.StorageFactory
 	// Used for custom proxy dialing, and proxy TLS options
+	EnableProxyHandlers bool
 	ProxyTransport      http.RoundTripper
 	KubeletClientConfig kubeletclient.KubeletClientConfig
 	EventTTL            time.Duration
@@ -192,7 +193,6 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 		"pods/log":         podStorage.Log,
 		"pods/exec":        podStorage.Exec,
 		"pods/portforward": podStorage.PortForward,
-		"pods/proxy":       podStorage.Proxy,
 		"pods/binding":     podStorage.Binding,
 		"bindings":         podStorage.Binding,
 
@@ -202,14 +202,12 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 		"replicationControllers/status": controllerStorage.Status,
 
 		"services":        serviceRest.Service,
-		"services/proxy":  serviceRest.Proxy,
 		"services/status": serviceStatusStorage,
 
 		"endpoints": endpointsStorage,
 
 		"nodes":        nodeStorage.Node,
 		"nodes/status": nodeStorage.Status,
-		"nodes/proxy":  nodeStorage.Proxy,
 
 		"events": eventStorage,
 
@@ -228,6 +226,12 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 		"configMaps":                    configMapStorage,
 
 		"componentStatuses": componentstatus.NewStorage(componentStatusStorage{c.StorageFactory}.serversToValidate),
+	}
+	if c.EnableProxyHandlers {
+		restStorageMap["pods/proxy"] = podStorage.Proxy
+		restStorageMap["services/proxy"] = serviceRest.Proxy
+		restStorageMap["nodes/proxy"] = nodeStorage.Proxy
+
 	}
 	if legacyscheme.Registry.IsEnabledVersion(schema.GroupVersion{Group: "autoscaling", Version: "v1"}) {
 		restStorageMap["replicationControllers/scale"] = controllerStorage.Scale

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -294,6 +294,7 @@ func NewMasterConfig() *master.Config {
 		ExtraConfig: master.ExtraConfig{
 			APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
 			StorageFactory:          storageFactory,
+			EnableProxyHandlers:     true,
 			EnableCoreControllers:   true,
 			KubeletClientConfig:     kubeletclient.KubeletClientConfig{Port: 10250},
 			APIServerServicePort:    443,


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/59885

```release-note
Add a flag that disables proxy handlers on resources that support proxying.
```
