### PR TITLE
[WIP] Allow user to specify labels in VolumeClaimTemplates for StatefulSet

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -63,6 +63,20 @@ func ValidatePodTemplateSpecForStatefulSet(template *api.PodTemplateSpec, select
 	return allErrs
 }
 
+func ValidateVolumeClaimTemplatesForStatefulSet(template *api.PersistentVolumeClaim, selector labels.Selector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if !selector.Empty() {
+		// Verify that the StatefulSet selector matches the labels in template.
+		volumeLabels := labels.Set(template.Labels)
+		if !selector.Matches(volumeLabels) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("metadata", "labels"), template.Labels, "`selector` does not match VolumeClaim template `labels`"))
+		}
+	}
+	allErrs = append(allErrs, unversionedvalidation.ValidateLabels(template.Labels, fldPath.Child("metadata", "labels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(template.Annotations, fldPath.Child("metadata", "annotations"))...)
+	return allErrs
+}
+
 // ValidateStatefulSetSpec tests if required fields in the StatefulSet spec are set.
 func ValidateStatefulSetSpec(spec *apps.StatefulSetSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -117,6 +131,9 @@ func ValidateStatefulSetSpec(spec *apps.StatefulSetSpec, fldPath *field.Path) fi
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, ""))
 	} else {
 		allErrs = append(allErrs, ValidatePodTemplateSpecForStatefulSet(&spec.Template, selector, fldPath.Child("template"))...)
+		for _, pvcTemplate := range spec.VolumeClaimTemplates {
+			allErrs = append(allErrs, ValidateVolumeClaimTemplatesForStatefulSet(&pvcTemplate, selector, fldPath.Child("volumeClaimTemplates"))...)
+		}
 	}
 
 	if spec.Template.Spec.RestartPolicy != api.RestartPolicyAlways {

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -149,7 +149,6 @@ func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1
 		claim := templates[i]
 		claim.Name = getPersistentVolumeClaimName(set, &claim, ordinal)
 		claim.Namespace = set.Namespace
-		claim.Labels = set.Spec.Selector.MatchLabels
 		claims[templates[i].Name] = claim
 	}
 	return claims


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently, we copy `StatefulSet.Spec.Selector.MatchLabels` to PVC's labels see this [line](https://github.com/kubernetes/kubernetes/blob/f9f5677b3edecfc73af3e643db814e716b7f694f/pkg/controller/statefulset/stateful_set_utils.go#L152), so if user specified labels in `StatefulSet.Spec.VolumeClaimTemplates`, these labels will be covered by `StatefulSet.Spec.Selector.MatchLabels`.

We should allow user to specify labels in `StatefulSet.Spec.VolumeClaimTemplates` and add validation to check whether these labels matching `StatefulSet.Spec.Selector.MatchLabels` or not.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
