### PR TITLE
trivial: Fix JSON format on openapi README

### DIFF
--- a/api/openapi-spec/README.md
+++ b/api/openapi-spec/README.md
@@ -21,11 +21,11 @@ For example:
     "/api/v1/namespaces/{namespace}/pods/{name}": {
         ...
         "get": {
-        ...
+            ...
             "x-kubernetes-group-version-kind": {
-            "group": "",
-            "version": "v1",
-            "kind": "Pod"
+                "group": "",
+                "version": "v1",
+                "kind": "Pod"
             }
         }
     }
@@ -47,7 +47,7 @@ For example:
     "/api/v1/namespaces/{namespace}/pods/{name}": {
         ...
         "get": {
-        ...
+            ...
             "x-kubernetes-action": "list"
         }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

It was a little unreadable due to invalid indents on the openapi README.md, so this fixes them.

**Release note**: "NONE"
