### PR TITLE
Automated cherry pick of #60842: Bump Cluster Autoscaler to 1.1.2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #60842 on release-1.9.

#60842: Bump Cluster Autoscaler to 1.1.2