### PR TITLE
pods with deletionTimestamp set should be less than running pods

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -759,6 +759,11 @@ func (s ActivePods) Less(i, j int) bool {
 	if !s[i].CreationTimestamp.Equal(&s[j].CreationTimestamp) {
 		return afterOrZero(&s[i].CreationTimestamp, &s[j].CreationTimestamp)
 	}
+	// 7. The ones already marked for deletions < running pods
+	// This is used to filter out the pods in GetFirstPod() used in CLI.
+	if s[i].DeletionTimestamp != nil && s[j].DeletionTimestamp == nil {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As the ActivePods is being used to determine the 'first pod' by GetFistPod() in CLI, there is a chance that this function will give you a terminating pod from an RS or RC when running `kubectl exec` (or any other command that invoke this function). 

This change should make the ActivePods prefer pods that are not being deleted.

```release-note

```
