### PR TITLE
Let webhook controller uses a local scheme that understand admissionReview

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/hashicorp/golang-lru:go_default_library",
+        "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
@@ -24,8 +24,10 @@ import (
 	"net/url"
 
 	lru "github.com/hashicorp/golang-lru"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	webhookerrors "k8s.io/apiserver/pkg/admission/plugin/webhook/errors"
 	"k8s.io/client-go/rest"
@@ -54,8 +56,13 @@ func NewClientManager() (ClientManager, error) {
 	if err != nil {
 		return ClientManager{}, err
 	}
+	admissionScheme := runtime.NewScheme()
+	admissionv1beta1.AddToScheme(admissionScheme)
 	return ClientManager{
 		cache: cache,
+		negotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
+			Serializer: serializer.NewCodecFactory(admissionScheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
+		}),
 	}, nil
 }
 
@@ -77,11 +84,6 @@ func (cm *ClientManager) SetServiceResolver(sr ServiceResolver) {
 	if sr != nil {
 		cm.serviceResolver = sr
 	}
-}
-
-// SetNegotiatedSerializer sets the NegotiatedSerializer.
-func (cm *ClientManager) SetNegotiatedSerializer(n runtime.NegotiatedSerializer) {
-	cm.negotiatedSerializer = n
 }
 
 // Validate checks if ClientManager is properly set up.

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/api/admissionregistration/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -131,9 +130,6 @@ func (a *MutatingWebhook) SetServiceResolver(sr config.ServiceResolver) {
 // SetScheme sets a serializer(NegotiatedSerializer) which is derived from the scheme
 func (a *MutatingWebhook) SetScheme(scheme *runtime.Scheme) {
 	if scheme != nil {
-		a.clientManager.SetNegotiatedSerializer(serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
-			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
-		}))
 		a.convertor.Scheme = scheme
 		a.defaulter = scheme
 		a.jsonSerializer = json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, false)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/api/admissionregistration/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/configuration"
@@ -128,9 +127,6 @@ func (a *ValidatingAdmissionWebhook) SetServiceResolver(sr config.ServiceResolve
 // SetScheme sets a serializer(NegotiatedSerializer) which is derived from the scheme
 func (a *ValidatingAdmissionWebhook) SetScheme(scheme *runtime.Scheme) {
 	if scheme != nil {
-		a.clientManager.SetNegotiatedSerializer(serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
-			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1beta1.SchemeGroupVersion),
-		}))
 		a.convertor.Scheme = scheme
 	}
 }


### PR DESCRIPTION
An alternative to #60965.
Fix #60963.
Fix kubernetes/sample-apiserver#21.

Created a scheme that only understands admission/v1beta1 and use it to
encode/decode admissionReviews.

```release-note
The webhook admission controller in a custom apiserver now works off-the-shelf.
```

cc @sttts 