### PR TITLE
fixtodo:Add TestValidateMutatingWebhookConfiguration for mutating webhooks

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -242,7 +242,526 @@ func newValidatingWebhookConfiguration(hooks []admissionregistration.Webhook) *a
 	}
 }
 
-// TODO: Add TestValidateMutatingWebhookConfiguration to test validation for mutating webhooks.
+func newMutatingWebhookConfiguration(hooks []admissionregistration.Webhook) *admissionregistration.MutatingWebhookConfiguration {
+	return &admissionregistration.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config",
+		},
+		Webhooks: hooks,
+	}
+}
+
+func TestValidateMutatingWebhookConfiguration(t *testing.T) {
+	validClientConfig := admissionregistration.WebhookClientConfig{
+		URL: strPtr("https://example.com"),
+	}
+	tests := []struct {
+		name          string
+		config        *admissionregistration.MutatingWebhookConfiguration
+		expectedError string
+	}{
+		{
+			name: "all Webhooks must have a fully qualified name",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+					},
+					{
+						Name:         "k8s.io",
+						ClientConfig: validClientConfig,
+					},
+					{
+						Name:         "",
+						ClientConfig: validClientConfig,
+					},
+				}),
+			expectedError: `webhooks[1].name: Invalid value: "k8s.io": should be a domain with at least three segments separated by dots, webhooks[2].name: Required value`,
+		},
+		{
+			name: "Operations must not be empty or nil",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a"},
+								},
+							},
+							{
+								Operations: nil,
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `webhooks[0].rules[0].operations: Required value, webhooks[0].rules[1].operations: Required value`,
+		},
+		{
+			name: "\"\" is NOT a valid operation",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE", ""},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `Unsupported value: ""`,
+		},
+		{
+			name: "operation must be either create/update/delete/connect",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"PATCH"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `Unsupported value: "PATCH"`,
+		},
+		{
+			name: "wildcard operation cannot be mixed with other strings",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE", "*"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `if '*' is present, must not specify other operations`,
+		},
+		{
+			name: `resource "*" can co-exist with resources that have subresources`,
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"*", "a/b", "a/*", "*/b"},
+								},
+							},
+						},
+					},
+				}),
+		},
+		{
+			name: `resource "*" cannot mix with resources that don't have subresources`,
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"*", "a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `if '*' is present, must not specify other resources without subresources`,
+		},
+		{
+			name: "resource a/* cannot mix with a/x",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a/*", "a/x"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `webhooks[0].rules[0].resources[1]: Invalid value: "a/x": if 'a/*' is present, must not specify a/x`,
+		},
+		{
+			name: "resource a/* can mix with a",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"a/*", "a"},
+								},
+							},
+						},
+					},
+				}),
+		},
+		{
+			name: "resource */a cannot mix with x/a",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"*/a", "x/a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `webhooks[0].rules[0].resources[1]: Invalid value: "x/a": if '*/a' is present, must not specify x/a`,
+		},
+		{
+			name: "resource */* cannot mix with other resources",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						Rules: []admissionregistration.RuleWithOperations{
+							{
+								Operations: []admissionregistration.OperationType{"CREATE"},
+								Rule: admissionregistration.Rule{
+									APIGroups:   []string{"a"},
+									APIVersions: []string{"a"},
+									Resources:   []string{"*/*", "a"},
+								},
+							},
+						},
+					},
+				}),
+			expectedError: `webhooks[0].rules[0].resources: Invalid value: []string{"*/*", "a"}: if '*/*' is present, must not specify other resources`,
+		},
+		{
+			name: "FailurePolicy can only be \"Ignore\" or \"Fail\"",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: validClientConfig,
+						FailurePolicy: func() *admissionregistration.FailurePolicyType {
+							r := admissionregistration.FailurePolicyType("other")
+							return &r
+						}(),
+					},
+				}),
+			expectedError: `webhooks[0].failurePolicy: Unsupported value: "other": supported values: "Fail", "Ignore"`,
+		},
+		{
+			name: "both service and URL missing",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name:         "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{},
+					},
+				}),
+			expectedError: `exactly one of`,
+		},
+		{
+			name: "both service and URL provided",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+							},
+							URL: strPtr("example.com/k8s/webhook"),
+						},
+					},
+				}),
+			expectedError: `[0].clientConfig.url: Required value: exactly one of url or service is required`,
+		},
+		{
+			name: "blank URL",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr(""),
+						},
+					},
+				}),
+			expectedError: `[0].clientConfig.url: Invalid value: "": host must be provided`,
+		},
+		{
+			name: "wrong scheme",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("http://example.com"),
+						},
+					},
+				}),
+			expectedError: `https`,
+		},
+		{
+			name: "missing host",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("https:///fancy/webhook"),
+						},
+					},
+				}),
+			expectedError: `host must be provided`,
+		},
+		{
+			name: "fragment",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("https://example.com/#bookmark"),
+						},
+					},
+				}),
+			expectedError: `"bookmark": fragments are not permitted`,
+		},
+		{
+			name: "query",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("https://example.com?arg=value"),
+						},
+					},
+				}),
+			expectedError: `"arg=value": query parameters are not permitted`,
+		},
+		{
+			name: "user",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("https://harry.potter@example.com/"),
+						},
+					},
+				}),
+			expectedError: `"harry.potter": user information is not permitted`,
+		},
+		{
+			name: "just totally wrong",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL: strPtr("arg#backwards=thisis?html.index/port:host//:https"),
+						},
+					},
+				}),
+			expectedError: `host must be provided`,
+		},
+		{
+			name: "path must start with slash",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("foo/"),
+							},
+						},
+					},
+				}),
+			expectedError: `clientConfig.service.path: Invalid value: "foo/": must start with a '/'`,
+		},
+		{
+			name: "path accepts slash",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("/"),
+							},
+						},
+					},
+				}),
+			expectedError: ``,
+		},
+		{
+			name: "path accepts no trailing slash",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("/foo"),
+							},
+						},
+					},
+				}),
+			expectedError: ``,
+		},
+		{
+			name: "path fails //",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("//"),
+							},
+						},
+					},
+				}),
+			expectedError: `clientConfig.service.path: Invalid value: "//": segment[0] may not be empty`,
+		},
+		{
+			name: "path no empty step",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("/foo//bar/"),
+							},
+						},
+					},
+				}),
+			expectedError: `clientConfig.service.path: Invalid value: "/foo//bar/": segment[1] may not be empty`,
+		},
+		{
+			name: "path no empty step 2",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("/foo/bar//"),
+							},
+						},
+					},
+				}),
+			expectedError: `clientConfig.service.path: Invalid value: "/foo/bar//": segment[2] may not be empty`,
+		},
+		{
+			name: "path no non-subdomain",
+			config: newMutatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							Service: &admissionregistration.ServiceReference{
+								Namespace: "ns",
+								Name:      "n",
+								Path:      strPtr("/apis/foo.bar/v1alpha1/--bad"),
+							},
+						},
+					},
+				}),
+			expectedError: `clientConfig.service.path: Invalid value: "/apis/foo.bar/v1alpha1/--bad": segment[3]: a DNS-1123 subdomain`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := ValidateMutatingWebhookConfiguration(test.config)
+			err := errs.ToAggregate()
+			if err != nil {
+				if e, a := test.expectedError, err.Error(); !strings.Contains(a, e) || e == "" {
+					t.Errorf("expected to contain %s, got %s", e, a)
+				}
+			} else {
+				if test.expectedError != "" {
+					t.Errorf("unexpected no error, expected to contain %s", test.expectedError)
+				}
+			}
+		})
+
+	}
+}
 
 func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 	validClientConfig := admissionregistration.WebhookClientConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
fixtodo:Add TestValidateMutatingWebhookConfiguration to test validation for mutating webhooks
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
There is a TODO: Add TestValidateMutatingWebhookConfiguration to test validation for mutating webhooks. So I add the unit test
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
