### PR TITLE
kubelet initial flag parse should normalize flags instead of exiting

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -104,6 +104,7 @@ const (
 // NewKubeletCommand creates a *cobra.Command object with default parameters
 func NewKubeletCommand() *cobra.Command {
 	cleanFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ContinueOnError)
+	cleanFlagSet.SetNormalizeFunc(flag.WordSepNormalizeFunc)
 	kubeletFlags := options.NewKubeletFlags()
 	kubeletConfig, err := options.NewKubeletConfiguration()
 	// programmer error


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets normalize func for kubelet cleanFlagSet, otherwise kubelet will exit if non-normalized flag is used. For example, this happened on a kubelet running v1.10.0-beta.2:
```
F0312 17:59:03.138986   25317 server.go:144] unknown flag: --cluster_dns
```

This is where the kubelet exits: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L142-L145. This would be a breaking change for anyone upgrading Kubernetes and using `_` in their flag names. 

```release-note
kubelet initial flag parse should normalize flags instead of exiting. 
```
