### PR TITLE
Add option --resync-interval to scheduler

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -127,6 +127,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.config.SchedulerName, "scheduler-name", o.config.SchedulerName, "Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's \"spec.SchedulerName\".")
 	fs.StringVar(&o.config.LeaderElection.LockObjectNamespace, "lock-object-namespace", o.config.LeaderElection.LockObjectNamespace, "Define the namespace of the lock object.")
 	fs.StringVar(&o.config.LeaderElection.LockObjectName, "lock-object-name", o.config.LeaderElection.LockObjectName, "Define the name of the lock object.")
+	fs.Int32Var(&o.config.CacheDebugResyncInterval, "cache-debug-resync-interval", o.config.CacheDebugResyncInterval, "The interval in seconds local cache is rebuilt and compared against existing cache (Only used for debug).")
 	fs.Int32Var(&o.config.HardPodAffinitySymmetricWeight, "hard-pod-affinity-symmetric-weight", o.config.HardPodAffinitySymmetricWeight,
 		"RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule corresponding "+
 			"to every RequiredDuringScheduling affinity rule. --hard-pod-affinity-symmetric-weight represents the weight of implicit PreferredDuringScheduling affinity rule.")
@@ -372,6 +373,7 @@ type SchedulerServer struct {
 	PodInformer                    coreinformers.PodInformer
 	AlgorithmSource                componentconfig.SchedulerAlgorithmSource
 	HardPodAffinitySymmetricWeight int32
+	CacheDebugResyncInterval       int32
 	EventClient                    v1core.EventsGetter
 	Recorder                       record.EventRecorder
 	Broadcaster                    record.EventBroadcaster
@@ -439,6 +441,7 @@ func NewSchedulerServer(config *componentconfig.KubeSchedulerConfiguration, mast
 		PodInformer:                    factory.NewPodInformer(client, 0, config.SchedulerName),
 		AlgorithmSource:                config.AlgorithmSource,
 		HardPodAffinitySymmetricWeight: config.HardPodAffinitySymmetricWeight,
+		CacheDebugResyncInterval:       config.CacheDebugResyncInterval,
 		EventClient:                    eventClient,
 		Recorder:                       recorder,
 		Broadcaster:                    eventBroadcaster,
@@ -658,6 +661,7 @@ func (s *SchedulerServer) SchedulerConfig() (*scheduler.Config, error) {
 		s.InformerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		storageClassInformer,
 		s.HardPodAffinitySymmetricWeight,
+		s.CacheDebugResyncInterval,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
 	)
 

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -111,6 +111,9 @@ type KubeSchedulerConfiguration struct {
 	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
 	// DEPRECATED: This is no longer used.
 	FailureDomains string
+
+	// CacheDebugResyncInterval is the interval between cache rebuild and compare. It's specified as integer as number of seconds.
+	CacheDebugResyncInterval int32
 }
 
 // KubeSchedulerLeaderElectionConfiguration expands LeaderElectionConfiguration

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -106,6 +106,9 @@ type KubeSchedulerConfiguration struct {
 
 	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
 	FailureDomains string `json:"failureDomains"`
+
+	// CacheDebugResyncInterval is the interval between cache rebuild and compare. It's specified as integer as number of seconds.
+	CacheDebugResyncInterval int32 `json:"cacheDebugResyncInterval"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -309,6 +309,7 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_componentconfig_KubeSche
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.FailureDomains = in.FailureDomains
+	out.CacheDebugResyncInterval = in.CacheDebugResyncInterval
 	return nil
 }
 
@@ -334,6 +335,7 @@ func autoConvert_componentconfig_KubeSchedulerConfiguration_To_v1alpha1_KubeSche
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.FailureDomains = in.FailureDomains
+	out.CacheDebugResyncInterval = in.CacheDebugResyncInterval
 	return nil
 }
 

--- a/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
@@ -38,6 +38,8 @@ import (
 
 const enableEquivalenceCache = true
 
+const resyncInterval int32 = 0
+
 func TestCompatibility_v1_Scheduler(t *testing.T) {
 	// Add serialized versions of scheduler config that exercise available options to ensure compatibility between releases
 	schedulerFiles := map[string]struct {
@@ -578,6 +580,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 			informerFactory.Storage().V1().StorageClasses(),
 			v1.DefaultHardPodAffinitySymmetricWeight,
+			resyncInterval,
 			enableEquivalenceCache,
 		).CreateFromConfig(policy); err != nil {
 			t.Errorf("%s: Error constructing: %v", v, err)

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -48,6 +48,8 @@ import (
 
 const enableEquivalenceCache = true
 
+const resyncInterval int32 = 0
+
 func TestCreate(t *testing.T) {
 	handler := utiltesting.FakeHandler{
 		StatusCode:   500,
@@ -532,6 +534,7 @@ func newConfigFactory(client *clientset.Clientset, hardPodAffinitySymmetricWeigh
 		informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		informerFactory.Storage().V1().StorageClasses(),
 		hardPodAffinitySymmetricWeight,
+		resyncInterval,
 		enableEquivalenceCache,
 	)
 }

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -83,6 +83,7 @@ func createConfiguratorWithPodInformer(
 		informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
+		0, // cache resync disabled
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
 	)
 }

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -111,6 +111,7 @@ func createSchedulerConfigurator(
 		informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
+		0, // disable cache resync
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The option specifies the interval as in seconds between scheduler cache
rebuild and comparison with existing cache. The result will be recorded
in logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60860

**Release note**:
```release-note
Add option --resync-interval to scheduler
```
