### PR TITLE
Fix initializing watch cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/BUILD
@@ -28,7 +28,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
@@ -377,7 +377,17 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 		if err != nil {
 			return fmt.Errorf("couldn't compute key: %v", err)
 		}
-		toReplace = append(toReplace, &storeElement{Key: key, Object: object})
+		objLabels, objFields, objUninitialized, err := w.getAttrsFunc(object)
+		if err != nil {
+			return err
+		}
+		toReplace = append(toReplace, &storeElement{
+			Key:           key,
+			Object:        object,
+			Labels:        objLabels,
+			Fields:        objFields,
+			Uninitialized: objUninitialized,
+		})
 	}
 
 	w.Lock()


### PR DESCRIPTION
When initializing watch cache, set auxiliary fields in `storeElement` object. Fixes #60507.

```release-note
NONE
```