### PR TITLE
Automated cherry pick of #60679: Update cluster-proportional-autoscaler-amd64 in typha addon

### DIFF
--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2-r2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler


### PR DESCRIPTION
Cherry pick of #60679 on release-1.9.

#60679: Update cluster-proportional-autoscaler-amd64 in typha addon

```release-note
Patch CVE-2016-8859 in alpine based image:
- gcr.io/google-containers/cluster-proportional-autoscaler-amd64
```