### PR TITLE
Revert "Use quotas in default performance tests"

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -487,7 +487,7 @@ var _ = SIGDescribe("Density", func() {
 	}
 
 	isCanonical := func(test *Density) bool {
-		return test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && test.quotas
+		return test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && !test.quotas
 	}
 
 	for _, testArg := range densityTests {

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -196,7 +196,7 @@ var _ = SIGDescribe("Load capacity", func() {
 	}
 
 	isCanonical := func(test *Load) bool {
-		return test.podsPerNode == 30 && test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && test.quotas
+		return test.podsPerNode == 30 && test.kind == api.Kind("ReplicationController") && test.daemonsPerNode == 0 && test.secretsPerPod == 0 && test.configMapsPerPod == 0 && !test.quotas
 	}
 
 	for _, testArg := range loadTests {


### PR DESCRIPTION
This reverts commit c3c10208bd545add54a9ecd8d7d7f5747d5a9e0b.

Ref https://github.com/kubernetes/kubernetes/issues/60988

/cc @gmarek 
/kind bug
/sig scalability
/priority critical-urgent

```release-note
NONE
```