### PR TITLE
AWS NLB: Support cross-zone load balancing annotation

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -313,6 +313,64 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 			}
 		}
 
+		desiredLoadBalancerAttributes := map[string]string{}
+		// Default values to ensured a remove annotation reverts back to the default
+		desiredLoadBalancerAttributes["load_balancing.cross_zone.enabled"] = "false"
+
+		// Determine if cross zone load balancing enabled/disabled has been specified
+		crossZoneLoadBalancingEnabledAnnotation := annotations[ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled]
+		if crossZoneLoadBalancingEnabledAnnotation != "" {
+			crossZoneEnabled, err := strconv.ParseBool(crossZoneLoadBalancingEnabledAnnotation)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing service annotation: %s=%s",
+					ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled,
+					crossZoneLoadBalancingEnabledAnnotation,
+				)
+			}
+
+			if crossZoneEnabled {
+				desiredLoadBalancerAttributes["load_balancing.cross_zone.enabled"] = "true"
+			}
+		}
+
+		// Whether the ELB was new or existing, sync attributes regardless. This accounts for things
+		// that cannot be specified at the time of creation and can only be modified after the fact,
+		// e.g. idle connection timeout.
+		describeAttributesRequest := &elbv2.DescribeLoadBalancerAttributesInput{
+			LoadBalancerArn: loadBalancer.LoadBalancerArn,
+		}
+		describeAttributesOutput, err := c.elbv2.DescribeLoadBalancerAttributes(describeAttributesRequest)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to retrieve load balancer attributes during attribute sync: %q", err)
+		}
+
+		changedAttributes := []*elbv2.LoadBalancerAttribute{}
+
+		// Identify to be changed attributes
+		for _, foundAttribute := range describeAttributesOutput.Attributes {
+			if targetValue, ok := desiredLoadBalancerAttributes[*foundAttribute.Key]; ok {
+				if targetValue != *foundAttribute.Value {
+					changedAttributes = append(changedAttributes, &elbv2.LoadBalancerAttribute{
+						Key:   foundAttribute.Key,
+						Value: aws.String(targetValue),
+					})
+				}
+			}
+		}
+
+		// Update attributes requiring changes
+		if len(changedAttributes) > 0 {
+			klog.V(2).Infof("Updating load-balancer attributes for %q", loadBalancerName)
+
+			_, err = c.elbv2.ModifyLoadBalancerAttributes(&elbv2.ModifyLoadBalancerAttributesInput{
+				LoadBalancerArn: loadBalancer.LoadBalancerArn,
+				Attributes:      changedAttributes,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Unable to update load balancer attributes during attribute sync: %q", err)
+			}
+		}
+
 		// Subnets cannot be modified on NLBs
 		if dirty {
 			loadBalancers, err := c.elbv2.DescribeLoadBalancers(


### PR DESCRIPTION
AWS Network Load Balancer recently got support for cross-zone load balancing.

Use the existing `service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled`
annotation to configure it.

AWS release announcement:
https://aws.amazon.com/about-aws/whats-new/2018/02/network-load-balancer-now-supports-cross-zone-load-balancing/

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AWS NLB: Support cross-zone load balancing annotation
```
