### PR TITLE
certs: exclude more nonsensical addresses from SANs

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -782,7 +782,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		var ips []net.IP
 		cfgAddress := net.ParseIP(kubeCfg.Address)
 		if cfgAddress == nil || cfgAddress.IsUnspecified() {
-			localIPs, err := allLocalIPsWithoutLoopback()
+			localIPs, err := allGlobalUnicastIPs()
 			if err != nil {
 				return nil, err
 			}
@@ -1201,7 +1201,7 @@ type Kubelet struct {
 	keepTerminatedPodVolumes bool // DEPRECATED
 }
 
-func allLocalIPsWithoutLoopback() ([]net.IP, error) {
+func allGlobalUnicastIPs() ([]net.IP, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return nil, fmt.Errorf("could not list network interfaces: %v", err)
@@ -1215,7 +1215,7 @@ func allLocalIPsWithoutLoopback() ([]net.IP, error) {
 		for _, address := range addresses {
 			switch v := address.(type) {
 			case *net.IPNet:
-				if !v.IP.IsLoopback() {
+				if v.IP.IsGlobalUnicast() {
 					ips = append(ips, v.IP)
 				}
 			}


### PR DESCRIPTION
I noticed this when I saw 169.254.* SANs using server TLS bootstrap.
This change excludes more nonsensical addresses from being requested as
SANs in that flow.
