### PR TITLE
fix azure file plugin failure issue on Windows after node restart

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -18,6 +18,7 @@ package azure_file
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -241,8 +242,20 @@ func (b *azureFileMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return err
 	}
 	if !notMnt {
-		return nil
+		// testing original mount point, make sure the mount link is valid
+		if _, err := ioutil.ReadDir(dir); err == nil {
+			glog.V(4).Infof("azureFile - already mounted to target %s", dir)
+			return nil
+		}
+		// mount link is invalid, now unmount and remount later
+		glog.Warningf("azureFile - ReadDir %s failed with %v, unmount this directory", dir, err)
+		if err := b.mounter.Unmount(dir); err != nil {
+			glog.Errorf("azureFile - Unmount directory %s failed with %v", dir, err)
+			return err
+		}
+		notMnt = true
 	}
+
 	var accountKey, accountName string
 	if accountName, accountKey, err = b.util.GetAzureCredentials(b.plugin.host, b.secretNamespace, b.secretName); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
azure file plugin on Windows does not work after node restart, this is due to New-SmbGlobalMapping powershell cmdlet has lost account name/key after reboot, we should remove the invalid link and do the mount again after kubelet restart.
add remount logic for azure file plugin in this PR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60624

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix azure file plugin failure issue on Windows after node restart
```
/sig azure
/sig windows
/assign @karataliu 
@feiskyer  pls mark this PR as v1.10 milestone, thanks
