### PR TITLE
Double container probe timeout

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -37,7 +37,7 @@ const (
 	probTestContainerName       = "test-webserver"
 	probTestInitialDelaySeconds = 15
 
-	defaultObservationTimeout = time.Minute * 2
+	defaultObservationTimeout = time.Minute * 4
 )
 
 var _ = framework.KubeDescribe("Probing container", func() {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -122,7 +122,7 @@ const (
 	slowPodStartTimeout = 15 * time.Minute
 
 	// How long to wait for a service endpoint to be resolvable.
-	ServiceStartTimeout = 1 * time.Minute
+	ServiceStartTimeout = 3 * time.Minute
 
 	// How often to Poll pods, nodes and claims.
 	Poll = 2 * time.Second


### PR DESCRIPTION
in some environments, we see a combination of start latency
and the corresponding effect on sync pod latency causing status
manager to fail to report within the 2 minute window.

```release-note
NONE
```