### PR TITLE
Add missing binaryData field to the ConfigMap Hash

### DIFF
--- a/pkg/kubectl/util/hash/hash.go
+++ b/pkg/kubectl/util/hash/hash.go
@@ -56,7 +56,11 @@ func SecretHash(sec *v1.Secret) (string, error) {
 // Data, Kind, and Name are taken into account.
 func encodeConfigMap(cm *v1.ConfigMap) (string, error) {
 	// json.Marshal sorts the keys in a stable order in the encoding
-	data, err := json.Marshal(map[string]interface{}{"kind": "ConfigMap", "name": cm.Name, "data": cm.Data})
+	m := map[string]interface{}{"kind": "ConfigMap", "name": cm.Name, "data": cm.Data}
+	if len(cm.BinaryData) > 0 {
+		m["binaryData"] = cm.BinaryData
+	}
+	data, err := json.Marshal(m)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubectl/util/hash/hash_test.go
+++ b/pkg/kubectl/util/hash/hash_test.go
@@ -32,11 +32,19 @@ func TestConfigMapHash(t *testing.T) {
 		err  string
 	}{
 		// empty map
-		{"empty data", &v1.ConfigMap{Data: map[string]string{}}, "42745tchd9", ""},
+		{"empty data", &v1.ConfigMap{Data: map[string]string{}, BinaryData: map[string][]byte{}}, "42745tchd9", ""},
 		// one key
 		{"one key", &v1.ConfigMap{Data: map[string]string{"one": ""}}, "9g67k2htb6", ""},
 		// three keys (tests sorting order)
 		{"three keys", &v1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}}, "f5h7t85m9b", ""},
+		// empty binary data map
+		{"empty binary data", &v1.ConfigMap{BinaryData: map[string][]byte{}}, "dk855m5d49", ""},
+		// one key with binary data
+		{"one key with binary data", &v1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}}, "mk79584b8c", ""},
+		// three keys with binary data (tests sorting order)
+		{"three keys with binary data", &v1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, "t458mc6db2", ""},
+		// two keys, one with string and another with binary data
+		{"two keys with one each", &v1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}}, "698h7c7t9m", ""},
 	}
 
 	for _, c := range cases {
@@ -89,6 +97,14 @@ func TestEncodeConfigMap(t *testing.T) {
 		{"one key", &v1.ConfigMap{Data: map[string]string{"one": ""}}, `{"data":{"one":""},"kind":"ConfigMap","name":""}`, ""},
 		// three keys (tests sorting order)
 		{"three keys", &v1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}}, `{"data":{"one":"","three":"3","two":"2"},"kind":"ConfigMap","name":""}`, ""},
+		// empty binary map
+		{"empty data", &v1.ConfigMap{BinaryData: map[string][]byte{}}, `{"data":null,"kind":"ConfigMap","name":""}`, ""},
+		// one key with binary data
+		{"one key", &v1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}}, `{"binaryData":{"one":""},"data":null,"kind":"ConfigMap","name":""}`, ""},
+		// three keys with binary data (tests sorting order)
+		{"three keys", &v1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, `{"binaryData":{"one":"","three":"Mw==","two":"Mg=="},"data":null,"kind":"ConfigMap","name":""}`, ""},
+		// two keys, one string and one binary values
+		{"two keys with one each", &v1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}}, `{"binaryData":{"two":""},"data":{"one":""},"kind":"ConfigMap","name":""}`, ""},
 	}
 	for _, c := range cases {
 		s, err := encodeConfigMap(c.cm)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In 7e158fb4f62a36a1a81ee12eb3521ac4db0bb3e5, we added a BinaryData
to ConfigMap, but totally forgot to add it to the hash method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The value of of BinaryData is now used in calculating the hash for the configmap
```
