### PR TITLE
[e2e service] Move apiserver restart validation logic into util

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -427,15 +427,9 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(framework.VerifyServeHostnameServiceUp(cs, ns, host, podNames1, svc1IP, servicePort))
 
 		// Restart apiserver
-		initialRestartCount, err := framework.GetApiserverRestartCount(cs)
-		Expect(err).NotTo(HaveOccurred(), "failed to get apiserver's restart count")
 		By("Restarting apiserver")
-		if err := framework.RestartApiserver(cs.Discovery()); err != nil {
+		if err := framework.RestartApiserver(cs); err != nil {
 			framework.Failf("error restarting apiserver: %v", err)
-		}
-		By("Waiting for apiserver to be restarted")
-		if err := framework.WaitForApiserverRestarted(cs, initialRestartCount); err != nil {
-			framework.Failf("error while waiting for apiserver to be restarted: %v", err)
 		}
 		By("Waiting for apiserver to come up by polling /healthz")
 		if err := framework.WaitForApiserverUp(cs); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of #60906, on GKE apiserver pod is invisible on k8s, hence test is failing.

This PR bakes the restart validation logic into the util function instead so it could be env-awared.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60761

**Special notes for your reviewer**:
Sorry for the noise.
/assign @rramkumar1 @bowei 
cc @krzyzacy 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
