### PR TITLE
Replaced hardcoded busybox image in e2e tests

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
 	frameworkmetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -56,7 +57,7 @@ var kubeletAddress = flag.String("kubelet-address", "http://127.0.0.1:10255", "H
 
 var startServices = flag.Bool("start-services", true, "If true, start local node services")
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
-var busyboxImage = "busybox"
+var busyboxImage = imageutils.GetE2EImage(imageutils.BusyBox)
 
 const (
 	// Kubelet internal cgroup name for node allocatable cgroup.


### PR DESCRIPTION
Some e2e tests use hardcoded busybox image. Replaced it with the one defined in "k8s.io/kubernetes/test/utils/image". This is relevant to the work of porting e2e tests to Windows k8s clusters.

Related to issue #60487

 ```release-note
NONE
 ```