### PR TITLE
Bump Cluster Autoscaler to 1.1.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.1.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.1.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Contains fixes around GPUs and base image change.
```release-note
Cluster Autoscaler 1.1.2 - release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.1.2
```
