### PR TITLE
 kubeadm: add test coverage to completion.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -81,6 +81,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "completion_test.go",
         "join_test.go",
         "reset_test.go",
         "token_test.go",
@@ -95,6 +96,7 @@ go_test(
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -89,13 +89,17 @@ var (
 	}
 )
 
-// NewCmdCompletion return command for executing "kubeadm completion" command
-func NewCmdCompletion(out io.Writer, boilerPlate string) *cobra.Command {
+// GetSupportedShells returns a list of supported shells
+func GetSupportedShells() []string {
 	shells := []string{}
 	for s := range completionShells {
 		shells = append(shells, s)
 	}
+	return shells
+}
 
+// NewCmdCompletion returns the "kubeadm completion" command
+func NewCmdCompletion(out io.Writer, boilerPlate string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "completion SHELL",
 		Short:   i18n.T("Output shell completion code for the specified shell (bash or zsh)."),
@@ -105,7 +109,7 @@ func NewCmdCompletion(out io.Writer, boilerPlate string) *cobra.Command {
 			err := RunCompletion(out, boilerPlate, cmd, args)
 			kubeadmutil.CheckErr(err)
 		},
-		ValidArgs: shells,
+		ValidArgs: GetSupportedShells(),
 	}
 
 	return cmd

--- a/cmd/kubeadm/app/cmd/completion_test.go
+++ b/cmd/kubeadm/app/cmd/completion_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const shellsError = "Unexpected empty completion shells list"
+
+func TestNewCmdCompletion(t *testing.T) {
+	var out bytes.Buffer
+	shells := GetSupportedShells()
+	if len(shells) == 0 {
+		t.Errorf(shellsError)
+	}
+	// test NewCmdCompletion with a valid shell.
+	// use a dummy parent command as NewCmdCompletion needs it.
+	parentCmd := &cobra.Command{}
+	args := []string{"completion", shells[0]}
+	parentCmd.SetArgs(args)
+	cmd := NewCmdCompletion(&out, "")
+	parentCmd.AddCommand(cmd)
+	if err := parentCmd.Execute(); err != nil {
+		t.Errorf("Cannot exectute NewCmdCompletion: %v", err)
+	}
+}
+
+func TestRunCompletion(t *testing.T) {
+	var out bytes.Buffer
+	type TestCase struct {
+		name          string
+		args          []string
+		expectedError bool
+	}
+
+	testCases := []TestCase{
+		{
+			name:          "invalid: missing argument",
+			args:          []string{},
+			expectedError: true,
+		},
+		{
+			name:          "invalid: too many arguments",
+			args:          []string{"", ""},
+			expectedError: true,
+		},
+		{
+			name:          "invalid: unsupported shell name",
+			args:          []string{"unsupported"},
+			expectedError: true,
+		},
+	}
+
+	// test all supported shells
+	shells := GetSupportedShells()
+	if len(shells) == 0 {
+		t.Errorf(shellsError)
+	}
+	for _, shell := range shells {
+		test := TestCase{
+			name: "valid: test shell " + shell,
+			args: []string{shell},
+		}
+		testCases = append(testCases, test)
+	}
+
+	// use dummy cobra commands
+	parentCmd := &cobra.Command{}
+	cmd := &cobra.Command{}
+	parentCmd.AddCommand(cmd)
+
+	for _, tc := range testCases {
+		if err := RunCompletion(&out, "", cmd, tc.args); (err != nil) != tc.expectedError {
+			t.Errorf("Test case %q: TestRunCompletion expected error: %v, saw: %v", tc.name, tc.expectedError, (err != nil))
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add `completion_test.go` with the following tests:
- TestNewCmdCompletion
- TestRunCompletion

A separate commit exports the function GetSupportedShells() to obtain the list of supported shells.

Test coverage is at 96%. The only untested bit is an `io.Writer.Write()` call in `RunCompletion()`. in the case of `bytes.Buffer` it would panic and/or always return `nil` for `error`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

NONE

**Special notes for your reviewer**:

NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
