### PR TITLE
Increase fluentd rolling-upgrade maxUnavailable to large value

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -10,6 +10,8 @@ metadata:
     version: v3.0.0
 spec:
   updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5000
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
~For testing wrt https://github.com/kubernetes/kubernetes/issues/61190#issuecomment-374899752~
Fixes issue https://github.com/kubernetes/kubernetes/issues/61190 wrt slow rolling-upgrade

/cc @x13n @wojtek-t 
/sig instrumentation
/kind bug
/priority critical-urgent

```release-note
NONE
```