### PR TITLE
NodeLost status on pod list instead of Unknown

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -593,7 +593,7 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1beta1.TableR
 	}
 
 	if pod.DeletionTimestamp != nil && pod.Status.Reason == node.NodeUnreachablePodReason {
-		reason = "Unknown"
+		reason = node.NodeUnreachablePodReason
 	} else if pod.DeletionTimestamp != nil {
 		reason = "Terminating"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of reporting `Unknown` for pods that are not running due to the node being unavailable, instead report the actual `NodeLost` reason.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
There are no issues that I can see, just some that reference this `Unknown` value and asking why the pod cannot be removed.

**Special notes for your reviewer**:

**Release note**:
```release-note
Report `NodeLost` status on `kubectl get pods` instead of `Unknown` when a pod is on a node that became unavailable
```
