### PR TITLE
GCB config for addon-manager build

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -14,7 +14,9 @@
 
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
-TEMP_DIR:=$(shell mktemp -d)
+ifndef TEMP_DIR
+	TEMP_DIR:=$(shell mktemp -d)
+endif
 VERSION=v8.6
 KUBECTL_VERSION?=v1.9.3
 
@@ -34,18 +36,20 @@ ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/debian
 endif
 
-.PHONY: build push
+.PHONY: build container push
 
-all: build
+all: container
 
 build:
 	cp ./* $(TEMP_DIR)
 	curl -sSL --retry 5 https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/$(ARCH)/kubectl > $(TEMP_DIR)/kubectl
 	chmod +x $(TEMP_DIR)/kubectl
 	cd $(TEMP_DIR) && sed -i.back "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+container: build
 	docker build --pull -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
 
-push: build
+push: container
 	docker push $(IMAGE)-$(ARCH):$(VERSION)
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag

--- a/cluster/addons/addon-manager/cloudbuild.yaml
+++ b/cluster/addons/addon-manager/cloudbuild.yaml
@@ -1,0 +1,37 @@
+timeout: 10800s
+
+substitutions:
+  { "_ARCH": "amd64",
+    "_IMAGE": "gcr.io/k8s-image-staging/kube-addon-manager",
+    "_VERSION": "v8.6"}
+
+steps:
+- name: gcr.io/cloud-builders/git
+  id: git-clone
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -ex
+    mkdir -p /workspace/src/k8s.io
+    mkdir -p /workspace/tmp-${_ARCH}
+    cd /workspace/src/k8s.io
+    git clone https://github.com/kubernetes/kubernetes.git
+
+- name: gcr.io/k8s-image-staging/make
+  id: make-build
+  entrypoint: bash
+  dir: "/workspace/src/k8s.io/kubernetes/cluster/addons/addon-manager"
+  args:
+  - "-c"
+  - |
+    set -ex
+    TEMP_DIR=/workspace/tmp-${_ARCH} make build
+
+- name: gcr.io/cloud-builders/docker
+  id: docker-build
+  dir: "/workspace/src/k8s.io/kubernetes/cluster/addons/addon-manager"
+  args: ["build", "--pull", "-t", "${_IMAGE}:${_VERSION}", "/workspace/tmp-${_ARCH}"]
+
+images:
+- "${_IMAGE}:${_VERSION}"


### PR DESCRIPTION
Adds Google Container Builder config for building the
addon-manager addon image. This is part of a larger effort to
automate the build for core addon images.

**What this PR does / why we need it**:
Part of future plans to automate the builds for all core Kubernetes addons. Provides build provenance by using Google Container Builder to ensure builds are created from checked in source and logs are maintained. Pushes to the k8s-image-staging registry which will be used for promoting images to eliminate the need for humans to push directly to google-containers.

```release-note
None
```
