### PR TITLE
Error handlig added to pkg/apis/meta/v1/register.go

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -53,12 +54,15 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		&GetOptions{},
 		&DeleteOptions{},
 	)
-	scheme.AddConversionFuncs(
-		Convert_versioned_Event_to_watch_Event,
-		Convert_versioned_InternalEvent_to_versioned_Event,
-		Convert_watch_Event_to_versioned_Event,
-		Convert_versioned_Event_to_versioned_InternalEvent,
+	scheme_err := scheme.AddConversionFuncs(
+			Convert_versioned_Event_to_watch_Event,
+			Convert_versioned_InternalEvent_to_versioned_Event,
+			Convert_watch_Event_to_versioned_Event,
+			Convert_versioned_Event_to_versioned_InternalEvent,
 	)
+	if scheme_err != nil {
+		fmt.Errorf("scheme.AddConversionFuncs: %v", scheme_err.Error())
+	}
 
 	// Register Unversioned types under their own special group
 	scheme.AddUnversionedTypes(Unversioned,
@@ -70,8 +74,16 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
-	AddConversionFuncs(scheme)
-	RegisterDefaults(scheme)
+	err := AddConversionFuncs(scheme)
+	if err != nil {
+		fmt.Errorf("scheme.AddConversionFuncs: %v", err.Error())
+	}
+
+	// Should always return nil
+	check_err := RegisterDefaults(scheme)
+	if check_err != nil {
+		fmt.Errorf("scheme.AddConversionFuncs: %v", check_err.Error())
+	}
 }
 
 // scheme is the registry for the common types that adhere to the meta v1 API spec.
@@ -89,5 +101,8 @@ func init() {
 	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
-	RegisterDefaults(scheme)
+	err := RegisterDefaults(scheme)
+	if err != nil {
+		fmt.Errorf("scheme.AddConversionFuncs: %v", err.Error())
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `k8s.io/apimachinery/pkg/apis/meta/v1/register.go` has poor error handling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #51457

**Special notes for your reviewer**:
1. I'm not sure if  `init()` should panic on error..
2. What should I do with `staging/src/k8s.io/client-go/kubernetes/scheme/register.go`?

**Release note**:

```release-note
NONE
```
/sig api-machinery
