### PR TITLE
increase timeout in TestCancelAndReadd

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/timed_workers_test.go
@@ -61,7 +61,7 @@ func TestExecuteDelayed(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)
@@ -89,7 +89,7 @@ func TestCancel(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)
@@ -119,7 +119,7 @@ func TestCancelAndReadd(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)


### PR DESCRIPTION
the flakes referenced in #51704 were still seen downstream. the current timeout approach is [known to be faulty](https://github.com/kubernetes/kubernetes/issues/51704#issuecomment-328459239), but fixing the tests has not been prioritized. this increases the timeout sufficiently to avoid flakes in the meantime

```release-note
NONE
```