### PR TITLE
ADD UT TEST of cinder volume

### DIFF
--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -235,7 +235,9 @@ func TestConstructVolumeSpec(t *testing.T) {
 	}
 
 	cinderSpec, err := plug.(*cinderPlugin).ConstructVolumeSpec("cinderVolume", "/cinderVolume/")
-
+	if err != nil {
+		t.Errorf("ConstructVolumeSpec failed: %v", err)
+	}
 	if cinderSpec.Name() != "cinderVolume" {
 		t.Errorf("Get wrong cinder spec name, got: %s", cinderSpec.Name())
 	}

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -220,3 +220,23 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Deleter() failed: %v", err)
 	}
 }
+
+func TestConstructVolumeSpec(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("cinderTest")
+	if err != nil {
+		t.Fatalf("Can't make a temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(tmpDir, nil, nil))
+	plug, err := plugMgr.FindPluginByName("kubernetes.io/cinder")
+	if err != nil {
+		t.Errorf("can't find cinder plugin by name")
+	}
+
+	cinderSpec, err := plug.(*cinderPlugin).ConstructVolumeSpec("cinderVolume", "/cinderVolume/")
+
+	if cinderSpec.Name() != "cinderVolume" {
+		t.Errorf("Get wrong cinder spec name, got: %s", cinderSpec.Name())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
add ut test to func ConstructVolumeSpec in cinder test 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
