### PR TITLE
Client-go raises error on duplicated name in kubeconfig

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/conversion"
@@ -105,7 +106,11 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				if err := s.Convert(&curr.Cluster, newCluster, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = newCluster
+				if (*out)[curr.Name] == nil {
+					(*out)[curr.Name] = newCluster
+				} else {
+					return fmt.Errorf("error converting *[]NamedCluster into *map[string]*api.Cluster: duplicate name \"%v\" in list: %v", curr.Name, *in)
+				}
 			}
 
 			return nil
@@ -136,7 +141,11 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				if err := s.Convert(&curr.AuthInfo, newAuthInfo, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = newAuthInfo
+				if (*out)[curr.Name] == nil {
+					(*out)[curr.Name] = newAuthInfo
+				} else {
+					return fmt.Errorf("error converting *[]NamedAuthInfo into *map[string]*api.AuthInfo: duplicate name \"%v\" in list: %v", curr.Name, *in)
+				}
 			}
 
 			return nil
@@ -167,7 +176,11 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				if err := s.Convert(&curr.Context, newContext, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = newContext
+				if (*out)[curr.Name] == nil {
+					(*out)[curr.Name] = newContext
+				} else {
+					return fmt.Errorf("error converting *[]NamedContext into *map[string]*api.Context: duplicate name \"%v\" in list: %v", curr.Name, *in)
+				}
 			}
 
 			return nil
@@ -198,7 +211,11 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				if err := s.Convert(&curr.Extension, &newExtension, 0); err != nil {
 					return err
 				}
-				(*out)[curr.Name] = newExtension
+				if (*out)[curr.Name] == nil {
+					(*out)[curr.Name] = newExtension
+				} else {
+					return fmt.Errorf("error converting *[]NamedExtension into *map[string]runtime.Object: duplicate name \"%v\" in list: %v", curr.Name, *in)
+				}
 			}
 
 			return nil


### PR DESCRIPTION
(for NamedCluster, NamedContext, NamedUser, NamedExtension)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Client should detect duplicated name when loading `name-value` based lists in kubeconfig: `users`, `clusters`, `contexts`. Currently if there are multiple value with same name, `client-python` will pick the first one, while `client-go` will pick the last.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref: kubernetes-client/python#445, kubernetes-client/python-base#47

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl and client-go now detects duplicated name for user, cluster and context when loading kubeconfig and reports error 
```

/sig api-machinery

cc @brendandburns @mbohlool 