### PR TITLE
Set default resource request value as a fixed fraction of machine capacity on 'GetNonzeroRequest'.

### DIFF
--- a/pkg/scheduler/algorithm/priorities/metadata.go
+++ b/pkg/scheduler/algorithm/priorities/metadata.go
@@ -61,7 +61,7 @@ func (pmf *PriorityMetadataFactory) PriorityMetadata(pod *v1.Pod, nodeNameToInfo
 		return nil
 	}
 	return &priorityMetadata{
-		nonZeroRequest:          getNonZeroRequests(pod),
+		nonZeroRequest:          getNonZeroRequests(pod, nil),
 		podTolerations:          getAllTolerationPreferNoSchedule(pod.Spec.Tolerations),
 		affinity:                pod.Spec.Affinity,
 		podSelectors:            getSelectors(pod, pmf.serviceLister, pmf.controllerLister, pmf.replicaSetLister, pmf.statefulSetLister),

--- a/pkg/scheduler/algorithm/priorities/resource_allocation.go
+++ b/pkg/scheduler/algorithm/priorities/resource_allocation.go
@@ -49,7 +49,7 @@ func (r *ResourceAllocationPriority) PriorityMap(
 		requested = *priorityMeta.nonZeroRequest
 	} else {
 		// We couldn't parse metadata - fallback to computing it.
-		requested = *getNonZeroRequests(pod)
+		requested = *getNonZeroRequests(pod, &node.Status.Capacity)
 	}
 
 	requested.MilliCPU += nodeInfo.NonZeroRequest().MilliCPU
@@ -73,11 +73,11 @@ func (r *ResourceAllocationPriority) PriorityMap(
 	}, nil
 }
 
-func getNonZeroRequests(pod *v1.Pod) *schedulercache.Resource {
+func getNonZeroRequests(pod *v1.Pod, capacity *v1.ResourceList) *schedulercache.Resource {
 	result := &schedulercache.Resource{}
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
-		cpu, memory := priorityutil.GetNonzeroRequests(&container.Resources.Requests)
+		cpu, memory := priorityutil.GetNonzeroRequests(&container.Resources.Requests, capacity)
 		result.MilliCPU += cpu
 		result.Memory += memory
 	}

--- a/pkg/scheduler/algorithm/priorities/util/non_zero.go
+++ b/pkg/scheduler/algorithm/priorities/util/non_zero.go
@@ -32,20 +32,34 @@ const DefaultMilliCPURequest int64 = 100 // 0.1 core
 // DefaultMemoryRequest defines default memory request size.
 const DefaultMemoryRequest int64 = 200 * 1024 * 1024 // 200 MB
 
+// DefaultMilliCPURequestFraction defines default milli cpu request fraction.
+const DefaultMilliCPURequestFraction = 0.1
+
+// DefaultMemoryRequestFraction defines default memory request fraction.
+const DefaultMemoryRequestFraction = 0.1
+
 // GetNonzeroRequests returns the default resource request if none is found or what is provided on the request
-// TODO: Consider setting default as a fixed fraction of machine capacity (take "capacity v1.ResourceList"
-// as an additional argument here) rather than using constants
-func GetNonzeroRequests(requests *v1.ResourceList) (int64, int64) {
+func GetNonzeroRequests(requests *v1.ResourceList, capacity *v1.ResourceList) (int64, int64) {
 	var outMilliCPU, outMemory int64
 	// Override if un-set, but not if explicitly set to zero
 	if _, found := (*requests)[v1.ResourceCPU]; !found {
 		outMilliCPU = DefaultMilliCPURequest
+		if capacity != nil {
+			if _, found := (*capacity)[v1.ResourceCPU]; found {
+				outMilliCPU = int64(DefaultMilliCPURequestFraction * float64(capacity.Cpu().MilliValue()))
+			}
+		}
 	} else {
 		outMilliCPU = requests.Cpu().MilliValue()
 	}
 	// Override if un-set, but not if explicitly set to zero
 	if _, found := (*requests)[v1.ResourceMemory]; !found {
 		outMemory = DefaultMemoryRequest
+		if capacity != nil {
+			if _, found := (*capacity)[v1.ResourceMemory]; found {
+				outMemory = int64(DefaultMemoryRequestFraction * float64(capacity.Memory().Value()))
+			}
+		}
 	} else {
 		outMemory = requests.Memory().Value()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes `TODO` below:
https://github.com/kubernetes/kubernetes/blob/f9f5677b3edecfc73af3e643db814e716b7f694f/pkg/scheduler/algorithm/priorities/util/non_zero.go#L36-L38

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

The default fraction values could be discussed to be more appropriate.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set default resource request value as a fixed fraction of machine capacity on 'GetNonzeroRequest'.
```
