### PR TITLE
Allow including both podSelector and namespaceSelector in a NetworkPolicyPeer

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -80920,15 +80920,15 @@
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.",
     "properties": {
      "ipBlock": {
-      "description": "IPBlock defines policy on a particular IPBlock",
+      "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IPBlock"
      },
      "namespaceSelector": {
-      "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.",
+      "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      },
      "podSelector": {
-      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.",
+      "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      }
     }
@@ -81574,18 +81574,18 @@
     ]
    },
    "io.k8s.api.networking.v1.NetworkPolicyPeer": {
-    "description": "NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.",
+    "description": "NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed",
     "properties": {
      "ipBlock": {
-      "description": "IPBlock defines policy on a particular IPBlock",
+      "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
       "$ref": "#/definitions/io.k8s.api.networking.v1.IPBlock"
      },
      "namespaceSelector": {
-      "description": "Selects Namespaces using cluster scoped-labels. This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.",
+      "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      },
      "podSelector": {
-      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.",
+      "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      }
     }

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -10120,15 +10120,15 @@
     "properties": {
      "podSelector": {
       "$ref": "v1.LabelSelector",
-      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace."
+      "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
      },
      "namespaceSelector": {
       "$ref": "v1.LabelSelector",
-      "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces."
+      "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
      },
      "ipBlock": {
       "$ref": "v1beta1.IPBlock",
-      "description": "IPBlock defines policy on a particular IPBlock"
+      "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
      }
     }
    },

--- a/api/swagger-spec/networking.k8s.io_v1.json
+++ b/api/swagger-spec/networking.k8s.io_v1.json
@@ -1427,19 +1427,19 @@
    },
    "v1.NetworkPolicyPeer": {
     "id": "v1.NetworkPolicyPeer",
-    "description": "NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.",
+    "description": "NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed",
     "properties": {
      "podSelector": {
       "$ref": "v1.LabelSelector",
-      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace."
+      "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
      },
      "namespaceSelector": {
       "$ref": "v1.LabelSelector",
-      "description": "Selects Namespaces using cluster scoped-labels. This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces."
+      "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
      },
      "ipBlock": {
       "$ref": "v1.IPBlock",
-      "description": "IPBlock defines policy on a particular IPBlock"
+      "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
      }
     }
    },

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -6137,21 +6137,25 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">podSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.<br>
+<br>
+If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy&#8217;s own Namespace.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespaceSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.<br>
+<br>
+If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ipBlock</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">IPBlock defines policy on a particular IPBlock</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ipblock">v1beta1.IPBlock</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/networking.k8s.io/v1/definitions.html
+++ b/docs/api-reference/networking.k8s.io/v1/definitions.html
@@ -918,7 +918,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1_networkpolicypeer">v1.NetworkPolicyPeer</h3>
 <div class="paragraph">
-<p>NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.</p>
+<p>NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -940,21 +940,25 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">podSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.<br>
+<br>
+If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy&#8217;s own Namespace.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespaceSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects Namespaces using cluster scoped-labels. This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.<br>
+<br>
+If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ipBlock</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">IPBlock defines policy on a particular IPBlock</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_ipblock">v1.IPBlock</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -159,22 +159,28 @@ type IPBlock struct {
 	Except []string
 }
 
-// NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields
-// must be specified.
+// NetworkPolicyPeer describes a peer to allow traffic from.
 type NetworkPolicyPeer struct {
-	// This is a label selector which selects Pods in this namespace. This field
-	// follows standard label selector semantics. If present but empty, this selector
-	// selects all pods in this namespace.
+	// This is a label selector which selects Pods. This field follows standard label
+	// selector semantics; if present but empty, it selects all pods.
+	//
+	// If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
 	// +optional
 	PodSelector *metav1.LabelSelector
 
-	// Selects Namespaces using cluster scoped-labels. This matches all pods in all
-	// namespaces selected by this label selector. This field follows standard label
-	// selector semantics. If present but empty, this selector selects all namespaces.
+	// Selects Namespaces using cluster-scoped labels. This field follows standard label
+	// selector semantics; if present but empty, it selects all namespaces.
+	//
+	// If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector
 
-	// IPBlock defines policy on a particular IPBlock
+	// IPBlock defines policy on a particular IPBlock. If this field is set then
+	// neither of the other fields can be.
 	// +optional
 	IPBlock *IPBlock
 }

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -33,6 +33,55 @@ func ValidateNetworkPolicyName(name string, prefix bool) []string {
 	return apivalidation.NameIsDNSSubdomain(name, prefix)
 }
 
+// ValidateNetworkPolicyPort validates a NetworkPolicyPort
+func ValidateNetworkPolicyPort(port *networking.NetworkPolicyPort, portPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP {
+		allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
+	}
+	if port.Port != nil {
+		if port.Port.Type == intstr.Int {
+			for _, msg := range validation.IsValidPortNum(int(port.Port.IntVal)) {
+				allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.IntVal, msg))
+			}
+		} else {
+			for _, msg := range validation.IsValidPortName(port.Port.StrVal) {
+				allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.StrVal, msg))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateNetworkPolicyPeer validates a NetworkPolicyPeer
+func ValidateNetworkPolicyPeer(peer *networking.NetworkPolicyPeer, peerPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	numPeers := 0
+
+	if peer.PodSelector != nil {
+		numPeers++
+		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(peer.PodSelector, peerPath.Child("podSelector"))...)
+	}
+	if peer.NamespaceSelector != nil {
+		numPeers++
+		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(peer.NamespaceSelector, peerPath.Child("namespaceSelector"))...)
+	}
+	if peer.IPBlock != nil {
+		numPeers++
+		allErrs = append(allErrs, ValidateIPBlock(peer.IPBlock, peerPath.Child("ipBlock"))...)
+	}
+
+	if numPeers == 0 {
+		allErrs = append(allErrs, field.Required(peerPath, "must specify a peer"))
+	} else if numPeers > 1 {
+		allErrs = append(allErrs, field.Forbidden(peerPath, "may not specify more than 1 peer"))
+	}
+
+	return allErrs
+}
+
 // ValidateNetworkPolicySpec tests if required fields in the networkpolicy spec are set.
 func ValidateNetworkPolicySpec(spec *networking.NetworkPolicySpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -43,41 +92,11 @@ func ValidateNetworkPolicySpec(spec *networking.NetworkPolicySpec, fldPath *fiel
 		ingressPath := fldPath.Child("ingress").Index(i)
 		for i, port := range ingress.Ports {
 			portPath := ingressPath.Child("ports").Index(i)
-			if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP {
-				allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
-			}
-			if port.Port != nil {
-				if port.Port.Type == intstr.Int {
-					for _, msg := range validation.IsValidPortNum(int(port.Port.IntVal)) {
-						allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.IntVal, msg))
-					}
-				} else {
-					for _, msg := range validation.IsValidPortName(port.Port.StrVal) {
-						allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.StrVal, msg))
-					}
-				}
-			}
+			allErrs = append(allErrs, ValidateNetworkPolicyPort(&port, portPath)...)
 		}
 		for i, from := range ingress.From {
 			fromPath := ingressPath.Child("from").Index(i)
-			numFroms := 0
-			if from.PodSelector != nil {
-				numFroms++
-				allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(from.PodSelector, fromPath.Child("podSelector"))...)
-			}
-			if from.NamespaceSelector != nil {
-				numFroms++
-				allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(from.NamespaceSelector, fromPath.Child("namespaceSelector"))...)
-			}
-			if from.IPBlock != nil {
-				numFroms++
-				allErrs = append(allErrs, ValidateIPBlock(from.IPBlock, fromPath.Child("ipBlock"))...)
-			}
-			if numFroms == 0 {
-				allErrs = append(allErrs, field.Required(fromPath, "must specify a from type"))
-			} else if numFroms > 1 {
-				allErrs = append(allErrs, field.Forbidden(fromPath, "may not specify more than 1 from type"))
-			}
+			allErrs = append(allErrs, ValidateNetworkPolicyPeer(&from, fromPath)...)
 		}
 	}
 	// Validate egress rules
