### PR TITLE
add a func to merge multiple Strategic Merge Patches into one patch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -880,6 +880,29 @@ func StrategicMergeMapPatchUsingLookupPatchMeta(original, patch JSONMap, schema 
 	return mergeMap(original, patch, schema, mergeOptions)
 }
 
+// MergeStrategicMergeMapPatchUsingLookupPatchMeta merges strategic merge
+// patches retaining `null` fields and parallel lists. If 2 patches change the
+// same fields and the latter one will override the former one. If you don't
+// want that happen, you need to run func MergingMapsHaveConflicts before
+// merging these patches. Applying the resulting merged merge patch to a JSONMap
+// yields the same as merging each strategic merge patch to the JSONMap in
+// succession.
+func MergeStrategicMergeMapPatchUsingLookupPatchMeta(schema LookupPatchMeta, patches ...JSONMap) (JSONMap, error) {
+	mergeOptions := MergeOptions{
+		MergeParallelList:    false,
+		IgnoreUnmatchedNulls: false,
+	}
+	merged := JSONMap{}
+	var err error
+	for _, patch := range patches {
+		merged, err = mergeMap(merged, patch, schema, mergeOptions)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}
+
 // handleDirectiveInMergeMap handles the patch directive when merging 2 maps.
 func handleDirectiveInMergeMap(directive interface{}, patch map[string]interface{}) (map[string]interface{}, error) {
 	if directive == replaceDirective {


### PR DESCRIPTION
This PR is adding a function similar to https://github.com/evanphx/json-patch/blob/9fa11df836c7537e8ad3d1639fa0d396559a7bab/merge.go#L95-L100
It merges multiple SMPs and yield another SMP.

This PR has no risk to existing SMP code.

```release-note
NONE
```
/cc @apelisse
/assign @pwittrock 
