### PR TITLE
Remove bootstrap dns clusterrole

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -48,6 +48,33 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -48,6 +48,33 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -48,6 +48,33 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -146,6 +146,26 @@ func createKubeDNSAddon(deploymentBytes, serviceBytes []byte, client clientset.I
 		return err
 	}
 
+	kubeDNSClusterRoles := &rbac.ClusterRole{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KubeDNSClusterRole), kubeDNSClusterRoles); err != nil {
+		return fmt.Errorf("unable to decode kube-dns clusterroles %v", err)
+	}
+
+	// Create the Clusterroles for kube-dns or update it in case it already exists
+	if err := apiclient.CreateOrUpdateClusterRole(client, kubeDNSClusterRoles); err != nil {
+		return err
+	}
+
+	kubeDNSClusterRolesBinding := &rbac.ClusterRoleBinding{}
+	if err := kuberuntime.DecodeInto(clientsetscheme.Codecs.UniversalDecoder(), []byte(KubeDNSClusterRoleBinding), kubeDNSClusterRolesBinding); err != nil {
+		return fmt.Errorf("unable to decode kube-dns clusterrolebindings %v", err)
+	}
+
+	// Create the Clusterrolebindings for kube-dns or update it in case it already exists
+	if err := apiclient.CreateOrUpdateClusterRoleBinding(client, kubeDNSClusterRolesBinding); err != nil {
+		return err
+	}
+
 	kubednsService := &v1.Service{}
 	return createDNSService(kubednsService, serviceBytes, client)
 }

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -208,6 +208,38 @@ spec:
     k8s-app: kube-dns
 `
 
+	// KubeDNSClusterRole is the kube-dns ClusterRole manifest
+	KubeDNSClusterRole = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeadm:kube-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch
+`
+	// KubeDNSClusterRoleBinding is the kube-dns Clusterrolebinding manifest
+	KubeDNSClusterRoleBinding = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns
+subjects:
+- kind: ServiceAccount
+  name: kube-dns
+  namespace: kube-system
+`
+
 	// CoreDNSDeployment is the CoreDNS Deployment manifest
 	CoreDNSDeployment = `
 apiVersion: apps/v1

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -442,6 +442,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 		},
 		{
 			// a role to use for the kube-dns pod
+			// deprecated and will be removed in a future version
 			ObjectMeta: metav1.ObjectMeta{Name: "system:kube-dns"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("endpoints", "services").RuleOrDie(),
@@ -533,6 +534,7 @@ func ClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 		rbacv1helpers.NewClusterBinding("system:basic-user").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:node-proxier").Users(user.KubeProxy).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:kube-controller-manager").Users(user.KubeControllerManager).BindingOrDie(),
+		// The default system:kube-dns cluster role binding is deprecated and will be removed in a future version
 		rbacv1helpers.NewClusterBinding("system:kube-dns").SAs("kube-system", "kube-dns").BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:kube-scheduler").Users(user.KubeScheduler).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:aws-cloud-provider").SAs("kube-system", "aws-cloud-provider").BindingOrDie(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is to remove the bootstrap clusterrole/clusterrolebinding, also update kubeadm to create
kube-dns clusterrole/clusterrolebinding

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/60897

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The bootstrap `system:kube-dns` ClusterRole and ClusterRoleBinding have been deprecated and will be removed in a future version. Installations of kube-dns should supply their own RBAC roles and bindings as part of their install manifests.
```
