### PR TITLE
Kubelet should fire an systemd notification like the apiserver

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -108,6 +108,7 @@ go_library(
         "//pkg/volume/util/volumepathhandler:go_default_library",
         "//pkg/volume/validation:go_default_library",
         "//third_party/forked/golang/expansion:go_default_library",
+        "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/golang/groupcache/lru:go_default_library",
         "//vendor/github.com/google/cadvisor/events:go_default_library",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -32,6 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/glog"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -1404,6 +1405,8 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 
 	// Start the pod lifecycle event generator.
 	kl.pleg.Start()
+
+	go daemon.SdNotify(false, "READY=1")
 	kl.syncLoop(updates, kl)
 }
 


### PR DESCRIPTION
Harmless if systemd isn't available, makes systemd units containing the
kubelet more reliable.

Fixes #59079