### PR TITLE
WIP - Prevent read anomalies from the watch cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -587,7 +587,11 @@ func (h *etcdHelper) GuaranteedUpdate(
 }
 
 func (*etcdHelper) Count(pathPerfix string) (int64, error) {
-	return 0, fmt.Errorf("Count is unimplemented for etcd2!")
+	return 0, storage.ErrNotImplemented
+}
+
+func (*etcdHelper) LastResourceVersion(ctx context.Context, keyPrefix string, from string) (string, error) {
+	return "", storage.ErrNotImplemented
 }
 
 // etcdCache defines interface used for caching objects stored in etcd. Objects are keyed by

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -17,7 +17,10 @@ limitations under the License.
 package storage
 
 import (
+	"errors"
+
 	"golang.org/x/net/context"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -109,6 +112,8 @@ func NewUIDPreconditions(uid string) *Preconditions {
 	return &Preconditions{UID: &u}
 }
 
+var ErrNotImplemented = errors.New("this functionality is not implemented")
+
 // Interface offers a common interface for object marshaling/unmarshaling operations and
 // hides all the storage-related operations behind it.
 type Interface interface {
@@ -198,4 +203,10 @@ type Interface interface {
 
 	// Count returns number of different entries under the key (generally being path prefix).
 	Count(key string) (int64, error)
+
+	// LastResourceVersion returns the most recent modification version under a given key
+	// prefix or returns an error. If the implementation does not support this operation it may
+	// return ErrNotImplemented. The implementation is expected to perform a strongly consistent
+	// read to satisfy this API.
+	LastResourceVersion(ctx context.Context, keyPrefix string, from string) (string, error)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
@@ -281,6 +281,13 @@ func (w *watchCache) List() []interface{} {
 	return w.store.List()
 }
 
+// ResourceVersion returns the last resource version the cache has observed.
+func (w *watchCache) ResourceVersion() uint64 {
+	w.RLock()
+	defer w.RUnlock()
+	return w.resourceVersion
+}
+
 // waitUntilFreshAndBlock waits until cache is at least as fresh as given <resourceVersion>.
 // NOTE: This function acquired lock and doesn't release it.
 // You HAVE TO explicitly call w.RUnlock() after this function.


### PR DESCRIPTION
The watch cache can be arbitrarily delayed in an HA setup (or could be
talking to an arbitrarily delayed etcd member in a single server
configuration after a crash). This means that clients using
resourceVersion=0 can experience stale reads and observe previously deleted
items. Because kubelets rely on a happens-before relationship between
deleting a pod and perform a new list when they restart, observing a
previously deleted pod could result in two pods with the same name running
on different nodes of the cluster which violates pod safety and could lead
to data corruption if the pods rely on our safety guarantees.

Since clients in general are very bad at knowing when they can safely see
historical results we want to prevent stale reads from the watch cache
while preserving some semblance of the performance gains from the watch
cache. 

INSERT ACTUAL FIX DESCRIPTION HERE

Fixes #59848

Needs to be backported, probably all the way to 1.7 (the earliest version we
implemented statefulsets on) although 1.5 was the first version we described
the pod safety guarantee. It *requires* etcd3 though to be performant, so any
version before 1.7 should probably just disable their watch cache.

@kubernetes/sig-api-machinery-pr-reviews @liggitt

```release-note
If the apiserver was connected to an etcd cluster member (in HA etcd configurations) that was delayed, it was possible for a Kubelet to restart and observe pods that had previously been scheduled on that node but were subsequently deleted, which could lead to two pods with the same name running on the cluster at the same time. That could lead to data corruption in application workloads that depended on pods being unique. This change allows apiservers that are using etcd3 and also have the watch cache enabled ensure that stale data is not served to clients.

For clusters using etcd2, disabling the watch cache is the only way to avoid this issue since the necessary API support did not exist.
```