### PR TITLE
Automated cherry pick of #61567: Fixes permissions error for Local SSD when created with NODE_LOCAL_SSDS flag

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -183,6 +183,7 @@ function safe-format-and-mount() {
   mkdir -p "${mountpoint}"
   echo "Mounting '${device}' at '${mountpoint}'"
   mount -o discard,defaults "${device}" "${mountpoint}"
+  chmod a+w "${mountpoint}"
 }
 
 # Gets a devices UUID and bind mounts the device to mount location in


### PR DESCRIPTION
Cherry pick of #61567 on release-1.10.

#61567: The PR fixes a permissions error introduced in 1.9 whereby users are unable to write to their Local SSD if it is created with the NODE_LOCAL_SSDS flag.

```release-note
NONE
```