### PR TITLE
translate hack/e2e.go -v to --verbose-commands

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -46,6 +46,7 @@ func parse(args []string) (flags, error) {
 	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	get := fs.Bool("get", getDefault, "go get -u kubetest if old or not installed")
 	old := fs.Duration("old", oldDefault, "Consider kubetest old if it exceeds this")
+	verbose := fs.Bool("v", true, "this flag is translated to kubetest's --verbose-commands")
 	var a []string
 	if err := fs.Parse(args[1:]); err == flag.ErrHelp {
 		os.Stderr.WriteString("  -- kubetestArgs\n")
@@ -58,7 +59,8 @@ func parse(args []string) (flags, error) {
 		log.Print("  The -- flag separator also suppresses this message")
 		a = args[len(args)-fs.NArg()-1:]
 	} else {
-		a = fs.Args()
+		a = append(a, fmt.Sprintf("--verbose-commands=%t", *verbose))
+		a = append(a, fs.Args()...)
 	}
 	return flags{*get, *old, a}, nil
 }

--- a/hack/e2e_test.go
+++ b/hack/e2e_test.go
@@ -63,13 +63,23 @@ func TestParse(t *testing.T) {
 		err      error
 	}{
 		{
+			[]string{"foo", "-v=false"},
+			flags{getDefault, oldDefault, []string{"--verbose-commands=false"}},
+			nil,
+		},
+		{
+			[]string{"foo", "-v"},
+			flags{getDefault, oldDefault, []string{"--verbose-commands=true"}},
+			nil,
+		},
+		{
 			[]string{"hello", "world"},
-			flags{getDefault, oldDefault, []string{"world"}},
+			flags{getDefault, oldDefault, []string{"--verbose-commands=true", "world"}},
 			nil,
 		},
 		{
 			[]string{"hello", "--", "--venus", "--karaoke"},
-			flags{getDefault, oldDefault, []string{"--venus", "--karaoke"}},
+			flags{getDefault, oldDefault, []string{"--verbose-commands=true", "--venus", "--karaoke"}},
 			nil,
 		},
 		{
@@ -84,12 +94,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			[]string{"omg", "--get=false", "--", "ugh"},
-			flags{false, oldDefault, []string{"ugh"}},
+			flags{false, oldDefault, []string{"--verbose-commands=true", "ugh"}},
 			nil,
 		},
 		{
 			[]string{"wee", "--old=5m", "--get"},
-			flags{true, 5 * time.Minute, []string{}},
+			flags{true, 5 * time.Minute, []string{"--verbose-commands=true"}},
 			nil,
 		},
 		{
@@ -104,7 +114,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			[]string{"wut", "--", "-h"},
-			flags{getDefault, oldDefault, []string{"-h"}},
+			flags{getDefault, oldDefault, []string{"--verbose-commands=true", "-h"}},
 			nil,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: translates the old `go run hack/e2e.go` `-v` flag to `--verbose-commands` for kubetest. kubetest now imports client-go, which imports `glog`, which registers an incompatible `-v level` flag so kubetest now uses `--verbose-commands` instead.

This should fix existing workflows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: See also: https://github.com/kubernetes/community/pull/1901

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
