### PR TITLE
Increase timeout of integration tests

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -44,7 +44,6 @@ export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
 export ARTIFACTS_DIR=${WORKSPACE}/artifacts
 # Save the verbose stdout as well.
 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
-export KUBE_TIMEOUT='-timeout 300s'
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 export LOG_LEVEL=4
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In #24509 we intended to increase the timeout to 600s, but it was reverted by accident in #57521 when overriding of the value was enabled. The jenkins job should honor the default of 600s instead of continuing to override it to 300s.
This lead to flaky integration tests, specifically TestCRDDeletionCascading

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59426

**Special notes for your reviewer**:

**Release note**:
```release-note
Increase timeout of integration tests
```
