### PR TITLE
csiAttacher: check deviceMountPath before hasStageUnstageCapability

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -248,6 +248,11 @@ func (c *csiAttacher) GetDeviceMountPath(spec *volume.Spec) (string, error) {
 func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) (err error) {
 	glog.V(4).Infof(log("attacher.MountDevice(%s, %s)", devicePath, deviceMountPath))
 
+	if deviceMountPath == "" {
+		err = fmt.Errorf("attacher.MountDevice failed, deviceMountPath is empty")
+		return err
+	}
+
 	mounted, err := isDirMounted(c.plugin, deviceMountPath)
 	if err != nil {
 		glog.Error(log("attacher.MountDevice failed while checking mount status for dir [%s]", deviceMountPath))
@@ -317,11 +322,6 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 	}
 
 	// Start MountDevice
-	if deviceMountPath == "" {
-		err = fmt.Errorf("attacher.MountDevice failed, deviceMountPath is empty")
-		return err
-	}
-
 	nodeName := string(c.plugin.host.GetNodeName())
 	attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 


### PR DESCRIPTION
csiAttacher#MountDevice: it is better to check `deviceMountPath` before `hasStageUnstageCapability`

**Release note**:
```
NONE
```
/release-note-none
/kind cleanup
/sig storage