### PR TITLE
Automated cherry pick of #61480: Use O_PATH to avoid errors on Openat

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -55,7 +55,9 @@ const (
 	// place for subpath mounts
 	containerSubPathDirectoryName = "volume-subpaths"
 	// syscall.Openat flags used to traverse directories not following symlinks
-	nofollowFlags = syscall.O_RDONLY | syscall.O_NOFOLLOW
+	nofollowFlags = unix.O_RDONLY | unix.O_NOFOLLOW
+	// flags for getting file descriptor without following the symlink
+	openFDFlags = unix.O_NOFOLLOW | unix.O_PATH
 )
 
 // Mounter provides the default implementation of mount.Interface
@@ -805,7 +807,9 @@ func findExistingPrefix(base, pathname string) (string, []string, error) {
 		}
 	}()
 	for i, dir := range dirs {
-		childFD, err := syscall.Openat(fd, dir, syscall.O_RDONLY, 0)
+		// Using O_PATH here will prevent hangs in case user replaces directory with
+		// fifo
+		childFD, err := syscall.Openat(fd, dir, unix.O_PATH, 0)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return currentPath, dirs[i:], nil
@@ -867,9 +871,19 @@ func doSafeOpen(pathname string, base string) (int, error) {
 		}
 
 		glog.V(5).Infof("Opening path %s", currentPath)
-		childFD, err = syscall.Openat(parentFD, seg, nofollowFlags, 0)
+		childFD, err = syscall.Openat(parentFD, seg, openFDFlags, 0)
 		if err != nil {
 			return -1, fmt.Errorf("cannot open %s: %s", currentPath, err)
+		}
+
+		var deviceStat unix.Stat_t
+		err := unix.Fstat(childFD, &deviceStat)
+		if err != nil {
+			return -1, fmt.Errorf("Error running fstat on %s with %v", currentPath, err)
+		}
+		fileFmt := deviceStat.Mode & syscall.S_IFMT
+		if fileFmt == syscall.S_IFLNK {
+			return -1, fmt.Errorf("Unexpected symlink found %s", currentPath)
 		}
 
 		// Close parentFD

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -21,6 +21,7 @@ package mount
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1042,6 +1043,44 @@ func TestBindSubPath(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "subpath-mounting-unix-socket",
+			prepare: func(base string) ([]string, string, string, error) {
+				volpath, subpathMount := getTestPaths(base)
+				mounts := []string{subpathMount}
+				if err := os.MkdirAll(volpath, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				if err := os.MkdirAll(subpathMount, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				testSocketFile := filepath.Join(volpath, "mount_test.sock")
+				_, err := net.Listen("unix", testSocketFile)
+				return mounts, volpath, testSocketFile, err
+			},
+			expectError: false,
+		},
+		{
+			name: "subpath-mounting-fifo",
+			prepare: func(base string) ([]string, string, string, error) {
+				volpath, subpathMount := getTestPaths(base)
+				mounts := []string{subpathMount}
+				if err := os.MkdirAll(volpath, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				if err := os.MkdirAll(subpathMount, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				testFifo := filepath.Join(volpath, "mount_test.fifo")
+				err := syscall.Mkfifo(testFifo, 0)
+				return mounts, volpath, testFifo, err
+			},
+			expectError: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -1171,6 +1210,7 @@ func TestParseMountInfo(t *testing.T) {
 
 func TestSafeOpen(t *testing.T) {
 	defaultPerm := os.FileMode(0750)
+
 	tests := []struct {
 		name string
 		// Function that prepares directory structure for the test under given
@@ -1298,6 +1338,32 @@ func TestSafeOpen(t *testing.T) {
 			"test",
 			true,
 		},
+		{
+			"mounting-unix-socket",
+			func(base string) error {
+				testSocketFile := filepath.Join(base, "mount_test.sock")
+				_, err := net.Listen("unix", testSocketFile)
+				if err != nil {
+					return fmt.Errorf("Error preparing socket file %s with %v", testSocketFile, err)
+				}
+				return nil
+			},
+			"mount_test.sock",
+			false,
+		},
+		{
+			"mounting-unix-socket-in-middle",
+			func(base string) error {
+				testSocketFile := filepath.Join(base, "mount_test.sock")
+				_, err := net.Listen("unix", testSocketFile)
+				if err != nil {
+					return fmt.Errorf("Error preparing socket file %s with %v", testSocketFile, err)
+				}
+				return nil
+			},
+			"mount_test.sock/bar",
+			true,
+		},
 	}
 
 	for _, test := range tests {
@@ -1413,6 +1479,17 @@ func TestFindExistingPrefix(t *testing.T) {
 			"",
 			[]string{"test", "directory"},
 			false,
+		},
+		{
+			"with-fifo-in-middle",
+			func(base string) error {
+				testFifo := filepath.Join(base, "mount_test.fifo")
+				return syscall.Mkfifo(testFifo, 0)
+			},
+			"mount_test.fifo/directory",
+			"",
+			nil,
+			true,
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #61480 on release-1.7.

#61480: Use O_PATH to avoid errors on Openat