### PR TITLE
Add e2e test for external metrics with Stackdriver

### DIFF
--- a/test/e2e/autoscaling/BUILD
+++ b/test/e2e/autoscaling/BUILD
@@ -11,7 +11,7 @@ go_library(
         "autoscaling_timer.go",
         "cluster_autoscaler_scalability.go",
         "cluster_size_autoscaling.go",
-        "custom_metrics_autoscaling.go",
+        "custom_metrics_stackdriver_autoscaling.go",
         "dns_autoscaling.go",
         "framework.go",
         "horizontal_pod_autoscaling.go",


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e tests for external metrics using Stackdriver adapter.
Rename the file to note that these are Stackdriver tests in anticipation of tests running with fake custom metrics apiserver. Refactor the tests to be more structured.

**Release note**:
```
NONE
```
