### PR TITLE
Fixed volume/rbd unit test on osx.

### DIFF
--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -538,6 +538,11 @@ func TestConstructVolumeSpec(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	fakeVolumeHost := volumetest.NewFakeVolumeHost(tmpDir, nil, nil)
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, fakeVolumeHost)
@@ -565,10 +570,10 @@ func TestConstructVolumeSpec(t *testing.T) {
 			t.Fatalf("Create mount path %s failed: %v", c.targetPath, err)
 		}
 		if err = fakeMounter.Mount("/dev/rbd0", c.targetPath, "fake", nil); err != nil {
-			t.Fatalf("Mount %s to %s failed: %v", c.targetPath, podMountPath, err)
+			t.Fatalf("Mount %s to %s failed: %v", c.targetPath, "/dev/rbd0", err)
 		}
 		if err = fakeMounter.Mount(c.targetPath, podMountPath, "fake", []string{"bind"}); err != nil {
-			t.Fatalf("Mount %s to %s failed: %v", c.targetPath, podMountPath, err)
+			t.Fatalf("Bind mount %s to %s failed: %v", podMountPath, c.targetPath, err)
 		}
 		spec, err := plug.ConstructVolumeSpec(c.volumeName, podMountPath)
 		if err != nil {


### PR DESCRIPTION
`volume/rbd` unit tests fail on osx.

```
$ pwd
<snip>/gopath/src/k8s.io/kubernetes/pkg/volume/rbd
$ go test
--- FAIL: TestConstructVolumeSpec (0.00s)
	rbd_test.go:575: ConstructVolumeSpec failed: directory /var/folders/59/yc7_f4fd53nbyw868zqpk78cn7shx9/T/rbd_test144865306/pods/pod123/volumes/kubernetes.io~rbd/vol is not mounted
	rbd_test.go:575: ConstructVolumeSpec failed: directory /var/folders/59/yc7_f4fd53nbyw868zqpk78cn7shx9/T/rbd_test144865306/pods/pod123/volumes/kubernetes.io~rbd/vol is not mounted
FAIL
exit status 1
FAIL	k8s.io/kubernetes/pkg/volume/rbd	0.063s
```

**Which issue(s) this PR fixes**:
Fixes #61571

**Special notes for your reviewer**:

To see this unit test fail, you need to run `go test` on an osx machine.

**Release note**:
```release-note
NONE
```
