### PR TITLE
Increase watch e2e test timeout

### DIFF
--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -191,7 +191,7 @@ func expectNoEvent(w watch.Interface, eventType watch.EventType, object runtime.
 }
 
 func waitForEvent(w watch.Interface, expectType watch.EventType, expectObject runtime.Object) (watch.Event, bool) {
-	stopTimer := time.NewTimer(10 * time.Second)
+	stopTimer := time.NewTimer(1 * time.Minute)
 	for {
 		select {
 		case actual := <-w.ResultChan():


### PR DESCRIPTION
**What this PR does / why we need it**:
The 10 second timeout was causing this test to flake.

The average time for the deletion of pod B to be observed when the test passes is between 2 and 9 seconds. Since the timeout is only 10 seconds, this is causing unreliable behavior.

This PR increases the timeout to 30 seconds, which should be well above the average time needed to delete a pod.

**Release note**:
```release-note
NONE
```

/kind flake
/sig api-machinery