### PR TITLE
fix error message of "kubectl version"

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -319,12 +319,13 @@ func (d *DiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIRes
 
 // ServerVersion retrieves and parses the server's version (git version).
 func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
-	body, err := d.restClient.Get().AbsPath("/version").Do().Raw()
-	if err != nil {
+	result := d.restClient.Get().AbsPath("/version").Do()
+	if err := result.Error(); err != nil {
 		return nil, err
 	}
+	body, _ := result.Raw()
 	var info version.Info
-	err = json.Unmarshal(body, &info)
+	err := json.Unmarshal(body, &info)
 	if err != nil {
 		return nil, fmt.Errorf("got '%s': %v", string(body), err)
 	}
@@ -333,21 +334,22 @@ func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
 
 // OpenAPISchema fetches the open api schema using a rest client and parses the proto.
 func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
-	data, err := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do().Raw()
-	if err != nil {
+	result := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do()
+	if err := result.Error(); err != nil {
 		if errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsNotAcceptable(err) {
 			// single endpoint not found/registered in old server, try to fetch old endpoint
 			// TODO(roycaihw): remove this in 1.11
-			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()
-			if err != nil {
+			result = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do()
+			if err = result.Error(); err != nil {
 				return nil, err
 			}
 		} else {
 			return nil, err
 		}
 	}
+	data, _ := result.Raw()
 	document := &openapi_v2.Document{}
-	err = proto.Unmarshal(data, document)
+	err := proto.Unmarshal(data, document)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this change:
```
$ kubectl version  --as=jane --as-group=aaaa 
Client Version: version.Info{Major:"1", Minor:"11+", GitVersion:"v1.11.0-alpha.0.1771+c8841cea3092f0", GitCommit:"c8841cea3092f0ef05d85b8686e552c93a040ec8", GitTreeState:"clean", BuildDate:"2018-03-28T12:21:30Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
Error from server (Forbidden): unknown
```

After this patch:
```
$ kubectl version  --as=jane --as-group=aaaa 
Client Version: version.Info{Major:"1", Minor:"11+", GitVersion:"v1.11.0-alpha.0.1771+c8841cea3092f0-dirty", GitCommit:"c8841cea3092f0ef05d85b8686e552c93a040ec8", GitTreeState:"dirty", BuildDate:"2018-03-28T12:19:30Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
Error from server (Forbidden): forbidden: User "jane" cannot get path "/version"
```
Related to https://github.com/kubernetes/kubernetes/issues/61805

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
