### PR TITLE
Added `kubernetes.io/nodename` label to node.

### DIFF
--- a/pkg/kubelet/apis/well_known_labels.go
+++ b/pkg/kubelet/apis/well_known_labels.go
@@ -18,6 +18,7 @@ package apis
 
 const (
 	LabelHostname           = "kubernetes.io/hostname"
+	LabelNodename           = "kubernetes.io/nodename"
 	LabelZoneFailureDomain  = "failure-domain.beta.kubernetes.io/zone"
 	LabelMultiZoneDelimiter = "__"
 	LabelZoneRegion         = "failure-domain.beta.kubernetes.io/region"

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -157,6 +157,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 func (kl *Kubelet) updateDefaultLabels(initialNode, existingNode *v1.Node) bool {
 	defaultLabels := []string{
 		kubeletapis.LabelHostname,
+		kubeletapis.LabelNodename,
 		kubeletapis.LabelZoneFailureDomain,
 		kubeletapis.LabelZoneRegion,
 		kubeletapis.LabelInstanceType,
@@ -222,6 +223,7 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 			Name: string(kl.nodeName),
 			Labels: map[string]string{
 				kubeletapis.LabelHostname: kl.hostname,
+				kubeletapis.LabelNodename: string(kl.nodeName),
 				kubeletapis.LabelOS:       goruntime.GOOS,
 				kubeletapis.LabelArch:     goruntime.GOARCH,
 			},

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -908,6 +908,7 @@ func TestRegisterWithApiServer(t *testing.T) {
 				Name: testKubeletHostname,
 				Labels: map[string]string{
 					kubeletapis.LabelHostname: testKubeletHostname,
+					kubeletapis.LabelNodename: testKubeletHostname,
 					kubeletapis.LabelOS:       goruntime.GOOS,
 					kubeletapis.LabelArch:     goruntime.GOARCH,
 				},


### PR DESCRIPTION
Signed-off-by: Da K. Ma <klaus1982.cn@gmail.com>

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/issues/59194, we'd like to use `NodeAffinity` feature to schedule DaemonSet pods by default scheduler instead of DaemonSet controller; but hostname maybe not the same with node name because of cloud provider. This PR is going to introduce a new label, named `kubernetes.io/nodename`, to provide node name info for default scheduler.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61410 

**Release note**:

```release-note
Added 'kubernetes.io/nodename' label to the node.
```
