### PR TITLE
Adding details to Conformance Tests using RFC 2119 standards.

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -30,9 +30,9 @@ var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
 	/*
-		    Testname: configmap-in-env-field
-		    Description: Make sure config map value can be used as an environment
-			variable in the container (on container.env field)
+		Release : v1.9
+		Testname: ConfigMap, from environment field
+		Description: Create a Pod with an environment variable value set using a value from ConfigMap. A ConfigMap value MUST be accessible in the container environment.
 	*/
 	framework.ConformanceIt("should be consumable via environment variable [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
@@ -78,9 +78,9 @@ var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-envfrom-field
-		    Description: Make sure config map value can be used as an source for
-			environment variables in the container (on container.envFrom field)
+		Release: v1.9
+		Testname: ConfigMap, from environment variables
+		Description: Create a Pod with a environment source from ConfigMap. All ConfigMap values MUST be available as environment variables in the container.
 	*/
 	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -33,18 +33,18 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
 	/*
-		    Testname: configmap-nomap-simple
-		    Description: Make sure config map without mappings works by mounting it
-			to a volume with a custom path (mapping) on the pod with no other settings.
+		Release : v1.9
+		Testname: ConfigMap Volume, without mapping
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
 	/*
-		    Testname: configmap-nomap-default-mode
-		    Description: Make sure config map without mappings works by mounting it
-			to a volume with a custom path (mapping) on the pod with defaultMode set
+		Release : v1.9
+		Testname: ConfigMap Volume, without mapping, volume mode set
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of ‘0x400’
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
@@ -57,9 +57,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-nomap-user
-		    Description: Make sure config map without mappings works by mounting it
-			to a volume with a custom path (mapping) on the pod as non-root.
+		Release : v1.9
+		Testname: ConfigMap Volume, without mapping, non-root user
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
@@ -70,19 +70,18 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-simple-mapped
-		    Description: Make sure config map works by mounting it to a volume with
-			a custom path (mapping) on the pod with no other settings and make sure
-			the pod actually consumes it.
+		Release : v1.9
+		Testname: ConfigMap Volume, with mapping
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST default to 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
 	/*
-		    Testname: configmap-with-item-mode-mapped
-		    Description: Make sure config map works with an item mode (e.g. 0400)
-			for the config map item.
+		Release : v1.9
+		Testname: ConfigMap Volume, with mapping, volume mode set
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. File mode is changed to a custom value of '0x400'. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The data content of the file MUST be readable and verified and file modes MUST be set to the custom value of ‘0x400’
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
 		mode := int32(0400)
@@ -90,8 +89,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-	   Testname: configmap-simple-user-mapped
-	   Description: Make sure config map works when it is mounted as non-root.
+		Release : v1.9
+		Testname: ConfigMap Volume, with mapping, non-root user
+		Description: Create a ConfigMap, create a Pod that mounts a volume and populates the volume with data stored in the ConfigMap. Files are mapped to a path in the volume. Pod is run as a non-root user with uid=1000. The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount. The file on the volume MUST have file mode set to default value of 0x644.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
@@ -102,9 +102,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-update-test
-		    Description: Make sure update operation is working on config map and
-			the result is observed on volumes mounted in containers.
+		Release : v1.9
+		Testname: ConfigMap Volume, update
+		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the ConfigMap is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod.
 	*/
 	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
@@ -276,9 +276,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-CUD-test
-		    Description: Make sure Create, Update, Delete operations are all working
-			on config map and the result is observed on volumes mounted in containers.
+		Release : v1.9
+		Testname: ConfigMap Volume, create, update and delete
+		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. When the config map is updated the change to the config map MUST be verified by reading the content from the mounted file in the Pod. Also when the item(file) is deleted from the map that MUST result in a error reading that item(file).
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
@@ -459,9 +459,9 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	})
 
 	/*
-		    Testname: configmap-multiple-volumes
-		    Description: Make sure config map works when it mounted as two different
-			volumes on the same node.
+		Release : v1.9
+		Testname: ConfigMap Volume, multiple volume maps
+		Description: The ConfigMap that is created MUST be accessible to read from the newly created Pod using the volume mount that is mapped to multiple paths in the Pod. The content MUST be accessible from all the mapped volume mounts.
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -50,9 +50,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-readiness-probe-initial-delay
-		    Description: Make sure that pod with readiness probe should not be
-			ready before initial delay and never restart.
+		Release : v1.9
+		Testname: Pod readiness probe, with initial delay
+		Description: Create a Pod that is configured with a initial delay set on the readiness probe. Check the Pod Start time to compare to the initial delay. The Pod MUST be ready only after the specified initial delay.
 	*/
 	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart [NodeConformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withInitialDelay().build(), nil))
