### PR TITLE
hack: when installing gazelle, checkout older version of buildtools

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -32,7 +32,8 @@ kube::util::go_install_from_commit \
     ae4e9a3906ace4ba657b7a09242610c6266e832c
 kube::util::go_install_from_commit \
     github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-    c72631a220406c4fae276861ee286aaec82c5af2
+    c72631a220406c4fae276861ee286aaec82c5af2 \
+    github.com/bazelbuild/buildtools@9455a9fa1081d94b2b3a11c66b7bde2ae5af3b86
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 


### PR DESCRIPTION
**What this PR does / why we need it**: fixes `hack/verify-bazel.sh` by ensuring we use a compatible version of bazelbuild/buildtools when installing gazelle. This is basically the hacky third option on https://github.com/kubernetes/kubernetes/issues/60447#issuecomment-369008319.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder @mikedanese 