### PR TITLE
Update fluentd-gcp and event-exporter images in 1.9

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.1.8
+  name: event-exporter-v0.1.9
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.1.8
+    version: v0.1.9
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -42,12 +42,12 @@ spec:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.1.8
+        version: v0.1.9
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.8
+        image: gcr.io/google-containers/event-exporter:v0.1.9
         command:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,13 +1,13 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-gcp-v2.0.10
+  name: fluentd-gcp-v2.0.17
   namespace: kube-system
   labels:
     k8s-app: fluentd-gcp
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v2.0.10
+    version: v2.0.17
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -16,7 +16,7 @@ spec:
       labels:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"
-        version: v2.0.10
+        version: v2.0.17
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.10
+        image: gcr.io/google-containers/fluentd-gcp:2.0.17
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q


### PR DESCRIPTION
This is a follow-up of https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/126 to apply the latest patches to the base images of fluentd and event-exporter.

```release-note
[fluentd-gcp addon] Update fluentd and event-exporter images to have the latest base image.
```

/assign @x13n 

Could you please take a look?
