### PR TITLE
Ensure multi-member etcd clusters enable quorum reads

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -87,6 +87,10 @@ func (s *EtcdOptions) Validate() []error {
 		allErrors = append(allErrors, fmt.Errorf("--etcd-servers must be specified"))
 	}
 
+	if len(s.StorageConfig.ServerList) > 1 && !s.StorageConfig.Quorum {
+		allErrors = append(allErrors, fmt.Errorf("--etcd-quorum-read must be enabled with multi-member etcd clusters"))
+	}
+
 	if !storageTypes.Has(s.StorageConfig.Type) {
 		allErrors = append(allErrors, fmt.Errorf("--storage-backend invalid, must be 'etcd3' or 'etcd2'. If not specified, it will default to 'etcd3'"))
 	}
@@ -104,6 +108,9 @@ func (s *EtcdOptions) Validate() []error {
 			continue
 		}
 
+		if len(strings.Split(tokens[1], ";")) > 1 && !s.StorageConfig.Quorum {
+			allErrors = append(allErrors, fmt.Errorf("--etcd-quorum-read must be enabled with multi-member etcd clusters"))
+		}
 	}
 
 	return allErrors


### PR DESCRIPTION
Alternative to https://github.com/kubernetes/kubernetes/pull/61635

In a single-member etcd2 cluster, quorum reads are not required for correctness (all reads go to the leader), but still perform badly (a raft proposal is done internally)

This allows --etcd-quorum-read=false *only* for single-member etcd configurations.

```release-note
kube-apiserver: the `--etcd-quorum-read` flag (deprecated since 1.9) may now only be set to `false` in single-member etcd clusters. The flag is still deprecated and will be removed in a future version.
```