### PR TITLE
fix warning info format

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -355,7 +355,7 @@ func runHelp(cmd *cobra.Command, args []string) {
 }
 
 func printDeprecationWarning(errOut io.Writer, command, alias string) {
-	fmt.Fprintf(errOut, "%s is DEPRECATED and will be removed in a future version. Use %s instead.", alias, command)
+	fmt.Fprintf(errOut, "%s is DEPRECATED and will be removed in a future version. Use %s instead.\n", alias, command)
 }
 
 // deprecatedAlias is intended to be used to create a "wrapper" command around

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -147,7 +147,7 @@ func RunScale(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args
 
 		mapping := info.ResourceMapping()
 		if mapping.Resource == "jobs" {
-			fmt.Fprintf(errOut, "%s scale job is DEPRECATED and will be removed in a future version.", cmd.Parent().Name())
+			fmt.Fprintf(errOut, "%s scale job is DEPRECATED and will be removed in a future version.\n", cmd.Parent().Name())
 		}
 
 		scaler, err := f.Scaler(mapping)


### PR DESCRIPTION
Before this change:
```
$ kubectl exec -p nginx-aaaaaaaaaaaaa-67b58bf687-r68b9 ls
-p POD_NAME is DEPRECATED and will be removed in a future version. Use exec POD_NAME instead.bin
boot
dev
...

$ kubectl scale --replicas=2 job/pi
kubectl scale job is DEPRECATED and will be removed in a future version.job.batch "pi" scaled
```

After this change:
```
$ kubectl exec -p nginx-aaaaaaaaaaaaa-67b58bf687-r68b9 ls
-p POD_NAME is DEPRECATED and will be removed in a future version. Use exec POD_NAME instead.
bin
boot
dev
...

$ kubectl scale --replicas=2 job/pi
kubectl scale job is DEPRECATED and will be removed in a future version.
job.batch "pi" scaled
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
