### PR TITLE
[1.7] Automated cherry pick of #58720 #60342

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -122,6 +122,13 @@ const (
 	// Enable the service proxy to contact external IP addresses. Note this feature is present
 	// only for backward compatability, it will be removed in the 1.11 release.
 	ServiceProxyAllowExternalIPs utilfeature.Feature = "ServiceProxyAllowExternalIPs"
+
+	// owner: @joelsmith
+	// deprecated: v1.10
+	//
+	// Mount secret, configMap, downwardAPI and projected volumes ReadOnly. Note: this feature
+	// gate is present only for backward compatability, it will be removed in the 1.11 release.
+	ReadOnlyAPIDataVolumes utilfeature.Feature = "ReadOnlyAPIDataVolumes"
 )
 
 func init() {
@@ -153,4 +160,5 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 
 	// features that enable backwards compatability but are scheduled to be removed
 	ServiceProxyAllowExternalIPs: {Default: false, PreRelease: utilfeature.Deprecated},
+	ReadOnlyAPIDataVolumes:       {Default: true, PreRelease: utilfeature.Deprecated},
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -48,6 +49,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/api/v1/validation"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -187,11 +189,13 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			}
 		}
 
+		mustMountRO := vol.Mounter.GetAttributes().ReadOnly && utilfeature.DefaultFeatureGate.Enabled(features.ReadOnlyAPIDataVolumes)
+
 		mounts = append(mounts, kubecontainer.Mount{
 			Name:           mount.Name,
 			ContainerPath:  containerPath,
 			HostPath:       hostPath,
-			ReadOnly:       mount.ReadOnly,
+			ReadOnly:       mount.ReadOnly || mustMountRO,
 			SELinuxRelabel: relabelVolume,
 		})
 	}

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -194,6 +194,9 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if err := wrapped.SetUpAt(dir, fsGroup); err != nil {
 		return err
 	}
