### PR TITLE
Automated cherry pick of #59019

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1219,6 +1219,7 @@ function start-kube-apiserver {
   params+=" --secure-port=443"
   params+=" --tls-cert-file=${APISERVER_SERVER_CERT_PATH}"
   params+=" --tls-private-key-file=${APISERVER_SERVER_KEY_PATH}"
+  params+=" --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
   if [[ ! -z "${REQUESTHEADER_CA_CERT:-}" ]]; then
     params+=" --requestheader-client-ca-file=${REQUESTHEADER_CA_CERT_PATH}"
     params+=" --requestheader-allowed-names=aggregator"


### PR DESCRIPTION
Cherry pick of #59019 on release-1.7.

#59019: Set --kubelet-preferred-address-types on apiserver by default

This is already cherrypicked into 1.9 and 1.8 and proved working. Cherrypicking it into 1.7 so that we can proceed with https://github.com/kubernetes/test-infra/issues/7156 (enabling zonal DNS on GCP projects).

```release-note
[GCE] Apiserver uses `InternalIP` as the most preferred kubelet address type by default.
```