### PR TITLE
increase wait in kubecontrollers

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -381,7 +381,7 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.
-	if err := genericcontrollerconfig.WaitForAPIServer(versionedClient, 10*time.Second); err != nil {
+	if err := genericcontrollerconfig.WaitForAPIServer(versionedClient, 5*time.Minute); err != nil {
 		return ControllerContext{}, fmt.Errorf("failed to wait for apiserver being healthy: %v", err)
 	}
 

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -140,7 +140,7 @@ func (b SAControllerClientBuilder) Config(name string) (*restclient.Config, erro
 			return b.CoreClient.Secrets(b.Namespace).Watch(options)
 		},
 	}
-	_, err = cache.ListWatchUntil(30*time.Second, lw,
+	_, err = cache.ListWatchUntil(2*time.Minute, lw,
 		func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Deleted:

--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -49,7 +49,7 @@ func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.Pos
 	// initializing CAs is important so that aggregated API servers can come up with "normal" config.
 	// We've seen lagging etcd before, so we want to retry this a few times before we decide to crashloop
 	// the API server on it.
-	err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
+	err := wait.Poll(1*time.Second, 5*time.Minute, func() (done bool, err error) {
 		// retry building the config since sometimes the server can be in an in-between state which caused
 		// some kind of auto detection failure as I recall from other post start hooks.
 		// TODO see if this is still true and fix the RBAC one too if it isn't.


### PR DESCRIPTION
crash-looping at a high frequency doesn't benefit a controller that is waiting on an API server to start up

/cc @deads2k

```release-note
NONE
```