### PR TITLE
rebreak the filter

### DIFF
--- a/pkg/kubectl/resource_filter.go
+++ b/pkg/kubectl/resource_filter.go
@@ -18,9 +18,7 @@ package kubectl
 
 import (
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/printers"
 )
@@ -52,27 +50,6 @@ func filterPods(obj runtime.Object, options printers.PrintOptions) bool {
 		return p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed
 	case *api.Pod:
 		return p.Status.Phase == api.PodSucceeded || p.Status.Phase == api.PodFailed
-	case *unstructured.Unstructured:
-		if (p.GroupVersionKind().GroupKind() != schema.GroupKind{Kind: "Pod"}) {
-			return false
-		}
-		status, ok := p.Object["status"]
-		if !ok {
-			return false
-		}
-		statusMap, ok := status.(map[string]interface{})
-		if !ok {
-			return false
-		}
-		phase, ok := statusMap["phase"]
-		if !ok {
-			return false
-		}
-		phaseString, ok := phase.(string)
-		if !ok {
-			return false
-		}
-		return phaseString == string(api.PodSucceeded) || phaseString == string(api.PodFailed)
 	}
 	return false
 }


### PR DESCRIPTION
Pull https://github.com/kubernetes/kubernetes/pull/60117/commits fixed a bug in the filtering code which was actually being exploited to get inconsistent printing behavior. This reverts the commit that "fixed" the inconsistency and adjusts the test back to the equivalent, pre-printing fixes.

/assign @soltysh 


```release-note
NONE
```