### PR TITLE
Add ingress e2e test for multiple TLS (SNI) support

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -311,6 +311,42 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			executeBacksideBacksideHTTPSTest(f, jig, "")
 		})
 
+		It("should support multiple TLS certs [Unreleased]", func() {
+			By("Creating an ingress with no certs.")
+			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "multiple-certs"), ns, map[string]string{
+				framework.IngressStaticIPKey: ns,
+			}, map[string]string{})
+
+			By("Adding multiple certs to the ingress.")
+			hosts := []string{"test1.ingress.com", "test2.ingress.com", "test3.ingress.com", "test4.ingress.com"}
+			secrets := []string{"tls-secret-1", "tls-secret-2", "tls-secret-3", "tls-secret-4"}
+			certs := [][]byte{}
+			for i, host := range hosts {
+				jig.AddHTTPS(secrets[i], host)
+				certs = append(certs, jig.GetRootCA(secrets[i]))
+			}
+			for i, host := range hosts {
+				err := jig.WaitForIngressWithCert(true, []string{host}, certs[i])
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unexpected error while waiting for ingress: %v", err))
+			}
+
+			By("Remove all but one of the certs on the ingress.")
+			jig.RemoveHTTPS(secrets[1])
+			jig.RemoveHTTPS(secrets[2])
+			jig.RemoveHTTPS(secrets[3])
+
+			By("Test that the remaining cert is properly served.")
+			err := jig.WaitForIngressWithCert(true, []string{hosts[0]}, certs[0])
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unexpected error while waiting for ingress: %v", err))
+
+			By("Add back one of the certs that was removed and check that all certs are served.")
+			jig.AddHTTPS(secrets[1], hosts[1])
+			for i, host := range hosts[:2] {
+				err := jig.WaitForIngressWithCert(true, []string{host}, certs[i])
+				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unexpected error while waiting for ingress: %v", err))
+			}
+		})
+
 		It("multicluster ingress should get instance group annotation", func() {
 			name := "echomap"
 			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "http"), ns, map[string]string{

--- a/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: multiple-certs
+spec:
+  rules:
+  - host: test1.ingress.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80
+  - host: test2.ingress.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80
+  - host: test3.ingress.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80
+  - host: test4.ingress.com
+    http:
+      paths:
+      - path: /test
+        backend:
+          serviceName: echoheaders-https
+          servicePort: 80

--- a/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/rc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: echoheaders-https
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: echoheaders-https
+    spec:
+      containers:
+      - name: echoheaders-https
+        image: gcr.io/google_containers/echoserver:1.10
+        ports:
+        - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/multiple-certs/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheaders-https
+  labels:
+    app: echoheaders-https
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders-https


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an e2e test for multiple TLS support in ingress-gce.

**Release note**:
```release-note
None
```
/assign @MrHohn 
/hold
