### PR TITLE
Fix literal copies lock value from fakePtr

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
+++ b/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
@@ -71,7 +71,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -83,14 +83,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -102,80 +102,80 @@ var _ clientset.Interface = &Clientset{}
 
 // Admissionregistration retrieves the AdmissionregistrationClient
 func (c *Clientset) Admissionregistration() admissionregistrationinternalversion.AdmissionregistrationInterface {
-	return &fakeadmissionregistrationinternalversion.FakeAdmissionregistration{Fake: &c.Fake}
+	return &fakeadmissionregistrationinternalversion.FakeAdmissionregistration{Fake: c.Fake}
 }
 
 // Core retrieves the CoreClient
 func (c *Clientset) Core() coreinternalversion.CoreInterface {
-	return &fakecoreinternalversion.FakeCore{Fake: &c.Fake}
+	return &fakecoreinternalversion.FakeCore{Fake: c.Fake}
 }
 
 // Apps retrieves the AppsClient
 func (c *Clientset) Apps() appsinternalversion.AppsInterface {
-	return &fakeappsinternalversion.FakeApps{Fake: &c.Fake}
+	return &fakeappsinternalversion.FakeApps{Fake: c.Fake}
 }
 
 // Authentication retrieves the AuthenticationClient
 func (c *Clientset) Authentication() authenticationinternalversion.AuthenticationInterface {
-	return &fakeauthenticationinternalversion.FakeAuthentication{Fake: &c.Fake}
+	return &fakeauthenticationinternalversion.FakeAuthentication{Fake: c.Fake}
 }
 
 // Authorization retrieves the AuthorizationClient
 func (c *Clientset) Authorization() authorizationinternalversion.AuthorizationInterface {
-	return &fakeauthorizationinternalversion.FakeAuthorization{Fake: &c.Fake}
+	return &fakeauthorizationinternalversion.FakeAuthorization{Fake: c.Fake}
 }
 
 // Autoscaling retrieves the AutoscalingClient
 func (c *Clientset) Autoscaling() autoscalinginternalversion.AutoscalingInterface {
-	return &fakeautoscalinginternalversion.FakeAutoscaling{Fake: &c.Fake}
+	return &fakeautoscalinginternalversion.FakeAutoscaling{Fake: c.Fake}
 }
 
 // Batch retrieves the BatchClient
 func (c *Clientset) Batch() batchinternalversion.BatchInterface {
-	return &fakebatchinternalversion.FakeBatch{Fake: &c.Fake}
+	return &fakebatchinternalversion.FakeBatch{Fake: c.Fake}
 }
 
 // Certificates retrieves the CertificatesClient
 func (c *Clientset) Certificates() certificatesinternalversion.CertificatesInterface {
-	return &fakecertificatesinternalversion.FakeCertificates{Fake: &c.Fake}
+	return &fakecertificatesinternalversion.FakeCertificates{Fake: c.Fake}
 }
 
 // Events retrieves the EventsClient
 func (c *Clientset) Events() eventsinternalversion.EventsInterface {
-	return &fakeeventsinternalversion.FakeEvents{Fake: &c.Fake}
+	return &fakeeventsinternalversion.FakeEvents{Fake: c.Fake}
 }
 
 // Extensions retrieves the ExtensionsClient
 func (c *Clientset) Extensions() extensionsinternalversion.ExtensionsInterface {
-	return &fakeextensionsinternalversion.FakeExtensions{Fake: &c.Fake}
+	return &fakeextensionsinternalversion.FakeExtensions{Fake: c.Fake}
 }
 
 // Networking retrieves the NetworkingClient
 func (c *Clientset) Networking() networkinginternalversion.NetworkingInterface {
-	return &fakenetworkinginternalversion.FakeNetworking{Fake: &c.Fake}
+	return &fakenetworkinginternalversion.FakeNetworking{Fake: c.Fake}
 }
 
 // Policy retrieves the PolicyClient
 func (c *Clientset) Policy() policyinternalversion.PolicyInterface {
-	return &fakepolicyinternalversion.FakePolicy{Fake: &c.Fake}
+	return &fakepolicyinternalversion.FakePolicy{Fake: c.Fake}
 }
 
 // Rbac retrieves the RbacClient
 func (c *Clientset) Rbac() rbacinternalversion.RbacInterface {
-	return &fakerbacinternalversion.FakeRbac{Fake: &c.Fake}
+	return &fakerbacinternalversion.FakeRbac{Fake: c.Fake}
 }
 
 // Scheduling retrieves the SchedulingClient
 func (c *Clientset) Scheduling() schedulinginternalversion.SchedulingInterface {
-	return &fakeschedulinginternalversion.FakeScheduling{Fake: &c.Fake}
+	return &fakeschedulinginternalversion.FakeScheduling{Fake: c.Fake}
 }
 
 // Settings retrieves the SettingsClient
 func (c *Clientset) Settings() settingsinternalversion.SettingsInterface {
-	return &fakesettingsinternalversion.FakeSettings{Fake: &c.Fake}
+	return &fakesettingsinternalversion.FakeSettings{Fake: c.Fake}
 }
 
 // Storage retrieves the StorageClient
 func (c *Clientset) Storage() storageinternalversion.StorageInterface {
-	return &fakestorageinternalversion.FakeStorage{Fake: &c.Fake}
+	return &fakestorageinternalversion.FakeStorage{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,10 +72,10 @@ var _ clientset.Interface = &Clientset{}
 
 // ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
 func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
+	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: c.Fake}
 }
 
 // Apiextensions retrieves the ApiextensionsV1beta1Client
 func (c *Clientset) Apiextensions() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: &c.Fake}
