### PR TITLE
Set a default NODE_IPAM_MODE value in gce/gci/configure-helpler.sh

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1765,7 +1765,7 @@ function start-kube-controller-manager {
     params+=" --terminated-pod-gc-threshold=${TERMINATED_POD_GC_THRESHOLD}"
   fi
   if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    params+=" --cidr-allocator-type=${NODE_IPAM_MODE}"
+    params+=" --cidr-allocator-type=${NODE_IPAM_MODE:-CloudAllocator}"
     params+=" --configure-cloud-routes=false"
   fi
   if [[ -n "${FEATURE_GATES:-}" ]]; then


### PR DESCRIPTION
GKE cluster failed to start because of

```
Mar 14 20:00:47 gke-2df471d0b2ef541eb798-4ca4-16a1-vm configure-helper.sh[1317]: /home/kubernetes/bin/configure-helper.sh: line 1768: NODE_IPAM_MODE: unbound variable
Mar 14 20:00:47 gke-2df471d0b2ef541eb798-4ca4-16a1-vm systemd[1]: kube-master-configuration.service: Main process exited, code=exited, status=1/FAILURE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
None
```

/assign @jingax10