### PR TITLE
Typo in IT translation

### DIFF
--- a/translations/kubectl/it_IT/LC_MESSAGES/k8s.po
+++ b/translations/kubectl/it_IT/LC_MESSAGES/k8s.po
@@ -3092,7 +3092,7 @@ msgstr "Imposta il current-context in un file kubeconfig"
 
 #: pkg/kubectl/cmd/describe.go:86
 msgid "Show details of a specific resource or group of resources"
-msgstr "Mostra i dettagli di una specifiche risorsa o un gruppo di risorse"
+msgstr "Mostra i dettagli di una specifica risorsa o un gruppo di risorse"
 
 #: pkg/kubectl/cmd/rollout/rollout_status.go:58
 msgid "Show the status of the rollout"


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes a typo in Italian translation

**Special notes for your reviewer**:
Merge trusting an Italian :)