### PR TITLE
If config is nil, `NewForConfig` will panic with a runtime error

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package internalclientset
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -172,6 +174,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package versioned
 
 import (
+	errors "errors"
+
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -60,6 +62,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package clientset
 
 import (
+	errors "errors"
+
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -60,6 +62,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package internalclientset
 
 import (
+	errors "errors"
+
 	apiextensionsinternalversion "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -52,6 +54,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package kubernetes
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	admissionregistrationv1alpha1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
@@ -396,6 +398,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package internalversion
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -60,6 +62,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package versioned
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -76,6 +78,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package versioned
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -76,6 +78,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -83,6 +83,7 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		"NewDiscoveryClientForConfigOrDie":     c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClientForConfigOrDie"}),
 		"NewDiscoveryClient":                   c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClient"}),
 		"flowcontrolNewTokenBucketRateLimiter": c.Universe.Function(types.Name{Package: "k8s.io/client-go/util/flowcontrol", Name: "NewTokenBucketRateLimiter"}),
+		"errorsNew":                            c.Universe.Function(types.Name{Package: "errors", Name: "New"}),
 	}
 	sw.Do(clientsetInterface, m)
 	sw.Do(clientsetTemplate, m)
@@ -149,6 +150,9 @@ func (c *Clientset) Discovery() $.DiscoveryInterface|raw$ {
 var newClientsetForConfigTemplate = `
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *$.Config|raw$) (*Clientset, error) {
+	if c == nil {
+		return nil, $.errorsNew|raw$("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = $.flowcontrolNewTokenBucketRateLimiter|raw$(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package clientset
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -68,6 +70,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package internalclientset
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -52,6 +54,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package clientset
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -68,6 +70,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package internalversion
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -52,6 +54,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package versioned
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -68,6 +70,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/clientset.go
@@ -19,6 +19,8 @@ limitations under the License.
 package versioned
 
 import (
+	errors "errors"
+
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -60,6 +62,9 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	if c == nil {
+		return nil, errors.New("config argument can't be nil")
+	}
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes a bug in which if a `nil` config is passed to `ClientSet.NewForConfig`, the application will panic with an error similar to this one:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe3c03a]

goroutine 1 [running]:
client-go/kubernetes.NewForConfig(0x0, 0x1716d40, 0xc42029b4f0, 0x10)
    client-go/kubernetes/clientset.go:398 +0x3a
main.main()
    /go/src/github.schibsted.io/spt-infrastructure/kiam-ca/main.go:55 +0x3c
```

That's because `configShallowCopy` (e.g. in https://github.com/kubernetes/kubernetes/pull/60711/files#diff-6e7bd9f48f830f8803bb98cef591ae84R181) assumes that config (`c`) is never `nil`, and tries to reference an invalid memory address. This PR checks if `c` is nil and returns an error if that's the case.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug in which `ClientSet.NewForConfig` crashes if it's passed a `nil` parameter.
```
