### PR TITLE
kubectl dynamic acquire resource types 

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -255,9 +255,12 @@ func NewTestFactory() *TestFactory {
 	// specify an optionalClientConfig to explicitly use in testing
 	// to avoid polluting an existing user config.
 	config, configFile := defaultFakeClientConfig()
+	restConfig, _ := config.ClientConfig()
 	return &TestFactory{
-		Factory:        cmdutil.NewFactory(config),
-		tempConfigFile: configFile,
+		Factory:         cmdutil.NewFactory(config),
+		Client:          &fake.RESTClient{},
+		ClientConfigVal: restConfig,
+		tempConfigFile:  configFile,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of hardcoded resources in `ValidResourceTypeList`, here serves a dynamic resources discovery.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
