### PR TITLE
kubectl get psp: show PRIV for column with privileged flag

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -340,7 +340,7 @@ func AddHandlers(h printers.PrintHandler) {
 
 	podSecurityPolicyColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
-		{Name: "Data", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["privileged"]},
+		{Name: "Priv", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["privileged"]},
 		{Name: "Caps", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["allowedCapabilities"]},
 		{Name: "SELinux", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["seLinux"]},
 		{Name: "RunAsUser", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["runAsUser"]},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves a header in the `kubectl get psp` output.

Prior this change:
```console
$ kubectl get psp privileged
NAME         DATA      CAPS      SELINUX    RUNASUSER          FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
privileged   true      *         RunAsAny   RunAsAny           RunAsAny   RunAsAny   false            *
```
Note that the 2nd column has DATA caption.

After this change:
```console
$ kubectl get psp 
NAME         PRIV      CAPS      SELINUX    RUNASUSER          FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
privileged   true      *         RunAsAny   RunAsAny           RunAsAny   RunAsAny   false            *
```

**Which issue(s) this PR fixes**:
This is regression after #49700


