### PR TITLE
check etcd servers by a random order

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
@@ -18,6 +18,7 @@ package preflight
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"time"
@@ -59,9 +60,11 @@ func parseServerURI(serverURI string) (*url.URL, error) {
 // CheckEtcdServers will attempt to reach all etcd servers once. If any
 // can be reached, return true.
 func (con EtcdConnection) CheckEtcdServers() (done bool, err error) {
-	// Attempt to reach every Etcd server in order
-	for _, serverURI := range con.ServerList {
-		host, err := parseServerURI(serverURI)
+	// Attempt to reach every Etcd server randomly.
+	serverNumber := len(con.ServerList)
+	serverPerms := rand.Perm(serverNumber)
+	for _, index := range serverPerms {
+		host, err := parseServerURI(con.ServerList[index])
 		if err != nil {
 			return false, err
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight/checks.go
@@ -26,12 +26,6 @@ import (
 
 const connectionTimeout = 1 * time.Second
 
-type connection interface {
-	serverReachable(address string) bool
-	parseServerList(serverList []string) error
-	CheckEtcdServers() (bool, error)
-}
-
 // EtcdConnection holds the Etcd server list
 type EtcdConnection struct {
 	ServerList []string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Every time a health check is called on the APIServer via the /healthz endpoint, an etcd healthcheck is performed. Here makes servers check with a random order.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61180

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
