### PR TITLE
Bump image for ingress downgrade test

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -86,7 +86,7 @@ func ingressUpgradeGCE(isUpgrade bool) error {
 		}
 	} else {
 		// Downgrade to latest release image.
-		command = "sudo sed -i -re 's/(image:)(.*)/\\1 k8s.gcr.io\\/google_containers\\/glbc:0.9.7/' /etc/kubernetes/manifests/glbc.manifest"
+		command = "sudo sed -i -re 's/(image:)(.*)/\\1 k8s.gcr.io\\/ingress-gce-glbc-amd64:1.0.0/' /etc/kubernetes/manifests/glbc.manifest"
 	}
 	// Kubelet should restart glbc automatically.
 	sshResult, err := NodeExec(GetMasterHost(), command)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the image to the latest released version. This should also fix the failing test.

/assign @bowei 

**Release note**:

```release-note
None
```
