### PR TITLE
fix TestRollingUpdateDaemonSetExistingPodAdoption DS integration test flakiness

### DIFF
--- a/test/integration/daemonset/util.go
+++ b/test/integration/daemonset/util.go
@@ -295,9 +295,6 @@ func listDaemonSetHistories(controllerRevisionClient appstyped.ControllerRevisio
 	if err != nil {
 		t.Fatalf("failed to list daemonset histories: %v", err)
 	}
-	if len(historyList.Items) == 0 {
-		t.Fatalf("failed to locate any daemonset history")
-	}
 	return historyList
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes flaky TestRollingUpdateDaemonSetExistingPodAdoption DaemonSet integration test by modifying a test util function that unnecessary prints an error message when there is no DaemonSet history.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61513

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/kind flake
/sig apps