### PR TITLE
Do not consider pods being deleted in the same namespace for spreading purposes  for service anti-affinity priority similar to selectorspread priority.

### DIFF
--- a/pkg/scheduler/algorithm/priorities/selector_spreading.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading.go
@@ -211,7 +211,9 @@ func filteredPod(namespace string, selector labels.Selector, nodeInfo *scheduler
 		return []*v1.Pod{}
 	}
 	for _, pod := range nodeInfo.Pods() {
-		if namespace == pod.Namespace && selector.Matches(labels.Set(pod.Labels)) {
+		// Ignore pods being deleted for spreading purposes
+		// Similar to how it is done for SelectorSpreadPriority
+		if namespace == pod.Namespace && pod.DeletionTimestamp == nil && selector.Matches(labels.Set(pod.Labels)) {
 			pods = append(pods, pod)
 		}
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently for service anti-affinity priority, pods being deleted in the same namespace are being considered in computation for spreading purposes, which should not happen. This PR aligns it with selectorspread priority, which also does spreading and does not consider pods being deleted in the same namespace. 

@bsalamat @timothysc @kubernetes/sig-scheduling-bugs 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