+	return &fakeapiextensionsv1beta1.FakeApiextensionsV1beta1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,5 +72,5 @@ var _ clientset.Interface = &Clientset{}
 
 // Apiextensions retrieves the ApiextensionsClient
 func (c *Clientset) Apiextensions() apiextensionsinternalversion.ApiextensionsInterface {
-	return &fakeapiextensionsinternalversion.FakeApiextensions{Fake: &c.Fake}
+	return &fakeapiextensionsinternalversion.FakeApiextensions{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -95,7 +95,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -107,14 +107,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -126,220 +126,220 @@ var _ clientset.Interface = &Clientset{}
 
 // AdmissionregistrationV1alpha1 retrieves the AdmissionregistrationV1alpha1Client
 func (c *Clientset) AdmissionregistrationV1alpha1() admissionregistrationv1alpha1.AdmissionregistrationV1alpha1Interface {
-	return &fakeadmissionregistrationv1alpha1.FakeAdmissionregistrationV1alpha1{Fake: &c.Fake}
+	return &fakeadmissionregistrationv1alpha1.FakeAdmissionregistrationV1alpha1{Fake: c.Fake}
 }
 
 // AdmissionregistrationV1beta1 retrieves the AdmissionregistrationV1beta1Client
 func (c *Clientset) AdmissionregistrationV1beta1() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface {
-	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: &c.Fake}
+	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: c.Fake}
 }
 
 // Admissionregistration retrieves the AdmissionregistrationV1beta1Client
 func (c *Clientset) Admissionregistration() admissionregistrationv1beta1.AdmissionregistrationV1beta1Interface {
-	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: &c.Fake}
+	return &fakeadmissionregistrationv1beta1.FakeAdmissionregistrationV1beta1{Fake: c.Fake}
 }
 
 // AppsV1beta1 retrieves the AppsV1beta1Client
 func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
-	return &fakeappsv1beta1.FakeAppsV1beta1{Fake: &c.Fake}
+	return &fakeappsv1beta1.FakeAppsV1beta1{Fake: c.Fake}
 }
 
 // AppsV1beta2 retrieves the AppsV1beta2Client
 func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
