### PR TITLE
Add field selector support to delete, label, annotate

### DIFF
--- a/pkg/kubectl/cmd/delete_flags.go
+++ b/pkg/kubectl/cmd/delete_flags.go
@@ -59,6 +59,8 @@ func (o *FileNameFlags) AddFlags(cmd *cobra.Command) {
 // used for commands requiring deletion logic.
 type DeleteFlags struct {
 	FileNameFlags *FileNameFlags
+	LabelSelector *string
+	FieldSelector *string
 
 	All            *bool
 	Cascade        *bool
@@ -79,6 +81,12 @@ func (f *DeleteFlags) ToOptions(out, errOut io.Writer) *DeleteOptions {
 	// add filename options
 	if f.FileNameFlags != nil {
 		options.FilenameOptions = f.FileNameFlags.ToOptions()
+	}
+	if f.LabelSelector != nil {
+		options.LabelSelector = *f.LabelSelector
+	}
+	if f.FieldSelector != nil {
+		options.FieldSelector = *f.FieldSelector
 	}
 
 	// add output format
@@ -113,7 +121,12 @@ func (f *DeleteFlags) ToOptions(out, errOut io.Writer) *DeleteOptions {
 
 func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	f.FileNameFlags.AddFlags(cmd)
-
+	if f.LabelSelector != nil {
+		cmd.Flags().StringVarP(f.LabelSelector, "selector", "l", *f.LabelSelector, "Selector (label query) to filter on, not including uninitialized ones.")
+	}
+	if f.FieldSelector != nil {
+		cmd.Flags().StringVarP(f.FieldSelector, "field-selector", "", *f.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	}
 	if f.All != nil {
 		cmd.Flags().BoolVar(f.All, "all", *f.All, "Delete all resources, including uninitialized ones, in the namespace of the specified resource types.")
 	}
@@ -153,6 +166,8 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	ignoreNotFound := false
 	now := false
 	output := ""
+	labelSelector := ""
+	fieldSelector := ""
 	timeout := time.Duration(0)
 
 	filenames := []string{}
@@ -160,6 +175,8 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 
 	return &DeleteFlags{
 		FileNameFlags: &FileNameFlags{Usage: usage, Filenames: &filenames, Recursive: &recursive},
+		LabelSelector: &labelSelector,
+		FieldSelector: &fieldSelector,
 
 		Cascade:     &cascade,
 		GracePeriod: &gracePeriod,

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -52,8 +52,6 @@ func fakecmd() *cobra.Command {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
 		},
 	}
-
-	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones.")
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -56,6 +56,7 @@ type LabelOptions struct {
 	all             bool
 	resourceVersion string
 	selector        string
+	fieldSelector   string
 	outputFormat    string
 
 	// results of arg parsing
@@ -142,6 +143,7 @@ func NewCmdLabel(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&o.list, "list", o.list, "If true, display the labels for a given resource.")
 	cmd.Flags().BoolVar(&o.local, "local", o.local, "If true, label will NOT contact api-server but run locally.")
 	cmd.Flags().StringVarP(&o.selector, "selector", "l", o.selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).")
+	cmd.Flags().StringVar(&o.fieldSelector, "field-selector", o.fieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().StringVar(&o.resourceVersion, "resource-version", o.resourceVersion, i18n.T("If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the labels"
@@ -184,6 +186,9 @@ func (o *LabelOptions) Validate() error {
 	if o.all && len(o.selector) > 0 {
 		return fmt.Errorf("cannot set --all and --selector at the same time")
 	}
+	if o.all && len(o.fieldSelector) > 0 {
+		return fmt.Errorf("cannot set --all and --field-selector at the same time")
+	}
 	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
 		return fmt.Errorf("one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
@@ -212,6 +217,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	if !o.local {
 		b = b.LabelSelectorParam(o.selector).
+			FieldSelectorParam(o.fieldSelector).
 			ResourceTypeOrNameArgs(o.all, o.resources...).
 			Latest()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Builds out field selector support for more bulk commands

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl now supports --field-selector for `delete`, `label`, and `annotate`
```