### PR TITLE
Do not allow duplicate PVC names in pod.Spec.Volumes

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3597,6 +3597,26 @@ func TestValidateVolumes(t *testing.T) {
 		t.Errorf("expected error type %v, got %v", field.ErrorTypeDuplicate, errs[0].Type)
 	}
 
+	duplicatePVCCases := []core.Volume{
+		{Name: "vol1", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "vol1"}}},
+		{Name: "vol2", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "vol1"}}},
+	}
+
+	_, dupErrors := ValidateVolumes(duplicatePVCCases, field.NewPath("field"))
+	if len(dupErrors) == 0 {
+		t.Errorf("Expected error for duplicate PVC volumes in spec")
+	}
+
+	uniquePVCs := []core.Volume{
+		{Name: "vol1", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "vol1"}}},
+		{Name: "vol2", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "vol2"}}},
+	}
+
+	_, dupErrors = ValidateVolumes(uniquePVCs, field.NewPath("field"))
+	if len(dupErrors) != 0 {
+		t.Errorf("Expected No error for unique pvcs in spec")
+	}
+
 	// Validate HugePages medium type for EmptyDir when HugePages feature is enabled/disabled
 	hugePagesCase := core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{Medium: core.StorageMediumHugePages}}
 


### PR DESCRIPTION
Such pods can never run because only one mount point is ever
created and pods get stuck in ContainerCreating state


```release-note
A pod should not have more than one volume that point to same PVC
```