@@ -82,9 +82,10 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-readiness-probe-failure
-		    Description: Make sure that pod with readiness probe that fails should
-			never be ready and never restart.
+		Release : v1.9
+		Testname: Pod readiness probe, failure
+		Description: Create a Pod with a readiness probe that fails consistently. When this Pod is created,
+			then the Pod MUST never be ready, never be running and restart count MUST be zero.
 	*/
 	framework.ConformanceIt("with readiness probe that fails should never be ready and never restart [NodeConformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withFailing().build(), nil))
@@ -107,9 +108,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-cat-liveness-probe-restarted
-		    Description: Make sure the pod is restarted with a cat /tmp/health
-			liveness probe.
+		Release : v1.9
+		Testname: Pod liveness probe, using local file, restart
+		Description: Create a Pod with liveness probe that that uses ExecAction handler to cat /temp/health file. The Container deletes the file /temp/health after 10 second, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
 	*/
 	framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
@@ -139,9 +140,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-cat-liveness-probe-not-restarted
-		    Description: Make sure the pod is not restarted with a cat /tmp/health
-			liveness probe.
+		Release : v1.9
+		Testname: Pod liveness probe, using local file, no restart
+		Description:  Pod is created with liveness probe that uses ‘exec’ command to cat /temp/health file. Liveness probe MUST not fail to check health and the restart count should remain 0.
 	*/
 	framework.ConformanceIt("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
@@ -171,9 +172,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-http-liveness-probe-restarted
-		    Description: Make sure when http liveness probe fails, the pod should
-			be restarted.
+		Release : v1.9
+		Testname: Pod liveness probe, using http endpoint, restart
+		Description: A Pod is created with liveness probe on http endpoint /healthz. The http handler on the /healthz will return a http error after 10 seconds since the Pod is started. This MUST result in liveness check failure. The Pod MUST now be killed and restarted incrementing restart count to 1.
 	*/
 	framework.ConformanceIt("should be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
@@ -205,9 +206,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 
 	// Slow by design (5 min)
 	/*
-		    Testname: pods-restart-count
-		    Description: Make sure when a pod gets restarted, its start count
-			should increase.
+		Release : v1.9
+		Testname: Pod liveness probe, using http endpoint, multiple restarts (slow)
+		Description: A Pod is created with liveness probe on http endpoint /healthz. The http handler on the /healthz will return a http error after 10 seconds since the Pod is started. This MUST result in liveness check failure. The Pod MUST now be killed and restarted incrementing restart count to 1. The liveness probe must fail again after restart once the http handler for /healthz enpoind on the Pod returns an http error after 10 seconds from the start. Restart counts MUST increment everytime health check fails, measure upto 5 restart.
 	*/
 	framework.ConformanceIt("should have monotonically increasing restart count [Slow][NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
@@ -238,9 +239,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-http-liveness-probe-not-restarted
-		    Description: Make sure when http liveness probe succeeds, the pod
-			should not be restarted.
+		Release : v1.9
+		Testname: Pod liveness probe, using http endpoint, failure
+		Description: A Pod is created with liveness probe on http endpoint ‘/’. Liveness probe on this endpoint will not fail. When liveness probe does not fail then the restart count MUST remain zero.
 	*/
 	framework.ConformanceIt("should *not* be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
@@ -272,9 +273,9 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		    Testname: pods-docker-liveness-probe-timeout
-		    Description: Make sure that the pod is restarted with a docker exec
-			liveness probe with timeout.
+		Release : v1.9
+		Testname: Pod liveness probe, docker exec, restart
+		Description: A Pod is created with liveness probe with a Exec action on the Pod. If the liveness probe call  does not return within the timeout specified, liveness probe MUST restart the Pod.
 	*/
 	It("should be restarted with a docker exec liveness probe with timeout ", func() {
 		// TODO: enable this test once the default exec handler supports timeout.

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -28,10 +28,9 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	f := framework.NewDefaultFramework("containers")
 
 	/*
-		    Testname: container-without-command-args
-		    Description: When a Pod is created neither 'command' nor 'args' are
-			provided for a Container, ensure that the docker image's default
-			command and args are used.
+		Release : v1.9
+		Testname: Docker containers, without command and arguments
+		Description: Default command and arguments from the docker image entrypoint MUST be used when Pod does not specify the container command
 	*/
 	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func() {
 		f.TestContainerOutput("use defaults", entrypointTestPod(), 0, []string{
@@ -40,10 +39,9 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	})
 
 	/*
-		    Testname: container-with-args
-		    Description: When a Pod is created and 'args' are provided for a
-			Container, ensure that they take precedent to the docker image's
-			default arguments, but that the default command is used.
+		Release : v1.9
+		Testname: Docker containers, with arguments
+		Description: Default command and  from the docker image entrypoint MUST be used when Pod does not specify the container command but the arguments from Pod spec MUST override when specified.
 	*/
 	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
 		pod := entrypointTestPod()
@@ -57,10 +55,9 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	// Note: when you override the entrypoint, the image's arguments (docker cmd)
 	// are ignored.
 	/*
-		    Testname: container-with-command
-		    Description: When a Pod is created and 'command' is provided for a
-			Container, ensure that it takes precedent to the docker image's default
-			command.
+		Release : v1.9
+		Testname: Docker containers, with command
+		Description: Default command from the docker image entrypoint MUST NOT be used when Pod specifies the container command.  Command from Pod spec MUST override the command in the image.
 	*/
 	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
 		pod := entrypointTestPod()
@@ -72,10 +69,9 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 	})
 
 	/*
-		    Testname: container-with-command-args
-		    Description: When a Pod is created and 'command' and 'args' are
-			provided for a Container, ensure that they take precedent to the docker
-			image's default command and arguments.
+		Release : v1.9
+		Testname: Docker containers, with command and arguments
+		Description: Default command and arguments from the docker image entrypoint MUST NOT be used when Pod specifies the container command and arguments.  Command and arguments from Pod spec MUST override the command and arguments in the image.
 	*/
 	framework.ConformanceIt("should be able to override the image's default command and arguments [NodeConformance]", func() {
 		pod := entrypointTestPod()

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -38,9 +38,9 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
 	/*
-		    Testname: downwardapi-env-name-namespace-podip
-		    Description: Ensure that downward API can provide pod's name, namespace
-			and IP address as environment variables.
+	   Release : v1.9
+	   Testname: DownwardAPI, environment for name, namespace and ip
+	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify Pod Name, namespace and IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide pod name, namespace and IP address as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
@@ -84,9 +84,9 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	})
 
 	/*
-		    Testname: downwardapi-env-host-ip
-		    Description: Ensure that downward API can provide an IP address for
-			host node as an environment variable.
+	   Release : v1.9
+	   Testname: DownwardAPI, environment for host ip
+	   Description: Downward API MUST expose Pod and Container fields as environment variables. Specify host IP as environment variable in the Pod Spec are visible at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide host IP as an env var [NodeConformance]", func() {
 		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
@@ -111,9 +111,9 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	})
 
 	/*
-		    Testname: downwardapi-env-limits-requests
-		    Description: Ensure that downward API can provide CPU/memory limit
-			and CPU/memory request as environment variables.
+	   Release : v1.9
+	   Testname: DownwardAPI, environment for CPU and memory limits and requests
+	   Description: Downward API MUST expose CPU request amd Memory request set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
@@ -162,10 +162,9 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	})
 
 	/*
-		    Testname: downwardapi-env-default-allocatable
-		    Description: Ensure that downward API can provide default node
-			allocatable values for CPU and memory as environment variables if CPU
-			and memory limits are not specified for a container.
+	   Release : v1.9
+	   Testname: DownwardAPI, environment for default CPU and memory limits and requests
+	   Description: Downward API MUST expose CPU request amd Memory limits set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
@@ -213,9 +212,9 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	})
 
 	/*
-		    Testname: downwardapi-env-pod-uid
-		    Description: Ensure that downward API can provide pod UID as an
-			environment variable.
+	   Release : v1.9
+	   Testname: DownwardAPI, environment for Pod UID
+	   Description: Downward API MUST expose Pod UID set through environment variables at runtime in the container.
 	*/
 	framework.ConformanceIt("should provide pod UID as env vars [NodeConformance]", func() {
 		framework.SkipUnlessServerVersionGTE(podUIDVersion, f.ClientSet.Discovery())

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -40,9 +40,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-podname
-		    Description: Ensure that downward API can provide pod's name through
-			DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, pod name
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -54,9 +54,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-set-default-mode
-		    Description: Ensure that downward API can set default file permission
-			mode for DownwardAPIVolumeFiles if no mode is specified.
+		Release : v1.9
+		Testname: DownwardAPI volume, volume mode 0400
+		Description: A Pod is configured with DownwardAPIVolumeSource with the volumesource mode set to -r-------- and DownwardAPIVolumeFiles contains a item for the Pod name. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -69,9 +69,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-set-mode
-		    Description: Ensure that downward API can set file permission mode for
-			DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, file mode 0400
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the Pod name with the file mode set to -r--------. The container runtime MUST be able to access Pod name from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -113,9 +113,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-update-label
-		    Description: Ensure that downward API updates labels in
-			DownwardAPIVolumeFiles when pod's labels get modified.
+		Release : v1.9
+		Testname: DownwardAPI volume, update label
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains list of items for each of the Pod labels. The container runtime MUST be able to access Pod labels from the specified path on the mounted volume. Update the labels by adding a new label to the running Pod. The new label MUST be available from the mounted volume.
 	*/
 	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
@@ -145,9 +145,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-update-annotation
-		    Description: Ensure that downward API updates annotations in
-			DownwardAPIVolumeFiles when pod's annotations get modified.
+		Release : v1.9
+		Testname: DownwardAPI volume, update annotations
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains list of items for each of the Pod annotations. The container runtime MUST be able to access Pod annotations from the specified path on the mounted volume. Update the annotations by adding a new annotation to the running Pod. The new annotation MUST be available from the mounted volume.
 	*/
 	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
@@ -179,9 +179,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-cpu-limit
-		    Description: Ensure that downward API can provide container's CPU limit
-			through DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, CPU limits
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the CPU limits. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -193,9 +193,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-memory-limit
-		    Description: Ensure that downward API can provide container's memory
-			limit through DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, memory limits
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the memory limits. The container runtime MUST be able to access memory limits from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -207,9 +207,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-cpu-request
-		    Description: Ensure that downward API can provide container's CPU
-			request through DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, CPU request
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the CPU request. The container runtime MUST be able to access CPU request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -221,9 +221,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-memory-request
-		    Description: Ensure that downward API can provide container's memory
-			request through DownwardAPIVolumeFiles.
+		Release : v1.9
+		Testname: DownwardAPI volume, memory request
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the memory request. The container runtime MUST be able to access memory request from the specified path on the mounted volume.
 	*/
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -235,10 +235,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-default-cpu
-		    Description: Ensure that downward API can provide default node
-			allocatable value for CPU through DownwardAPIVolumeFiles if CPU
-			limit is not specified for a container.
+		Release : v1.9
+		Testname: DownwardAPI volume, CPU limit, default node allocatable
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the CPU limits. CPU limits is not specified for the container. The container runtime MUST be able to access CPU limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -248,10 +247,9 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 	})
 
 	/*
-		    Testname: downwardapi-volume-default-memory
-		    Description: Ensure that downward API can provide default node
-			allocatable value for memory through DownwardAPIVolumeFiles if memory
-			limit is not specified for a container.
+		Release : v1.9
+		Testname: DownwardAPI volume, memory limit, default node allocatable
+		Description: A Pod is configured with DownwardAPIVolumeSource and DownwartAPIVolumeFiles contains a item for the memory limits. memory limits is not specified for the container. The container runtime MUST be able to access memory limits from the specified path on the mounted volume and the value MUST be default node allocatable.
 	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -67,139 +67,126 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 	})
 
 	/*
-		    Testname: volume-emptydir-mode-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure the volume has 0777 unix file permissions and tmpfs
-			mount type.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode default
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
 	*/
 	framework.ConformanceIt("volume on tmpfs should have the correct mode [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0644-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a root owned file with 0644 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0644
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0644,tmpfs) [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0666-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a root owned file with 0666 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0666
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0666,tmpfs) [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0777-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a root owned file with 0777 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0777
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0777,tmpfs) [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0644-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a user owned file with 0644 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0644, non-root user
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,tmpfs) [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0666-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a user owned file with 0666 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0666,, non-root user
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,tmpfs) [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0777-tmpfs
-		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
-			of 'Memory', ensure a user owned file with 0777 unix file permissions
-			is created correctly, has tmpfs mount type, and enforces the permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium memory, volume mode 0777, non-root user
+		Description: A Pod created with an 'emptyDir' Volume and 'medium' as 'Memory', the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,tmpfs) [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
-		    Testname: volume-emptydir-mode
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure the
-			volume has 0777 unix file permissions.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode default
+		Description: A Pod created with an 'emptyDir' Volume, the volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs.
 	*/
 	framework.ConformanceIt("volume on default medium should have the correct mode [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0644
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			root owned file with 0644 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0644
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0644,default) [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0666
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			root owned file with 0666 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0666
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0666,default) [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-root-0777
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			root owned file with 0777 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0777
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777.  The volume MUST have mode set as -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (root,0777,default) [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0644
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			user owned file with 0644 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0644
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0644. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-r--r-- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,default) [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0666
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			user owned file with 0666 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0666
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0666. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rw-rw-rw- and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,default) [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
-		    Testname: volume-emptydir-user-0777
-		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
-			user owned file with 0777 unix file permissions is created and enforced
-			correctly.
+		Release : v1.9
+		Testname: EmptyDir, medium default, volume mode 0777
+		Description: A Pod created with an 'emptyDir' Volume, the volume mode set to 0777. Volume is mounted into the container where container is run as a non-root user. The volume MUST have mode -rwxrwxrwx and mount type set to tmpfs and the contents MUST be readable.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,default) [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -33,9 +33,9 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	f := framework.NewDefaultFramework("var-expansion")
 
 	/*
-		    Testname: var-expansion-env
-		    Description: Make sure environment variables can be set using an
-			expansion of previously defined environment variables
+		Release : v1.9
+		Testname: Environment variables, expansion
+		Description: Create a Pod with environment variables. Environment variables defined using previously defined environment variables MUST expand to proper values.
 	*/
 	framework.ConformanceIt("should allow composing env vars into new env vars [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
@@ -78,9 +78,9 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-command
-		    Description: Make sure a container's commands can be set using an
-			expansion of environment variables.
+		Release : v1.9
+		Testname: Environment variables, command expansion
+		Description: Create a Pod with environment variables and container command using them. Container command using the  defined environment variables MUST expand to proper values.
 	*/
 	framework.ConformanceIt("should allow substituting values in a container's command [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
@@ -113,9 +113,9 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-arg
-		    Description: Make sure a container's args can be set using an
-			expansion of environment variables.
+		Release : v1.9
+		Testname: Environment variables, command argument expansion
+		Description: Create a Pod with environment variables and container command arguments using them. Container command arguments using the  defined environment variables MUST expand to proper values.
 	*/
 	framework.ConformanceIt("should allow substituting values in a container's args [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -40,10 +40,9 @@ var _ = Describe("[sig-storage] HostPath", func() {
 	})
 
 	/*
-		    Testname: volume-hostpath-mode
-		    Description: For a Pod created with a 'HostPath' Volume, ensure the
-			volume is a directory with 0777 unix file permissions and that is has
-			the sticky bit (mode flag t) set.
+	   Release : v1.9
+	   Testname: Host path, volume mode default
+	   Description: Create a Pod with host volume mounted. The volume mounted MUST be a directory with permissions mode -rwxrwxrwx and that is has the sticky bit (mode flag t) set.
 	*/
 	framework.ConformanceIt("should give a volume the correct mode [NodeConformance]", func() {
 		source := &v1.HostPathVolumeSource{

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -51,9 +51,12 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 	}
 
 	/*
-		    Testname: kubelet-managed-etc-hosts
-		    Description: Make sure Kubelet correctly manages /etc/hosts and mounts
-			it into the container.
+		Release : v1.9
+		Testname: Kubelet, managed etc hosts
+		Description: Create a Pod with containers with hostNetwork set to false, one of the containers mounts the /etc/hosts file form the host. Create a second Pod with hostNetwork set to true.
+			1. The Pod with hostNetwork=false MUST have /etc/hosts of containers managed by the Kubelet.
+			2. The Pod with hostNetwork=false but the container mounts /etc/hosts file from the host. The /etc/hosts file MUST not be managed by the Kubelet.
+			3. The Pod with hostNetwork=true , /etc/hosts file MUST not be managed by the Kubelet.
 	*/
 	framework.ConformanceIt("should test kubelet managed /etc/hosts file [NodeConformance]", func() {
 		By("Setting up the test")

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -31,9 +31,10 @@ var _ = Describe("[sig-network] Networking", func() {
 		// expect exactly one unique hostname. Each of these endpoints reports
 		// its own hostname.
 		/*
-			    Testname: networking-intra-pod-http
-			    Description: Try to hit test endpoints from a test container and make
-				sure each of them can report a unique hostname.
+			Release : v1.9
+			Testname: Networking, intra pod http
+			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
+			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
@@ -43,9 +44,10 @@ var _ = Describe("[sig-network] Networking", func() {
 		})
 
 		/*
-			    Testname: networking-intra-pod-udp
-			    Description: Try to hit test endpoints from a test container using udp
-				and make sure each of them can report a unique hostname.
+			Release : v1.9
+			Testname: Networking, intra pod udp
+			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
+			The kubectl exec on the webserver container MUST reach a udp port on the each of service proxy endpoints in the cluster and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
@@ -55,9 +57,10 @@ var _ = Describe("[sig-network] Networking", func() {
 		})
 
 		/*
-			    Testname: networking-node-pod-http
-			    Description: Try to hit test endpoints from the pod and make sure each
-				of them can report a unique hostname.
+			Release : v1.9
+			Testname: Networking, intra pod http, from node
+			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
+			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=tcp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for node-pod communication: http [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
@@ -67,9 +70,10 @@ var _ = Describe("[sig-network] Networking", func() {
 		})
 
 		/*
-			    Testname: networking-node-pod-udp
-			    Description: Try to hit test endpoints from the pod using udp and make sure
-				each of them can report a unique hostname.
+			Release : v1.9
+			Testname: Networking, intra pod http, from node
+			Description: Create a hostexec pod that is capable of curl to netcat commands. Create a test Pod that will act as a webserver front end exposing ports 8080 for tcp and 8081 for udp. The netserver service proxies are created on specified number of nodes.
+			The kubectl exec on the webserver container MUST reach a http port on the each of service proxy endpoints in the cluster using a http post(protocol=udp)  and the request MUST be successful. Container will execute curl command to reach the service port within specified max retry limit and MUST result in reporting unique hostnames.
 		*/
 		framework.ConformanceIt("should function for node-pod communication: udp [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -129,9 +129,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	/*
-		    Testname: pods-created-pod-assigned-hostip
-		    Description: Make sure when a pod is created that it is assigned a host IP
-			Address.
+		Release : v1.9
+		Testname: Pods, assigned hostip
+		Description: Create a Pod. Pod status MUST return successfully and contains a valid IP address.
 	*/
 	framework.ConformanceIt("should get a host IP [NodeConformance]", func() {
 		name := "pod-hostip-" + string(uuid.NewUUID())
@@ -151,9 +151,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	/*
-		    Testname: pods-submitted-removed
-		    Description: Makes sure a pod is created, a watch can be setup for the pod,
-			pod creation was observed, pod is deleted, and pod deletion is observed.
+		Release : v1.9
+		Testname: Pods, lifecycle
+		Description: A Pod is created with a unique label. Pod MUST be accessible when queried using the label selector upon creation. Add a watch, check if the Pod is running. Pod then deleted, The pod deletion timestamp is observed. The watch MUST return the pod deleted event. Query with the original selector for the Pod MUST return empty list.
 	*/
 	framework.ConformanceIt("should be submitted and removed [NodeConformance]", func() {
 		By("creating the pod")
@@ -277,8 +277,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	/*
-	   Testname: pods-updated-successfully
-	   Description: Make sure it is possible to successfully update a pod's labels.
+		Release : v1.9
+		Testname: Pods, update
+		Description: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful. Update the pod to change the value of the Label. Query for the Pod with the new value for the label MUST be successful.
 	*/
 	framework.ConformanceIt("should be updated [NodeConformance]", func() {
 		By("creating the pod")
@@ -330,10 +331,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	/*
-		    Testname: pods-update-active-deadline-seconds
-		    Description: Make sure it is possible to create a pod, update its
-			activeDeadlineSecondsValue, and then waits for the deadline to pass
-			and verifies the pod is terminated.
+		Release : v1.9
+		Testname: Pods, ActiveDeadlineSeconds
+		Description: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful. The Pod is updated with ActiveDeadlineSeconds set on the Pod spec. Pod MUST terminate of the specified time elapses.
 	*/
 	framework.ConformanceIt("should allow activeDeadlineSeconds to be updated [NodeConformance]", func() {
 		By("creating the pod")
@@ -377,9 +377,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	/*
-		    Testname: pods-contain-services-environment-variables
-		    Description: Make sure that when a pod is created it contains environment
-			variables for each active service.
+		Release : v1.9
+		Testname: Pods, service environment variables
+		Description: Create a server Pod listening on port 9376. A Service called fooservice is created for the server Pod listening on port 8765 targeting port 8080. If a new Pod is created in the cluster then the Pod MUST have the fooservice environment variables available from this new Pod. The new create Pod MUST have environment variables such as FOOSERVICE_SERVICE_HOST, FOOSERVICE_SERVICE_PORT, FOOSERVICE_PORT, FOOSERVICE_PORT_8765_TCP_PORT, FOOSERVICE_PORT_8765_TCP_PROTO, FOOSERVICE_PORT_8765_TCP and FOOSERVICE_PORT_8765_TCP_ADDR that are populated with proper values.
 	*/
 	framework.ConformanceIt("should contain environment variables for services [NodeConformance]", func() {
 		// Make a pod that will be a service.

--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -36,16 +36,18 @@ var _ = Describe("[sig-storage] Projected", func() {
 	f := framework.NewDefaultFramework("projected")
 
 	/*
-	   Testname: projected-secret-no-defaultMode
-	   Description: Simple projected Secret test with no defaultMode set.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, volume mode default
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with default permission mode. Pod MUST be able to read the content of the key successfully and the mode MUST be -rw-r--r-- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
 	/*
-	   Testname: projected-secret-with-defaultMode
-	   Description: Simple projected Secret test with defaultMode set.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, volume mode 0400
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with permission mode set to 0x400 on the Pod. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-—————.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
@@ -53,9 +55,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-secret-with-nonroot-defaultMode-fsGroup
-		    Description: Simple projected Secret test as non-root with
-			defaultMode and fsGroup set.
+	   Release : v1.9
+	   Testname: Project Volume, Secrets, non-root, custom fsGroup
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key. The volume has permission mode set to 0440, fsgroup set to 1001 and user set to non-root uid of 1000. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-r————-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
@@ -65,19 +67,18 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-secret-simple-mapped
-		    Description: Simple projected Secret test, by setting a secret and
-			mounting it to a volume with a custom path (mapping) on the pod with
-			no other settings and make sure the pod actually consumes it.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, mapped
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with default permission mode. The secret is also mapped to a custom path. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-—————— on the mapped volume.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedSecretE2EWithMapping(f, nil)
 	})
 
 	/*
-		    Testname: projected-secret-with-item-mode-mapped
-		    Description: Repeat the projected-secret-simple-mapped but this time
-			with an item mode (e.g. 0400) for the secret map item.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, mapped, volume mode 0400
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key with permission mode set to 0400. The secret is also mapped to a specific name. Pod MUST be able to read the content of the key successfully and the mode MUST be -r—-—————— on the mapped volume.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
 		mode := int32(0400)
@@ -106,9 +107,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-secret-multiple-volumes
-		    Description: Make sure secrets works when mounted as two different
-			volumes on the same node.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, mapped, multiple paths
+	   Description: A Pod is created with a projected volume source ‘secret’ to store a secret with a specified key. The secret is mapped to two different volume mounts. Pod MUST be able to read the content of the key successfully from the two volume mounts and the mode MUST be -r—-—————— on the mapped volumes.
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
@@ -200,8 +201,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-	   Testname: projected-secret-simple-optional
-	   Description: Make sure secrets works when optional updates included.
+	   Release : v1.9
+	   Testname: Projected Volume, Secrets, create, update delete
+	   Description: Create a Pod with three containers with secrets namely a create, update and delete container. Create Container when started MUST no have a secret, update and delete containers MUST be created with a secret value. Create a secret in the create container, the Pod MUST be able to read the secret from the create container. Update the secret in the update container, Pod MUST be able to read the updated secret value. Delete the secret in the delete container. Pod MUST fail to read the secret from the delete container.
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
@@ -401,18 +403,18 @@ var _ = Describe("[sig-storage] Projected", func() {
 
 	// Part 2/3 - ConfigMaps
 	/*
-		    Testname: projected-volume-configMap-nomappings-succeeds
-		    Description: Make sure that a projected volume with a configMap with
-			no mappings succeeds properly.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, volume mode default
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with default permission mode. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r—-r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
 	/*
-		    Testname: projected-volume-configMap-consumable-defaultMode
-		    Description: Make sure that a projected volume configMap is consumable
-			with defaultMode set.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, volume mode 0400
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with permission mode set to 0400. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -r——-——-—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
@@ -425,9 +427,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-volume-configMap-consumable-nonroot
-		    Description: Make sure that a projected volume configMap is consumable
-			by a non-root userID.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, non-root user
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw—r——r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
@@ -438,19 +440,18 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-configmap-simple-mapped
-		    Description: Simplest projected ConfigMap test, by setting a config
-			map and mounting it to a volume with a custom path (mapping) on the
-			pod with no other settings and make sure the pod actually consumes it.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, mapped
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with default permission mode. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -rw—r——r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
 	/*
-		    Testname: projected-secret-with-item-mode-mapped
-		    Description: Repeat the projected-secret-simple-mapped but this time
-			with an item mode (e.g. 0400) for the secret map item
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, mapped, volume mode 0400
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap with permission mode set to 0400. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r-—r——r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
 		mode := int32(0400)
@@ -458,9 +459,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-configmap-simpler-user-mapped
-		    Description: Repeat the projected-config-map-simple-mapped but this
-			time with a user other than root.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, mapped, non-root user
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r-—r——r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
@@ -471,10 +472,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-volume-configMaps-updated-successfully
-		    Description: Make sure that if a projected volume has configMaps,
-			that the values in these configMaps can be updated, deleted,
-			and created.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, update
+	   Description: A Pod is created with projected volume source ‘ConfigMap’ to store a configMap and performs a create and update to new value. Pod MUST be able to create the configMap with value-1. Pod MUST be able to update the value in the confgiMap to value-2.
 	*/
 	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
@@ -560,10 +560,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-volume-optional-configMaps-updated-successfully
-		    Description: Make sure that if a projected volume has optional
-			configMaps, that the values in these configMaps can be updated,
-			deleted, and created.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, create, update and delete
+	   Description: Create a Pod with three containers with ConfigMaps namely a create, update and delete container. Create Container when started MUST not have configMap, update and delete containers MUST be created with a ConfigMap value as ‘value-1’. Create a configMap in the create container, the Pod MUST be able to read the configMap from the create container. Update the configMap in the update container, Pod MUST be able to read the updated configMap value. Delete the configMap in the delete container. Pod MUST fail to read the configMap from the delete container.
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
@@ -762,9 +761,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-configmap-multiple-volumes
-		    Description: Make sure config map works when it mounted as two
-			different volumes on the same node.
+	   Release : v1.9
+	   Testname: Projected Volume, ConfigMap, multiple volume paths
+	   Description: A Pod is created with a projected volume source ‘ConfigMap’ to store a configMap. The configMap is mapped to two different volume mounts. Pod MUST be able to read the content of the configMap successfully from the two volume mounts.
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (
@@ -860,9 +859,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-podname
-		    Description: Ensure that downward API can provide pod's name through
-			DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, pod name
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -874,10 +873,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-set-default-mode
-		    Description: Ensure that downward API can set default file permission
-			mode for DownwardAPIVolumeFiles if no mode is specified in a projected
-			volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, volume mode 0400
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r—-—————.
 	*/
 	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -890,9 +888,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-set-mode
-		    Description: Ensure that downward API can set file permission mode for
-			DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, volume mode 0400
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. The default mode for the volume mount is set to 0400. Pod MUST be able to read the pod name from the mounted DownwardAPIVolumeFiles and the volume mode must be -r—-—————.
 	*/
 	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -934,10 +932,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-update-label
-		    Description: Ensure that downward API updates labels in
-			DownwardAPIVolumeFiles when pod's labels get modified in a projected
-			volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, update labels
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests and label items. Pod MUST be able to read the labels from the mounted DownwardAPIVolumeFiles. Labels are then updated. Pod MUST be able to read the updated values for the Labels.
 	*/
 	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
@@ -967,10 +964,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-update-annotation
-		    Description: Ensure that downward API updates annotations in
-			DownwardAPIVolumeFiles when pod's annotations get modified in a
-			projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, update annotation
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests and annotation items. Pod MUST be able to read the annotations from the mounted DownwardAPIVolumeFiles. Annotations are then updated. Pod MUST be able to read the updated values for the Annotations.
 	*/
 	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
@@ -1002,9 +998,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-cpu-limit
-		    Description: Ensure that downward API can provide container's CPU
-			limit through DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, CPU limits
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1016,9 +1012,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-memory-limit
-		    Description: Ensure that downward API can provide container's memory
-			limit through DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, memory limits
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1030,9 +1026,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-cpu-request
-		    Description: Ensure that downward API can provide container's CPU
-			request through DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, CPU request
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the cpu request from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1044,9 +1040,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-memory-request
-		    Description: Ensure that downward API can provide container's memory
-			request through DownwardAPIVolumeFiles in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, memory request
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the memory request from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1058,10 +1054,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-default-cpu
-		    Description: Ensure that downward API can provide default node
-			allocatable value for CPU through DownwardAPIVolumeFiles if CPU limit
-			is not specified for a container in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, CPU limit, node allocatable
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default cpu limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1071,10 +1066,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 	})
 
 	/*
-		    Testname: projected-downwardapi-volume-default-memory
-		    Description: Ensure that downward API can provide default node
-			allocatable value for memory through DownwardAPIVolumeFiles if memory
-			limit is not specified for a container in a projected volume.
+	   Release : v1.9
+	   Testname: Projected Volume, DownwardAPI, memory limit, node allocatable
+	   Description: A Pod is created with a projected volume source for downwardAPI with pod name, cpu and memory limits and cpu and memory requests.  The CPU and memory resources for requests and limits are NOT specified for the container. Pod MUST be able to read the default memory limits from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
@@ -1085,9 +1079,9 @@ var _ = Describe("[sig-storage] Projected", func() {
 
 	// Test multiple projections
 	/*
-		    Testname: projected-configmap-secret-same-dir
-		    Description: This test projects a secret and configmap into the same
-			directory to ensure projection is working as intended.
+	   Release : v1.9
+	   Testname: Projected Volume, multiple projections
+	   Description: A Pod is created with a projected volume source for secrets, configMap and downwardAPI with pod name, cpu and memory limits and cpu and memory requests. Pod MUST be able to read the secrets, configMap values and the cpu and memory limits as well as cpu and memory requests from the mounted DownwardAPIVolumeFiles.
 	*/
 	framework.ConformanceIt("should project all components that make up the projection API [Projection][NodeConformance]", func() {
 		var err error

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -31,9 +31,9 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
 	/*
-		    Testname: secret-env-vars
-		    Description: Ensure that secret can be consumed via environment
-			variables.
+		Release : v1.9
+		Testname: Secrets, pod environment field
+		Description: Create a secret. Create a Pod with Container that declares a environment variable which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
 	framework.ConformanceIt("should be consumable from pods in env vars [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
@@ -80,9 +80,9 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 	})
 
 	/*
-		    Testname: secret-configmaps-source
-		    Description: Ensure that secret can be consumed via source of a set
-			of ConfigMaps.
+		Release : v1.9
+		Testname: Secrets, pod environment from source
+		Description: Create a secret. Create a Pod with Container that declares a environment variable using ‘EnvFrom’ which references the secret created to extract a key value from the secret. Pod MUST have the environment variable that contains proper value for the key to the secret.
 	*/
 	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -34,18 +34,18 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
 	/*
-		    Testname: secret-volume-mount-without-mapping
-		    Description: Ensure that secret can be mounted without mapping to a
-			pod volume.
+		Release : v1.9
+		Testname: Secrets Volume, default
+		Description: Create a secret. Create a Pod with secret volume source configured into the container. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -rw-r--r-- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
 	/*
-		    Testname: secret-volume-mount-without-mapping-default-mode
-		    Description: Ensure that secret can be mounted without mapping to a
-			pod volume in default mode.
+		Release : v1.9
+		Testname: Secrets Volume, volume mode 0400
+		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r——--—-—- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
@@ -53,9 +53,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	})
 
 	/*
-		    Testname: secret-volume-mount-without-mapping-non-root-default-mode-fsgroup
-		    Description: Ensure that secret can be mounted without mapping to a pod
-			volume as non-root in default mode with fsGroup set.
+		Release : v1.9
+		Testname: Secrets Volume, volume mode 0440, fsGroup 1001 and uid 1000
+		Description: Create a secret. Create a Pod with secret volume source configured into the container with file mode set to 0x440 as a non-root user with uid 1000 and fsGroup id 1001. Pod MUST be able to read the secret from the mounted volume from the container runtime and the file mode of the secret MUST be -r——r-—-—- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
@@ -65,18 +65,18 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	})
 
 	/*
-		    Testname: secret-volume-mount-with-mapping
-		    Description: Ensure that secret can be mounted with mapping to a pod
-			volume.
+		Release : v1.9
+		Testname: Secrets Volume, mapping
+		Description: Create a secret. Create a Pod with secret volume source configured into the container with a custom path. Pod MUST be able to read the secret from the mounted volume from the specified custom path. The file mode of the secret MUST be -rw—r-—r—- by default.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doSecretE2EWithMapping(f, nil)
 	})
 
 	/*
-		    Testname: secret-volume-mount-with-mapping-item-mode
-		    Description: Ensure that secret can be mounted with mapping to a pod
-			volume in item mode.
+		Release : v1.9
+		Testname: Secrets Volume, mapping, volume mode 0400
+		Description: Create a secret. Create a Pod with secret volume source configured into the container with a custom path and file mode set to 0x400. Pod MUST be able to read the secret from the mounted volume from the specified custom path. The file mode of the secret MUST be -r-—r-—r—-.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
 		mode := int32(0400)
@@ -105,8 +105,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	})
 
 	/*
-	   Testname: secret-multiple-volume-mounts
-	   Description: Ensure that secret can be mounted to multiple pod volumes.
+		Release : v1.9
+		Testname: Secrets Volume, mapping multiple volume paths
+		Description: Create a secret. Create a Pod with two secret volume sources configured into the container in to two different custom paths. Pod MUST be able to read the secret from the both the mounted volumes from the two specified custom paths.
 	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
@@ -182,9 +183,9 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	})
 
 	/*
-		    Testname: secret-mounted-volume-optional-update-change
-		    Description: Ensure that optional update change to secret can be
-			reflected on a mounted volume.
+		Release : v1.9
+		Testname: Secrets Volume, create, update and delete
+		Description: Create a Pod with three containers with secrets volume sources namely a create, update and delete container. Create Container when started MUST not have secret, update and delete containers MUST be created with a secret value. Create a secret in the create container, the Pod MUST be able to read the secret from the create container. Update the secret in the update container, Pod MUST be able to read the updated secret value. Delete the secret in the delete container. Pod MUST fail to read the secret from the delete container.
 	*/
 	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)


### PR DESCRIPTION
This PR is part of the conformance documentation. This is to provide more formal specification using RFC 2119 keywords to describe the test so that who ever is running conformance tests do not have to go through the code to understand why and what is tested.
The documentation information added here into each of the tests eventually result into a document which is currently checked in at location https://github.com/cncf/k8s-conformance/blob/master/docs/KubeConformance-1.9.md

I would like to have this PR reviewed for v1.10 as I consider it important to strengthen the conformance documents.