### PR TITLE
Fix GCE PD dynamic provisioning 1.9 upgrade test failure

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -100,11 +100,11 @@ func testDynamicProvisioning(t storageClassTest, client clientset.Interface, cla
 	// Check sizes
 	expectedCapacity := resource.MustParse(t.expectedSize)
 	pvCapacity := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]
-	Expect(pvCapacity.Value()).To(Equal(expectedCapacity.Value()), "pvCapacity is not equal to expectedCapacity")
+	Expect(pvCapacity.Value()).To(BeNumerically(">=", expectedCapacity.Value()), "pvCapacity is not greater than or equal to expectedCapacity")
 
 	requestedCapacity := resource.MustParse(t.claimSize)
 	claimCapacity := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	Expect(claimCapacity.Value()).To(Equal(requestedCapacity.Value()), "claimCapacity is not equal to requestedCapacity")
+	Expect(claimCapacity.Value()).To(BeNumerically(">=", requestedCapacity.Value()), "claimCapacity is not greater than or equal to requestedCapacity")
 
 	// Check PV properties
 	By("checking the PV")
@@ -256,8 +256,8 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 						"type": "pd-ssd",
 						"zone": cloudZone,
 					},
-					"1.5Gi",
-					"2Gi",
+					"1.5G",
+					"2G",
 					func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-ssd")
 					},
@@ -269,8 +269,8 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 					map[string]string{
 						"type": "pd-standard",
 					},
-					"1.5Gi",
-					"2Gi",
+					"1.5G",
+					"2G",
 					func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-standard")
 					},
@@ -435,8 +435,8 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 				map[string]string{
 					"type": "pd-standard",
 				},
-				"1Gi",
-				"1Gi",
+				"1G",
+				"1G",
 				func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -469,8 +469,8 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 				map[string]string{
 					"type": "pd-standard",
 				},
-				"1Gi",
-				"1Gi",
+				"1G",
+				"1G",
 				func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -520,7 +520,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 				name:        "unmanaged_zone",
 				provisioner: "kubernetes.io/gce-pd",
 				parameters:  map[string]string{"zone": unmanagedZone},
-				claimSize:   "1Gi",
+				claimSize:   "1G",
 			}
 			sc := newStorageClass(test, ns, suffix)
 			sc, err = c.StorageV1().StorageClasses().Create(sc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Fixes storage unit discrepancy between actual size and expected size for GCE PD dynamic provisioning tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60766 

/sig storage
/assign @gnufied @jingxu97 
/cc @mbohlool 

Placing hold as 1.9 branch is currently frozen
/hold