### PR TITLE
Add note on upgrading cluster by kubeadm.

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -230,6 +230,39 @@ kind: KubeProxyConfiguration
 **  SupportIPVSProxyMode: true**
 ```
 
+If your cluster was installed by kubeadm, you should edit the `featureGates` field in the `kubeadm-config` ConfigMap. You can do this using `kubectl -n kube-system edit cm kubeadm-config` before upgrading. For example:
+
+kubeadm-config Before:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+data:
+  MasterConfiguration: |
+    kubeProxy:
+      config:
+        featureGates: "SupportIPVSProxyMode=true"
+```
+
+kubeadm-config After:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeadm-config
+data:
+  MasterConfiguration: |
+    kubeProxy:
+      config:
+        featureGates:
+          SupportIPVSProxyMode: true
+```
+
+If no featureGates was specified in `kubeadm-config`, just change `featureGates: ""` to `featureGates: {}`.
+
 ([#57962](https://github.com/kubernetes/kubernetes/pull/57962), [@xiangpengzhao](https://github.com/xiangpengzhao))
 
 * The `kubeletconfig` API group has graduated from alpha to beta, and the name has changed to `kubelet.config.k8s.io`. Please use `kubelet.config.k8s.io/v1beta1`, as `kubeletconfig/v1alpha1` is no longer available.  ([#53833](https://github.com/kubernetes/kubernetes/pull/53833), [@mtaufen](https://github.com/mtaufen))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Upgrading cluster from 1.9.x to 1.10.0 by kubeadm fails due to type change of `featureGates` in `KubeProxyConfiguration` done in #57962. This PR add a note on what should be done before upgrading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref #61764

**Special notes for your reviewer**:
cc @kubernetes/sig-cluster-lifecycle-bugs @liggitt @fgbreel
Thanks @berlinsaint for the workaround!

We may need a patch (if possible) for kubeadm to do this automatically as suggested by @danderson .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
