### PR TITLE
Support --all flag for patch

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -717,6 +717,10 @@ run_pod_tests() {
   kubectl patch "${kube_flags[@]}" pod valid-pod -p="${YAML_PATCH}"
   # Post-condition: valid-pod POD has image nginx
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
+  # prove that patch can act on all resources of a type
+  kubectl patch pod --all --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new-image"}]'
+  # Post-condition: all pods have image new-image
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'new-image:'
   ## Patch pod from JSON can change image
   # Command
   kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause-amd64:3.1"}]}}'

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -100,6 +100,7 @@ func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringP("patch", "p", "", "The patch to be applied to the resource JSON file.")
 	cmd.MarkFlagRequired("patch")
 	cmd.Flags().String("type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
+	cmd.Flags().Bool("all", false, "Select all resources in the namespace of the specified resource types")
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
@@ -143,12 +144,14 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		return fmt.Errorf("unable to parse %q: %v", patch, err)
 	}
 
+	all := cmdutil.GetFlagBool(cmd, "all")
+
 	r := f.NewBuilder().
 		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
-		ResourceTypeOrNameArgs(false, args...).
+		ResourceTypeOrNameArgs(all, args...).
 		Flatten().
 		Do()
 	err = r.Err()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds a `--all` flag for `patch` allowing patching of all resources of the specified type

**Which issue(s) this PR fixes**:
https://github.com/openshift/origin/issues/18644

**Special notes for your reviewer**:

**Release note**:
```release-note
kubectl now supports --all for `patch`
```
