### PR TITLE
Automated cherry pick of #61303: Fixes 'Zone is empty' errors in PD upgrade tests; skips pd

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/controller/node:go_default_library",
         "//pkg/kubectl:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/events:go_default_library",

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -690,6 +690,14 @@ func createPD(zone string) (string, error) {
 			return "", err
 		}
 
+		if zone == "" && TestContext.CloudConfig.MultiZone {
+			zones, err := gceCloud.GetAllZonesFromCloudProvider()
+			if err != nil {
+				return "", err
+			}
+			zone, _ = zones.PopAny()
+		}
+
 		tags := map[string]string{}
 		err = gceCloud.CreateDisk(pdName, gcecloud.DiskTypeSSD, zone, 10 /* sizeGb */, tags)
 		if err != nil {

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -62,6 +62,8 @@ var _ = SIGDescribe("Pod Disks", func() {
 	BeforeEach(func() {
 		framework.SkipUnlessNodeCountIsAtLeast(2)
 
+		framework.SkipIfMultizone(f.ClientSet)
+
 		podClient = f.ClientSet.Core().Pods(f.Namespace.Name)
 		nodeClient = f.ClientSet.Core().Nodes()
 		nodes = framework.GetReadySchedulableNodesOrDie(f.ClientSet)


### PR DESCRIPTION
Cherry pick of #61303 on release-1.8.

#61303: Fixes 'Zone is empty' errors in PD upgrade tests; skips pd