### PR TITLE
Add scheduling.k8s.io to the known groups for audit logging on GCE.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -729,6 +729,7 @@ function create-master-audit-policy {
       - group: "networking.k8s.io"
       - group: "policy"
       - group: "rbac.authorization.k8s.io"
+      - group: "scheduling.k8s.io"
       - group: "settings.k8s.io"
       - group: "storage.k8s.io"'
 


### PR DESCRIPTION
This lets PriorityClass objects get logged.

```release-note
NONE
```