### PR TITLE
tests: e2e: empty msg from channel other than stdout should be non-fatal

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -523,7 +523,13 @@ var _ = framework.KubeDescribe("Pods", func() {
 					continue
 				}
 				if msg[0] != 1 {
-					framework.Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
+					if len(msg) == 1 {
+						// skip an empty message on stream other than stdout
+						continue
+					} else {
+						framework.Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
+					}
+
 				}
 				buf.Write(msg[1:])
 			}


### PR DESCRIPTION
Currently, if the exec websocket encounters a message that is not in the stdout stream, it immediately fails.  However it also currently requests the stderr steam in the query params.  There doesn't seem to be any guarantee that we don't get an empty message on the stderr stream.

Requesting the stderr stream in the query is desirable if, for some reason, something in the container fails and writes to stderr.

However, we do not need fail the test if we get an empty message on another stream.  If the message is not empty, then that _does_ indicate and error and we should fail.

This is the situation we are currently observing with docker 1.13 in the origin CI https://github.com/openshift/origin/issues/18726

@derekwaynecarr @smarterclayton @gabemontero @liggitt @deads2k 

/sig node