### PR TITLE
Support completion for kubectl apply view/edit-last-applied

### DIFF
--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -67,6 +67,8 @@ func NewViewLastAppliedOptions(out, err io.Writer) *ViewLastAppliedOptions {
 
 func NewCmdApplyViewLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	options := NewViewLastAppliedOptions(out, err)
+	validArgs := cmdutil.ValidArgList(f)
+
 	cmd := &cobra.Command{
 		Use: "view-last-applied (TYPE [NAME | -l label] | TYPE/NAME | -f FILENAME)",
 		DisableFlagsInUseLine: true,
@@ -78,6 +80,8 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Co
 			cmdutil.CheckErr(options.Validate(cmd))
 			cmdutil.CheckErr(options.RunApplyViewLastApplied(cmd))
 		},
+		ValidArgs:  validArgs,
+		ArgAliases: kubectl.ResourceAliases(validArgs),
 	}
 
 	cmd.Flags().StringVarP(&options.OutputFormat, "output", "o", options.OutputFormat, "Output format. Must be one of yaml|json")

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -168,7 +168,8 @@ __kubectl_require_pod_and_container()
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_edit | kubectl_patch |\
-        kubectl_annotate | kubectl_expose | kubectl_scale | kubectl_autoscale | kubectl_taint | kubectl_rollout_*)
+        kubectl_annotate | kubectl_expose | kubectl_scale | kubectl_autoscale | kubectl_taint | kubectl_rollout_* |\
+        kubectl_apply_edit-last-applied | kubectl_apply_view-last-applied)
             __kubectl_get_resource
             return
             ;;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: With this PR, `kubectl apply view/edit-last-applied` support completion.
```
$ kubectl apply view-last-applied <tab>
certificatesigningrequest  configmap           daemonset   event                    job            node                   pod                  podtemplate            rolebinding  serviceaccount  storageclass
clusterrolebinding         controllerrevision  deployment  horizontalpodautoscaler  namespace      persistentvolume       poddisruptionbudget  replicaset             secret       statefulset     
componentstatus            cronjob             endpoints   ingress                  networkpolicy  persistentvolumeclaim  podsecuritypolicy    replicationcontroller  service      status
$ kubectl apply view-last-applied deployment nginx<tab>
nginx   nginx2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubectl apply view/edit-last-applied support completion.
```
