### PR TITLE
Record an event when node comes back from NodeNotReady to NodeReady

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -669,12 +669,17 @@ func (nc *Controller) monitorNodeStatus() error {
 				}
 			}
 
-			// Report node event.
+			// Report node event: NodeReady -> NodeNotReady
 			if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
 				nodeutil.RecordNodeStatusChange(nc.recorder, node, "NodeNotReady")
 				if err = nodeutil.MarkAllPodsNotReady(nc.kubeClient, node); err != nil {
 					utilruntime.HandleError(fmt.Errorf("Unable to mark all pods NotReady on node %v: %v", node.Name, err))
 				}
+			}
+
+			// Report node event: NodeNotReady -> NodeReady
+			if observedReadyCondition.Status != v1.ConditionTrue && currentReadyCondition.Status == v1.ConditionTrue {
+				nodeutil.RecordNodeStatusChange(nc.recorder, node, "NodeReady")
 			}
 
 			// Check with the cloud provider to see if the node still exists. If it


### PR DESCRIPTION
I'm taking a wild stab in the dark here.

I've noticed that we log an event when a node becomes not ready but nothing when it comes back ready.

This is an **untested** attempt to do so.