### PR TITLE
check for commands in kubelet command line

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -146,6 +146,13 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				glog.Fatal(err)
 			}
 
+			// check if there are non-flag arguments in the command line
+			cmds := cleanFlagSet.Args()
+			if len(cmds) > 0 {
+				cmd.Usage()
+				glog.Fatalf("unknown command: %s", cmds[0])
+			}
+
 			// short-circuit on help
 			help, err := cleanFlagSet.GetBool("help")
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubelet doesn't support subcommands and silently ignores them.
This causes a lot of confusion among users, for example:

  Running 'kubelet logs' can produce this output:
```
    I0206 16:20:40.010949    5712 feature_gate.go:220] feature gates: &{{} map[]}
    I0206 16:20:40.011054    5712 controller.go:114] kubelet config controller: starting controller
    ...
    error: failed to run Kubelet: failed to create kubelet:
           misconfiguration: kubelet cgroup driver: "cgroupfs" is different from
           docker cgroup driver: "systemd"
```

The output in this case looks like a valid log output. The error is not
caused by incorrectly configured cgroup driver though. It's caused by
the fact that kubelet ignores 'logs' subcommand, so 'kubelet logs' is
essentially the same as 'kubelet': it runs kubelet with the default set
of parameters, including default cgroup driver.

**The fix**:
Added check to prevent kubelet from running if user specifies
subcommands in the command line.

**Which issue(s) this PR fixes**:
Fixes: kubeadm issue 639

**Release note**:
```release-note
NONE
```