@@ -85,41 +104,11 @@ func ValidateNetworkPolicySpec(spec *networking.NetworkPolicySpec, fldPath *fiel
 		egressPath := fldPath.Child("egress").Index(i)
 		for i, port := range egress.Ports {
 			portPath := egressPath.Child("ports").Index(i)
-			if port.Protocol != nil && *port.Protocol != api.ProtocolTCP && *port.Protocol != api.ProtocolUDP {
-				allErrs = append(allErrs, field.NotSupported(portPath.Child("protocol"), *port.Protocol, []string{string(api.ProtocolTCP), string(api.ProtocolUDP)}))
-			}
-			if port.Port != nil {
-				if port.Port.Type == intstr.Int {
-					for _, msg := range validation.IsValidPortNum(int(port.Port.IntVal)) {
-						allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.IntVal, msg))
-					}
-				} else {
-					for _, msg := range validation.IsValidPortName(port.Port.StrVal) {
-						allErrs = append(allErrs, field.Invalid(portPath.Child("port"), port.Port.StrVal, msg))
-					}
-				}
-			}
+			allErrs = append(allErrs, ValidateNetworkPolicyPort(&port, portPath)...)
 		}
 		for i, to := range egress.To {
 			toPath := egressPath.Child("to").Index(i)
-			numTo := 0
-			if to.PodSelector != nil {
-				numTo++
-				allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(to.PodSelector, toPath.Child("podSelector"))...)
-			}
-			if to.NamespaceSelector != nil {
-				numTo++
-				allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(to.NamespaceSelector, toPath.Child("namespaceSelector"))...)
-			}
-			if to.IPBlock != nil {
-				numTo++
-				allErrs = append(allErrs, ValidateIPBlock(to.IPBlock, toPath.Child("ipBlock"))...)
-			}
-			if numTo == 0 {
-				allErrs = append(allErrs, field.Required(toPath, "must specify a to type"))
-			} else if numTo > 1 {
-				allErrs = append(allErrs, field.Forbidden(toPath, "may not specify more than 1 to type"))
-			}
+			allErrs = append(allErrs, ValidateNetworkPolicyPeer(&to, toPath)...)
 		}
 	}
 	// Validate PolicyTypes

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -75,8 +75,8 @@ func ValidateNetworkPolicyPeer(peer *networking.NetworkPolicyPeer, peerPath *fie
 
 	if numPeers == 0 {
 		allErrs = append(allErrs, field.Required(peerPath, "must specify a peer"))
-	} else if numPeers > 1 {
-		allErrs = append(allErrs, field.Forbidden(peerPath, "may not specify more than 1 peer"))
+	} else if numPeers > 1 && peer.IPBlock != nil {
+		allErrs = append(allErrs, field.Forbidden(peerPath, "may not specify both ipBlock and another peer"))
 	}
 
 	return allErrs

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -128,6 +128,28 @@ func TestValidateNetworkPolicy(t *testing.T) {
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{"a": "b"},
 				},
+				Ingress: []networking.NetworkPolicyIngressRule{
+					{
+						From: []networking.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"c": "d"},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"e": "f"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: networking.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
+				},
 				Egress: []networking.NetworkPolicyEgressRule{
 					{
 						To: []networking.NetworkPolicyPeer{
@@ -256,7 +278,7 @@ func TestValidateNetworkPolicy(t *testing.T) {
 
 	invalidSelector := map[string]string{"NoUppercaseOrSpecialCharsLike=Equals": "b"}
 	errorCases := map[string]networking.NetworkPolicy{
-		"namespaceSelector and podSelector": {
+		"namespaceSelector and ipBlock": {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
 			Spec: networking.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -266,15 +288,24 @@ func TestValidateNetworkPolicy(t *testing.T) {
 					{
 						From: []networking.NetworkPolicyPeer{
 							{
-								PodSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"c": "d"},
-								},
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"c": "d"},
+								},
+								IPBlock: &networking.IPBlock{
+									CIDR:   "192.168.0.0/16",
+									Except: []string{"192.168.3.0/24", "192.168.4.0/24"},
 								},
 							},
 						},
 					},
+				},
+			},
+		},
+		"podSelector and ipBlock": {
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Spec: networking.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"a": "b"},
 				},
 				Egress: []networking.NetworkPolicyEgressRule{
 					{
@@ -283,8 +314,9 @@ func TestValidateNetworkPolicy(t *testing.T) {
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"c": "d"},
 								},
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"c": "d"},
+								IPBlock: &networking.IPBlock{
+									CIDR:   "192.168.0.0/16",
+									Except: []string{"192.168.3.0/24", "192.168.4.0/24"},
 								},
 							},
 						},

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -678,20 +678,26 @@ message NetworkPolicyList {
 
 // DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.
 message NetworkPolicyPeer {
-  // This is a label selector which selects Pods in this namespace.
-  // This field follows standard label selector semantics.
-  // If present but empty, this selector selects all pods in this namespace.
+  // This is a label selector which selects Pods. This field follows standard label
+  // selector semantics; if present but empty, it selects all pods.
+  // 
+  // If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+  // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+  // Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
-  // Selects Namespaces using cluster scoped-labels.  This
-  // matches all pods in all namespaces selected by this label selector.
-  // This field follows standard label selector semantics.
-  // If present but empty, this selector selects all namespaces.
+  // Selects Namespaces using cluster-scoped labels. This field follows standard label
+  // selector semantics; if present but empty, it selects all namespaces.
+  // 
+  // If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+  // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+  // Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
 
-  // IPBlock defines policy on a particular IPBlock
+  // IPBlock defines policy on a particular IPBlock. If this field is set then
+  // neither of the other fields can be.
   // +optional
   optional IPBlock ipBlock = 3;
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -1256,22 +1256,26 @@ type IPBlock struct {
 
 // DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.
 type NetworkPolicyPeer struct {
-	// Exactly one of the following must be specified.
-
-	// This is a label selector which selects Pods in this namespace.
-	// This field follows standard label selector semantics.
-	// If present but empty, this selector selects all pods in this namespace.
+	// This is a label selector which selects Pods. This field follows standard label
+	// selector semantics; if present but empty, it selects all pods.
+	//
+	// If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
 	// +optional
 	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty" protobuf:"bytes,1,opt,name=podSelector"`
 
-	// Selects Namespaces using cluster scoped-labels.  This
-	// matches all pods in all namespaces selected by this label selector.
-	// This field follows standard label selector semantics.
-	// If present but empty, this selector selects all namespaces.
+	// Selects Namespaces using cluster-scoped labels. This field follows standard label
+	// selector semantics; if present but empty, it selects all namespaces.
+	//
+	// If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty" protobuf:"bytes,2,opt,name=namespaceSelector"`
 
-	// IPBlock defines policy on a particular IPBlock
+	// IPBlock defines policy on a particular IPBlock. If this field is set then
+	// neither of the other fields can be.
 	// +optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -407,9 +407,9 @@ func (NetworkPolicyList) SwaggerDoc() map[string]string {
 
 var map_NetworkPolicyPeer = map[string]string{
 	"":                  "DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.",
-	"podSelector":       "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.",
-	"namespaceSelector": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.",
-	"ipBlock":           "IPBlock defines policy on a particular IPBlock",
+	"podSelector":       "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.",
+	"namespaceSelector": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.",
+	"ipBlock":           "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
 }
 
 func (NetworkPolicyPeer) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -111,22 +111,29 @@ message NetworkPolicyList {
   repeated NetworkPolicy items = 2;
 }
 
-// NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields
-// must be specified.
+// NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of
+// fields are allowed
 message NetworkPolicyPeer {
-  // This is a label selector which selects Pods in this namespace. This field
-  // follows standard label selector semantics. If present but empty, this selector
-  // selects all pods in this namespace.
+  // This is a label selector which selects Pods. This field follows standard label
+  // selector semantics; if present but empty, it selects all pods.
+  // 
+  // If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+  // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+  // Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector podSelector = 1;
 
-  // Selects Namespaces using cluster scoped-labels. This matches all pods in all
-  // namespaces selected by this label selector. This field follows standard label
-  // selector semantics. If present but empty, this selector selects all namespaces.
+  // Selects Namespaces using cluster-scoped labels. This field follows standard label
+  // selector semantics; if present but empty, it selects all namespaces.
+  // 
+  // If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+  // the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+  // Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
 
-  // IPBlock defines policy on a particular IPBlock
+  // IPBlock defines policy on a particular IPBlock. If this field is set then
+  // neither of the other fields can be.
   // +optional
   optional IPBlock ipBlock = 3;
 }

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -161,22 +161,29 @@ type IPBlock struct {
 	Except []string `json:"except,omitempty" protobuf:"bytes,2,rep,name=except"`
 }
 
-// NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields
-// must be specified.
+// NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of
+// fields are allowed
 type NetworkPolicyPeer struct {
-	// This is a label selector which selects Pods in this namespace. This field
-	// follows standard label selector semantics. If present but empty, this selector
-	// selects all pods in this namespace.
+	// This is a label selector which selects Pods. This field follows standard label
+	// selector semantics; if present but empty, it selects all pods.
+	//
+	// If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
 	// +optional
 	PodSelector *metav1.LabelSelector `json:"podSelector,omitempty" protobuf:"bytes,1,opt,name=podSelector"`
 
-	// Selects Namespaces using cluster scoped-labels. This matches all pods in all
-	// namespaces selected by this label selector. This field follows standard label
-	// selector semantics. If present but empty, this selector selects all namespaces.
+	// Selects Namespaces using cluster-scoped labels. This field follows standard label
+	// selector semantics; if present but empty, it selects all namespaces.
+	//
+	// If PodSelector is also set, then the NetworkPolicyPeer as a whole selects
+	// the Pods matching PodSelector in the Namespaces selected by NamespaceSelector.
+	// Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty" protobuf:"bytes,2,opt,name=namespaceSelector"`
 
-	// IPBlock defines policy on a particular IPBlock
+	// IPBlock defines policy on a particular IPBlock. If this field is set then
+	// neither of the other fields can be.
 	// +optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }

--- a/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/networking/v1/types_swagger_doc_generated.go
@@ -78,10 +78,10 @@ func (NetworkPolicyList) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkPolicyPeer = map[string]string{
-	"":                  "NetworkPolicyPeer describes a peer to allow traffic from. Exactly one of its fields must be specified.",
-	"podSelector":       "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.",
-	"namespaceSelector": "Selects Namespaces using cluster scoped-labels. This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.",
-	"ipBlock":           "IPBlock defines policy on a particular IPBlock",
+	"":                  "NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed",
+	"podSelector":       "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.",
+	"namespaceSelector": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.",
+	"ipBlock":           "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
 }
 
 func (NetworkPolicyPeer) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Updates NetworkPolicy API docs and validation to allow podSelector and namespaceSelector to be specified together in a NetworkPolicyPeer

Fixes #58637

**Release note**:
```release-note
NetworkPolicies can now target specific pods in other namespaces by including both a namespaceSelector and a podSelector in the same peer element.
```
