### PR TITLE
Automated cherry pick of #61394: Remove 'system' prefix from Metadata Agent rbac configuration

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent-rbac.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:metadata-agent
+  name: stackdriver:metadata-agent
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -20,14 +20,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:metadata-agent
+  name: stackdriver:metadata-agent
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:metadata-agent
+  name: stackdriver:metadata-agent
 subjects:
 - kind: ServiceAccount
   name: metadata-agent


### PR DESCRIPTION
Cherry pick of #61394 on release-1.10.

#61394: Remove 'system' prefix from Metadata Agent rbac configuration

**Release note**:
```release-note
Remove 'system' prefix from Metadata Agent rbac configuration
```