### PR TITLE
Add support for --dry-run to kubectl create job

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -77,6 +77,7 @@ selfsubjectaccessreviews="selfsubjectaccessreviews"
 customresourcedefinitions="customresourcedefinitions"
 daemonsets="daemonsets"
 controllerrevisions="controllerrevisions"
+job="jobs"
 
 
 # include shell2junit library
@@ -4006,6 +4007,46 @@ run_service_accounts_tests() {
   set +o errexit
 }
 
+run_job_tests() {
+  set -o nounset
+  set -o errexit
+
+  create_and_use_new_namespace
+  kube::log::status "Testing job"
+
+  ### Create a new namespace
+  # Pre-condition: the test-jobs namespace does not exist
+  kube::test::get_object_assert 'namespaces' '{{range.items}}{{ if eq $id_field \"test-jobs\" }}found{{end}}{{end}}:' ':'
+  # Command
+  kubectl create namespace test-jobs
+  # Post-condition: namespace 'test-jobs' is created.
+  kube::test::get_object_assert 'namespaces/test-jobs' "{{$id_field}}" 'test-jobs'
+
+  ### Create a cronjob in a specific namespace
+  kubectl run pi --schedule="59 23 31 2 *" --namespace=test-jobs --generator=cronjob/v1beta1 "--image=$IMAGE_PERL" --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(20)' "${kube_flags[@]}"
+  # Post-Condition: assertion object exists
+  kube::test::get_object_assert 'cronjob/pi --namespace=test-jobs' "{{$id_field}}" 'pi'
+
+  ### Create a job in dry-run mode
+  output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=true --namespace=test-jobs -o name)
+  # Post-condition: The text 'job.batch/test-job' should be part of the output
+  kube::test::if_has_string "${output_message}" 'job.batch/test-job'
+  # Post-condition: The test-job wasn't created actually
+  kube::test::get_object_assert jobs "{{range.items}}{{$id_field}}{{end}}" ''
+
+  ### Create a job in a specific namespace
+  kubectl create job test-job --from=cronjob/pi --namespace=test-jobs
+  # Post-Condition: assertion object exists
+  kube::test::get_object_assert 'job/test-job --namespace=test-jobs' "{{$id_field}}" 'test-job'
+  #Clean up
+  kubectl delete job test-job --namespace=test-jobs
+  kubectl delete cronjob pi --namespace=test-jobs
+  kubectl delete namespace test-jobs
+
+  set +o nounset
+  set +o errexit
+}
+
 run_pod_templates_tests() {
   set -o nounset
   set -o errexit
@@ -4978,6 +5019,14 @@ runTests() {
 
   if kube::test::if_supports_resource "${namespaces}" && kube::test::if_supports_resource "${serviceaccounts}" ; then
     record_command run_service_accounts_tests
+  fi
+
+  ####################
+  # Job              #
+  ####################
+
+  if kube::test::if_supports_resource "${job}" ; then
+    record_command run_job_tests
   fi
 
   #################


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Create job subcommand lacks dry-run flag, this patch fix this.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
