### PR TITLE
Cluster Autoscaler 1.2.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.0-beta1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note
Cluster Autoscaler 1.2.0 - release notes available here: https://github.com/kubernetes/autoscaler/releases
```
