### PR TITLE
Kube apiserver ServerRunOptions set default called before use

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -102,9 +102,13 @@ func StartTestServer(t Logger, customFlags []string, storageConfig *storagebacke
 	s.APIEnablement.RuntimeConfig.Set("api/all=true")
 
 	fs.Parse(customFlags)
+	completedOptions, err := app.Complete(s)
+	if err != nil {
+		return result, fmt.Errorf("failed to set default ServerRunOptions: %v", err)
+	}
 
 	t.Logf("Starting kube-apiserver on port %d...", s.SecureServing.BindPort)
-	server, err := app.CreateServerChain(s, stopCh)
+	server, err := app.CreateServerChain(completedOptions, stopCh)
 	if err != nil {
 		return result, fmt.Errorf("failed to create server chain: %v", err)
 

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,5 +1,6 @@
 cluster/images/etcd-version-monitor
 cmd/hyperkube
+cmd/kube-apiserver/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app
 cmd/kube-scheduler/app

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -735,12 +735,16 @@ func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV
 		kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
 		kubeAPIServerOptions.Authorization.Modes = []string{"RBAC"}
 		kubeAPIServerOptions.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-
-		tunneler, proxyTransport, err := app.CreateNodeDialer(kubeAPIServerOptions)
+		completedOptions, err := app.Complete(kubeAPIServerOptions)
 		if err != nil {
 			t.Fatal(err)
 		}
-		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport)
+
+		tunneler, proxyTransport, err := app.CreateNodeDialer(completedOptions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -110,12 +110,16 @@ func TestAggregatedAPIServer(t *testing.T) {
 		kubeAPIServerOptions.Authentication.RequestHeader.ClientCAFile = proxyCACertFile.Name()
 		kubeAPIServerOptions.Authentication.ClientCert.ClientCA = clientCACertFile.Name()
 		kubeAPIServerOptions.Authorization.Modes = []string{"RBAC"}
-
-		tunneler, proxyTransport, err := app.CreateNodeDialer(kubeAPIServerOptions)
+		completedOptions, err := app.Complete(kubeAPIServerOptions)
 		if err != nil {
 			t.Fatal(err)
 		}
-		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport)
+
+		tunneler, proxyTransport, err := app.CreateNodeDialer(completedOptions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/integration/tls/BUILD
+++ b/test/integration/tls/BUILD
@@ -9,14 +9,8 @@ go_test(
     ],
     tags = ["integration"],
     deps = [
-        "//cmd/kube-apiserver/app:go_default_library",
-        "//cmd/kube-apiserver/app/options:go_default_library",
+        "//cmd/kube-apiserver/app/testing:go_default_library",
         "//test/integration/framework:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/test/integration/tls/ciphers_test.go
+++ b/test/integration/tls/ciphers_test.go
@@ -61,6 +61,9 @@ func runBasicSecureAPIServer(t *testing.T, ciphers []string) (uint32, error) {
 		kubeAPIServerOptions.InsecureServing.BindPort = 0
 		kubeAPIServerOptions.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURL()}
 		kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
+		if err := app.DefaultOptions(kubeAPIServerOptions); err != nil {
+			t.Fatal(err)
+		}
 
 		tunneler, proxyTransport, err := app.CreateNodeDialer(kubeAPIServerOptions)
 		if err != nil {

--- a/test/integration/tls/ciphers_test.go
+++ b/test/integration/tls/ciphers_test.go
@@ -19,110 +19,26 @@ package tls
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
-	"net"
 	"net/http"
-	"os"
-	"sync/atomic"
+	"strings"
 	"testing"
-	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-	genericapiserver "k8s.io/apiserver/pkg/server"
-	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
-	client "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
-func runBasicSecureAPIServer(t *testing.T, ciphers []string) (uint32, error) {
-	certDir, _ := ioutil.TempDir("", "test-integration-tls")
-	defer os.RemoveAll(certDir)
-	_, defaultServiceClusterIPRange, _ := net.ParseCIDR("10.0.0.0/24")
-	kubeClientConfigValue := atomic.Value{}
-	var kubePort uint32
-
-	go func() {
-		listener, port, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		atomic.StoreUint32(&kubePort, uint32(port))
-
-		kubeAPIServerOptions := options.NewServerRunOptions()
-		kubeAPIServerOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
-		kubeAPIServerOptions.SecureServing.BindPort = port
-		kubeAPIServerOptions.SecureServing.Listener = listener
-		kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
-		kubeAPIServerOptions.SecureServing.CipherSuites = ciphers
-		kubeAPIServerOptions.InsecureServing.BindPort = 0
-		kubeAPIServerOptions.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURL()}
-		kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
-		if err := app.DefaultOptions(kubeAPIServerOptions); err != nil {
-			t.Fatal(err)
-		}
-
-		tunneler, proxyTransport, err := app.CreateNodeDialer(kubeAPIServerOptions)
-		if err != nil {
-			t.Fatal(err)
-		}
-		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport)
-		if err != nil {
-			t.Fatal(err)
-		}
-		kubeClientConfigValue.Store(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
-
-		kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers, versionedInformers)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(wait.NeverStop); err != nil {
-			t.Log(err)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}()
-
-	// Ensure server is ready
-	err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-		obj := kubeClientConfigValue.Load()
-		if obj == nil {
-			return false, nil
-		}
-		kubeClientConfig := kubeClientConfigValue.Load().(*rest.Config)
-		kubeClientConfig.ContentType = ""
-		kubeClientConfig.AcceptContentTypes = ""
-		kubeClient, err := client.NewForConfig(kubeClientConfig)
-		if err != nil {
-			// this happens because we race the API server start
-			t.Log(err)
-			return false, nil
-		}
-		if _, err := kubeClient.Discovery().ServerVersion(); err != nil {
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return 0, err
-	}
-
-	securePort := atomic.LoadUint32(&kubePort)
-	return securePort, nil
+func runBasicSecureAPIServer(t *testing.T, ciphers []string) (kubeapiservertesting.TearDownFunc, int) {
+	flags := []string{"--tls-cipher-suites", strings.Join(ciphers, ",")}
+	testServer := kubeapiservertesting.StartTestServerOrDie(t, flags, framework.SharedEtcd())
+	return testServer.TearDownFn, testServer.ServerOpts.SecureServing.BindPort
 }
 
 func TestAPICiphers(t *testing.T) {
 
 	basicServerCiphers := []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305", "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"}
 
-	kubePort, err := runBasicSecureAPIServer(t, basicServerCiphers)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	tearDown, port := runBasicSecureAPIServer(t, basicServerCiphers)
+	defer tearDown()
 	tests := []struct {
 		clientCiphers []uint16
 		expectedError bool
@@ -140,11 +56,11 @@ func TestAPICiphers(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		runTestAPICiphers(t, i, kubePort, test.clientCiphers, test.expectedError)
+		runTestAPICiphers(t, i, port, test.clientCiphers, test.expectedError)
 	}
 }
 
-func runTestAPICiphers(t *testing.T, testID int, kubePort uint32, clientCiphers []uint16, expectedError bool) {
+func runTestAPICiphers(t *testing.T, testID int, kubePort int, clientCiphers []uint16, expectedError bool) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -158,14 +74,13 @@ func runTestAPICiphers(t *testing.T, testID int, kubePort uint32, clientCiphers 
 		t.Fatal(err)
 	}
 	resp, err := client.Do(req)
+	if err == nil {
+		defer resp.Body.Close()
+	}
 
 	if expectedError == true && err == nil {
 		t.Fatalf("%d: expecting error for cipher test, client cipher is supported and it should't", testID)
 	} else if err != nil && expectedError == false {
 		t.Fatalf("%d: not expecting error by client with cipher failed: %+v", testID, err)
-	}
-
-	if err == nil {
-		defer resp.Body.Close()
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

move `ServerRunOptions` set default function  `defaultOptions` out of `CreateKubeAPIServerConfig`, it should be called before real use `CreateNodeDialer`. So move it to cobra.Command just after kube-apiserver flags parsed.

Similarly `ServerRunOptions.Validate` move there too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
