### PR TITLE
Critical pods shouldn't be restricted to kube-system

### DIFF
--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -144,7 +144,7 @@ func (sp SyncPodType) String() string {
 // or equal to SystemCriticalPriority. Both the rescheduler(deprecated in 1.10) and the kubelet use this function
 // to make admission and scheduling decisions.
 func IsCriticalPod(pod *v1.Pod) bool {
-	return IsCritical(pod.Namespace, pod.Annotations) || (pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(pod.Namespace, *pod.Spec.Priority))
+	return IsCritical(pod.Namespace, pod.Annotations) || (pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(*pod.Spec.Priority))
 }
 
 // IsCritical returns true if parameters bear the critical pod annotation
@@ -163,11 +163,7 @@ func IsCritical(ns string, annotations map[string]string) bool {
 }
 
 // IsCriticalPodBasedOnPriority checks if the given pod is a critical pod based on priority resolved from pod Spec.
-func IsCriticalPodBasedOnPriority(ns string, priority int32) bool {
-	// Critical pods are restricted to "kube-system" namespace as of now.
-	if ns != kubeapi.NamespaceSystem {
-		return false
-	}
+func IsCriticalPodBasedOnPriority(priority int32) bool {
 	if priority >= scheduling.SystemCriticalPriority {
 		return true
 	}

--- a/pkg/kubelet/types/pod_update_test.go
+++ b/pkg/kubelet/types/pod_update_test.go
@@ -176,3 +176,28 @@ func TestIsCriticalPod(t *testing.T) {
 		}
 	}
 }
+
+func TestIsCriticalPodBasedOnPriority(t *testing.T) {
+	tests := []struct {
+		priority    int32
+		description string
+		expected    bool
+	}{
+		{
+			priority:    int32(2000000001),
+			description: "A system critical pod",
+			expected:    true,
+		},
+		{
+			priority:    int32(1000000000),
+			description: "A non system critical pod",
+			expected:    false,
+		},
+	}
+	for _, test := range tests {
+		actual := IsCriticalPodBasedOnPriority(test.priority)
+		if actual != test.expected {
+			t.Errorf("IsCriticalPodBased on priority should have returned %v for test %v but got %v", test.expected, test.description, actual)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To make sure that critical pods are not restricted to kube-system namespace.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60596

**Special notes for your reviewer**:
@bsalamat @liggitt @aveshagarwal - Can we hold this till we merge quota restriction PR #57963.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
