### PR TITLE
Explicit HTTP link for the local proxy server 

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -153,7 +153,7 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	fmt.Fprintf(out, "Starting to serve on %s\n", l.Addr().String())
+	fmt.Fprintf(out, "Starting to serve on http://%s\n", l.Addr().String())
 	glog.Fatal(server.ServeOnListener(l))
 	return nil
 }


### PR DESCRIPTION
fix http link format