### PR TITLE
Adding resource constraints for fluentd-gcp

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -30,5 +30,7 @@ spec:
           value: 100m
         - name: MEMORY_REQUEST
           value: 200Mi
+        - name: CPU_LIMIT
+          value: 300m
         - name: MEMORY_LIMIT
-          value: 300Mi
+          value: 500Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds resource constraints to `fluentd-gcp`. Values mostly lifted from `fluentd-es`, cpu cap set to a sensible value after reviewing various threads.

**Which issue(s) this PR fixes**
Fixes #55416

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