-	return &fakeappsv1beta2.FakeAppsV1beta2{Fake: &c.Fake}
+	return &fakeappsv1beta2.FakeAppsV1beta2{Fake: c.Fake}
 }
 
 // AppsV1 retrieves the AppsV1Client
 func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
-	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
+	return &fakeappsv1.FakeAppsV1{Fake: c.Fake}
 }
 
 // Apps retrieves the AppsV1Client
 func (c *Clientset) Apps() appsv1.AppsV1Interface {
-	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
+	return &fakeappsv1.FakeAppsV1{Fake: c.Fake}
 }
 
 // AuthenticationV1 retrieves the AuthenticationV1Client
 func (c *Clientset) AuthenticationV1() authenticationv1.AuthenticationV1Interface {
-	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: &c.Fake}
+	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: c.Fake}
 }
 
 // Authentication retrieves the AuthenticationV1Client
 func (c *Clientset) Authentication() authenticationv1.AuthenticationV1Interface {
-	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: &c.Fake}
+	return &fakeauthenticationv1.FakeAuthenticationV1{Fake: c.Fake}
 }
 
 // AuthenticationV1beta1 retrieves the AuthenticationV1beta1Client
 func (c *Clientset) AuthenticationV1beta1() authenticationv1beta1.AuthenticationV1beta1Interface {
-	return &fakeauthenticationv1beta1.FakeAuthenticationV1beta1{Fake: &c.Fake}
+	return &fakeauthenticationv1beta1.FakeAuthenticationV1beta1{Fake: c.Fake}
 }
 
 // AuthorizationV1 retrieves the AuthorizationV1Client
 func (c *Clientset) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
