### PR TITLE
Check unmounter before Assignment in TestPluginNewUnmounter

### DIFF
--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -215,7 +215,7 @@ func TestPluginNewMounter(t *testing.T) {
 		t.Error("mounter pod not set")
 	}
 	if csiMounter.podUID == types.UID("") {
-		t.Error("mounter podUID mot set")
+		t.Error("mounter podUID not set")
 	}
 }
 
@@ -226,18 +226,17 @@ func TestPluginNewUnmounter(t *testing.T) {
 	pv := makeTestPV("test-pv", 10, testDriver, testVol)
 
 	unmounter, err := plug.NewUnmounter(pv.ObjectMeta.Name, testPodUID)
-	csiUnmounter := unmounter.(*csiMountMgr)
 
 	if err != nil {
 		t.Fatalf("Failed to make a new Unmounter: %v", err)
 	}
-
-	if csiUnmounter == nil {
+	if unmounter == nil {
 		t.Fatal("failed to create CSI Unmounter")
 	}
+	csiUnmounter := unmounter.(*csiMountMgr)
 
 	if csiUnmounter.podUID != testPodUID {
-		t.Error("podUID not set")
+		t.Error("unmounter podUID not set")
 	}
 
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Check unmounter is not nil before Assignment in TestPluginNewUnmounter
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
