### PR TITLE
webhook-admission: quickfix of registering AdmissionReview in provided scheme

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -131,6 +131,9 @@ func (a *MutatingWebhook) SetServiceResolver(sr config.ServiceResolver) {
 // SetScheme sets a serializer(NegotiatedSerializer) which is derived from the scheme
 func (a *MutatingWebhook) SetScheme(scheme *runtime.Scheme) {
 	if scheme != nil {
+		// TODO: we should not mutate a scheme we don't own. We should have a fallback serializer instead.
+		admissionv1beta1.AddToScheme(scheme)
+
 		a.clientManager.SetNegotiatedSerializer(serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
 			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
 		}))

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
@@ -128,6 +128,9 @@ func (a *ValidatingAdmissionWebhook) SetServiceResolver(sr config.ServiceResolve
 // SetScheme sets a serializer(NegotiatedSerializer) which is derived from the scheme
 func (a *ValidatingAdmissionWebhook) SetScheme(scheme *runtime.Scheme) {
 	if scheme != nil {
+		// TODO: we should not mutate a scheme we don't own. We should have a fallback serializer instead.
+		admissionv1beta1.AddToScheme(scheme)
+
 		a.clientManager.SetNegotiatedSerializer(serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
 			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
 		}))


### PR DESCRIPTION
Fixing https://github.com/kubernetes/kubernetes/issues/60963. 
Fixing https://github.com/kubernetes/sample-apiserver/pull/21.

We should not mutate a scheme provided to the webhooks. Instead we should have
a serializer that uses a local scheme and falls back to the provided scheme
for the embedded payload objects.