### PR TITLE
apiserver endpoint handler parseTimeout with client set timeout, requ…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -73,6 +73,7 @@ type APIGroupVersion struct {
 	Admit   admission.Interface
 	Context request.RequestContextMapper
 
+	RequestTimeout    time.Duration
 	MinRequestTimeout time.Duration
 
 	// EnableAPIResponseCompression indicates whether API Responses should support compression
@@ -88,6 +89,7 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
 	installer := &APIInstaller{
 		group:                        g,
 		prefix:                       prefix,
+		requestTimeout:               g.RequestTimeout,
 		minRequestTimeout:            g.MinRequestTimeout,
 		enableAPIResponseCompression: g.EnableAPIResponseCompression,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -40,9 +40,6 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 		trace := utiltrace.New("Create " + req.URL.Path)
 		defer trace.LogIfLong(500 * time.Millisecond)
 
-		// TODO: we either want to remove timeout or document it (if we document, move timeout out of this function and declare it in api_installer)
-		timeout := parseTimeout(req.URL.Query().Get("timeout"))
-
 		var (
 			namespace, name string
 			err             error
@@ -105,6 +102,10 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 
 		// TODO: replace with content type negotiation?
 		includeUninitialized := req.URL.Query().Get("includeUninitialized") == "1"
+
+		requestReceived := request.TimeStampFrom(ctx)
+		// TODO: we either want to remove timeout or document it (if we document, move timeout out of this function and declare it in api_installer)
+		timeout := parseTimeout(req.URL.Query().Get("timeout"), scope.RequestTimeout, requestReceived)
 
 		trace.Step("About to store object in database")
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -65,11 +65,6 @@ func PatchResource(r rest.Patcher, scope RequestScope, admit admission.Interface
 			return
 		}
 
-		// TODO: we either want to remove timeout or document it (if we
-		// document, move timeout out of this function and declare it in
-		// api_installer)
-		timeout := parseTimeout(req.URL.Query().Get("timeout"))
-
 		namespace, name, err := scope.Namer.Name(req)
 		if err != nil {
 			scope.err(err, w, req)
@@ -114,6 +109,10 @@ func PatchResource(r rest.Patcher, scope RequestScope, admit admission.Interface
 			}
 			return nil
 		}
+
+		requestReceived := request.TimeStampFrom(ctx)
+		// TODO: we either want to remove timeout or document it (if we document, move timeout out of this function and declare it in api_installer)
+		timeout := parseTimeout(req.URL.Query().Get("timeout"), scope.RequestTimeout, requestReceived)
 
 		result, err := patchResource(
 			ctx,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -716,14 +716,17 @@ func TestHasUID(t *testing.T) {
 }
 
 func TestParseTimeout(t *testing.T) {
-	if d := parseTimeout(""); d != 30*time.Second {
+	if d := parseTimeout("", 0, time.Time{}); d != 30*time.Second {
 		t.Errorf("blank timeout produces %v", d)
 	}
-	if d := parseTimeout("not a timeout"); d != 30*time.Second {
+	if d := parseTimeout("not a timeout", 0, time.Time{}); d != 30*time.Second {
 		t.Errorf("bad timeout produces %v", d)
 	}
-	if d := parseTimeout("10s"); d != 10*time.Second {
+	if d := parseTimeout("10s", 60*time.Second, time.Now()); d != 10*time.Second {
 		t.Errorf("10s timeout produced: %v", d)
+	}
+	if d := parseTimeout("", 60*time.Second, time.Now()); d < 50*time.Second {
+		t.Errorf("bad timeout produces %v", d)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -51,6 +51,7 @@ const (
 type APIInstaller struct {
 	group                        *APIGroupVersion
 	prefix                       string // Path prefix where API resources are to be registered.
+	requestTimeout               time.Duration
 	minRequestTimeout            time.Duration
 	enableAPIResponseCompression bool
 }
@@ -515,6 +516,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		Kind:        fqKindToRegister,
 
 		MetaGroupVersion: metav1.SchemeGroupVersion,
+		RequestTimeout:   a.requestTimeout,
 	}
 	if a.group.MetaGroupVersion != nil {
 		reqScope.MetaGroupVersion = *a.group.MetaGroupVersion

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -67,6 +67,9 @@ const (
 
 	// auditKey is the context key for the audit event.
 	auditKey
+
+	// timestampKey is the context key for the timestamp when request come in.
+	timestampKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -156,4 +159,15 @@ func WithAuditEvent(parent Context, ev *audit.Event) Context {
 func AuditEventFrom(ctx Context) *audit.Event {
 	ev, _ := ctx.Value(auditKey).(*audit.Event)
 	return ev
+}
+
+// WithTimeStamp returns a copy of parent in which the timestamp value is set
+func WithTimeStamp(parent Context, t time.Time) Context {
+	return WithValue(parent, timestampKey, t)
+}
+
+// AuditEventFrom returns value of the timestamp key on the ctx
+func TimeStampFrom(ctx Context) time.Time {
+	t, _ := ctx.Value(timestampKey).(time.Time)
+	return t
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -473,6 +473,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		HandlerChainWaitGroup:  c.HandlerChainWaitGroup,
 
 		minRequestTimeout: time.Duration(c.MinRequestTimeout) * time.Second,
+		requestTimeout:    c.RequestTimeout,
 		ShutdownTimeout:   c.RequestTimeout,
 
 		SecureServingInfo: c.SecureServing,

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -54,6 +54,12 @@ func WithTimeoutForNonLongRunningRequests(handler http.Handler, requestContextMa
 		if longRunning(req, requestInfo) {
 			return nil, nil, nil
 		}
+
+		ctx = apirequest.WithTimeStamp(ctx, time.Now())
+		if err := requestContextMapper.Update(req, ctx); err != nil {
+			return nil, nil, apierrors.NewInternalError(fmt.Errorf("failed to attach request received timestamp to context: %v", err))
+		}
+
 		metricFn := func() {
 			metrics.Record(req, requestInfo, "", http.StatusGatewayTimeout, 0, 0)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -84,6 +84,10 @@ type GenericAPIServer struct {
 	// minRequestTimeout is how short the request timeout can be.  This is used to build the RESTHandler
 	minRequestTimeout time.Duration
 
+	// If specified, all requests except those which match the LongRunningFunc predicate will timeout
+	// after this duration.
+	requestTimeout time.Duration
+
 	// ShutdownTimeout is the timeout used for server shutdown. This specifies the timeout before server
 	// gracefully shutdown returns.
 	ShutdownTimeout time.Duration
@@ -449,6 +453,7 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Admit:                        s.admissionControl,
 		Context:                      s.RequestContextMapper(),
 		MinRequestTimeout:            s.minRequestTimeout,
+		RequestTimeout:               s.requestTimeout,
 		EnableAPIResponseCompression: s.enableAPIResponseCompression,
 	}
 }

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -552,7 +552,8 @@ func testWebhook(f *framework.Framework) {
 	client = f.ClientSet
 	// Creating the pod, the request should be rejected
 	pod = hangingPod(f)
-	_, err = client.CoreV1().Pods(f.Namespace.Name).Create(pod)
+	result := &v1.Pod{}
+	err = client.CoreV1().RESTClient().Post().Namespace(f.Namespace.Name).Resource("pods").Body(pod).Param("timeout", "30s").Do().Into(result)
 	Expect(err).NotTo(BeNil())
 	expectedTimeoutErr := "request did not complete within allowed duration"
 	if !strings.Contains(err.Error(), expectedTimeoutErr) {


### PR DESCRIPTION
…estTimeout set in apiserver and request received time


1. record `timestamp` in request context in `WithTimeoutForNonLongRunningRequests`
2. e.g. in createHandler, when we calculate timeout we should compare `requestTimeout - (now - timestamp)` with client specified `timeout` in url query. and select the smaller as the timeout value.

Fixes #60347


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
