### PR TITLE
Automated cherry pick of #61531: Ensure cloudprovider.InstanceNotFound is reported when the VM is not found on Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 // requestBackoff if backoff is disabled in cloud provider it
@@ -51,6 +52,9 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 	var retryErr error
 	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		machine, retryErr = az.getVirtualMachine(name)
+		if retryErr == cloudprovider.InstanceNotFound {
+			return true, cloudprovider.InstanceNotFound
+		}
 		if retryErr != nil {
 			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
 			return false, nil

--- a/pkg/cloudprovider/providers/azure/azure_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard.go
@@ -366,6 +366,9 @@ func (as *availabilitySet) GetInstanceIDByNodeName(name string) (string, error) 
 	var err error
 
 	machine, err = as.getVirtualMachine(types.NodeName(name))
+	if err == cloudprovider.InstanceNotFound {
+		return "", cloudprovider.InstanceNotFound
+	}
 	if err != nil {
 		if as.CloudProviderBackoff {
 			glog.V(2).Infof("InstanceID(%s) backing off", name)


### PR DESCRIPTION
Cherry pick of #61531 on release-1.10.

#61531: Ensure cloudprovider.InstanceNotFound is reported when the VM is not found on Azure