### PR TITLE
Fix conformance testdata OWNERS file.

### DIFF
--- a/test/conformance/testdata/OWNERS
+++ b/test/conformance/testdata/OWNERS
@@ -1,8 +1,6 @@
 # To be owned by sig-architecture.
-# TODO(mml): Exclude parent owners once
-# https://github.com/kubernetes/test-infra/issues/5197 is implemented.
 options:
-  - no_parent_owners: true
+  no_parent_owners: true
 reviewers:
   - bgrant0607
   - smarterclayton


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherrypick of https://github.com/kubernetes/kubernetes/pull/56904
Fixes OWNERS file parse error.
/cc @yguo0905 @mml 

```release-note
none
```
