### PR TITLE
test: Disable ui dashboard test for gke

### DIFF
--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -33,6 +33,11 @@ import (
 )
 
 var _ = SIGDescribe("Kubernetes Dashboard", func() {
+	BeforeEach(func() {
+		// TODO(kubernetes/kubernetes#61559): Enable dashboard here rather than skip the test.
+		framework.SkipIfProviderIs("gke")
+	})
+
 	const (
 		uiServiceName = "kubernetes-dashboard"
 		uiAppName     = uiServiceName


### PR DESCRIPTION
The dashboard is disabled on GKE 1.10, the test is failing because it's
not alive. Let's just skip this use-case, and keep a todo that it'd be
nice to enable the dashboard to test it.

**What this PR does / why we need it**:
Disable dashboard test for GKE.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61559

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

cc @mml @konryd 