### PR TITLE
Separate docker image tag and etcd version out in etcd cluster image …

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -27,9 +27,10 @@
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last tag from $(TAGS).
 TAGS?=2.2.1 2.3.7 3.0.17 3.1.11 3.2.14
-REGISTRY_TAG?=3.2.14
-# ROLLBACK_REGISTRY_TAG specified the tag that REGISTRY_TAG may be rolled back to.
-ROLLBACK_REGISTRY_TAG?=3.1.11
+VERSION?=3.2.14
+# ROLLBACK_VERSION specified the tag that VERSION may be rolled back to.
+ROLLBACK_VERSION?=3.1.11
+REGISTRY_TAG?=$(VERSION)
 ARCH?=amd64
 REGISTRY?=k8s.gcr.io
 # golang version should match the golang version from https://github.com/coreos/etcd/releases for REGISTRY_TAG version of etcd.
@@ -116,45 +117,45 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push $(REGISTRY)/etcd:$(REGISTRY_TAG)
 endif
 
-ETCD2_ROLLBACK_NEW_TAG=3.0.17
-ETCD2_ROLLBACK_OLD_TAG=2.2.1
+ETCD2_ROLLBACK_NEW_VERSION=3.0.17
+ETCD2_ROLLBACK_OLD_VERSION=2.2.1
 
 # Test a rollback to etcd2 from the earliest etcd3 version.
 test-rollback-etcd2:
 	mkdir -p $(TEMP_DIR)/rollback-etcd2
 	cd $(TEMP_DIR)/rollback-etcd2
 
-	@echo "Starting $(ETCD2_ROLLBACK_NEW_TAG) etcd and writing some sample data."
+	@echo "Starting $(ETCD2_ROLLBACK_NEW_VERSION) etcd and writing some sample data."
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
 		-e "TARGET_STORAGE=etcd3" \
-		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_NEW_TAG)" \
+		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_NEW_VERSION)" \
 		-e "DATA_DIRECTORY=/var/etcd/data" \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
 			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
 			/usr/local/bin/migrate-if-needed.sh && \
 			source /usr/local/bin/start-stop-etcd.sh && \
-			START_STORAGE=etcd3 START_VERSION=$(ETCD2_ROLLBACK_NEW_TAG) start_etcd && \
-			ETCDCTL_API=3 /usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_NEW_TAG) --endpoints http://127.0.0.1:$${ETCD_PORT} put /registry/k1 value1 && \
+			START_STORAGE=etcd3 START_VERSION=$(ETCD2_ROLLBACK_NEW_VERSION) start_etcd && \
+			ETCDCTL_API=3 /usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_NEW_VERSION) --endpoints http://127.0.0.1:$${ETCD_PORT} put /registry/k1 value1 && \
 			stop_etcd && \
-			[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_NEW_TAG)/etcd3 ]'
+			[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_NEW_VERSION)/etcd3 ]'
 
 	@echo "Rolling back to the previous version of etcd and recording keyspace to a flat file."
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
 		-e "TARGET_STORAGE=etcd2" \
-		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_OLD_TAG)" \
+		-e "TARGET_VERSION=$(ETCD2_ROLLBACK_OLD_VERSION)" \
 		-e "DATA_DIRECTORY=/var/etcd/data" \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
 			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
 			/usr/local/bin/migrate-if-needed.sh && \
 			source /usr/local/bin/start-stop-etcd.sh && \
-			START_STORAGE=etcd2 START_VERSION=$(ETCD2_ROLLBACK_OLD_TAG) start_etcd && \
-			/usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_OLD_TAG) --endpoint 127.0.0.1:$${ETCD_PORT} get /registry/k1 > /var/etcd/keyspace.txt && \
+			START_STORAGE=etcd2 START_VERSION=$(ETCD2_ROLLBACK_OLD_VERSION) start_etcd && \
+			/usr/local/bin/etcdctl-$(ETCD2_ROLLBACK_OLD_VERSION) --endpoint 127.0.0.1:$${ETCD_PORT} get /registry/k1 > /var/etcd/keyspace.txt && \
 			stop_etcd'
 
-	@echo "Checking if rollback successfully downgraded etcd to $(ETCD2_ROLLBACK_OLD_TAG)"
+	@echo "Checking if rollback successfully downgraded etcd to $(ETCD2_ROLLBACK_OLD_VERSION)"
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-etcd2:/var/etcd \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
-			'[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_OLD_TAG)/etcd2 ] && \
+			'[ $$(cat /var/etcd/data/version.txt) = $(ETCD2_ROLLBACK_OLD_VERSION)/etcd2 ] && \
 			 grep -q value1 /var/etcd/keyspace.txt'
 
 # Test a rollback from the latest version to the previous version.
