### PR TITLE
Use charm env in actions to get have charmhelpers available

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
+++ b/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #

--- a/cluster/juju/layers/kubernetes-master/actions/namespace-create
+++ b/cluster/juju/layers/kubernetes-master/actions/namespace-create
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python3
 import os
 from yaml import safe_load as load
 from charmhelpers.core.hookenv import (

--- a/cluster/juju/layers/kubernetes-worker/actions/microbot
+++ b/cluster/juju/layers/kubernetes-worker/actions/microbot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/sbin/charm-env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/local/sbin/charm-env python3
 #
 # For a usage examples, see README.md
 #


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Due to changes in the base layer the actions in the Juju charms do not have access to charmhelpers in the default environment. This PR fixes this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
