### PR TITLE
kubeadm: add test coverage to join.go

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -81,16 +81,19 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "join_test.go",
         "reset_test.go",
         "token_test.go",
         "version_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
+        "//pkg/api/legacyscheme:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+)
+
+const (
+	testConfig = `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data:
+    server: localhost:9008
+  name: prod
+contexts:
+- context:
+    cluster: prod
+    namespace: default
+    user: default-service-account
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data:
+    client-key-data:
+`
+)
+
+func TestNewValidJoin(t *testing.T) {
+	// create temp directory
+	tmpDir, err := ioutil.TempDir("", "kubeadm-join-test")
+	if err != nil {
+		t.Errorf("Unable to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// create config file
+	configFilePath := filepath.Join(tmpDir, "test-config-file")
+	cfgFile, err := os.Create(configFilePath)
+	if err != nil {
+		t.Errorf("Unable to create file %q: %v", configFilePath, err)
+	}
+	defer cfgFile.Close()
+
+	testCases := []struct {
+		name                  string
+		args                  []string
+		skipPreFlight         bool
+		cfgPath               string
+		configToWrite         string
+		featureGatesString    string
+		ignorePreflightErrors []string
+		testJoinValidate      bool
+		testJoinRun           bool
+		cmdPersistentFlags    map[string]string
+		nodeConfig            *kubeadm.NodeConfiguration
+		expectedError         bool
+	}{
+		{
+			name:          "invalid: missing config file",
+			skipPreFlight: true,
+			cfgPath:       "missing-path-to-a-config",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: incorrect config file",
+			skipPreFlight: true,
+			cfgPath:       configFilePath,
+			configToWrite: "bad-config-contents",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: fail at preflight.RunJoinNodeChecks()",
+			skipPreFlight: false,
+			cfgPath:       configFilePath,
+			configToWrite: testConfig,
+			expectedError: true,
+		},
+		{
+			name:                  "invalid: incorrect ignorePreflight argument",
+			skipPreFlight:         true,
+			cfgPath:               configFilePath,
+			configToWrite:         testConfig,
+			ignorePreflightErrors: []string{"some-unsupported-preflight-arg"},
+			expectedError:         true,
+		},
+		{
+			name:               "invalid: incorrect featureGatesString",
+			featureGatesString: "bad-feature-gate-string",
+			expectedError:      true,
+		},
+		{
+			name:             "invalid: fail Join.Validate() with wrong flags",
+			skipPreFlight:    true,
+			cfgPath:          configFilePath,
+			configToWrite:    testConfig,
+			testJoinValidate: true,
+			cmdPersistentFlags: map[string]string{
+				"config":    "some-config",
+				"node-name": "some-node-name",
+			},
+			expectedError: true,
+		},
+		{
+			name:             "invalid: fail Join.Validate() with wrong node configuration",
+			skipPreFlight:    true,
+			cfgPath:          configFilePath,
+			configToWrite:    testConfig,
+			testJoinValidate: true,
+			expectedError:    true,
+		},
+		{
+			name:          "invalid: fail Join.Run() with invalid node config",
+			skipPreFlight: true,
+			cfgPath:       configFilePath,
+			configToWrite: testConfig,
+			testJoinRun:   true,
+			expectedError: true,
+		},
+	}
+
+	var out bytes.Buffer
+	cfg := &kubeadmapiext.NodeConfiguration{}
+	legacyscheme.Scheme.Default(cfg)
+
+	errorFormat := "Test case %q: NewValidJoin expected error: %v, saw: %v, error: %v"
+
+	for _, tc := range testCases {
+		if _, err = cfgFile.WriteString(tc.configToWrite); err != nil {
+			t.Fatalf("Unable to write file %q: %v", tc.cfgPath, err)
+		}
+
+		join, err := NewValidJoin(cfg, tc.args, tc.skipPreFlight, tc.cfgPath, tc.featureGatesString, tc.ignorePreflightErrors)
+		cmd := NewCmdJoin(&out)
+
+		if tc.cmdPersistentFlags != nil {
+			for key, value := range tc.cmdPersistentFlags {
+				cmd.PersistentFlags().Set(key, value)
+			}
+		}
+		if tc.nodeConfig != nil {
+			join.cfg = tc.nodeConfig
+		}
+
+		// test Join.Run()
+		if err == nil && tc.testJoinRun {
+			err = join.Run(&out)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf(errorFormat, tc.name, tc.expectedError, (err != nil), err)
+			}
+			// test Join.Validate()
+		} else if err == nil && tc.testJoinValidate {
+			if err = join.Validate(cmd); (err != nil) != tc.expectedError {
+				t.Fatalf(errorFormat, tc.name, tc.expectedError, (err != nil), err)
+			}
+			// check error for NewValidJoin()
+		} else if (err != nil) != tc.expectedError {
+			t.Fatalf(errorFormat, tc.name, tc.expectedError, (err != nil), err)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add test coverage to `join.go`.

A separate commit exports the function `ValidateJoinCommandLine()` from `join.go` so that testing this file is more flexible.

Test coverage is at 76%. One untested part is successfully running `Join.Run()` without errors, but that requires a valid HTTPS API server running and a valid config. i got this partially working but gave up because i faced some cert / config blockers. suggestions on how to get that to work easily are welcome.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

NONE

**Special notes for your reviewer**:

NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
