### PR TITLE
custom resource strategy: grace value added to the delete option

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -91,7 +91,8 @@ func newREST(resource schema.GroupResource, listKind schema.GroupVersionKind, st
 		UpdateStrategy: strategy,
 		DeleteStrategy: strategy,
 
-		TableConvertor: tableConvertor,
+		TableConvertor:      tableConvertor,
+		ReturnDeletedObject: true,
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: strategy.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -157,6 +157,7 @@ func TestDelete(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.CustomResource.Store.DestroyFunc()
 	test := registrytest.New(t, storage.CustomResource.Store)
+	test = test.SkipDefaultGrace()
 	test.TestDeleteGraceful(validNewCustomResource(), 30)
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -157,7 +157,7 @@ func TestDelete(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.CustomResource.Store.DestroyFunc()
 	test := registrytest.New(t, storage.CustomResource.Store)
-	test.TestDelete(validNewCustomResource())
+	test.TestDeleteGraceful(validNewCustomResource(), 30)
 }
 
 func TestCategories(t *testing.T) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -182,3 +182,11 @@ func (a customResourceStrategy) MatchCustomResourceDefinitionStorage(label label
 		GetAttrs: a.GetAttrs,
 	}
 }
+
+// CheckGracefulDelete updates the delete option with the desiered grace value
+func (a customResourceStrategy) CheckGracefulDelete(ctx genericapirequest.Context, obj runtime.Object, options *metav1.DeleteOptions) bool {
+	if options == nil || options.GracePeriodSeconds == nil {
+		return false
+	}
+	return true
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
@@ -10,6 +10,7 @@ go_test(
     srcs = [
         "basic_test.go",
         "finalization_test.go",
+        "grace_period_test.go",
         "registration_test.go",
         "subresources_test.go",
         "validation_test.go",

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/grace_period_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/grace_period_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apiextensions-apiserver/test/integration/testserver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGracePeriod(t *testing.T) {
+	stopCh, apiExtensionClient, clientPool, err := testserver.StartDefaultServerWithClients()
+	require.NoError(t, err)
+	defer close(stopCh)
+
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
+	require.NoError(t, err)
+
+	ns := "not-the-default"
+	name := "foo123"
+	noxuResourceClient := NewNamespacedCustomResourceClient(ns, noxuVersionClient, noxuDefinition)
+
+	instance := testserver.NewNoxuInstance(ns, name)
+	instance.SetFinalizers([]string{"noxu.example.com/finalizer"})
+	createdNoxuInstance, err := instantiateCustomResource(t, instance, noxuResourceClient, noxuDefinition)
+	require.NoError(t, err)
+	period := int64(30)
+	uid := createdNoxuInstance.GetUID()
+	err = noxuResourceClient.Delete(name, &metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: &uid,
+		},
+		GracePeriodSeconds: &period,
+	})
+	require.NoError(t, err)
+	// Testing Grace period is updating or not
+
+	gottenNoxuInstance, err := noxuResourceClient.Get(name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, *gottenNoxuInstance.GetDeletionGracePeriodSeconds(), period)
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -344,11 +344,8 @@ values:
 		if err != nil {
 			t.Fatal(err)
 		}
-		if obj.GetAPIVersion() != "v1" || obj.GetKind() != "Status" {
-			t.Fatalf("unexpected response: %s", string(result))
-		}
-		if v, ok, err := unstructured.NestedString(obj.Object, "status"); v != "Success" || !ok || err != nil {
-			t.Fatal(v, ok, err, string(result))
+		if obj.GetUID() != uid {
+			t.Fatalf("delete expected to give deleted object. expected uid %v got %v", uid, obj.GetUID())
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
@@ -75,6 +75,11 @@ func (t *Tester) ReturnDeletedObject() *Tester {
 	return t
 }
 
+func (t *Tester) SkipDefaultGrace() *Tester {
+	t.tester = t.tester.SkipDefaultGrace()
+	return t
+}
+
 func (t *Tester) TestCreate(valid runtime.Object, invalid ...runtime.Object) {
 	t.tester.TestCreate(
 		valid,

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -47,6 +47,7 @@ type Tester struct {
 	generatesName       bool
 	returnDeletedObject bool
 	namer               func(int) string
+	skipDefaultGrace    bool
 }
 
 func New(t *testing.T, storage rest.Storage) *Tester {
@@ -80,6 +81,11 @@ func (t *Tester) AllowCreateOnUpdate() *Tester {
 
 func (t *Tester) GeneratesName() *Tester {
 	t.generatesName = true
+	return t
+}
+
+func (t *Tester) SkipDefaultGrace() *Tester {
+	t.skipDefaultGrace = true
 	return t
 }
 
@@ -182,7 +188,9 @@ func (t *Tester) TestDelete(valid runtime.Object, createFn CreateFunc, getFn Get
 
 // Test gracefully deleting an object.
 func (t *Tester) TestDeleteGraceful(valid runtime.Object, createFn CreateFunc, getFn GetFunc, expectedGrace int64) {
-	t.testDeleteGracefulHasDefault(valid.DeepCopyObject(), createFn, getFn, expectedGrace)
+	if !t.skipDefaultGrace {
+		t.testDeleteGracefulHasDefault(valid.DeepCopyObject(), createFn, getFn, expectedGrace)
+	}
 	t.testDeleteGracefulWithValue(valid.DeepCopyObject(), createFn, getFn, expectedGrace)
 	t.testDeleteGracefulUsesZeroOnNil(valid.DeepCopyObject(), createFn, expectedGrace)
 	t.testDeleteGracefulExtend(valid.DeepCopyObject(), createFn, getFn, expectedGrace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Grace value will updated if user request for grace period in the request body.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56567

**Special notes for your reviewer**:
do we have any default grace value(if finalizer set in the custom resource)?
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
grace period will updated on deleting custom resource
```
