### PR TITLE
Add support for CNI on Windows Server 2016 RTM

### DIFF
--- a/pkg/kubelet/dockershim/helpers_windows.go
+++ b/pkg/kubelet/dockershim/helpers_windows.go
@@ -115,6 +115,17 @@ func (ds *dockerService) determinePodIPBySandboxID(sandboxID string) string {
 		// Todo: Add a kernel version check for more validation
 
 		if networkMode := os.Getenv("CONTAINER_NETWORK"); networkMode == "" {
+			// On Windows, every container that is created in a Sandbox, needs to invoke CNI plugin again for adding the Network,
+			// with the shared container name as NetNS info,
+			// This is passed down to the platform to replicate some necessary information to the new container
+
+			//
+			// This place is chosen as a hack for now, since ds.getIP would end up calling CNI's addToNetwork
+			// That is why addToNetwork is required to be idempotent
+
+			// Instead of relying on this call, an explicit call to addToNetwork should be
+			// done immediately after ContainerCreation, in case of Windows only. TBD Issue # to handle this
+
 			if r.HostConfig.Isolation == kubeletapis.HypervIsolationValue {
 				// Hyper-V only supports one container per Pod yet and the container will have a different
 				// IP address from sandbox. Return the first non-sandbox container IP as POD IP.
@@ -127,18 +138,8 @@ func (ds *dockerService) determinePodIPBySandboxID(sandboxID string) string {
 				ds.getIP(sandboxID, r)
 			}
 		} else {
-			// On Windows, every container that is created in a Sandbox, needs to invoke CNI plugin again for adding the Network,
-			// with the shared container name as NetNS info,
-			// This is passed down to the platform to replicate some necessary information to the new container
-
-			//
-			// This place is chosen as a hack for now, since getContainerIP would end up calling CNI's addToNetwork
-			// That is why addToNetwork is required to be idempotent
-
-			// Instead of relying on this call, an explicit call to addToNetwork should be
-			// done immediately after ContainerCreation, in case of Windows only. TBD Issue # to handle this
-
-			if containerIP := getContainerIP(r); containerIP != "" {
+			// ds.getIP will call the CNI plugin to fetch the IP
+			if containerIP := ds.getIP(c.ID, r); containerIP != "" {
 				return containerIP
 			}
 		}
@@ -152,15 +153,4 @@ func getNetworkNamespace(c *dockertypes.ContainerJSON) (string, error) {
 	// Like docker, the referenced container id is used to figure out the network namespace id internally by the platform
 	// so returning the docker networkMode (which holds container:<ref containerid> for network namespace here
 	return string(c.HostConfig.NetworkMode), nil
-}
-
-func getContainerIP(container *dockertypes.ContainerJSON) string {
-	if container.NetworkSettings != nil {
-		for _, network := range container.NetworkSettings.Networks {
-			if network.IPAddress != "" {
-				return network.IPAddress
-			}
-		}
-	}
-	return ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Windows Server 2016 RTM has limited CNI support. This PR makes it possible for the CNI plugin to be used to setup POD networking on Windows Server 2016 RTM (build number 14393).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61939

**Special notes for your reviewer**:
The old mode is not supported and tested on Windows Server 2016 RTM. This change allows the CNI plugin to be used on Windows Server 2016 RTM to retrieve the container IP instead of using workarounds (docker inspect).

CNI support has been added for Windows Server 2016 version 1709 (build number 16299), this patch will just allow the same support for older build numbers.

Windows Server 2016 RTM has a longer lifecycle (LTS) than Windows Server 2016 version 1709.
https://support.microsoft.com/en-us/lifecycle/search/19761 vs https://support.microsoft.com/en-us/lifecycle/search/20311


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
