### PR TITLE
	Separate pod log file from resource file

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -215,7 +215,7 @@ func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, out io.Writer) error
 		for ix := range pods.Items {
 			pod := &pods.Items[ix]
 			containers := pod.Spec.Containers
-			writer := setupOutputWriter(cmd, out, path.Join(namespace, pod.Name, "logs.txt"))
+			writer := setupOutputWriter(cmd, out, path.Join(namespace, "PodLog", pod.Name, "logs.txt"))
 
 			for i := range containers {
 				printContainer(writer, containers[i], pod)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kubectl cluster-info dump --output-directory=xxx`
will put pod log file and other resource file on same directory like this:

>  -rw-rw-r-- 1 wlh wlh   125 3月   5 16:48 daemonsets.json
> -rw-rw-r-- 1 wlh wlh   126 3月   5 16:48 deployments.json
> -rw-rw-r-- 1 wlh wlh 22455 3月   5 16:48 events.json
> -rw-rw-r-- 1 wlh wlh 22942 3月   5 16:48 pods.json
> -rw-rw-r-- 1 wlh wlh   126 3月   5 16:48 replicasets.json
> -rw-rw-r-- 1 wlh wlh   120 3月   5 16:48 replication-controllers.json
> -rw-rw-r-- 1 wlh wlh   106 3月   5 16:48 services.json
> drwxr-xr-x 2 wlh wlh  4096 3月   5 16:48 test1
> drwxr-xr-x 2 wlh wlh  4096 3月   5 16:48 test2
> drwxr-xr-x 2 wlh wlh  4096 3月   5 16:48 test3

test[1-3] are pod log files.
Imagine a namespace with hundreds of pods,  this output cloud be hard to use or analysis.
This pacth puts all pod log files into one directory. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
