### PR TITLE
Fixing e2e CSI test, II

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -95,7 +95,7 @@ func csiClusterRole(
 			{
 				APIGroups: []string{""},
 				Resources: []string{"events"},
-				Verbs:     []string{"get", "list", "watch", "creat", "update", "patch"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
The fix for #60803 in commit 2ae33cc324fb had a typo, so the "Server
rejected event" error still showed up in the external-provisioner log
of the "Sanity CSI plugin test using hostPath CSI driver" e2e test.

```release-note
None
```
