### PR TITLE
apiserver: add warning about not trusting authz of aggregator

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -59,7 +59,8 @@ func (s *RequestHeaderAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ClientCAFile, "requestheader-client-ca-file", s.ClientCAFile, ""+
 		"Root certificate bundle to use to verify client certificates on incoming requests "+
-		"before trusting usernames in headers specified by --requestheader-username-headers")
+		"before trusting usernames in headers specified by --requestheader-username-headers. "+
+		"WARNING: generally do not depend on authorization being already done for incoming requests.")
 
 	fs.StringSliceVar(&s.AllowedNames, "requestheader-allowed-names", s.AllowedNames, ""+
 		"List of client certificate common names to allow to provide usernames in headers "+
@@ -218,8 +219,12 @@ func (s *DelegatingAuthenticationOptions) ToAuthenticationConfig() (authenticato
 
 const (
 	authenticationConfigMapNamespace = metav1.NamespaceSystem
-	authenticationConfigMapName      = "extension-apiserver-authentication"
-	authenticationRoleName           = "extension-apiserver-authentication-reader"
+	// authenticationConfigMapName is the name of ConfigMap in the kube-system namespace holding the root certificate
+	// bundle to use to verify client certificates on incoming requests before trusting usernames in headers specified
+	// by --requestheader-username-headers. This is created in the cluster by the kube-apiserver.
+	// "WARNING: generally do not depend on authorization being already done for incoming requests.")
+	authenticationConfigMapName = "extension-apiserver-authentication"
+	authenticationRoleName      = "extension-apiserver-authentication-reader"
 )
 
 func (s *DelegatingAuthenticationOptions) getClientCA() (*ClientCertAuthenticationOptions, error) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -29,7 +29,10 @@ import (
 )
 
 // DelegatingAuthorizationOptions provides an easy way for composing API servers to delegate their authorization to
-// the root kube API server
+// the root kube API server.
+// WARNING: never assume that every authenticated incoming request already does authorization.
+//          The aggregator in the kube API server does this today, but this behaviour is not
+//          guaranteed in the future.
 type DelegatingAuthorizationOptions struct {
 	// RemoteKubeConfigFile is the file to use to connect to a "normal" kube API server which hosts the
 	// SubjectAccessReview.authorization.k8s.io endpoint for checking tokens.


### PR DESCRIPTION
The aggregator does authorization for proxied resources. But aggregated apiservers should not depend on it, but do delegated authorization in addition.

```release-note
Add warnings that authors of aggregated API servers must not rely on authorization being done by the kube-apiserver.
```