### PR TITLE
kubeadm: add test coverage to cmd.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -80,6 +80,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cmd_test.go",
         "reset_test.go",
         "token_test.go",
     ],

--- a/cmd/kubeadm/app/cmd/cmd_test.go
+++ b/cmd/kubeadm/app/cmd/cmd_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewKubeadmCommand(t *testing.T) {
+	var buf bytes.Buffer
+	found := []string{}
+	commandUses := []string{
+		"alpha",
+		"completion SHELL",
+		"config",
+		"init",
+		"join",
+		"reset",
+		"token",
+		"upgrade",
+		"version",
+	}
+
+	// obtain the list of command from NewKubeadmCommand()
+	// and then match the command uses in the `commandUses` slice,
+	// while filling the `found` slice at the same time.
+	// report differences.
+	kubeadmCommands := NewKubeadmCommand(&buf, &buf, &buf)
+	cmdList := kubeadmCommands.Commands()
+	if len(commandUses) != len(cmdList) {
+		reportLengthError(t, len(commandUses), len(cmdList))
+	}
+
+	for _, cmd := range cmdList {
+		use := cmd.Use
+		if contains(found, use) {
+			t.Fatalf("Multiple definitions of command: %s", use)
+		}
+		if contains(commandUses, use) {
+			found = append(found, use)
+		} else {
+			t.Fatalf("Unknown command %q", use)
+		}
+	}
+
+	if len(found) != len(commandUses) {
+		reportLengthError(t, len(commandUses), len(found))
+	}
+}
+
+func reportLengthError(t *testing.T, lenE, lenF int) {
+	t.Fatalf("Expected %d commands, found %d", lenE, lenF)
+}
+
+func contains(slice []string, element string) bool {
+	for _, v := range slice {
+		if element == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
this PR adds test coverage for `cmd.go` in kubeadm.
one thing to test here is to validate the list of commands from `NewKubeadmCommand()` against a predefined list.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
