### PR TITLE
Avoid data races in unit tests

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_file_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_file_test.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -69,9 +68,6 @@ func stderrCapture(t *testing.T, f func() State) (bytes.Buffer, State) {
 }
 
 func TestFileStateTryRestore(t *testing.T) {
-	flag.Set("alsologtostderr", "true")
-	flag.Parse()
-
 	testCases := []struct {
 		description      string
 		stateFileContent string
@@ -292,9 +288,6 @@ func TestFileStateTryRestorePanic(t *testing.T) {
 }
 
 func TestUpdateStateFile(t *testing.T) {
-	flag.Set("alsologtostderr", "true")
-	flag.Parse()
-
 	testCases := []struct {
 		description   string
 		expErr        string

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package devicemanager
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -546,7 +545,6 @@ type TestResource struct {
 }
 
 func TestPodContainerDeviceAllocation(t *testing.T) {
-	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
 	res1 := TestResource{
 		resourceName:     "domain1.com/resource1",
 		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),


### PR DESCRIPTION
Setting global flags in unit tests leads to data races like this:

```
==================
WARNING: DATA RACE
Write at 0x0000028f5241 by goroutine 47:
  flag.(*boolValue).Set()
      /home/jliggitt/.gvm/gos/go1.9.5/src/flag/flag.go:91 +0x7b
  flag.(*FlagSet).Set()
      /home/jliggitt/.gvm/gos/go1.9.5/src/flag/flag.go:366 +0x10c
  flag.Set()
      /home/jliggitt/.gvm/gos/go1.9.5/src/flag/flag.go:379 +0x76
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.TestPodContainerDeviceAllocation()
      /home/jliggitt/go/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go:549 +0x126
  testing.tRunner()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:746 +0x16c

Previous read at 0x0000028f5241 by goroutine 34:
  k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).output()
      /home/jliggitt/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:682 +0x730
  k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).printf()
      /home/jliggitt/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:655 +0x259
  k8s.io/kubernetes/vendor/github.com/golang/glog.Errorf()
      /home/jliggitt/go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:1118 +0x74
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*endpointImpl).run()
      /home/jliggitt/go/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/endpoint.go:132 +0x1c7e
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).addEndpoint.func1()
      /home/jliggitt/go/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager.go:378 +0x3f

Goroutine 47 (running) created at:
  testing.(*T).Run()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:789 +0x568
  testing.runTests.func1()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:1004 +0xa7
  testing.tRunner()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:746 +0x16c
  testing.runTests()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:1002 +0x521
  testing.(*M).Run()
      /home/jliggitt/.gvm/gos/go1.9.5/src/testing/testing.go:921 +0x206
  main.main()
      k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/_test/_testmain.go:68 +0x1d3

Goroutine 34 (finished) created at:
  k8s.io/kubernetes/pkg/kubelet/cm/devicemanager.(*ManagerImpl).addEndpoint()
      /home/jliggitt/go/src/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager.go:377 +0x9d6
==================
--- FAIL: TestPodContainerDeviceAllocation (0.00s)
	testing.go:699: race detected during execution of test
FAIL
FAIL	k8s.io/kubernetes/pkg/kubelet/cm/devicemanager	0.124s

```