### PR TITLE
Relax time tolerance on KMS test, limit to platforms with unix sockets available

### DIFF
--- a/test/integration/master/BUILD
+++ b/test/integration/master/BUILD
@@ -11,12 +11,43 @@ go_test(
     size = "large",
     srcs = [
         "crd_test.go",
-        "kms_transformation_test.go",
         "kube_apiserver_test.go",
         "main_test.go",
         "secrets_transformation_test.go",
         "synthetic_master_test.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "kms_transformation_test.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "kms_transformation_test.go",
+        ],
+        "//conditions:default": [],
+    }),
     embed = [":go_default_library"],
     tags = ["integration"],
     deps = [
@@ -49,7 +80,6 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/aes:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest:go_default_library",
@@ -58,7 +88,39 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -77,9 +139,40 @@ filegroup(
 go_library(
     name = "go_default_library",
     srcs = [
-        "kms_plugin_mock.go",
         "transformation_testcase.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "kms_plugin_mock.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "kms_plugin_mock.go",
+        ],
+        "//conditions:default": [],
+    }),
     importpath = "k8s.io/kubernetes/test/integration/master",
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",
@@ -87,14 +180,63 @@ go_library(
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
-        "//vendor/golang.org/x/sys/unix:go_default_library",
-        "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+            "//vendor/google.golang.org/grpc:go_default_library",
+            "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/test/integration/master/kms_plugin_mock.go
+++ b/test/integration/master/kms_plugin_mock.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
 Copyright 2017 The Kubernetes Authors.
 

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -141,7 +143,7 @@ func getDEKFromKMSPlugin(pluginMock *base64Plugin) ([]byte, error) {
 	select {
 	case e := <-pluginMock.encryptRequest:
 		return e.Plain, nil
-	case <-time.After(1 * time.Microsecond):
+	case <-time.After(time.Second):
 		return nil, fmt.Errorf("timed-out while getting encryption request from KMS Plugin Mock")
 	}
 }


### PR DESCRIPTION
Fixes #60613
Fixes #60614 

```release-note
NONE
```