### PR TITLE
Fixed volume/fc unit test on osx

### DIFF
--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -47,7 +47,15 @@ func (mounter *Mounter) Unmount(target string) error {
 // GetMountRefs finds all other references to the device referenced
 // by mountPath; returns a list of paths.
 func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
-	return []string{}, nil
+	mps, err := mounter.List()
+	if err != nil {
+		return nil, err
+	}
+	var refs []string
+	for i := range mps {
+		refs = append(refs, mps[i].Path)
+	}
+	return refs, nil
 }
 
 func (mounter *Mounter) List() ([]MountPoint, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`volume/fc` unit tests fail on osx.

```
$ pwd
<snip>/gopath/src/k8s.io/kubernetes/pkg/volume/fc
$ go test
--- FAIL: Test_ConstructVolumeSpec (0.00s)
    fc_test.go:450: couldn't fetch mountrefs
    fc_test.go:469: failed to retrieve WWIDs
    fc_test.go:450: couldn't fetch mountrefs
    fc_test.go:469: failed to retrieve WWIDs
FAIL
exit status 1
FAIL    k8s.io/kubernetes/pkg/volume/fc    0.054s
```

**Which issue(s) this PR fixes** :
Fixes #61569

**Special notes for your reviewer**:

To see this unit test fail, you need to run `go test` on an osx machine.

**Release note**:
```release-note
NONE
```
