### PR TITLE
Added NetworkUnavailable toleration to pod using host network.

### DIFF
--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -135,6 +135,19 @@ func (p *podTolerationsPlugin) Admit(a admission.Attributes) error {
 			},
 		})
 	}
+
+	// If using host network, the Pod should tolerate network unavailable taint.
+	if pod.Spec.SecurityContext != nil &&
+		pod.Spec.SecurityContext.HostNetwork {
+		finalTolerations = tolerations.MergeTolerations(finalTolerations, []api.Toleration{
+			{
+				Key:      algorithm.TaintNodeNetworkUnavailable,
+				Operator: api.TolerationOpExists,
+				Effect:   api.TaintEffectNoSchedule,
+			},
+		})
+	}
+
 	pod.Spec.Tolerations = finalTolerations
 
 	return p.Validate(a)


### PR DESCRIPTION
Signed-off-by: Da K. Ma <klaus1982.cn@gmail.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61312 

**Release note**:
```release-note
If pod using host network, `node.kubernetes.io/network-unavailable` toleration is added to the pod automatically.
```