### PR TITLE
Marked '--admission-control' flag as deprecated

### DIFF
--- a/cluster/centos/master/scripts/apiserver.sh
+++ b/cluster/centos/master/scripts/apiserver.sh
@@ -60,7 +60,7 @@ KUBE_ALLOW_PRIV="--allow-privileged=false"
 # This must not overlap with any IP ranges assigned to nodes for pods.
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}"
 
-# --admission-control="AlwaysAdmit": Ordered list of plug-ins
+# --admission-control="AlwaysAdmit": DEPRECATED (Use '--enable-admission-plugins' and '--disable-admission-plugins') Ordered list of plug-ins
 # to do admission control of resources into cluster.
 # Comma-delimited list of:
 #   LimitRanger, AlwaysDeny, SecurityContextDeny, NamespaceExists,


### PR DESCRIPTION
**What this PR does / why we need it**:

To fix kubernetes/website-issue-7235, updating the docs to replace the '--admission-control' flag with the '--(enable|disable)-admission-plugins' flags. In this case, marked the old flag as 'DEPRECATED' in doc comments (used to generate website reference doc). 
The other file used to generate relevant reference doc (pkg/kubeapiserver/options/admission.go) has the old flag already marked deprecated. 

@jdumars 

**Release note**:
```release-note
NONE
```

@Bradamant3 