### PR TITLE
Add description of mount options to PersistentVolume describe printer

### DIFF
--- a/pkg/kubectl/describe/versioned/describe.go
+++ b/pkg/kubectl/describe/versioned/describe.go
@@ -1327,6 +1327,11 @@ func describePersistentVolume(pv *corev1.PersistentVolume, events *corev1.EventL
 		}
 		w.Write(LEVEL_0, "Reclaim Policy:\t%v\n", pv.Spec.PersistentVolumeReclaimPolicy)
 		w.Write(LEVEL_0, "Access Modes:\t%s\n", storageutil.GetAccessModesAsString(pv.Spec.AccessModes))
+		if len(pv.Spec.MountOptions) == 0 {
+			w.Write(LEVEL_0, "MountOptions:\t<none>\n")
+		} else {
+			w.Write(LEVEL_0, "MountOptions:\t%s\n", strings.Join(pv.Spec.MountOptions, ", "))
+		}
 		if pv.Spec.VolumeMode != nil {
 			w.Write(LEVEL_0, "VolumeMode:\t%v\n", *pv.Spec.VolumeMode)
 		}

--- a/pkg/kubectl/describe/versioned/describe_test.go
+++ b/pkg/kubectl/describe/versioned/describe_test.go
@@ -1273,6 +1273,34 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			},
 			expectedElements: []string{"Driver", "VolumeHandle", "ReadOnly", "VolumeAttributes"},
 		},
+		// Tests for mount options.
+		{
+			name:   "test18",
+			plugin: "hostpath-with-mount-options",
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Type: new(corev1.HostPathType)},
+					},
+					MountOptions: []string{"test", "mount", "options"},
+				},
+			},
+			expectedElements: []string{"MountOptions:", "test, mount, options"},
+		},
+		{
+			name:   "test19",
+			plugin: "hostpath-without-mount-options",
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Type: new(corev1.HostPathType)},
+					},
+				},
+			},
+			expectedElements: []string{"MountOptions:", "<none>"},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Print `PersistentVolume.MountOptions` for `kubectl` describe command.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
