### PR TITLE
kubeadm: Controllable timeout for join failures

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -128,6 +128,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.DiscoveryFile = "foo"
 			obj.DiscoveryToken = "foo"
 			obj.DiscoveryTokenAPIServers = []string{"foo"}
+			obj.DiscoveryTimeout = &metav1.Duration{Duration: 1}
 			obj.TLSBootstrapToken = "foo"
 			obj.Token = "foo"
 			obj.CRISocket = "foo"

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -224,6 +224,8 @@ type NodeConfiguration struct {
 	// will be fetched. Currently we only pay attention to one API server but
 	// hope to support >1 in the future.
 	DiscoveryTokenAPIServers []string
+	// DiscoveryTimeout modifies the discovery timeout
+	DiscoveryTimeout *metav1.Duration
 	// NodeName is the name of the node to join the cluster. Defaults
 	// to the name of the host.
 	NodeName string

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"net/url"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,6 +69,9 @@ const (
 	DefaultProxyBindAddressv6 = "::"
 	// KubeproxyKubeConfigFileName defines the file name for the kube-proxy's KubeConfig file
 	KubeproxyKubeConfigFileName = "/var/lib/kube-proxy/kubeconfig.conf"
+
+	// DefaultDiscoveryTimeout specifies the default discovery timeout for kubeadm (used unless one is specified in the NodeConfiguration)
+	DefaultDiscoveryTimeout = 5 * time.Minute
 )
 
 var (
@@ -175,6 +179,11 @@ func SetDefaults_NodeConfiguration(obj *NodeConfiguration) {
 		u, err := url.Parse(obj.DiscoveryFile)
 		if err == nil && u.Scheme == "file" {
 			obj.DiscoveryFile = u.Path
+		}
+	}
+	if obj.DiscoveryTimeout == nil {
+		obj.DiscoveryTimeout = &metav1.Duration{
+			Duration: DefaultDiscoveryTimeout,
 		}
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -214,6 +214,8 @@ type NodeConfiguration struct {
 	// will be fetched. Currently we only pay attention to one API server but
 	// hope to support >1 in the future.
 	DiscoveryTokenAPIServers []string `json:"discoveryTokenAPIServers,omitempty"`
+	// DiscoveryTimeout modifies the discovery timeout
+	DiscoveryTimeout *metav1.Duration `json:"discoveryTimeout,omitempty"`
 	// NodeName is the name of the node to join the cluster. Defaults
 	// to the name of the host.
 	NodeName string `json:"nodeName"`

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -347,6 +347,7 @@ func autoConvert_v1alpha1_NodeConfiguration_To_kubeadm_NodeConfiguration(in *Nod
 	out.DiscoveryFile = in.DiscoveryFile
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
+	out.DiscoveryTimeout = (*v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
 	out.NodeName = in.NodeName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token
@@ -367,6 +368,7 @@ func autoConvert_kubeadm_NodeConfiguration_To_v1alpha1_NodeConfiguration(in *kub
 	out.DiscoveryFile = in.DiscoveryFile
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
+	out.DiscoveryTimeout = (*v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
 	out.NodeName = in.NodeName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
@@ -309,6 +309,15 @@ func (in *NodeConfiguration) DeepCopyInto(out *NodeConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DiscoveryTimeout != nil {
+		in, out := &in.DiscoveryTimeout, &out.DiscoveryTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.DiscoveryTokenCACertHashes != nil {
 		in, out := &in.DiscoveryTokenCACertHashes, &out.DiscoveryTokenCACertHashes
 		*out = make([]string, len(*in))

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -309,6 +309,15 @@ func (in *NodeConfiguration) DeepCopyInto(out *NodeConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DiscoveryTimeout != nil {
+		in, out := &in.DiscoveryTimeout, &out.DiscoveryTimeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.DiscoveryTokenCACertHashes != nil {
 		in, out := &in.DiscoveryTokenCACertHashes, &out.DiscoveryTokenCACertHashes
 		*out = make([]string, len(*in))

--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -59,7 +59,7 @@ func GetValidatedClusterInfoObject(cfg *kubeadmapi.NodeConfiguration) (*clientcm
 		}
 		return file.RetrieveValidatedClusterInfo(cfg.DiscoveryFile)
 	case len(cfg.DiscoveryToken) != 0:
-		return token.RetrieveValidatedClusterInfo(cfg.DiscoveryToken, cfg.DiscoveryTokenAPIServers, cfg.DiscoveryTokenCACertHashes)
+		return token.RetrieveValidatedClusterInfo(cfg)
 	default:
 		return nil, fmt.Errorf("couldn't find a valid discovery configuration")
 	}

--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = ["token.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/discovery/token",
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//cmd/kubeadm/app/util/pubkeypin:go_default_library",

--- a/cmd/kubeadm/app/discovery/token/token_test.go
+++ b/cmd/kubeadm/app/discovery/token/token_test.go
@@ -68,11 +68,14 @@ func TestRunForEndpointsAndReturnFirst(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		returnKubeConfig := runForEndpointsAndReturnFirst(rt.endpoints, func(endpoint string) (*clientcmdapi.Config, error) {
+		returnKubeConfig, err := runForEndpointsAndReturnFirst(rt.endpoints, 5*time.Minute, func(endpoint string) (*clientcmdapi.Config, error) {
 			timeout, _ := strconv.Atoi(endpoint)
 			time.Sleep(time.Second * time.Duration(timeout))
 			return kubeconfigutil.CreateBasic(endpoint, "foo", "foo", []byte{}), nil
 		})
+		if err != nil {
+			t.Errorf("unexpected error: %v for endpoint %s", err, rt.expectedEndpoint)
+		}
 		endpoint := returnKubeConfig.Clusters[returnKubeConfig.Contexts[returnKubeConfig.CurrentContext].Cluster].Server
 		if endpoint != rt.expectedEndpoint {
 			t.Errorf(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR introduces a timeout for `kubeadm join`. During that time kubeadm will try to join as many times as possible. The timeout can be controlled via the `discoveryTimeout` config option. Its default value is 5 minutes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#677

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @luxas
/assign @timothysc

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: Introduce join timeout that can be controlled via the discoveryTimeout config option (set to 5 minutes by default).
```
