### PR TITLE
remove "scale job" from help info

### DIFF
--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	scaleLong = templates.LongDesc(i18n.T(`
-		Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
+		Set a new size for a Deployment, ReplicaSet, Replication Controller, or StatefulSet.
 
 		Scale also allows users to specify one or more preconditions for the scale action.
 
@@ -52,8 +52,8 @@ var (
 		# Scale multiple replication controllers.
 		kubectl scale --replicas=5 rc/foo rc/bar rc/baz
 
-		# Scale job named 'cron' to 3.
-		kubectl scale --replicas=3 job/cron`))
+		# Scale statefulset named 'web' to 3.
+		kubectl scale --replicas=3 statefulset/web`))
 )
 
 // NewCmdScale returns a cobra command with the appropriate configuration and flags to run scale


### PR DESCRIPTION
Remove "scale job" from help info since it's deprecated

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @deads2k @soltysh 
