### PR TITLE
bootstrappolicy: defaulting instead of overriding labels and annotations

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -64,7 +64,9 @@ func addDefaultMetadata(obj runtime.Object) {
 		labels = map[string]string{}
 	}
 	for k, v := range Label {
-		labels[k] = v
+		if _, found := labels[k]; !found {
+			labels[k] = v
+		}
 	}
 	metadata.SetLabels(labels)
 
@@ -73,7 +75,9 @@ func addDefaultMetadata(obj runtime.Object) {
 		annotations = map[string]string{}
 	}
 	for k, v := range Annotation {
-		annotations[k] = v
+		if _, found := annotations[k]; !found {
+			annotations[k] = v
+		}
 	}
 	metadata.SetAnnotations(annotations)
 }


### PR DESCRIPTION
The bootstrappolicy currently always set:

1. label: kubernetes.io/bootstraping: rbac-defaults
2. annotations: rbac.authorization.kubernetes.io/autoupdate: true

This actually disabled the capability to add roles(or rolebindings)
which does not require reconciliation(by set the annotation value
to be false).

```release-note
NONE
```
