### PR TITLE
Backport etcd.manifest fixes for HA clusters from #61241 to 1.8

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -61,6 +61,15 @@
       { "name": "DATA_DIRECTORY",
         "value": "/var/etcd/data{{ suffix }}"
       },
+      { "name": "INITIAL_CLUSTER",
+        "value": "{{ etcd_cluster }}"
+      },
+      { "name": "LISTEN_PEER_URLS",
+        "value": "{{ etcd_protocol }}://{{ hostname }}:{{ server_port }}"
+      },
+      { "name": "INITIAL_ADVERTISE_PEER_URLS",
+        "value": "{{ etcd_protocol }}://{{ hostname }}:{{ server_port }}"
+      },
       { "name": "ETCD_CREDS",
         "value": "{{ etcd_creds }}"
       }


### PR DESCRIPTION
Backport the `etcd.manifest` changes from #61241 to kubernetes 1.8. This fixes GCE configurations using HA etcd with k8s.gcr.io/etcd images built from #61241 (k8s.gcr.io/etcd:e.g. 3.1.13-0).

Note: I am not including the #60422 fix to use `host_ip` instead of `hostname` in this backport, which is required for running etcd 3.2+.  We might need that, but I'd like backport it in a separate PR if we do.

```release-note
Fix GCE etcd scripts to pass in all required parameters for the etcd migration utility to correctly perform HA upgrades and downgrades
```
