### PR TITLE
Add selector to DaemonSet in newDaemonSet function so that the v1 api…

### DIFF
--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -439,6 +439,9 @@ func newDaemonSet(dsName, image string, label map[string]string) *apps.DaemonSet
 			Name: dsName,
 		},
 		Spec: apps.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: label,
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: label,


### PR DESCRIPTION
**What this PR does / why we need it**:
When we upgraded the DaemonSet e2e to use apps v1 I neglected to add a selector to match the labels of the created Pods. This broke some apps Serial tests.

```release-note
NONE
```
