### PR TITLE
Automated cherry pick of #58433: bugfix(mount): lstat with abs path of parent instead of '/..'

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -189,7 +189,7 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	rootStat, err := os.Lstat(file + "/..")
+	rootStat, err := os.Lstat(filepath.Dir(strings.TrimSuffix(file, "/")))
 	if err != nil {
 		return true, err
 	}


### PR DESCRIPTION
Cherry pick of #58433 on release-1.7.

#58433: bugfix(mount): lstat with abs path of parent instead of '/..'

```release-note
Fix a regression that prevented cleanup of a `subPath` volume mount
```