### PR TITLE
Automated cherry pick of #61531: Ensure cloudprovider.InstanceNotFound is reported when the VM is not found on Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -17,13 +17,14 @@ limitations under the License.
 package azure
 
 import (
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 // requestBackoff if backoff is disabled in cloud provider it
@@ -47,6 +48,9 @@ func (az *Cloud) GetVirtualMachineWithRetry(name types.NodeName) (compute.Virtua
 	var retryErr error
 	err := wait.ExponentialBackoff(az.requestBackoff(), func() (bool, error) {
 		machine, retryErr = az.getVirtualMachine(name)
+		if retryErr == cloudprovider.InstanceNotFound {
+			return true, cloudprovider.InstanceNotFound
+		}
 		if retryErr != nil {
 			glog.Errorf("backoff: failure, will retry,err=%v", retryErr)
 			return false, nil

--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -179,6 +179,9 @@ func (az *Cloud) getStandardInstanceID(name types.NodeName) (string, error) {
 	var err error
 	az.operationPollRateLimiter.Accept()
 	machine, err = az.getVirtualMachine(name)
+	if err == cloudprovider.InstanceNotFound {
+		return "", cloudprovider.InstanceNotFound
+	}
 	if err != nil {
 		if az.CloudProviderBackoff {
 			glog.V(2).Infof("InstanceID(%s) backing off", name)


### PR DESCRIPTION
Cherry pick of #61531 on release-1.9.

#61531: Ensure cloudprovider.InstanceNotFound is reported when the VM is not found on Azure