### PR TITLE
kubelet: fix bug where character device is not recognized

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -432,7 +432,7 @@ func (mounter *Mounter) GetFileType(pathname string) (FileType, error) {
 	case syscall.S_IFBLK:
 		return FileTypeBlockDev, nil
 	case syscall.S_IFCHR:
-		return FileTypeBlockDev, nil
+		return FileTypeCharDev, nil
 	case syscall.S_IFDIR:
 		return FileTypeDirectory, nil
 	case syscall.S_IFREG:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where character devices are not recognized by the kubelet because we return `FileTypeBlockDev` instead of `FileTypeCharDev`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related issue: https://github.com/kubernetes/kubernetes/issues/5607

**Special notes for your reviewer**:
Kubelet event for bug: https://github.com/kubernetes/kubernetes/issues/5607#issuecomment-366366340
```
Warning		FailedMount		MountVolume.SetUp failed for volume "dev-fuse" : hostPath type check failed: /dev/fuse is not a character device
```

Commit where bug was introduced: https://github.com/kubernetes/kubernetes/commit/57ead4898b850037c9544e034a5e5cc8420990ad 
**Release note**:
```release-note
Fixes a bug where character devices are not recongized by the kubelet
```
