### PR TITLE
Enable default HugePages limit and request per namespace

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -178,7 +178,6 @@ var overcommitBlacklist = sets.NewString(string(core.ResourceNvidiaGPU))
 // namespace and not blacklisted.
 func IsOvercommitAllowed(name core.ResourceName) bool {
 	return IsDefaultNamespaceResource(name) &&
-		!IsHugePageResourceName(name) &&
 		!overcommitBlacklist.Has(string(name))
 }
 

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -480,7 +480,7 @@ func TestIsOvercommitAllowed(t *testing.T) {
 		},
 		{
 			name:    HugePageResourceName(resource.MustParse("2Mi")),
-			allowed: false,
+			allowed: true,
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3646,28 +3646,6 @@ func TestAlphaHugePagesIsolation(t *testing.T) {
 				DNSPolicy:     core.DNSClusterFirst,
 			},
 		},
-	}
-	failureCases := []core.Pod{
-		{ // Basic fields.
-			ObjectMeta: metav1.ObjectMeta{Name: "hugepages-requireCpuOrMemory", Namespace: "ns"},
-			Spec: core.PodSpec{
-				Containers: []core.Container{
-					{
-						Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File",
-						Resources: core.ResourceRequirements{
-							Requests: core.ResourceList{
-								core.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
-							},
-							Limits: core.ResourceList{
-								core.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
-							},
-						},
-					},
-				},
-				RestartPolicy: core.RestartPolicyAlways,
-				DNSPolicy:     core.DNSClusterFirst,
-			},
-		},
 		{ // Basic fields.
 			ObjectMeta: metav1.ObjectMeta{Name: "hugepages-shared", Namespace: "ns"},
 			Spec: core.PodSpec{
@@ -3684,6 +3662,28 @@ func TestAlphaHugePagesIsolation(t *testing.T) {
 								core.ResourceName(core.ResourceCPU):    resource.MustParse("10"),
 								core.ResourceName(core.ResourceMemory): resource.MustParse("10G"),
 								core.ResourceName("hugepages-2Mi"):     resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+				RestartPolicy: core.RestartPolicyAlways,
+				DNSPolicy:     core.DNSClusterFirst,
+			},
+		},
+	}
+	failureCases := []core.Pod{
+		{ // Basic fields.
+			ObjectMeta: metav1.ObjectMeta{Name: "hugepages-requireCpuOrMemory", Namespace: "ns"},
+			Spec: core.PodSpec{
+				Containers: []core.Container{
+					{
+						Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File",
+						Resources: core.ResourceRequirements{
+							Requests: core.ResourceList{
+								core.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
+							},
+							Limits: core.ResourceList{
+								core.ResourceName("hugepages-2Mi"): resource.MustParse("1Gi"),
 							},
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: By default LimitRange plugin disable setting default limit per namespace for HugePages. Now it's possible to set this limit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60782

**Special notes for your reviewer**: 
Tests haven't yet been written.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HugePages: LimitRange support.
```
