### PR TITLE
Cluster Autoscaler 1.2.0 for K8S 1.10

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.1.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This is a part of regular Cluster Autoscaler release process. 
```release-note
Cluster Autoscaler 1.2.0 - release notes available here: https://github.com/kubernetes/autoscaler/releases
```
