### PR TITLE
hack: when installing gazelle, checkout older version of buildtools

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -550,9 +550,11 @@ kube::util::ensure_no_staging_repos_in_gopath() {
 }
 
 # Installs the specified go package at a particular commit.
+# Optionally specify an additional dependency constraint as "pkg@revision".
 kube::util::go_install_from_commit() {
   local -r pkg=$1
   local -r commit=$2
+  local -r extra_constraint=${3:-}
 
   kube::util::ensure-temp-dir
   mkdir -p "${KUBE_TEMP}/go/src"
@@ -565,6 +567,12 @@ kube::util::go_install_from_commit() {
     git fetch # TODO(spiffxp): workaround
     git checkout -q "${commit}"
     GOPATH="${KUBE_TEMP}/go" go get -d "${pkg}" #TODO(spiffxp): workaround
+    if [[ "${extra_constraint}" =~ ^(.+)@(.+)$ ]]; then
+      (
+        cd "${KUBE_TEMP}/go/src/${BASH_REMATCH[1]}"
+        git checkout -q "${BASH_REMATCH[2]}"
+      )
+    fi
     GOPATH="${KUBE_TEMP}/go" go install "${pkg}"
   )
   PATH="${KUBE_TEMP}/go/bin:${PATH}"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -25,8 +25,13 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
-kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
+kube::util::go_install_from_commit \
+    github.com/kubernetes/repo-infra/kazel \
+    4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
+kube::util::go_install_from_commit \
+    github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
+    82483596ec203eb9c1849937636f4cbed83733eb \
+    github.com/bazelbuild/buildtools@9455a9fa1081d94b2b3a11c66b7bde2ae5af3b86
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -32,8 +32,13 @@ fi
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
-kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
+kube::util::go_install_from_commit \
+    github.com/kubernetes/repo-infra/kazel \
+    4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
+kube::util::go_install_from_commit \
+    github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
+    82483596ec203eb9c1849937636f4cbed83733eb \
+    github.com/bazelbuild/buildtools@9455a9fa1081d94b2b3a11c66b7bde2ae5af3b86
 
 gazelle_diff=$(gazelle fix -build_file_name=BUILD,BUILD.bazel -external=vendored -mode=diff -repo_root="$(kube::realpath ${KUBE_ROOT})")
 kazel_diff=$(kazel -dry-run -print-diff -root="$(kube::realpath ${KUBE_ROOT})")


### PR DESCRIPTION
**What this PR does / why we need it**: #60522, but for the 1.8 release branch. This fixes `hack/verify-bazel.sh` by ensuring we use a compatible version of bazelbuild/buildtools when installing gazelle. This is basically the hacky third option on https://github.com/kubernetes/kubernetes/issues/60447#issuecomment-369008319.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

fixes #60482

/assign @BenTheElder @mikedanese 
/cc @cblecker 