### PR TITLE
Fix cross build error

### DIFF
--- a/pkg/util/nsenter/nsenter_unsupported.go
+++ b/pkg/util/nsenter/nsenter_unsupported.go
@@ -35,7 +35,7 @@ func NewNsenter() *Nsenter {
 }
 
 // Exec executes nsenter commands in hostProcMountNsPath mount namespace
-func (ne *Nsenter) Exec(args ...string) exec.Cmd {
+func (ne *Nsenter) Exec(cmd string, args []string) exec.Cmd {
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix the cross build error for windows:

```
# k8s.io/kubernetes/pkg/util/io
pkg/util/io/writer.go:61:21: cannot use echoArgs (type []string) as type string in argument to ne.Exec
pkg/util/io/writer.go:71:29: cannot use chmodArgs (type []string) as type string in argument to ne.Exec
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60266

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
