### PR TITLE
Revert "Increase fluentd rolling-upgrade maxUnavailable to large value"

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -10,8 +10,6 @@ metadata:
     version: v3.0.0
 spec:
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 5000
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
This reverts commit 7dd6adc4380b0c27694abf34f67f0cb8b749b44c.

Ref https://github.com/kubernetes/kubernetes/issues/61190#issuecomment-376159552

/cc @wojtek-t 

```release-note
NONE
```