### PR TITLE
[WIP]moving the constants in api groups to a consts package

### DIFF
--- a/pkg/apis/admission/types.go
+++ b/pkg/apis/admission/types.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/consts/admission"
 	"k8s.io/kubernetes/pkg/apis/authentication"
 )
 
@@ -64,7 +65,7 @@ type AdmissionRequest struct {
 	// +optional
 	Namespace string
 	// Operation is the operation being performed
-	Operation Operation
+	Operation admission.Operation
 	// UserInfo is information about the requesting user
 	UserInfo authentication.UserInfo
 	// Object is the object from the incoming request prior to default values being applied
@@ -91,24 +92,5 @@ type AdmissionResponse struct {
 	Patch []byte
 	// PatchType indicates the form the Patch will take. Currently we only support "JSONPatch".
 	// +optional
-	PatchType *PatchType
+	PatchType *admission.PatchType
 }
-
-// PatchType is the type of patch being used to represent the mutated object
-type PatchType string
-
-// PatchType constants.
-const (
-	PatchTypeJSONPatch PatchType = "JSONPatch"
-)
-
-// Operation is the type of resource operation being checked for admission control
-type Operation string
-
-// Operation constants
-const (
-	Create  Operation = "CREATE"
-	Update  Operation = "UPDATE"
-	Delete  Operation = "DELETE"
-	Connect Operation = "CONNECT"
-)

--- a/staging/src/k8s.io/api/admission/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admission/v1beta1/types.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/consts/admission"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -62,7 +63,7 @@ type AdmissionRequest struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
 	// Operation is the operation being performed
-	Operation Operation `json:"operation" protobuf:"bytes,7,opt,name=operation"`
+	Operation admission.Operation `json:"operation" protobuf:"bytes,7,opt,name=operation"`
 	// UserInfo is information about the requesting user
 	UserInfo authenticationv1.UserInfo `json:"userInfo" protobuf:"bytes,8,opt,name=userInfo"`
 	// Object is the object from the incoming request prior to default values being applied
@@ -93,24 +94,5 @@ type AdmissionResponse struct {
 
 	// The type of Patch. Currently we only allow "JSONPatch".
 	// +optional
-	PatchType *PatchType `json:"patchType,omitempty" protobuf:"bytes,5,opt,name=patchType"`
+	PatchType *admission.PatchType `json:"patchType,omitempty" protobuf:"bytes,5,opt,name=patchType"`
 }
-
-// PatchType is the type of patch being used to represent the mutated object
-type PatchType string
-
-// PatchType constants.
-const (
-	PatchTypeJSONPatch PatchType = "JSONPatch"
-)
-
-// Operation is the type of resource operation being checked for admission control
-type Operation string
-
-// Operation constants
-const (
-	Create  Operation = "CREATE"
-	Update  Operation = "UPDATE"
-	Delete  Operation = "DELETE"
-	Connect Operation = "CONNECT"
-)

--- a/staging/src/k8s.io/consts/admission/consts.go
+++ b/staging/src/k8s.io/consts/admission/consts.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+// PatchType is the type of patch being used to represent the mutated object
+type PatchType string
+
+// PatchType constants.
+const (
+	PatchTypeJSONPatch PatchType = "JSONPatch"
+)
+
+// Operation is the type of resource operation being checked for admission control
+type Operation string
+
+// Operation constants
+const (
+	Create  Operation = "CREATE"
+	Update  Operation = "UPDATE"
+	Delete  Operation = "DELETE"
+	Connect Operation = "CONNECT"
+)

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/consts/admission"
 	// TODO: try this library to see if it generates correct json patch
 	// https://github.com/mattbaird/jsonpatch
 )
@@ -130,7 +131,7 @@ func mutatePods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	reviewResponse.Allowed = true
 	if pod.Name == "webhook-to-be-mutated" {
 		reviewResponse.Patch = []byte(addInitContainerPatch)
-		pt := v1beta1.PatchTypeJSONPatch
+		pt := admission.PatchTypeJSONPatch
 		reviewResponse.PatchType = &pt
 	}
 	return &reviewResponse
@@ -189,7 +190,7 @@ func mutateConfigmaps(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		reviewResponse.Patch = []byte(patch2)
 	}
 
-	pt := v1beta1.PatchTypeJSONPatch
+	pt := admission.PatchTypeJSONPatch
 	reviewResponse.PatchType = &pt
 
 	return &reviewResponse
@@ -218,7 +219,7 @@ func mutateCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	if cr.Data["mutation-stage-1"] == "yes" {
 		reviewResponse.Patch = []byte(patch2)
 	}
-	pt := v1beta1.PatchTypeJSONPatch
+	pt := admission.PatchTypeJSONPatch
 	reviewResponse.PatchType = &pt
 	return &reviewResponse
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

moving the constants in api groups to a consts package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59557  
**Special notes for your reviewer**:
modify [https://github.com/kubernetes/kubernetes/pull/59565](https://github.com/kubernetes/kubernetes/pull/59565)
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
