### PR TITLE
Use grpc to improve the CPU utilization of the logging agent.

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -377,6 +377,7 @@ data:
       disable_retry_limit
       # Use multiple threads for processing.
       num_threads 2
+      use_grpc true
       labels {
         # The logging backend will take responsibility for double writing to
         # the necessary resource types when this label is set.
@@ -404,6 +405,7 @@ data:
       max_retry_wait 30
       disable_retry_limit
       num_threads 2
+      use_grpc true
       labels {
         # The logging backend will take responsibility for double writing to
         # the necessary resource types when this label is set.


### PR DESCRIPTION
Fixes #60762

**What this PR does / why we need it**:
Using gRPC improves the CPU utilization of the logging agent be reducing 
serialization overhead and reusing TCP connections.

**Release note**:
```release-note
NONE
```
