### PR TITLE
WIP: add support for synchronous buffered backends

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -111,6 +111,13 @@ type AuditWebhookOptions struct {
 func NewAuditOptions() *AuditOptions {
 	defaultLogBatchConfig := pluginbuffered.NewDefaultBatchConfig()
 	defaultLogBatchConfig.ThrottleEnable = false
+	// Set the max batch size to 1, and scale the throttle accordingly.
+	defaultLogBatchConfig.ThrottleQPS = defaultLogBatchConfig.ThrottleQPS * float32(defaultLogBatchConfig.MaxBatchSize)
+	defaultLogBatchConfig.ThrottleBurst = defaultLogBatchConfig.ThrottleBurst * defaultLogBatchConfig.MaxBatchSize
+	defaultLogBatchConfig.MaxBatchSize = 1
+	// TODO: Allow infinite wait times.
+	defaultLogBatchConfig.MaxBatchWait = time.Hour * 24 * 360
+	defaultLogBatchConfig.AsyncDelegate = false
 
 	return &AuditOptions{
 		WebhookOptions: AuditWebhookOptions{

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
@@ -57,6 +57,9 @@ type BatchConfig struct {
 	// ThrottleBurst defines the maximum rate of batches per second sent to the delegate backend in case
 	// the capacity defined by ThrottleQPS was not utilized.
 	ThrottleBurst int
+
+	// Whether the delegate backend should be called asynchronously.
+	AsyncDelegate bool
 }
 
 // NewDefaultBatchConfig returns new Config objects populated by default values.
@@ -69,6 +72,8 @@ func NewDefaultBatchConfig() BatchConfig {
 		ThrottleEnable: true,
 		ThrottleQPS:    defaultBatchThrottleQPS,
 		ThrottleBurst:  defaultBatchThrottleBurst,
+
+		AsyncDelegate: true,
 	}
 }
 
@@ -84,6 +89,9 @@ type bufferedBackend struct {
 	//
 	// Receiving maxBatchSize events will always trigger sending a batch, regardless of the amount of time passed.
 	maxBatchWait time.Duration
+
+	// Whether the delegate backend should be called asynchronously.
+	asyncDelegate bool
 
 	// Channel to signal that the batching routine has processed all remaining events and exited.
 	// Once `shutdownCh` is closed no new events will be sent to the delegate backend.
@@ -112,6 +120,7 @@ func NewBackend(delegate audit.Backend, config BatchConfig) audit.Backend {
 		buffer:          make(chan *auditinternal.Event, config.BufferSize),
 		maxBatchSize:    config.MaxBatchSize,
 		maxBatchWait:    config.MaxBatchWait,
+		asyncDelegate:   config.AsyncDelegate,
 		shutdownCh:      make(chan struct{}),
 		wg:              sync.WaitGroup{},
 		throttle:        throttle,
@@ -234,15 +243,25 @@ func (b *bufferedBackend) processEvents(events []*auditinternal.Event) {
 		b.throttle.Accept()
 	}
 
-	b.wg.Add(1)
-	go func() {
-		defer b.wg.Done()
-		defer runtime.HandleCrash()
+	if b.asyncDelegate {
+		b.wg.Add(1)
+		go func() {
+			defer b.wg.Done()
+			defer runtime.HandleCrash()
 
-		// Execute the real processing in a goroutine to keep it from blocking.
-		// This lets the batching routine continue draining the queue immediately.
-		b.delegateBackend.ProcessEvents(events...)
-	}()
+			// Execute the real processing in a goroutine to keep it from blocking.
+			// This lets the batching routine continue draining the queue immediately.
+			b.delegateBackend.ProcessEvents(events...)
+		}()
+	} else {
+		func() {
+			defer runtime.HandleCrash()
+
+			// Execute the real processing in a goroutine to keep it from blocking.
+			// This lets the batching routine continue draining the queue immediately.
+			b.delegateBackend.ProcessEvents(events...)
+		}()
+	}
 }
 
 func (b *bufferedBackend) ProcessEvents(ev ...*auditinternal.Event) {


### PR DESCRIPTION
Alternative approach to https://github.com/kubernetes/kubernetes/pull/61027 to limit log backend writers.