### PR TITLE
run 1.8 kubemark test with kubetest directly

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -44,7 +44,7 @@ fi
 
 if [[ -f /.dockerenv ]]; then
 	# Running inside a dockerized runner.
-	go run ./hack/e2e.go -- --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
+	kubetest --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
 else
 	# Running locally.
  	ARGS=$(echo $ARGS | sed 's/\[/\\\[/g' | sed 's/\]/\\\]/g')


### PR DESCRIPTION
to fix incompatible go version and allow kubemark job to pass