### PR TITLE
Modified test ingress manifests to use deployment instead of replication controller

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -1089,7 +1089,7 @@ func NewIngressTestJig(c clientset.Interface) *IngressTestJig {
 }
 
 // CreateIngress creates the Ingress and associated service/rc.
-// Required: ing.yaml, rc.yaml, svc.yaml must exist in manifestPath
+// Required: ing.yaml, dep.yaml, svc.yaml must exist in manifestPath
 // Optional: secret.yaml, ingAnnotations
 // If ingAnnotations is specified it will overwrite any annotations in ing.yaml
 // If svcAnnotations is specified it will overwrite any annotations in svc.yaml
@@ -1099,8 +1099,8 @@ func (j *IngressTestJig) CreateIngress(manifestPath, ns string, ingAnnotations m
 		return filepath.Join(TestContext.RepoRoot, manifestPath, file)
 	}
 
-	j.Logger.Infof("creating replication controller")
-	RunKubectlOrDie("create", "-f", mkpath("rc.yaml"), fmt.Sprintf("--namespace=%v", ns))
+	j.Logger.Infof("creating deployment")
+	RunKubectlOrDie("create", "-f", mkpath("dep.yaml"), fmt.Sprintf("--namespace=%v", ns))
 
 	j.Logger.Infof("creating service")
 	RunKubectlOrDie("create", "-f", mkpath("svc.yaml"), fmt.Sprintf("--namespace=%v", ns))

--- a/test/e2e/testing-manifests/ingress/http/dep.yaml
+++ b/test/e2e/testing-manifests/ingress/http/dep.yaml
@@ -1,9 +1,14 @@
 apiVersion: v1
-kind: ReplicationController
+kind: Deployment
 metadata:
   name: echoheaders
+  labels:
+    app: echoheaders
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: echoheaders
   template:
     metadata:
       labels:

--- a/test/e2e/testing-manifests/ingress/neg/dep.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/dep.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/dep.yaml
@@ -1,9 +1,14 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: echoheaders-https
+  labels:
+    app: echoheaders-https
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: echoheaders-https
   template:
     metadata:
       labels:

--- a/test/e2e/testing-manifests/ingress/static-ip-2/dep.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip-2/dep.yaml
@@ -1,9 +1,14 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: echoheaders-https
+  labels:
+    app: echoheaders-https
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: echoheaders-https
   template:
     metadata:
       labels:

--- a/test/e2e/testing-manifests/ingress/static-ip/dep.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/dep.yaml
@@ -1,9 +1,14 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: echoheaders-https
+  labels:
+    app: echoheaders-https
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: echoheaders-https
   template:
     metadata:
       labels:
@@ -11,6 +16,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/google_containers/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.6
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
See title. Deployment is now the standard way of doing things.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58629

Release Note:
```release-note
None
```

/assign @MrHohn 
