### PR TITLE
remove invalid resource replicationControllers in DefaultResourcePrefixes

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -26,7 +26,6 @@ import (
 
 // SpecialDefaultResourcePrefixes are prefixes compiled into Kubernetes.
 var SpecialDefaultResourcePrefixes = map[schema.GroupResource]string{
-	{Group: "", Resource: "replicationControllers"}:        "controllers",
 	{Group: "", Resource: "replicationcontrollers"}:        "controllers",
 	{Group: "", Resource: "endpoints"}:                     "services/endpoints",
 	{Group: "", Resource: "nodes"}:                         "minions",


### PR DESCRIPTION
As all resources are lowercased, so remove invalid GroupResource `{Group: "", Resource: "replicationControllers"}`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
