### PR TITLE
add --from-literal --from-file docker-reg secret

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -171,6 +171,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, cmdOut io.Writer) *cobr
 	cmd.Flags().String("docker-email", "", i18n.T("Email for Docker registry"))
 	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", i18n.T("Server location for Docker registry"))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
 
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	return cmd
@@ -182,22 +183,27 @@ func CreateSecretDockerRegistry(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.
 	if err != nil {
 		return err
 	}
-	requiredFlags := []string{"docker-username", "docker-password", "docker-server"}
-	for _, requiredFlag := range requiredFlags {
-		if value := cmdutil.GetFlagString(cmd, requiredFlag); len(value) == 0 {
-			return cmdutil.UsageErrorf(cmd, "flag %s is required", requiredFlag)
+	fromFileFlag := cmdutil.GetFlagStringSlice(cmd, "from-file")
+	if len(fromFileFlag) == 0 {
+		requiredFlags := []string{"docker-username", "docker-password", "docker-server"}
+		for _, requiredFlag := range requiredFlags {
+			if value := cmdutil.GetFlagString(cmd, requiredFlag); len(value) == 0 {
+				return cmdutil.UsageErrorf(cmd, "flag %s is required", requiredFlag)
+			}
 		}
 	}
+
 	var generator kubectl.StructuredGenerator
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.SecretForDockerRegistryV1GeneratorName:
 		generator = &kubectl.SecretForDockerRegistryGeneratorV1{
-			Name:       name,
-			Username:   cmdutil.GetFlagString(cmd, "docker-username"),
-			Email:      cmdutil.GetFlagString(cmd, "docker-email"),
-			Password:   cmdutil.GetFlagString(cmd, "docker-password"),
-			Server:     cmdutil.GetFlagString(cmd, "docker-server"),
-			AppendHash: cmdutil.GetFlagBool(cmd, "append-hash"),
+			Name:        name,
+			Username:    cmdutil.GetFlagString(cmd, "docker-username"),
+			Email:       cmdutil.GetFlagString(cmd, "docker-email"),
+			Password:    cmdutil.GetFlagString(cmd, "docker-password"),
+			Server:      cmdutil.GetFlagString(cmd, "docker-server"),
+			AppendHash:  cmdutil.GetFlagBool(cmd, "append-hash"),
+			FileSources: cmdutil.GetFlagStringSlice(cmd, "from-file"),
 		}
 	default:
 		return errUnsupportedGenerator(cmd, generatorName)

--- a/pkg/kubectl/secret_for_docker_registry.go
+++ b/pkg/kubectl/secret_for_docker_registry.go
@@ -30,6 +30,8 @@ import (
 type SecretForDockerRegistryGeneratorV1 struct {
 	// Name of secret (required)
 	Name string
+	// FileSources to derive the secret from (optional)
+	FileSources []string
 	// Username for registry (required)
 	Username string
 	// Email for registry (optional)
@@ -85,15 +87,22 @@ func (s SecretForDockerRegistryGeneratorV1) StructuredGenerate() (runtime.Object
 	if err := s.validate(); err != nil {
 		return nil, err
 	}
-	dockercfgJsonContent, err := handleDockerCfgJsonContent(s.Username, s.Password, s.Email, s.Server)
-	if err != nil {
-		return nil, err
-	}
 	secret := &v1.Secret{}
 	secret.Name = s.Name
 	secret.Type = v1.SecretTypeDockerConfigJson
 	secret.Data = map[string][]byte{}
-	secret.Data[v1.DockerConfigJsonKey] = dockercfgJsonContent
+	if len(s.FileSources) > 0 {
+		if err := handleFromFileSources(secret, s.FileSources); err != nil {
+			return nil, err
+		}
+	}
+	if len(s.FileSources) == 0 {
+		dockercfgJsonContent, err := handleDockerCfgJsonContent(s.Username, s.Password, s.Email, s.Server)
+		if err != nil {
+			return nil, err
+		}
+		secret.Data[v1.DockerConfigJsonKey] = dockercfgJsonContent
+	}
 	if s.AppendHash {
 		h, err := hash.SecretHash(secret)
 		if err != nil {
@@ -108,6 +117,7 @@ func (s SecretForDockerRegistryGeneratorV1) StructuredGenerate() (runtime.Object
 func (s SecretForDockerRegistryGeneratorV1) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"name", true},
+		{"from-file", false},
 		{"docker-username", true},
 		{"docker-email", false},
 		{"docker-password", true},
@@ -121,14 +131,17 @@ func (s SecretForDockerRegistryGeneratorV1) validate() error {
 	if len(s.Name) == 0 {
 		return fmt.Errorf("name must be specified")
 	}
-	if len(s.Username) == 0 {
-		return fmt.Errorf("username must be specified")
-	}
-	if len(s.Password) == 0 {
-		return fmt.Errorf("password must be specified")
-	}
-	if len(s.Server) == 0 {
-		return fmt.Errorf("server must be specified")
+
+	if len(s.FileSources) == 0 {
+		if len(s.Username) == 0 {
+			return fmt.Errorf("username must be specified")
+		}
+		if len(s.Password) == 0 {
+			return fmt.Errorf("password must be specified")
+		}
+		if len(s.Server) == 0 {
+			return fmt.Errorf("server must be specified")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Related downstream issue https://github.com/openshift/origin/issues/18833

Adds `--from-file` and `--from-literal` flag support to `kubectl create secret docker-registry`.
These flags have the same behavior as their counterparts in `kubectl create secret generic`.

cc @bparees @soltysh 
