### PR TITLE
Add myself for sig-cli related stuff as approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,6 +23,7 @@ aliases:
     - liggitt
     - pwittrock
     - smarterclayton
+    - soltysh
   sig-cli:
     - adohe
     - deads2k

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -25,3 +25,4 @@ approvers:
   - gmarek
   - vishh
   - liggitt
+  - soltysh # for sig-cli related stuff


### PR DESCRIPTION
This is adding me as an approver for sig-cli related things.

/assign @pwittrock 

**Release note**:
```release-note
None
```
