### PR TITLE
Automated cherry pick of #60683: Bugfix: Fix ordering of ValidateObjectMetaUpdate method

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2792,7 +2792,7 @@ func ValidatePodTemplate(pod *api.PodTemplate) field.ErrorList {
 // ValidatePodTemplateUpdate tests to see if the update is legal for an end user to make. newPod is updated with fields
 // that cannot be changed.
 func ValidatePodTemplateUpdate(newPod, oldPod *api.PodTemplate) field.ErrorList {
-	allErrs := ValidateObjectMetaUpdate(&oldPod.ObjectMeta, &newPod.ObjectMeta, field.NewPath("metadata"))
+	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidatePodTemplateSpec(&newPod.Template, field.NewPath("template"))...)
 	return allErrs
 }


### PR DESCRIPTION
Cherry pick of #60683 on release-1.7.

#60683: Bugfix: Fix ordering of ValidateObjectMetaUpdate method


```release-note
fixed foreground deletion of podtemplates
```