### PR TITLE
kubeadm: add better test coverage to version.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -82,12 +82,14 @@ go_test(
     srcs = [
         "reset_test.go",
         "token_test.go",
+        "version_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/cmd/version_test.go
+++ b/cmd/kubeadm/app/cmd/version_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/ghodss/yaml"
+	"testing"
+)
+
+func TestNewCmdVersion(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := NewCmdVersion(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Cannot execute version command: %v", err)
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	var buf bytes.Buffer
+	iface := make(map[string]interface{})
+	flagNameOutput := "output"
+	cmd := NewCmdVersion(&buf)
+
+	testCases := []struct {
+		name              string
+		flag              string
+		expectedError     bool
+		shouldBeValidYAML bool
+		shouldBeValidJSON bool
+	}{
+		{
+			name: "valid: run without flags",
+		},
+		{
+			name: "valid: run with flag 'short'",
+			flag: "short",
+		},
+		{
+			name:              "valid: run with flag 'yaml'",
+			flag:              "yaml",
+			shouldBeValidYAML: true,
+		},
+		{
+			name:              "valid: run with flag 'json'",
+			flag:              "json",
+			shouldBeValidJSON: true,
+		},
+		{
+			name:          "invalid: run with unsupported flag",
+			flag:          "unsupported-flag",
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		var err error
+		if len(tc.flag) > 0 {
+			if err = cmd.Flags().Set(flagNameOutput, tc.flag); err != nil {
+				goto error
+			}
+		}
+		buf.Reset()
+		if err = RunVersion(&buf, cmd); err != nil {
+			goto error
+		}
+		if buf.String() == "" {
+			err = fmt.Errorf("empty output")
+			goto error
+		}
+		if tc.shouldBeValidYAML {
+			err = yaml.Unmarshal(buf.Bytes(), &iface)
+		} else if tc.shouldBeValidJSON {
+			err = json.Unmarshal(buf.Bytes(), &iface)
+		}
+	error:
+		if (err != nil) != tc.expectedError {
+			t.Errorf("Test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds unit tests for the file `kubeadm/app/cmd/version.go` via `version_test.go`. Test coverage is increased to 90% for this file. only a couple of functions are tested.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None

**Special notes for your reviewer**:

related PRs:
https://github.com/kubernetes/kubernetes/pull/59220
https://github.com/kubernetes/kubernetes/pull/58540

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
