### PR TITLE
prune Bazel build files from imported go deps and update to gazelle 0.10.1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1976,6 +1976,7 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
@@ -2456,6 +2457,7 @@
 		},
 		{
 			"ImportPath": "github.com/pelletier/go-buffruneio",
+			"Comment": "v0.1.0",
 			"Rev": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
 		},
 		{
@@ -2805,6 +2807,7 @@
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",
+			"Comment": "0.0.1",
 			"Rev": "07dd2e8dfe18522e9c447ba95f2fe95262f63bb2"
 		},
 		{

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -81,6 +81,11 @@ done
 rm -rf vendor/github.com/docker/docker/project/
 
 kube::log::status "Updating BUILD files"
+# Assume that anything imported through godep doesn't need Bazel to build.
+# Prune out any Bazel build files, since these can break the build due to
+# missing dependencies that aren't included by godep.
+find vendor/ -type f \( -name BUILD -o -name BUILD.bazel -o -name WORKSPACE \) \
+  -exec rm -f {} \;
 hack/update-bazel.sh >/dev/null
 
 kube::log::status "Updating LICENSES file"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -32,7 +32,7 @@ kube::util::go_install_from_commit \
     97099dccc8807e9159dc28f374a8f0602cab07e1
 kube::util::go_install_from_commit \
     github.com/bazelbuild/bazel-gazelle/cmd/gazelle \
-    578e73e57d6a4054ef933db1553405c9284322c7
+    0.10.1
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 


### PR DESCRIPTION
**What this PR does / why we need it**: updates the `hack/godep-save.sh` script to prune any imported `BUILD`, `BUILD.bazel`, or `WORKSPACE` files.

We assume anything imported through godep doesn't need Bazel, but a Bazel-enabled Go project may include `BUILD` files with missing dependencies not imported by godep. To prevent this from breaking the Bazel build, remove these. (Gazelle will then regenerate the `BUILD` files based on the go build metadata.)
 
Additionally, there seems to be a bug in gazelle where it follows the `vendor/k8s.io` staging symlinks only when run through `hack/run-in-gopath.sh`. Updating to gazelle 0.10.1 fixes this bug.

A similar PR was recently merged in kubernetes/test-infra: https://github.com/kubernetes/test-infra/pull/7366

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @thockin 
cc @jayconrod 