### PR TITLE
Improve clarity of message for the "Killing container" event

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -569,7 +569,7 @@ func (m *kubeGenericRuntimeManager) killContainer(pod *v1.Pod, containerID kubec
 
 	message := fmt.Sprintf("Killing container with id %s", containerID.String())
 	if reason != "" {
-		message = fmt.Sprint(message, ":", reason)
+		message = fmt.Sprintf("%s for reason: %s", message, reason)
 	}
 	m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, message)
 	m.containerRefManager.ClearRef(containerID)


### PR DESCRIPTION
This avoids appending any characters onto the container ID and more
clearly separates the first word of the reason from it.

Old:
Killing container with id docker://cockroachdb:Need to kill Pod

New:
Killing container with id docker://cockroachdb for reason: Need to kill Pod

**Release note**:
```release-note
NONE
```
