### PR TITLE
Disable mount propagation for windows containers

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -272,6 +272,12 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 // translateMountPropagation transforms v1.MountPropagationMode to
 // runtimeapi.MountPropagation.
 func translateMountPropagation(mountMode *v1.MountPropagationMode) (runtimeapi.MountPropagation, error) {
+	if runtime.GOOS == "windows" {
+		// Windows containers doesn't support mount propagation, use private for it.
+		// Refer https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation.
+		return runtimeapi.MountPropagation_PROPAGATION_PRIVATE, nil
+	}
+
 	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
 		// mount propagation is disabled, use private as in the old versions
 		return runtimeapi.MountPropagation_PROPAGATION_PRIVATE, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Windows containers don't support mount propagation. This PR disables it for windows containers.

Without this PR, windows containers creation would fail with error:

 Error: Error response from daemon: invalid bind mount spec "c:\\var\\lib\\kubelet\\pods\\a260a7c4-1852-11e8-bb1d-000d3a19c1da\\volumes\\kubernetes.io~secret\\default-token-rj7qv:c:/var/run/secrets/kubernetes.io/serviceaccount:ro,rslave": invalid volume specification: 'c:\var\lib\kubelet\pods\a260a7c4-1852-11e8-bb1d-000d3a19c1da\volumes\kubernetes.io~secret\default-token-rj7qv:c:\var\run\secrets\kubernetes.io\serviceaccount:ro,rslave'


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60274

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable mount propagation for windows containers.
```
