### PR TITLE
Volume deletion should be idempotent

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
 	"google.golang.org/api/googleapi"
 	"k8s.io/api/core/v1"
@@ -678,6 +679,22 @@ func DeletePDWithRetry(diskName string) error {
 	return fmt.Errorf("unable to delete PD %q: %v", diskName, err)
 }
 
+func newAWSClient(zone string) *ec2.EC2 {
+	var cfg *aws.Config
+
+	if zone == "" {
+		zone = TestContext.CloudConfig.Zone
+	}
+	if zone == "" {
+		glog.Warning("No AWS zone configured!")
+		cfg = nil
+	} else {
+		region := zone[:len(zone)-1]
+		cfg = &aws.Config{Region: aws.String(region)}
+	}
+	return ec2.New(session.New(), cfg)
+}
+
 func createPD(zone string) (string, error) {
 	if zone == "" {
 		zone = TestContext.CloudConfig.Zone
@@ -698,8 +715,7 @@ func createPD(zone string) (string, error) {
 		}
 		return pdName, nil
 	} else if TestContext.Provider == "aws" {
-		client := ec2.New(session.New())
-
+		client := newAWSClient(zone)
 		request := &ec2.CreateVolumeInput{}
 		request.AvailabilityZone = aws.String(zone)
 		request.Size = aws.Int64(10)
@@ -751,7 +767,7 @@ func deletePD(pdName string) error {
 		}
 		return err
 	} else if TestContext.Provider == "aws" {
-		client := ec2.New(session.New())
+		client := newAWSClient("")
 
 		tokens := strings.Split(pdName, "/")
 		awsVolumeID := tokens[len(tokens)-1]


### PR DESCRIPTION
- Describe* calls should return `aws.Error` so caller can handle individual errors. `aws.Error` already has enough context (`"InvalidVolume.NotFound: The volume 'vol-0a06cc096e989c5a2' does not exist"`)
- Deletion of already deleted volume should succeed.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

Fixes: #60778

```release-note
NONE
```

/sig storage
/sig aws

/assign @justinsb @gnufied 