### PR TITLE
Automated cherry pick of #60872: purge all the -v references from e2e.go

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -213,7 +213,7 @@ test-e2e:
 	@echo "$$TEST_E2E_HELP_INFO"
 else
 test-e2e: ginkgo generated_files
-	go run hack/e2e.go -- -v --build --up --test --down
+	go run hack/e2e.go -- --build --up --test --down
 endif
 
 define TEST_E2E_NODE_HELP_INFO

--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -44,7 +44,7 @@ fi
 
 if [[ -f /.dockerenv ]]; then
 	# Running inside a dockerized runner.
-	go run ./hack/e2e.go -- -v --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
+	go run ./hack/e2e.go -- --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
 else
 	# Running locally.
  	ARGS=$(echo $ARGS | sed 's/\[/\\\[/g' | sed 's/\]/\\\]/g')


### PR DESCRIPTION
Cherry pick of #60872 on release-1.8.

#60872: purge all the -v references from e2e.go