### PR TITLE
[minor] apimachinery: remove note for quota serialization

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/generated.proto
@@ -67,11 +67,6 @@ option go_package = "resource";
 //   1.5 will be serialized as "1500m"
 //   1.5Gi will be serialized as "1536Mi"
 // 
-// NOTE: We reserve the right to amend this canonical format, perhaps to
-//   allow 1.5 to be canonical.
-// TODO: Remove above disclaimer after all bikeshedding about format is over,
-//   or after March 2015.
-// 
 // Note that the quantity will NEVER be internally represented by a
 // floating point number. That is the whole point of this exercise.
 // 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -71,11 +71,6 @@ import (
 //   1.5 will be serialized as "1500m"
 //   1.5Gi will be serialized as "1536Mi"
 //
-// NOTE: We reserve the right to amend this canonical format, perhaps to
-//   allow 1.5 to be canonical.
-// TODO: Remove above disclaimer after all bikeshedding about format is over,
-//   or after March 2015.
-//
 // Note that the quantity will NEVER be internally represented by a
 // floating point number. That is the whole point of this exercise.
 //
@@ -508,7 +503,7 @@ func (q *Quantity) Sign() int {
 	return q.i.Sign()
 }
 
-// AsScaled returns the current value, rounded up to the provided scale, and returns
+// AsScale returns the current value, rounded up to the provided scale, and returns
 // false if the scale resulted in a loss of precision.
 func (q *Quantity) AsScale(scale Scale) (CanonicalValue, bool) {
 	if q.d.Dec != nil {


### PR DESCRIPTION
Fixes #53503 

We are way ahead of 1.5 now.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc sttts 