### PR TITLE
Fix summary_test to work when XFS is used under overlay2 and add a check for Delegate=yes missing from docker.service

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -324,7 +324,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 					{
 						Name:    "busybox-container",
 						Image:   busyboxImage,
-						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file;"),
+						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file;"),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This fixes the summary_test checks to work in cases where:
1. Docker is using overlay2 for its images with XFS as backing filesystem.
1. The systemd unit for Docker does not include Delegate=yes.

The former will break RootFs minimum usage check from summary_test, since it expects _some_ usage even though the upper layer only contains directories that are used as mount points. It turns out the XFS filesystem returns "0" blocks in the stat() result for a directory, so this breaks the test. Fix it by creating a file with some small contents in the test, so that `du` will actually return some usage.

**NOTE**: I introduced this step in the loop part of the function. It works, but maybe it's not the best... Let me know if you think we should do some small cleanup here too, I'd be happy to do that.

Regarding the latter, when `Delegate=yes` is not included in `docker.service`, then systemd might choose not to create Memory and CPU cgroups (actually, any of the resource cgroups) for the unit when it starts it. It's a bit more complicated than that, because it *does* create them if any sibling units need it, so the behavior is a bit hard to control... In any case, here we're checking on it and accepting that we might get a "nil" from cAdvisor in cases where `Delegate=yes` is missing.

Both of these issues can be found on CentOS/RHEL, that's the motivation for the fixes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
/assign dashpole

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

