### PR TITLE
cronjob_remove_getNextStartTimeAfter

### DIFF
--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -89,24 +89,6 @@ func groupJobsByParent(js []batchv1.Job) map[types.UID][]batchv1.Job {
 	return jobsBySj
 }
 
-// getNextStartTimeAfter gets the latest scheduled start time that is less than "now", or an error.
-func getNextStartTimeAfter(schedule string, now time.Time) (time.Time, error) {
-	// Using robfig/cron for cron scheduled parsing and next runtime
-	// computation. Not using the entire library because:
-	// - I want to detect when we missed a runtime due to being down.
-	//   - How do I set the time such that I can detect the last known runtime?
-	// - I guess the functions could launch a go-routine to start the job and
-	// then return.
-	// How to handle concurrency control.
-	// How to detect changes to schedules or deleted schedules and then
-	// update the jobs?
-	sched, err := cron.Parse(schedule)
-	if err != nil {
-		return time.Unix(0, 0), fmt.Errorf("Unparseable schedule: %s : %s", schedule, err)
-	}
-	return sched.Next(now), nil
-}
-
 // getRecentUnmetScheduleTimes gets a slice of times (from oldest to latest) that have passed when a Job should have started but did not.
 //
 // If there are too many (>100) unstarted times, just give up and return an empty slice.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`getNextStartTimeAfter` has not been used anywhere in Kubernetes and as it is a inter-pkg method, it is safe to remove it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