+	if err := volumeutil.MakeNestedMountpoints(b.volName, dir, b.pod); err != nil {
+		return err
+	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
 	configMap, err := b.getConfigMap(b.pod.Namespace, b.source.Name)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -184,6 +184,9 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		glog.Errorf("Unable to setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
 		return err
 	}
+	if err := volumeutil.MakeNestedMountpoints(b.volName, dir, *b.pod); err != nil {
+		return err
+	}
 
 	data, err := CollectData(b.source.Items, b.pod, b.plugin.host, b.source.DefaultMode)
 	if err != nil {

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -191,6 +191,9 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if err := wrapped.SetUpAt(dir, fsGroup); err != nil {
 		return err
 	}
+	if err := volumeutil.MakeNestedMountpoints(s.volName, dir, *s.pod); err != nil {
+		return err
+	}
 
 	data, err := s.collectData()
 	if err != nil {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -193,6 +193,9 @@ func (b *secretVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if err := wrapped.SetUpAt(dir, fsGroup); err != nil {
 		return err
 	}
+	if err := volumeutil.MakeNestedMountpoints(b.volName, dir, b.pod); err != nil {
+		return err
+	}
 
 	optional := b.source.Optional != nil && *b.source.Optional
 	secret, err := b.getSecret(b.pod.Namespace, b.source.SecretName)

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -17,6 +17,7 @@ go_library(
         "doc.go",
         "fs.go",
         "io_util.go",
+        "nested_volumes.go",
         "util.go",
     ],
     tags = ["automanaged"],
@@ -39,6 +40,7 @@ go_test(
     srcs = [
         "atomic_writer_test.go",
         "device_util_linux_test.go",
+        "nested_volumes_test.go",
         "util_test.go",
     ],
     library = ":go_default_library",
@@ -47,6 +49,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/api/v1/helper:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/util/testing:go_default_library",
     ],

--- a/pkg/volume/util/nested_volumes.go
+++ b/pkg/volume/util/nested_volumes.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// getNestedMountpoints returns a list of mountpoint directories that should be created
+// for the volume indicated by name.
+// note: the returned list is relative to baseDir
+func getNestedMountpoints(name, baseDir string, pod v1.Pod) ([]string, error) {
+	var retval []string
+	checkContainer := func(container *v1.Container) error {
+		var allMountPoints []string // all mount points in this container
+		var myMountPoints []string  // mount points that match name
+		for _, vol := range container.VolumeMounts {
+			cleaned := filepath.Clean(vol.MountPath)
+			allMountPoints = append(allMountPoints, cleaned)
+			if vol.Name == name {
+				myMountPoints = append(myMountPoints, cleaned)
+			}
+		}
+		sort.Strings(allMountPoints)
+		parentPrefix := ".." + string(os.PathSeparator)
+		// Examine each place where this volume is mounted
+		for _, myMountPoint := range myMountPoints {
+			if strings.HasPrefix(myMountPoint, parentPrefix) {
+				// Don't let a container trick us into creating directories outside of its rootfs
+				return fmt.Errorf("Invalid container mount point %v", myMountPoint)
+			}
+			myMPSlash := myMountPoint + string(os.PathSeparator)
+			// The previously found nested mountpoint (or "" if none found yet)
+			prevNestedMP := ""
+			// examine each mount point to see if it's nested beneath this volume
+			// (but skip any that are double-nested beneath this volume)
+			// For example, if this volume is mounted as /dir and other volumes are mounted
+			//              as /dir/nested and /dir/nested/other, only create /dir/nested.
+			for _, mp := range allMountPoints {
+				if !strings.HasPrefix(mp, myMPSlash) {
+					continue // skip -- not nested beneath myMountPoint
+				}
+				if prevNestedMP != "" && strings.HasPrefix(mp, prevNestedMP) {
+					continue // skip -- double nested beneath myMountPoint
+				}
+				// since this mount point is nested, remember it so that we can check that following ones aren't nested beneath this one
+				prevNestedMP = mp + string(os.PathSeparator)
+				retval = append(retval, mp[len(myMPSlash):])
+			}
+		}
+		return nil
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if err := checkContainer(&container); err != nil {
+			return nil, err
+		}
+	}
+	for _, container := range pod.Spec.Containers {
+		if err := checkContainer(&container); err != nil {
+			return nil, err
+		}
+	}
+	return retval, nil
+}
+
+// MakeNestedMountpoints creates mount points in baseDir for volumes mounted beneath name
+func MakeNestedMountpoints(name, baseDir string, pod v1.Pod) error {
+	dirs, err := getNestedMountpoints(name, baseDir, pod)
+	if err != nil {
+		return err
+	}
+	for _, dir := range dirs {
+		err := os.MkdirAll(path.Join(baseDir, dir), 0755)
+		if err != nil {
+			return fmt.Errorf("Unable to create nested volume mountpoints: %v", err)
+		}
+	}
+	return nil
+}

--- a/pkg/volume/util/nested_volumes_test.go
+++ b/pkg/volume/util/nested_volumes_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+type testCases struct {
+	name     string
+	err      bool
+	expected sets.String
+	volname  string
+	pod      v1.Pod
+}
+
+func TestGetNestedMountpoints(t *testing.T) {
+	var (
+		testNamespace = "test_namespace"
+		testPodUID    = types.UID("test_pod_uid")
+	)
+
+	tc := []testCases{
+		{
+			name:     "Simple Pod",
+			err:      false,
+			expected: sets.NewString(),
+			volname:  "vol1",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/dir", Name: "vol1"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Simple Nested Pod",
+			err:      false,
+			expected: sets.NewString("nested"),
+			volname:  "vol1",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/dir", Name: "vol1"},
+								{MountPath: "/dir/nested", Name: "vol2"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Unsorted Nested Pod",
+			err:      false,
+			expected: sets.NewString("nested", "nested2"),
+			volname:  "vol1",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/dir/nested/double", Name: "vol3"},
+								{MountPath: "/ignore", Name: "vol4"},
+								{MountPath: "/dir/nested", Name: "vol2"},
+								{MountPath: "/ignore2", Name: "vol5"},
+								{MountPath: "/dir", Name: "vol1"},
+								{MountPath: "/dir/nested2", Name: "vol3"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Multiple vol1 mounts Pod",
+			err:      false,
+			expected: sets.NewString("nested", "nested2"),
+			volname:  "vol1",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/dir", Name: "vol1"},
+								{MountPath: "/dir/nested", Name: "vol2"},
+								{MountPath: "/ignore", Name: "vol4"},
+								{MountPath: "/other", Name: "vol1"},
+								{MountPath: "/other/nested2", Name: "vol3"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Big Pod",
+			err:      false,
+			volname:  "vol1",
+			expected: sets.NewString("sub1/sub2/sub3", "sub1/sub2/sub4", "sub1/sub2/sub6", "sub"),
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/mnt", Name: "vol1"},
+								{MountPath: "/ignore", Name: "vol2"},
+								{MountPath: "/mnt/sub1/sub2/sub3", Name: "vol3"},
+								{MountPath: "/mnt/sub1/sub2/sub4", Name: "vol4"},
+								{MountPath: "/mnt/sub1/sub2/sub4/skip", Name: "vol5"},
+								{MountPath: "/mnt/sub1/sub2/sub4/skip2", Name: "vol5a"},
+								{MountPath: "/mnt/sub1/sub2/sub6", Name: "vol6"},
+								{MountPath: "/mnt7", Name: "vol7"},
+							},
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "/mnt/dir", Name: "vol1"},
+								{MountPath: "/mnt/dir_ignore", Name: "vol8"},
+								{MountPath: "/ignore", Name: "vol9"},
+								{MountPath: "/mnt/dir/sub", Name: "vol11"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "Naughty Pod",
+			err:      true,
+			expected: nil,
+			volname:  "vol1",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							VolumeMounts: []v1.VolumeMount{
+								{MountPath: "foo/../../dir", Name: "vol1"},
+								{MountPath: "foo/../../dir/skip", Name: "vol10"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tc {
+		dir, err := ioutil.TempDir("", "TestMakeNestedMountpoints.")
+		if err != nil {
+			t.Errorf("Unexpected error trying to create temp directory: %v", err)
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		rootdir := path.Join(dir, "vol")
+		err = os.Mkdir(rootdir, 0755)
+		if err != nil {
+			t.Errorf("Unexpected error trying to create temp root directory: %v", err)
+			return
+		}
+
+		dirs, err := getNestedMountpoints(test.volname, rootdir, test.pod)
+		if test.err {
+			if err == nil {
+				t.Errorf("%v: expected error, got nil", test.name)
+			}
+			continue
+		} else {
+			if err != nil {
+				t.Errorf("%v: expected no error, got %v", test.name, err)
+				continue
+			}
+		}
+		actual := sets.NewString(dirs...)
+		if !test.expected.Equal(actual) {
+			t.Errorf("%v: unexpected nested directories created:\nexpected: %v\n     got: %v", test.name, test.expected, actual)
+		}
+	}
+}

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -41,7 +41,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide podname only [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
@@ -51,20 +51,20 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 	It("should set DefaultMode on files [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
-		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", nil, &defaultMode)
+		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--------",
+			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
 
 	It("should set mode on item file [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
-		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
+		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--------",
+			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
 
@@ -72,7 +72,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
-		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 			FSGroup:   &gid,
@@ -87,13 +87,13 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		uid := int64(1001)
 		gid := int64(1234)
 		mode := int32(0440) /* setting fsGroup sets mode to at least 440 */
-		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
+		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 			FSGroup:   &gid,
 		}
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--r-----",
+			"mode of file \"/etc/podinfo/podname\": -r--r-----",
 		})
 	})
 
@@ -103,7 +103,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		labels["key2"] = "value2"
 
 		podName := "labelsupdate" + string(uuid.NewUUID())
-		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/labels")
+		pod := downwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		By("Creating the pod")
 		podClient.CreateSync(pod)
@@ -128,7 +128,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
-		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/annotations")
+		pod := downwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
 
 		containerName := "client-container"
 		By("Creating the pod")
@@ -155,7 +155,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide container's cpu limit [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
@@ -164,7 +164,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide container's memory limit [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
@@ -173,7 +173,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide container's cpu request [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
@@ -182,7 +182,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide container's memory request [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
@@ -191,14 +191,14 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 
 	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
+		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
 	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")
+		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
@@ -216,7 +216,7 @@ func downwardAPIVolumePodForModeTest(name, filePath string, itemMode, defaultMod
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 				},
 			},
 		},
@@ -242,7 +242,7 @@ func downwardAPIVolumePodForSimpleTest(name string, filePath string) *v1.Pod {
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 					ReadOnly:  false,
 				},
 			},
@@ -283,7 +283,7 @@ func downwardAPIVolumeBaseContainers(name, filePath string) []v1.Container {
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 					ReadOnly:  false,
 				},
 			},
@@ -301,7 +301,7 @@ func downwardAPIVolumeDefaultBaseContainer(name, filePath string) []v1.Container
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 				},
 			},
 		},
@@ -320,7 +320,7 @@ func downwardAPIVolumePodForUpdateTest(name string, labels, annotations map[stri
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 					ReadOnly:  false,
 				},
 			},

--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -804,7 +804,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide podname only [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("%s\n", podName),
@@ -814,20 +814,20 @@ var _ = framework.KubeDescribe("Projected", func() {
 	It("should set DefaultMode on files [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
-		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podname", nil, &defaultMode)
+		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--------",
+			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
 
 	It("should set mode on item file [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
-		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
+		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--------",
+			"mode of file \"/etc/podinfo/podname\": -r--------",
 		})
 	})
 
@@ -835,7 +835,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
-		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
+		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 			FSGroup:   &gid,
@@ -850,13 +850,13 @@ var _ = framework.KubeDescribe("Projected", func() {
 		uid := int64(1001)
 		gid := int64(1234)
 		mode := int32(0440) /* setting fsGroup sets mode to at least 440 */
-		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
+		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
 		pod.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 			FSGroup:   &gid,
 		}
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
-			"mode of file \"/etc/podname\": -r--r-----",
+			"mode of file \"/etc/podinfo/podname\": -r--r-----",
 		})
 	})
 
