### PR TITLE
Make `test-cmd` work with OS-X tooling

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -3868,7 +3868,7 @@ run_assert_categories_tests() {
   set -o errexit
 
   kube::log::status "Testing propagation of categories for resources"
-  output_message=$(kubectl get --raw=/api/v1 | grep -Po '"name":"pods".*?}')
+  output_message=$(kubectl get --raw=/api/v1 | grep -o '"name":"pods"[^}]*}')
   kube::test::if_has_string "${output_message}" '"categories":\["all"\]'
 
   set +o nounset
@@ -4729,13 +4729,15 @@ runTests() {
   kube::log::status "Checking kubectl version"
   kubectl version
 
-  # use timestamp as the name of namespace because increasing the variable inside subshell
-  # does not affect the value of the variable outside the subshell.
+  # Generate a random namespace name, based on the current time (to make
+  # debugging slightly easier) and a random number. Don't use `date +%N`
+  # because that doesn't work on OSX.
   create_and_use_new_namespace() {
-    namespace_number=$(date +%s%N)
-    kube::log::status "Creating namespace namespace${namespace_number}"
-    kubectl create namespace "namespace${namespace_number}"
-    kubectl config set-context "${CONTEXT}" --namespace="namespace${namespace_number}"
+    local ns_name
+    ns_name="namespace-$(date +%s)-${RANDOM}"
+    kube::log::status "Creating namespace ${ns_name}"
+    kubectl create namespace "$ns_name"
+    kubectl config set-context "${CONTEXT}" --namespace="$ns_name"
   }
 
   kube_flags=(

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4736,8 +4736,8 @@ runTests() {
     local ns_name
     ns_name="namespace-$(date +%s)-${RANDOM}"
     kube::log::status "Creating namespace ${ns_name}"
-    kubectl create namespace "$ns_name"
-    kubectl config set-context "${CONTEXT}" --namespace="$ns_name"
+    kubectl create namespace "${ns_name}"
+    kubectl config set-context "${CONTEXT}" --namespace="${ns_name}"
   }
 
   kube_flags=(


### PR DESCRIPTION
OS-X thips with the BSD versions of `date` and `grep`. Those don't have
certain features the script relies on:
- BSD date does not support nanoseconds (`%N`)
- BSD grep does not support perl RegEx (`-P`)

As we use `bash` specifically in the hashbang anyway it is probably fine
to rely on the `$RANDOM` bashism here.

**What this PR does / why we need it**:

Currently `make test-cmd` doesn't work on OSX. This PR makes `make test-cmd` work on OSX.

**Release note**:
```release-note
`make test-cmd` now works on OSX.
```

cc: @apelisse 