### PR TITLE
Fixing ingress controller daemonset on k8s < 1.9

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -746,6 +746,10 @@ def launch_default_ingress_controller():
         else:
             context['ingress_image'] = \
                 "k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.15" # noqa
+    if get_version('kubelet') < (1, 9):
+        context['daemonset_api_version'] = 'extensions/v1beta1'
+    else:
+        context['daemonset_api_version'] = 'apps/v1beta2'
     context['juju_application'] = hookenv.service_name()
     manifest = addon_path.format('ingress-daemon-set.yaml')
     render('ingress-daemon-set.yaml', manifest, context)

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
@@ -127,7 +127,7 @@ kind: ConfigMap
 metadata:
   name: nginx-load-balancer-{{ juju_application }}-conf
 ---
-apiVersion: apps/v1beta2
+apiVersion: {{ daemonset_api_version }}
 kind: DaemonSet
 metadata:
   name: nginx-ingress-{{ juju_application }}-controller


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When we switched to an ingress daemonset, we didn't account for older installs. The api version changed on version 1.9, so anything pre-1.9 needs a different version. This PR makes the api version a template so we can change it depending on the version of k8s installed.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/526
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed ingress issue with CDK and pre-1.9 versions of kubernetes.
```