-	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: &c.Fake}
+	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: c.Fake}
 }
 
 // Authorization retrieves the AuthorizationV1Client
 func (c *Clientset) Authorization() authorizationv1.AuthorizationV1Interface {
-	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: &c.Fake}
+	return &fakeauthorizationv1.FakeAuthorizationV1{Fake: c.Fake}
 }
 
 // AuthorizationV1beta1 retrieves the AuthorizationV1beta1Client
 func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {
-	return &fakeauthorizationv1beta1.FakeAuthorizationV1beta1{Fake: &c.Fake}
+	return &fakeauthorizationv1beta1.FakeAuthorizationV1beta1{Fake: c.Fake}
 }
 
 // AutoscalingV1 retrieves the AutoscalingV1Client
 func (c *Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
-	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: &c.Fake}
+	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: c.Fake}
 }
 
 // Autoscaling retrieves the AutoscalingV1Client
 func (c *Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
-	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: &c.Fake}
+	return &fakeautoscalingv1.FakeAutoscalingV1{Fake: c.Fake}
 }
 
 // AutoscalingV2beta1 retrieves the AutoscalingV2beta1Client
 func (c *Clientset) AutoscalingV2beta1() autoscalingv2beta1.AutoscalingV2beta1Interface {
-	return &fakeautoscalingv2beta1.FakeAutoscalingV2beta1{Fake: &c.Fake}
+	return &fakeautoscalingv2beta1.FakeAutoscalingV2beta1{Fake: c.Fake}
 }
 
 // BatchV1 retrieves the BatchV1Client
 func (c *Clientset) BatchV1() batchv1.BatchV1Interface {
-	return &fakebatchv1.FakeBatchV1{Fake: &c.Fake}
+	return &fakebatchv1.FakeBatchV1{Fake: c.Fake}
 }
 
 // Batch retrieves the BatchV1Client
 func (c *Clientset) Batch() batchv1.BatchV1Interface {
-	return &fakebatchv1.FakeBatchV1{Fake: &c.Fake}
+	return &fakebatchv1.FakeBatchV1{Fake: c.Fake}
 }
 
 // BatchV1beta1 retrieves the BatchV1beta1Client
 func (c *Clientset) BatchV1beta1() batchv1beta1.BatchV1beta1Interface {
-	return &fakebatchv1beta1.FakeBatchV1beta1{Fake: &c.Fake}
+	return &fakebatchv1beta1.FakeBatchV1beta1{Fake: c.Fake}
 }
 
 // BatchV2alpha1 retrieves the BatchV2alpha1Client
 func (c *Clientset) BatchV2alpha1() batchv2alpha1.BatchV2alpha1Interface {
-	return &fakebatchv2alpha1.FakeBatchV2alpha1{Fake: &c.Fake}
+	return &fakebatchv2alpha1.FakeBatchV2alpha1{Fake: c.Fake}
 }
 
 // CertificatesV1beta1 retrieves the CertificatesV1beta1Client
 func (c *Clientset) CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta1Interface {
-	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: &c.Fake}
+	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: c.Fake}
 }
 
 // Certificates retrieves the CertificatesV1beta1Client
 func (c *Clientset) Certificates() certificatesv1beta1.CertificatesV1beta1Interface {
-	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: &c.Fake}
+	return &fakecertificatesv1beta1.FakeCertificatesV1beta1{Fake: c.Fake}
 }
 
 // CoreV1 retrieves the CoreV1Client
 func (c *Clientset) CoreV1() corev1.CoreV1Interface {
-	return &fakecorev1.FakeCoreV1{Fake: &c.Fake}
+	return &fakecorev1.FakeCoreV1{Fake: c.Fake}
 }
 
 // Core retrieves the CoreV1Client
 func (c *Clientset) Core() corev1.CoreV1Interface {
-	return &fakecorev1.FakeCoreV1{Fake: &c.Fake}
+	return &fakecorev1.FakeCoreV1{Fake: c.Fake}
 }
 
 // EventsV1beta1 retrieves the EventsV1beta1Client
 func (c *Clientset) EventsV1beta1() eventsv1beta1.EventsV1beta1Interface {
-	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: &c.Fake}
+	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: c.Fake}
 }
 
 // Events retrieves the EventsV1beta1Client
 func (c *Clientset) Events() eventsv1beta1.EventsV1beta1Interface {
-	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: &c.Fake}
+	return &fakeeventsv1beta1.FakeEventsV1beta1{Fake: c.Fake}
 }
 
 // ExtensionsV1beta1 retrieves the ExtensionsV1beta1Client
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
-	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: &c.Fake}
+	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: c.Fake}
 }
 
 // Extensions retrieves the ExtensionsV1beta1Client
 func (c *Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
-	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: &c.Fake}
+	return &fakeextensionsv1beta1.FakeExtensionsV1beta1{Fake: c.Fake}
 }
 
 // NetworkingV1 retrieves the NetworkingV1Client
 func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
