### PR TITLE
Support overriding the --node-cidr-mask-size arg passed to kube-controller-manager

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -157,6 +157,10 @@ type Networking struct {
 	PodSubnet string
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
 	DNSDomain string
+	// NodeCIDRMaskSize is the size of the Pod subnet allocated to each node. Only
+	// applies when PodSubnet is also specified. Defaults to "24" for IPv4 or a
+	// calculated subset of an IPv6 PodSubnet.
+	NodeCIDRMaskSize string
 }
 
 // Etcd contains elements describing Etcd configuration.

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -157,10 +157,6 @@ type Networking struct {
 	PodSubnet string
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
 	DNSDomain string
-	// NodeCIDRMaskSize is the size of the Pod subnet allocated to each node. Only
-	// applies when PodSubnet is also specified. Defaults to "24" for IPv4 or a
-	// calculated subset of an IPv6 PodSubnet.
-	NodeCIDRMaskSize string
 }
 
 // Etcd contains elements describing Etcd configuration.

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -336,7 +336,10 @@ func getControllerManagerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion
 	// Let the controller-manager allocate Node CIDRs for the Pod network.
 	// Each node will get a subspace of the address CIDR provided with --pod-network-cidr.
 	if cfg.Networking.PodSubnet != "" {
-		maskSize := calcNodeCidrSize(cfg.Networking.PodSubnet)
+		maskSize := cfg.Networking.NodeCIDRMaskSize
+		if maskSize == "" {
+			maskSize = calcNodeCidrSize(cfg.Networking.PodSubnet)
+		}
 		command = append(command, "--allocate-node-cidrs=true", "--cluster-cidr="+cfg.Networking.PodSubnet,
 			"--node-cidr-mask-size="+maskSize)
 	}

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -776,6 +776,28 @@ func TestGetControllerManagerCommand(t *testing.T) {
 		},
 		{
 			cfg: &kubeadmapi.MasterConfiguration{
+				Networking:        kubeadmapi.Networking{PodSubnet: "10.0.1.15/16", NodeCIDRMaskSize: "20"},
+				CertificatesDir:   testCertsDir,
+				KubernetesVersion: "v1.7.0",
+			},
+			expected: []string{
+				"kube-controller-manager",
+				"--address=127.0.0.1",
+				"--leader-elect=true",
+				"--kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
+				"--root-ca-file=" + testCertsDir + "/ca.crt",
+				"--service-account-private-key-file=" + testCertsDir + "/sa.key",
+				"--cluster-signing-cert-file=" + testCertsDir + "/ca.crt",
+				"--cluster-signing-key-file=" + testCertsDir + "/ca.key",
+				"--use-service-account-credentials=true",
+				"--controllers=*,bootstrapsigner,tokencleaner",
+				"--allocate-node-cidrs=true",
+				"--cluster-cidr=10.0.1.15/16",
+				"--node-cidr-mask-size=20",
+			},
+		},
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
 				Networking:        kubeadmapi.Networking{PodSubnet: "2001:db8::/64"},
 				CertificatesDir:   testCertsDir,
 				KubernetesVersion: "v1.7.0",

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -776,9 +776,10 @@ func TestGetControllerManagerCommand(t *testing.T) {
 		},
 		{
 			cfg: &kubeadmapi.MasterConfiguration{
-				Networking:        kubeadmapi.Networking{PodSubnet: "10.0.1.15/16", NodeCIDRMaskSize: "20"},
-				CertificatesDir:   testCertsDir,
-				KubernetesVersion: "v1.7.0",
+				Networking:                 kubeadmapi.Networking{PodSubnet: "10.0.1.15/16"},
+				ControllerManagerExtraArgs: map[string]string{"node-cidr-mask-size": "20"},
+				CertificatesDir:            testCertsDir,
+				KubernetesVersion:          "v1.7.0",
 			},
 			expected: []string{
 				"kube-controller-manager",


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubeadm/issues/724

**Release note**:
```release-note
kubeadm config can now override the Node CIDR Mask Size passed to kube-controller-manager.
```
