### PR TITLE
fix "make test"

### DIFF
--- a/pkg/kubelet/winstats/BUILD
+++ b/pkg/kubelet/winstats/BUILD
@@ -2,7 +2,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = select({
+    srcs = [
+        "doc.go",
+    ] + select({
         "@io_bazel_rules_go//go/platform:windows": [
             "perfcounter_nodestats.go",
             "perfcounters.go",

--- a/pkg/kubelet/winstats/doc.go
+++ b/pkg/kubelet/winstats/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package winstats provides a client to get node and pod level stats on windows
+package winstats // import "k8s.io/kubernetes/pkg/kubelet/winstats"

--- a/pkg/kubelet/winstats/winstats.go
+++ b/pkg/kubelet/winstats/winstats.go
@@ -144,6 +144,7 @@ func (c *StatsClient) createRootContainerInfo() (*cadvisorapiv2.ContainerInfo, e
 	return &rootInfo, nil
 }
 
+// GetDirFsInfo returns filesystem capacity and usage information.
 func (c *StatsClient) GetDirFsInfo(path string) (cadvisorapiv2.FsInfo, error) {
 	var freeBytesAvailable, totalNumberOfBytes, totalNumberOfFreeBytes int64
 	var err error


### PR DESCRIPTION
Before this pr, we get this in linux:
```
$ make test
Running tests for APIVersion: v1,admissionregistration.k8s.io/v1alpha1,admissionregistration.k8s.io/v1beta1,admission.k8s.io/v1beta1,apps/v1beta1,apps/v1beta2,apps/v1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2beta1,batch/v1,batch/v1beta1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,events.k8s.io/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1beta1,storage.k8s.io/v1,storage.k8s.io/v1alpha1,
+++ [0224 16:10:13] Running tests without code coverage
can't load package: package k8s.io/kubernetes/pkg/kubelet/winstats: build constraints exclude all Go files in /home/fujitsu/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/winstats
!!! [0224 16:10:15] Call tree:
!!! [0224 16:10:15]  1: hack/make-rules/test.sh:402 runTests(...)
Makefile:182: recipe for target 'test' failed
make: *** [test] Error 1
```

```release-note
NONE
```
