### PR TITLE
Do not create dangling legacy symlink

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -146,9 +146,15 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 	legacySymlink := legacyLogSymlink(containerID, containerMeta.Name, sandboxMeta.Name,
 		sandboxMeta.Namespace)
 	containerLog := filepath.Join(podSandboxConfig.LogDirectory, containerConfig.LogPath)
-	if err := m.osInterface.Symlink(containerLog, legacySymlink); err != nil {
-		glog.Errorf("Failed to create legacy symbolic link %q to container %q log %q: %v",
-			legacySymlink, containerID, containerLog, err)
+	// only create legacy symlink if containerLog path exists (or the error is not IsNotExist).
+	// Because if containerLog path does not exist, only dandling legacySymlink is created.
+	// This dangling legacySymlink is later removed by container gc, so it does not make sense
+	// to create it in the first place. it happens when journald logging driver is used with docker.
+	if _, err := m.osInterface.Stat(containerLog); !os.IsNotExist(err) {
+		if err := m.osInterface.Symlink(containerLog, legacySymlink); err != nil {
+			glog.Errorf("Failed to create legacy symbolic link %q to container %q log %q: %v",
+				legacySymlink, containerID, containerLog, err)
+		}
 	}
 
 	// Step 4: execute the post start hook.


### PR DESCRIPTION
Do not create dangling legacy symlink if the new symlink to container logs does not exist.
These dangling legacy symlink are later removed by kube runtime gc, so it's better if we do not
create them in the first place to avoid unnecessary work from kube runtime gc. This situation occurs when docker uses journald logging driver.  

**What this PR does / why we need it**:
This PR fixes an issue where dangling symlink are being created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None.
```
@derekwaynecarr @sjenning @dashpole @kubernetes/sig-node-pr-reviews 