### PR TITLE
kubectl: Support getting the editor from the $VISUAL environment variable

### DIFF
--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -33,7 +33,7 @@ var (
 		Edit the latest last-applied-configuration annotations of resources from the default editor.
 
 		The edit-last-applied command allows you to directly edit any API resource you can retrieve via the
-		command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+		command line tools. It will open the editor defined by your KUBE_EDITOR, VISUAL or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts filenames as well as command line arguments, although the files you point to must

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -35,8 +35,8 @@ var (
 		Edit a resource from the default editor.
 
 		The edit command allows you to directly edit any API resource you can retrieve via the
-		command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
-		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
+		command line tools. It will open the editor defined by your KUBE_EDITOR, VISUAL or
+		EDITOR environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts filenames as well as command line arguments, although the files you point to must
 		be previously saved versions of resources.

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -644,7 +644,7 @@ func (f *ring0Factory) CanBeAutoscaled(kind schema.GroupKind) error {
 }
 
 func (f *ring0Factory) EditorEnvs() []string {
-	return []string{"KUBE_EDITOR", "EDITOR"}
+	return []string{"KUBE_EDITOR", "VISUAL", "EDITOR"}
 }
 
 // overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

If `KUBE_EDITOR` is not set, kubectl will fall back to `EDITOR`. However `EDITOR` is meant to be a (rather inconvenient) line-based editor like ed, meant to be used on slow teletype terminals.
Most programs nowadays, such as less and crontab, will attempt to get the editor from `VISUAL` first and only fall back to `EDITOR` if it is not set.
This commit replicates this behavior in kubectl.

More about this on [Wikibooks](https://en.wikibooks.org/wiki/Guide_to_Unix/Environment_Variables#VISUAL) and [StackExchange](https://unix.stackexchange.com/questions/4859/visual-vs-editor-whats-the-difference).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support getting the editor from the $VISUAL environment variable
```
