### PR TITLE
Add Google Container Builder config for debian-iptables

### DIFF
--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -18,7 +18,9 @@ REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
 TAG=v10
 ARCH?=amd64
-TEMP_DIR:=$(shell mktemp -d)
+ifndef TEMP_DIR
+	TEMP_DIR:=$(shell mktemp -d)
+endif
 QEMUVERSION=v2.9.1
 
 ifeq ($(ARCH),arm)
@@ -52,9 +54,10 @@ else
 	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
 
+container: build
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 
-push: build
+push: container
 	docker push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
 
 all: push

--- a/build/debian-iptables/cloudbuild.yaml
+++ b/build/debian-iptables/cloudbuild.yaml
@@ -1,0 +1,38 @@
+timeout: 10800s
+
+substitutions:
+  { "_ARCH": "amd64",
+    "_REGISTRY": "gcr.io/k8s-image-staging",
+    "_TAG": "v10" }
+
+steps:
+- name: gcr.io/cloud-builders/git
+  id: git-clone
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -ex
+    mkdir -p /workspace/src/k8s.io
+    mkdir -p /workspace/tmp-${_ARCH}
+    cd /workspace/src/k8s.io
+    git clone https://github.com/kubernetes/kubernetes.git
+
+- name: gcr.io/k8s-image-staging/make
+  id: make-build
+  entrypoint: bash
+  dir: "/workspace/src/k8s.io/kubernetes/build/debian-iptables"
+  args:
+  - "-c"
+  - |
+    set -ex
+    TEMP_DIR=/workspace/tmp-${_ARCH} make build
+
+- name: gcr.io/cloud-builders/docker
+  id: docker-build
+  dir: "/workspace/src/k8s.io/kubernetes/build/debian-iptables"
+  args: ["build", "-t", "${_REGISTRY}/debian-iptables-${_ARCH}:${_TAG}",
+         "/workspace/tmp-${_ARCH}"]
+
+images:
+  - "${_REGISTRY}/debian-iptables-${_ARCH}:${_TAG}"


### PR DESCRIPTION
Creates a GCB config that will be used for build automation of
Kubernetes addon images.

**What this PR does / why we need it**:
Part of future plans to automate the builds for all core Kubernetes addons. Provides build provenance by using Google Container Builder to ensure builds are created from checked in source and logs are maintained. Pushes to the k8s-image-staging registry which will be used for promoting images to eliminate the need for humans to push directly to google-containers.

```release-note
None
```
