### PR TITLE
Observe .spec.publishNotReadyAddresses.

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -428,6 +428,8 @@ func (e *EndpointController) syncService(key string) error {
 		} else {
 			utilruntime.HandleError(fmt.Errorf("Failed to parse annotation %v: %v", TolerateUnreadyEndpointsAnnotation, err))
 		}
+	} else {
+		tolerateUnreadyEndpoints = service.Spec.PublishNotReadyAddresses
 	}
 
 	subsets := []v1.EndpointSubset{}

--- a/test/e2e/testing-manifests/statefulset/cockroachdb/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/service.yaml
@@ -9,13 +9,6 @@ metadata:
   labels:
     app: cockroachdb
   annotations:
-    # This is needed to make the peer-finder work properly and to help avoid
-    # edge cases where instance 0 comes up after losing its data and needs to
-    # decide whether it should create a new cluster or try to join an existing
-    # one. If it creates a new cluster when it should have joined an existing
-    # one, we'd end up with two separate clusters listening at the same service
-    # endpoint, which would be very bad.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"
@@ -31,3 +24,10 @@ spec:
   clusterIP: None
   selector:
     app: cockroachdb
+  # This is needed to make the peer-finder work properly and to help avoid
+  # edge cases where instance 0 comes up after losing its data and needs to
+  # decide whether it should create a new cluster or try to join an existing
+  # one. If it creates a new cluster when it should have joined an existing
+  # one, we'd end up with two separate clusters listening at the same service
+  # endpoint, which would be very bad.
+  publishNotReadyAddresses: true

--- a/test/e2e/testing-manifests/statefulset/etcd/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/service.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-metadata:
   name: etcd
   labels:
     app: etcd
@@ -16,3 +13,4 @@ spec:
   clusterIP: None
   selector:
     app: etcd
+  publishNotReadyAddresses: true

--- a/test/e2e/testing-manifests/statefulset/mysql-galera/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-galera/service.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: galera
   labels:
     app: mysql
@@ -15,4 +13,4 @@ spec:
   clusterIP: None
   selector:
     app: mysql
-
+  publishNotReadyAddresses: true

--- a/test/e2e/testing-manifests/statefulset/redis/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/service.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: redis
   labels:
     app: redis
@@ -15,4 +13,5 @@ spec:
   clusterIP: None
   selector:
     app: redis
+  publishNotReadyAddresses: true
 

--- a/test/e2e/testing-manifests/statefulset/zookeeper/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/service.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: zk
   labels:
     app: zk
@@ -17,4 +15,5 @@ spec:
   clusterIP: None
   selector:
     app: zk
+  publishNotReadyAddresses: true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR makes a service's `.spec.publishNotReadyAddresses` field be observed when set to `true`. If set to `false` or not set, the value to `service.alpha.kubernetes.io/tolerate-unready-endpoints` is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #58662.

**Special notes for your reviewer**:
I am not sure what the best way to test this would be. Would appreciate some guidance.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Observe `.spec.publishNotReadyAddresses` if set to `true`.
```
