### PR TITLE
1.10 CHANGELOG: remove beta announcement for out-of-tree cloud provider feature

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -193,10 +193,6 @@ Kubernetes 1.10 includes alpha [Azure support for cluster-autoscaler](https://gi
 
 This release includes a change to [kubectl get and describe to work better with extensions](https://github.com/kubernetes/features/issues/515), as the server, rather than the client, returns this information for a smoother user experience.
 
-### Cluster Lifecycle
-
-This release includes beta [support for out-of-process and out-of-tree cloud providers](https://github.com/kubernetes/features/issues/88).
-
 ### Network
 
 In terms of networking, Kubernetes 1.10 is about control. Users now have beta support for the ability to [configure a pod's resolv.conf](https://github.com/kubernetes/features/issues/504), rather than relying on the cluster DNS, as well as [configuring the NodePort IP address](https://github.com/kubernetes/features/issues/539). You can also  [switch the default DNS plugin to CoreDNS](https://github.com/kubernetes/features/issues/427) (beta). 


### PR DESCRIPTION
**What this PR does / why we need it**:
removes beta announcement for external cloud provider feature in 1.10 CHANGELOG. 

**Special notes for your reviewer**:
As per https://github.com/kubernetes/features/issues/88#issuecomment-370904224 we had no plans to move this feature to beta as we're still working out how to facilitate e2e tests for external cloud providers. 

**Release note**:
```release-note
NONE
```
