### PR TITLE
catch err when Watch testResource failed in func TestWatchCallNonNamespace

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -63,6 +63,9 @@ func TestWatchCallNonNamespace(t *testing.T) {
 	codecs := serializer.NewCodecFactory(scheme)
 	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
 	watch, err := o.Watch(testResource, ns)
+	if err != nil {
+		t.Fatalf("test resource watch failed in %s: %v ", ns, err)
+	}
 	go func() {
 		err := o.Create(testResource, testObj, ns)
 		if err != nil {
@@ -85,7 +88,13 @@ func TestWatchCallAllNamespace(t *testing.T) {
 	codecs := serializer.NewCodecFactory(scheme)
 	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
 	w, err := o.Watch(testResource, "test_namespace")
+	if err != nil {
+		t.Fatalf("test resource watch failed in test_namespace: %v", err)
+	}
 	wAll, err := o.Watch(testResource, "")
+	if err != nil {
+		t.Fatalf("test resource watch failed in all namespaces: %v", err)
+	}
 	go func() {
 		err := o.Create(testResource, testObj, ns)
 		assert.NoError(t, err, "test resource creation failed")
@@ -161,6 +170,9 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	for idx, watchNamespace := range watchNamespaces {
 		i := idx
 		w, err := o.Watch(testResource, watchNamespace)
+		if err != nil {
+			t.Fatalf("test resource watch failed in %s: %v", watchNamespace, err)
+		}
 		go func() {
 			assert.NoError(t, err, "watch invocation failed")
 			for _, c := range cases {


### PR DESCRIPTION
**What this PR does / why we need it**:
catch err when Watch testResource failed in func TestWatchCallNonNamespace
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
[#61155](https://github.com/kubernetes/kubernetes/issues/61155)
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
