### PR TITLE
Automated cherry pick of #61068: Exclude commas when pulling the tag out of the git

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -45,7 +45,7 @@ kube::version::get_version_vars() {
     # When a 'git archive' is exported, the '$Format:%D$' below will look
     # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
     # can be extracted from it.
-    if [[ '$Format:%D$' =~ tag:\ (v[^ ]+) ]]; then
+    if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
      KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
     fi
   fi


### PR DESCRIPTION
Cherry pick of #61068 on release-1.9.

#61068: Exclude commas when pulling the tag out of the git