### PR TITLE
improved error message when object with generateName already exists

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
@@ -8,14 +8,22 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["meta_test.go"],
+    srcs = [
+        "create_test.go",
+        "meta_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -89,6 +89,8 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx genericapirequest.Context, ob
 	FillObjectMetaSystemFields(ctx, objectMeta)
 	if len(objectMeta.GetGenerateName()) > 0 && len(objectMeta.GetName()) == 0 {
 		objectMeta.SetName(strategy.GenerateName(objectMeta.GetGenerateName()))
+	} else {
+		objectMeta.SetGenerateName("")
 	}
 
 	// Ensure Initializers are not set unless the feature is enabled

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/storage/names"
+)
+
+type mockStrategy struct {
+	names.NameGenerator
+}
+
+func (m mockStrategy) NamespaceScoped() bool {
+	return false
+}
+
+func (m mockStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
+
+}
+func (m mockStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
+	return nil
+}
+
+func (m mockStrategy) Canonicalize(obj runtime.Object) {
+
+}
+
+func (m mockStrategy) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	return []schema.GroupVersionKind{{Group: "mygroup.example.com", Version: "v1beta1", Kind: "Secret"}}, true, nil
+}
+func (m mockStrategy) Recognizes(gvk schema.GroupVersionKind) bool {
+	return false
+}
+
+func TestBeforeCreate(t *testing.T) {
+	ctx := genericapirequest.NewContext()
+	tests := []struct {
+		resource *unstructured.Unstructured
+		expected string
+	}{
+		{
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name":         "foo",
+						"generatename": "bar",
+					},
+				},
+			},
+		}, {
+			resource: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"generatename": "bar",
+					},
+				},
+			},
+		},
+	}
+	mock := mockStrategy{names.SimpleNameGenerator}
+	for _, test := range tests {
+		BeforeCreate(mock, ctx, test.resource)
+		objectMeta, _, kerr := objectMetaAndKind(mock, test.resource)
+		if kerr != nil {
+			t.Fatal(kerr)
+		}
+
+		if len(objectMeta.GetName()) > 0 {
+			if objectMeta.GetGenerateName() != "" {
+				t.Fatal("Generate name has to empty, if the resource has name")
+			}
+		}
+
+		if test.resource.GetGenerateName() != objectMeta.GetGenerateName() {
+			t.Fatalf("error in generate name expected %s got %s", test.resource.GetGenerateName(), objectMeta.GetGenerateName())
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: பாலாஜி <rbalajis25@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
improved error message when object with generateName already exists
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #32220

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
