### PR TITLE
Fixing e2e CSI test

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -94,6 +94,16 @@ func csiClusterRole(
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "watch", "creat", "update", "patch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"nodes"},
 				Verbs:     []string{"get", "list", "watch", "update"},
 			},


### PR DESCRIPTION
Closes #60803

After switching to CSI 0.2.0 spec, additional RBAC permissions are required.  This PR adds missing permissions.

```release-note
None
```
