### PR TITLE
fix print object should be updated error

### DIFF
--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -166,7 +166,7 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 
 	// Create ClusterRole.
 	if !c.DryRun {
-		_, err = c.Client.ClusterRoles().Create(clusterRole)
+		clusterRole, err = c.Client.ClusterRoles().Create(clusterRole)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -286,7 +286,7 @@ func (c *CreateRoleOptions) RunCreateRole() error {
 
 	// Create role.
 	if !c.DryRun {
-		_, err = c.Client.Roles(c.Namespace).Create(role)
+		role, err = c.Client.Roles(c.Namespace).Create(role)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
	Print object should be updated.
　　After this patch, it goes the same as create.go
https://github.com/kubernetes/kubernetes/blob/025439988428d2b78342549419706639cd6e52a6/pkg/kubectl/cmd/create.go#L346
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
