### PR TITLE
oidc authentication: hd claim support

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -59,6 +59,7 @@ type AuthenticatorConfig struct {
 	OIDCGroupsClaim             string
 	OIDCGroupsPrefix            string
 	OIDCSigningAlgs             []string
+	OIDCHostedDomain            string
 	ServiceAccountKeyFiles      []string
 	ServiceAccountLookup        bool
 	ServiceAccountIssuer        string
@@ -153,7 +154,7 @@ func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDe
 	// simply returns an error, the OpenID Connect plugin may query the provider to
 	// update the keys, causing performance hits.
 	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
-		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCUsernamePrefix, config.OIDCGroupsClaim, config.OIDCGroupsPrefix, config.OIDCSigningAlgs)
+		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCUsernamePrefix, config.OIDCGroupsClaim, config.OIDCGroupsPrefix, config.OIDCSigningAlgs, config.OIDCHostedDomain)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -245,7 +246,7 @@ func newAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Token, e
 }
 
 // newAuthenticatorFromOIDCIssuerURL returns an authenticator.Token or an error.
-func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClaim, usernamePrefix, groupsClaim, groupsPrefix string, signingAlgs []string) (authenticator.Token, error) {
+func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClaim, usernamePrefix, groupsClaim, groupsPrefix string, signingAlgs []string, hostedDomain string) (authenticator.Token, error) {
 	const noUsernamePrefix = "-"
 
 	if usernamePrefix == "" && usernameClaim != "email" {
@@ -270,6 +271,7 @@ func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClai
 		GroupsClaim:          groupsClaim,
 		GroupsPrefix:         groupsPrefix,
 		SupportedSigningAlgs: signingAlgs,
+		HostedDomain:         hostedDomain,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -63,6 +63,7 @@ type OIDCAuthenticationOptions struct {
 	GroupsClaim    string
 	GroupsPrefix   string
 	SigningAlgs    []string
+	HostedDomain   string
 }
 
 type PasswordFileAuthenticationOptions struct {
@@ -222,6 +223,9 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"Comma-separated list of allowed JOSE asymmetric signing algorithms. JWTs with a "+
 			"'alg' header value not in this list will be rejected. "+
 			"Values are defined by RFC 7518 https://tools.ietf.org/html/rfc7518#section-3.1.")
+
+		fs.StringVar(&s.OIDC.HostedDomain, "oidc-hosted-domain", "", ""+
+			"If provided, the hosted domain of the user.")
 	}
 
 	if s.PasswordFile != nil {
@@ -297,6 +301,7 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.Au
 		ret.OIDCUsernameClaim = s.OIDC.UsernameClaim
 		ret.OIDCUsernamePrefix = s.OIDC.UsernamePrefix
 		ret.OIDCSigningAlgs = s.OIDC.SigningAlgs
+		ret.OIDCHostedDomain = s.OIDC.HostedDomain
 	}
 
 	if s.PasswordFile != nil {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -405,6 +405,76 @@ func TestToken(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "hosted-domain-claim",
+			options: Options{
+				IssuerURL:     "https://auth.example.com",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				HostedDomain:  "example.com",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": "my-client",
+				"username": "jane",
+				"hd": "example.com",
+				"exp": %d
+			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name: "jane",
+			},
+		},
+		{
+			name: "no-hosted-domain-claim",
+			options: Options{
+				IssuerURL:     "https://auth.example.com",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				HostedDomain:  "example.com",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": "my-client",
+				"username": "jane",
+				"exp": %d
+			}`, valid.Unix()),
+			wantErr: true,
+		},
+		{
+			name: "invalid-hosted-domain-claim",
+			options: Options{
+				IssuerURL:     "https://auth.example.com",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				HostedDomain:  "example.com",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": "my-client",
+				"username": "jane",
+				"hd": "example.org",
+				"exp": %d
+			}`, valid.Unix()),
+			wantErr: true,
+		},
+		{
 			name: "invalid-signature",
 			options: Options{
 				IssuerURL:     "https://auth.example.com",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the hd claim support for the OIDC authentication. It allows to add an --oidc-hosted-domain flag, and a string value, in the API config. This value is checked against the `hd` claim from the ID Token.

This is for example needed when a company uses Google Auth with its own domain, and want to authorize its domain only.
https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61276

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
oidc authentication: hd claim support
```
