### PR TITLE
Fix kubectl completion so that file names are listed

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2567,13 +2567,13 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
-			"Comment": "v0.0.1-28-gfd32f09",
-			"Rev": "fd32f09af19efc9b1279c54e0d8ed23f66232a15"
+			"Comment": "v0.0.1-27-g9395926",
+			"Rev": "93959269ad99e80983c9ba742a7e01203a4c0e4f"
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra/doc",
-			"Comment": "v0.0.1-28-gfd32f09",
-			"Rev": "fd32f09af19efc9b1279c54e0d8ed23f66232a15"
+			"Comment": "v0.0.1-27-g9395926",
+			"Rev": "93959269ad99e80983c9ba742a7e01203a4c0e4f"
 		},
 		{
 			"ImportPath": "github.com/spf13/jwalterweatherman",

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -584,7 +584,7 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
-			"Rev": "fd32f09af19efc9b1279c54e0d8ed23f66232a15"
+			"Rev": "93959269ad99e80983c9ba742a7e01203a4c0e4f"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -268,7 +268,7 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
-			"Rev": "fd32f09af19efc9b1279c54e0d8ed23f66232a15"
+			"Rev": "93959269ad99e80983c9ba742a7e01203a4c0e4f"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -252,7 +252,7 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
-			"Rev": "fd32f09af19efc9b1279c54e0d8ed23f66232a15"
+			"Rev": "93959269ad99e80983c9ba742a7e01203a4c0e4f"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes kubectl completion so that file names are listed with `--filename`. I tested in bash and zsh. This problem is caused by spf13/cobra#520, so I updates vendor github.com/spf13/cobra to just before that commit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60517 

**Special notes for your reviewer**: @janetkuo @mengqiy @eparis 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
