### PR TITLE
fix memory leak in mutation detector

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -85,9 +85,10 @@ func NewSharedIndexInformer(lw ListerWatcher, objType runtime.Object, defaultEve
 		objectType:                      objType,
 		resyncCheckPeriod:               defaultEventHandlerResyncPeriod,
 		defaultEventHandlerResyncPeriod: defaultEventHandlerResyncPeriod,
-		cacheMutationDetector:           NewCacheMutationDetector(fmt.Sprintf("%T", objType)),
+		cacheMutationDetector:           NewCacheMutationDetector(fmt.Sprintf("%T", objType), DeletionHandlingMetaNamespaceKeyFunc),
 		clock: realClock,
 	}
+
 	return sharedIndexInformer
 }
 
@@ -363,6 +364,7 @@ func (s *sharedIndexInformer) HandleDeltas(obj interface{}) error {
 				s.processor.distribute(addNotification{newObj: d.Object}, isSync)
 			}
 		case Deleted:
+			s.cacheMutationDetector.DeleteObject(d.Object)
 			if err := s.indexer.Delete(d.Object); err != nil {
 				return err
 			}


### PR DESCRIPTION
fix memory leak in mutation detector by removing obj when it is deleted 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
