### PR TITLE
Move retry-based updates to a different pkg

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2782,9 +2782,7 @@ func ScaleResource(
 ) error {
 	By(fmt.Sprintf("Scaling %v %s in namespace %s to %d", kind, name, ns, size))
 	scaler := kubectl.ScalerFor(kind, internalClientset.Batch(), scalesGetter, gr)
-	waitForScale := kubectl.NewRetryParams(5*time.Second, 1*time.Minute)
-	waitForReplicas := kubectl.NewRetryParams(5*time.Second, 5*time.Minute)
-	if err := scaler.Scale(ns, name, size, nil, waitForScale, waitForReplicas); err != nil {
+	if err := testutil.ScaleResourceWithRetries(scaler, ns, name, size); err != nil {
 		return fmt.Errorf("error while scaling RC %s to %d replicas: %v", name, size, err)
 	}
 	if !wait {

--- a/test/utils/BUILD
+++ b/test/utils/BUILD
@@ -16,6 +16,7 @@ go_library(
         "replicaset.go",
         "runners.go",
         "tmpdir.go",
+        "update_resources.go",
     ],
     importpath = "k8s.io/kubernetes/test/utils",
     deps = [
@@ -25,6 +26,7 @@ go_library(
         "//pkg/apis/extensions:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
+        "//pkg/kubectl:go_default_library",
         "//pkg/util/labels:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/kubernetes/pkg/kubectl"
+)
+
+const (
+	// Parameters for retrying updates/waits with linear backoff.
+	// TODO: Try to move this to exponential backoff by modifying kubectl.Scale().
+	updateRetryInterval = 5 * time.Second
+	updateRetryTimeout  = 1 * time.Minute
+	waitRetryInterval   = 5 * time.Second
+	waitRetryTImeout    = 5 * time.Minute
+)
+
+func ScaleResourceWithRetries(scaler kubectl.Scaler, namespace, name string, size uint) error {
+	waitForScale := kubectl.NewRetryParams(updateRetryInterval, updateRetryTimeout)
+	waitForReplicas := kubectl.NewRetryParams(waitRetryInterval, waitRetryTImeout)
+	if err := scaler.Scale(namespace, name, size, nil, waitForScale, waitForReplicas); err != nil {
+		return fmt.Errorf("Error while scaling %s to %d replicas: %v", name, size, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/55860

This PR is not really changing retries for updates (it was there even before), just moving it to a separate place where we can add more functions later.
I'll work on my earlier PR https://github.com/kubernetes/kubernetes/pull/56075 to make RC Scale() poll-based to solve issues like https://github.com/kubernetes/kubernetes/issues/56064.

/cc @wojtek-t 

```release-note
NONE
```