### PR TITLE
Added support for Standard LoadBlanacer Sku

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -197,7 +197,7 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 	isInternal := requiresInternalLoadBalancer(service)
 	var defaultLB *network.LoadBalancer
 	primaryVMSetName := az.vmSet.GetPrimaryVMSetName()
-	defaultLBName := az.getLoadBalancerName(clusterName, primaryVMSetName, isInternal)
+	defaultLBName := az.getLoadBalancerName(clusterName, primaryVMSetName, isInternal, string(getLoadBalancerSku(service).Name))
 
 	existingLBs, err := az.ListLBWithRetry()
 	if err != nil {
@@ -272,7 +272,7 @@ func (az *Cloud) selectLoadBalancer(clusterName string, service *v1.Service, exi
 	}
 	selectedLBRuleCount := math.MaxInt32
 	for _, currASName := range *vmSetNames {
-		currLBName := az.getLoadBalancerName(clusterName, currASName, isInternal)
+		currLBName := az.getLoadBalancerName(clusterName, currASName, isInternal, string(getLoadBalancerSku(service).Name))
 		lb, exists := mapExistingLBs[currLBName]
 		if !exists {
 			// select this LB as this is a new LB and will have minimum rules

--- a/pkg/cloudprovider/providers/azure/azure_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard.go
@@ -121,7 +121,7 @@ func (az *Cloud) mapLoadBalancerNameToVMSet(lbName string, clusterName string) (
 // Thus Azure do not allow mixed type (public and internal) load balancer.
 // So we'd have a separate name for internal load balancer.
 // This would be the name for Azure LoadBalancer resource.
-func (az *Cloud) getLoadBalancerName(clusterName string, vmSetName string, isInternal bool) string {
+func (az *Cloud) getLoadBalancerName(clusterName string, vmSetName string, isInternal bool, lbTypeName string) string {
 	lbNamePrefix := vmSetName
 	if strings.EqualFold(vmSetName, az.vmSet.GetPrimaryVMSetName()) {
 		lbNamePrefix = clusterName
@@ -129,7 +129,7 @@ func (az *Cloud) getLoadBalancerName(clusterName string, vmSetName string, isInt
 	if isInternal {
 		return fmt.Sprintf("%s%s", lbNamePrefix, InternalLoadBalancerNameSuffix)
 	}
-	return lbNamePrefix
+	return fmt.Sprintf("%s-%s", lbNamePrefix, lbTypeName)
 }
 
 // isMasterNode returns true if the node has a master role label.


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends support for Azure LoadBalancers to the new Standard LoadBalancer which offers additional capabilities over the Basic LoadBalancer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61783

**Special notes for your reviewer**:

**Release note**:
```release-note
By default a kubernetes service provisions an Azure Load Balancer of type Basic. To provision an Azure Standard LoadBalancer include the following annotation in the Service definition:

[...]
metadata:
    name: my-service
    annotations:
        service.beta.kubernetes.io/azure-load-balancer-sku: "Standard"
[...]
```

/sig azure