-	return &fakenetworkingv1.FakeNetworkingV1{Fake: &c.Fake}
+	return &fakenetworkingv1.FakeNetworkingV1{Fake: c.Fake}
 }
 
 // Networking retrieves the NetworkingV1Client
 func (c *Clientset) Networking() networkingv1.NetworkingV1Interface {
-	return &fakenetworkingv1.FakeNetworkingV1{Fake: &c.Fake}
+	return &fakenetworkingv1.FakeNetworkingV1{Fake: c.Fake}
 }
 
 // PolicyV1beta1 retrieves the PolicyV1beta1Client
 func (c *Clientset) PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface {
-	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: &c.Fake}
+	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: c.Fake}
 }
 
 // Policy retrieves the PolicyV1beta1Client
 func (c *Clientset) Policy() policyv1beta1.PolicyV1beta1Interface {
-	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: &c.Fake}
+	return &fakepolicyv1beta1.FakePolicyV1beta1{Fake: c.Fake}
 }
 
 // RbacV1 retrieves the RbacV1Client
 func (c *Clientset) RbacV1() rbacv1.RbacV1Interface {
-	return &fakerbacv1.FakeRbacV1{Fake: &c.Fake}
+	return &fakerbacv1.FakeRbacV1{Fake: c.Fake}
 }
 
 // Rbac retrieves the RbacV1Client
 func (c *Clientset) Rbac() rbacv1.RbacV1Interface {
-	return &fakerbacv1.FakeRbacV1{Fake: &c.Fake}
+	return &fakerbacv1.FakeRbacV1{Fake: c.Fake}
 }
 
 // RbacV1beta1 retrieves the RbacV1beta1Client
 func (c *Clientset) RbacV1beta1() rbacv1beta1.RbacV1beta1Interface {
-	return &fakerbacv1beta1.FakeRbacV1beta1{Fake: &c.Fake}
+	return &fakerbacv1beta1.FakeRbacV1beta1{Fake: c.Fake}
 }
 
 // RbacV1alpha1 retrieves the RbacV1alpha1Client
 func (c *Clientset) RbacV1alpha1() rbacv1alpha1.RbacV1alpha1Interface {
-	return &fakerbacv1alpha1.FakeRbacV1alpha1{Fake: &c.Fake}
+	return &fakerbacv1alpha1.FakeRbacV1alpha1{Fake: c.Fake}
 }
 
 // SchedulingV1alpha1 retrieves the SchedulingV1alpha1Client
 func (c *Clientset) SchedulingV1alpha1() schedulingv1alpha1.SchedulingV1alpha1Interface {
-	return &fakeschedulingv1alpha1.FakeSchedulingV1alpha1{Fake: &c.Fake}
+	return &fakeschedulingv1alpha1.FakeSchedulingV1alpha1{Fake: c.Fake}
 }
 
 // Scheduling retrieves the SchedulingV1alpha1Client
 func (c *Clientset) Scheduling() schedulingv1alpha1.SchedulingV1alpha1Interface {
-	return &fakeschedulingv1alpha1.FakeSchedulingV1alpha1{Fake: &c.Fake}
+	return &fakeschedulingv1alpha1.FakeSchedulingV1alpha1{Fake: c.Fake}
 }
 
 // SettingsV1alpha1 retrieves the SettingsV1alpha1Client
 func (c *Clientset) SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface {
-	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: &c.Fake}
+	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: c.Fake}
 }
 
 // Settings retrieves the SettingsV1alpha1Client
 func (c *Clientset) Settings() settingsv1alpha1.SettingsV1alpha1Interface {
-	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: &c.Fake}
+	return &fakesettingsv1alpha1.FakeSettingsV1alpha1{Fake: c.Fake}
 }
 
 // StorageV1beta1 retrieves the StorageV1beta1Client
 func (c *Clientset) StorageV1beta1() storagev1beta1.StorageV1beta1Interface {
-	return &fakestoragev1beta1.FakeStorageV1beta1{Fake: &c.Fake}
+	return &fakestoragev1beta1.FakeStorageV1beta1{Fake: c.Fake}
 }
 
 // StorageV1 retrieves the StorageV1Client
 func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
+	return &fakestoragev1.FakeStorageV1{Fake: c.Fake}
 }
 
 // Storage retrieves the StorageV1Client
 func (c *Clientset) Storage() storagev1.StorageV1Interface {
-	return &fakestoragev1.FakeStorageV1{Fake: &c.Fake}
+	return &fakestoragev1.FakeStorageV1{Fake: c.Fake}
 }
 
 // StorageV1alpha1 retrieves the StorageV1alpha1Client
 func (c *Clientset) StorageV1alpha1() storagev1alpha1.StorageV1alpha1Interface {
-	return &fakestoragev1alpha1.FakeStorageV1alpha1{Fake: &c.Fake}
+	return &fakestoragev1alpha1.FakeStorageV1alpha1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/clientset_generated.go
@@ -43,7 +43,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -55,14 +55,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -74,10 +74,10 @@ var _ clientset.Interface = &Clientset{}
 
 // Example retrieves the ExampleClient
 func (c *Clientset) Example() exampleinternalversion.ExampleInterface {
-	return &fakeexampleinternalversion.FakeExample{Fake: &c.Fake}
+	return &fakeexampleinternalversion.FakeExample{Fake: c.Fake}
 }
 
 // SecondExample retrieves the SecondExampleClient
 func (c *Clientset) SecondExample() secondexampleinternalversion.SecondExampleInterface {
-	return &fakesecondexampleinternalversion.FakeSecondExample{Fake: &c.Fake}
+	return &fakesecondexampleinternalversion.FakeSecondExample{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
@@ -43,7 +43,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -55,14 +55,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -74,20 +74,20 @@ var _ clientset.Interface = &Clientset{}
 
 // ExampleV1 retrieves the ExampleV1Client
 func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
+	return &fakeexamplev1.FakeExampleV1{Fake: c.Fake}
 }
 
 // Example retrieves the ExampleV1Client
 func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
+	return &fakeexamplev1.FakeExampleV1{Fake: c.Fake}
 }
 
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
+	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: c.Fake}
 }
 
 // SecondExample retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
