### PR TITLE
[fluentd-gcp addon] Fix passing location to event exporter

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -50,7 +50,7 @@ spec:
         image: k8s.gcr.io/event-exporter:v0.1.8
         command:
         - /event-exporter
-        - -sink-opts="-location={{ event_exporter_zone }}"
+        - -sink-opts=-location={{ event_exporter_zone }}
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
         image: k8s.gcr.io/prometheus-to-sd:v0.2.4

--- a/test/e2e/instrumentation/logging/stackdrvier/basic.go
+++ b/test/e2e/instrumentation/logging/stackdrvier/basic.go
@@ -162,7 +162,8 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 			}()
 
 			ginkgo.By("Waiting for events to ingest")
-			c := utils.NewLogChecker(p, utils.UntilFirstEntry, utils.JustTimeout, "")
+			zone := framework.TestContext.CloudConfig.Zone
+			c := utils.NewLogChecker(p, utils.UntilFirstEntryFromZone(zone), utils.JustTimeout, "")
 			err := utils.WaitForLogs(c, ingestionInterval, ingestionTimeout)
 			framework.ExpectNoError(err)
 		})

--- a/test/e2e/instrumentation/logging/utils/wait.go
+++ b/test/e2e/instrumentation/logging/utils/wait.go
@@ -55,6 +55,19 @@ func UntilFirstEntryFromLog(log string) IngestionPred {
 	}
 }
 
+// UntilFirstEntryFromZone is a IngestionPred that checks that at least one
+// entry from the log with a given name was ingested.
+func UntilFirstEntryFromZone(zone string) IngestionPred {
+	return func(_ string, entries []LogEntry) (bool, error) {
+		for _, e := range entries {
+			if e.Location == zone {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
 // TimeoutFun is a function that is called when the waiting times out.
 type TimeoutFun func([]string, []bool) error
 


### PR DESCRIPTION
Fix passing argument to event-expoter in https://github.com/kubernetes/kubernetes/pull/58090

```release-note
NONE
```
