### PR TITLE
Update Cluster Autoscaler version to 1.2.0-beta1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.1.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.0-beta1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.2.0-beta1

```release-note:
NONE
```