### PR TITLE
Keep temporary PVC matching state to optimize PVs that don’t use node affinity

### DIFF
--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -16,6 +16,7 @@ go_library(
         "scheduler_binder.go",
         "scheduler_binder_cache.go",
         "scheduler_binder_fake.go",
+        "scheduler_pvc_cache.go",
         "volume_host.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/controller/volume/persistentvolume",
@@ -73,6 +74,7 @@ go_test(
         "scheduler_assume_cache_test.go",
         "scheduler_binder_cache_test.go",
         "scheduler_binder_test.go",
+        "scheduler_pvc_cache_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_fake.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_fake.go
@@ -61,3 +61,7 @@ func (b *FakeVolumeBinder) BindPodVolumes(assumedPod *v1.Pod) error {
 func (b *FakeVolumeBinder) GetBindingsCache() PodBindingCache {
 	return nil
 }
+
+func (b *FakeVolumeBinder) GetMatchingCache() PVCMatchingCache {
+	return nil
+}

--- a/pkg/controller/volume/persistentvolume/scheduler_pvc_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_pvc_cache.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolume
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// PVCMatchingCache store Pod's PVC temporary state of matching PVs if
+// none of the PVs have node affinity. Then we can skip PV matching on
+// subsequent nodes, and just return the result of the first attempt.
+// Because PVs under a given storage class name may change. Pod's PVC matching
+// states are only cached in one scheduler pass, should be invalidated when Pod
+// is rescheduled again.
+// Pod's PVC matching states are also removed when the Pod is deleted or
+// updated to no longer be schedulable.
+type PVCMatchingCache interface {
+	// UpdateMatching
+	UpdateMatching(pod *v1.Pod, pvc *v1.PersistentVolumeClaim, state *matching)
+
+	// DeleteMatchings will remove all cached entries for the given pod.
+	DeleteMatchings(pod *v1.Pod)
+
+	// GetMatching will return the cached state for the given pod and pvc.
+	GetMatching(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) *matching
+
+	// GetMatchings will return the cached states for the given pod.
+	GetMatchings(pod *v1.Pod) matchings
+}
+
+type matching struct {
+	// Indicates success or failure of previously matching PVs.
+	err error
+
+	// Proposed PV to bind to this claim.
+	pv *v1.PersistentVolume
+}
+
+// Key = pvc name
+// Value = pointer to matching
+type matchings map[string]*matching
+
+// Since the scheduelr is serialized, we don't need lock here.
+type pvcMatchingCache struct {
+	// Key = pod name
+	// Value = matchings
+	pvcMatchings map[string]matchings
+}
+
+func NewPVCMatchingCache() PVCMatchingCache {
+	return &pvcMatchingCache{pvcMatchings: map[string]matchings{}}
+}
+
+func (c *pvcMatchingCache) UpdateMatching(pod *v1.Pod, pvc *v1.PersistentVolumeClaim, state *matching) {
+	podName := getPodName(pod)
+	states, ok := c.pvcMatchings[podName]
+	if !ok {
+		states = matchings{}
+		c.pvcMatchings[podName] = states
+	}
+	states[getPVCName(pvc)] = state
+}
+
+func (c *pvcMatchingCache) DeleteMatchings(pod *v1.Pod) {
+	podName := getPodName(pod)
+	delete(c.pvcMatchings, podName)
+}
+
+func (c *pvcMatchingCache) GetMatching(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) *matching {
+	matchings := c.GetMatchings(pod)
+	if matchings != nil {
+		return matchings[getPVCName(pvc)]
+	}
+	return nil
+}
+
+func (c *pvcMatchingCache) GetMatchings(pod *v1.Pod) matchings {
+	podName := getPodName(pod)
+	matchings, ok := c.pvcMatchings[podName]
+	if !ok {
+		return nil
+	}
+	return matchings
+}

--- a/pkg/controller/volume/persistentvolume/scheduler_pvc_cache_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_pvc_cache_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolume
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpdateMatchings(t *testing.T) {
+	testcases := map[string]struct {
+		updatePod      string
+		updatePVC      string
+		updateMatching *matching
+
+		getPod      string
+		getPVC      string
+		getMatching *matching
+	}{
+		"matching-exists": {
+			updatePod:      "pod1",
+			updatePVC:      "pvc1",
+			updateMatching: &matching{err: errors.New("test")},
+			getPod:         "pod1",
+			getPVC:         "pvc1",
+			getMatching:    &matching{err: errors.New("test")},
+		},
+		"another-get-pvc": {
+			updatePod:      "pod1",
+			updatePVC:      "pvc1",
+			updateMatching: &matching{err: errors.New("test")},
+			getPod:         "pod1",
+			getPVC:         "pvc2",
+			getMatching:    nil,
+		},
+	}
+
+	for name, v := range testcases {
+		cache := NewPVCMatchingCache()
+
+		// update
+		updatePod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: v.updatePod, Namespace: "ns"}}
+		updatePVC := &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: v.updatePVC, Namespace: "ns"}}
+		cache.UpdateMatching(updatePod, updatePVC, v.updateMatching)
+
+		// verify update
+		matching := cache.GetMatching(updatePod, updatePVC)
+		if !reflect.DeepEqual(matching, v.updateMatching) {
+			t.Errorf("Test %v failed: returned matching after update different. Got %+v, expected %+v", name, matching, v.updateMatching)
+		}
+
+		// verify get
+		getPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: v.getPod, Namespace: "ns"}}
+		getPVC := &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: v.getPVC, Namespace: "ns"}}
+		getMatching := cache.GetMatching(getPod, getPVC)
+		if !reflect.DeepEqual(getMatching, v.getMatching) {
+			t.Errorf("Test %v failed: returned matching after get different. Got %+v, expected %+v", name, getMatching, v.getMatching)
+		}
+	}
+}
+
+func TestDeleteMatchings(t *testing.T) {
+	initialMatching := &matching{err: nil, pv: &v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv1"}}}
+	cache := NewPVCMatchingCache()
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns"}}
+	pvc := &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "ns"}}
+
+	// Get nil matching.
+	matching := cache.GetMatching(pod, pvc)
+	if matching != nil {
+		t.Errorf("Test failed: expect initla nil matching, got %+v", matching)
+	}
+
+	// Delete nothing.
+	cache.DeleteMatchings(pod)
+
+	// Perform update.
+	cache.UpdateMatching(pod, pvc, initialMatching)
+
+	// Verify.
+	matching = cache.GetMatching(pod, pvc)
+	if !reflect.DeepEqual(matching, initialMatching) {
+		t.Errorf("Test failed: expected matching %+v, got %+v", initialMatching, matching)
+	}
+
+	// Delete
+	cache.DeleteMatchings(pod)
+
+	// Verify after delete.
+	matching = cache.GetMatching(pod, pvc)
+	if matching != nil {
+		t.Errorf("Test failed: expected nil matching, got %+v", matching)
+	}
+}

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -668,6 +668,7 @@ func (c *configFactory) deletePodFromSchedulingQueue(obj interface{}) {
 	if c.volumeBinder != nil {
 		// Volume binder only wants to keep unassigned pods
 		c.volumeBinder.DeletePodBindings(pod)
+		c.volumeBinder.DeletePodPVCMatching(pod)
 	}
 }
 
