### PR TITLE
Expect NetworkTier not to be set as GCE value (all uppercase)

### DIFF
--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		By("creating a Service of type LoadBalancer using the standard network tier")
 		svc := jig.CreateTCPServiceOrFail(ns, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
-			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard.ToGCEValue())
+			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard)
 		})
 		// Verify that service has been updated properly.
 		svcTier, err := gcecloud.GetServiceNetworkTier(svc)
@@ -120,7 +120,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		By("updating the Service to use the standard tier with a requested IP")
 		svc = jig.UpdateServiceOrFail(ns, svc.Name, func(svc *v1.Service) {
 			svc.Spec.LoadBalancerIP = requestedIP
-			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard.ToGCEValue())
+			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard)
 		})
 		// Verify that service has been updated properly.
 		Expect(svc.Spec.LoadBalancerIP).To(Equal(requestedIP))

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		By("creating a Service of type LoadBalancer using the standard network tier")
 		svc := jig.CreateTCPServiceOrFail(ns, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
-			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard)
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
 		})
 		// Verify that service has been updated properly.
 		svcTier, err := gcecloud.GetServiceNetworkTier(svc)
@@ -120,7 +120,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		By("updating the Service to use the standard tier with a requested IP")
 		svc = jig.UpdateServiceOrFail(ns, svc.Name, func(svc *v1.Service) {
 			svc.Spec.LoadBalancerIP = requestedIP
-			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard)
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
 		})
 		// Verify that service has been updated properly.
 		Expect(svc.Spec.LoadBalancerIP).To(Equal(requestedIP))


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts L76 and L123 from this PR - https://github.com/kubernetes/kubernetes/pull/59941/files#diff-497d33fc55a7de6c5bde6cbe33ecbb3cL78 . NetworkTier is set on the mock Service in Camel Case, not all uppercase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60721

**Release note**:
```release-note
NONE
```

/assign MrHohn nicksardo