### PR TITLE
vsphere compile error 

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -185,6 +185,10 @@ const (
 	// This is a duplicate definition of the constant in pkg/controller/service/service_controller.go
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
 
+	// TaintExternalCloudProvider indicate that a node has not been initialized
+	// This is a duplicate definition of the constant in pkg/scheduler/algorithm/well_known_labels.go
+	TaintExternalCloudProvider = "node.cloudprovider.kubernetes.io/uninitialized"
+
 	// MasterConfigurationConfigMap specifies in what ConfigMap in the kube-system namespace the `kubeadm init` configuration should be stored
 	MasterConfigurationConfigMap = "kubeadm-config"
 
@@ -274,6 +278,13 @@ var (
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
+	// CloudProviderUninitializedToleration is the toleration to apply on the PodSpec for being able to run that
+	// Pod on the cloudprovider uninitialized node
+	CloudProviderUninitializedToleration = v1.Toleration{
+		Key:    TaintExternalCloudProvider,
+		Effect: v1.TaintEffectNoSchedule,
+		Value:  "true",
+	}
 	// AuthorizationPolicyPath defines the supported location of authorization policy file
 	AuthorizationPolicyPath = filepath.Join(KubernetesDir, "abac_policy.json")
 	// AuthorizationWebhookConfigPath defines the supported location of webhook config file

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -48,14 +48,14 @@ func TestMutatePodSpec(t *testing.T) {
 					{
 						Name: "kube-apiserver",
 						Command: []string{
-							"--advertise-address=$(HOST_IP)",
+							"--advertise-address=$(POD_IP)",
 						},
 						Env: []v1.EnvVar{
 							{
-								Name: "HOST_IP",
+								Name: "POD_IP",
 								ValueFrom: &v1.EnvVarSource{
 									FieldRef: &v1.ObjectFieldSelector{
-										FieldPath: "status.hostIP",
+										FieldPath: "status.podIP",
 									},
 								},
 							},
@@ -68,6 +68,7 @@ func TestMutatePodSpec(t *testing.T) {
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
+					kubeadmconstants.CloudProviderUninitializedToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -81,6 +82,7 @@ func TestMutatePodSpec(t *testing.T) {
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
+					kubeadmconstants.CloudProviderUninitializedToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -94,6 +96,7 @@ func TestMutatePodSpec(t *testing.T) {
 				},
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
+					kubeadmconstants.CloudProviderUninitializedToleration,
 				},
 				DNSPolicy: v1.DNSClusterFirstWithHostNet,
 			},
@@ -156,6 +159,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 			expected: v1.PodSpec{
 				Tolerations: []v1.Toleration{
 					kubeadmconstants.MasterToleration,
+					kubeadmconstants.CloudProviderUninitializedToleration,
 				},
 			},
 		},
@@ -169,6 +173,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 				Tolerations: []v1.Toleration{
 					{Key: "foo", Value: "bar"},
 					kubeadmconstants.MasterToleration,
+					kubeadmconstants.CloudProviderUninitializedToleration,
 				},
 			},
 		},
@@ -213,7 +218,7 @@ func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 	}
 }
 
-func TestSetHostIPOnPodSpec(t *testing.T) {
+func TestSetPodIPOnPodSpec(t *testing.T) {
 	var tests = []struct {
 		podSpec  *v1.PodSpec
 		expected v1.PodSpec
@@ -235,17 +240,17 @@ func TestSetHostIPOnPodSpec(t *testing.T) {
 					{
 						Name: "kube-apiserver",
 						Command: []string{
-							"--advertise-address=$(HOST_IP)",
+							"--advertise-address=$(POD_IP)",
 						},
 						Env: []v1.EnvVar{
-							{
-								Name: "HOST_IP",
-								ValueFrom: &v1.EnvVarSource{
-									FieldRef: &v1.ObjectFieldSelector{
-										FieldPath: "status.hostIP",
-									},
+						{
+							Name: "POD_IP",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "status.podIP",
 								},
 							},
+						},
 						},
 					},
 				},
@@ -254,10 +259,10 @@ func TestSetHostIPOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setHostIPOnPodSpec(rt.podSpec)
+		setPodIPOnPodSpec(rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
-			t.Errorf("failed setHostIPOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+			t.Errorf("failed setPodIPOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
 		}
 	}
 }

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -134,7 +134,7 @@ spec:
         - --service-cluster-ip-range=10.96.0.0/12
         - --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
         - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
-        - --advertise-address=$(HOST_IP)
+        - --advertise-address=$(POD_IP)
         - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
         - --insecure-port=0
         - --experimental-bootstrap-token-auth=true
@@ -149,10 +149,10 @@ spec:
         - --authorization-mode=Node,RBAC
         - --etcd-servers=http://127.0.0.1:2379
         env:
-        - name: HOST_IP
+        - name: POD_IP
           valueFrom:
             fieldRef:
-              fieldPath: status.hostIP
+              fieldPath: status.podIP
         image: k8s.gcr.io/kube-apiserver-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8
@@ -184,6 +184,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
       volumes:
       - hostPath:
           path: /etc/kubernetes/pki
@@ -334,6 +337,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
       volumes:
       - hostPath:
           path: /etc/kubernetes/pki
@@ -449,6 +455,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
       volumes:
       - hostPath:
           path: /etc/kubernetes/scheduler.conf

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -32,7 +32,7 @@ import (
 	"gopkg.in/gcfg.v1"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
+	"context"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"


### PR DESCRIPTION
/kind bug

## Problem Describption

vsphere cloudprovider imported a wrong package of context  which cause complile error showing below. 

```
/usr/local/go/bin/go test -v k8s.io/kubernetes/cmd/kubeadm/app/phases/selfhosting

# k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere
FAIL	k8s.io/kubernetes/cmd/kubeadm/app/phases/selfhosting [build failed]

pkg/cloudprovider/providers/vsphere/vsphere.go:423: cannot use vs (type *VSphere) as type cloudprovider.Instances in return argument:

	*VSphere does not implement cloudprovider.Instances (wrong type for AddSSHKeyToAllInstances method)

		have AddSSHKeyToAllInstances("k8s.io/kubernetes/vendor/golang.org/x/net/context".Context, string, []byte) error

		want AddSSHKeyToAllInstances("context".Context, string, []byte) error

```

## Fix 

see changes. 

/important
/compile failure