### PR TITLE
Ensure -o yaml populates kind/apiVersion

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -2386,6 +2386,13 @@ run_secrets_test() {
 
   create_and_use_new_namespace
   kube::log::status "Testing secrets"
+
+  # Ensure dry run succeeds and includes kind, apiVersion and data
+  output_message=$(kubectl create secret generic test --from-literal=key1=value1 --dry-run -o yaml)
+  kube::test::if_has_string "${output_message}" 'kind: Secret'
+  kube::test::if_has_string "${output_message}" 'apiVersion: v1'
+  kube::test::if_has_string "${output_message}" 'key1: dmFsdWUx'
+
   ### Create a new namespace
   # Pre-condition: the test-secrets namespace does not exist
   kube::test::get_object_assert 'namespaces' '{{range.items}}{{ if eq $id_field \"test-secrets\" }}found{{end}}{{end}}:' ':'

--- a/pkg/kubectl/cmd/create_clusterrole_test.go
+++ b/pkg/kubectl/cmd/create_clusterrole_test.go
@@ -50,6 +50,7 @@ func TestCreateClusterRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "pods,pods",
 			expectedClusterRole: &rbac.ClusterRole{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: clusterRoleName,
 				},
@@ -67,6 +68,7 @@ func TestCreateClusterRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "pods,deployments.extensions",
 			expectedClusterRole: &rbac.ClusterRole{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: clusterRoleName,
 				},
@@ -90,6 +92,7 @@ func TestCreateClusterRole(t *testing.T) {
 			verbs:          "get",
 			nonResourceURL: "/logs/,/healthz",
 			expectedClusterRole: &rbac.ClusterRole{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: clusterRoleName,
 				},
@@ -106,6 +109,7 @@ func TestCreateClusterRole(t *testing.T) {
 			nonResourceURL: "/logs/,/healthz",
 			resources:      "pods",
 			expectedClusterRole: &rbac.ClusterRole{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: clusterRoleName,
 				},

--- a/pkg/kubectl/cmd/create_role_test.go
+++ b/pkg/kubectl/cmd/create_role_test.go
@@ -51,6 +51,7 @@ func TestCreateRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "pods,pods",
 			expectedRole: &rbac.Role{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: roleName,
 				},
@@ -68,6 +69,7 @@ func TestCreateRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "replicasets/scale",
 			expectedRole: &rbac.Role{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: roleName,
 				},
@@ -85,6 +87,7 @@ func TestCreateRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "replicasets.extensions/scale",
 			expectedRole: &rbac.Role{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: roleName,
 				},
@@ -102,6 +105,7 @@ func TestCreateRole(t *testing.T) {
 			verbs:     "get,watch,list",
 			resources: "pods,deployments.extensions",
 			expectedRole: &rbac.Role{
+				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
 					Name: roleName,
 				},

--- a/pkg/printers/versioned.go
+++ b/pkg/printers/versioned.go
@@ -76,6 +76,11 @@ func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	}
 
 	if !needsConversion {
+		// We might be an external type, but have empty kind/apiVersion fields. Ensure they are populated before printing.
+		if obj.GetObjectKind().GroupVersionKind().Empty() {
+			obj = obj.DeepCopyObject()
+			obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+		}
 		return p.printer.PrintObj(obj, w)
 	}
 


### PR DESCRIPTION
Fixes #61780 

```release-note
kubectl: fixes issue with `-o yaml` and `-o json` omitting kind and apiVersion when used with `--dry-run`
```