### PR TITLE
Set CPU Quota in enforceNodeAllocatableCgroups

### DIFF
--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -155,6 +155,10 @@ func getCgroupConfig(rl v1.ResourceList) *ResourceConfig {
 		// CPU is defined in milli-cores.
 		val := MilliCPUToShares(q.MilliValue())
 		rc.CpuShares = &val
+		// Set CPU Quota
+		valQuota, valPeriod := MilliCPUToQuota(q.MilliValue())
+		rc.CpuQuota = &valQuota
+		rc.CpuPeriod = &valPeriod
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.HugePages) {
 		rc.HugePageLimit = HugePageLimits(rl)

--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -159,6 +159,7 @@ func getCgroupConfig(rl v1.ResourceList) *ResourceConfig {
 		valQuota, valPeriod := MilliCPUToQuota(q.MilliValue())
 		rc.CpuQuota = &valQuota
 		rc.CpuPeriod = &valPeriod
+		glog.V(4).Infof("CPU Quota: %v, Period: %v", valQuota, valPeriod)
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.HugePages) {
 		rc.HugePageLimit = HugePageLimits(rl)


### PR DESCRIPTION
Set CPU Quota in enforceNodeAllocatableCgroups

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Set CPU Quota in enforceNodeAllocatableCgroups.  Write it to /sys/fs/cgroup/cpu/kubepods/cpu.cfs_quota_us 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is in the TODO state for a long time：// TODO(vishh): Set CPU Quota if necessary.
/assign @vishh
/assign @derekwaynecarr 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
