### PR TITLE
Use quotas in default performance tests

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -491,7 +491,7 @@ var _ = SIGDescribe("Density", func() {
 	}
 
 	isCanonical := func(test *Density) bool {
-		return test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && !test.quotas
+		return test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && test.quotas
 	}
 
 	for _, testArg := range densityTests {

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -197,7 +197,7 @@ var _ = SIGDescribe("Load capacity", func() {
 	}
 
 	isCanonical := func(test *Load) bool {
-		return test.podsPerNode == 30 && test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && !test.quotas
+		return test.podsPerNode == 30 && test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && test.quotas
 	}
 
 	for _, testArg := range loadTests {


### PR DESCRIPTION
Better to use more features in default tests if possible.

LGTM whenever you think we're ready.

```release-note
NONE
```