### PR TITLE
Deprecate PSP-related types in extensions/v1beta1

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -80103,7 +80103,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.AllowedFlexVolume": {
-    "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+    "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.",
     "required": [
      "driver"
     ],
@@ -80115,7 +80115,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.AllowedHostPath": {
-    "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+    "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.",
     "properties": {
      "pathPrefix": {
       "description": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
@@ -80580,7 +80580,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions": {
-    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
@@ -80627,7 +80627,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.HostPortRange": {
-    "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+    "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.",
     "required": [
      "min",
      "max"
@@ -80646,7 +80646,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IDRange": {
-    "description": "IDRange provides a min/max of an allowed range of IDs.",
+    "description": "IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.",
     "required": [
      "min",
      "max"
@@ -80990,7 +80990,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicy": {
-    "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+    "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -81018,7 +81018,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicyList": {
-    "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects.",
+    "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.",
     "required": [
      "items"
     ],
@@ -81052,7 +81052,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec": {
-    "description": "PodSecurityPolicySpec defines the policy enforced.",
+    "description": "PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.",
     "required": [
      "seLinux",
      "runAsUser",
@@ -81348,7 +81348,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions": {
-    "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.",
     "required": [
      "rule"
     ],
@@ -81367,7 +81367,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions": {
-    "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.",
     "required": [
      "rule"
     ],
@@ -81449,7 +81449,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions": {
-    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -10188,7 +10188,7 @@
    },
    "v1beta1.PodSecurityPolicyList": {
     "id": "v1beta1.PodSecurityPolicyList",
-    "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects.",
+    "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.",
     "required": [
      "items"
     ],
@@ -10216,7 +10216,7 @@
    },
    "v1beta1.PodSecurityPolicy": {
     "id": "v1beta1.PodSecurityPolicy",
-    "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+    "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -10238,7 +10238,7 @@
    },
    "v1beta1.PodSecurityPolicySpec": {
     "id": "v1beta1.PodSecurityPolicySpec",
-    "description": "PodSecurityPolicySpec defines the policy enforced.",
+    "description": "PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.",
     "required": [
      "seLinux",
      "runAsUser",
@@ -10347,7 +10347,7 @@
    },
    "v1beta1.HostPortRange": {
     "id": "v1beta1.HostPortRange",
-    "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+    "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.",
     "required": [
      "min",
      "max"
@@ -10367,7 +10367,7 @@
    },
    "v1beta1.SELinuxStrategyOptions": {
     "id": "v1beta1.SELinuxStrategyOptions",
-    "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.",
     "required": [
      "rule"
     ],
@@ -10384,7 +10384,7 @@
    },
    "v1beta1.RunAsUserStrategyOptions": {
     "id": "v1beta1.RunAsUserStrategyOptions",
-    "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.",
     "required": [
      "rule"
     ],
@@ -10404,7 +10404,7 @@
    },
    "v1beta1.IDRange": {
     "id": "v1beta1.IDRange",
-    "description": "IDRange provides a min/max of an allowed range of IDs.",
+    "description": "IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.",
     "required": [
      "min",
      "max"
@@ -10424,7 +10424,7 @@
    },
    "v1beta1.SupplementalGroupsStrategyOptions": {
     "id": "v1beta1.SupplementalGroupsStrategyOptions",
-    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.",
     "properties": {
      "rule": {
       "type": "string",
@@ -10441,7 +10441,7 @@
    },
    "v1beta1.FSGroupStrategyOptions": {
     "id": "v1beta1.FSGroupStrategyOptions",
-    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.",
     "properties": {
      "rule": {
       "type": "string",
@@ -10458,7 +10458,7 @@
    },
    "v1beta1.AllowedHostPath": {
     "id": "v1beta1.AllowedHostPath",
-    "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+    "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.",
     "properties": {
      "pathPrefix": {
       "type": "string",
@@ -10468,7 +10468,7 @@
    },
    "v1beta1.AllowedFlexVolume": {
     "id": "v1beta1.AllowedFlexVolume",
-    "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+    "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.",
     "required": [
      "driver"
     ],

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -421,7 +421,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_allowedhostpath">v1beta1.AllowedHostPath</h3>
 <div class="paragraph">
-<p>AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.</p>
+<p>AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1508,7 +1508,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicylist">v1beta1.PodSecurityPolicyList</h3>
 <div class="paragraph">
-<p>PodSecurityPolicyList is a list of PodSecurityPolicy objects.</p>
+<p>PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1604,7 +1604,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_fsgroupstrategyoptions">v1beta1.FSGroupStrategyOptions</h3>
 <div class="paragraph">
-<p>FSGroupStrategyOptions defines the strategy type and options used to create the strategy.</p>
+<p>FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2989,7 +2989,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_selinuxstrategyoptions">v1beta1.SELinuxStrategyOptions</h3>
 <div class="paragraph">
-<p>SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.</p>
+<p>SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3030,7 +3030,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_runasuserstrategyoptions">v1beta1.RunAsUserStrategyOptions</h3>
 <div class="paragraph">
-<p>RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.</p>
+<p>RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3362,7 +3362,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_supplementalgroupsstrategyoptions">v1beta1.SupplementalGroupsStrategyOptions</h3>
 <div class="paragraph">
-<p>SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.</p>
+<p>SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4318,7 +4318,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicy">v1beta1.PodSecurityPolicy</h3>
 <div class="paragraph">
-<p>PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.</p>
+<p>PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6756,7 +6756,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <div class="sect2">
 <h3 id="_v1beta1_allowedflexvolume">v1beta1.AllowedFlexVolume</h3>
 <div class="paragraph">
-<p>AllowedFlexVolume represents a single Flexvolume that is allowed to be used.</p>
+<p>AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7522,7 +7522,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <div class="sect2">
 <h3 id="_v1beta1_hostportrange">v1beta1.HostPortRange</h3>
 <div class="paragraph">
-<p>HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.</p>
+<p>HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7901,7 +7901,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicyspec">v1beta1.PodSecurityPolicySpec</h3>
 <div class="paragraph">
-<p>PodSecurityPolicySpec defines the policy enforced.</p>
+<p>PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -8315,7 +8315,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <div class="sect2">
 <h3 id="_v1beta1_idrange">v1beta1.IDRange</h3>
 <div class="paragraph">
-<p>IDRange provides a min/max of an allowed range of IDs.</p>
+<p>IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -33,6 +33,7 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 option go_package = "v1beta1";
 
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+// Deprecated: use AllowedFlexVolume from policy API Group instead.
 message AllowedFlexVolume {
   // driver is the name of the Flexvolume driver.
   optional string driver = 1;
@@ -40,6 +41,7 @@ message AllowedFlexVolume {
 
 // AllowedHostPath defines the host volume conditions that will be enabled by a policy
 // for pods to use. It requires the path prefix to be defined.
+// Deprecated: use AllowedHostPath from policy API Group instead.
 message AllowedHostPath {
   // pathPrefix is the path prefix that the host volume must match.
   // It does not support `*`.
@@ -409,6 +411,7 @@ message DeploymentStrategy {
 }
 
 // FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+// Deprecated: use FSGroupStrategyOptions from policy API Group instead.
 message FSGroupStrategyOptions {
   // rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
   // +optional
@@ -450,6 +453,7 @@ message HTTPIngressRuleValue {
 
 // HostPortRange defines a range of host ports that will be enabled by a policy
 // for pods to use.  It requires both the start and end to be defined.
+// Deprecated: use HostPortRange from policy API Group instead.
 message HostPortRange {
   // min is the start of the range, inclusive.
   optional int32 min = 1;
@@ -459,6 +463,7 @@ message HostPortRange {
 }
 
 // IDRange provides a min/max of an allowed range of IDs.
+// Deprecated: use IDRange from policy API Group instead.
 message IDRange {
   // min is the start of the range, inclusive.
   optional int64 min = 1;
@@ -763,6 +768,7 @@ message NetworkPolicySpec {
 
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context
 // that will be applied to a pod and container.
+// Deprecated: use PodSecurityPolicy from policy API Group instead.
 message PodSecurityPolicy {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -775,6 +781,7 @@ message PodSecurityPolicy {
 }
 
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects.
+// Deprecated: use PodSecurityPolicyList from policy API Group instead.
 message PodSecurityPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -786,6 +793,7 @@ message PodSecurityPolicyList {
 }
 
 // PodSecurityPolicySpec defines the policy enforced.
+// Deprecated: use PodSecurityPolicySpec from policy API Group instead.
 message PodSecurityPolicySpec {
   // privileged determines if a pod can request to be run as privileged.
   // +optional
@@ -1049,6 +1057,7 @@ message RollingUpdateDeployment {
 }
 
 // RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
+// Deprecated: use RunAsUserStrategyOptions from policy API Group instead.
 message RunAsUserStrategyOptions {
   // rule is the strategy that will dictate the allowable RunAsUser values that may be set.
   optional string rule = 1;
@@ -1060,6 +1069,7 @@ message RunAsUserStrategyOptions {
 }
 
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
+// Deprecated: use SELinuxStrategyOptions from policy API Group instead.
 message SELinuxStrategyOptions {
   // rule is the strategy that will dictate the allowable labels that may be set.
   optional string rule = 1;
@@ -1112,6 +1122,7 @@ message ScaleStatus {
 }
 
 // SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+// Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.
 message SupplementalGroupsStrategyOptions {
   // rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
   // +optional

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -864,6 +864,7 @@ type ReplicaSetCondition struct {
 
 // PodSecurityPolicy governs the ability to make requests that affect the Security Context
 // that will be applied to a pod and container.
+// Deprecated: use PodSecurityPolicy from policy API Group instead.
 type PodSecurityPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -877,6 +878,7 @@ type PodSecurityPolicy struct {
 }
 
 // PodSecurityPolicySpec defines the policy enforced.
+// Deprecated: use PodSecurityPolicySpec from policy API Group instead.
 type PodSecurityPolicySpec struct {
 	// privileged determines if a pod can request to be run as privileged.
 	// +optional
@@ -948,6 +950,7 @@ type PodSecurityPolicySpec struct {
 
 // AllowedHostPath defines the host volume conditions that will be enabled by a policy
 // for pods to use. It requires the path prefix to be defined.
+// Deprecated: use AllowedHostPath from policy API Group instead.
 type AllowedHostPath struct {
 	// pathPrefix is the path prefix that the host volume must match.
 	// It does not support `*`.
@@ -960,6 +963,7 @@ type AllowedHostPath struct {
 }
 
 // FSType gives strong typing to different file systems that are used by volumes.
+// Deprecated: use FSType from policy API Group instead.
 type FSType string
 
 var (
@@ -988,6 +992,7 @@ var (
 )
 
 // AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+// Deprecated: use AllowedFlexVolume from policy API Group instead.
 type AllowedFlexVolume struct {
 	// driver is the name of the Flexvolume driver.
 	Driver string `json:"driver" protobuf:"bytes,1,opt,name=driver"`
@@ -995,6 +1000,7 @@ type AllowedFlexVolume struct {
 
 // HostPortRange defines a range of host ports that will be enabled by a policy
 // for pods to use.  It requires both the start and end to be defined.
+// Deprecated: use HostPortRange from policy API Group instead.
 type HostPortRange struct {
 	// min is the start of the range, inclusive.
 	Min int32 `json:"min" protobuf:"varint,1,opt,name=min"`
@@ -1003,6 +1009,7 @@ type HostPortRange struct {
 }
 
 // SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
+// Deprecated: use SELinuxStrategyOptions from policy API Group instead.
 type SELinuxStrategyOptions struct {
 	// rule is the strategy that will dictate the allowable labels that may be set.
 	Rule SELinuxStrategy `json:"rule" protobuf:"bytes,1,opt,name=rule,casttype=SELinuxStrategy"`
@@ -1014,16 +1021,20 @@ type SELinuxStrategyOptions struct {
 
 // SELinuxStrategy denotes strategy types for generating SELinux options for a
 // Security Context.
+// Deprecated: use SELinuxStrategy from policy API Group instead.
 type SELinuxStrategy string
 
 const (
 	// SELinuxStrategyMustRunAs means that container must have SELinux labels of X applied.
+	// Deprecated: use SELinuxStrategyMustRunAs from policy API Group instead.
 	SELinuxStrategyMustRunAs SELinuxStrategy = "MustRunAs"
 	// SELinuxStrategyRunAsAny means that container may make requests for any SELinux context labels.
+	// Deprecated: use SELinuxStrategyRunAsAny from policy API Group instead.
 	SELinuxStrategyRunAsAny SELinuxStrategy = "RunAsAny"
 )
 
 // RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
+// Deprecated: use RunAsUserStrategyOptions from policy API Group instead.
 type RunAsUserStrategyOptions struct {
 	// rule is the strategy that will dictate the allowable RunAsUser values that may be set.
 	Rule RunAsUserStrategy `json:"rule" protobuf:"bytes,1,opt,name=rule,casttype=RunAsUserStrategy"`
@@ -1034,6 +1045,7 @@ type RunAsUserStrategyOptions struct {
 }
 
 // IDRange provides a min/max of an allowed range of IDs.
+// Deprecated: use IDRange from policy API Group instead.
 type IDRange struct {
 	// min is the start of the range, inclusive.
 	Min int64 `json:"min" protobuf:"varint,1,opt,name=min"`
@@ -1043,18 +1055,23 @@ type IDRange struct {
 
 // RunAsUserStrategy denotes strategy types for generating RunAsUser values for a
 // Security Context.
+// Deprecated: use RunAsUserStrategy from policy API Group instead.
 type RunAsUserStrategy string
 
 const (
 	// RunAsUserStrategyMustRunAs means that container must run as a particular uid.
+	// Deprecated: use RunAsUserStrategyMustRunAs from policy API Group instead.
 	RunAsUserStrategyMustRunAs RunAsUserStrategy = "MustRunAs"
 	// RunAsUserStrategyMustRunAsNonRoot means that container must run as a non-root uid.
+	// Deprecated: use RunAsUserStrategyMustRunAsNonRoot from policy API Group instead.
 	RunAsUserStrategyMustRunAsNonRoot RunAsUserStrategy = "MustRunAsNonRoot"
 	// RunAsUserStrategyRunAsAny means that container may make requests for any uid.
+	// Deprecated: use RunAsUserStrategyRunAsAny from policy API Group instead.
 	RunAsUserStrategyRunAsAny RunAsUserStrategy = "RunAsAny"
 )
 
 // FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+// Deprecated: use FSGroupStrategyOptions from policy API Group instead.
 type FSGroupStrategyOptions struct {
 	// rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
 	// +optional
@@ -1067,16 +1084,20 @@ type FSGroupStrategyOptions struct {
 
 // FSGroupStrategyType denotes strategy types for generating FSGroup values for a
 // SecurityContext
+// Deprecated: use FSGroupStrategyType from policy API Group instead.
 type FSGroupStrategyType string
 
 const (
 	// FSGroupStrategyMustRunAs meant that container must have FSGroup of X applied.
+	// Deprecated: use FSGroupStrategyMustRunAs from policy API Group instead.
 	FSGroupStrategyMustRunAs FSGroupStrategyType = "MustRunAs"
 	// FSGroupStrategyRunAsAny means that container may make requests for any FSGroup labels.
+	// Deprecated: use FSGroupStrategyRunAsAny from policy API Group instead.
 	FSGroupStrategyRunAsAny FSGroupStrategyType = "RunAsAny"
 )
 
 // SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+// Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.
 type SupplementalGroupsStrategyOptions struct {
 	// rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
 	// +optional
@@ -1089,18 +1110,22 @@ type SupplementalGroupsStrategyOptions struct {
 
 // SupplementalGroupsStrategyType denotes strategy types for determining valid supplemental
 // groups for a SecurityContext.
+// Deprecated: use SupplementalGroupsStrategyType from policy API Group instead.
 type SupplementalGroupsStrategyType string
 
 const (
 	// SupplementalGroupsStrategyMustRunAs means that container must run as a particular gid.
+	// Deprecated: use SupplementalGroupsStrategyMustRunAs from policy API Group instead.
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
 	// SupplementalGroupsStrategyRunAsAny means that container may make requests for any gid.
+	// Deprecated: use SupplementalGroupsStrategyRunAsAny from policy API Group instead.
 	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodSecurityPolicyList is a list of PodSecurityPolicy objects.
+// Deprecated: use PodSecurityPolicyList from policy API Group instead.
 type PodSecurityPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -28,7 +28,7 @@ package v1beta1
 
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_AllowedFlexVolume = map[string]string{
-	"":       "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+	"":       "AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.",
 	"driver": "driver is the name of the Flexvolume driver.",
 }
 
@@ -37,7 +37,7 @@ func (AllowedFlexVolume) SwaggerDoc() map[string]string {
 }
 
 var map_AllowedHostPath = map[string]string{
-	"":           "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+	"":           "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.",
 	"pathPrefix": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
 }
 
@@ -229,7 +229,7 @@ func (DeploymentStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_FSGroupStrategyOptions = map[string]string{
-	"":       "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+	"":       "FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.",
 	"rule":   "rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
 	"ranges": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
 }
@@ -258,7 +258,7 @@ func (HTTPIngressRuleValue) SwaggerDoc() map[string]string {
 }
 
 var map_HostPortRange = map[string]string{
-	"":    "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+	"":    "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.",
 	"min": "min is the start of the range, inclusive.",
 	"max": "max is the end of the range, inclusive.",
 }
@@ -268,7 +268,7 @@ func (HostPortRange) SwaggerDoc() map[string]string {
 }
 
 var map_IDRange = map[string]string{
-	"":    "IDRange provides a min/max of an allowed range of IDs.",
+	"":    "IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.",
 	"min": "min is the start of the range, inclusive.",
 	"max": "max is the end of the range, inclusive.",
 }
@@ -439,7 +439,7 @@ func (NetworkPolicySpec) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicy = map[string]string{
-	"":         "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+	"":         "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "spec defines the policy enforced.",
 }
@@ -449,7 +449,7 @@ func (PodSecurityPolicy) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicyList = map[string]string{
-	"":         "PodSecurityPolicyList is a list of PodSecurityPolicy objects.",
+	"":         "PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"items":    "items is a list of schema objects.",
 }
@@ -459,7 +459,7 @@ func (PodSecurityPolicyList) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicySpec = map[string]string{
-	"":                                "PodSecurityPolicySpec defines the policy enforced.",
+	"":                                "PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.",
 	"privileged":                      "privileged determines if a pod can request to be run as privileged.",
 	"defaultAddCapabilities":          "defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.",
 	"requiredDropCapabilities":        "requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
@@ -581,7 +581,7 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 }
 
 var map_RunAsUserStrategyOptions = map[string]string{
-	"":       "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.",
+	"":       "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.",
 	"rule":   "rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
 	"ranges": "ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.",
 }
@@ -591,7 +591,7 @@ func (RunAsUserStrategyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_SELinuxStrategyOptions = map[string]string{
-	"":               "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.",
+	"":               "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.",
 	"rule":           "rule is the strategy that will dictate the allowable labels that may be set.",
 	"seLinuxOptions": "seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
 }
@@ -632,7 +632,7 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_SupplementalGroupsStrategyOptions = map[string]string{
-	"":       "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+	"":       "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.",
 	"rule":   "rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
 	"ranges": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deprecates PSP-related types in `extensions/v1beta1` API Group and suggests to use their versions from `policy/v1beta1`. This is a part of PSP migration away from `extensions` API Group.

**Which issue(s) this PR fixes**:
Addressed to https://github.com/kubernetes/features/issues/5