### PR TITLE
Exclude commas when pulling the tag out of the git export-subst format string

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -45,7 +45,7 @@ kube::version::get_version_vars() {
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.
-    if [[ '$Format:%D$' =~ tag:\ (v[^ ]+) ]]; then
+    if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
      KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
     fi
   fi


### PR DESCRIPTION
**What this PR does / why we need it**: the version tag is not guaranteed to be the last item in the ref names substituted into the format string, so we need to be sure not to match on the trailing comma.

For example, v1.9.3 was exported with `HEAD -> release-1.9, tag: v1.9.3, origin/release-1.9`, where we only want to match `v1.9.3`, not `v1.9.3,`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61029, though we need to backport this to all active branches.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @david-mcmahon 
/priority important-soon
