### PR TITLE
Bump debian-iptables-amd64 in release-1.8

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v8
+  debian_iptables_version=v10
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -56,10 +56,10 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:2e747bc7455b46350d8e57f05c03e109fa306861e7b2a2e8e1cd563932170cf1",
+    digest = "sha256:fb18678f8203ca1bd2fad2671e3ebd80cb408a1baae423d4ad39c05f4caac4e1",
     registry = "gcr.io",
     repository = "google-containers/debian-iptables-amd64",
-    tag = "v8",  # ignored, but kept here for documentation
+    tag = "v10",  # ignored, but kept here for documentation
 )
 
 docker_pull(


### PR DESCRIPTION
**What this PR does / why we need it**:
1.8, 1.9 and 1.10 all can use v10 of debian-iptables-amd64.

/assign @mikedanese 
/cc @tallclair 

**Release note**:
```release-note
None
```
