### PR TITLE
Automated cherry pick of #59447: Fixes the regression of GCEPD not provisioning correctly on

### DIFF
--- a/pkg/volume/gce_pd/BUILD
+++ b/pkg/volume/gce_pd/BUILD
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/cloudprovider:go_default_library",
         "//pkg/cloudprovider/providers/gce:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
@@ -42,6 +43,7 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/volume/gce_pd",
     library = ":go_default_library",
     deps = [
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -88,7 +88,7 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName ty
 		// Volume is already attached to node.
 		glog.Infof("Attach operation is successful. PD %q is already attached to node %q.", pdName, nodeName)
 	} else {
-		if err := attacher.gceDisks.AttachDisk(pdName, nodeName, readOnly); err != nil {
+		if err := attacher.gceDisks.AttachDisk(pdName, nodeName, readOnly, isRegionalPD(spec)); err != nil {
 			glog.Errorf("Error attaching PD %q to node %q: %+v", pdName, nodeName, err)
 			return "", err
 		}

--- a/pkg/volume/gce_pd/attacher_test.go
+++ b/pkg/volume/gce_pd/attacher_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/types"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	"strings"
 )
 
 func TestGetDeviceName_Volume(t *testing.T) {
@@ -48,7 +50,7 @@ func TestGetDeviceName_Volume(t *testing.T) {
 func TestGetDeviceName_PersistentVolume(t *testing.T) {
 	plugin := newPlugin()
 	name := "my-pd-pv"
-	spec := createPVSpec(name, true)
+	spec := createPVSpec(name, true, nil)
 
 	deviceName, err := plugin.GetVolumeName(spec)
 	if err != nil {
@@ -74,10 +76,39 @@ type testcase struct {
 	expectedReturn error
 }
 
+func TestAttachDetachRegional(t *testing.T) {
+	diskName := "disk"
+	nodeName := types.NodeName("instance")
+	readOnly := false
+	regional := true
+	spec := createPVSpec(diskName, readOnly, []string{"zone1", "zone2"})
+	// Successful Attach call
+	testcase := testcase{
+		name:           "Attach_Regional_Positive",
+		diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
+		attach:         attachCall{diskName, nodeName, readOnly, regional, nil},
+		test: func(testcase *testcase) error {
+			attacher := newAttacher(testcase)
+			devicePath, err := attacher.Attach(spec, nodeName)
+			if devicePath != "/dev/disk/by-id/google-disk" {
+				return fmt.Errorf("devicePath incorrect. Expected<\"/dev/disk/by-id/google-disk\"> Actual: <%q>", devicePath)
+			}
+			return err
+		},
+	}
+
+	err := testcase.test(&testcase)
+	if err != testcase.expectedReturn {
+		t.Errorf("%s failed: expected err=%q, got %q", testcase.name, testcase.expectedReturn.Error(), err.Error())
+	}
+	t.Logf("Test %q succeeded", testcase.name)
+}
+
 func TestAttachDetach(t *testing.T) {
 	diskName := "disk"
 	nodeName := types.NodeName("instance")
 	readOnly := false
+	regional := false
 	spec := createVolSpec(diskName, readOnly)
 	attachError := errors.New("Fake attach error")
 	detachError := errors.New("Fake detach error")
@@ -87,7 +118,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:           "Attach_Positive",
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
-			attach:         attachCall{diskName, nodeName, readOnly, nil},
+			attach:         attachCall{diskName, nodeName, readOnly, regional, nil},
 			test: func(testcase *testcase) error {
 				attacher := newAttacher(testcase)
 				devicePath, err := attacher.Attach(spec, nodeName)
@@ -116,7 +147,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:           "Attach_Positive_CheckFails",
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			attach:         attachCall{diskName, nodeName, readOnly, nil},
+			attach:         attachCall{diskName, nodeName, readOnly, regional, nil},
 			test: func(testcase *testcase) error {
 				attacher := newAttacher(testcase)
 				devicePath, err := attacher.Attach(spec, nodeName)
@@ -131,7 +162,7 @@ func TestAttachDetach(t *testing.T) {
 		{
 			name:           "Attach_Negative",
 			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			attach:         attachCall{diskName, nodeName, readOnly, attachError},
+			attach:         attachCall{diskName, nodeName, readOnly, regional, attachError},
 			test: func(testcase *testcase) error {
 				attacher := newAttacher(testcase)
 				devicePath, err := attacher.Attach(spec, nodeName)
@@ -238,8 +269,8 @@ func createVolSpec(name string, readOnly bool) *volume.Spec {
 	}
 }
 
-func createPVSpec(name string, readOnly bool) *volume.Spec {
-	return &volume.Spec{
+func createPVSpec(name string, readOnly bool, zones []string) *volume.Spec {
+	spec := &volume.Spec{
 		PersistentVolume: &v1.PersistentVolume{
 			Spec: v1.PersistentVolumeSpec{
 				PersistentVolumeSource: v1.PersistentVolumeSource{
@@ -251,6 +282,15 @@ func createPVSpec(name string, readOnly bool) *volume.Spec {
 			},
 		},
 	}
+
+	if zones != nil {
+		zonesLabel := strings.Join(zones, kubeletapis.LabelMultiZoneDelimiter)
+		spec.PersistentVolume.ObjectMeta.Labels = map[string]string{
+			kubeletapis.LabelZoneFailureDomain: zonesLabel,
+		}
+	}
+
+	return spec
 }
 
 // Fake GCE implementation
@@ -259,6 +299,7 @@ type attachCall struct {
 	diskName string
 	nodeName types.NodeName
 	readOnly bool
+	regional bool
 	ret      error
 }
 
@@ -275,7 +316,7 @@ type diskIsAttachedCall struct {
 	ret        error
 }
 
-func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, readOnly bool) error {
+func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, readOnly bool, regional bool) error {
 	expected := &testcase.attach
 
 	if expected.diskName == "" && expected.nodeName == "" {
@@ -298,6 +339,11 @@ func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, r
 	if expected.readOnly != readOnly {
 		testcase.t.Errorf("Unexpected AttachDisk call: expected readOnly %v, got %v", expected.readOnly, readOnly)
 		return errors.New("Unexpected AttachDisk call: wrong readOnly")
+	}
+
+	if expected.regional != regional {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected regional %v, got %v", expected.regional, regional)
+		return errors.New("Unexpected AttachDisk call: wrong regional")
 	}
 
 	glog.V(4).Infof("AttachDisk call: %s, %s, %v, returning %v", diskName, nodeName, readOnly, expected.ret)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/utils/exec"
@@ -356,4 +357,14 @@ func udevadmChangeToDrive(drivePath string) error {
 		return fmt.Errorf("udevadmChangeToDrive: udevadm trigger failed for drive %q with %v.", drive, err)
 	}
 	return nil
+}
+
+// Checks whether the given GCE PD volume spec is associated with a regional PD.
+func isRegionalPD(spec *volume.Spec) bool {
+	if spec.PersistentVolume != nil {
+		zonesLabel := spec.PersistentVolume.Labels[kubeletapis.LabelZoneFailureDomain]
+		zones := strings.Split(zonesLabel, kubeletapis.LabelMultiZoneDelimiter)
+		return len(zones) > 1
+	}
+	return false
 }


### PR DESCRIPTION
Cherry pick of #59447 on release-1.9.

#59447: Fixes the regression of GCEPD not provisioning correctly on

```release-note
Bug fix: Clusters with GCE feature 'DiskAlphaAPI' enabled were unable to dynamically provision GCE PD volumes.
```