### PR TITLE
Remove ActiveDeadlineSeconds from Watch e2e Test

### DIFF
--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -64,7 +64,6 @@ var _ = SIGDescribe("Watchers", func() {
 				},
 			},
 			Spec: v1.PodSpec{
-				ActiveDeadlineSeconds: int64ptr(20),
 				Containers: []v1.Container{
 					{
 						Name:  "example",
@@ -81,7 +80,6 @@ var _ = SIGDescribe("Watchers", func() {
 				},
 			},
 			Spec: v1.PodSpec{
-				ActiveDeadlineSeconds: int64ptr(20),
 				Containers: []v1.Container{
 					{
 						Name:  "example",
@@ -97,7 +95,7 @@ var _ = SIGDescribe("Watchers", func() {
 		expectNoEvent(watchB, watch.Added, testPodA)
 
 		testPodA, err = updatePod(f, testPodA.GetName(), func(p *v1.Pod) {
-			p.Spec.ActiveDeadlineSeconds = int64ptr(10)
+			p.ObjectMeta.Labels["mutation"] = "1"
 		})
 		Expect(err).NotTo(HaveOccurred())
 		expectEvent(watchA, watch.Modified, testPodA)
@@ -105,7 +103,7 @@ var _ = SIGDescribe("Watchers", func() {
 		expectNoEvent(watchB, watch.Modified, testPodA)
 
 		testPodA, err = updatePod(f, testPodA.GetName(), func(p *v1.Pod) {
-			p.Spec.ActiveDeadlineSeconds = int64ptr(5)
+			p.ObjectMeta.Labels["mutation"] = "2"
 		})
 		Expect(err).NotTo(HaveOccurred())
 		expectEvent(watchA, watch.Modified, testPodA)


### PR DESCRIPTION
**What this PR does / why we need it**:
I originally updated ActiveDeadlineSeconds because it is one of the few fields on Pods which can change, but I didn't consider how it might affect the reliability of the test. This PR replaces the update done to ActiveDeadlineSeconds with a more predictable update to a label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Might fix #61846

**Release note**:
```release-note
NONE
```