### PR TITLE
svcacct: pass pod information in user.Info.Extra() when available

### DIFF
--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -131,7 +131,7 @@ type Validator interface {
 	// Validate validates a token and returns user information or an error.
 	// Validator can assume that the issuer and signature of a token are already
 	// verified when this function is called.
-	Validate(tokenData string, public *jwt.Claims, private interface{}) (namespace, name, uid string, err error)
+	Validate(tokenData string, public *jwt.Claims, private interface{}) (*ServiceAccountInfo, error)
 	// NewPrivateClaims returns a struct that the authenticator should
 	// deserialize the JWT payload into. The authenticator may then pass this
 	// struct back to the Validator as the 'private' argument to a Validate()
@@ -172,12 +172,12 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(tokenData string) (user.Info, 
 
 	// If we get here, we have a token with a recognized signature and
 	// issuer string.
-	ns, name, uid, err := j.validator.Validate(tokenData, public, private)
+	sa, err := j.validator.Validate(tokenData, public, private)
 	if err != nil {
 		return nil, false, err
 	}
 
-	return UserInfo(ns, name, uid), true, nil
+	return sa.UserInfo(), true, nil
 }
 
 // hasCorrectIssuer returns true if tokenData is a valid JWT in compact

--- a/pkg/serviceaccount/legacy.go
+++ b/pkg/serviceaccount/legacy.go
@@ -62,37 +62,37 @@ type legacyValidator struct {
 
 var _ = Validator(&legacyValidator{})
 
-func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, privateObj interface{}) (string, string, string, error) {
+func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, privateObj interface{}) (*ServiceAccountInfo, error) {
 	private, ok := privateObj.(*legacyPrivateClaims)
 	if !ok {
 		glog.Errorf("jwt validator expected private claim of type *legacyPrivateClaims but got: %T", privateObj)
-		return "", "", "", errors.New("Token could not be validated.")
+		return nil, errors.New("Token could not be validated.")
 	}
 
 	// Make sure the claims we need exist
 	if len(public.Subject) == 0 {
-		return "", "", "", errors.New("sub claim is missing")
+		return nil, errors.New("sub claim is missing")
 	}
 	namespace := private.Namespace
 	if len(namespace) == 0 {
-		return "", "", "", errors.New("namespace claim is missing")
+		return nil, errors.New("namespace claim is missing")
 	}
 	secretName := private.SecretName
 	if len(secretName) == 0 {
-		return "", "", "", errors.New("secretName claim is missing")
+		return nil, errors.New("secretName claim is missing")
 	}
 	serviceAccountName := private.ServiceAccountName
 	if len(serviceAccountName) == 0 {
-		return "", "", "", errors.New("serviceAccountName claim is missing")
+		return nil, errors.New("serviceAccountName claim is missing")
 	}
 	serviceAccountUID := private.ServiceAccountUID
 	if len(serviceAccountUID) == 0 {
-		return "", "", "", errors.New("serviceAccountUID claim is missing")
+		return nil, errors.New("serviceAccountUID claim is missing")
 	}
 
 	subjectNamespace, subjectName, err := apiserverserviceaccount.SplitUsername(public.Subject)
 	if err != nil || subjectNamespace != namespace || subjectName != serviceAccountName {
-		return "", "", "", errors.New("sub claim is invalid")
+		return nil, errors.New("sub claim is invalid")
 	}
 
 	if v.lookup {
@@ -100,34 +100,38 @@ func (v *legacyValidator) Validate(tokenData string, public *jwt.Claims, private
 		secret, err := v.getter.GetSecret(namespace, secretName)
 		if err != nil {
 			glog.V(4).Infof("Could not retrieve token %s/%s for service account %s/%s: %v", namespace, secretName, namespace, serviceAccountName, err)
-			return "", "", "", errors.New("Token has been invalidated")
+			return nil, errors.New("Token has been invalidated")
 		}
 		if secret.DeletionTimestamp != nil {
 			glog.V(4).Infof("Token is deleted and awaiting removal: %s/%s for service account %s/%s", namespace, secretName, namespace, serviceAccountName)
-			return "", "", "", errors.New("Token has been invalidated")
+			return nil, errors.New("Token has been invalidated")
 		}
 		if bytes.Compare(secret.Data[v1.ServiceAccountTokenKey], []byte(tokenData)) != 0 {
 			glog.V(4).Infof("Token contents no longer matches %s/%s for service account %s/%s", namespace, secretName, namespace, serviceAccountName)
-			return "", "", "", errors.New("Token does not match server's copy")
+			return nil, errors.New("Token does not match server's copy")
 		}
 
 		// Make sure service account still exists (name and UID)
 		serviceAccount, err := v.getter.GetServiceAccount(namespace, serviceAccountName)
 		if err != nil {
 			glog.V(4).Infof("Could not retrieve service account %s/%s: %v", namespace, serviceAccountName, err)
-			return "", "", "", err
+			return nil, err
 		}
 		if serviceAccount.DeletionTimestamp != nil {
 			glog.V(4).Infof("Service account has been deleted %s/%s", namespace, serviceAccountName)
-			return "", "", "", fmt.Errorf("ServiceAccount %s/%s has been deleted", namespace, serviceAccountName)
+			return nil, fmt.Errorf("ServiceAccount %s/%s has been deleted", namespace, serviceAccountName)
 		}
 		if string(serviceAccount.UID) != serviceAccountUID {
 			glog.V(4).Infof("Service account UID no longer matches %s/%s: %q != %q", namespace, serviceAccountName, string(serviceAccount.UID), serviceAccountUID)
-			return "", "", "", fmt.Errorf("ServiceAccount UID (%s) does not match claim (%s)", serviceAccount.UID, serviceAccountUID)
+			return nil, fmt.Errorf("ServiceAccount UID (%s) does not match claim (%s)", serviceAccount.UID, serviceAccountUID)
 		}
 	}
 
-	return private.Namespace, private.ServiceAccountName, private.ServiceAccountUID, nil
+	return &ServiceAccountInfo{
+		Namespace: private.Namespace,
+		Name:      private.ServiceAccountName,
+		UID:       private.ServiceAccountUID,
+	}, nil
 }
 
 func (v *legacyValidator) NewPrivateClaims() interface{} {

--- a/pkg/serviceaccount/util.go
+++ b/pkg/serviceaccount/util.go
@@ -22,13 +22,42 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
+const (
+	// PodNameKey is the key used in a user's "extra" to specify the pod name of
+	// the authenticating request.
+	PodNameKey = "authentication.kubernetes.io/pod-name"
+	// PodUIDKey is the key used in a user's "extra" to specify the pod UID of
+	// the authenticating request.
+	PodUIDKey = "authentication.kubernetes.io/pod-uid"
+)
+
 // UserInfo returns a user.Info interface for the given namespace, service account name and UID
 func UserInfo(namespace, name, uid string) user.Info {
-	return &user.DefaultInfo{
-		Name:   apiserverserviceaccount.MakeUsername(namespace, name),
-		UID:    uid,
-		Groups: apiserverserviceaccount.MakeGroupNames(namespace),
+	return (&ServiceAccountInfo{
+		Name:      name,
+		Namespace: namespace,
+		UID:       uid,
+	}).UserInfo()
+}
+
+type ServiceAccountInfo struct {
+	Name, Namespace, UID string
+	PodName, PodUID      string
+}
+
+func (sa *ServiceAccountInfo) UserInfo() user.Info {
+	info := &user.DefaultInfo{
+		Name:   apiserverserviceaccount.MakeUsername(sa.Namespace, sa.Name),
+		UID:    sa.UID,
+		Groups: apiserverserviceaccount.MakeGroupNames(sa.Namespace),
 	}
+	if sa.PodName != "" && sa.PodUID != "" {
+		info.Extra = map[string][]string{
+			PodNameKey: {sa.PodName},
+			PodUIDKey:  {sa.PodUID},
+		}
+	}
+	return info
 }
 
 // IsServiceAccountToken returns true if the secret is a valid api token for the service account


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/59670 but won't fix until we move to the new token volume source.

ref #58790

```release-note
UserInfo derived from service account tokens created from the TokenRequest API now include the pod name and UID in the Extra field.
```