### PR TITLE
deep copy fake client actions to avoid accidental mutation

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fake.go
+++ b/staging/src/k8s.io/client-go/testing/fake.go
@@ -134,13 +134,13 @@ func (c *Fake) Invokes(action Action, defaultReturnObj runtime.Object) (runtime.
 	c.Lock()
 	defer c.Unlock()
 
-	c.actions = append(c.actions, action)
+	c.actions = append(c.actions, action.DeepCopy())
 	for _, reactor := range c.ReactionChain {
 		if !reactor.Handles(action) {
 			continue
 		}
 
-		handled, ret, err := reactor.React(action)
+		handled, ret, err := reactor.React(action.DeepCopy())
 		if !handled {
 			continue
 		}
@@ -157,13 +157,13 @@ func (c *Fake) InvokesWatch(action Action) (watch.Interface, error) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.actions = append(c.actions, action)
+	c.actions = append(c.actions, action.DeepCopy())
 	for _, reactor := range c.WatchReactionChain {
 		if !reactor.Handles(action) {
 			continue
 		}
 
-		handled, ret, err := reactor.React(action)
+		handled, ret, err := reactor.React(action.DeepCopy())
 		if !handled {
 			continue
 		}
@@ -180,13 +180,13 @@ func (c *Fake) InvokesProxy(action Action) restclient.ResponseWrapper {
 	c.Lock()
 	defer c.Unlock()
 
-	c.actions = append(c.actions, action)
+	c.actions = append(c.actions, action.DeepCopy())
 	for _, reactor := range c.ProxyReactionChain {
 		if !reactor.Handles(action) {
 			continue
 		}
 
-		handled, ret, err := reactor.React(action)
+		handled, ret, err := reactor.React(action.DeepCopy())
 		if !handled || err != nil {
 			continue
 		}

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/fake/fake_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/fake/fake_client.go
@@ -51,6 +51,18 @@ func (i GetForActionImpl) GetSubresource() string {
 	return i.MetricName
 }
 
+func (i GetForActionImpl) DeepCopy() testing.Action {
+	var labelSelector labels.Selector
+	if i.LabelSelector != nil {
+		labelSelector = i.LabelSelector.DeepCopySelector()
+	}
+	return GetForActionImpl{
+		GetAction:     i.GetAction.DeepCopy().(testing.GetAction),
+		MetricName:    i.MetricName,
+		LabelSelector: labelSelector,
+	}
+}
+
 func NewGetForAction(groupKind schema.GroupKind, namespace, name string, metricName string, labelSelector labels.Selector) GetForActionImpl {
 	// the version doesn't matter
 	gvk := groupKind.WithVersion("")


### PR DESCRIPTION
I just got bit by this downstream.  Without a deep copy it is possible accidentally mutate the thing you created, thus invalidating your testing.  It's particularly nasty inside of a controller doing a loop on objects, making refs to them, and creating.  This works running in an actual process since we serialize and write, but fails unit tests since there is no serialization step.

@kubernetes/sig-api-machinery-bugs 

```release-note
NONE
```