### PR TITLE
sh2ju.sh: suppress `which` command output when gdate not found in $PATH

### DIFF
--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -59,7 +59,7 @@ function juLogClean() {
 function juLog() {
   suite="";
   errfile=/tmp/evErr.$$.log
-  date=`which gdate || which date`
+  date=`which gdate 2>/dev/null || which date`
   asserts=00; errors=0; total=0; content=""
 
   # parse arguments


### PR DESCRIPTION
**What this PR does / why we need it**:
`make quick-verify` (and probably some other commands) doesn't produce a lot of unrelated and useless information to a console now.

Here is the related PR in the upstream: https://github.com/manolo/shell2junit/pull/7

How it was before:
>SUCCESS  verify-pkg-names.sh	1s
>Verifying verify-readonly-packages.sh
>which: no gdate in (/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/coder/bin:/home/coder/git/bin:/opt/maven/bin:/opt/go1.9.2/bin:/home/coder/.cargo/bin:/home/coder/git/src/github.com/openshift/origin/_output/local/bin/linux/amd64:/home/coder/git/kubernetes/third_party/etcd:/opt/groovy-2.4.12/bin:/home/coder/bin:/home/coder/git/bin:/opt/maven/bin:/opt/go1.9.2/bin:/home/coder/.cargo/bin:/home/coder/git/src/github.com/openshift/origin/_output/local/bin/linux/amd64:/home/coder/git/kubernetes/third_party/etcd:/opt/groovy-2.4.12/bin)