### PR TITLE
Indicate clusterrolebinding, rolebinding subjects are optional fields

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -82143,7 +82143,6 @@
    "io.k8s.api.rbac.v1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -82327,7 +82326,6 @@
    "io.k8s.api.rbac.v1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -82531,7 +82529,6 @@
    "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -82715,7 +82712,6 @@
    "io.k8s.api.rbac.v1alpha1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -82919,7 +82915,6 @@
    "io.k8s.api.rbac.v1beta1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -83103,7 +83098,6 @@
    "io.k8s.api.rbac.v1beta1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1.json
@@ -3351,7 +3351,6 @@
     "id": "v1.ClusterRoleBinding",
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -3927,7 +3926,6 @@
     "id": "v1.RoleBinding",
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -3351,7 +3351,6 @@
     "id": "v1alpha1.ClusterRoleBinding",
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -3927,7 +3926,6 @@
     "id": "v1alpha1.RoleBinding",
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1beta1.json
@@ -3351,7 +3351,6 @@
     "id": "v1beta1.ClusterRoleBinding",
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {
@@ -3927,7 +3926,6 @@
     "id": "v1beta1.RoleBinding",
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
     "required": [
-     "subjects",
      "roleRef"
     ],
     "properties": {

--- a/docs/api-reference/rbac.authorization.k8s.io/v1/definitions.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1/definitions.html
@@ -502,7 +502,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_subject">v1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -1443,7 +1443,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_subject">v1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/definitions.html
@@ -924,7 +924,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1alpha1_subject">v1alpha1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -1791,7 +1791,7 @@ When an object is created, the system will populate this list with the current s
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1alpha1_subject">v1alpha1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1beta1/definitions.html
@@ -1196,7 +1196,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_subject">v1beta1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -1930,7 +1930,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">subjects</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Subjects holds references to the objects the role applies to.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_subject">v1beta1.Subject</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
@@ -138,7 +138,6 @@ items:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
     name: system:node
-  subjects: null
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -62,6 +62,7 @@ message ClusterRoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -134,6 +135,7 @@ message RoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -124,7 +124,8 @@ type RoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
@@ -199,7 +200,8 @@ type ClusterRoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -61,6 +61,7 @@ message ClusterRoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -134,6 +135,7 @@ message RoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -126,7 +126,8 @@ type RoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
@@ -201,7 +202,8 @@ type ClusterRoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -62,6 +62,7 @@ message ClusterRoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can only reference a ClusterRole in the global namespace.
@@ -135,6 +136,7 @@ message RoleBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Subjects holds references to the objects the role applies to.
+  // +optional
   repeated Subject subjects = 2;
 
   // RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -125,7 +125,8 @@ type RoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.
@@ -199,7 +200,8 @@ type ClusterRoleBinding struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Subjects holds references to the objects the role applies to.
-	Subjects []Subject `json:"subjects" protobuf:"bytes,2,rep,name=subjects"`
+	// +optional
+	Subjects []Subject `json:"subjects,omitempty" protobuf:"bytes,2,rep,name=subjects"`
 
 	// RoleRef can only reference a ClusterRole in the global namespace.
 	// If the RoleRef cannot be resolved, the Authorizer must return an error.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: With this PR, clusterrolebinding and rolebinding subjects are marked optional instead of required. Currently we cannot create clusterrolebinding and rolebinding with subjects are empty using `kubectl create/apply/replace -f`.

```
$ kubectl create rolebinding test --clusterrole view
rolebinding "test" created
$ kubectl get rolebinding test -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: 2018-03-02T06:58:16Z
  name: test
  namespace: default
  resourceVersion: "5606612"
  selfLink: /apis/rbac.authorization.k8s.io/v1/namespaces/default/rolebindings/test
  uid: 155c5c29-1de7-11e8-9f6f-fa163ec89f2a
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: view
subjects: null
$ kubectl get rolebinding test -o yaml | kubectl replace -f -
error: error validating "STDIN": error validating data: ValidationError(RoleBinding): missing required field "subjects" in io.k8s.api.rbac.v1.RoleBinding; if you choose to ignore these errors, turn validation off with --validate=false
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: This is a same issue with https://github.com/kubernetes/kubernetes/issues/59403. /cc @liggitt 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
