### PR TITLE
oidc authentication: email_verified claim is not required for JWT validation

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -287,7 +287,7 @@ func TestToken(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// If "email_verified" isn't present, assume false
+			// If "email_verified" isn't present, assume true
 			name: "no-email-verified-claim",
 			options: Options{
 				IssuerURL:     "https://auth.example.com",
@@ -303,6 +303,30 @@ func TestToken(t *testing.T) {
 				"iss": "https://auth.example.com",
 				"aud": "my-client",
 				"email": "jane@example.com",
+				"exp": %d
+			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name: "jane@example.com",
+			},
+		},
+		{
+			name: "invalid-email-verified-claim",
+			options: Options{
+				IssuerURL:     "https://auth.example.com",
+				ClientID:      "my-client",
+				UsernameClaim: "email",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			// string value for "email_verified"
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": "my-client",
+				"email": "jane@example.com",
+				"email_verified": "false",
 				"exp": %d
 			}`, valid.Unix()),
 			wantErr: true,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the "email_verified" claim is required by the API server to verify an OIDC token. Many OIDC providers do not support the "email_verified" claim. We want to be able to allow their OIDC tokens as valid.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59496

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OIDC authentication now allows tokens without an "email_verified" claim when using the "email" claim. If an "email_verified" claim is present when using the "email" claim, it must be `true`.
```
/sig auth
/kind feature
/assign @ericchiang 

CC: @sreetummidi 