### PR TITLE
Pass in etcd TLS credentials during migrate and rollback: 1.8 edition

### DIFF
--- a/cluster/images/etcd/migrate-if-needed.sh
+++ b/cluster/images/etcd/migrate-if-needed.sh
@@ -98,6 +98,9 @@ fi
 
 # Starts 'etcd' version ${START_VERSION} and writes to it:
 # 'etcd_version' -> "${START_VERSION}"
+# ETCD_CREDS may optionally be  set to provide flags for TLS credentials
+# such as '--cert-file' and '--peer-cert-file'. For a complete list of
+# flags, see https://coreos.com/etcd/docs/latest/op-guide/security.html.
 # Successful write confirms that etcd is up and running.
 # Sets ETCD_PID at the end.
 # Returns 0 if etcd was successfully started, non-0 otherwise.
@@ -105,6 +108,7 @@ start_etcd() {
   # Use random ports, so that apiserver cannot connect to etcd.
   ETCD_PORT=18629
   ETCD_PEER_PORT=2380
+  ETCD_CREDS="${ETCD_CREDS:-}"
   # Avoid collisions between etcd and event-etcd.
   case "${DATA_DIRECTORY}" in
     *event*)
@@ -127,7 +131,8 @@ start_etcd() {
     --listen-client-urls http://127.0.0.1:${ETCD_PORT} \
     --advertise-client-urls http://127.0.0.1:${ETCD_PORT} \
     --listen-peer-urls http://127.0.0.1:${ETCD_PEER_PORT} \
-    --initial-advertise-peer-urls http://127.0.0.1:${ETCD_PEER_PORT} &
+    --initial-advertise-peer-urls http://127.0.0.1:${ETCD_PEER_PORT} \
+    ${ETCD_CREDS} &
   ETCD_PID=$!
   # Wait until we can write to etcd.
   for i in $(seq 240); do

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -60,6 +60,9 @@
       },
       { "name": "DATA_DIRECTORY",
         "value": "/var/etcd/data{{ suffix }}"
+      },
+      { "name": "ETCD_CREDS",
+        "value": "{{ etcd_creds }}"
       }
         ],
     "livenessProbe": {


### PR DESCRIPTION
1.8 edition of #60808 : "For HA etcd clusters, the etcd-creds settings, specifically the --peer-* TLS flags that may be included, must be passed in to start-stop-etcd.sh in order for the etcd server mode started during migrate and rollback steps to be able to communicate between peers."

**Release note**:
```release-note
NONE
```
