### PR TITLE
Fix a grammatical error in a comment

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -106,7 +106,7 @@ type genericScheduler struct {
 	pvcLister                corelisters.PersistentVolumeClaimLister
 }
 
-// Schedule tries to schedule the given pod to one of node in the node list.
+// Schedule tries to schedule the given pod to one of the nodes in the node list.
 // If it succeeds, it will return the name of the node.
 // If it fails, it will return a FitError error with reasons.
 func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister) (string, error) {


### PR DESCRIPTION
Fix a grammatical error in a comment in scheduler's code. We should use a word's plural form after "one of".

```release-note
NONE
```
