### PR TITLE
[e2e] Fix panicing ingress jobs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -61,6 +61,9 @@ func JoinPreservingTrailingSlash(elem ...string) string {
 // differentiate probable errors in connection behavior between normal "this is
 // disconnected" should use the method.
 func IsProbableEOF(err error) bool {
+	if err == nil {
+		return false
+	}
 	if uerr, ok := err.(*url.Error); ok {
 		err = uerr.Err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a nil error is passed into IsProbableEOF(), test will panic. Ref https://github.com/kubernetes/kubernetes/issues/60381#issuecomment-369353511.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60381

**Special notes for your reviewer**:
/assign @shyamjvs 
cc @krzyzacy 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
