### PR TITLE
make reapers tolerate 404s on scaling down

### DIFF
--- a/pkg/kubectl/scale_test.go
+++ b/pkg/kubectl/scale_test.go
@@ -87,8 +87,7 @@ func TestReplicationControllerScaleInvalid(t *testing.T) {
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
-	e, ok := err.(ScaleError)
-	if err == nil || !ok || e.FailureType != ScaleUpdateFailure {
+	if err == nil {
 		t.Errorf("Expected error on invalid update failure, got %v", err)
 	}
 	actions := scaleClient.Actions()
@@ -252,8 +251,7 @@ func TestJobScaleInvalid(t *testing.T) {
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
-	e, ok := err.(ScaleError)
-	if err == nil || !ok || e.FailureType != ScaleUpdateFailure {
+	if err == nil {
 		t.Errorf("Expected error on invalid update failure, got %v", err)
 	}
 }
@@ -486,8 +484,7 @@ func TestDeploymentScaleInvalid(t *testing.T) {
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
-	e, ok := err.(ScaleError)
-	if err == nil || !ok || e.FailureType != ScaleUpdateFailure {
+	if err == nil {
 		t.Errorf("Expected error on invalid update failure, got %v", err)
 	}
 	actions := scaleClient.Actions()
@@ -599,8 +596,7 @@ func TestStatefulSetScaleInvalid(t *testing.T) {
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
-	e, ok := err.(ScaleError)
-	if err == nil || !ok || e.FailureType != ScaleUpdateFailure {
+	if err == nil {
 		t.Errorf("Expected error on invalid update failure, got %v", err)
 	}
 	actions := scaleClient.Actions()
@@ -712,8 +708,7 @@ func TestReplicaSetScaleInvalid(t *testing.T) {
 	if pass {
 		t.Errorf("Expected an update failure to return pass = false, got pass = %v", pass)
 	}
-	e, ok := err.(ScaleError)
-	if err == nil || !ok || e.FailureType != ScaleUpdateFailure {
+	if err == nil {
 		t.Errorf("Expected error on invalid update failure, got %v", err)
 	}
 	actions := scaleClient.Actions()
@@ -859,7 +854,7 @@ func TestGenericScale(t *testing.T) {
 			resName:      "abc",
 			scaleGetter:  scaleClient,
 		},
-		// scenario 2: a resource name cannot be empty
+		//scenario 2: a resource name cannot be empty
 		{
 			name:         "a resource name cannot be empty",
 			precondition: ScalePrecondition{10, ""},
@@ -883,8 +878,8 @@ func TestGenericScale(t *testing.T) {
 	}
 
 	// act
-	for index, scenario := range scenarios {
-		t.Run(fmt.Sprintf("running scenario %d: %s", index+1, scenario.name), func(t *testing.T) {
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
 			target := NewScaler(scenario.scaleGetter, scenario.targetGR)
 
 			err := target.Scale("default", scenario.resName, uint(scenario.newSize), &scenario.precondition, nil, scenario.waitForReplicas)

--- a/staging/src/k8s.io/client-go/scale/client.go
+++ b/staging/src/k8s.io/client-go/scale/client.go
@@ -138,7 +138,7 @@ func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) 
 		SubResource("scale").
 		Do()
 	if err := result.Error(); err != nil {
-		return nil, fmt.Errorf("could not fetch the scale for %s %s: %v", resource.String(), name, err)
+		return nil, err
 	}
 
 	scaleBytes, err := result.Raw()


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/61748

This fixes the scale client to return the actual API error, not a wrapped one.  It also updates scalers to do the same.  Then it fixes the reapers to tolerate 404s, since that means they achieved their objective.

/assign @janetkuo 
/assign @p0lyn0mial 

```release-note
NONE
```