### PR TITLE
Fix stackdriver logging test

### DIFF
--- a/test/e2e/instrumentation/logging/utils/wait.go
+++ b/test/e2e/instrumentation/logging/utils/wait.go
@@ -48,9 +48,6 @@ func UntilFirstEntryFromLog(log string) IngestionPred {
 	return func(_ string, entries []LogEntry) (bool, error) {
 		for _, e := range entries {
 			if e.LogName == log {
-				if e.Location != framework.TestContext.CloudConfig.Zone {
-					return false, fmt.Errorf("Bad location in logs '%s' != '%d'", e.Location, framework.TestContext.CloudConfig.Zone)
-				}
 				return true, nil
 			}
 		}


### PR DESCRIPTION
Fixes https://k8s-testgrid.appspot.com/google-gce#gci-gce-sd-logging

Removes location verification that was used for event-exporter tests.

```release-note
NONE
```