@@ -1148,6 +1149,10 @@ func (c *configFactory) getNextPod() *v1.Pod {
 		return pod
 	}
 	glog.Errorf("Error while retrieving next pod from scheduling queue: %v", err)
+	if c.volumeBinder != nil {
+		// Clear pod pvc matching cache at the begining.
+		c.volumeBinder.DeletePodPVCMatching(pod)
+	}
 	return nil
 }
 
@@ -1316,6 +1321,7 @@ func (c *configFactory) MakeDefaultErrorFunc(backoff *util.PodBackoff, podQueue 
 						if c.volumeBinder != nil {
 							// Volume binder only wants to keep unassigned pods
 							c.volumeBinder.DeletePodBindings(pod)
+							c.volumeBinder.DeletePodPVCMatching(pod)
 						}
 					}
 					break
@@ -1326,6 +1332,7 @@ func (c *configFactory) MakeDefaultErrorFunc(backoff *util.PodBackoff, podQueue 
 					if c.volumeBinder != nil {
 						// Volume binder only wants to keep unassigned pods
 						c.volumeBinder.DeletePodBindings(origPod)
+						c.volumeBinder.DeletePodPVCMatching(pod)
 					}
 					return
 				}

--- a/pkg/scheduler/volumebinder/volume_binder.go
+++ b/pkg/scheduler/volumebinder/volume_binder.go
@@ -72,3 +72,11 @@ func (b *VolumeBinder) DeletePodBindings(pod *v1.Pod) {
 		cache.DeleteBindings(pod)
 	}
 }
+
+// DeletePodPVCMatching will delete the cached pvc matchings for the given pod.
+func (b *VolumeBinder) DeletePodPVCMatching(pod *v1.Pod) {
+	cache := b.Binder.GetMatchingCache()
+	if cache != nil && pod != nil {
+		cache.DeleteMatchings(pod)
+	}
+}

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -263,6 +263,21 @@ func GetClassForVolume(kubeClient clientset.Interface, pv *v1.PersistentVolume) 
 	return class, nil
 }
 
+// HasNodeAdffinity returns true if PV has node affinity, false otherwise.
+func HasNodeAffinity(pv *v1.PersistentVolume) bool {
+	affinity, err := v1helper.GetStorageNodeAffinityFromAnnotation(pv.Annotations)
+	if err != nil {
+		return false
+	}
+	if affinity != nil {
+		return true
+	}
+	if pv.Spec.NodeAffinity != nil {
+		return true
+	}
+	return false
+}
+
 // CheckNodeAffinity looks at the PV node affinity, and checks if the node has the same corresponding labels
 // This ensures that we don't mount a volume that doesn't belong to this node
 func CheckNodeAffinity(pv *v1.PersistentVolume, nodeLabels map[string]string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Implement optimization 1.2 in https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volume-topology-scheduling.md#performance-and-optimizations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I wrote a PVCMatchingCache in SchedulerBinder to keep temporary PVC matching state if none of PVs under PVC storage class has node affinity. In `SchedulerBinder.findMatchingVolumes`, if a cached matching is found, then skip `findMatchingVolume`, and just return cached matching as result.

Scheduler clears PVC matching cache for Pod at the beginning of scheduler pass, and also clears when the Pod is deleted or updated to no longer be schedulable.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```