### PR TITLE
Make admission webhooks honor scheme part of url

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
@@ -168,7 +168,7 @@ func (cm *ClientManager) HookClient(h *v1beta1.Webhook) (*rest.RESTClient, error
 	}
 
 	cfg := rest.CopyConfig(restConfig)
-	cfg.Host = u.Host
+	cfg.Host = u.Scheme + "://" + u.Host
 	cfg.APIPath = u.Path
 
 	return complete(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bug fix, allow webhooks to use the scheme provided in clientConfig, instead of defaulting to http.
(more in issue)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60942

```release-note
Bug fix, allow webhooks to use the scheme provided in clientConfig, instead of defaulting to http.
```

/kind bug
/sig api-machinery