### PR TITLE
Specify DHCP domain for hostname

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -121,6 +121,7 @@ type RouterOpts struct {
 type MetadataOpts struct {
 	SearchOrder    string     `gcfg:"search-order"`
 	RequestTimeout MyDuration `gcfg:"request-timeout"`
+	DHCPDomain     string     `gcfg:"dhcp-domain"`
 }
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
@@ -233,6 +234,7 @@ func configFromEnv() (cfg Config, ok bool) {
 			cfg.Global.TrustID != "")
 
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
+	cfg.Metadata.DHCPDomain = "novalocal"
 	cfg.BlockStorage.BSVersion = "auto"
 
 	return
@@ -250,6 +252,7 @@ func readConfig(config io.Reader) (Config, error) {
 	cfg.BlockStorage.TrustDevicePath = false
 	cfg.BlockStorage.IgnoreVolumeAZ = false
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
+	cfg.Metadata.DHCPDomain = "novalocal"
 
 	err := gcfg.ReadInto(&cfg, config)
 	return cfg, err

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -61,6 +61,10 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
+	domain := "." + i.opts.DHCPDomain
+	if i.opts.DHCPDomain != "" && strings.HasSuffix(md.Hostname, domain) {
+		return types.NodeName(strings.TrimSuffix(md.Hostname, domain)), nil
+	}
 	return types.NodeName(strings.Split(md.Hostname, ".")[0]), nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In 9a8c6db448f200ddd9a06813affab804b183de20, we looked at the hostname
in the metadata service and used '.' as the delimiter to chop off the
dhcp_domain (specified in nova.conf). However administrators need to
better control the dhcp domain better as there may be a '.' in the host
name itself. So let's introduce a config option that we can use and
default it to what nova uses when dhcp_domain is not specified which is
"novalocal"


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
new dhcp-domain parameter to be used for figuring out the hostname of a node
```
