### PR TITLE
[kubeadm] fix mirror-pod hash race condition

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -186,7 +186,7 @@ func upgradeComponent(component string, waiter apiclient.Waiter, pathMgr StaticP
 	// notice the removal of the Static Pod, leading to a false positive below where we check that the API endpoint is healthy
 	// If we don't do this, there is a case where we remove the Static Pod manifest, kubelet is slow to react, kubeadm checks the
 	// API endpoint below of the OLD Static Pod component and proceeds quickly enough, which might lead to unexpected results.
-	if err := waiter.WaitForStaticPodControlPlaneHashChange(cfg.NodeName, component, beforePodHash); err != nil {
+	if err := waiter.WaitForStaticPodHashChange(cfg.NodeName, component, beforePodHash); err != nil {
 		return rollbackOldManifests(recoverManifests, err, pathMgr, recoverEtcd)
 	}
 

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -117,8 +117,8 @@ func (w *fakeWaiter) WaitForStaticPodSingleHash(_ string, _ string) (string, err
 	return "", w.errsToReturn[waitForHashes]
 }
 
-// WaitForStaticPodControlPlaneHashChange returns an error if set from errsToReturn
-func (w *fakeWaiter) WaitForStaticPodControlPlaneHashChange(_, _, _ string) error {
+// WaitForStaticPodHashChange returns an error if set from errsToReturn
+func (w *fakeWaiter) WaitForStaticPodHashChange(_, _, _ string) error {
 	return w.errsToReturn[waitForHashChange]
 }
 

--- a/cmd/kubeadm/app/util/apiclient/BUILD
+++ b/cmd/kubeadm/app/util/apiclient/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -106,8 +106,7 @@ func (w *Waiter) WaitForHealthyKubelet(_ time.Duration, healthzEndpoint string) 
 // SetTimeout is a no-op; we don't wait in this implementation
 func (w *Waiter) SetTimeout(_ time.Duration) {}
 
-// WaitForStaticPodControlPlaneHashes returns an empty hash for all control plane images; WaitForStaticPodControlPlaneHashChange won't block in any case
-// but the empty strings there are needed
+// WaitForStaticPodControlPlaneHashes returns an empty hash for all control plane images;
 func (w *Waiter) WaitForStaticPodControlPlaneHashes(_ string) (map[string]string, error) {
 	return map[string]string{
 		constants.KubeAPIServer:         "",
@@ -122,7 +121,7 @@ func (w *Waiter) WaitForStaticPodSingleHash(_ string, _ string) (string, error) 
 	return "", nil
 }
 
-// WaitForStaticPodControlPlaneHashChange returns a dummy nil error in order for the flow to just continue as we're dryrunning
-func (w *Waiter) WaitForStaticPodControlPlaneHashChange(_, _, _ string) error {
+// WaitForStaticPodHashChange returns a dummy nil error in order for the flow to just continue as we're dryrunning
+func (w *Waiter) WaitForStaticPodHashChange(_, _, _ string) error {
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Update kubeadm static pod upgrades to use the 'kubernetes.io/config.hash' annotation on the mirror pod rather than generating a hash from the full object info. Previously, a status update for the pod would allow the upgrade to proceed before the new static pod manifest was actually deployed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue with kubeadm upgrade apply where updates to the static pod manifests were not properly being validated prior to proceeding to the next upgrade step.
```
