### PR TITLE
Backport etcd.manifest fixes for HA clusters from #61241 to 1.10

### DIFF
--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -37,6 +37,12 @@
       { "name": "INITIAL_CLUSTER",
         "value": "{{ etcd_cluster }}"
       },
+      { "name": "LISTEN_PEER_URLS",
+        "value": "{{ etcd_protocol }}://{{ host_ip }}:{{ server_port }}"
+      },
+      { "name": "INITIAL_ADVERTISE_PEER_URLS",
+        "value": "{{ etcd_protocol }}://{{ hostname }}:{{ server_port }}"
+      },
       { "name": "ETCD_CREDS",
         "value": "{{ etcd_creds }}"
       }


### PR DESCRIPTION
Backport the `etcd.manifest` changes from #61241 to kubernetes 1.8. This fixes GCE configurations using HA etcd with k8s.gcr.io/etcd images built from #61241 (k8s.gcr.io/etcd:e.g. 3.1.13-0).

```release-note
Fix GCE etcd scripts to pass in all required parameters for the etcd migration utility to correctly perform HA upgrades and downgrades
```
