### PR TITLE
[e2e service] Refine apiserver restart logic

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -427,9 +427,15 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(framework.VerifyServeHostnameServiceUp(cs, ns, host, podNames1, svc1IP, servicePort))
 
 		// Restart apiserver
+		initialRestartCount, err := framework.GetApiserverRestartCount(cs)
+		Expect(err).NotTo(HaveOccurred(), "failed to get apiserver's restart count")
 		By("Restarting apiserver")
 		if err := framework.RestartApiserver(cs.Discovery()); err != nil {
 			framework.Failf("error restarting apiserver: %v", err)
+		}
+		By("Waiting for apiserver to be restarted")
+		if err := framework.WaitForApiserverRestarted(cs, initialRestartCount); err != nil {
+			framework.Failf("error while waiting for apiserver to be restarted: %v", err)
 		}
 		By("Waiting for apiserver to come up by polling /healthz")
 		if err := framework.WaitForApiserverUp(cs); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubernetes/issues/60761#issuecomment-371308569, wait for apiserver's restart count increases before proceeding the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes (hopefully) #60761

**Special notes for your reviewer**:
/assign @rramkumar1 @bowei 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
