### PR TITLE
Added e2e test for local volume provisioner discovery of new mountpoints while running.

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -403,6 +403,24 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			By("Deleting provisioner daemonset")
 			deleteProvisionerDaemonset(config)
 		})
+		It("should discover dynamicly created local persistent volume mountpoint in discovery directory", func() {
+			By("Starting a provisioner daemonset")
+			createProvisionerDaemonset(config)
+
+			By("Creating a volume in discovery directory")
+			dynamicVolumePath := path.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
+			setupLocalVolumeProvisionerMountPoint(config, dynamicVolumePath, config.node0)
+
+			By("Waiting for the PersistentVolume to be created")
+			_, err := waitForLocalPersistentVolume(config.client, dynamicVolumePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting provisioner daemonset")
+			deleteProvisionerDaemonset(config)
+
+			By("Deleting volume in discovery directory")
+			cleanupLocalVolumeProvisionerMountPoint(config, dynamicVolumePath, config.node0)
+		})
 	})
 
 	Context("StatefulSet with pod anti-affinity", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an e2e test for the local volume provisioner leveraging of the MountPropogation feature (https://github.com/kubernetes/kubernetes/pull/46444) to discover newly created mountpoints. The MountPropogation feature is now in beta (https://github.com/kubernetes/kubernetes/blob/master/pkg/features/kube_features.go#L146).

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/58416

**Special notes for your reviewer**:

```
KUBE_FEATURE_GATES="BlockVolume=true" NUM_NODES=1 go run hack/e2e.go -- --up

go run hack/e2e.go -- --test --test_args='--ginkgo.focus=PersistentVolumes-local.*Local.*volume.*provisioner'
```

**Release note**:
```release-note
NONE
```
