### PR TITLE
Make sh2ju use awk instead of bc.

### DIFF
--- a/third_party/forked/shell2junit/sh2ju.sh
+++ b/third_party/forked/shell2junit/sh2ju.sh
@@ -130,8 +130,8 @@ function juLog() {
   # calculate vars
   asserts=$(($asserts+1))
   errors=$(($errors+$err))
-  time=`echo "${end} - ${ini}" | bc -l`
-  total=`echo "${total} + ${time}" | bc -l`
+  time=`echo "${end} ${ini}" | awk '{print $1 - $2}'`
+  total=`echo "${total} ${time}" | awk '{print $1 + $2}'`
 
   # write the junit xml report
   ## failure tag


### PR DESCRIPTION
awk is available in all of our test runners (as part of busybox or debian base packages), bc is not.

This will fix spurious errors in the typecheck job.

**Release note**:
```release-note
NONE
```
