### PR TITLE
don't use storage cache during apiserver unit test

### DIFF
--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -92,7 +92,10 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, informers.SharedI
 	resourceEncoding.SetVersionEncoding(certificates.GroupName, *testapi.Certificates.GroupVersion(), schema.GroupVersion{Group: certificates.GroupName, Version: runtime.APIVersionInternal})
 	storageFactory := serverstorage.NewDefaultStorageFactory(*storageConfig, testapi.StorageMediaType(), legacyscheme.Codecs, resourceEncoding, DefaultAPIResourceConfigSource(), nil)
 
-	err := options.NewEtcdOptions(storageConfig).ApplyWithStorageFactoryTo(storageFactory, config.GenericConfig)
+	etcdOptions := options.NewEtcdOptions(storageConfig)
+	// unit tests don't need watch cache and it leaks lots of goroutines with etcd testing functions during unit tests
+	etcdOptions.EnableWatchCache = false
+	err := etcdOptions.ApplyWithStorageFactoryTo(storageFactory, config.GenericConfig)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
General apiserver unit tests don't need to test the caching storage.  It also leaks a bunch a goroutines which does bad things with race detection on and caused timeouts when upgrading etcd.

@kubernetes/sig-api-machinery-bugs 
@sttts you can try pulling this in.
@liggitt doesn't affect "normal" runtime, which is why we only see it during tests.  See relax.