### PR TITLE
Automated cherry pick of #61002: IsNotFound should check ErrDefault404 and

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -537,8 +537,17 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 }
 
 func isNotFound(err error) bool {
-	e, ok := err.(*gophercloud.ErrUnexpectedResponseCode)
-	return ok && e.Actual == http.StatusNotFound
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return true
+	}
+
+	if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+		if errCode.Actual == http.StatusNotFound {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (os *OpenStack) Zones() (cloudprovider.Zones, bool) {


### PR DESCRIPTION
Cherry pick of #61002 on release-1.9.

#61002: IsNotFound should check ErrDefault404 and