### PR TITLE
Remove dep-reviewers

### DIFF
--- a/Godeps/OWNERS
+++ b/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -225,10 +225,6 @@ aliases:
     - piosz
     - jsafrane
     - jbeda
-  dep-reviewers:
-    - cblecker
-    - thockin
-    - sttts
   dep-approvers:
     - cblecker
     - thockin

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -89,8 +89,6 @@ hack/update-godep-licenses.sh >/dev/null
 kube::log::status "Creating OWNERS file"
 rm -f "Godeps/OWNERS" "vendor/OWNERS"
 cat <<__EOF__ > "Godeps/OWNERS"
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers
 __EOF__

--- a/staging/src/k8s.io/api/Godeps/OWNERS
+++ b/staging/src/k8s.io/api/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/apimachinery/Godeps/OWNERS
+++ b/staging/src/k8s.io/apimachinery/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/apiserver/Godeps/OWNERS
+++ b/staging/src/k8s.io/apiserver/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/client-go/Godeps/OWNERS
+++ b/staging/src/k8s.io/client-go/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/code-generator/Godeps/OWNERS
+++ b/staging/src/k8s.io/code-generator/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/kube-aggregator/Godeps/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/metrics/Godeps/OWNERS
+++ b/staging/src/k8s.io/metrics/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/sample-apiserver/Godeps/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/staging/src/k8s.io/sample-controller/Godeps/OWNERS
+++ b/staging/src/k8s.io/sample-controller/Godeps/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers

--- a/vendor/OWNERS
+++ b/vendor/OWNERS
@@ -1,4 +1,2 @@
-reviewers:
-- dep-reviewers
 approvers:
 - dep-approvers


### PR DESCRIPTION
**What this PR does / why we need it**:
The dep-reviewers group seems to get assigned PRs early the the review process. However, most code changes should be reviewed in the importing part of the code base first, and then assigned to an approver after.

By removing the reviewers group, the approvers plugin will still suggest assigning to an approver, but won't assign for review when the PR is initially opened.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
