### PR TITLE
apiserver: fix testing etcd config in preparation for etcd 3.2.16+

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/utils.go
@@ -155,7 +155,6 @@ func configureTestCluster(t *testing.T, name string, https bool) *EtcdTestServer
 		if err != nil {
 			t.Fatal(err)
 		}
-		m.AuthToken = "simple"
 	} else {
 		cln := newLocalListener(t)
 		m.ClientListeners = []net.Listener{cln}
@@ -165,6 +164,7 @@ func configureTestCluster(t *testing.T, name string, https bool) *EtcdTestServer
 		}
 	}
 
+	m.AuthToken = "simple"
 	m.Name = name
 	m.DataDir, err = ioutil.TempDir(baseDir, "etcd")
 	if err != nil {


### PR DESCRIPTION
The AuthToken must be set, also in non-https mode. Otherwise, etcd refuses to start.