@@ -165,33 +166,33 @@ test-rollback:
 	@echo "Starting $(REGISTRY_TAG) etcd and writing some sample data."
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
 		-e "TARGET_STORAGE=etcd3" \
-		-e "TARGET_VERSION=$(REGISTRY_TAG)" \
+		-e "TARGET_VERSION=$(VERSION)" \
 		-e "DATA_DIRECTORY=/var/etcd/data" \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
 			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
 			/usr/local/bin/migrate-if-needed.sh && \
 			source /usr/local/bin/start-stop-etcd.sh && \
-			START_STORAGE=etcd3 START_VERSION=$(REGISTRY_TAG) start_etcd && \
+			START_STORAGE=etcd3 START_VERSION=$(VERSION) start_etcd && \
 			ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} put /registry/k1 value1 && \
 			stop_etcd'
 
 	@echo "Rolling back to the previous version of etcd and recording keyspace to a flat file."
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
 		-e "TARGET_STORAGE=etcd3" \
-		-e "TARGET_VERSION=$(ROLLBACK_REGISTRY_TAG)" \
+		-e "TARGET_VERSION=$(ROLLBACK_VERSION)" \
 		-e "DATA_DIRECTORY=/var/etcd/data" \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
 			'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
 			/usr/local/bin/migrate-if-needed.sh && \
 			source /usr/local/bin/start-stop-etcd.sh && \
-			START_STORAGE=etcd3 START_VERSION=$(ROLLBACK_REGISTRY_TAG) start_etcd && \
+			START_STORAGE=etcd3 START_VERSION=$(ROLLBACK_VERSION) start_etcd && \
 			ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} get --prefix / > /var/etcd/keyspace.txt && \
 			stop_etcd'
 
-	@echo "Checking if rollback successfully downgraded etcd to $(ROLLBACK_REGISTRY_TAG)"
+	@echo "Checking if rollback successfully downgraded etcd to $(ROLLBACK_VERSION)"
 	docker run --tty --interactive -v $(TEMP_DIR)/rollback-test:/var/etcd \
 		gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
-			'[ $$(cat /var/etcd/data/version.txt) = $(ROLLBACK_REGISTRY_TAG)/etcd3 ] && \
+			'[ $$(cat /var/etcd/data/version.txt) = $(ROLLBACK_VERSION)/etcd3 ] && \
 			 grep -q value1 /var/etcd/keyspace.txt'
 
 # Test migrating from each supported versions to the latest version.
@@ -220,19 +221,19 @@ test-migrate:
 		echo " Migrating from $${tag} to $(REGISTRY_TAG) and capturing keyspace" && \
 		docker run --tty --interactive -v $(TEMP_DIR)/migrate-$${tag}:/var/etcd \
 			-e "TARGET_STORAGE=etcd3" \
-			-e "TARGET_VERSION=$(REGISTRY_TAG)" \
+			-e "TARGET_VERSION=$(VERSION)" \
 			-e "DATA_DIRECTORY=/var/etcd/data" \
 			gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
 				'INITIAL_CLUSTER=etcd-$$(hostname)=http://localhost:2380 \
 				/usr/local/bin/migrate-if-needed.sh && \
 				source /usr/local/bin/start-stop-etcd.sh && \
-				START_STORAGE=etcd3 START_VERSION=$(REGISTRY_TAG) start_etcd && \
+				START_STORAGE=etcd3 START_VERSION=$(VERSION) start_etcd && \
 				ETCDCTL_API=3 /usr/local/bin/etcdctl --endpoints http://127.0.0.1:$${ETCD_PORT} get --prefix / > /var/etcd/keyspace.txt && \
 				stop_etcd'  && \
 		echo "Checking if migrate from $${tag} successfully upgraded etcd to $(REGISTRY_TAG)" && \
 		docker run --tty --interactive -v $(TEMP_DIR)/migrate-$${tag}:/var/etcd \
 			gcr.io/google_containers/etcd-$(ARCH):$(REGISTRY_TAG) /bin/sh -c \
-				'[ $$(cat /var/etcd/data/version.txt) = $(REGISTRY_TAG)/etcd3 ] && \
+				'[ $$(cat /var/etcd/data/version.txt) = $(VERSION)/etcd3 ] && \
 				 grep -q value1 /var/etcd/keyspace.txt'; \
 	done
 


### PR DESCRIPTION
This script previously conflated docker image ("registry") tags with etcd versions.  This makes them more clearly distinct, which also allows for things like overriding the VERSION and ROLLBACK_VERSION when testing, or testing with an alternate REGISTRY tag.

Release note:
```release-note
NONE
```