### PR TITLE
Fix deprecated gcloud compute networks --mode switches.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1639,7 +1639,7 @@ function create-network() {
       network_mode="custom"
     fi
     echo "Creating new ${network_mode} network: ${NETWORK}"
-    gcloud compute networks create --project "${NETWORK_PROJECT}" "${NETWORK}" --mode="${network_mode}"
+    gcloud compute networks create --project "${NETWORK_PROJECT}" "${NETWORK}" --subnet-mode="${network_mode}"
   else
     PREEXISTING_NETWORK=true
     PREEXISTING_NETWORK_MODE="$(check-network-mode)"
@@ -1674,8 +1674,8 @@ function create-network() {
 }
 
 function expand-default-subnetwork() {
-  gcloud compute networks switch-mode "${NETWORK}" \
-    --mode custom \
+  gcloud compute networks update "${NETWORK}" \
+    --switch-to-custom-subnet-mode \
     --project "${NETWORK_PROJECT}" \
     --quiet || true
   gcloud compute networks subnets expand-ip-range "${NETWORK}" \


### PR DESCRIPTION
"create --mode" becomes "create --subnet-mode", and switch-mode has been
folded into "update".

Create --mode was deprecated in October and will be removed in the next
gcloud release. It is already failing in staging tests.
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** Fixes #54238

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```