### PR TITLE
prevent https serving without tls certificate configured 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -125,6 +125,9 @@ func RunServer(
 		var listener net.Listener
 		listener = tcpKeepAliveListener{ln.(*net.TCPListener)}
 		if server.TLSConfig != nil {
+			if len(server.TLSConfig.Certificates) == 0 && server.TLSConfig.GetCertificate == nil {
+				glog.Fatalf("tls: neither Certificates nor GetCertificate set in Config")
+			}
 			listener = tls.NewListener(listener, server.TLSConfig)
 		}
 


### PR DESCRIPTION
Fixes #61381

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent https serving without tls certificate configured.
```