+	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -43,7 +43,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -55,14 +55,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -74,20 +74,20 @@ var _ clientset.Interface = &Clientset{}
 
 // ExampleV1 retrieves the ExampleV1Client
 func (c *Clientset) ExampleV1() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
+	return &fakeexamplev1.FakeExampleV1{Fake: c.Fake}
 }
 
 // Example retrieves the ExampleV1Client
 func (c *Clientset) Example() examplev1.ExampleV1Interface {
-	return &fakeexamplev1.FakeExampleV1{Fake: &c.Fake}
+	return &fakeexamplev1.FakeExampleV1{Fake: c.Fake}
 }
 
 // SecondExampleV1 retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExampleV1() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
+	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: c.Fake}
 }
 
 // SecondExample retrieves the SecondExampleV1Client
 func (c *Clientset) SecondExample() secondexamplev1.SecondExampleV1Interface {
-	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: &c.Fake}
+	return &fakesecondexamplev1.FakeSecondExampleV1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -125,7 +125,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -137,14 +137,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -160,13 +160,13 @@ var _ clientset.Interface = &Clientset{}
 var clientsetInterfaceImplTemplate = `
 // $.GroupGoName$$.Version$ retrieves the $.GroupGoName$$.Version$Client
 func (c *Clientset) $.GroupGoName$$.Version$() $.PackageAlias$.$.GroupGoName$$.Version$Interface {
-	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: &c.Fake}
+	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: c.Fake}
 }
 `
 
 var clientsetInterfaceDefaultVersionImpl = `
 // $.GroupGoName$ retrieves the $.GroupGoName$$.Version$Client
 func (c *Clientset) $.GroupGoName$() $.PackageAlias$.$.GroupGoName$$.Version$Interface {
-	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: &c.Fake}
+	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: c.Fake}
 }
 `

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -43,7 +43,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -55,14 +55,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -74,15 +74,15 @@ var _ clientset.Interface = &Clientset{}
 
 // ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
 func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
