### PR TITLE
WIP: Use containerized rootfs mount point when handling subpath

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -107,6 +107,10 @@ func (mi *fakeMountInterface) SafeMakeDir(_, _ string, _ os.FileMode) error {
 	return nil
 }
 
+func (mi *fakeMountInterface) GetAbsoluteHostPath(_ string) (string, error) {
+	return "", nil
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -207,16 +207,17 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 				return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %v", mount.SubPath, err)
 			}
 
-			fileinfo, err := os.Lstat(hostPath)
+			volumePath, err := mounter.GetAbsoluteHostPath(hostPath)
+			if err != nil {
+				return nil, cleanupAction, err
+			}
+
+			fileinfo, err := os.Lstat(volumePath)
 			if err != nil {
 				return nil, cleanupAction, err
 			}
 			perm := fileinfo.Mode()
 
-			volumePath, err := filepath.EvalSymlinks(hostPath)
-			if err != nil {
-				return nil, cleanupAction, err
-			}
 			hostPath = filepath.Join(volumePath, mount.SubPath)
 
 			if subPathExists, err := utilfile.FileOrSymlinkExists(hostPath); err != nil {

--- a/pkg/util/mount/exec_mount.go
+++ b/pkg/util/mount/exec_mount.go
@@ -151,3 +151,7 @@ func (m *execMounter) CleanSubPaths(podDir string, volumeName string) error {
 func (m *execMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return m.wrappedMounter.SafeMakeDir(pathname, base, perm)
 }
+
+func (m *execMounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return m.wrappedMounter.GetAbsoluteHostPath(pathname)
+}

--- a/pkg/util/mount/exec_mount_test.go
+++ b/pkg/util/mount/exec_mount_test.go
@@ -163,3 +163,7 @@ func (fm *fakeMounter) CleanSubPaths(podDir string, volumeName string) error {
 func (fm *fakeMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return nil
 }
+
+func (fm *fakeMounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return "", nil
+}

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -208,3 +208,6 @@ func (f *FakeMounter) CleanSubPaths(podDir string, volumeName string) error {
 func (mounter *FakeMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return nil
 }
+func (mounter *FakeMounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return "", nil
+}

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -108,6 +108,9 @@ type Interface interface {
 	// subpath starts. On the other hand, Interface.CleanSubPaths must be called
 	// when the pod finishes.
 	PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error)
+	// GetAbsoluteHostPath resolves any symlinks in the given path.
+	// Will operate in the host mount namespace if kubelet is running in a container
+	GetAbsoluteHostPath(pathname string) (string, error)
 }
 
 type Subpath struct {

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -1155,3 +1155,11 @@ func doSafeOpen(pathname string, base string) (int, error) {
 
 	return finalFD, nil
 }
+
+func (mounter *Mounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return doGetAbsoluteHostPath(pathname)
+}
+
+func doGetAbsoluteHostPath(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -121,3 +121,7 @@ func (mounter *Mounter) CleanSubPaths(podDir string, volumeName string) error {
 func (mounter *Mounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return nil
 }
+
+func (mounter *Mounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return "", nil
+}

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -578,3 +578,7 @@ func findExistingPrefix(base, pathname string) (string, []string, error) {
 
 	return pathname, []string{}, nil
 }
+
+func (mounter *Mounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -32,6 +32,8 @@ import (
 )
 
 const (
+	// rootFsMount is the path where the host "/" is mounted into the kubelet container
+	rootFsMount = "/rootfs"
 	// hostProcMountsPath is the default mount path for rootfs
 	hostProcMountsPath = "/rootfs/proc/1/mounts"
 	// hostProcMountinfoPath is the default mount info path for rootfs
@@ -317,4 +319,8 @@ func (mounter *NsenterMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath 
 
 func (mounter *NsenterMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return doSafeMakeDir(pathname, base, perm)
+}
+
+func (mounter *NsenterMounter) GetAbsoluteHostPath(pathname string) (string, error) {
+	return doGetAbsoluteHostPath(filepath.Join(rootFsMount, pathname))
 }

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -91,6 +91,10 @@ func (mounter *fakeMounter) SafeMakeDir(_, _ string, _ os.FileMode) error {
 	return nil
 }
 
+func (mounter *fakeMounter) GetAbsoluteHostPath(_ string) (string, error) {
+	return "", nil
+}
+
 func (mounter *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	name := path.Base(file)
 	if strings.HasPrefix(name, "mount") {

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -388,6 +388,10 @@ func (fftc *fakeFileTypeChecker) SafeMakeDir(_, _ string, _ os.FileMode) error {
 	return nil
 }
 
+func (fftc *fakeFileTypeChecker) GetAbsoluteHostPath(_ string) (string, error) {
+	return "", nil
+}
+
 func setUp() error {
 	err := os.MkdirAll("/tmp/ExistingFolder", os.FileMode(0755))
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
For containerized kubelet environments, subpath handling needs prepend the hostpath with the rootfs mount point.  This mainly impacts hostpath volumes, where the volume host path is not under "/var/lib/kubelet" like the other volume types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61456

**Special notes for your reviewer**:
Not tested yet

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes issue where hostpath subpath volume mounts do not work in containerized kubelet environments
```
