### PR TITLE
validate CABundle field of admissionregistration.WebhookClientConfig

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"strings"
@@ -234,6 +235,23 @@ func validateWebhookClientConfig(fldPath *field.Path, cc *admissionregistration.
 	if cc.Service != nil {
 		allErrors = append(allErrors, validateWebhookService(fldPath.Child("service"), cc.Service)...)
 	}
+
+	var (
+		caBytes  = cc.CABundle
+		pemBlock *pem.Block
+	)
+	for len(caBytes) > 0 {
+		pemBlock, caBytes = pem.Decode(caBytes)
+		if pemBlock == nil {
+			allErrors = append(allErrors, field.Invalid(fldPath.Child("caBundle"), string(cc.CABundle), "caBundle is invalid"))
+			break
+		}
+		if pemBlock.Type != "CERTIFICATE" {
+			allErrors = append(allErrors, field.Invalid(fldPath.Child("caBundle"), string(cc.CABundle), "caBundle should be a TLS certificate, got a "+pemBlock.Type))
+			break
+		}
+	}
+
 	return allErrors
 }
 

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -736,6 +736,21 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 				}),
 			expectedError: `clientConfig.service.path: Invalid value: "/apis/foo.bar/v1alpha1/--bad": segment[3]: a DNS-1123 subdomain`,
 		},
+		{
+			name: "caBundle is invalid",
+			config: newValidatingWebhookConfiguration(
+				[]admissionregistration.Webhook{
+					{
+						Name: "webhook.k8s.io",
+						ClientConfig: admissionregistration.WebhookClientConfig{
+							URL:      strPtr("https://example.com"),
+							CABundle: []byte("invalid"),
+						},
+					},
+				},
+			),
+			expectedError: "caBundle is invalid",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Display an error if the user provides an invalid TLS certificate in `caBundle` field.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
/release-note-none
```
