### PR TITLE
Made image registries configurable from registry.yaml file

### DIFF
--- a/test/utils/image/BUILD
+++ b/test/utils/image/BUILD
@@ -9,6 +9,9 @@ go_library(
     name = "go_default_library",
     srcs = ["manifest.go"],
     importpath = "k8s.io/kubernetes/test/utils/image",
+    deps = [
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+    ],
 )
 
 filegroup(

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -18,16 +18,19 @@ package image
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
-const (
-	dockerLibraryRegistry = "docker.io/library"
-	e2eRegistry           = "gcr.io/kubernetes-e2e-test-images"
-	gcRegistry            = "k8s.gcr.io"
-	PrivateRegistry       = "gcr.io/k8s-authenticated-test"
-	sampleRegistry        = "gcr.io/google-samples"
-)
-
+type RegistryList struct {
+	DockerLibraryRegistry string `yaml:"dockerLibraryRegistry"`
+	E2eRegistry           string `yaml:"e2eRegistry"`
+	GcRegistry            string `yaml:"gcRegistry"`
+	PrivateRegistry       string `yaml:"privateRegistry"`
+	SampleRegistry        string `yaml:"sampleRegistry"`
+}
 type ImageConfig struct {
 	registry string
 	name     string
@@ -46,7 +49,39 @@ func (i *ImageConfig) SetVersion(version string) {
 	i.version = version
 }
 
+func initReg() RegistryList {
+	registry := RegistryList{
+		DockerLibraryRegistry: "docker.io/library",
+		E2eRegistry:           "gcr.io/kubernetes-e2e-test-images",
+		GcRegistry:            "k8s.gcr.io",
+		PrivateRegistry:       "gcr.io/k8s-authenticated-test",
+		SampleRegistry:        "gcr.io/google-samples",
+	}
+	repoList := os.Getenv("KUBE_TEST_REPO_LIST")
+	if repoList == "" {
+		return registry
+	}
+
+	fileContent, err := ioutil.ReadFile(repoList)
+	if err != nil {
+		panic(fmt.Errorf("Error reading '%v' file contents: %v", repoList, err))
+	}
+
+	err = yaml.Unmarshal(fileContent, &registry)
+	if err != nil {
+		panic(fmt.Errorf("Error unmarshalling '%v' YAML file: %v", repoList, err))
+	}
+	return registry
+}
+
 var (
+	registry              = initReg()
+	dockerLibraryRegistry = registry.DockerLibraryRegistry
+	e2eRegistry           = registry.E2eRegistry
+	gcRegistry            = registry.GcRegistry
+	PrivateRegistry       = registry.PrivateRegistry
+	sampleRegistry        = registry.SampleRegistry
+
 	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v2"}
 	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0"}
 	AppArmorLoader           = ImageConfig{e2eRegistry, "apparmor-loader", "1.0"}


### PR DESCRIPTION
Make image registries used by e2e tests configurable via a registry.yaml file. File path is sent via env variable. If no such variable is set, registry names default to the ones already defined.

Fixes #60487 

