### PR TITLE
Ensure reasons end up as comments in kubectl edit.

### DIFF
--- a/pkg/kubectl/cmd/util/editor/BUILD
+++ b/pkg/kubectl/cmd/util/editor/BUILD
@@ -41,7 +41,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["editor_test.go"],
+    srcs = [
+        "editoptions_test.go",
+        "editor_test.go",
+    ],
     embed = [":go_default_library"],
 )
 

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -657,12 +657,12 @@ func (h *editHeader) writeTo(w io.Writer, editMode EditMode) error {
 
 	for _, r := range h.reasons {
 		if len(r.other) > 0 {
-			fmt.Fprintf(w, "# %s:\n", r.head)
+			fmt.Fprintf(w, "# %s:\n", hashOnLineBreak(r.head))
 		} else {
-			fmt.Fprintf(w, "# %s\n", r.head)
+			fmt.Fprintf(w, "# %s\n", hashOnLineBreak(r.head))
 		}
 		for _, o := range r.other {
-			fmt.Fprintf(w, "# * %s\n", o)
+			fmt.Fprintf(w, "# * %s\n", hashOnLineBreak(o))
 		}
 		fmt.Fprintln(w, "#")
 	}
@@ -737,4 +737,19 @@ func hasLines(r io.Reader) (bool, error) {
 		return false, err
 	}
 	return false, nil
+}
+
+// hashOnLineBreak returns a string built from the provided string by inserting any necessary '#'
+// characters after '\n' characters, indicating a comment.
+func hashOnLineBreak(s string) string {
+	r := ""
+	for i, ch := range s {
+		j := i + 1
+		if j < len(s) && ch == '\n' && s[j] != '#' {
+			r += "\n# "
+		} else {
+			r += string(ch)
+		}
+	}
+	return r
 }

--- a/pkg/kubectl/cmd/util/editor/editoptions_test.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package editor
+
+import (
+	"testing"
+)
+
+func TestHashOnLineBreak(t *testing.T) {
+	tests := []struct {
+		original string
+		expected string
+	}{
+		{
+			original: "",
+			expected: "",
+		},
+		{
+			original: "\n",
+			expected: "\n",
+		},
+		{
+			original: "a\na\na\n",
+			expected: "a\n# a\n# a\n",
+		},
+		{
+			original: "a\n\n\na\n\n",
+			expected: "a\n# \n# \n# a\n# \n",
+		},
+	}
+	for _, test := range tests {
+		r := hashOnLineBreak(test.original)
+		if r != test.expected {
+			t.Errorf("expected: %s, saw: %s", test.expected, r)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR helps making sure that all text in the header of the file is prefixed with `#` when using `kubectl edit` to fix schema validation errors. The problem is best described with an example:

*Before:*

```yaml
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# mycrd "example-cr" was not valid:
# * []: Invalid value: map[string]interface {}{"apiVersion":"example.com/v1alpha1", "kind":"MyCRD", "metadata":map[string]interface {}{"clusterName":"", "creationTimestamp":"2018-03-09T16:16:41Z", "name":"example-cr", "namespace":"default", "resourceVersion":"12399", "selfLink":"", "uid":"4089f5bd-23b5-11e8-a33f-42010aa40081", "generation":0}, "spec":map[string]interface {}{"size":-1}}: validation failure list:
spec.size in body should be greater than or equal to 1
#
apiVersion: example.com/v1alpha1
kind: MyCRD
```

This obviously won't be accepted as input, the user having to manually add a `#` to the line in the header.

*After:*

```yaml
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# mycrd "example-cr" was not valid:
# * []: Invalid value: map[string]interface {}{"apiVersion":"example.com/v1alpha1", "kind":"MyCRD", "metadata":map[string]interface {}{"clusterName":"", "creationTimestamp":"2018-03-09T16:16:41Z", "name":"example-cr", "namespace":"default", "resourceVersion":"12399", "selfLink":"", "uid":"4089f5bd-23b5-11e8-a33f-42010aa40081", "generation":0}, "spec":map[string]interface {}{"size":-1}}: validation failure list:
# spec.size in body should be greater than or equal to 1
#
apiVersion: example.com/v1alpha1
kind: MyCRD
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
(None that I am aware of)

**Special notes for your reviewer**:
(None)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure reasons end up as comments in `kubectl edit`.
```
