### PR TITLE
auth: reregister auth providers

### DIFF
--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
     ],
 )
 

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -28,6 +28,9 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
+
+	// Import to initialize client auth plugins.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {


### PR DESCRIPTION
Alternatively we can register this in the mains of most (or all) components.

Fixes GKE e2es
Fixes: 5d721bff817ba4ef8c2cbab53bb46e69b955ebe3

That PR unregistered auth providers for kubectl and probably elsewhere.

```release-note
NONE
```
