### PR TITLE
Fix of changing ListItem to MapListItem for readablity and making more sense

### DIFF
--- a/pkg/kubectl/apply/element.go
+++ b/pkg/kubectl/apply/element.go
@@ -224,9 +224,9 @@ func (s *CombinedPrimitiveSlice) UpsertRemote(l interface{}) {
 	v.remoteSet = true
 }
 
-// ListItem represents a single value in a slice of maps or types
-type ListItem struct {
-	// KeyValue is the merge key value of the item
+// MapItem represents a single value in a slice of maps or types
+type MapItem struct {
+	// KeyValue is the merge key value of the map item
 	KeyValue MergeKeyValue
 
 	// RawElementData contains the field values
@@ -235,11 +235,11 @@ type ListItem struct {
 
 // CombinedMapSlice is a slice of maps or types with merge keys
 type CombinedMapSlice struct {
-	Items []*ListItem
+	Items []*MapItem
 }
 
-// Lookup returns the ListItem matching the merge key, or nil if not found.
-func (s *CombinedMapSlice) lookup(v MergeKeyValue) *ListItem {
+// Lookup returns the MapItem matching the merge key, or nil if not found.
+func (s *CombinedMapSlice) lookup(v MergeKeyValue) *MapItem {
 	for _, i := range s.Items {
 		if i.KeyValue.Equal(v) {
 			return i
@@ -248,8 +248,8 @@ func (s *CombinedMapSlice) lookup(v MergeKeyValue) *ListItem {
 	return nil
 }
 
-func (s *CombinedMapSlice) upsert(key MergeKeys, l interface{}) (*ListItem, error) {
-	// Get the identity of the item
+func (s *CombinedMapSlice) upsert(key MergeKeys, l interface{}) (*MapItem, error) {
+	// Get the identity of the map item
 	val, err := key.GetMergeKeyValue(l)
 	if err != nil {
 		return nil, err
@@ -260,8 +260,8 @@ func (s *CombinedMapSlice) upsert(key MergeKeys, l interface{}) (*ListItem, erro
 		return item, nil
 	}
 
-	// Otherwise create a new item and append to the list
-	item := &ListItem{
+	// Otherwise create a new map item and append to the list
+	item := &MapItem{
 		KeyValue: val,
 	}
 	s.Items = append(s.Items, item)


### PR DESCRIPTION
**Why we need it**:
To create ListElement in apply parse procedure, It branches two ways to merge items to a combined slice based on the subitem type, (e.g. Primitive, or Map). Thus, PrimitiveListItem struct is already defined for CombinedPrimitiveSlice. Similarly, a "map item in list" struct is defined for CombinedMapSlice too. This map-like struct refers to a map, and consists a `CombinedMapSlice` struct.

So, this PR is about renaming the `ListItem` to `MapItem` for making it more sense and improving readability, like : 
>
>type CombinedMapSlice struct {
>         Items []*MapItem
>}
> 
