### PR TITLE
Skip the MetricsGrabber tests when the prerequisites are not fulfilled instead of make…

### DIFF
--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -71,8 +71,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 			}
 		}
 		if !masterRegistered {
-			framework.Logf("Master is node api.Registry. Skipping testing Scheduler metrics.")
-			return
+			framework.Skipf("Master is node api.Registry. Skipping testing Scheduler metrics.")
 		}
 		response, err := grabber.GrabFromScheduler()
 		framework.ExpectNoError(err)
@@ -92,8 +91,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 			}
 		}
 		if !masterRegistered {
-			framework.Logf("Master is node api.Registry. Skipping testing ControllerManager metrics.")
-			return
+			framework.Skipf("Master is node api.Registry. Skipping testing ControllerManager metrics.")
 		}
 		response, err := grabber.GrabFromControllerManager()
 		framework.ExpectNoError(err)


### PR DESCRIPTION
… them pass

Signed-off-by: Jean-Christophe Sirot <jean-christophe.sirot@docker.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**Special notes for your reviewer**:
These SIG instrumentation E2E tests
- MetricsGrabber should grab all metrics from a Scheduler
- MetricsGrabber should grab all metrics from a ControllerManager

requires a master node to be registered. When no master node is present, the test just pass and  nothing has been actually tested. This PR calls `framework.Skipf(...)` when the test is skipped.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```