### PR TITLE
Fix PodTemplate validation

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3503,7 +3503,7 @@ func ValidatePodTemplate(pod *core.PodTemplate) field.ErrorList {
 // ValidatePodTemplateUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
 // that cannot be changed.
 func ValidatePodTemplateUpdate(newPod, oldPod *core.PodTemplate) field.ErrorList {
-	allErrs := ValidateObjectMetaUpdate(&oldPod.ObjectMeta, &newPod.ObjectMeta, field.NewPath("metadata"))
+	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidatePodTemplateSpec(&newPod.Template, field.NewPath("template"))...)
 	return allErrs
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a bugfix for pod template validation, which can be reproduced by deleting with "foreground deletion" mode (`DeleteOptions.PropagationPolicy = metav1.DeletePropagationForeground`).
Because of this bug GC will never delete a pod template with `foregroundDeletion` finalizer.

**Special notes for your reviewer**:
The issue was originally found and confirmed in the PR #59851, where switching to foreground deletion in `kubectl` broke a unit test revealing this bug.
Extracted for easier backporting to releases as suggested in https://github.com/kubernetes/kubernetes/pull/59851#discussion_r171576397

/cc @liggitt @caesarxuchao 
/sig api-machinery

```release-note
fixed foreground deletion of podtemplates
```