### PR TITLE
Ensure that NODE_IPAM_MODE has a value in start-kube-controller-manager.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1765,7 +1765,7 @@ function start-kube-controller-manager {
     params+=" --terminated-pod-gc-threshold=${TERMINATED_POD_GC_THRESHOLD}"
   fi
   if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    params+=" --cidr-allocator-type=${NODE_IPAM_MODE}"
+    params+=" --cidr-allocator-type=${NODE_IPAM_MODE:-CloudAllocator}"
     params+=" --configure-cloud-routes=false"
   fi
   if [[ -n "${FEATURE_GATES:-}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: Ensures that NODE_IPAM_MODE has a value in start-kube-controller-manager for GCE

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # TBD

**Special notes for your reviewer**: Previously NODE_IPAM_MODE has a value of CloudAllocator.
The value should have already been set at which point the default is ignored.
However if the value is not set then we will continue, rather than crash, using the original behavior.

**Release note**:
```release-note
NONE
```
