### PR TITLE
client-go/util/cert go_library shouldn't depend on testdata

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/BUILD
+++ b/staging/src/k8s.io/client-go/util/cert/BUILD
@@ -24,9 +24,6 @@ go_library(
         "io.go",
         "pem.go",
     ],
-    data = [
-        "testdata/dontUseThisKey.pem",
-    ],
     importpath = "k8s.io/client-go/util/cert",
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: https://github.com/kubernetes/kubernetes/commit/981dd8dc6615f397a9b85c5b965998dc8a0b1338#diff-eb996d3ca3a215d7d93faaaffb77dbd7 accidentally added a testdata dependency on the go_library rule, rather than the go_test. This breaks vendoring of this rule into other bazel projects that prune out tests and testdata.

Only the unit test depends on testdata, so the BUILD file should reflect that, too.

x-ref https://github.com/kubernetes/test-infra/pull/6835#discussion_r173010769

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @BenTheElder @krzyzacy 
