### PR TITLE
Tolerate 406 mime-type errors attempting to load new openapi schema

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -335,7 +335,7 @@ func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
 func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	data, err := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do().Raw()
 	if err != nil {
-		if errors.IsForbidden(err) || errors.IsNotFound(err) {
+		if errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsNotAcceptable(err) {
 			// single endpoint not found/registered in old server, try to fetch old endpoint
 			// TODO(roycaihw): remove this in 1.11
 			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -326,12 +326,12 @@ var returnedOpenAPI = openapi_v2.Document{
 	},
 }
 
-func openapiSchemaDeprecatedFakeServer() (*httptest.Server, error) {
+func openapiSchemaDeprecatedFakeServer(status int) (*httptest.Server, error) {
 	var sErr error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// old server returns 403 on new endpoint request
 		if req.URL.Path == "/openapi/v2" {
-			w.WriteHeader(http.StatusForbidden)
+			// write the error status for the new endpoint request
+			w.WriteHeader(status)
 			return
 		}
 		if req.URL.Path != "/swagger-2.0.0.pb-v1" {
@@ -398,8 +398,42 @@ func TestGetOpenAPISchema(t *testing.T) {
 	}
 }
 
-func TestGetOpenAPISchemaFallback(t *testing.T) {
-	server, err := openapiSchemaDeprecatedFakeServer()
+func TestGetOpenAPISchemaForbiddenFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusForbidden)
+	if err != nil {
+		t.Errorf("unexpected error starting fake server: %v", err)
+	}
+	defer server.Close()
+
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.OpenAPISchema()
+	if err != nil {
+		t.Fatalf("unexpected error getting openapi: %v", err)
+	}
+	if e, a := returnedOpenAPI, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetOpenAPISchemaNotFoundFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusNotFound)
+	if err != nil {
+		t.Errorf("unexpected error starting fake server: %v", err)
+	}
+	defer server.Close()
+
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+	got, err := client.OpenAPISchema()
+	if err != nil {
+		t.Fatalf("unexpected error getting openapi: %v", err)
+	}
+	if e, a := returnedOpenAPI, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetOpenAPISchemaNotAcceptableFallback(t *testing.T) {
+	server, err := openapiSchemaDeprecatedFakeServer(http.StatusNotAcceptable)
 	if err != nil {
 		t.Errorf("unexpected error starting fake server: %v", err)
 	}


### PR DESCRIPTION
Fixes #61805
Fixes #61943 

```release-note
kubectl: improves compatibility with older servers when creating/updating API objects
```