### PR TITLE
Automated cherry pick of #60524: Temporary fix for LeaderElect for kube-scheduler

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -151,6 +151,9 @@ func NewOptions() (*Options, error) {
 		return nil, err
 	}
 
+	// TODO: we should fix this up better (PR 59732)
+	o.config.LeaderElection.LeaderElect = true
+
 	return o, nil
 }
 


### PR DESCRIPTION
Cherry pick of #60524 on release-1.9.

#60524: Temporary fix for LeaderElect for kube-scheduler

Fixes #59729

```release-note
kube-scheduler: restores default leader election behavior. leader-elect command line parameter should "true"
```
