### PR TITLE
[WIP] instrument aggregator with more metrics

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
@@ -70,6 +71,7 @@ go_library(
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apiserver/metrics:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apiserver/scheme:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/informers/internalversion:go_default_library",
@@ -93,6 +95,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics:all-srcs",
         "//staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "k8s.io/kube-aggregator/pkg/apiserver/metrics",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/prometheus/client_golang/prometheus:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	proxyActiveCounts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "aggregator_proxy_active",
+			Help: "Indicates if the proxy is active for a label (group/version).",
+		},
+		[]string{"apiservice"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	// Register the metrics.
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(proxyActiveCounts)
+	})
+}
+
+func SetProxyingGroupVersionActive(apiServiceName string) {
+	proxyActiveCounts.WithLabelValues(apiServiceName).Set(float64(1))
+}
+func SetProxyingGroupVersionInactive(apiServiceName string) {
+	proxyActiveCounts.WithLabelValues(apiServiceName).Set(float64(0))
+}


### PR DESCRIPTION
Adds metrics for requests from the aggregator.  This is a WIP while I think about using the same `apiserver_request_count` metrics or creating new metrics specific to the aggregator.  I'm leaning towards the latter.

@kubernetes/sig-api-machinery-misc 
@sttts @gmarek 