### PR TITLE
Auto check the current year in boilerplate

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 
 import argparse
+import datetime
 import difflib
 import glob
 import json
@@ -171,12 +172,17 @@ def get_files(extensions):
             outfiles.append(pathname)
     return outfiles
 
+def get_dates():
+    years = datetime.datetime.now().year
+    return '(%s)' % '|'.join((str(year) for year in range(2014, years+1)))
+
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
-    # dates can be 2014, 2015, 2016, 2017, or 2018; company holder names can be anything
-    regexs["date"] = re.compile( '(2014|2015|2016|2017|2018)' )
+    # get_dates return 2014, 2015, 2016, 2017, or 2018 until the current year as a regex like: "(2014|2015|2016|2017|2018)";
+    # company holder names can be anything
+    regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Every new year we need to add the current year to boilerplate.py manually like #[Update boilerplate for 2018](https://github.com/kubernetes/kubernetes/commit/bec420875ea5c64a9c4fa1269ada2a856b3d5ab7#diff-0f66228ea46785f57b8df9ca08b23f49), #[Update boilerplate.py to support 2017](https://github.com/kubernetes/kubernetes/commit/98534200bce7d2e039d6f127af828bd64dfe6086#diff-0f66228ea46785f57b8df9ca08b23f49), it should be auto checked.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [Update boilerplate for 2018](https://github.com/kubernetes/kubernetes/commit/bec420875ea5c64a9c4fa1269ada2a856b3d5ab7#diff-0f66228ea46785f57b8df9ca08b23f49) , #[Update boilerplate.py to support 2017](https://github.com/kubernetes/kubernetes/commit/98534200bce7d2e039d6f127af828bd64dfe6086#diff-0f66228ea46785f57b8df9ca08b23f49)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
