### PR TITLE
client go: option added to set different timeout for different verb

### DIFF
--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -120,6 +120,17 @@ func TestDoRequestFailed(t *testing.T) {
 	}
 }
 
+func TestTimeOut(t *testing.T) {
+	wantedTimeout := 30 * time.Second
+	testServer, _, _ := testServerEnv(t, 200)
+	defer testServer.Close()
+	c, _ := restClient(testServer)
+	url := c.Timeout(wantedTimeout).Get().URL()
+	obtainedTimeout := url.Query().Get("timeout")
+	if obtainedTimeout != wantedTimeout.String() {
+		t.Errorf("wanted timeout %s obtained timeout %s", wantedTimeout.String(), obtainedTimeout)
+	}
+}
 func TestDoRawRequestFailed(t *testing.T) {
 	status := &metav1.Status{
 		Code:    http.StatusNotFound,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
user able to set different timeout for different verb
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #48926

**Special notes for your reviewer**:
```go
func (r *Request) Timeout(d time.Duration) *Request {
	if r.err != nil {
		return r
	}
	r.timeout = d
	return r
}
```
I didn't see anywhere that timeout is set back to the client.I think timeout has to be set back to client
(I maybe wrong cuz I'm new to code base)
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
option added to set different timeout for different verb
```
