### PR TITLE
Add missing `configmaps` resources for `kube-dns`

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -440,7 +440,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			// a role to use for the kube-dns pod
 			ObjectMeta: metav1.ObjectMeta{Name: "system:kube-dns"},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("endpoints", "services").RuleOrDie(),
+				rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("endpoints", "services", "configmaps").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -770,6 +770,7 @@ items:
     resources:
     - endpoints
     - services
+    - configmaps
     verbs:
     - list
     - watch


### PR DESCRIPTION
ClusterRole `kube-dns` requires to be able
to list the `configmaps` with the `system:kube-dns` service account.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When enabling RBAC, the `kube-dns`  POD fails to bootstrap itself due to lack of cluster-role permissions.


The `kube-dns` docker image is: `k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.5`

Here's an actual log with RBAC enabled:

```
E0316 17:05:28.023758       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-sy[1947/1947]
ns" cannot list configmaps in the namespace "kube-system"
E0316 17:05:29.026449       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-system:kube-d
ns" cannot list configmaps in the namespace "kube-system"
E0316 17:05:30.029096       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-system:kube-d
ns" cannot list configmaps in the namespace "kube-system"
E0316 17:05:31.031390       1 reflector.go:199] k8s.io/dns/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:kube-system:kube-d
ns" cannot list configmaps in the namespace "kube-system"
```

In the diff you can see what the resources were.

After enabling the `configmaps`, the log produced finished the bootstrap.


```
I0316 17:21:54.479878       1 sync_configmap.go:107] ConfigMap kube-system:kube-dns was created
I0316 17:21:54.479894       1 dns.go:198] Configuration updated: {TypeMeta:{Kind: APIVersion:} Federations:map[] StubDomains:map[] UpstreamNameservers:[]}
```


**Special notes for your reviewer**:

**Release note**:

```release-note
Fix `system:kube-dns` clusterRole not having permissions on resources `configmaps` 
```

@erictune
@liggitt
@deads2k
@ericchiang
@enj
