### PR TITLE
remove docker-email from required args for "create secret docker-registry"

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -182,7 +182,7 @@ func CreateSecretDockerRegistry(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.
 	if err != nil {
 		return err
 	}
-	requiredFlags := []string{"docker-username", "docker-password", "docker-email", "docker-server"}
+	requiredFlags := []string{"docker-username", "docker-password", "docker-server"}
 	for _, requiredFlag := range requiredFlags {
 		if value := cmdutil.GetFlagString(cmd, requiredFlag); len(value) == 0 {
 			return cmdutil.UsageErrorf(cmd, "flag %s is required", requiredFlag)


### PR DESCRIPTION
Completes https://github.com/kubernetes/kubernetes/pull/42191

While that removed `docker-email` as required from the generator, the CLI still asserts the presence of the argument resulting in "error: flag docker-email is required" when `--docker-email` is omitted from a `kubectl create secret docker-registry` call.

Comments on the original issue (https://github.com/kubernetes/kubernetes/issues/41727) note that this change is still needed to accomplish the original intent.