### PR TITLE
Bump debian-iptables-amd64 digest for release 1.9

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -87,7 +87,7 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:a3b936c0fb98a934eecd2cfb91f73658d402b29116084e778ce9ddb68e55383e",
+    digest = "sha256:fb18678f8203ca1bd2fad2671e3ebd80cb408a1baae423d4ad39c05f4caac4e1",
     registry = "gcr.io",
     repository = "google-containers/debian-iptables-amd64",
     tag = "v10",  # ignored, but kept here for documentation


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to make the digest consistent with 1.8, 1.9, and 1.10 branches

/assign @mikedanese 
```release-note
None
```
