### PR TITLE
update metrics to true like it is for kube-apiserver

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -419,7 +419,6 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 	genericConfig.OpenAPIConfig.PostProcessSpec = postProcessOpenAPISpecForBackwardCompatibility
 	genericConfig.OpenAPIConfig.Info.Title = "Kubernetes"
 	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
-	genericConfig.EnableMetrics = true
 	genericConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
 		sets.NewString("watch", "proxy"),
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"),

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -284,9 +284,6 @@ func (cfg *Config) Complete(informers informers.SharedInformerFactory) Completed
 		c.ExtraConfig.EndpointReconcilerConfig.Reconciler = cfg.createEndpointReconciler()
 	}
 
-	// this has always been hardcoded true in the past
-	c.GenericConfig.EnableMetrics = true
-
 	return CompletedConfig{&c}
 }
 

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -108,7 +108,6 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, informers.SharedI
 	config.GenericConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.GenericConfig.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	config.GenericConfig.LoopbackClientConfig = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs}}
-	config.GenericConfig.EnableMetrics = true
 	config.ExtraConfig.EnableCoreControllers = false
 	config.ExtraConfig.KubeletClientConfig = kubeletclient.KubeletClientConfig{Port: 10250}
 	config.ExtraConfig.ProxyTransport = utilnet.SetTransportDefaults(&http.Transport{

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -262,6 +262,7 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		EnableIndex:                  true,
 		EnableDiscovery:              true,
 		EnableProfiling:              true,
+		EnableMetrics:                true,
 		MaxRequestsInFlight:          400,
 		MaxMutatingRequestsInFlight:  200,
 		RequestTimeout:               time.Duration(60) * time.Second,

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -109,6 +109,7 @@ func TestNewWithDelegate(t *testing.T) {
     "/healthz/poststarthook/generic-apiserver-start-informers",
     "/healthz/poststarthook/wrapping-post-start-hook",
     "/healthz/wrapping-health",
+    "/metrics",
     "/swaggerapi"
   ]
 }`, t)

--- a/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
+++ b/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
@@ -33,7 +33,6 @@ import (
 func TestAdmission(t *testing.T) {
 	masterConfig := framework.NewMasterConfig()
 	masterConfig.GenericConfig.EnableProfiling = true
-	masterConfig.GenericConfig.EnableMetrics = true
 	masterConfig.GenericConfig.AdmissionControl = defaulttolerationseconds.NewDefaultTolerationSeconds()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -124,8 +124,6 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 
 	if masterConfig == nil {
 		masterConfig = NewMasterConfig()
-		masterConfig.GenericConfig.EnableProfiling = true
-		masterConfig.GenericConfig.EnableMetrics = true
 		masterConfig.GenericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, legacyscheme.Scheme)
 		masterConfig.GenericConfig.OpenAPIConfig.Info = &spec.Info{
 			InfoProps: spec.InfoProps{
@@ -218,6 +216,15 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	return m, s, closeFn
 }
 
+// Returns the master config appropriate for most integration tests.
+func NewIntegrationTestMasterConfig() *master.Config {
+	masterConfig := NewMasterConfig()
+	masterConfig.ExtraConfig.EnableCoreControllers = true
+	masterConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	masterConfig.ExtraConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
+	return masterConfig
+}
+
 // Returns a basic master config.
 func NewMasterConfig() *master.Config {
 	// This causes the integration tests to exercise the etcd
@@ -280,7 +287,6 @@ func NewMasterConfig() *master.Config {
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
 	genericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
-	genericConfig.EnableMetrics = true
 
 	err := etcdOptions.ApplyWithStorageFactoryTo(storageFactory, genericConfig)
 	if err != nil {
@@ -300,15 +306,6 @@ func NewMasterConfig() *master.Config {
 	}
 }
 
-// Returns the master config appropriate for most integration tests.
-func NewIntegrationTestMasterConfig() *master.Config {
-	masterConfig := NewMasterConfig()
-	masterConfig.ExtraConfig.EnableCoreControllers = true
-	masterConfig.GenericConfig.PublicAddress = net.ParseIP("192.168.10.4")
-	masterConfig.ExtraConfig.APIResourceConfigSource = master.DefaultAPIResourceConfigSource()
-	return masterConfig
-}
-
 // CloseFunc can be called to cleanup the master
 type CloseFunc func()
 
@@ -316,7 +313,6 @@ func RunAMaster(masterConfig *master.Config) (*master.Master, *httptest.Server, 
 	if masterConfig == nil {
 		masterConfig = NewMasterConfig()
 		masterConfig.GenericConfig.EnableProfiling = true
-		masterConfig.GenericConfig.EnableMetrics = true
 	}
 	return startMasterOrDie(masterConfig, nil, nil)
 }


### PR DESCRIPTION
The kube-apiserver always hardcoded to true, but nothing else knew too.  I changed the default to true (I can't think of why you wouldn't want it even if you don't often use it).

@kubernetes/sig-api-machinery-bugs 
@MikeSpreitzer see if this fixes you?