### PR TITLE
clean up elasticsearch from unit test

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -228,11 +228,6 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"namespace-dev":       &api.Namespace{},
 			"namespace-prod":      &api.Namespace{},
 		},
-		"../examples/elasticsearch": {
-			"es-rc":           &api.ReplicationController{},
-			"es-svc":          &api.Service{},
-			"service-account": nil,
-		},
 		"../examples/explorer": {
 			"pod": &api.Pod{},
 		},


### PR DESCRIPTION
The example of elasticsearch has been removed.

**Release note**:
```release-note
NONE
```
