### PR TITLE
[WIP] ReplicaSet will actively delete failed pods without DeletionTimestamp

### DIFF
--- a/test/integration/replicationcontroller/replicationcontroller_test.go
+++ b/test/integration/replicationcontroller/replicationcontroller_test.go
@@ -539,16 +539,17 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	stopCh := runControllerAndInformers(t, rm, informers, 0)
 	defer close(stopCh)
 
-	rc := newRC("rc", ns.Name, 2)
+	replicas := 3
+	rc := newRC("rc", ns.Name, replicas)
 	rcs, _ := createRCsPods(t, c, []*v1.ReplicationController{rc}, []*v1.Pod{})
 	rc = rcs[0]
 	waitRCStable(t, c, rc)
 
-	// Verify RC creates 2 pods
+	// Verify RC creates 3 pods
 	podClient := c.CoreV1().Pods(ns.Name)
 	pods := getPods(t, podClient, labelMap())
-	if len(pods.Items) != 2 {
-		t.Fatalf("len(pods) = %d, want 2", len(pods.Items))
+	if len(pods.Items) != replicas {
+		t.Fatalf("len(pods) = %d, want %d", len(pods.Items), replicas)
 	}
 
 	// Set first pod as deleting pod
@@ -562,25 +563,40 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	}
 
 	// Set second pod as failed pod
-	failedPod := &pods.Items[1]
+	// Set finalizers for the pod to simulate pending deletion status
+	failedDeletingPod := &pods.Items[1]
+	updatePodStatus(t, podClient, failedDeletingPod, func(pod *v1.Pod) {
+		pod.Status.Phase = v1.PodFailed
+		pod.Finalizers = []string{"fake.example.com/blockDeletion"}
+	})
+	if err := c.CoreV1().Pods(ns.Name).Delete(failedDeletingPod.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Error deleting pod %s: %v", failedDeletingPod.Name, err)
+	}
+
+	// Set third pod as failed pod
+	failedPod := &pods.Items[2]
 	updatePodStatus(t, podClient, failedPod, func(pod *v1.Pod) {
 		pod.Status.Phase = v1.PodFailed
 	})
 
-	// Pool until 2 new pods have been created to replace deleting and failed pods
+	// Pool until 2 new pods have been created to replace deleting and failed & deleting pods
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		pods = getPods(t, podClient, labelMap())
-		return len(pods.Items) == 4, nil
+		return len(pods.Items) == replicas+2, nil
 	}); err != nil {
-		t.Fatalf("Failed to verify 2 new pods have been created (expected 4 pods): %v", err)
+		t.Fatalf("Failed to verify 2 new pods have been created (expected %d pods): %v", replicas+2, err)
 	}
 
 	// Verify deleting and failed pods are among the four pods
 	foundDeletingPod := false
+	foundFailedDeletingPod := false
 	foundFailedPod := false
 	for _, pod := range pods.Items {
 		if pod.UID == deletingPod.UID {
 			foundDeletingPod = true
+		}
+		if pod.UID == failedDeletingPod.UID {
+			foundFailedDeletingPod = true
 		}
 		if pod.UID == failedPod.UID {
 			foundFailedPod = true
@@ -590,9 +606,13 @@ func TestDeletingAndFailedPods(t *testing.T) {
 	if !foundDeletingPod {
 		t.Fatalf("expected deleting pod %s exists, but it is not found", deletingPod.Name)
 	}
-	// Verify failed pod exists
+	// Verify failed deleting pod exists
+	if !foundFailedDeletingPod {
+		t.Fatalf("expected failed deleting pod %s exists, but it is not found", failedDeletingPod.Name)
+	}
+	// Verify failed pod doesn't exist
 	if !foundFailedPod {
-		t.Fatalf("expected failed pod %s exists, but it is not found", failedPod.Name)
+		t.Fatalf("expected failed pod %s not found, but it exists", failedPod.Name)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60162

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
