### PR TITLE
Add unit testcases for ensureExternalLoadBalancer to make sure it doesn't panic when errors raised.

### DIFF
--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -433,3 +433,38 @@ func GetFirewallsUnauthorizedErrHook(ctx context.Context, key *meta.Key, m *clou
 func GetTargetPoolInternalErrHook(ctx context.Context, key *meta.Key, m *cloud.MockTargetPools) (bool, *ga.TargetPool, error) {
 	return true, nil, &googleapi.Error{Code: http.StatusInternalServerError}
 }
+
+// GetForwardingRulesInternalErrHook mocks getting forwarding rules and returns an internal server error.
+func GetForwardingRulesInternalErrHook(ctx context.Context, key *meta.Key, m *cloud.MockForwardingRules) (bool, *ga.ForwardingRule, error) {
+	return true, nil, &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
+// GetAddressesInternalErrHook mocks getting network address and returns an internal server error.
+func GetAddressesInternalErrHook(ctx context.Context, key *meta.Key, m *cloud.MockAddresses) (bool, *ga.Address, error) {
+	return true, nil, &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
+// GetHTTPHealthChecksInternalErrHook mocks getting http health check and returns an internal server error.
+func GetHTTPHealthChecksInternalErrHook(ctx context.Context, key *meta.Key, m *cloud.MockHttpHealthChecks) (bool, *ga.HttpHealthCheck, error) {
+	return true, nil, &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
+// InsertTargetPoolsInternalErrHook mocks getting target pool and returns an internal server error.
+func InsertTargetPoolsInternalErrHook(ctx context.Context, key *meta.Key, obj *ga.TargetPool, m *cloud.MockTargetPools) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
+// InsertForwardingRulesInternalErrHook mocks getting forwarding rule and returns an internal server error.
+func InsertForwardingRulesInternalErrHook(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *cloud.MockForwardingRules) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusInternalServerError}
+}
+
+// DeleteAddressesNotFoundErrHook mocks deleting network address and returns a not found error.
+func DeleteAddressesNotFoundErrHook(ctx context.Context, key *meta.Key, m *cloud.MockAddresses) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusNotFound}
+}
+
+// DeleteAddressesInternalErrHook mocks delete address and returns an internal server error.
+func DeleteAddressesInternalErrHook(ctx context.Context, key *meta.Key, m *cloud.MockAddresses) (bool, error) {
+	return true, &googleapi.Error{Code: http.StatusInternalServerError}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add unit testcases for ensureExternalLoadBalancer to make sure it doesn't panic when errors raised. Increase code coverage from 76.5% to 81.5%.

<!--
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
-->

**Release note**: 
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

\assign @MrHohn 