### PR TITLE
fix persist typo

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -279,7 +279,7 @@ func (p *oidcAuthProvider) idToken() (string, error) {
 
 	// Persist new config and if successful, update the in memory config.
 	if err = p.persister.Persist(newCfg); err != nil {
-		return "", fmt.Errorf("could not perist new tokens: %v", err)
+		return "", fmt.Errorf("could not persist new tokens: %v", err)
 	}
 	p.cfg = newCfg
 


### PR DESCRIPTION
I wonder this pr should pull to kubernetes/kubernetes  or  kubernetes/client-go ?

```
NONE
```