### PR TITLE
fix advanced audit e2e test

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1515,6 +1515,10 @@ function start-kube-apiserver {
       # grows at 10MiB/s (~30K QPS), it will rotate after ~6 years if apiserver
       # never restarts. Please manually restart apiserver before this time.
       params+=" --audit-log-maxsize=2000000000"
+      params+=" --audit-log-mode=batch"
+      # If we want to validate audit events from log files, we always need to wait
+      # more than 30 seconds util audit events are force writing to disk.
+      params+=" --audit-log-batch-max-wait=30s"
     fi
     if [[ "${ADVANCED_AUDIT_BACKEND:-}" == *"webhook"* ]]; then
       params+=" --audit-webhook-mode=batch"

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -41,6 +42,9 @@ import (
 var (
 	watchTestTimeout int64 = 1
 	auditTestUser          = "kubecfg"
+	// we must wait util audit events are force writing to disk
+	// This time should be larger than --audit-log-batch-max-wait
+	waitingBatchTime = 30*time.Second + 5*time.Second
 
 	crd          = testserver.NewRandomNameCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
 	crdName      = strings.SplitN(crd.Name, ".", 2)[0]
@@ -630,6 +634,7 @@ var _ = SIGDescribe("Advanced Audit", func() {
 			expectedEvents = append(expectedEvents, t.events...)
 		}
 
+		time.Sleep(waitingBatchTime)
 		expectAuditLines(f, expectedEvents)
 	})
 })


### PR DESCRIPTION
If we want to validate audit events from log files, we always need to wait util audit events are force writing to disk.

@crassirostris @tallclair 

**Release note**:
```release-note
NONE
```
