### PR TITLE
PSP: fix strategy name in the error messages

### DIFF
--- a/pkg/security/podsecuritypolicy/user/mustrunas.go
+++ b/pkg/security/podsecuritypolicy/user/mustrunas.go
@@ -33,10 +33,10 @@ type mustRunAs struct {
 // NewMustRunAs provides a strategy that requires the container to run as a specific UID in a range.
 func NewMustRunAs(options *extensions.RunAsUserStrategyOptions) (RunAsUserStrategy, error) {
 	if options == nil {
-		return nil, fmt.Errorf("MustRunAsRange requires run as user options")
+		return nil, fmt.Errorf("MustRunAs requires run as user options")
 	}
 	if len(options.Ranges) == 0 {
-		return nil, fmt.Errorf("MustRunAsRange requires at least one range")
+		return nil, fmt.Errorf("MustRunAs requires at least one range")
 	}
 	return &mustRunAs{
 		opts: options,

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -1954,7 +1954,7 @@ func TestCreateProvidersFromConstraints(t *testing.T) {
 					},
 				}
 			},
-			expectedErr: "MustRunAsRange requires at least one range",
+			expectedErr: "MustRunAs requires at least one range",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR corrects strategy names in the error messages.