### PR TITLE
[1.9] - Fix Golang version check to work with >=1.10

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -323,7 +323,7 @@ EOF
   go_version=($(go version))
   local minimum_go_version
   minimum_go_version=go1.9.1
-  if [[ "${go_version[2]}" < "${minimum_go_version}" && "${go_version[2]}" != "devel" ]]; then
+  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.
 Kubernetes requires ${minimum_go_version} or greater.


### PR DESCRIPTION
backport of https://github.com/kubernetes/kubernetes/pull/58207

```release-note
NONE
```
