### PR TITLE
gce: allow extra addons to be sourced form a url

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1954,6 +1954,33 @@ function setup-addon-manifests {
   fi
 }
 
+# A function that downloads extra addons from a URL and puts them in the GCI
+# manifests directory.
+function download-extra-addons {
+  local -r out_dir="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/gce-extras"
+
+  mkdir -p "${out_dir}"
+
+  local curl_cmd=(
+    "curl"
+    "--fail"
+    "--retry" "5"
+    "--retry-delay" "3"
+    "--silent"
+    "--show-error"
+  )
+  if [[ -n "${CURL_RETRY_CONNREFUSED:-}" ]]; then
+    curl_cmd+=("${CURL_RETRY_CONNREFUSED}")
+  fi
+  if [[ -n "${EXTRA_ADDONS_HEADER:-}" ]]; then
+    curl_cmd+=("-H" "${EXTRA_ADDONS_HEADER}")
+  fi
+  curl_cmd+=("-o" "${out_dir}/extras.json")
+  curl_cmd+=("${EXTRA_ADDONS_URL}")
+
+  "${curl_cmd[@]}"
+}
+
 # A helper function for copying manifests and setting dir/files
 # permissions.
 #
@@ -2244,6 +2271,10 @@ EOF
     else
       setup-addon-manifests "addons" "istio/noauth"
     fi
+  fi
+  if [[ -n "${EXTRA_ADDONS_URL:-}" ]]; then
+    download-extra-addons
+    setup-addon-manifests "addons" "gce-extras"
   fi
 
   # Place addon manager pod manifest.


### PR DESCRIPTION
This will allow istio configs to move out of the repo. Deleting https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/istio will follow shortly.

cc @ostromart @MrHohn

```release-note
NONE
```
