### PR TITLE
pkg/volume/nfs/nfs.go: correct error messages

### DIFF
--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -255,7 +255,7 @@ func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if err != nil {
 		notMnt, mntErr := b.mounter.IsNotMountPoint(dir)
 		if mntErr != nil {
-			glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
+			glog.Errorf("IsNotMountPoint check failed: %v", mntErr)
 			return err
 		}
 		if !notMnt {
@@ -265,7 +265,7 @@ func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 			}
 			notMnt, mntErr := b.mounter.IsNotMountPoint(dir)
 			if mntErr != nil {
-				glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
+				glog.Errorf("IsNotMountPoint check failed: %v", mntErr)
 				return err
 			}
 			if !notMnt {


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't use `IsLikelyNotMountPoint()` function since 45d21ee36b1a49e3b86d99810a7875b7496da30a commit. This PR updates the error messages to mention a new function instead of the old one.