### PR TITLE
Automated cherry pick of #60959: Set node external IP for azure node when disabling UseInstanceMetadata

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -132,11 +132,11 @@ func (az *Cloud) VirtualMachineClientListWithRetry() ([]compute.VirtualMachine, 
 }
 
 // GetIPForMachineWithRetry invokes az.getIPForMachine with exponential backoff retry
-func (az *Cloud) GetIPForMachineWithRetry(name types.NodeName) (string, error) {
-	var ip string
+func (az *Cloud) GetIPForMachineWithRetry(name types.NodeName) (string, string, error) {
+	var ip, publicIP string
 	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		var retryErr error
-		ip, retryErr = az.getIPForMachine(name)
+		ip, publicIP, retryErr = az.getIPForMachine(name)
 		if retryErr != nil {
 			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
 			return false, nil
@@ -144,7 +144,7 @@ func (az *Cloud) GetIPForMachineWithRetry(name types.NodeName) (string, error) {
 		glog.V(2).Infof("backoff: success")
 		return true, nil
 	})
-	return ip, err
+	return ip, publicIP, err
 }
 
 // CreateOrUpdateSGWithRetry invokes az.SecurityGroupsClient.CreateOrUpdate with exponential backoff retry

--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -29,9 +29,39 @@ import (
 
 // NodeAddresses returns the addresses of the specified instance.
 func (az *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
+	addressGetter := func(nodeName types.NodeName) ([]v1.NodeAddress, error) {
+		ip, publicIP, err := az.GetIPForMachineWithRetry(nodeName)
+		if err != nil {
+			glog.V(2).Infof("NodeAddresses(%s) abort backoff", nodeName)
+			return nil, err
+		}
+
+		addresses := []v1.NodeAddress{
+			{Type: v1.NodeInternalIP, Address: ip},
+			{Type: v1.NodeHostName, Address: string(name)},
+		}
+		if len(publicIP) > 0 {
+			addresses = append(addresses, v1.NodeAddress{
+				Type:    v1.NodeExternalIP,
+				Address: publicIP,
+			})
+		}
+		return addresses, nil
+	}
+
 	if az.UseInstanceMetadata {
+		isLocalInstance, err := az.isCurrentInstance(name)
+		if err != nil {
+			return nil, err
+		}
+
+		// Not local instance, get addresses from Azure ARM API.
+		if !isLocalInstance {
+			return addressGetter(name)
+		}
+
 		ipAddress := IPAddress{}
-		err := az.metadata.Object("instance/network/interface/0/ipv4/ipAddress/0", &ipAddress)
+		err = az.metadata.Object("instance/network/interface/0/ipv4/ipAddress/0", &ipAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -48,16 +78,8 @@ func (az *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 		}
 		return addresses, nil
 	}
-	ip, err := az.GetIPForMachineWithRetry(name)
-	if err != nil {
-		glog.V(2).Infof("NodeAddresses(%s) abort backoff", name)
-		return nil, err
-	}
 
-	return []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: ip},
-		{Type: v1.NodeHostName, Address: string(name)},
-	}, nil
+	return addressGetter(name)
 }
 
 // NodeAddressesByProviderID returns the node addresses of an instances with the specified unique providerID

--- a/pkg/cloudprovider/providers/azure/azure_routes.go
+++ b/pkg/cloudprovider/providers/azure/azure_routes.go
@@ -103,7 +103,7 @@ func (az *Cloud) CreateRoute(clusterName string, nameHint string, kubeRoute *clo
 		}
 	}
 
-	targetIP, err := az.getIPForMachine(kubeRoute.TargetNode)
+	targetIP, _, err := az.getIPForMachine(kubeRoute.TargetNode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #60959 on release-1.9.

#60959: Set node external IP for azure node when disabling UseInstanceMetadata