### PR TITLE
Remove old featureGate flag in Readme

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -24,15 +24,7 @@ Users should export the env `KUBE_PROXY_MODE=ipvs` to specify the ipvs mode befo
 
 Kube-proxy will run in iptables mode by default in a cluster deployed by [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/). 
 
-Since IPVS mode is still feature-gated, users should add the flag `--feature-gates=SupportIPVSProxyMode=true` in `kubeadm init` command
-
-```
-kubeadm init --feature-gates=SupportIPVSProxyMode=true
-```
-
-to specify the ipvs mode before deploying the cluster if want to run kube-proxy in ipvs mode.
-
-If you are using kubeadm with a configuration file, you can specify the ipvs mode adding `SupportIPVSProxyMode: true` below the `featureGates` field.
+If you are using kubeadm with a [configuration file](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file), you can specify the ipvs mode adding `SupportIPVSProxyMode: true` below the `kubeProxy` field.
 Then the configuration file is similar to:
 
 ```json


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR corrects the Readme for ipvs mode: https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/README.md. `kubeadm init` doesn't support the `--feature-gates=SupportIPVSProxyMode=true` flag anymore since IPVS is in beta and not alpha anymore.


```
sudo kubeadm init --help
Run this command in order to set up the Kubernetes master.

Usage:
  kubeadm init [flags]

Flags:
      --apiserver-advertise-address string      The IP address the API Server will advertise it's listening on. Specify '0.0.0.0' to use the address of the default network interface.
      --apiserver-bind-port int32               Port for the API Server to bind to. (default 6443)
      --apiserver-cert-extra-sans stringSlice   Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.
      --cert-dir string                         The path where to save and store the certificates. (default "/etc/kubernetes/pki")
      --config string                           Path to kubeadm config file. WARNING: Usage of a configuration file is experimental.
      --cri-socket string                       Specify the CRI socket to connect to. (default "/var/run/dockershim.sock")
      --dry-run                                 Don't apply any changes; just output what would be done.
      --feature-gates string                    A set of key=value pairs that describe feature gates for various features. Options are:
CoreDNS=true|false (ALPHA - default=false)
DynamicKubeletConfig=true|false (ALPHA - default=false)
SelfHosting=true|false (ALPHA - default=false)
StoreCertsInSecrets=true|false (ALPHA - default=false)
      --ignore-preflight-errors stringSlice     A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.
      --kubernetes-version string               Choose a specific Kubernetes version for the control plane. (default "stable-1.9")
      --node-name string                        Specify the node name.
      --pod-network-cidr string                 Specify range of IP addresses for the pod network. If set, the control plane will automatically allocate CIDRs for every node.
      --service-cidr string                     Use alternative range of IP address for service VIPs. (default "10.96.0.0/12")
      --service-dns-domain string               Use alternative domain for services, e.g. "myorg.internal". (default "cluster.local")
      --skip-token-print                        Skip printing of the default bootstrap token generated by 'kubeadm init'.
      --token string                            The token to use for establishing bidirectional trust between nodes and masters.
      --token-ttl duration                      The duration before the bootstrap token is automatically deleted. If set to '0', the token will never expire. (default 24h0m0s)
```

**Special notes for your reviewer**:
Used kubeadm version:

```bash
sudo kubeadm version
kubeadm version: &version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-07T11:55:20Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
