### PR TITLE
Schedule even if extender is not available when using extender 

### DIFF
--- a/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/pkg/scheduler/algorithm/scheduler_interface.go
@@ -64,6 +64,10 @@ type SchedulerExtender interface {
 
 	// SupportsPreemption returns if the scheduler extender support preemption or not.
 	SupportsPreemption() bool
+
+	// IsIgnorable returns true indicates scheduling should not fail when this extender
+	// is unavailable. This gives scheduler ability to fail fast and tolerate non-critical extenders as well.
+	IsIgnorable() bool
 }
 
 // ScheduleAlgorithm is an interface implemented by things that know how to schedule pods

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -192,6 +192,9 @@ type ExtenderConfig struct {
 	//   will skip checking the resource in predicates.
 	// +optional
 	ManagedResources []ExtenderManagedResource
+	// Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+	// fail when the extender returns an error or is not reachable.
+	Ignorable bool
 }
 
 // ExtenderPreemptionResult represents the result returned by preemption phase of extender.

--- a/pkg/scheduler/api/v1/types.go
+++ b/pkg/scheduler/api/v1/types.go
@@ -174,6 +174,9 @@ type ExtenderConfig struct {
 	//   will skip checking the resource in predicates.
 	// +optional
 	ManagedResources []ExtenderManagedResource `json:"managedResources,omitempty"`
+	// Ignorable specifies if the extender is ignorable, i.e. scheduling should not
+	// fail when the extender returns an error or is not reachable.
+	Ignorable bool `json:"ignorable,omitempty"`
 }
 
 // ExtenderArgs represents the arguments needed by the extender to filter/prioritize

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -146,7 +146,10 @@ func (f *FakeExtender) ProcessPreemption(
 
 	for node, victims := range nodeToVictimsCopy {
 		// Try to do preemption on extender side.
-		extenderVictimPods, extendernPDBViolations, fits := f.selectVictimsOnNodeByExtender(pod, node, nodeNameToInfo)
+		extenderVictimPods, extendernPDBViolations, fits, err := f.selectVictimsOnNodeByExtender(pod, node, nodeNameToInfo)
+		if err != nil {
+			return nil, err
+		}
 		// If it's unfit after extender's preemption, this node is unresolvable by preemption overall,
 		// let's remove it from potential preemption nodes.
 		if !fits {
@@ -169,15 +172,18 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 	pod *v1.Pod,
 	node *v1.Node,
 	nodeNameToInfo map[string]*schedulercache.NodeInfo,
-) ([]*v1.Pod, int, bool) {
-	// TODO(harry): add more test in generic_scheduler_test.go to verify this logic.
+) ([]*v1.Pod, int, bool, error) {
 	// If a extender support preemption but have no cached node info, let's run filter to make sure
 	// default scheduler's decision still stand with given pod and node.
 	if !f.nodeCacheCapable {
-		if fits, _ := f.runPredicate(pod, node); !fits {
-			return nil, 0, false
+		fits, err := f.runPredicate(pod, node)
+		if err != nil {
+			return nil, 0, false, err
 		}
-		return []*v1.Pod{}, 0, true
+		if !fits {
+			return nil, 0, false, nil
+		}
+		return []*v1.Pod{}, 0, true, nil
 	}
 
 	// Otherwise, as a extender support preemption and have cached node info, we will assume cachedNodeNameToInfo is available
@@ -205,8 +211,12 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 
 	// If the new pod does not fit after removing all the lower priority pods,
 	// we are almost done and this node is not suitable for preemption.
-	if fits, _ := f.runPredicate(pod, nodeInfoCopy.Node()); !fits {
-		return nil, 0, false
+	fits, err := f.runPredicate(pod, nodeInfoCopy.Node())
+	if err != nil {
+		return nil, 0, false, err
+	}
+	if !fits {
+		return nil, 0, false, nil
 	}
 
 	var victims []*v1.Pod
@@ -230,7 +240,7 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(
 		reprievePod(p.(*v1.Pod))
 	}
 
-	return victims, numViolatingVictim, true
+	return victims, numViolatingVictim, true, nil
 }
 
 // runPredicate run predicates of extender one by one for given pod and node.
@@ -444,7 +454,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			// Filter/Prioritize phases if the extender is not interested in
 			// the pod.
 			//
-			// If scheduler sends the pod by mistake, the test will fail
+			// If scheduler sends the pod by mistake, the test would fail
 			// because of the errors from errorPredicateExtender and/or
 			// errorPrioritizerExtender.
 			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
@@ -465,7 +475,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			// Scheduling is expected to not fail in
 			// Filter/Prioritize phases if the extender is not available and ignorable.
 			//
-			// If scheduler did not ignore the extender, the test will fail
+			// If scheduler did not ignore the extender, the test would fail
 			// because of the errors from errorPredicateExtender.
 			predicates:   map[string]algorithm.FitPredicate{"true": truePredicate},
 			prioritizers: []algorithm.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -269,12 +269,24 @@ func (g *genericScheduler) processPreemptionWithExtenders(
 	if len(nodeToVictims) > 0 {
 		for _, extender := range g.extenders {
 			if extender.SupportsPreemption() {
-				var err error
-				// Replace nodeToVictims with result after preemption from extender.
-				if nodeToVictims, err = extender.ProcessPreemption(pod, nodeToVictims, g.cachedNodeInfoMap); err != nil {
+				newNodeToVictims, err := extender.ProcessPreemption(
+					pod,
+					nodeToVictims,
+					g.cachedNodeInfoMap,
+				)
+				if err != nil {
+					if extender.IsIgnorable() {
+						glog.Warningf("Skipping extender %v as it returned error %v and has ignorable flag set",
+							extender, err)
+						continue
+					}
 					return nil, err
 				}
-				// If node list is empty, no preemption will happen, skip other extenders.
+				// Replace nodeToVictims with new result after preemption. So the
+				// rest of extenders can continue use it as parameter.
+				nodeToVictims = newNodeToVictims
+
+				// If node list becomes empty, no preemption can happen regardless of other extenders.
 				if len(nodeToVictims) == 0 {
 					break
 				}
@@ -384,7 +396,13 @@ func findNodesThatFit(
 			}
 			filteredList, failedMap, err := extender.Filter(pod, filtered, nodeNameToInfo)
 			if err != nil {
-				return []*v1.Node{}, FailedPredicateMap{}, err
+				if extender.IsIgnorable() {
+					glog.Warningf("Skipping extender %v as it returned error %v and has ignorable flag set",
+						extender, err)
+					continue
+				} else {
+					return []*v1.Node{}, FailedPredicateMap{}, err
+				}
 			}
 
 			for failedNodeName, failedMsg := range failedMap {

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -282,6 +282,7 @@ func (g *genericScheduler) processPreemptionWithExtenders(
 					}
 					return nil, err
 				}
+
 				// Replace nodeToVictims with new result after preemption. So the
 				// rest of extenders can continue use it as parameter.
 				nodeToVictims = newNodeToVictims

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -539,6 +539,11 @@ func newConfigFactory(client *clientset.Clientset, hardPodAffinitySymmetricWeigh
 type fakeExtender struct {
 	isBinder          bool
 	interestedPodName string
+	ignorable         bool
+}
+
+func (f *fakeExtender) IsIgnorable() bool {
+	return f.ignorable
 }
 
 func (f *fakeExtender) ProcessPreemption(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When using scheduler extender, if the extender is not available scheduling of all pods fail.
We should let the scheduling happen but display error message that extender is failing.

`IsIgnorable()`  is added to extender to indicate: if scheduling of all pods should fail when it's unavailable

**Backward compabtiility:**

We use `IsIgnorable` instead of `IsCritical` so that when this flag is not set, the default value will be `false`, i.e. not ignorable, which consistent with the current behavior in existing extenders.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #60616

**Special notes for your reviewer**:
kindly cc @ravisantoshgudimetla to see if this meets your expectation

TODO: update the examples in kubernetes/examples, but the strategy there is not clear to me for now

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Schedule even if extender is not available when using extender 
```
