### PR TITLE
expunge the word 'manifest' from Kubelet's config API

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -66,10 +66,10 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.KubeletConfiguration = kubeadm.KubeletConfiguration{
 				BaseConfig: &kubeletconfigv1beta1.KubeletConfiguration{
-					PodManifestPath: "foo",
-					ClusterDNS:      []string{"foo"},
-					ClusterDomain:   "foo",
-					Authorization:   kubeletconfigv1beta1.KubeletAuthorization{Mode: "foo"},
+					StaticPodPath: "foo",
+					ClusterDNS:    []string{"foo"},
+					ClusterDomain: "foo",
+					Authorization: kubeletconfigv1beta1.KubeletAuthorization{Mode: "foo"},
 					Authentication: kubeletconfigv1beta1.KubeletAuthentication{
 						X509: kubeletconfigv1beta1.KubeletX509Authentication{ClientCAFile: "foo"},
 					},

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -197,8 +197,8 @@ func SetDefaults_KubeletConfiguration(obj *MasterConfiguration) {
 	if obj.KubeletConfiguration.BaseConfig == nil {
 		obj.KubeletConfiguration.BaseConfig = &kubeletconfigv1beta1.KubeletConfiguration{}
 	}
-	if obj.KubeletConfiguration.BaseConfig.PodManifestPath == "" {
-		obj.KubeletConfiguration.BaseConfig.PodManifestPath = DefaultManifestsDir
+	if obj.KubeletConfiguration.BaseConfig.StaticPodPath == "" {
+		obj.KubeletConfiguration.BaseConfig.StaticPodPath = DefaultManifestsDir
 	}
 	if obj.KubeletConfiguration.BaseConfig.ClusterDNS == nil {
 		dnsIP, err := constants.GetDNSIP(obj.Networking.ServiceSubnet)

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -65,7 +65,7 @@ type KubeletFlags struct {
 	//                Kubelet's runonce mode anymore, so it may be a candidate
 	//                for deprecation and removal.
 	// If runOnce is true, the Kubelet will check the API server once for pods,
-	// run those in addition to the pods specified by the local manifest, and exit.
+	// run those in addition to the pods specified by static pod files, and exit.
 	RunOnce bool
 
 	// enableServer enables the Kubelet's server
@@ -344,7 +344,7 @@ func (f *KubeletFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&f.ReallyCrashForTesting, "really-crash-for-testing", f.ReallyCrashForTesting, "If true, when panics occur crash. Intended for testing.")
 	fs.Float64Var(&f.ChaosChance, "chaos-chance", f.ChaosChance, "If > 0.0, introduce random client errors and latency. Intended for testing.")
 
-	fs.BoolVar(&f.RunOnce, "runonce", f.RunOnce, "If true, exit after spawning pods from local manifests or remote urls. Exclusive with --enable-server")
+	fs.BoolVar(&f.RunOnce, "runonce", f.RunOnce, "If true, exit after spawning pods from static pod files or remote urls. Exclusive with --enable-server")
 	fs.BoolVar(&f.EnableServer, "enable-server", f.EnableServer, "Enable the Kubelet's server")
 
 	fs.StringVar(&f.HostnameOverride, "hostname-override", f.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
@@ -440,12 +440,12 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.BoolVar(&c.FailSwapOn, "experimental-fail-swap-on", c.FailSwapOn, "DEPRECATED: please use --fail-swap-on instead.")
 	fs.MarkDeprecated("experimental-fail-swap-on", "This flag is deprecated and will be removed in future releases. please use --fail-swap-on instead.")
 
-	fs.StringVar(&c.PodManifestPath, "pod-manifest-path", c.PodManifestPath, "Path to the directory containing pod manifest files to run, or the path to a single pod manifest file. Files starting with dots will be ignored.")
+	fs.StringVar(&c.StaticPodPath, "pod-manifest-path", c.StaticPodPath, "Path to the directory containing static pod files to run, or the path to a single static pod file. Files starting with dots will be ignored.")
 	fs.DurationVar(&c.SyncFrequency.Duration, "sync-frequency", c.SyncFrequency.Duration, "Max period between synchronizing running containers and config")
 	fs.DurationVar(&c.FileCheckFrequency.Duration, "file-check-frequency", c.FileCheckFrequency.Duration, "Duration between checking config files for new data")
 	fs.DurationVar(&c.HTTPCheckFrequency.Duration, "http-check-frequency", c.HTTPCheckFrequency.Duration, "Duration between checking http for new data")
-	fs.StringVar(&c.ManifestURL, "manifest-url", c.ManifestURL, "URL for accessing the container manifest")
-	fs.Var(flag.NewColonSeparatedMultimapStringString(&c.ManifestURLHeader), "manifest-url-header", "Comma-separated list of HTTP headers to use when accessing the manifest URL. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: `--manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'`")
+	fs.StringVar(&c.StaticPodURL, "manifest-url", c.StaticPodURL, "URL for accessing additional Pod specifications to run")
+	fs.Var(flag.NewColonSeparatedMultimapStringString(&c.StaticPodURLHeader), "manifest-url-header", "Comma-separated list of HTTP headers to use when accessing the url provided to --manifest-url. Multiple headers with the same name will be added in the same order provided. This flag can be repeatedly invoked. For example: `--manifest-url-header 'a:hello,b:again,c:world' --manifest-url-header 'b:beautiful'`")
 	fs.Var(componentconfig.IPVar{Val: &c.Address}, "address", "The IP address for the Kubelet to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces)")
 	fs.Int32Var(&c.Port, "port", c.Port, "The port for the Kubelet to serve on.")
 	fs.Int32Var(&c.ReadOnlyPort, "read-only-port", c.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -89,7 +89,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.CgroupsPerQOS = true
 			obj.CgroupDriver = "cgroupfs"
 			obj.EnforceNodeAllocatable = v1beta1.DefaultNodeAllocatableEnforcement
-			obj.ManifestURLHeader = make(map[string][]string)
+			obj.StaticPodURLHeader = make(map[string][]string)
 			obj.ContainerLogMaxFiles = 5
 			obj.ContainerLogMaxSize = "10Mi"
 		},

--- a/pkg/kubelet/apis/kubeletconfig/helpers.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers.go
@@ -21,7 +21,7 @@ package kubeletconfig
 // passing the configuration to the application. This method must be kept up to date as new fields are added.
 func KubeletConfigurationPathRefs(kc *KubeletConfiguration) []*string {
 	paths := []*string{}
-	paths = append(paths, &kc.PodManifestPath)
+	paths = append(paths, &kc.StaticPodPath)
 	paths = append(paths, &kc.Authentication.X509.ClientCAFile)
 	paths = append(paths, &kc.TLSCertFile)
 	paths = append(paths, &kc.TLSPrivateKeyFile)

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -128,7 +128,7 @@ func TestAllPrimitiveFieldPaths(t *testing.T) {
 var (
 	// KubeletConfiguration fields that contain file paths. If you update this, also update KubeletConfigurationPathRefs!
 	kubeletConfigurationPathFieldPaths = sets.NewString(
-		"PodManifestPath",
+		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
 		"TLSCertFile",
 		"TLSPrivateKeyFile",
@@ -187,8 +187,8 @@ var (
 		"KubeReserved[*]",
 		"KubeletCgroups",
 		"MakeIPTablesUtilChains",
-		"ManifestURL",
-		"ManifestURLHeader[*][*]",
+		"StaticPodURL",
+		"StaticPodURLHeader[*][*]",
 		"MaxOpenFiles",
 		"MaxPods",
 		"NodeStatusUpdateFrequency.Duration",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -44,9 +44,9 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta
 
-	// podManifestPath is the path to the directory containing pod manifests to
-	// run, or the path to a single manifest file
-	PodManifestPath string
+	// staticPodPath is the path to the directory containing local (static) pods to
+	// run, or the path to a single static pod file.
+	StaticPodPath string
 	// syncFrequency is the max period between synchronizing running
 	// containers and config
 	SyncFrequency metav1.Duration
@@ -55,10 +55,10 @@ type KubeletConfiguration struct {
 	FileCheckFrequency metav1.Duration
 	// httpCheckFrequency is the duration between checking http for new data
 	HTTPCheckFrequency metav1.Duration
-	// manifestURL is the URL for accessing the container manifest
-	ManifestURL string
-	// manifestURLHeader is a map of slices with HTTP headers to use when accessing the manifestURL
-	ManifestURLHeader map[string][]string
+	// staticPodURL is the URL for accessing static pods to run
+	StaticPodURL string
+	// staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
+	StaticPodURLHeader map[string][]string
 	// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 	// for all interfaces)
 	Address string

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -44,11 +44,11 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// podManifestPath is the path to the directory containing pod manifests to
-	// run, or the path to a single manifest file.
+	// staticPodPath is the path to the directory containing local (static) pods to
+	// run, or the path to a single static pod file.
 	// Default: ""
 	// +optional
-	PodManifestPath string `json:"podManifestPath,omitempty"`
+	StaticPodPath string `json:"staticPodPath,omitempty"`
 	// syncFrequency is the max period between synchronizing running
 	// containers and config.
 	// Default: "1m"
@@ -63,14 +63,14 @@ type KubeletConfiguration struct {
 	// Default: "20s"
 	// +optional
 	HTTPCheckFrequency metav1.Duration `json:"httpCheckFrequency,omitempty"`
-	// manifestURL is the URL for accessing the container manifest
+	// staticPodURL is the URL for accessing static pods to run
 	// Default: ""
 	// +optional
-	ManifestURL string `json:"manifestURL,omitempty"`
-	// manifestURLHeader is a map of slices with HTTP headers to use when accessing the manifestURL
+	StaticPodURL string `json:"staticPodURL,omitempty"`
+	// staticPodURLHeader is a map of slices with HTTP headers to use when accessing the podURL
 	// Default: nil
 	// +optional
-	ManifestURLHeader map[string][]string `json:"manifestURLHeader,omitempty"`
+	StaticPodURLHeader map[string][]string `json:"staticPodURLHeader,omitempty"`
 	// address is the IP address for the Kubelet to serve on (set to 0.0.0.0
 	// for all interfaces).
 	// Default: "0.0.0.0"

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
@@ -141,12 +141,12 @@ func Convert_kubeletconfig_KubeletAuthorization_To_v1beta1_KubeletAuthorization(
 }
 
 func autoConvert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(in *KubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
-	out.PodManifestPath = in.PodManifestPath
+	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
 	out.HTTPCheckFrequency = in.HTTPCheckFrequency
-	out.ManifestURL = in.ManifestURL
-	out.ManifestURLHeader = *(*map[string][]string)(unsafe.Pointer(&in.ManifestURLHeader))
+	out.StaticPodURL = in.StaticPodURL
+	out.StaticPodURLHeader = *(*map[string][]string)(unsafe.Pointer(&in.StaticPodURLHeader))
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
@@ -262,12 +262,12 @@ func Convert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(
 }
 
 func autoConvert_kubeletconfig_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in *kubeletconfig.KubeletConfiguration, out *KubeletConfiguration, s conversion.Scope) error {
-	out.PodManifestPath = in.PodManifestPath
+	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
 	out.HTTPCheckFrequency = in.HTTPCheckFrequency
-	out.ManifestURL = in.ManifestURL
-	out.ManifestURLHeader = *(*map[string][]string)(unsafe.Pointer(&in.ManifestURLHeader))
+	out.StaticPodURL = in.StaticPodURL
+	out.StaticPodURLHeader = *(*map[string][]string)(unsafe.Pointer(&in.StaticPodURLHeader))
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
@@ -92,8 +92,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
 	out.HTTPCheckFrequency = in.HTTPCheckFrequency
-	if in.ManifestURLHeader != nil {
-		in, out := &in.ManifestURLHeader, &out.ManifestURLHeader
+	if in.StaticPodURLHeader != nil {
+		in, out := &in.StaticPodURLHeader, &out.StaticPodURLHeader
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
 			if val == nil {

--- a/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
@@ -83,8 +83,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
 	out.HTTPCheckFrequency = in.HTTPCheckFrequency
-	if in.ManifestURLHeader != nil {
-		in, out := &in.ManifestURLHeader, &out.ManifestURLHeader
+	if in.StaticPodURLHeader != nil {
+		in, out := &in.StaticPodURLHeader, &out.StaticPodURLHeader
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
 			if val == nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -255,8 +255,8 @@ type Dependencies struct {
 // KubeletConfiguration or returns an error.
 func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *Dependencies, nodeName types.NodeName, bootstrapCheckpointPath string) (*config.PodConfig, error) {
 	manifestURLHeader := make(http.Header)
-	if len(kubeCfg.ManifestURLHeader) > 0 {
-		for k, v := range kubeCfg.ManifestURLHeader {
+	if len(kubeCfg.StaticPodURLHeader) > 0 {
+		for k, v := range kubeCfg.StaticPodURLHeader {
 			for i := range v {
 				manifestURLHeader.Add(k, v[i])
 			}
@@ -267,15 +267,15 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder)
 
 	// define file config source
-	if kubeCfg.PodManifestPath != "" {
-		glog.Infof("Adding manifest path: %v", kubeCfg.PodManifestPath)
-		config.NewSourceFile(kubeCfg.PodManifestPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
+	if kubeCfg.StaticPodPath != "" {
+		glog.Infof("Adding pod path: %v", kubeCfg.StaticPodPath)
+		config.NewSourceFile(kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
 	}
 
 	// define url config source
-	if kubeCfg.ManifestURL != "" {
-		glog.Infof("Adding manifest url %q with HTTP header %v", kubeCfg.ManifestURL, manifestURLHeader)
-		config.NewSourceURL(kubeCfg.ManifestURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(kubetypes.HTTPSource))
+	if kubeCfg.StaticPodURL != "" {
+		glog.Infof("Adding pod url %q with HTTP header %v", kubeCfg.StaticPodURL, manifestURLHeader)
+		config.NewSourceURL(kubeCfg.StaticPodURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(kubetypes.HTTPSource))
 	}
 
 	// Restore from the checkpoint path

--- a/pkg/kubelet/kubeletconfig/configfiles/configfiles_test.go
+++ b/pkg/kubelet/kubeletconfig/configfiles/configfiles_test.go
@@ -114,20 +114,20 @@ apiVersion: kubelet.config.k8s.io/v1beta1`),
 			"yaml, relative path is resolved",
 			newString(fmt.Sprintf(`kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
-podManifestPath: %s`, relativePath)),
+staticPodPath: %s`, relativePath)),
 			func() *kubeletconfig.KubeletConfiguration {
 				kc := newConfig(t)
-				kc.PodManifestPath = filepath.Join(configDir, relativePath)
+				kc.StaticPodPath = filepath.Join(configDir, relativePath)
 				return kc
 			}(),
 			"",
 		},
 		{
 			"json, relative path is resolved",
-			newString(fmt.Sprintf(`{"kind":"KubeletConfiguration","apiVersion":"kubelet.config.k8s.io/v1beta1","podManifestPath":"%s"}`, relativePath)),
+			newString(fmt.Sprintf(`{"kind":"KubeletConfiguration","apiVersion":"kubelet.config.k8s.io/v1beta1","staticPodPath":"%s"}`, relativePath)),
 			func() *kubeletconfig.KubeletConfiguration {
 				kc := newConfig(t)
-				kc.PodManifestPath = filepath.Join(configDir, relativePath)
+				kc.StaticPodPath = filepath.Join(configDir, relativePath)
 				return kc
 			}(),
 			"",

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -105,7 +105,7 @@ func GetHollowKubeletConfig(
 	podsPerCore int) (*options.KubeletFlags, *kubeletconfig.KubeletConfiguration) {
 
 	testRootDir := utils.MakeTempDirOrDie("hollow-kubelet.", "")
-	manifestFilePath := utils.MakeTempDirOrDie("manifest", testRootDir)
+	podFilePath := utils.MakeTempDirOrDie("static-pods", testRootDir)
 	glog.Infof("Using %s as root dir for hollow-kubelet", testRootDir)
 
 	// Flags struct
@@ -125,11 +125,11 @@ func GetHollowKubeletConfig(
 		panic(err)
 	}
 
-	c.ManifestURL = ""
+	c.StaticPodURL = ""
 	c.Address = "0.0.0.0" /* bind address */
 	c.Port = int32(kubeletPort)
 	c.ReadOnlyPort = int32(kubeletReadOnlyPort)
-	c.PodManifestPath = manifestFilePath
+	c.StaticPodPath = podFilePath
 	c.FileCheckFrequency.Duration = 20 * time.Second
 	c.HTTPCheckFrequency.Duration = 20 * time.Second
 	c.NodeStatusUpdateFrequency.Duration = 10 * time.Second

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -39,16 +39,16 @@ import (
 var _ = framework.KubeDescribe("MirrorPod", func() {
 	f := framework.NewDefaultFramework("mirror-pod")
 	Context("when create a mirror pod ", func() {
-		var ns, manifestPath, staticPodName, mirrorPodName string
+		var ns, podPath, staticPodName, mirrorPodName string
 		BeforeEach(func() {
 			ns = f.Namespace.Name
 			staticPodName = "static-pod-" + string(uuid.NewUUID())
 			mirrorPodName = staticPodName + "-" + framework.TestContext.NodeName
 
-			manifestPath = framework.TestContext.KubeletConfig.PodManifestPath
+			podPath = framework.TestContext.KubeletConfig.StaticPodPath
 
 			By("create the static pod")
-			err := createStaticPod(manifestPath, staticPodName, ns,
+			err := createStaticPod(podPath, staticPodName, ns,
 				imageutils.GetE2EImage(imageutils.NginxSlim), v1.RestartPolicyAlways)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -65,7 +65,7 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 
 			By("update the static pod container image")
 			image := imageutils.GetPauseImageNameForHostArch()
-			err = createStaticPod(manifestPath, staticPodName, ns, image, v1.RestartPolicyAlways)
+			err = createStaticPod(podPath, staticPodName, ns, image, v1.RestartPolicyAlways)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("wait for the mirror pod to be updated")
@@ -111,7 +111,7 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 		})
 		AfterEach(func() {
 			By("delete the static pod")
-			err := deleteStaticPod(manifestPath, staticPodName, ns)
+			err := deleteStaticPod(podPath, staticPodName, ns)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("wait for the mirror pod to disappear")

--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -146,15 +146,15 @@ func loadConformanceImage(host, workspace string) error {
 // kubeletLauncherLog is the log of kubelet launcher.
 const kubeletLauncherLog = "kubelet-launcher.log"
 
-// kubeletPodManifestPath is a fixed known pod manifest path. We can not use the random pod
+// kubeletPodPath is a fixed known pod specification path. We can not use the random pod
 // manifest directory generated in e2e_node.test because we need to mount the directory into
 // the conformance test container, it's easier if it's a known directory.
 // TODO(random-liu): Get rid of this once we switch to cluster e2e node bootstrap script.
-var kubeletPodManifestPath = "conformance-pod-manifest-" + timestamp
+var kubeletPodPath = "conformance-pod-manifest-" + timestamp
 
-// getPodManifestPath returns pod manifest full path.
-func getPodManifestPath(workspace string) string {
-	return filepath.Join(workspace, kubeletPodManifestPath)
+// getPodPath returns pod manifest full path.
+func getPodPath(workspace string) string {
+	return filepath.Join(workspace, kubeletPodPath)
 }
 
 // isSystemd returns whether the node is a systemd node.
@@ -173,7 +173,7 @@ func isSystemd(host string) (bool, error) {
 // node conformance test.
 // TODO(random-liu): Switch to use standard node bootstrap script.
 func launchKubelet(host, workspace, results, testArgs string) error {
-	podManifestPath := getPodManifestPath(workspace)
+	podManifestPath := getPodPath(workspace)
 	if output, err := SSH(host, "mkdir", podManifestPath); err != nil {
 		return fmt.Errorf("failed to create kubelet pod manifest path %q: error - %v output - %q",
 			podManifestPath, err, output)
@@ -249,7 +249,7 @@ func stopKubelet(host, workspace string) error {
 	}
 	glog.Info("Successfully stop kubelet")
 	// Clean up the pod manifest path
-	podManifestPath := getPodManifestPath(workspace)
+	podManifestPath := getPodPath(workspace)
 	if output, err := SSH(host, "rm", "-f", filepath.Join(workspace, podManifestPath)); err != nil {
 		return fmt.Errorf("failed to cleanup pod manifest directory %q: error - %v, output - %q",
 			podManifestPath, err, output)
@@ -291,7 +291,7 @@ func (c *ConformanceRemote) RunTest(host, workspace, results, imageDesc, junitFi
 
 	// Run the tests
 	glog.V(2).Infof("Starting tests on %q", host)
-	podManifestPath := getPodManifestPath(workspace)
+	podManifestPath := getPodPath(workspace)
 	cmd := fmt.Sprintf("'timeout -k 30s %fs docker run --rm --privileged=true --net=host -v /:/rootfs -v %s:%s -v %s:/var/result -e TEST_ARGS=--report-prefix=%s %s'",
 		timeout.Seconds(), podManifestPath, podManifestPath, results, junitFilePrefix, getConformanceTestImageName(systemSpecName))
 	testOutput, err := SSH(host, "sh", "-c", cmd)


### PR DESCRIPTION
The word 'manifest' technically refers to a container-group specification
that predated the Pod abstraction. We should avoid using this legacy
terminology where possible. Fortunately, the Kubelet's config API will
be beta in 1.10 for the first time, so we still had the chance to make
this change.

I left the flags alone, since they're deprecated anyway.

I changed a few var names in files I touched too, but this PR is the
just the first shot, not the whole campaign
(`git grep -i manifest | wc -l -> 1248`).

```release-note
Some field names in the Kubelet's now v1beta1 config API differ from the v1alpha1 API: PodManifestPath is renamed to StaticPodPath, ManifestURL is renamed to StaticPodURL, ManifestURLHeader is renamed to StaticPodURLHeader.
```
