### PR TITLE
Do not allow annoymous authentication when authz mode is AlwaysAllow.

### DIFF
--- a/cmd/kubelet/app/auth.go
+++ b/cmd/kubelet/app/auth.go
@@ -46,6 +46,13 @@ func BuildAuth(nodeName types.NodeName, client clientset.Interface, config kubel
 		sarClient = client.AuthorizationV1beta1().SubjectAccessReviews()
 	}
 
+	// authorization ModeAlwaysAllow cannot be combined with AnonymousAuth.
+	// in such a case the AnonymousAuth is stomped to false and you get a message
+	if config.Authentication.Anonymous.Enabled &&
+		config.Authorization.Mode == kubeletconfig.KubeletAuthorizationModeAlwaysAllow {
+		config.Authentication.Anonymous.Enabled = false
+	}
+
 	authenticator, err := BuildAuthn(tokenClient, config.Authentication)
 	if err != nil {
 		return nil, err

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -707,9 +707,6 @@ function start_kubelet {
       if [[ -n "${KUBELET_AUTHENTICATION_WEBHOOK:-}" ]]; then
         auth_args="${auth_args} --authentication-token-webhook"
       fi
-      if [[ -n "${CLIENT_CA_FILE:-}" ]]; then
-        auth_args="${auth_args} --client-ca-file=${CLIENT_CA_FILE}"
-      fi
 
       cni_conf_dir_args=""
       if [[ -n "${CNI_CONF_DIR}" ]]; then
@@ -753,6 +750,7 @@ function start_kubelet {
         --eviction-pressure-transition-period=${EVICTION_PRESSURE_TRANSITION_PERIOD} \
         --pod-manifest-path="${POD_MANIFEST_PATH}" \
         --fail-swap-on="${FAIL_SWAP_ON}" \
+        --client-ca-file="${CERT_DIR}/client-ca.crt" \
         ${auth_args} \
         ${dns_args} \
         ${cni_conf_dir_args} \


### PR DESCRIPTION
**What this PR does / why we need it**:

set annoy-auth = false when authz mode is AlwaysAllow.

This is what kube-apiserver does now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61239


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
