### PR TITLE
Remove k8s prefix from gcr.io/k8s-ingress-gce-image-push repo

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -82,7 +82,7 @@ func ingressUpgradeGCE(isUpgrade bool) error {
 			command = fmt.Sprintf("sudo sed -i -re 's|(image:)(.*)|\\1 %s|' /etc/kubernetes/manifests/glbc.manifest", targetImage)
 		} else {
 			// Upgrade to latest HEAD image.
-			command = "sudo sed -i -re 's/(image:)(.*)/\\1 k8s.gcr.io\\/k8s-ingress-image-push\\/ingress-gce-e2e-glbc-amd64:latest/' /etc/kubernetes/manifests/glbc.manifest"
+			command = "sudo sed -i -re 's/(image:)(.*)/\\1 gcr.io\\/k8s-ingress-image-push\\/ingress-gce-e2e-glbc-amd64:latest/' /etc/kubernetes/manifests/glbc.manifest"
 		}
 	} else {
 		// Downgrade to latest release image.


### PR DESCRIPTION
**What this PR does / why we need it**:
Was causing e2e tests to fail. 

**Release note**:

```release-note
None
```

/assign @MrHohn 
