### PR TITLE
Prevent 1.9 e2es testing deprecated/removed features in 1.10

### DIFF
--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//pkg/controller/endpoint:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/master/ports:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/images/net/nat:go_default_library",

--- a/test/e2e/ui/BUILD
+++ b/test/e2e/ui/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/ui",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",


### PR DESCRIPTION
1.9 e2e tests get run against 1.10.0+ masters during upgrade tests. This version-gates testing deprecated features removed in 1.10

http://k8s-testgrid.appspot.com/sig-release-master-upgrade#gce-1.9-master-upgrade-master

Fixes #60769
Fixes #60767