### PR TITLE
run kubetest directly for release-1.7

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -40,7 +40,7 @@ fi
 
 if [[ -f /.dockerenv ]]; then
 	# Running inside a dockerized runner.
-	go run ./hack/e2e.go -- --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
+	kubetest --check-version-skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
 else
 	# Running locally.
  	ARGS=$(echo $ARGS | sed 's/\[/\\\[/g' | sed 's/\]/\\\]/g')


### PR DESCRIPTION
e2e.go does nothing but rebuild kubetest, we should just run kubetest here for older releases.
1.7 version of https://github.com/kubernetes/kubernetes/pull/61636

/assign @wojtek-t 