### PR TITLE
Update volumes that cannot reconstruct the volume spec

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -177,16 +177,8 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 }
 
 func (plugin *azureFilePlugin) ConstructVolumeSpec(volName, mountPath string) (*volume.Spec, error) {
-	azureVolume := &v1.Volume{
-		Name: volName,
-		VolumeSource: v1.VolumeSource{
-			AzureFile: &v1.AzureFileVolumeSource{
-				SecretName: volName,
-				ShareName:  volName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(azureVolume), nil
+	//  To reconstruct volume spec we need source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct azure_file volume spec from volume mountpath")
 }
 
 // azureFile volumes represent mount of an AzureFile share.

--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -168,16 +168,8 @@ func (plugin *cephfsPlugin) newUnmounterInternal(volName string, podUID types.UI
 }
 
 func (plugin *cephfsPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	cephfsVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			CephFS: &v1.CephFSVolumeSource{
-				Monitors: []string{},
-				Path:     mountPath,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(cephfsVolume), nil
+	//  To reconstruct volume spec we need source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct cephfs volume spec from volume mountpath")
 }
 
 // CephFS volumes represent a bare host file or directory mount of an CephFS export.

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -115,26 +115,6 @@ func TestPlugin(t *testing.T) {
 	}
 }
 
-func TestConstructVolumeSpec(t *testing.T) {
-	tmpDir, err := utiltesting.MkTmpdir("cephTest")
-	if err != nil {
-		t.Fatalf("Can't make a temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-	plugMgr := volume.VolumePluginMgr{}
-	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(tmpDir, nil, nil))
-	plug, err := plugMgr.FindPluginByName("kubernetes.io/cephfs")
-	if err != nil {
-		t.Errorf("can't find cephfs plugin by name")
-	}
-
-	cephfsSpec, err := plug.(*cephfsPlugin).ConstructVolumeSpec("cephfsVolume", "/cephfsVolume/")
-
-	if cephfsSpec.Name() != "cephfsVolume" {
-		t.Errorf("Get wrong cephfs spec name, got: %s", cephfsSpec.Name())
-	}
-}
-
 type testcase struct {
 	name      string
 	defaultNs string

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -117,13 +117,8 @@ func (plugin *configMapPlugin) NewUnmounter(volName string, podUID types.UID) (v
 }
 
 func (plugin *configMapPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	configMapVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{},
-		},
-	}
-	return volume.NewSpecFromVolume(configMapVolume), nil
+	//  To reconstruct volume spec we need source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct volume spec from volume mountpath")
 }
 
 type configMapVolume struct {

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -117,13 +117,8 @@ func (plugin *downwardAPIPlugin) NewUnmounter(volName string, podUID types.UID) 
 }
 
 func (plugin *downwardAPIPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	downwardAPIVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			DownwardAPI: &v1.DownwardAPIVolumeSource{},
-		},
-	}
-	return volume.NewSpecFromVolume(downwardAPIVolume), nil
+	//  To reconstruct volume spec we need source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct volume spec from volume mountpath")
 }
 
 // downwardAPIVolume retrieves downward API data and placing them into the volume on the host.

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -142,13 +142,8 @@ func (plugin *emptyDirPlugin) newUnmounterInternal(volName string, podUID types.
 }
 
 func (plugin *emptyDirPlugin) ConstructVolumeSpec(volName, mountPath string) (*volume.Spec, error) {
-	emptyDirVolume := &v1.Volume{
-		Name: volName,
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{},
-		},
-	}
-	return volume.NewSpecFromVolume(emptyDirVolume), nil
+	//  To reconstruct volume spec we need source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct emptyDir volume spec from volume mountpath")
 }
 
 // mountDetector abstracts how to find what kind of mount a path is backed by.

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -225,15 +225,8 @@ func (plugin *flexVolumeAttachablePlugin) NewDetacher() (volume.Detacher, error)
 
 // ConstructVolumeSpec is part of the volume.AttachableVolumePlugin interface.
 func (plugin *flexVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	flexVolume := &api.Volume{
-		Name: volumeName,
-		VolumeSource: api.VolumeSource{
-			FlexVolume: &api.FlexVolumeSource{
-				Driver: plugin.driverName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(flexVolume), nil
+	//  To reconstruct volume spec we need driver name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct flexvolume spec from volume mountpath")
 }
 
 func (plugin *flexVolumePlugin) SupportsMountOption() bool {

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -181,15 +181,8 @@ func (p *flockerPlugin) newUnmounterInternal(volName string, podUID types.UID, m
 }
 
 func (p *flockerPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	flockerVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Flocker: &v1.FlockerVolumeSource{
-				DatasetName: volumeName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(flockerVolume), nil
+	//  To reconstruct volume spec we need flocker source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct flocker volume spec from volume mountpath")
 }
 
 func (b *flockerVolume) GetDatasetUUID() (datasetUUID string, err error) {

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -117,13 +117,8 @@ func (plugin *gitRepoPlugin) NewUnmounter(volName string, podUID types.UID) (vol
 }
 
 func (plugin *gitRepoPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	gitVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			GitRepo: &v1.GitRepoVolumeSource{},
-		},
-	}
-	return volume.NewSpecFromVolume(gitVolume), nil
+	//  To reconstruct volume spec we need git_repo source name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct git_repo volume spec from volume mountpath")
 }
 
 // gitRepo volumes are directories which are pre-filled from a git repository.

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -163,15 +163,8 @@ func (plugin *nfsPlugin) Recycle(pvName string, spec *volume.Spec, eventRecorder
 }
 
 func (plugin *nfsPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	nfsVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			NFS: &v1.NFSVolumeSource{
-				Path: volumeName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(nfsVolume), nil
+	//  To reconstruct volume spec we need nfs source path name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct nfs volume spec from volume mountpath")
 }
 
 // NFS volumes represent a bare host file or directory mount of an NFS export.

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -172,15 +172,8 @@ func (plugin *portworxVolumePlugin) newProvisionerInternal(options volume.Volume
 }
 
 func (plugin *portworxVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	portworxVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			PortworxVolume: &v1.PortworxVolumeSource{
-				VolumeID: volumeName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(portworxVolume), nil
+	//  To reconstruct volume spec we need volumeID which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct portworx volume spec from volume mountpath")
 }
 
 func (plugin *portworxVolumePlugin) SupportsMountOption() bool {

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -127,14 +127,8 @@ func (plugin *projectedPlugin) NewUnmounter(volName string, podUID types.UID) (v
 }
 
 func (plugin *projectedPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	projectedVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Projected: &v1.ProjectedVolumeSource{},
-		},
-	}
-
-	return volume.NewSpecFromVolume(projectedVolume), nil
+	//  To reconstruct volume spec we need projected volume source which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct projected volume spec from volume mountpath")
 }
 
 type projectedVolume struct {

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -142,15 +142,8 @@ func getVolumeSource(spec *volume.Spec) (*v1.QuobyteVolumeSource, bool, error) {
 }
 
 func (plugin *quobytePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	quobyteVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Quobyte: &v1.QuobyteVolumeSource{
-				Volume: volumeName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(quobyteVolume), nil
+	//  To reconstruct volume spec we need quobyte name which cannot be retrieved from volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct quobyte volume spec from volume mountpath")
 }
 
 func (plugin *quobytePlugin) NewMounter(spec *volume.Spec, pod *v1.Pod, _ volume.VolumeOptions) (volume.Mounter, error) {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -124,15 +124,8 @@ func (plugin *secretPlugin) NewUnmounter(volName string, podUID types.UID) (volu
 }
 
 func (plugin *secretPlugin) ConstructVolumeSpec(volName, mountPath string) (*volume.Spec, error) {
-	secretVolume := &v1.Volume{
-		Name: volName,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName: volName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(secretVolume), nil
+	//  To reconstruct volume spec we need secret name which cannot be retrieved from  volumeName and mountPath.
+	return nil, fmt.Errorf("impossible to reconstruct secret volume spec from volume mountpath")
 }
 
 type secretVolume struct {


### PR DESCRIPTION
This PR update the volume plugins that cannot reconstruct their volume
spec. Before, volume reconstruct uses wrong information to construct the
volume spec which will cause issue such as fail to cleanup.
After this update, reconciler will try to clean up the mounts directly
for the volumes which cannot construct the volume spec
 
This is the second PR for design https://github.com/kubernetes/community/pull/1601