### PR TITLE
Automated cherry pick of #61284 upstream release 1.7

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -764,7 +764,19 @@ func doSafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	// so user can read/write it. This is the behavior of previous code.
 	// TODO: chmod all created directories, not just the last one.
 	// parentFD is the last created directory.
-	if err = syscall.Fchmod(parentFD, uint32(perm)&uint32(os.ModePerm)); err != nil {
+
+	// Translate perm (os.FileMode) to uint32 that fchmod() expects
+	kernelPerm := uint32(perm & os.ModePerm)
+	if perm&os.ModeSetgid > 0 {
+		kernelPerm |= syscall.S_ISGID
+	}
+	if perm&os.ModeSetuid > 0 {
+		kernelPerm |= syscall.S_ISUID
+	}
+	if perm&os.ModeSticky > 0 {
+		kernelPerm |= syscall.S_ISVTX
+	}
+	if err = syscall.Fchmod(parentFD, kernelPerm); err != nil {
 		return fmt.Errorf("chmod %q failed: %s", currentPath, err)
 	}
 	return nil

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -281,7 +281,7 @@ func TestPathWithinBase(t *testing.T) {
 }
 
 func TestSafeMakeDir(t *testing.T) {
-	defaultPerm := os.FileMode(0750)
+	defaultPerm := os.FileMode(0750) + os.ModeDir
 	tests := []struct {
 		name string
 		// Function that prepares directory structure for the test under given
@@ -289,6 +289,7 @@ func TestSafeMakeDir(t *testing.T) {
 		prepare     func(base string) error
 		path        string
 		checkPath   string
+		perm        os.FileMode
 		expectError bool
 	}{
 		{
@@ -298,6 +299,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"test/directory",
+			defaultPerm,
 			false,
 		},
 		{
@@ -307,6 +309,37 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"test/directory",
+			defaultPerm,
+			false,
+		},
+		{
+			"directory-with-sgid",
+			func(base string) error {
+				return nil
+			},
+			"test/directory",
+			"test/directory",
+			os.FileMode(0777) + os.ModeDir + os.ModeSetgid,
+			false,
+		},
+		{
+			"directory-with-suid",
+			func(base string) error {
+				return nil
+			},
+			"test/directory",
+			"test/directory",
+			os.FileMode(0777) + os.ModeDir + os.ModeSetuid,
+			false,
+		},
+		{
+			"directory-with-sticky-bit",
+			func(base string) error {
+				return nil
+			},
+			"test/directory",
+			"test/directory",
+			os.FileMode(0777) + os.ModeDir + os.ModeSticky,
 			false,
 		},
 		{
@@ -316,6 +349,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"",
 			"",
+			defaultPerm,
 			false,
 		},
 		{
@@ -325,6 +359,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"..",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -334,6 +369,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/../../..",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -346,6 +382,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"destination/directory",
+			defaultPerm,
 			false,
 		},
 		{
@@ -355,6 +392,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -377,6 +415,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test1/dir/dir/dir/dir/dir/dir/dir/foo",
 			"test2/foo",
+			defaultPerm,
 			false,
 		},
 		{
@@ -386,6 +425,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -395,6 +435,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -404,6 +445,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -419,6 +461,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"dir/test",
 			"",
+			defaultPerm,
 			false,
 		},
 		{
@@ -431,6 +474,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"dir/test",
 			"",
+			defaultPerm,
 			true,
 		},
 		{
@@ -440,6 +484,7 @@ func TestSafeMakeDir(t *testing.T) {
 			},
 			"test/directory",
 			"",
+			defaultPerm,
 			true,
 		},
 	}
@@ -452,7 +497,7 @@ func TestSafeMakeDir(t *testing.T) {
 		}
 		test.prepare(base)
 		pathToCreate := filepath.Join(base, test.path)
-		err = doSafeMakeDir(pathToCreate, base, defaultPerm)
+		err = doSafeMakeDir(pathToCreate, base, test.perm)
 		if err != nil && !test.expectError {
 			t.Errorf("test %q: %s", test.name, err)
 		}
@@ -464,14 +509,17 @@ func TestSafeMakeDir(t *testing.T) {
 		}
 
 		if test.checkPath != "" {
-			if _, err := os.Stat(filepath.Join(base, test.checkPath)); err != nil {
+			st, err := os.Stat(filepath.Join(base, test.checkPath))
+			if err != nil {
 				t.Errorf("test %q: cannot read path %s", test.name, test.checkPath)
+			}
+			if st.Mode() != test.perm {
+				t.Errorf("test %q: expected permissions %o, got %o", test.name, test.perm, st.Mode())
 			}
 		}
 
 		os.RemoveAll(base)
 	}
-
 }
 
 func validateDirEmpty(dir string) error {

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -39,8 +39,8 @@ var _ = framework.KubeDescribe("EmptyDir volumes", func() {
 
 	f := framework.NewDefaultFramework("emptydir")
 
-	Context("when FSGroup is specified [Feature:FSGroup]", func() {
-		It("new files should be created with FSGroup ownership when container is root [Volume]", func() {
+	Context("when FSGroup is specified", func() {
+		It("new files should be created with FSGroup ownership when container is root", func() {
 			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})
 
@@ -167,6 +167,7 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--file_perm=%v", volumePath),
 		fmt.Sprintf("--file_owner=%v", volumePath),
+		fmt.Sprintf("--file_mode=%v", volumePath),
 	}
 
 	pod.Spec.Containers[0].VolumeMounts[0].SubPath = subPath
@@ -179,6 +180,7 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 		"perms of file \"/test-volume\": -rwxrwxrwx",
 		"owner UID of \"/test-volume\": 0",
 		"owner GID of \"/test-volume\": 123",
+		"mode of file \"/test-volume\": dgtrwxrwxrwx",
 	}
 	if medium == v1.StorageMediumMemory {
 		out = append(out, "mount type of \"/test-volume\": tmpfs")


### PR DESCRIPTION
**What this PR does / why we need it**:
cherrypick #61284 into 1.7
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61283

**Special notes for your reviewer**:
@jsafrane @liggitt 
**Release note**:
```release-note
Fix a regression preventing subpath mounts in pods using fsGroup from having set-GID bits set properly
```
