### PR TITLE
make kubeproxy config struct Burst use int instead of int32 unify with kubeConfig

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -154,7 +154,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead")
 	fs.StringVar(&o.config.ClientConnection.ContentType, "kube-api-content-type", o.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
 	fs.Float32Var(&o.config.ClientConnection.QPS, "kube-api-qps", o.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
-	fs.Int32Var(&o.config.ClientConnection.Burst, "kube-api-burst", o.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
+	fs.IntVar(&o.config.ClientConnection.Burst, "kube-api-burst", o.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
 	fs.DurationVar(&o.config.UDPIdleTimeout.Duration, "udp-timeout", o.config.UDPIdleTimeout.Duration, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
 	if o.config.Conntrack.Max == nil {
 		o.config.Conntrack.Max = utilpointer.Int32Ptr(0)
@@ -422,8 +422,7 @@ func createClients(config kubeproxyconfig.ClientConnectionConfiguration, masterO
 	kubeConfig.AcceptContentTypes = config.AcceptContentTypes
 	kubeConfig.ContentType = config.ContentType
 	kubeConfig.QPS = config.QPS
-	//TODO make config struct use int instead of int32?
-	kubeConfig.Burst = int(config.Burst)
+	kubeConfig.Burst = config.Burst
 
 	client, err := clientset.NewForConfig(kubeConfig)
 	if err != nil {

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -37,7 +37,7 @@ type ClientConnectionConfiguration struct {
 	// qps controls the number of queries per second allowed for this connection.
 	QPS float32
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
-	Burst int32
+	Burst int
 }
 
 // KubeProxyIPTablesConfiguration contains iptables-related configuration

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
@@ -55,7 +55,7 @@ func autoConvert_v1alpha1_ClientConnectionConfiguration_To_kubeproxyconfig_Clien
 	out.AcceptContentTypes = in.AcceptContentTypes
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
-	out.Burst = int32(in.Burst)
+	out.Burst = in.Burst
 	return nil
 }
 
@@ -69,7 +69,7 @@ func autoConvert_kubeproxyconfig_ClientConnectionConfiguration_To_v1alpha1_Clien
 	out.AcceptContentTypes = in.AcceptContentTypes
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
-	out.Burst = int(in.Burst)
+	out.Burst = in.Burst
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix todo: make kubeproxy config struct Burst use int instead of int32 unify with kubeConfig
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
[#61272](https://github.com/kubernetes/kubernetes/issues/61272)
**Special notes for your reviewer**:
In pkg/proxy/apis/kubeproxyconfig/types.go struct ClientConnectionConfiguration.burst is int32 and in staging/src/k8s.io/client-go/rest struct Config.burst is int. I think we should unify it.So that we needn't convert it.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
