### PR TITLE
Bump fluentd-gcp-scaler version

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: fluentd-gcp-scaler
-    version: v0.2.0
+    version: v0.3.0
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: fluentd-gcp-scaler
       containers:
       - name: fluentd-gcp-scaler
-        image: gcr.io/google-containers/fluentd-gcp-scaler:0.2
+        image: gcr.io/google-containers/fluentd-gcp-scaler:0.3
         command:
           - /scaler.sh
           - --ds-name=fluentd-gcp-v3.0.0


### PR DESCRIPTION

**What this PR does / why we need it**:
This version fixes a bug in which scaler was setting resources for all containers in the pod, not only fluentd-gcp one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60763

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
