### PR TITLE
fix bug in apiserver.k8s.io RootScopedKinds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
@@ -30,7 +30,7 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apiserver.GroupName,
-			RootScopedKinds:            sets.NewString("APIService"),
+			RootScopedKinds:            sets.NewString("AdmissionConfiguration"),
 			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: apiserver.AddToScheme,
 		},


### PR DESCRIPTION
RootScopedKinds in group ` apiserver.k8s.io` should be `AdmissionConfiguration`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
