### PR TITLE
Add //test/e2e/... and //test/integration/... to //build/visible_to:COMMON_testing

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -40,13 +40,8 @@ package_group(
         "//hack",
         "//hack/lib",
         "//hack/make-rules",
-        "//test/e2e",
-        "//test/e2e/framework",
-        "//test/e2e/kubectl",
-        "//test/e2e/workload",
-        "//test/integration/etcd",
-        "//test/integration/framework",
-        "//test/integration/kubectl",
+        "//test/e2e/...",
+        "//test/integration/...",
     ],
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: adds the common test packages `//test/e2e/...` and `//test/integration/...` to the `COMMON_testing` package group.

The immediate need for this is that #60580 unintentionally broke the integration tests under bazel since it added a new dependency on `//pkg/kubectl/cmd/util` without adding an appropriate entry to `//build/visible_to:COMMON_testing`, and the integration tests aren't currently run under bazel for PRs. 

This PR fixes this breakage and proactively fixes future breakages by adding all packages under `//test/e2e` or `//test/integration` to `COMMON_testing`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder @monopole 
/kind bug
/priority important-soon
/sig testing
cc @kad 