### PR TITLE
fixtodo:Move ServeHostnameService constants and default settings to service_util.go

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -43,7 +43,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// TODO(yankaiz): Move constants and default settings to service_util.go.
 const (
 	defaultServeHostnameServicePort = 80
 	defaultServeHostnameServiceName = "svc-hostname"


### PR DESCRIPTION
**What this PR does / why we need it**:
fixtodo:Move ServeHostnameService constants and default settings to service_util.go
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
