### PR TITLE
don't do attach and deatch when cinder volume status is error

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -310,7 +310,8 @@ func (os *OpenStack) OperationPending(diskName string) (bool, string, error) {
 	}
 	volumeStatus := volume.Status
 	if volumeStatus == volumeErrorStatus {
-		return false, volumeStatus, nil
+		err = fmt.Errorf("status of volume %s is %s", diskName, volumeStatus)
+		return false, volumeStatus, err
 	}
 	if volumeStatus == volumeAvailableStatus || volumeStatus == volumeInUseStatus || volumeStatus == volumeDeletedStatus {
 		return false, volume.Status, nil


### PR DESCRIPTION
When cinder volume status is `error`, it is not supposed to handle operation like `attach` and `detach`

@dims  @FengyunPan2

```release-note
cinder volume plugin : 
When the cinder volume status is `error`,  controller will not do `attach ` and `detach ` operation
```  
