### PR TITLE
Fix subpath e2e tests on multizone cluster.

### DIFF
--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -552,7 +552,7 @@ func (s *emptydirSource) cleanupVolume(f *framework.Framework) {
 }
 
 type gcepdSource struct {
-	diskName string
+	pvc *v1.PersistentVolumeClaim
 }
 
 func initGCEPD() volSource {
@@ -563,21 +563,29 @@ func initGCEPD() volSource {
 func (s *gcepdSource) createVolume(f *framework.Framework) volInfo {
 	var err error
 
-	framework.Logf("Creating GCE PD volume")
-	s.diskName, err = framework.CreatePDWithRetry()
-	framework.ExpectNoError(err, "Error creating PD")
+	framework.Logf("Creating GCE PD volume via dynamic provisioning")
+	testCase := storageClassTest{
+		name:      "subpath",
+		claimSize: "2G",
+	}
+
+	pvc := newClaim(testCase, f.Namespace.Name, "subpath")
+	s.pvc, err = framework.CreatePVC(f.ClientSet, f.Namespace.Name, pvc)
+	framework.ExpectNoError(err, "Error creating PVC")
 
 	return volInfo{
 		source: &v1.VolumeSource{
-			GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{PDName: s.diskName},
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				ClaimName: s.pvc.Name,
+			},
 		},
 	}
 }
 
 func (s *gcepdSource) cleanupVolume(f *framework.Framework) {
-	if s.diskName != "" {
-		err := framework.DeletePDWithRetry(s.diskName)
-		framework.ExpectNoError(err, "Error deleting PD")
+	if s.pvc != nil {
+		err := f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(s.pvc.Name, nil)
+		framework.ExpectNoError(err, "Error deleting PVC")
 	}
 }
 


### PR DESCRIPTION
Use dynamically provisioned PV to run GCE PD tests. This will make sure that the pod is scheduled to the right zone and GCE PD can be attached to a node.

**Which issue(s) this PR fixes**:
Fixes #61101 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/sig storage
@msau42 @verult 
