### PR TITLE
Automated cherry pick of #60054

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -83,6 +83,7 @@ func TestAddFlags(t *testing.T) {
 		"--etcd-keyfile=/var/run/kubernetes/etcd.key",
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
+		"--http2-max-streams-per-connection=42",
 		"--kubelet-https=true",
 		"--kubelet-read-only-port=10255",
 		"--kubelet-timeout=5s",
@@ -142,6 +143,7 @@ func TestAddFlags(t *testing.T) {
 				CertDirectory: "/var/run/kubernetes",
 				PairName:      "apiserver",
 			},
+			HTTP2MaxStreamsPerConnection: 42,
 		},
 		InsecureServing: &kubeoptions.InsecureServingOptions{
 			BindAddress: net.ParseIP("127.0.0.1"),

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -71,6 +71,7 @@ go_library(
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -227,6 +227,10 @@ type SecureServingInfo struct {
 	// CipherSuites optionally overrides the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	CipherSuites []uint16
+
+	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
+	// A value of zero means to use the default provided by golang's HTTP/2 support.
+	HTTP2MaxStreamsPerConnection int
 }
 
 // NewConfig returns a Config struct with the default values

--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -38,9 +38,17 @@ type RecommendedOptions struct {
 }
 
 func NewRecommendedOptions(prefix string, codec runtime.Codec) *RecommendedOptions {
+	sso := NewSecureServingOptions()
+
+	// We are composing recommended options for an aggregated api-server,
+	// whose client is typically a proxy multiplexing many operations ---
+	// notably including long-running ones --- into one HTTP/2 connection
+	// into this server.  So allow many concurrent operations.
+	sso.HTTP2MaxStreamsPerConnection = 1000
+
 	return &RecommendedOptions{
 		Etcd:           NewEtcdOptions(storagebackend.NewDefaultConfig(prefix, codec)),
-		SecureServing:  NewSecureServingOptions(),
+		SecureServing:  sso,
 		Authentication: NewDelegatingAuthenticationOptions(),
 		Authorization:  NewDelegatingAuthorizationOptions(),
 		Audit:          NewAuditOptions(),

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -51,6 +51,10 @@ type SecureServingOptions struct {
 	ServerCert GeneratableKeyCert
 	// SNICertKeys are named CertKeys for serving secure traffic with SNI support.
 	SNICertKeys []utilflag.NamedCertKey
+
+	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
+	// A value of zero means to use the default provided by golang's HTTP/2 support.
+	HTTP2MaxStreamsPerConnection int
 }
 
 type CertKey struct {
@@ -142,6 +146,11 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"trump over extracted names. For multiple key/certificate pairs, use the "+
 		"--tls-sni-cert-key multiple times. "+
 		"Examples: \"example.crt,example.key\" or \"foo.crt,foo.key:*.foo.com,foo.com\".")
+
+	fs.IntVar(&s.HTTP2MaxStreamsPerConnection, "http2-max-streams-per-connection", s.HTTP2MaxStreamsPerConnection, ""+
+		"The limit that the server gives to clients for "+
+		"the maximum number of streams in an HTTP/2 connection. "+
+		"Zero means to use golang's default.")
 }
 
 func (s *SecureServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {
@@ -173,6 +182,7 @@ func (s *SecureServingOptions) ApplyTo(c *server.Config) error {
 	}
 
 	c.SecureServingInfo.Listener = s.Listener
+	c.SecureServingInfo.HTTP2MaxStreamsPerConnection = s.HTTP2MaxStreamsPerConnection
 
 	// create self-signed cert+key with the fake server.LoopbackClientServerNameOverride and
 	// let the server return it when the loopback client connects.

--- a/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"golang.org/x/net/http2"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -84,6 +85,12 @@ func (s *GenericAPIServer) serveSecurely(stopCh <-chan struct{}) error {
 		secureServer.TLSConfig.ClientAuth = tls.RequestClientCert
 		// Specify allowed CAs for client certificates
 		secureServer.TLSConfig.ClientCAs = s.SecureServingInfo.ClientCA
+	}
+
+	if s.SecureServingInfo.HTTP2MaxStreamsPerConnection > 0 {
+		http2.ConfigureServer(secureServer, &http2.Server{
+			MaxConcurrentStreams: uint32(s.SecureServingInfo.HTTP2MaxStreamsPerConnection),
+		})
 	}
 
 	glog.Infof("Serving securely on %s", secureServer.Addr)


### PR DESCRIPTION
Cherry pick of #60054 on release-1.9.

#60054: Fixes for HTTP/2 max streams per connection setting