### PR TITLE
etcdv3 client: add dial timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -29,11 +29,13 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 )
 
-// The short keepalive timeout and interval have been chosen to aggressively
-// detect a failed etcd server without introducing much overhead.
 var (
+	// The short keepalive timeout and interval have been chosen to aggressively
+	// detect a failed etcd server without introducing much overhead.
 	keepaliveTime    = 30 * time.Second
 	keepaliveTimeout = 10 * time.Second
+	// dialTimeout is the timeout for failing to establish a connection.
+	dialTimeout = 10 * time.Second
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
@@ -52,6 +54,7 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
+		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,
 		Endpoints:            c.ServerList,


### PR DESCRIPTION
dial timeout is necessary for a reliable system, this pr add it for establishing an etcd connection.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kube-apiserver now sets a dial timeout when connecting to etcd, to allow it to tolerate/retry connections to a dead etcd server
```
