### PR TITLE
Update Cluster Autoscaler version to 1.0.5

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.4",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.5",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.0.5

```release-note:
Update Cluster Autoscaler version to 1.0.5 to fix security vulnerabilities
```