-	return &fakeapiregistrationv1beta1.FakeApiregistrationV1beta1{Fake: &c.Fake}
+	return &fakeapiregistrationv1beta1.FakeApiregistrationV1beta1{Fake: c.Fake}
 }
 
 // ApiregistrationV1 retrieves the ApiregistrationV1Client
 func (c *Clientset) ApiregistrationV1() apiregistrationv1.ApiregistrationV1Interface {
-	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: &c.Fake}
+	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: c.Fake}
 }
 
 // Apiregistration retrieves the ApiregistrationV1Client
 func (c *Clientset) Apiregistration() apiregistrationv1.ApiregistrationV1Interface {
-	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: &c.Fake}
+	return &fakeapiregistrationv1.FakeApiregistrationV1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,5 +72,5 @@ var _ clientset.Interface = &Clientset{}
 
 // Apiregistration retrieves the ApiregistrationClient
 func (c *Clientset) Apiregistration() apiregistrationinternalversion.ApiregistrationInterface {
-	return &fakeapiregistrationinternalversion.FakeApiregistration{Fake: &c.Fake}
+	return &fakeapiregistrationinternalversion.FakeApiregistration{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -43,7 +43,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -55,14 +55,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -74,15 +74,15 @@ var _ clientset.Interface = &Clientset{}
 
 // MetricsV1alpha1 retrieves the MetricsV1alpha1Client
 func (c *Clientset) MetricsV1alpha1() metricsv1alpha1.MetricsV1alpha1Interface {
-	return &fakemetricsv1alpha1.FakeMetricsV1alpha1{Fake: &c.Fake}
+	return &fakemetricsv1alpha1.FakeMetricsV1alpha1{Fake: c.Fake}
 }
 
 // MetricsV1beta1 retrieves the MetricsV1beta1Client
 func (c *Clientset) MetricsV1beta1() metricsv1beta1.MetricsV1beta1Interface {
-	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: &c.Fake}
+	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: c.Fake}
 }
 
 // Metrics retrieves the MetricsV1beta1Client
 func (c *Clientset) Metrics() metricsv1beta1.MetricsV1beta1Interface {
-	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: &c.Fake}
+	return &fakemetricsv1beta1.FakeMetricsV1beta1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,5 +72,5 @@ var _ clientset.Interface = &Clientset{}
 
 // Wardle retrieves the WardleClient
 func (c *Clientset) Wardle() wardleinternalversion.WardleInterface {
-	return &fakewardleinternalversion.FakeWardle{Fake: &c.Fake}
+	return &fakewardleinternalversion.FakeWardle{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,10 +72,10 @@ var _ clientset.Interface = &Clientset{}
 
 // WardleV1alpha1 retrieves the WardleV1alpha1Client
 func (c *Clientset) WardleV1alpha1() wardlev1alpha1.WardleV1alpha1Interface {
-	return &fakewardlev1alpha1.FakeWardleV1alpha1{Fake: &c.Fake}
+	return &fakewardlev1alpha1.FakeWardleV1alpha1{Fake: c.Fake}
 }
 
 // Wardle retrieves the WardleV1alpha1Client
 func (c *Clientset) Wardle() wardlev1alpha1.WardleV1alpha1Interface {
-	return &fakewardlev1alpha1.FakeWardleV1alpha1{Fake: &c.Fake}
+	return &fakewardlev1alpha1.FakeWardleV1alpha1{Fake: c.Fake}
 }

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -41,7 +41,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
+	fakePtr := &testing.Fake{}
 	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
 	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -53,14 +53,14 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: fakePtr}}
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a
 // struct to get a default implementation. This makes faking out just the method
 // you want to test easier.
 type Clientset struct {
-	testing.Fake
+	*testing.Fake
 	discovery *fakediscovery.FakeDiscovery
 }
 
@@ -72,10 +72,10 @@ var _ clientset.Interface = &Clientset{}
 
 // SamplecontrollerV1alpha1 retrieves the SamplecontrollerV1alpha1Client
 func (c *Clientset) SamplecontrollerV1alpha1() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
-	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: &c.Fake}
+	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: c.Fake}
 }
 
 // Samplecontroller retrieves the SamplecontrollerV1alpha1Client
 func (c *Clientset) Samplecontroller() samplecontrollerv1alpha1.SamplecontrollerV1alpha1Interface {
-	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: &c.Fake}
+	return &fakesamplecontrollerv1alpha1.FakeSamplecontrollerV1alpha1{Fake: c.Fake}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes go vet errors when copying a lock by value.
https://github.com/kubernetes/kops/pull/4517
https://travis-ci.org/kubernetes/kops/jobs/346356096

```
# k8s.io/kops/pkg/client/clientset_generated/internalclientset/fake
pkg/client/clientset_generated/internalclientset/fake/clientset_generated.go:50: literal copies lock value from fakePtr: k8s.io/kops/vendor/k8s.io/client-go/testing.Fake
```

**Special notes for your reviewer**:
```release-note
NONE
```


