### PR TITLE
Updated lv-provisioner image to v2.1.0 in e2e tests

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -122,7 +122,7 @@ const (
 	// volumeConfigName is the configmap passed to bootstrapper and provisioner
 	volumeConfigName = "local-volume-config"
 	// provisioner image used for e2e tests
-	provisionerImageName = "quay.io/external_storage/local-volume-provisioner:v2.0.0"
+	provisionerImageName = "quay.io/external_storage/local-volume-provisioner:v2.1.0"
 	// provisioner daemonSetName name
 	daemonSetName = "local-volume-provisioner"
 	// provisioner default mount point folder


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the [local volume provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/local-volume) to v2.1.0 in the e2e tests for k8s v1.10.

**Which issue(s) this PR fixes**:
Fixes #61596

**Special notes for your reviewer**:

The following commands can be used to perform these tests:
```
$ make WHAT=test/e2e/e2e.test

$ KUBE_FEATURE_GATES="BlockVolume=true" NUM_NODES=1 go run hack/e2e.go -- --up

$ go run hack/e2e.go -- --test --test_args='--ginkgo.focus=PersistentVolumes-local.*Local.*volume.*provisioner’
```

**Release note**:
```release-note
NONE
```
