### PR TITLE
[WIP] Upload kubeadm Etcd Secrets when using SelfHosted StoreCertsInSecrets

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -88,6 +88,23 @@ func apiServerCertificatesVolumeSource() v1.VolumeSource {
 				{
 					Secret: &v1.SecretProjection{
 						LocalObjectReference: v1.LocalObjectReference{
+							Name: kubeadmconstants.APIServerEtcdClientCertAndKeyBaseName,
+						},
+						Items: []v1.KeyToPath{
+							{
+								Key:  v1.TLSCertKey,
+								Path: kubeadmconstants.APIServerEtcdClientCertName,
+							},
+							{
+								Key:  v1.TLSPrivateKeyKey,
+								Path: kubeadmconstants.APIServerEtcdClientKeyName,
+							},
+						},
+					},
+				},
+				{
+					Secret: &v1.SecretProjection{
+						LocalObjectReference: v1.LocalObjectReference{
 							Name: kubeadmconstants.ServiceAccountKeyBaseName,
 						},
 						Items: []v1.KeyToPath{
@@ -278,6 +295,11 @@ func getTLSKeyPairs() []*tlsKeyPair {
 			name: kubeadmconstants.APIServerKubeletClientCertAndKeyBaseName,
 			cert: kubeadmconstants.APIServerKubeletClientCertName,
 			key:  kubeadmconstants.APIServerKubeletClientKeyName,
+		},
+		{
+			name: kubeadmconstants.APIServerEtcdClientCertAndKeyBaseName,
+			cert: kubeadmconstants.APIServerEtcdClientCertName,
+			key:  kubeadmconstants.APIServerEtcdClientKeyName,
 		},
 		{
 			name: kubeadmconstants.ServiceAccountKeyBaseName,


### PR DESCRIPTION
**What this PR does / why we need it**:
This change uploads the APIServerEtcdClientCert, APIServerEtcdClientKey, and EtcdCACert to the cluster when using:
`kubeadm init --feature-gates=SelfHosting=true,StoreCertsInSecrets=true`

It fixes a bug where the selfhosted apiserver pod would fail to start because of the absence of these TLS artifacts.

**Which issue(s) this PR fixes**
Fixes #61322

**Special notes for your reviewer**:
`StoreCertsInSecrets` doesn't seem to be covered by e2e tests.

**Release note**:
```release-note
NONE
```