@@ -866,7 +866,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		labels["key2"] = "value2"
 
 		podName := "labelsupdate" + string(uuid.NewUUID())
-		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/labels")
+		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, labels, map[string]string{}, "/etc/podinfo/labels")
 		containerName := "client-container"
 		By("Creating the pod")
 		podClient.CreateSync(pod)
@@ -891,7 +891,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
-		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/annotations")
+		pod := projectedDownwardAPIVolumePodForUpdateTest(podName, map[string]string{}, annotations, "/etc/podinfo/annotations")
 
 		containerName := "client-container"
 		By("Creating the pod")
@@ -918,7 +918,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide container's cpu limit [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("2\n"),
@@ -927,7 +927,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide container's memory limit [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("67108864\n"),
@@ -936,7 +936,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide container's cpu request [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("1\n"),
@@ -945,7 +945,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide container's memory request [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
+		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
 		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
 			fmt.Sprintf("33554432\n"),
@@ -954,14 +954,14 @@ var _ = framework.KubeDescribe("Projected", func() {
 
 	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
+		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
 	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [Volume]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
-		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")
+		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
@@ -1373,7 +1373,7 @@ func projectedDownwardAPIVolumePodForModeTest(name, filePath string, itemMode, d
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 				},
 			},
 		},
@@ -1399,7 +1399,7 @@ func projectedDownwardAPIVolumePodForUpdateTest(name string, labels, annotations
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
-					MountPath: "/etc",
+					MountPath: "/etc/podinfo",
 					ReadOnly:  false,
 				},
 			},


### PR DESCRIPTION
Cherry pick of #58720 #60342 on release-1.7.

#58720: Ensure that the runtime mounts RO volumes read-only
#60342: Fix nested volume mounts for read-only API data volumes

Fixes https://github.com/kubernetes/kubernetes/issues/60814 for 1.7

```release-note
Changes secret, configMap, downwardAPI and projected volumes to mount read-only, instead of allowing applications to write data and then reverting it automatically. Until version 1.11, setting the feature gate ReadOnlyAPIDataVolumes=false will preserve the old behavior.
```