### PR TITLE
[e2e ingress-gce] Run preshared-cert and backend HTTPS tests with kubemci

### DIFF
--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -6,6 +6,10 @@ metadata:
   # annotations:
   #  ingress.gcp.kubernetes.io/pre-shared-cert: "test-pre-shared-cert"
 spec:
+  # kubemci requires a default backend.
+  backend:
+    serviceName: echoheaders-https
+    servicePort: 80
   rules:
   - host: test.ingress.com
     http:


### PR DESCRIPTION
**What this PR does / why we need it**:

Make preshared-cert and backside-reencryption tests compatible with kubemci.

Test is currently failing with the symptom described on https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/131#issuecomment-377098544.

@nikhiljindal @g-harmon 
/hold

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
