### PR TITLE
Adding details to Conformance Tests using RFC 2119 standards.

### DIFF
--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -36,6 +36,11 @@ import (
 var _ = SIGDescribe("Events", func() {
 	f := framework.NewDefaultFramework("events")
 
+	/*
+		Release : v1.9
+		Testname: Pod events, verify event from Scheduler and Kubelet
+		Description: Create a Pod, make sure that the Pod can be queried. Create a event selector for the kind=Pod and the source is the Scheduler. List of the events MUST be at least one. Create a event selector for kind=Pod and the source is the Kubelet. List of the events MUST be at least one. Both Scheduler and Kubelet MUST send events when scheduling and running a Pod.
+	*/
 	framework.ConformanceIt("should be sent by kubelets and the scheduler about pods scheduling and running ", func() {
 
 		podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -47,6 +47,11 @@ var _ = SIGDescribe("Pods Extended", func() {
 			podClient = f.PodClient()
 		})
 		// Flaky issue #36821.
+		/*
+			Release : v1.9
+			Testname: Pods, delete grace period
+			Description: Create a pod, make sure it is running, create a watch to observe Pod creation. Create a 'kubectl local proxy', capture the port the proxy is listening. Using the http client send a ‘delete’ with gracePeriodSeconds=30. Pod SHOULD get deleted within 30 seconds.
+		*/
 		framework.ConformanceIt("should be submitted and removed  [Flaky]", func() {
 			By("creating the pod")
 			name := "pod-submit-remove-" + string(uuid.NewUUID())
@@ -199,6 +204,11 @@ var _ = SIGDescribe("Pods Extended", func() {
 		BeforeEach(func() {
 			podClient = f.PodClient()
 		})
+		/*
+			Release : v1.9
+			Testname: Pods, QOS
+			Description:  Create a Pod with CPU and Memory request and limits. Pos status MUST have QOSClass set to PodQOSGuaranteed.
+		*/
 		framework.ConformanceIt("should be submitted and removed ", func() {
 			By("creating the pod")
 			name := "pod-qos-class-" + string(uuid.NewUUID())

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -162,9 +162,9 @@ var _ = SIGDescribe("PreStop", func() {
 	f := framework.NewDefaultFramework("prestop")
 
 	/*
-		    Testname: pods-prestop-handler-invoked
-		    Description: Makes sure a pod's preStop handler is successfully
-			invoked immediately before a container is terminated.
+		Release : v1.9
+		Testname: Pods, prestop hook
+		Description: Create a server pod with a rest endpoint '/write' that changes state.Received field. Create a Pod with a pre-stop handle that posts to the /write endpoint on the server Pod. Verify that the Pod with pre-stop hook is running. Delete the Pod with the pre-stop hook. Before the Pod is deleted, pre-stop handler MUST be called when configured. Verify that the Pod is deleted and a call to prestop hook is verified by checking the status received on the server Pod.
 	*/
 	framework.ConformanceIt("should call prestop when killing a pod ", func() {
 		testPreStop(f.ClientSet, f.Namespace.Name)

--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -39,6 +39,11 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 	})
 	Context("when scheduling a busybox command in a pod", func() {
 		podName := "busybox-scheduling-" + string(uuid.NewUUID())
+		/*
+			Release : v1.9
+			Testname: Kubelet, log output, default
+			Description: By default the stdout and stderr from the process being executed in a pod MUST be sent to the pod's logs.
+		*/
 		framework.ConformanceIt("it should print the output to logs [NodeConformance]", func() {
 			podClient.CreateSync(&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -164,6 +169,11 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 	})
 	Context("when scheduling a read only busybox container", func() {
 		podName := "busybox-readonly-fs" + string(uuid.NewUUID())
+		/*
+			Release : v1.9
+			Testname: Kubelet, Pod with read only root file system
+			Description: Create a Pod with security context set with ReadOnlyRootFileSystem set to true. The Pod then tries to write to the /file on the root, write operation to the root filesystem MUST fail as expected.
+		*/
 		framework.ConformanceIt("it should not write to root filesystem [NodeConformance]", func() {
 			isReadOnly := true
 			podClient.CreateSync(&v1.Pod{

--- a/test/e2e_node/lifecycle_hook_test.go
+++ b/test/e2e_node/lifecycle_hook_test.go
@@ -84,6 +84,11 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 				}, preStopWaitTimeout, podCheckInterval).Should(BeNil())
 			}
 		}
+		/*
+			Release : v1.9
+			Testname: Pod Lifecycle, post start exec hook
+			Description: When a post start handler is specified in the container lifecycle using a ‘Exec’ action, then the handler MUST be invoked after the start of the container. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a post start that invokes the server pod using ExecAction to validate that the post start is executed.
+		*/
 		framework.ConformanceIt("should execute poststart exec hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PostStart: &v1.Handler{
@@ -95,6 +100,11 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
 			testPodWithHook(podWithHook)
 		})
+		/*
+			Release : v1.9
+			Testname: Pod Lifecycle, prestop exec hook
+			Description: When a pre-stop handler is specified in the container lifecycle using a ‘Exec’ action, then the handler MUST be invoked before the container is terminated. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a pre-stop that invokes the server pod using ExecAction to validate that the pre-stop is executed.
+		*/
 		framework.ConformanceIt("should execute prestop exec hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PreStop: &v1.Handler{
@@ -106,6 +116,11 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", imageutils.GetE2EImage(imageutils.Hostexec), lifecycle)
 			testPodWithHook(podWithHook)
 		})
+		/*
+			Release : v1.9
+			Testname: Pod Lifecycle, post start http hook
+			Description: When a post start handler is specified in the container lifecycle using a HttpGet action, then the handler MUST be invoked after the start of the container. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a post start that invokes the server pod to validate that the post start is executed.
+		*/
 		framework.ConformanceIt("should execute poststart http hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PostStart: &v1.Handler{
@@ -119,6 +134,11 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 			podWithHook := getPodWithHook("pod-with-poststart-http-hook", imageutils.GetPauseImageName(), lifecycle)
 			testPodWithHook(podWithHook)
 		})
+		/*
+			Release : v1.9
+			Testname: Pod Lifecycle, prestop http hook
+			Description: When a pre-stop handler is specified in the container lifecycle using a ‘HttpGet’ action, then the handler MUST be invoked before the container is terminated. A server pod is created that will serve http requests, create a second pod with a container lifecycle specifying a pre-stop that invokes the server pod to validate that the pre-stop is executed.
+		*/
 		framework.ConformanceIt("should execute prestop http hook properly [NodeConformance]", func() {
 			lifecycle := &v1.Lifecycle{
 				PreStop: &v1.Handler{

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -57,6 +57,11 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 				return checkMirrorPodRunning(f.ClientSet, mirrorPodName, ns)
 			}, 2*time.Minute, time.Second*4).Should(BeNil())
 		})
+		/*
+			Release : v1.9
+			Testname: Mirror Pod, update
+			Description: Updating a static Pod MUST recreate an updated mirror Pod. Create a static pod, verify that a mirror pod is created. Update the static pod by changing the container image, the mirror pod MUST be re-created and updated with the new image.
+		*/
 		framework.ConformanceIt("should be updated when static pod updated [NodeConformance]", func() {
 			By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(mirrorPodName, metav1.GetOptions{})
@@ -79,6 +84,11 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 			Expect(len(pod.Spec.Containers)).Should(Equal(1))
 			Expect(pod.Spec.Containers[0].Image).Should(Equal(image))
 		})
+		/*
+			Release : v1.9
+			Testname: Mirror Pod, delete
+			Description:  When a mirror-Pod is deleted then the mirror pod MUST be re-created. Create a static pod, verify that a mirror pod is created. Delete the mirror pod, the mirror pod MUST be re-created and running.
+		*/
 		framework.ConformanceIt("should be recreated when mirror pod gracefully deleted [NodeConformance]", func() {
 			By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(mirrorPodName, metav1.GetOptions{})
@@ -94,6 +104,11 @@ var _ = framework.KubeDescribe("MirrorPod", func() {
 				return checkMirrorPodRecreatedAndRunnig(f.ClientSet, mirrorPodName, ns, uid)
 			}, 2*time.Minute, time.Second*4).Should(BeNil())
 		})
+		/*
+			Release : v1.9
+			Testname: Mirror Pod, force delete
+			Description: When a mirror-Pod is deleted, forcibly, then the mirror pod MUST be re-created. Create a static pod, verify that a mirror pod is created. Delete the mirror pod with delete wait time set to zero forcing immediate deletion, the mirror pod MUST be re-created and running.
+		*/
 		framework.ConformanceIt("should be recreated when mirror pod forcibly deleted [NodeConformance]", func() {
 			By("get mirror pod uid")
 			pod, err := f.ClientSet.CoreV1().Pods(ns).Get(mirrorPodName, metav1.GetOptions{})

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -46,6 +46,11 @@ var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 
 	Describe("container runtime conformance blackbox test", func() {
 		Context("when starting a container that exits", func() {
+			/*
+				Release : v1.9
+				Testname: Container Runtime, restart policy
+				Description:  If the restart policy is set to ‘Always’, Pod MUST be started when terminated, If restart policy is ‘OnFailure’, Pod MUST be started only if it is terminated with non-zero exit code. If the restart policy is ‘Never’, Pod MUST never be restarted. All these three test cases MUST verify the restart counts accordingly.
+			*/
 			framework.ConformanceIt("it should run with the expected status [NodeConformance]", func() {
 				restartCountVolumeName := "restart-count"
 				restartCountVolumePath := "/restart-count"


### PR DESCRIPTION
This PR is part of the conformance documentation. This is to provide more formal specification using RFC 2119 keywords to describe the test so that who ever is running conformance tests do not have to go through the code to understand why and what is tested.
The documentation information added here into each of the tests eventually result into a document which is currently checked in at location https://github.com/cncf/k8s-conformance/blob/master/docs/KubeConformance-1.9.md

I would like to have this PR reviewed for v1.10 as I consider it important to strengthen the conformance documents.