### PR TITLE
Automated cherry pick of #61298: Fix a bug where malformed paths don't get written to the

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -311,6 +311,12 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) e
 	return nil
 }
 
+// clean prevents path traversals by stripping them out.
+// This is adapted from https://golang.org/src/net/http/fs.go#L74
+func clean(fileName string) string {
+	return path.Clean(string(os.PathSeparator) + fileName)
+}
+
 func untarAll(reader io.Reader, destFile, prefix string) error {
 	entrySeq := -1
 
@@ -326,7 +332,7 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 		}
 		entrySeq++
 		mode := header.FileInfo().Mode()
-		outFileName := path.Join(destFile, header.Name[len(prefix):])
+		outFileName := path.Join(destFile, clean(header.Name[len(prefix):]))
 		baseName := path.Dir(outFileName)
 		if err := os.MkdirAll(baseName, 0755); err != nil {
 			return err
@@ -345,7 +351,7 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 				return err
 			}
 			if exists {
-				outFileName = filepath.Join(outFileName, path.Base(header.Name))
+				outFileName = filepath.Join(outFileName, path.Base(clean(header.Name)))
 			}
 		}
 


### PR DESCRIPTION
Cherry pick of #61298 on release-1.9.

#61298: Fix a bug where malformed paths don't get written to the