### PR TITLE
flag value bindings for kubectl apply commands

### DIFF
--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -60,7 +60,9 @@ var (
 
 func NewCmdApplyEditLastApplied(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	options := &editor.EditOptions{
-		EditMode: editor.ApplyEditMode,
+		EditMode:           editor.ApplyEditMode,
+		Output:             "yaml",
+		WindowsLineEndings: runtime.GOOS == "windows",
 	}
 	validArgs := cmdutil.ValidArgList(f)
 
@@ -85,8 +87,8 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, out, errOut io.Writer) *cobra
 
 	usage := "to use to edit the resource"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
-	cmd.Flags().StringVarP(&options.Output, "output", "o", "yaml", "Output format. One of: yaml|json.")
-	cmd.Flags().BoolVar(&options.WindowsLineEndings, "windows-line-endings", runtime.GOOS == "windows",
+	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Output format. One of: yaml|json.")
+	cmd.Flags().BoolVar(&options.WindowsLineEndings, "windows-line-endings", options.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddRecordVarFlag(cmd, &options.Record)
 	cmdutil.AddIncludeUninitializedFlag(cmd)

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -99,7 +99,7 @@ func NewCmdApplySetLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Com
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddPrinterFlags(cmd)
-	cmd.Flags().BoolVar(&options.CreateAnnotation, "create-annotation", false, "Will create 'last-applied-configuration' annotations if current objects doesn't have one")
+	cmd.Flags().BoolVar(&options.CreateAnnotation, "create-annotation", options.CreateAnnotation, "Will create 'last-applied-configuration' annotations if current objects doesn't have one")
 	usage := "that contains the last-applied-configuration annotations"
 	kubectl.AddJsonFilenameFlag(cmd, &options.FilenameOptions.Filenames, "Filename, directory, or URL to files "+usage)
 

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -57,8 +57,16 @@ var (
 		kubectl apply view-last-applied -f deploy.yaml -o json`))
 )
 
+func NewViewLastAppliedOptions(out, err io.Writer) *ViewLastAppliedOptions {
+	return &ViewLastAppliedOptions{
+		Out:          out,
+		ErrOut:       err,
+		OutputFormat: "yaml",
+	}
+}
+
 func NewCmdApplyViewLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
-	options := &ViewLastAppliedOptions{Out: out, ErrOut: err}
+	options := NewViewLastAppliedOptions(out, err)
 	cmd := &cobra.Command{
 		Use: "view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAME)",
 		DisableFlagsInUseLine: true,
@@ -66,23 +74,22 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Co
 		Long:    applyViewLastAppliedLong,
 		Example: applyViewLastAppliedExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(options.ValidateOutputArgs(cmd))
-			cmdutil.CheckErr(options.Complete(f, args))
+			cmdutil.CheckErr(options.Complete(cmd, f, args))
 			cmdutil.CheckErr(options.Validate(cmd))
-			cmdutil.CheckErr(options.RunApplyViewLastApplied())
+			cmdutil.CheckErr(options.RunApplyViewLastApplied(cmd))
 		},
 	}
 
-	cmd.Flags().StringP("output", "o", "", "Output format. Must be one of yaml|json")
-	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
-	cmd.Flags().BoolVar(&options.All, "all", false, "Select all resources in the namespace of the specified resource types")
+	cmd.Flags().StringVarP(&options.OutputFormat, "output", "o", options.OutputFormat, "Output format. Must be one of yaml|json")
+	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().BoolVar(&options.All, "all", options.All, "Select all resources in the namespace of the specified resource types")
 	usage := "that contains the last-applied-configuration annotations"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 
 	return cmd
 }
 
-func (o *ViewLastAppliedOptions) Complete(f cmdutil.Factory, args []string) error {
+func (o *ViewLastAppliedOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args []string) error {
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -130,7 +137,7 @@ func (o *ViewLastAppliedOptions) Validate(cmd *cobra.Command) error {
 	return nil
 }
 
-func (o *ViewLastAppliedOptions) RunApplyViewLastApplied() error {
+func (o *ViewLastAppliedOptions) RunApplyViewLastApplied(cmd *cobra.Command) error {
 	for _, str := range o.LastAppliedConfigurationList {
 		switch o.OutputFormat {
 		case "json":
@@ -146,23 +153,13 @@ func (o *ViewLastAppliedOptions) RunApplyViewLastApplied() error {
 				return err
 			}
 			fmt.Fprint(o.Out, string(yamlOutput))
+		default:
+			return cmdutil.UsageErrorf(
+				cmd,
+				"Unexpected -o output mode: %s, the flag 'output' must be one of yaml|json",
+				o.OutputFormat)
 		}
 	}
 
 	return nil
-}
-
-func (o *ViewLastAppliedOptions) ValidateOutputArgs(cmd *cobra.Command) error {
-	format := cmdutil.GetFlagString(cmd, "output")
-	switch format {
-	case "json":
-		o.OutputFormat = "json"
-		return nil
-	// If flag -o is not specified, use yaml as default
-	case "yaml", "":
-		o.OutputFormat = "yaml"
-		return nil
-	default:
-		return cmdutil.UsageErrorf(cmd, "Unexpected -o output mode: %s, the flag 'output' must be one of yaml|json", format)
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
/kind cleanup
/sig cli

xxxOptions did not get bound as default value for some flags.
This PR cleans those flag bindings for `kubectl apply` commands.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #60366

**Special notes for your reviewer**:
/assign @deads2k 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
