### PR TITLE
Add node-e2e test for ShareProcessNamespace

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -166,6 +166,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [

--- a/test/e2e_node/docker_test.go
+++ b/test/e2e_node/docker_test.go
@@ -37,46 +37,6 @@ var _ = framework.KubeDescribe("Docker features [Feature:Docker]", func() {
 		framework.RunIfContainerRuntimeIs("docker")
 	})
 
-	Context("when shared PID namespace is enabled", func() {
-		It("processes in different containers of the same pod should be able to see each other", func() {
-			// TODO(yguo0905): Change this test to run unless the runtime is
-			// Docker and its version is <1.13.
-			By("Check whether shared PID namespace is supported.")
-			isEnabled, err := isSharedPIDNamespaceSupported()
-			framework.ExpectNoError(err)
-			if !isEnabled {
-				framework.Skipf("Skipped because shared PID namespace is not supported by this docker version.")
-			}
-
-			By("Create a pod with two containers.")
-			f.PodClient().CreateSync(&v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "shared-pid-ns-test-pod"},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:    "test-container-1",
-							Image:   "busybox",
-							Command: []string{"/bin/top"},
-						},
-						{
-							Name:    "test-container-2",
-							Image:   "busybox",
-							Command: []string{"/bin/sleep"},
-							Args:    []string{"10000"},
-						},
-					},
-				},
-			})
-
-			By("Check if the process in one container is visible to the process in the other.")
-			pid1 := f.ExecCommandInContainer("shared-pid-ns-test-pod", "test-container-1", "/bin/pidof", "top")
-			pid2 := f.ExecCommandInContainer("shared-pid-ns-test-pod", "test-container-2", "/bin/pidof", "top")
-			if pid1 != pid2 {
-				framework.Failf("PIDs are not the same in different containers: test-container-1=%v, test-container-2=%v", pid1, pid2)
-			}
-		})
-	})
-
 	Context("when live-restore is enabled [Serial] [Slow] [Disruptive]", func() {
 		It("containers should not be disrupted when the daemon shuts down and restarts", func() {
 			const (

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -258,7 +258,6 @@ func (e *E2EServices) startKubelet() (*server, error) {
 	cmdArgs = append(cmdArgs,
 		"--kubeconfig", kubeconfigPath,
 		"--root-dir", KubeletRootDirectory,
-		"--docker-disable-shared-pid=false",
 		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
 		"--allow-privileged", "true",
 	)


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a node-e2e test for kubernetes/features#495

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59554

**Special notes for your reviewer**: This requires a feature gate to be enabled in both the kubelet and API server. I'm not sure which jenkins configs need to be updated (or if these are even still used) so I just updated a pile of them.

opened kubernetes/test-infra#7030 for https://github.com/kubernetes/test-infra/blob/master/jobs/config.json

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
