### PR TITLE
stop using AlwaysAdmit admission

### DIFF
--- a/test/integration/auth/BUILD
+++ b/test/integration/auth/BUILD
@@ -44,7 +44,6 @@ go_test(
         "//pkg/registry/rbac/rolebinding:go_default_library",
         "//pkg/registry/rbac/rolebinding/storage:go_default_library",
         "//pkg/serviceaccount:go_default_library",
-        "//plugin/pkg/admission/admit:go_default_library",
         "//plugin/pkg/admission/noderestriction:go_default_library",
         "//plugin/pkg/auth/authenticator/token/bootstrap:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac:go_default_library",

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -31,7 +31,6 @@ import (
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -57,7 +56,6 @@ func TestSubjectAccessReview(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
 	masterConfig.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
-	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()
 
@@ -151,7 +149,6 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 		return &user.DefaultInfo{Name: username}, true, nil
 	})
 	masterConfig.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
-	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()
 
@@ -231,7 +228,6 @@ func TestLocalSubjectAccessReview(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
 	masterConfig.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
-	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()
 

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -51,7 +51,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
-	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -555,7 +554,6 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	masterConfig := framework.NewIntegrationTestMasterConfig()
 	masterConfig.GenericConfig.Authentication.Authenticator = getTestTokenAuth()
 	masterConfig.GenericConfig.Authorization.Authorizer = allowAliceAuthorizer{}
-	masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()
 

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	bootstrapapi "k8s.io/client-go/tools/bootstrap/token/api"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
 	bootstraputil "k8s.io/kubernetes/test/e2e/lifecycle/bootstrap"
 	"k8s.io/kubernetes/test/integration"
@@ -126,7 +125,6 @@ func TestBootstrapTokenAuth(t *testing.T) {
 		// Set up a master
 		masterConfig := framework.NewIntegrationTestMasterConfig()
 		masterConfig.GenericConfig.Authentication.Authenticator = authenticator
-		masterConfig.GenericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 		_, s, closeFn := framework.RunAMaster(masterConfig)
 		defer closeFn()
 

--- a/test/integration/framework/BUILD
+++ b/test/integration/framework/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//pkg/master:go_default_library",
         "//pkg/util/env:go_default_library",
         "//pkg/version:go_default_library",
-        "//plugin/pkg/admission/admit:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -59,7 +59,6 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/version"
-	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 )
 
 // Config is a struct of configuration directives for NewMasterComponents.
@@ -281,7 +280,6 @@ func NewMasterConfig() *master.Config {
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
 	genericConfig.Authorization.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()
-	genericConfig.AdmissionControl = admit.NewAlwaysAdmit()
 	genericConfig.EnableMetrics = true
 
 	err := etcdOptions.ApplyWithStorageFactoryTo(storageFactory, genericConfig)


### PR DESCRIPTION

`AlwaysAdmit ` was deprecated, and stop using it in test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
