### PR TITLE
Increase API watch test timeout to avoid flakes.

### DIFF
--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -191,7 +191,7 @@ func expectNoEvent(w watch.Interface, eventType watch.EventType, object runtime.
 }
 
 func waitForEvent(w watch.Interface, expectType watch.EventType, expectObject runtime.Object) (watch.Event, bool) {
-	stopTimer := time.NewTimer(10 * time.Second)
+	stopTimer := time.NewTimer(1 * time.Minute)
 	for {
 		select {
 		case actual := <-w.ResultChan():


### PR DESCRIPTION
**What this PR does / why we need it**:
This test has been [flaking repeatedly](https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1#82a58388c2f346567b72), probably because 10 seconds it too short of a deadline. One minute should be more generous.

**Release note**:
```release-note
NONE
```