### PR TITLE
Fix use of "-w" flag to iptables-restore

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -124,7 +124,7 @@ const MinCheckVersion = "1.4.11"
 const WaitMinVersion = "1.4.20"
 const WaitSecondsMinVersion = "1.4.22"
 const WaitString = "-w"
-const WaitSecondsString = "-w5"
+const WaitSecondsValue = "5"
 
 const LockfilePath16x = "/run/xtables.lock"
 
@@ -558,7 +558,7 @@ func getIPTablesWaitFlag(vstring string) []string {
 	if version.LessThan(minVersion) {
 		return []string{WaitString}
 	} else {
-		return []string{WaitSecondsString}
+		return []string{WaitString, WaitSecondsValue}
 	}
 }
 
@@ -594,7 +594,7 @@ func getIPTablesRestoreWaitFlag(exec utilexec.Interface, protocol Protocol) []st
 		return nil
 	}
 
-	return []string{WaitSecondsString}
+	return []string{WaitString, WaitSecondsValue}
 }
 
 // getIPTablesRestoreVersionString runs "iptables-restore --version" to get the version string


### PR DESCRIPTION
iptables accepts "-w5" but iptables-restore requires "-w 5", so kube-proxy is currently broken for people with an iptables-restore new enough that kube-proxy tries to use the new flags.

Fixes #58956

**Release note**:
```release-note
Fixed kube-proxy to work correctly with iptables 1.6.2 and later.
```
