### PR TITLE
Updates kubeadm default to use 1.10

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -38,7 +38,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.9"
+	DefaultKubernetesVersion = "stable-1.10"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultAuthorizationModes defines default authorization modes


### PR DESCRIPTION
**What this PR does / why we need it**:
In line with https://github.com/kubernetes/kubeadm/blob/master/docs/release-cycle.md, the default branch for kubeadm to deploy should be bumped right before the rc.1.
This can even be manually merged by the someone from the release team.

**Which issue(s) this PR fixes** :
Fixes #60608 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Updates default deployment for kubeadm to 1.10 
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/sig-release-members  @dims @jberkus @jdumars 
