### PR TITLE
certs: only append locally discovered addresses when we get none from the cloudprovider

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -737,20 +737,28 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) && kubeDeps.TLSOptions != nil {
-		var ips []net.IP
-		cfgAddress := net.ParseIP(kubeCfg.Address)
-		if cfgAddress == nil || cfgAddress.IsUnspecified() {
+		var (
+			ips   []net.IP
+			names []string
+		)
+
+		// If the address was explicitly configured, use that. Otherwise, try to
+		// discover addresses from the cloudprovider. Otherwise, make a best guess.
+		if cfgAddress := net.ParseIP(kubeCfg.Address); cfgAddress != nil && !cfgAddress.IsUnspecified() {
+			ips = []net.IP{cfgAddress}
+			names = []string{klet.GetHostname(), hostnameOverride}
+		} else if len(cloudIPs) != 0 || len(cloudNames) != 0 {
+			ips = cloudIPs
+			names = cloudNames
+		} else {
 			localIPs, err := allGlobalUnicastIPs()
 			if err != nil {
 				return nil, err
 			}
 			ips = localIPs
-		} else {
-			ips = []net.IP{cfgAddress}
+			names = []string{klet.GetHostname(), hostnameOverride}
 		}
 
-		ips = append(ips, cloudIPs...)
-		names := append([]string{klet.GetHostname(), hostnameOverride}, cloudNames...)
 		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, ips, names, certDirectory)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize certificate manager: %v", err)


### PR DESCRIPTION
The cloudprovider is right, and only cloudprovider addresses can be verified centrally, so don't add any extra when we have them.