### PR TITLE
[WIP] kubeadm: add better test coverage to config.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -80,6 +80,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "config_test.go",
         "reset_test.go",
         "token_test.go",
     ],

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	ServerAddr = "localhost:9008"
+	TestConfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data:
+    server: ` + ServerAddr + `
+  name: prod
+contexts:
+- context:
+    cluster: prod
+    namespace: default
+    user: default-service-account
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data:
+    client-key-data:
+`
+	ValidResponseYAML = `api:
+  advertiseAddress: 127.0.0.1
+  bindPort: 9008
+`
+)
+
+func TestNewCmdConfigView(t *testing.T) {
+	var buf bytes.Buffer
+	testConfigFile := "test-config-file"
+
+	tmpDir, err := ioutil.TempDir("", "kubeadm-token-test")
+	if err != nil {
+		t.Errorf("Unable to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	fullPath := filepath.Join(tmpDir, testConfigFile)
+
+	f, err := os.Create(fullPath)
+	if err != nil {
+		t.Errorf("Unable to create test file %q: %v", fullPath, err)
+	}
+	defer f.Close()
+
+	if _, err = f.WriteString(TestConfig); err != nil {
+		t.Errorf("Unable to write test file %q: %v", fullPath, err)
+	}
+
+	http.HandleFunc("/", httpHandler)
+	httpServer := &http.Server{Addr: ServerAddr}
+	go func() {
+		err := httpServer.ListenAndServe()
+		if err != nil {
+			t.Errorf("Failed to start dummy API server: %s\n", ServerAddr)
+		}
+	}()
+
+	cmd := NewCmdConfigView(&buf, &fullPath)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Failed to execute NewCmdConfigView for config file: %v; %v", fullPath, err)
+	}
+}
+
+func httpHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/yaml")
+	w.WriteHeader(200)
+	w.Write([]byte(ValidResponseYAML))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Perform a test for `kubeadm config view`.
The tests for `kubeadm config upload ...` seem
to fail with:
  "no kind "Config" is registered for version "v1".
and are not included in this change due to
not enough information on how to fake the upload.

**Q: does anyone know how to trick the Decoder to work with a dummy config file?**
i get the same error if i run `kubeadm config upload from-file --config=./some-valid-config` without a running cluster.
 "no kind "Config" is registered for version "v1".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

NONE

**Special notes for your reviewer**:

NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
