### PR TITLE
kubectl-container no longer exists in the kubernetes/examples repo

### DIFF
--- a/examples/kubectl-container/README.md
+++ b/examples/kubectl-container/README.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/examples/blob/master/staging/kubectl-container/README.md](https://github.com/kubernetes/examples/blob/master/staging/kubectl-container/README.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
kubectl-container no longer exists in the kubernetes/examples repo.

xref:
https://github.com/kubernetes/examples/pull/136
https://github.com/kubernetes/website/pull/6713