### PR TITLE
apiserver clean code

### DIFF
--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -61,10 +61,5 @@ func createAPIExtensionsConfig(kubeAPIServerConfig genericapiserver.Config, exte
 }
 
 func createAPIExtensionsServer(apiextensionsConfig *apiextensionsapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget) (*apiextensionsapiserver.CustomResourceDefinitions, error) {
-	apiextensionsServer, err := apiextensionsConfig.Complete().New(delegateAPIServer)
-	if err != nil {
-		return nil, err
-	}
-
-	return apiextensionsServer, nil
+	return apiextensionsConfig.Complete().New(delegateAPIServer)
 }

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -50,36 +50,36 @@ func validateServiceNodePort(options *ServerRunOptions) []error {
 }
 
 // Validate checks ServerRunOptions and return a slice of found errors.
-func (options *ServerRunOptions) Validate() []error {
+func (s *ServerRunOptions) Validate() []error {
 	var errors []error
-	if errs := options.Etcd.Validate(); len(errs) > 0 {
+	if errs := s.Etcd.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := validateClusterIPFlags(options); len(errs) > 0 {
+	if errs := validateClusterIPFlags(s); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := validateServiceNodePort(options); len(errs) > 0 {
+	if errs := validateServiceNodePort(s); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.SecureServing.Validate(); len(errs) > 0 {
+	if errs := s.SecureServing.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.Authentication.Validate(); len(errs) > 0 {
+	if errs := s.Authentication.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.Audit.Validate(); len(errs) > 0 {
+	if errs := s.Audit.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.Admission.Validate(); len(errs) > 0 {
+	if errs := s.Admission.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if errs := options.InsecureServing.Validate("insecure-port"); len(errs) > 0 {
+	if errs := s.InsecureServing.Validate(); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
-	if options.MasterCount <= 0 {
-		errors = append(errors, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", options.MasterCount))
+	if s.MasterCount <= 0 {
+		errors = append(errors, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", s.MasterCount))
 	}
-	if errs := options.APIEnablement.Validate(legacyscheme.Registry, apiextensionsapiserver.Registry, aggregatorscheme.Registry); len(errs) > 0 {
+	if errs := s.APIEnablement.Validate(legacyscheme.Registry, apiextensionsapiserver.Registry, aggregatorscheme.Registry); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
 

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -81,7 +81,7 @@ func NewInsecureServingOptions() *InsecureServingOptions {
 	}
 }
 
-func (s InsecureServingOptions) Validate(portArg string) []error {
+func (s InsecureServingOptions) Validate() []error {
 	errors := []error{}
 
 	if s.BindPort < 0 || s.BindPort > 65535 {


### PR DESCRIPTION
**What this PR does / why we need it**:

1. clean up some redundant code in kube-apiserver startup

1. comment on `preparedGenericAPIServer`, which is just a wrapper of `GenericAPIServer`.



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
