### PR TITLE
WIP:Make pod hostname/subdomain feature compatible with Deployments

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2894,6 +2894,9 @@ func ValidatePod(pod *core.Pod) field.ErrorList {
 	fldPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMeta(&pod.ObjectMeta, true, ValidatePodName, fldPath)
 	allErrs = append(allErrs, ValidatePodSpecificAnnotations(pod.ObjectMeta.Annotations, &pod.Spec, fldPath.Child("annotations"))...)
+	if len(pod.Spec.Hostname) == 0 {
+		pod.Spec.Hostname = pod.Name
+	}
 	allErrs = append(allErrs, ValidatePodSpec(&pod.Spec, field.NewPath("spec"))...)
 
 	// we do additional validation only pertinent for pods and not pod templates


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes pod hostname compatible with Deployments by automatically setting pod.Spec.Hostname before pods are created.

 
**Which issue(s) this PR fixes**:
Fixes #60789 

**Special notes for your reviewer**:
Before this PR, Kubelet use pod.name as the default value for ```pod.Spec.Hostname```, but Kubelet Never updates the hostname back into the pod.Spec. This PR fixes this issue by setting the ```pod.Spec.Hostname``` in kube-apiserver using the same rule as kubelet does.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
