### PR TITLE
cluster/gce/list-resources.sh: also list stackdriver logging sinks

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -38,17 +38,18 @@ if [[ "${KUBERNETES_PROVIDER:-}" == "gke" ]]; then
   INSTANCE_PREFIX="${INSTANCE_PREFIX:0:26}"
 fi
 
-# Usage: gcloud-compute-list <resource> <additional parameters to gcloud...>
+# Usage: gcloud-list <group> <resource> <additional parameters to gcloud...>
 # GREP_REGEX is applied to the output of gcloud if set
 GREP_REGEX=""
-function gcloud-compute-list() {
-  local -r resource=$1
-  local -r filter=${2:-}
-  echo -e "\n\n[ ${resource} ]"
+function gcloud-list() {
+  local -r group=$1
+  local -r resource=$2
+  local -r filter=${3:-}
+  echo -e "\n\n[ ${group} ${resource} ]"
   local attempt=1
   local result=""
   while true; do
-    if result=$(gcloud compute ${resource} list --project=${PROJECT} ${filter:+--filter="$filter"} ${@:3}); then
+    if result=$(gcloud ${group} ${resource} list --project=${PROJECT} ${filter:+--filter="$filter"} ${@:4}); then
       if [[ ! -z "${GREP_REGEX}" ]]; then
         result=$(echo "${result}" | grep "${GREP_REGEX}" || true)
       fi
@@ -74,21 +75,23 @@ echo "Provider: ${KUBERNETES_PROVIDER:-}"
 
 # List resources related to instances, filtering by the instance prefix if
 # provided.
-gcloud-compute-list instance-templates "name ~ '${INSTANCE_PREFIX}.*'"
-gcloud-compute-list instance-groups "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
-gcloud-compute-list instances "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
+gcloud-list compute instance-templates "name ~ '${INSTANCE_PREFIX}.*'"
+gcloud-list compute instance-groups "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
+gcloud-list compute instances "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
 
 # List disk resources, filtering by instance prefix if provided.
-gcloud-compute-list disks "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
+gcloud-list compute disks "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
 
 # List network resources. We include names starting with "a", corresponding to
 # those that Kubernetes creates.
-gcloud-compute-list addresses "${REGION:+"region=(${REGION}) AND "}name ~ 'a.*|${INSTANCE_PREFIX}.*'"
+gcloud-list compute addresses "${REGION:+"region=(${REGION}) AND "}name ~ 'a.*|${INSTANCE_PREFIX}.*'"
 # Match either the header or a line with the specified e2e network.
 # This assumes that the network name is the second field in the output.
 GREP_REGEX="^NAME\|^[^ ]\+[ ]\+\(default\|${NETWORK}\) "
-gcloud-compute-list routes "name ~ 'default.*|${INSTANCE_PREFIX}.*'"
-gcloud-compute-list firewall-rules "name ~ 'default.*|k8s-fw.*|${INSTANCE_PREFIX}.*'"
+gcloud-list compute routes "name ~ 'default.*|${INSTANCE_PREFIX}.*'"
+gcloud-list compute firewall-rules "name ~ 'default.*|k8s-fw.*|${INSTANCE_PREFIX}.*'"
 GREP_REGEX=""
-gcloud-compute-list forwarding-rules ${REGION:+"region=(${REGION})"}
-gcloud-compute-list target-pools ${REGION:+"region=(${REGION})"}
+gcloud-list compute forwarding-rules ${REGION:+"region=(${REGION})"}
+gcloud-list compute target-pools ${REGION:+"region=(${REGION})"}
+
+gcloud-list logging sinks


### PR DESCRIPTION
**What this PR does / why we need it**: we seem to be logging stackdriver logging sinks on GCE, likely because we're not keeping track of them. (ref https://github.com/kubernetes/test-infra/issues/7295)

This doesn't fix the leaks, but it'll hopefully help us detect when that happens.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @krzyzacy @crassirostris @summit 