### PR TITLE
Deployment to stop adding pod-template-hash labels/selector on adoption

### DIFF
--- a/pkg/controller/deployment/BUILD
+++ b/pkg/controller/deployment/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/controller/deployment/util/BUILD
+++ b/pkg/controller/deployment/util/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",

--- a/pkg/controller/deployment/util/replicaset_util.go
+++ b/pkg/controller/deployment/util/replicaset_util.go
@@ -17,8 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -26,8 +24,6 @@ import (
 	unversionedextensions "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	extensionslisters "k8s.io/client-go/listers/extensions/v1beta1"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/pkg/controller"
-	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 )
 
 // TODO: use client library instead when it starts to support update retries
@@ -61,11 +57,4 @@ func UpdateRSWithRetries(rsClient unversionedextensions.ReplicaSetInterface, rsL
 	}
 
 	return rs, retryErr
-}
-
-// GetReplicaSetHash returns the pod template hash of a ReplicaSet's pod template space
-func GetReplicaSetHash(rs *extensions.ReplicaSet, uniquifier *int32) (string, error) {
-	rsTemplate := rs.Spec.Template.DeepCopy()
-	rsTemplate.Labels = labelsutil.CloneAndRemoveLabel(rsTemplate.Labels, extensions.DefaultDeploymentUniqueLabelKey)
-	return fmt.Sprintf("%d", controller.ComputeHash(rsTemplate, uniquifier)), nil
 }

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -274,10 +274,6 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	_, allOldRSs, err := deploymentutil.GetOldReplicaSets(deployment, c.ExtensionsV1beta1())
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(allOldRSs)).Should(Equal(1))
-	// The old RS should contain pod-template-hash in its selector, label, and template label
-	Expect(len(allOldRSs[0].Labels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
-	Expect(len(allOldRSs[0].Spec.Selector.MatchLabels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
-	Expect(len(allOldRSs[0].Spec.Template.Labels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
 }
 
 func testRecreateDeployment(f *framework.Framework) {

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -81,6 +81,32 @@ func TestNewDeployment(t *testing.T) {
 	if newRS.Annotations[v1.LastAppliedConfigAnnotation] != "" {
 		t.Errorf("expected new ReplicaSet last-applied annotation not copied from Deployment %s", tester.deployment.Name)
 	}
+
+	// New RS should contain pod-template-hash in its selector, label, and template label
+	rsHash, err := checkRSHashLabels(newRS)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// All pods targeted by the deployment should contain pod-template-hash in their labels
+	selector, err := metav1.LabelSelectorAsSelector(tester.deployment.Spec.Selector)
+	if err != nil {
+		t.Fatalf("failed to parse deployment %s selector: %v", name, err)
+	}
+	pods, err := c.CoreV1().Pods(ns.Name).List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		t.Fatalf("failed to list pods of deployment %s: %v", name, err)
+	}
+	if len(pods.Items) != int(replicas) {
+		t.Errorf("expected %d pods, got %d pods", replicas, len(pods.Items))
+	}
+	podHash, err := checkPodsHashLabel(pods)
+	if err != nil {
+		t.Error(err)
+	}
+	if rsHash != podHash {
+		t.Errorf("found mismatching pod-template-hash value: rs hash = %s whereas pod hash = %s", rsHash, podHash)
+	}
 }
 
 // Deployments should support roll out, roll back, and roll over
@@ -652,104 +678,6 @@ func checkPodsHashLabel(pods *v1.PodList) (string, error) {
 		}
 	}
 	return hash, nil
-}
-
-// Deployment should label adopted ReplicaSets and Pods.
-func TestDeploymentLabelAdopted(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
-	defer closeFn()
-	name := "test-adopted-deployment"
-	ns := framework.CreateTestingNamespace(name, s, t)
-	defer framework.DeleteTestingNamespace(ns, s, t)
-
-	// Start informer and controllers
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informers.Start(stopCh)
-	go rm.Run(5, stopCh)
-	go dc.Run(5, stopCh)
-
-	// Create a RS to be adopted by the deployment.
-	rsName := "test-adopted-controller"
-	replicas := int32(1)
-	rs := newReplicaSet(rsName, ns.Name, replicas)
-	_, err := c.ExtensionsV1beta1().ReplicaSets(ns.Name).Create(rs)
-	if err != nil {
-		t.Fatalf("failed to create replicaset %s: %v", rsName, err)
-	}
-	// Mark RS pods as ready.
-	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
-	if err != nil {
-		t.Fatalf("failed to parse replicaset %s selector: %v", rsName, err)
-	}
-	if err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		pods, err := c.CoreV1().Pods(ns.Name).List(metav1.ListOptions{LabelSelector: selector.String()})
-		if err != nil {
-			return false, err
-		}
-		if len(pods.Items) != int(replicas) {
-			return false, nil
-		}
-		for _, pod := range pods.Items {
-			if err = markPodReady(c, ns.Name, &pod); err != nil {
-				return false, nil
-			}
-		}
-		return true, nil
-	}); err != nil {
-		t.Fatalf("failed to mark pods replicaset %s as ready: %v", rsName, err)
-	}
-
-	// Create a Deployment to adopt the old rs.
-	tester := &deploymentTester{t: t, c: c, deployment: newDeployment(name, ns.Name, replicas)}
-	if tester.deployment, err = c.ExtensionsV1beta1().Deployments(ns.Name).Create(tester.deployment); err != nil {
-		t.Fatalf("failed to create deployment %s: %v", tester.deployment.Name, err)
-	}
-
-	// Wait for the Deployment to be updated to revision 1
-	if err = tester.waitForDeploymentRevisionAndImage("1", fakeImage); err != nil {
-		t.Fatal(err)
-	}
-
-	// The RS and pods should be relabeled after the Deployment finishes adopting it and completes.
-	if err := tester.waitForDeploymentComplete(); err != nil {
-		t.Fatal(err)
-	}
-
-	// There should be no old RSes (overlapping RS)
-	oldRSs, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(tester.deployment, c.ExtensionsV1beta1())
-	if err != nil {
-		t.Fatalf("failed to get all replicasets owned by deployment %s: %v", name, err)
-	}
-	if len(oldRSs) != 0 || len(allOldRSs) != 0 {
-		t.Errorf("expected deployment to have no old replicasets, got %d old replicasets", len(allOldRSs))
-	}
-
-	// New RS should be relabeled, i.e. contain pod-template-hash in its selector, label, and template label
-	rsHash, err := checkRSHashLabels(newRS)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// All pods targeted by the deployment should contain pod-template-hash in their labels, and there should be only 3 pods
-	selector, err = metav1.LabelSelectorAsSelector(tester.deployment.Spec.Selector)
-	if err != nil {
-		t.Fatalf("failed to parse deployment %s selector: %v", name, err)
-	}
-	pods, err := c.CoreV1().Pods(ns.Name).List(metav1.ListOptions{LabelSelector: selector.String()})
-	if err != nil {
-		t.Fatalf("failed to list pods of deployment %s: %v", name, err)
-	}
-	if len(pods.Items) != int(replicas) {
-		t.Errorf("expected %d pods, got %d pods", replicas, len(pods.Items))
-	}
-	podHash, err := checkPodsHashLabel(pods)
-	if err != nil {
-		t.Error(err)
-	}
-	if rsHash != podHash {
-		t.Errorf("found mismatching pod-template-hash value: rs hash = %s whereas pod hash = %s", rsHash, podHash)
-	}
 }
 
 // Deployment should have a timeout condition when it fails to progress after given deadline.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This is a blocker for #55714, because ReplicaSet selector becomes immutable in `apps/v1`. With controller ref, Deployment's ReplicaSets and Pods can avoid fighting with each others without unique label/selector (pod-template-hash), so it's safe to stop adding hash label/selector on adoption. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61433

**Special notes for your reviewer**: This is a behavioral change to Deployment controller that will affect all versions of Deployment APIs (`apps/v1`, `extensions/v1beta1`, `apps/v1beta1`, `apps/v1beta2`). 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deployment will stop adding pod-template-hash labels/selector to ReplicaSets and Pods it adopts. Resources created by Deployments are not affected (will still have pod-template-hash labels/selector). 
```
