### PR TITLE
Pod deletion can be contended, causing test failure

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -166,7 +166,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			deleted := false
 			timeout := false
 			var lastPod *v1.Pod
-			timer := time.After(1 * time.Minute)
+			timer := time.After(2 * time.Minute)
 			for !deleted && !timeout {
 				select {
 				case event, _ := <-w.ResultChan():


### PR DESCRIPTION
Observed this running e2e tests downstream

```release-note
NONE
```