### PR TITLE
Update cadvisor to v0.29.1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1475,218 +1475,218 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.29.0",
-			"Rev": "aaaa65dba02880718d0237cd4e80ab8eb278bb19"
+			"Comment": "v0.29.1",
+			"Rev": "2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/vendor/github.com/google/cadvisor/container/containerd/handler.go
+++ b/vendor/github.com/google/cadvisor/container/containerd/handler.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
@@ -103,10 +104,28 @@ func newContainerdContainerHandler(
 		return nil, err
 	}
 
-	taskPid, err := client.TaskPid(ctx, id)
-	if err != nil {
-		return nil, err
+	// Cgroup is created during task creation. When cadvisor sees the cgroup,
+	// task may not be fully created yet. Use a retry+backoff to tolerant the
+	// race condition.
+	// TODO(random-liu): Use cri-containerd client to talk with cri-containerd
+	// instead. cri-containerd has some internal synchronization to make sure
+	// `ContainerStatus` only returns result after `StartContainer` finishes.
+	var taskPid uint32
+	backoff := 100 * time.Millisecond
+	retry := 5
+	for {
+		taskPid, err = client.TaskPid(ctx, id)
+		if err == nil {
+			break
+		}
+		retry--
+		if !errdefs.IsNotFound(err) || retry == 0 {
+			return nil, err
+		}
+		time.Sleep(backoff)
+		backoff *= 2
 	}
+
 	rootfs := "/"
 	if !inHostNamespace {
 		rootfs = "/rootfs"


### PR DESCRIPTION
Update cadvisor to v0.29.1 to include a bug fix for containerd integration. https://github.com/google/cadvisor/pull/1894

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
