### PR TITLE
kubectl top Documentation

### DIFF
--- a/pkg/kubectl/cmd/top.go
+++ b/pkg/kubectl/cmd/top.go
@@ -33,11 +33,17 @@ var (
 		"v1beta1",
 	}
 	topLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage.
+		Display Resource (CPU/Memory) usage.
 
 		The top command allows you to see the resource consumption for nodes or pods.
 
-		This command requires Heapster to be correctly configured and working on the server. `))
+		This command requires Metrics Server or Heapster running in the cluster.
+
+		Metric Servers should register itself for handling Metrics API in apiserver.
+		If Metrics API is available kubectl will send request to apiserver that will pass it down to Metrics Server.
+		In other case request will be sent to heapster service.
+
+		Both components are responsible for scraping metrics from kubelets summary API, with Heapster being deprecated.`))
 )
 
 func NewCmdTop(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -77,9 +77,17 @@ func (o *HeapsterTopOptions) Bind(flags *pflag.FlagSet) {
 
 var (
 	topNodeLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage of nodes.
+		Display Resource (CPU/Memory) usage of nodes.
 
-		The top-node command allows you to see the resource consumption of nodes.`))
+		The 'top node' command allows you to see the resource consumption for nodes.
+
+		This command requires Metrics Server or Heapster running in the cluster.
+
+		Metric Servers should register itself for handling Metrics API in apiserver.
+		If Metrics API is available kubectl will send request to apiserver that will pass it down to Metrics Server.
+		In other case request will be sent to heapster service.
+
+		Both components are responsible for scraping metrics from kubelets summary API, with Heapster being deprecated.`))
 
 	topNodeExample = templates.Examples(i18n.T(`
 		  # Show metrics for all nodes

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -57,12 +57,20 @@ const metricsCreationDelay = 2 * time.Minute
 
 var (
 	topPodLong = templates.LongDesc(i18n.T(`
-		Display Resource (CPU/Memory/Storage) usage of pods.
+		Display Resource (CPU/Memory) usage of pods.
 
 		The 'top pod' command allows you to see the resource consumption of pods.
 
 		Due to the metrics pipeline delay, they may be unavailable for a few minutes
-		since pod creation.`))
+		since pod creation.
+
+		This command requires Metrics Server or Heapster running in the cluster.
+
+		Metric Servers should register itself for handling Metrics API in apiserver.
+		If Metrics API is available kubectl will send request to apiserver that will pass it down to Metrics Server.
+		In other case request will be sent to heapster service.
+
+		Both components are responsible for scraping metrics from kubelets summary API, with Heapster being deprecated.`))
 
 	topPodExample = templates.Examples(i18n.T(`
 		# Show metrics for all pods in the default namespace


### PR DESCRIPTION
Adds documentation for kubectl top, describing current flow of metrics.
```release-note
NONE
```
