### PR TITLE
Fix registry flunder and fisher strategy method names to a standard

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
@@ -31,16 +31,19 @@ import (
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 )
 
+// NewStrategy creates and returns a fischerStrategy instance
 func NewStrategy(typer runtime.ObjectTyper) fischerStrategy {
 	return fischerStrategy{typer, names.SimpleNameGenerator}
 }
 
+// GetAttrs returns labels.Set, fields.Set, the presence of Initializers if any
+// and error in case the given runtime.Object is not a Fischer
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
 	apiserver, ok := obj.(*wardle.Fischer)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a Fischer.")
+		return nil, nil, false, fmt.Errorf("given object is not a Fischer")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), fischerToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	return labels.Set(apiserver.ObjectMeta.Labels), SelectableFields(apiserver), apiserver.Initializers != nil, nil
 }
 
 // MatchFischer is the filter used by the generic etcd backend to watch events
@@ -53,8 +56,8 @@ func MatchFischer(label labels.Selector, field fields.Selector) storage.Selectio
 	}
 }
 
-// fischerToSelectableFields returns a field set that represents the object.
-func fischerToSelectableFields(obj *wardle.Fischer) fields.Set {
+// SelectableFields returns a field set that represents the object.
+func SelectableFields(obj *wardle.Fischer) fields.Set {
 	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -31,16 +31,19 @@ import (
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 )
 
+// NewStrategy creates and returns a flunderStrategy instance
 func NewStrategy(typer runtime.ObjectTyper) flunderStrategy {
 	return flunderStrategy{typer, names.SimpleNameGenerator}
 }
 
+// GetAttrs returns labels.Set, fields.Set, the presence of Initializers if any
+// and error in case the given runtime.Object is not a Flunder
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
 	apiserver, ok := obj.(*wardle.Flunder)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("given object is not a Flunder.")
+		return nil, nil, false, fmt.Errorf("given object is not a Flunder")
 	}
-	return labels.Set(apiserver.ObjectMeta.Labels), FlunderToSelectableFields(apiserver), apiserver.Initializers != nil, nil
+	return labels.Set(apiserver.ObjectMeta.Labels), SelectableFields(apiserver), apiserver.Initializers != nil, nil
 }
 
 // MatchFlunder is the filter used by the generic etcd backend to watch events
@@ -53,8 +56,8 @@ func MatchFlunder(label labels.Selector, field fields.Selector) storage.Selectio
 	}
 }
 
-// FlunderToSelectableFields returns a field set that represents the object.
-func FlunderToSelectableFields(obj *wardle.Flunder) fields.Set {
+// SelectableFields returns a field set that represents the object.
+func SelectableFields(obj *wardle.Flunder) fields.Set {
 	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, true)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes function names for sample-apiserver registry strategy methods that were named not matching golang specifications/recommendations. Adds a few missing comments on public methods

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
no functional changes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
