### PR TITLE
Adding details to Conformance Tests using RFC 2119 standards.

### DIFF
--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -38,6 +38,12 @@ import (
 var _ = SIGDescribe("ReplicationController", func() {
 	f := framework.NewDefaultFramework("replication-controller")
 
+	/*
+		Release : v1.9
+		Testname: Replication Controller, run basic image
+		Description: Replication Controller MUST create a Pod with Basic Image and MUST run the service with the provided image. Image MUST be tested by dialing into the service listening through TCP, UDP and HTTP.
+	*/
+
 	framework.ConformanceIt("should serve a basic image on each replica with a public image ", func() {
 		TestReplicationControllerServeImageOrFail(f, "basic", framework.ServeHostnameImage)
 	})

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -109,6 +109,11 @@ func newPodQuota(name, number string) *v1.ResourceQuota {
 var _ = SIGDescribe("ReplicaSet", func() {
 	f := framework.NewDefaultFramework("replicaset")
 
+	/*
+		Release : v1.9
+		Testname: Replica Set, run basic image
+		Description: Create a ReplicaSet with a Pod and a single Container. Make sure that the Pod is running. Pod SHOULD send a valid response when queried.
+	*/
 	framework.ConformanceIt("should serve a basic image on each replica with a public image ", func() {
 		testReplicaSetServeImageOrFail(f, "basic", framework.ServeHostnameImage)
 	})

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -249,12 +249,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-			Testname: StatefulSet-RollingUpdate
-			Description: StatefulSet MUST support the RollingUpdate strategy to automatically replace Pods
-				one at a time when the Pod template changes. The StatefulSet's status MUST indicate the
-				CurrentRevision and UpdateRevision. If the template is changed to match a prior revision,
-				StatefulSet MUST detect this as a rollback instead of creating a new revision.
-				This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
+			Release : v1.9
+			Testname: StatefulSet, Rolling Update
+			Description: StatefulSet MUST support the RollingUpdate strategy to automatically replace Pods one at a time when the Pod template changes. The StatefulSet's status MUST indicate the CurrentRevision and UpdateRevision. If the template is changed to match a prior revision, StatefulSet MUST detect this as a rollback instead of creating a new revision. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
 		framework.ConformanceIt("should perform rolling updates and roll backs of template modifications", func() {
 			By("Creating a new StatefulSet")
@@ -372,11 +369,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-			Testname: StatefulSet-RollingUpdatePartition
-			Description: StatefulSet's RollingUpdate strategy MUST support the Partition parameter for
-				canaries and phased rollouts. If a Pod is deleted while a rolling update is in progress,
-				StatefulSet MUST restore the Pod without violating the Partition.
-				This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
+			Release : v1.9
+			Testname: StatefulSet, Rolling Update with Partition
+			Description: StatefulSet's RollingUpdate strategy MUST support the Partition parameter for canaries and phased rollouts. If a Pod is deleted while a rolling update is in progress, StatefulSet MUST restore the Pod without violating the Partition. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
 		framework.ConformanceIt("should perform canary updates and phased rolling updates of template modifications", func() {
 			By("Creating a new StaefulSet")
@@ -670,11 +665,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-			Testname: StatefulSet-Scaling
-			Description: StatefulSet MUST create Pods in ascending order by ordinal index when scaling up,
-				and delete Pods in descending order when scaling down. Scaling up or down MUST pause if any
-				Pods belonging to the StatefulSet are unhealthy.
-				This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
+			Release : v1.9
+			Testname: StatefulSet, Scaling
+			Description: StatefulSet MUST create Pods in ascending order by ordinal index when scaling up, and delete Pods in descending order when scaling down. Scaling up or down MUST pause if any Pods belonging to the StatefulSet are unhealthy. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
 		framework.ConformanceIt("Scaling should happen in predictable order and halt if any stateful pod is unhealthy", func() {
 			psLabels := klabels.Set(labels)
@@ -753,9 +746,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-			Testname: StatefulSet-BurstScaling
-			Description: StatefulSet MUST support the Parallel PodManagementPolicy for burst scaling.
-				This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
+			Release : v1.9
+			Testname: StatefulSet, Burst Scaling
+			Description: StatefulSet MUST support the Parallel PodManagementPolicy for burst scaling. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
 		framework.ConformanceIt("Burst scaling should run to completion even with unhealthy pods", func() {
 			psLabels := klabels.Set(labels)
@@ -796,10 +789,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 		})
 
 		/*
-			Testname: StatefulSet-RecreateFailedPod
-			Description: StatefulSet MUST delete and recreate Pods it owns that go into a Failed state,
-				such as when they are rejected or evicted by a Node.
-				This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
+			Release : v1.9
+			Testname: StatefulSet, Recreate Failed Pod
+			Description: StatefulSet MUST delete and recreate Pods it owns that go into a Failed state, such as when they are rejected or evicted by a Node. This test does not depend on a preexisting default StorageClass or a dynamic provisioner.
 		*/
 		framework.ConformanceIt("Should recreate evicted statefulset", func() {
 			podName := "test-pod"


### PR DESCRIPTION
This PR is part of the conformance documentation. This is to provide more formal specification using RFC 2119 keywords to describe the test so that who ever is running conformance tests do not have to go through the code to understand why and what is tested.
The documentation information added here into each of the tests eventually result into a document which is currently checked in at location https://github.com/cncf/k8s-conformance/blob/master/docs/KubeConformance-1.9.md

I would like to have this PR reviewed for v1.10 as I consider it important to strengthen the conformance documents.