### PR TITLE
Cleanup CRD/CR confusion in webhook e2e tests

### DIFF
--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE = gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64
-TAG = 1.9v2
+TAG = 1.10v1
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -204,8 +204,8 @@ func mutateConfigmaps(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	return &reviewResponse
 }
 
-func mutateCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-	glog.V(2).Info("mutating crd")
+func mutateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("mutating custom resource")
 	cr := struct {
 		metav1.ObjectMeta
 		Data map[string]string
@@ -232,8 +232,8 @@ func mutateCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	return &reviewResponse
 }
 
-func admitCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-	glog.V(2).Info("admitting crd")
+func admitCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("admitting custom resource")
 	cr := struct {
 		metav1.ObjectMeta
 		Data map[string]string
@@ -324,12 +324,12 @@ func serveMutateConfigmaps(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, mutateConfigmaps)
 }
 
-func serveCRD(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, admitCRD)
+func serveCustomResource(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, admitCustomResource)
 }
 
-func serveMutateCRD(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, mutateCRD)
+func serveMutateCustomResource(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, mutateCustomResource)
 }
 
 func main() {
@@ -342,8 +342,8 @@ func main() {
 	http.HandleFunc("/mutating-pods", serveMutatePods)
 	http.HandleFunc("/configmaps", serveConfigmaps)
 	http.HandleFunc("/mutating-configmaps", serveMutateConfigmaps)
-	http.HandleFunc("/crd", serveCRD)
-	http.HandleFunc("/mutating-crd", serveMutateCRD)
+	http.HandleFunc("/custom-resource", serveCustomResource)
+	http.HandleFunc("/mutating-custom-resource", serveMutateCustomResource)
 	clientset := getClient()
 	server := &http.Server{
 		Addr:      ":443",

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -48,7 +48,7 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.9v2", true}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.10v1", true}
 	APIServer                = ImageConfig{e2eRegistry, "k8s-aggregator-sample-apiserver", "1.7v2", true}
 	AppArmorLoader           = ImageConfig{gcRegistry, "apparmor-loader", "0.1", false}
 	BusyBox                  = ImageConfig{gcRegistry, "busybox", "1.24", false}


### PR DESCRIPTION
**What this PR does / why we need it**:
We keep referring to custom resources as CRDs in these which is really confusing because we also refer to CRDs as CRDs

```release-note
NONE
```
