### PR TITLE
bzl: fix update-bazel.sh

### DIFF
--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -2,6 +2,7 @@
 # gazelle:exclude _gopath
 # gazelle:exclude _output
 # gazelle:exclude _tmp
+# gazelle:prefix k8s.io/kubernetes
 
 package(default_visibility = ["//visibility:public"])
 

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -32,7 +32,7 @@ kube::util::go_install_from_commit \
     97099dccc8807e9159dc28f374a8f0602cab07e1
 kube::util::go_install_from_commit \
     github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
-    39e8257565d3917c1674bf37d6538c10cdac2260
+    a85b63b06c2e0c75931e57c4a1a18d4e566bb6f4
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 


### PR DESCRIPTION
pickup https://github.com/bazelbuild/bazel-gazelle/commit/a85b63b06c2e0c75931e57c4a1a18d4e566bb6f4

fixes #60439, fixes #60447
we need to vendor gazelle.

```release-note
NONE
```
