### PR TITLE
Adding rramkumar1 and MrHohn as reviewer & approver to pkg/test

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -90,6 +90,7 @@ aliases:
     - mrhohn
     - nicksardo
     - thockin
+    - rramkumar1
   sig-apps-reviewers:
     - enisoc
     - erictune

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
   - bowei
+  - rramkumar1
+  - MrHohn
   - deads2k
   - enisoc
   - enj # for test/integration/etcd/etcd_storage_path_test.go
@@ -27,6 +29,8 @@ reviewers:
 approvers:
   - bowei # for test/e2e/{dns*,network}.go
   - cblecker
+  - rramkumar1
+  - MrHohn
   - deads2k
   - enisoc
   - enj # for test/integration/etcd/etcd_storage_path_test.go


### PR DESCRIPTION
We both have been working quite extensively with the e2e testing framework, especially for ingress.

**Release note**:
```release-note
None
```

/cc @MrHohn 
/assign @bowei 
