### PR TITLE
fix todo item in pkg/registry/rbac/validation/policy_comparator.go

### DIFF
--- a/pkg/registry/rbac/validation/policy_comparator.go
+++ b/pkg/registry/rbac/validation/policy_comparator.go
@@ -50,7 +50,11 @@ func Covers(ownerRules, servantRules []rbac.PolicyRule) (bool, []rbac.PolicyRule
 		}
 	}
 
-	return (len(uncoveredRules) == 0), uncoveredRules
+	compactedRules, err := CompactRules(uncoveredRules)
+	if err != nil {
+		return (len(uncoveredRules) == 0), uncoveredRules
+	}
+	return (len(uncoveredRules) == 0), compactedRules
 }
 
 // BreadownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In pkg/registry/rbac/validation/policy_comparator.go exists a todo item.
https://github.com/kubernetes/kubernetes/blob/3a2fe7b8f93e39c93b1f5e1c92f74c72c6671fc4/pkg/registry/rbac/validation/policy_comparator.go#L31
This todo item may cause a problem in` kubectl auth reconcile` command.
After this patch ,the output of this command will be squashed.
Example in
https://github.com/kubernetes/kubernetes/issues/61703
will be like:
```
{
    "kind": "Role",
    "apiVersion": "rbac.authorization.k8s.io/v1",
    "metadata": {
        "name": "xiaomi",
        "namespace": "office",
        "selfLink": "/apis/rbac.authorization.k8s.io/v1/namespaces/office/roles/xiaomi",
        "uid": "f92f8911-30e2-11e8-a88f-901b0e3ac8bc",
        "resourceVersion": "333",
        "creationTimestamp": "2018-03-26T10:46:43Z"
    },
    "rules": [
        {
            "verbs": [
                "get",
                "list",
                "watch",
                "create",
                "update",
                "patch",
                "delete"
            ],
            "apiGroups": [
                "extensions"
            ],
            "resources": [
                "deployments"
            ]
        },
        {
            "verbs": [
                "create",
                "delete",
                "get",
                "list",
                "patch",
                "update",
                "watch"
            ],
            "apiGroups": [
                "",
                "apps",
                "extensions"
            ],
            "resources": [
                "replicasets"
            ]
        },
        {
            "verbs": [
                "create",
                "delete",
                "get",
                "list",
                "patch",
                "update",
                "watch"
            ],
            "apiGroups": [
                "",
                "apps",
                "extensions"
            ],
            "resources": [
                "pods"
            ]
        },
        {
            "verbs": [
                "create",
                "delete",
                "get",
                "list",
                "patch",
                "update",
                "watch"
            ],
            "apiGroups": [
                "",
                "apps"
            ],
            "resources": [
                "deployments"
            ]
        }
    ]
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61703

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
