### PR TITLE
Increase apiserver mem-threshold in density test

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -166,7 +166,7 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 	} else {
 		if numNodes <= 100 {
 			apiserverCPU = 1.8
-			apiserverMem = 1500 * (1024 * 1024)
+			apiserverMem = 1700 * (1024 * 1024)
 			controllerCPU = 0.5
 			controllerMem = 500 * (1024 * 1024)
 			schedulerCPU = 0.4


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/60500#issuecomment-372682659 (fixes part of that issue)

/sig scalability
/kind bug
/priority important-soon
/cc @wojtek-t
/cc @crassirostris (for the release-note)

```release-note
Audit logging with buffering enabled can increase apiserver memory usage (e.g. up to 200MB in 100-node cluster). The increase is bounded by the buffer size (configurable). Ref: issue #60500
```