### PR TITLE
Make serverAddressByClientCIDRs in discovery API optional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -84336,8 +84336,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "apiVersion": {

--- a/api/swagger-spec/admissionregistration.k8s.io.json
+++ b/api/swagger-spec/admissionregistration.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -62,8 +62,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/apps.json
+++ b/api/swagger-spec/apps.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/authentication.k8s.io.json
+++ b/api/swagger-spec/authentication.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/authorization.k8s.io.json
+++ b/api/swagger-spec/authorization.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/autoscaling.json
+++ b/api/swagger-spec/autoscaling.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/batch.json
+++ b/api/swagger-spec/batch.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/certificates.k8s.io.json
+++ b/api/swagger-spec/certificates.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/events.k8s.io.json
+++ b/api/swagger-spec/events.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/extensions.json
+++ b/api/swagger-spec/extensions.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/networking.k8s.io.json
+++ b/api/swagger-spec/networking.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/policy.json
+++ b/api/swagger-spec/policy.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/rbac.authorization.k8s.io.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/scheduling.k8s.io.json
+++ b/api/swagger-spec/scheduling.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/settings.k8s.io.json
+++ b/api/swagger-spec/settings.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/storage.k8s.io.json
+++ b/api/swagger-spec/storage.k8s.io.json
@@ -38,8 +38,7 @@
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
-     "versions",
-     "serverAddressByClientCIDRs"
+     "versions"
     ],
     "properties": {
      "kind": {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -49,6 +49,7 @@ message APIGroup {
   // The server returns only those CIDRs that it thinks that the client can match.
   // For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP.
   // Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
+  // +optional
   repeated ServerAddressByClientCIDR serverAddressByClientCIDRs = 4;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -799,7 +799,8 @@ type APIGroup struct {
 	// The server returns only those CIDRs that it thinks that the client can match.
 	// For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP.
 	// Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.
-	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs" protobuf:"bytes,4,rep,name=serverAddressByClientCIDRs"`
+	// +optional
+	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs,omitempty" protobuf:"bytes,4,rep,name=serverAddressByClientCIDRs"`
 }
 
 // ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
See https://github.com/kubernetes/kubernetes/issues/61868

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61868

**Special notes for your reviewer**:
WIP: I'm having trouble updating swagger-spec using our update scripts. Thinking about removing swagger-spec from our code base as it has long passed deprecation. Sending this PR now to see the test results. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Property `serverAddressByClientCIDRs` in `metav1.APIGroup` (discovery API) now become optional instead of required
```

/sig api-machinery