### PR TITLE
Revert "Enable partial success in fluentd-gcp"

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -402,8 +402,6 @@ data:
         # the necessary resource types when this label is set.
         "logging.googleapis.com/k8s_compatibility": "true"
       }
-      # Only drop failed entries partially, instead of dropping the whole request.
-      partial_success true
     </match>
 
     # Keep a smaller buffer here since these logs are less important than the user's
@@ -432,10 +430,9 @@ data:
         # the necessary resource types when this label is set.
         "logging.googleapis.com/k8s_compatibility": "true"
       }
-      partial_success true
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.2.5
+  name: fluentd-gcp-config-v1.2.4
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -108,4 +108,4 @@ spec:
           path: /var/lib/docker/containers
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.2.5
+          name: fluentd-gcp-config-v1.2.4


### PR DESCRIPTION
Reverts kubernetes/kubernetes#61773

As @Random-Liu noticed in https://github.com/kubernetes/kubernetes/pull/61773#issuecomment-377140834, it broke tests, possibly because of higher memory utilization

/assign @x13n 

```release-note
NONE
```