### PR TITLE
Use mktemp instead of static temporary file path in scripts.

### DIFF
--- a/hack/build-ui.sh
+++ b/hack/build-ui.sh
@@ -30,7 +30,8 @@ if ! which go-bindata > /dev/null 2>&1 ; then
   exit 1
 fi
 
-readonly TMP_DATAFILE="/tmp/datafile.go"
+kube::util::ensure-temp-dir
+readonly TMP_DATAFILE="${KUBE_TEMP}/datafile.go"
 readonly SWAGGER_SRC="third_party/swagger-ui/..."
 readonly SWAGGER_PKG="swagger"
 

--- a/hack/update-translations.sh
+++ b/hack/update-translations.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
 KUBECTL_FILES="pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go"
 
 generate_pot="false"
@@ -62,8 +65,9 @@ if [[ "${generate_pot}" == "true" ]]; then
   perl -pi -e 's/CHARSET/UTF-8/' tmp.pot
   perl -pi -e 's/\\\(/\\\\\(/g' tmp.pot
   perl -pi -e 's/\\\)/\\\\\)/g' tmp.pot
-  if msgcat -s tmp.pot > /tmp/template.pot; then
-    mv /tmp/template.pot translations/kubectl/template.pot
+  kube::util::ensure-temp-dir
+  if msgcat -s tmp.pot > "${KUBE_TEMP}/template.pot"; then
+    mv "${KUBE_TEMP}/template.pot" translations/kubectl/template.pot
     rm tmp.pot
   else
     echo "Failed to update template.pot"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Using static file names in `/tmp` is considered to be a security anti-pattern, even if the modern Linux distributions make it difficult for the attacker to use symbolic link attacks against the `/tmp` directory. We should consider changing to the pattern of safely creating a temporary directory which only the user can access and placing the temporary files there. This assumes that `mktemp` command is installed -- it should be a safe assumption since the command is already widely used in the kubernetes scripts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
