### PR TITLE
Enable partial success in fluentd-gcp

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -402,6 +402,8 @@ data:
         # the necessary resource types when this label is set.
         "logging.googleapis.com/k8s_compatibility": "true"
       }
+      # Only drop failed entries partially, instead of dropping the whole request.
+      partial_success true
     </match>
 
     # Keep a smaller buffer here since these logs are less important than the user's
@@ -430,9 +432,10 @@ data:
         # the necessary resource types when this label is set.
         "logging.googleapis.com/k8s_compatibility": "true"
       }
+      partial_success true
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.2.4
+  name: fluentd-gcp-config-v1.2.5
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -108,4 +108,4 @@ spec:
           path: /var/lib/docker/containers
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.2.4
+          name: fluentd-gcp-config-v1.2.5


### PR DESCRIPTION
Enable partial success in fluentd-gcp. This will allow to reduce amount of lost data in case of invalid (e.g. too big) entries: instead of dropping the whole request, only failed entries will be dropped.

```release-note
NONE
```

/assign @x13n 
/cc @bmoyles0117
