### PR TITLE
Change defaults for deployments in extensions/v1beta1

### DIFF
--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -28,8 +28,8 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart
 // in extensions. These addons are:
-// - MaxUnavailable during rolling update set to 25% (1 in extensions)
-// - MaxSurge value during rolling update set to 25% (1 in extensions)
+// - MaxUnavailable during rolling update set to 25%
+// - MaxSurge value during rolling update set to 25%
 // - RevisionHistoryLimit set to 10 (not set in extensions)
 // - ProgressDeadlineSeconds set to 600s (not set in extensions)
 func SetDefaults_Deployment(obj *appsv1.Deployment) {

--- a/pkg/apis/apps/v1beta1/defaults.go
+++ b/pkg/apis/apps/v1beta1/defaults.go
@@ -65,8 +65,8 @@ func SetDefaults_StatefulSet(obj *appsv1beta1.StatefulSet) {
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart
 // in extensions. These addons are:
-// - MaxUnavailable during rolling update set to 25% (1 in extensions)
-// - MaxSurge value during rolling update set to 25% (1 in extensions)
+// - MaxUnavailable during rolling update set to 25%
+// - MaxSurge value during rolling update set to 25%
 // - RevisionHistoryLimit set to 2 (not set in extensions)
 // - ProgressDeadlineSeconds set to 600s (not set in extensions)
 func SetDefaults_Deployment(obj *appsv1beta1.Deployment) {

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -79,8 +79,8 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart
 // in extensions. These addons are:
-// - MaxUnavailable during rolling update set to 25% (1 in extensions)
-// - MaxSurge value during rolling update set to 25% (1 in extensions)
+// - MaxUnavailable during rolling update set to 25%
+// - MaxSurge value during rolling update set to 25%
 // - RevisionHistoryLimit set to 10 (not set in extensions)
 // - ProgressDeadlineSeconds set to 600s (not set in extensions)
 func SetDefaults_Deployment(obj *appsv1beta2.Deployment) {

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -100,13 +100,13 @@ func SetDefaults_Deployment(obj *extensionsv1beta1.Deployment) {
 			strategy.RollingUpdate = &rollingUpdate
 		}
 		if strategy.RollingUpdate.MaxUnavailable == nil {
-			// Set default MaxUnavailable as 1 by default.
-			maxUnavailable := intstr.FromInt(1)
+			// Set default MaxUnavailable as 25% by default.
+			maxUnavailable := intstr.FromString("25%")
 			strategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
 		if strategy.RollingUpdate.MaxSurge == nil {
-			// Set default MaxSurge as 1 by default.
-			maxSurge := intstr.FromInt(1)
+			// Set default MaxSurge as 25% by default.
+			maxSurge := intstr.FromString("25%")
 			strategy.RollingUpdate.MaxSurge = &maxSurge
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes defaults for deployment in `extensions/v1beta1 `from 1 to 25%. This essentially will prevent cases when the desired replicas are only 1 but due to `maxUnavailable` being 1 by default, `MinimumReplicasAvailable` in conditions is set to true even if available replicas are 0.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61205

**Special notes for your reviewer**:
We should also probably make kubectl use `apps/v1` when the user is executing `kubectl run` for deployments instead of `extensions/v1beta`, which doesn't have this issue.
**Release note**:

```release-note
Change defaults for deployment in extensions/v1beta1
```
