### PR TITLE
Quobyte Volume name validation

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -911,11 +911,13 @@ func validateQuobyteVolumeSource(quobyte *core.QuobyteVolumeSource, fldPath *fie
 			}
 		}
 	}
-
+	quobyteVolFmt := regexp.MustCompile(`[^\w\s/-]`)
 	if len(quobyte.Volume) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volume"), ""))
-	} else if strings.Contains(quobyte.Volume, "#") {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("volume"), quobyte.Volume, "Volume must not contain #"))
+	} else if strings.Contains(quobyte.Volume, "\\") {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("volume"), quobyte.Volume, "volume must not contain \\"))
+	} else if quobyteVolFmt.MatchString(quobyte.Volume) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("volume"), quobyte.Volume, "quobyte volume can only consists of alphanumeric and -,/,_,space characters"))
 	}
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -914,6 +914,8 @@ func validateQuobyteVolumeSource(quobyte *core.QuobyteVolumeSource, fldPath *fie
 
 	if len(quobyte.Volume) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volume"), ""))
+	} else if strings.Contains(quobyte.Volume, "#") {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("volume"), quobyte.Volume, "Volume must not contain #"))
 	}
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -79,6 +79,9 @@ var iscsiInitiatorNaaRegex = regexp.MustCompile(`^naa.[[:alnum:]]{32}$`)
 
 var csiDriverNameRexp = regexp.MustCompile(csiDriverNameRexpFmt)
 
+// Quobyte volume name validator
+var quobyteVolFmt = regexp.MustCompile(`[^\w\s/-]`)
+
 // ValidateHasLabel requires that metav1.ObjectMeta has a Label with key and expectedValue
 func ValidateHasLabel(meta metav1.ObjectMeta, fldPath *field.Path, key, expectedValue string) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -911,7 +914,6 @@ func validateQuobyteVolumeSource(quobyte *core.QuobyteVolumeSource, fldPath *fie
 			}
 		}
 	}
-	quobyteVolFmt := regexp.MustCompile(`[^\w\s/-]`)
 	if len(quobyte.Volume) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("volume"), ""))
 	} else if strings.Contains(quobyte.Volume, "\\") {


### PR DESCRIPTION
Validates Quobyte volume name to make sure volume name does special characters. Quobyte currently only allows special charters space and - in the volume names.
