### PR TITLE
Separate instance name from node name

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -206,6 +206,10 @@ func startControllers(c *cloudcontrollerconfig.CompletedConfig, kubeconfig *rest
 	versionedClient := rootClientBuilder.ClientOrDie("shared-informers")
 	sharedInformers := informers.NewSharedInformerFactory(versionedClient, resyncPeriod(c)())
 
+	if informerUser, ok := cloud.(cloudprovider.InformerUser); ok {
+		informerUser.SetInformers(sharedInformers)
+	}
+
 	// Start the CloudNodeController
 	nodeController := cloudcontrollers.NewCloudNodeController(
 		sharedInformers.Core().V1().Nodes(),

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -751,7 +751,7 @@ func (gce *GCECloud) addNodeToInstanceMap(newNode *v1.Node) error {
 	defer gce.instanceNameMapLock.Unlock()
 
 	if newNode != nil {
-		instanceName, err := getInstanceName(newNode.Spec.ProviderID)
+		_, _, instanceName, err := splitProviderID(newNode.Spec.ProviderID)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -523,7 +523,7 @@ func (gce *GCECloud) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 }
 
 func (gce *GCECloud) AttachDisk(diskName string, nodeName types.NodeName, readOnly bool, regional bool) error {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	instance, err := gce.getInstanceByName(instanceName)
 	if err != nil {
 		return fmt.Errorf("error getting instance %q", instanceName)
@@ -566,7 +566,7 @@ func (gce *GCECloud) AttachDisk(diskName string, nodeName types.NodeName, readOn
 }
 
 func (gce *GCECloud) DetachDisk(devicePath string, nodeName types.NodeName) error {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	inst, err := gce.getInstanceByName(instanceName)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {
@@ -591,7 +591,7 @@ func (gce *GCECloud) DetachDisk(devicePath string, nodeName types.NodeName) erro
 }
 
 func (gce *GCECloud) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, error) {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	instance, err := gce.getInstanceByName(instanceName)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {
@@ -621,7 +621,7 @@ func (gce *GCECloud) DisksAreAttached(diskNames []string, nodeName types.NodeNam
 	for _, diskName := range diskNames {
 		attached[diskName] = false
 	}
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	instance, err := gce.getInstanceByName(instanceName)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -611,7 +611,7 @@ func (gce *GCECloud) computeHostTags(hosts []*gceInstance) ([]string, error) {
 // GetNodeTags will first try returning the list of tags specified in GCE cloud Configuration.
 // If they weren't provided, it'll compute the host tags with the given hostnames. If the list
 // of hostnames has not changed, a cached set of nodetags are returned.
-func (gce *GCECloud) GetNodeTags(nodeNames []string) ([]string, error) {
+func (gce *GCECloud) GetNodeTags(nodes []*v1.Node) ([]string, error) {
 	// If nodeTags were specified through configuration, use them
 	if len(gce.nodeTags) > 0 {
 		return gce.nodeTags, nil
@@ -621,13 +621,13 @@ func (gce *GCECloud) GetNodeTags(nodeNames []string) ([]string, error) {
 	defer gce.computeNodeTagLock.Unlock()
 
 	// Early return if hosts have not changed
-	hosts := sets.NewString(nodeNames...)
+	hosts := sets.NewString(nodeNames(nodes)...)
 	if hosts.Equal(gce.lastKnownNodeNames) {
 		return gce.lastComputedNodeTags, nil
 	}
 
 	// Get GCE instance data by hostname
-	instances, err := gce.getInstancesByNames(nodeNames)
+	instances, err := gce.getInstancesByNames(gce.instanceNames(nodes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -157,7 +157,7 @@ func (gce *GCECloud) InstanceTypeByProviderID(ctx context.Context, providerID st
 
 // ExternalID returns the cloud provider ID of the node with the specified NodeName (deprecated).
 func (gce *GCECloud) ExternalID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	if gce.useMetadataServer {
 		// Use metadata, if possible, to fetch ID. See issue #12000
 		if gce.isCurrentInstance(instanceName) {
@@ -192,7 +192,7 @@ func (gce *GCECloud) InstanceExistsByProviderID(ctx context.Context, providerID 
 
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
 func (gce *GCECloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	if gce.useMetadataServer {
 		// Use metadata, if possible, to fetch ID. See issue #12000
 		if gce.isCurrentInstance(instanceName) {
@@ -211,7 +211,7 @@ func (gce *GCECloud) InstanceID(ctx context.Context, nodeName types.NodeName) (s
 
 // InstanceType returns the type of the specified node with the specified NodeName.
 func (gce *GCECloud) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	if gce.useMetadataServer {
 		// Use metadata, if possible, to fetch ID. See issue #12000
 		if gce.isCurrentInstance(instanceName) {
@@ -350,7 +350,7 @@ func (gce *GCECloud) CurrentNodeName(ctx context.Context, hostname string) (type
 // "<ip>/<netmask>".
 func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err error) {
 	var instance *gceInstance
-	instance, err = gce.getInstanceByName(mapNodeNameToInstanceName(nodeName))
+	instance, err = gce.getInstanceByName(gce.mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return
 	}
@@ -373,7 +373,7 @@ func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err e
 // secondary range.
 func (gce *GCECloud) AddAliasToInstance(nodeName types.NodeName, alias *net.IPNet) error {
 
-	v1instance, err := gce.getInstanceByName(mapNodeNameToInstanceName(nodeName))
+	v1instance, err := gce.getInstanceByName(gce.mapNodeNameToInstanceName(nodeName))
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -311,7 +311,7 @@ func (gce *GCECloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcN
 
 func (gce *GCECloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, sourceRanges []string, ports []string, protocol v1.Protocol, nodes []*v1.Node) error {
 	glog.V(2).Infof("ensureInternalFirewall(%v): checking existing firewall", fwName)
-	targetTags, err := gce.GetNodeTags(nodeNames(nodes))
+	targetTags, err := gce.GetNodeTags(nodes)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/providers/gce/gce_routes.go
+++ b/pkg/cloudprovider/providers/gce/gce_routes.go
@@ -62,7 +62,7 @@ func (gce *GCECloud) ListRoutes(ctx context.Context, clusterName string) ([]*clo
 func (gce *GCECloud) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
 	mc := newRoutesMetricContext("create")
 
-	targetInstance, err := gce.getInstanceByName(mapNodeNameToInstanceName(route.TargetNode))
+	targetInstance, err := gce.getInstanceByName(gce.mapNodeNameToInstanceName(route.TargetNode))
 	if err != nil {
 		return mc.Observe(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -43,6 +43,7 @@ secondary-range-name = my-secondary-range
 node-tags = my-node-tag1
 node-instance-prefix = my-prefix
 multizone = true
+instance-name = vm-123456abcd
    `
 	reader := strings.NewReader(s)
 	config, err := readConfig(reader)
@@ -61,6 +62,7 @@ multizone = true
 		NodeTags:           []string{"my-node-tag1"},
 		NodeInstancePrefix: "my-prefix",
 		Multizone:          true,
+		InstanceName:       "vm-123456abcd",
 	}}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -460,6 +462,19 @@ func TestGenerateCloudConfigs(t *testing.T) {
 			cloud: func() CloudConfig {
 				v := cloudBoilerplate
 				v.SecondaryRangeName = "my-secondary"
+				return v
+			},
+		},
+		{
+			name: "Instance Name",
+			config: func() ConfigGlobal {
+				v := configBoilerplate
+				v.InstanceName = "vm-instancename"
+				return v
+			},
+			cloud: func() CloudConfig {
+				v := cloudBoilerplate
+				v.InstanceName = "vm-instancename"
 				return v
 			},
 		},

--- a/pkg/cloudprovider/providers/gce/gce_util.go
+++ b/pkg/cloudprovider/providers/gce/gce_util.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -133,9 +135,24 @@ func lastComponent(s string) string {
 }
 
 // mapNodeNameToInstanceName maps a k8s NodeName to a GCE Instance Name
-// This is a simple string cast.
-func mapNodeNameToInstanceName(nodeName types.NodeName) string {
-	return string(nodeName)
+func (gce *GCECloud) mapNodeNameToInstanceName(nodeName types.NodeName) string {
+	instanceName, ok := gce.instanceNameMap[string(nodeName)]
+	if !ok {
+		if gce.instanceName == "" {
+			instanceName = string(nodeName)
+		} else {
+			instanceName = gce.instanceName
+		}
+	}
+	return instanceName
+}
+
+func getInstanceName(providerID string) (string, error) {
+	u, err := url.Parse(providerID)
+	if err != nil {
+		return "", err
+	}
+	return path.Base(u.Path), nil
 }
 
 // mapInstanceToNodeName maps a GCE Instance to a k8s NodeName

--- a/pkg/cloudprovider/providers/gce/gce_util.go
+++ b/pkg/cloudprovider/providers/gce/gce_util.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
-	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -145,14 +143,6 @@ func (gce *GCECloud) mapNodeNameToInstanceName(nodeName types.NodeName) string {
 		}
 	}
 	return instanceName
-}
-
-func getInstanceName(providerID string) (string, error) {
-	u, err := url.Parse(providerID)
-	if err != nil {
-		return "", err
-	}
-	return path.Base(u.Path), nil
 }
 
 // mapInstanceToNodeName maps a GCE Instance to a k8s NodeName

--- a/pkg/cloudprovider/providers/gce/gce_zones.go
+++ b/pkg/cloudprovider/providers/gce/gce_zones.go
@@ -58,7 +58,7 @@ func (gce *GCECloud) GetZoneByProviderID(ctx context.Context, providerID string)
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
 func (gce *GCECloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	instanceName := mapNodeNameToInstanceName(nodeName)
+	instanceName := gce.mapNodeNameToInstanceName(nodeName)
 	instance, err := gce.getInstanceByName(instanceName)
 	if err != nil {
 		return cloudprovider.Zone{}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This change allows the node's instance name to be provided through the cloud config file when using the GCE cloud provider. That allows the node's hostname to be different from GCE instance name, which helps an operator to bring their own TLS certs for nodes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This change is fully backwards compatible, if an operator wants to keep using the GCP instance-name as hostname and node-name, no extra configuration is required. 

However, if the operator wants to give different hostnames and bring their own TLS, they'd need  to:

1. Add `instance-name` to the GCE cloud config
2. Start kubelet with --hostname-override set to whatever hostname they would like the kubelet to be addressed with
```
