### PR TITLE
Add nodes to the list of resources kubedns can access

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -440,7 +440,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			// a role to use for the kube-dns pod
 			ObjectMeta: metav1.ObjectMeta{Name: "system:kube-dns"},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("endpoints", "services").RuleOrDie(),
+				rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("endpoints", "nodes", "services").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -769,6 +769,7 @@ items:
     - ""
     resources:
     - endpoints
+    - nodes
     - services
     verbs:
     - list


### PR DESCRIPTION
Kubedns resolves the dns names to an external server in the clusters which are federated and missing the local shard of the federated service. To form the dns name, it needs to access the nodeList [as here](https://github.com/kubernetes/dns/blob/master/pkg/dns/dns.go#L919), which is missing in the recent releases.

cc @kubernetes/sig-multicluster-bugs @quinton-hoole 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
release-notes-none
```
