### PR TITLE
Update Cluster Autoscaler version to 0.6.4

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.3",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.4",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 0.6.4

```release-note:
Update Cluster Autoscaler version to 0.6.4 to fix security vulnerabilities 
```