### PR TITLE
Support auto completion for initContainers' name for kubectl logs

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -140,7 +140,7 @@ __kubectl_get_resource_clusterrole()
 __kubectl_get_containers()
 {
     local template
-    template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
+    template="{{ range .spec.containers }}{{ .name }} {{ end }}{{ range .spec.initContainers }}{{ .name }} {{ end }}"
     __kubectl_debug "${FUNCNAME} nouns are ${nouns[*]}"
 
     local len="${#nouns[@]}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `kubectl logs POD_NAME -c <TAB>` does not complete
initContainers' name, so this patch supports it.

Fixes # N/A

**Release note**:

```release-note
NONE
```

Fixes: https://github.com/kubernetes/kubernetes/issues/62255