### PR TITLE
Turn server-print on by default in kubectl

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1324,15 +1324,15 @@ run_kubectl_run_tests() {
   set +o errexit
 }
 
-run_kubectl_server_print_tests() {
+run_kubectl_old_print_tests() {
   set -o nounset
   set -o errexit
 
   create_and_use_new_namespace
-  kube::log::status "Testing kubectl get --experimental-server-print"
+  kube::log::status "Testing kubectl get --server-print=false"
   ### Test retrieval of all types in discovery
   # Pre-condition: no resources exist
-  output_message=$(kubectl get pods --experimental-server-print 2>&1 "${kube_flags[@]}")
+  output_message=$(kubectl get pods --server-print=false 2>&1 "${kube_flags[@]}")
   # Post-condition: Expect text indicating no resources were found
   kube::test::if_has_string "${output_message}" 'No resources found.'
 
@@ -1343,7 +1343,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get pod "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get pod --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get pod --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of daemonsets against server-side printing
@@ -1353,7 +1353,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get ds "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get ds --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get ds --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of replicationcontrollers against server-side printing
@@ -1363,7 +1363,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get rc "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get rc --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get rc --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of replicasets against server-side printing
@@ -1373,7 +1373,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get rs "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get rs --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get rs --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of jobs against server-side printing
@@ -1383,7 +1383,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get jobs/pi "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get jobs/pi --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get jobs/pi --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of clusterroles against server-side printing
@@ -1393,7 +1393,7 @@ run_kubectl_server_print_tests() {
   # Compare "old" output with experimental output and ensure both are the same
   # remove the last column, as it contains the object's AGE, which could cause a mismatch.
   expected_output=$(kubectl get clusterroles/sample-role "${kube_flags[@]}" | awk 'NF{NF--};1')
-  actual_output=$(kubectl get clusterroles/sample-role --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get clusterroles/sample-role --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   ### Test retrieval of crds against server-side printing
@@ -1422,7 +1422,7 @@ __EOF__
   kube::test::get_object_assert foos "{{range.items}}{{$id_field}}:{{end}}" ''
   # Compare "old" output with experimental output and ensure both are the same
   expected_output=$(kubectl get foos "${kube_flags[@]}")
-  actual_output=$(kubectl get foos --experimental-server-print "${kube_flags[@]}" | awk 'NF{NF--};1')
+  actual_output=$(kubectl get foos --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
   # teardown
@@ -4935,7 +4935,7 @@ runTests() {
 
   if kube::test::if_supports_resource "${pods}" ; then
     record_command run_kubectl_get_tests
-    record_command run_kubectl_server_print_tests
+    record_command run_kubectl_old_print_tests
   fi
 
 

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -122,7 +122,7 @@ var (
 
 const (
 	useOpenAPIPrintColumnFlagLabel = "use-openapi-print-columns"
-	useServerPrintColumns          = "experimental-server-print"
+	useServerPrintColumns          = "server-print"
 )
 
 // NewGetOptions returns a GetOptions with default chunk size 500.
@@ -201,6 +201,13 @@ func (options *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		return err
 	}
 	options.Sort = len(isSorting) > 0
+
+	// TODO (soltysh): currently we don't support sorting and custom columns
+	// with server side print. So in these cases force the old behavior.
+	outputOption := cmd.Flags().Lookup("output").Value.String()
+	if options.Sort && outputOption == "custom-columns" {
+		options.ServerPrint = false
+	}
 
 	options.IncludeUninitialized = cmdutil.ShouldIncludeUninitialized(cmd, false)
 
@@ -727,7 +734,7 @@ func addOpenAPIPrintColumnFlags(cmd *cobra.Command) {
 }
 
 func addServerPrintColumnFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(useServerPrintColumns, false, "If true, have the server return the appropriate table output. Supports extension APIs and CRD. Experimental.")
+	cmd.Flags().Bool(useServerPrintColumns, true, "If true, have the server return the appropriate table output. Supports extension APIs and CRDs.")
 }
 
 func shouldGetNewPrinterForMapping(printer printers.ResourcePrinter, lastMapping, mapping *meta.RESTMapping) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
#55637 introduced `-experimental-server-print` that enabled users to opt-in to user server-side printing. This is a followup which enables this functionality by default, with the ability to fallback not to do it with `--server-print=false`. 

/assign @smarterclayton @juanvallejo 

**Release note**:
```release-note
Enable server-side print in kubectl by default, with the ability to turn it off with --server-print=false
```
