### PR TITLE
Automated cherry pick of #61284 upstream release 1.8

### DIFF
--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -42,8 +42,8 @@ var _ = framework.KubeDescribe("EmptyDir volumes", func() {
 
 	f := framework.NewDefaultFramework("emptydir")
 
-	Context("when FSGroup is specified [Feature:FSGroup]", func() {
-		It("new files should be created with FSGroup ownership when container is root [sig-storage]", func() {
+	Context("when FSGroup is specified", func() {
+		It("new files should be created with FSGroup ownership when container is root", func() {
 			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})
 
@@ -170,6 +170,7 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--file_perm=%v", volumePath),
 		fmt.Sprintf("--file_owner=%v", volumePath),
+		fmt.Sprintf("--file_mode=%v", volumePath),
 	}
 
 	pod.Spec.Containers[0].VolumeMounts[0].SubPath = subPath
@@ -182,6 +183,7 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 		"perms of file \"/test-volume\": -rwxrwxrwx",
 		"owner UID of \"/test-volume\": 0",
 		"owner GID of \"/test-volume\": 123",
+		"mode of file \"/test-volume\": dgtrwxrwxrwx",
 	}
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")


### PR DESCRIPTION
**What this PR does / why we need it**:
cherrypick #61284 into 1.8
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@jsafrane @liggitt 
**Release note**:
```release-note
Fix a regression preventing subpath mounts in pods using fsGroup from having set-GID bits set properly
```
