### PR TITLE
Change DeepEqual to use Equal in time_test.go

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -166,7 +166,7 @@ func TestTimeProto(t *testing.T) {
 		if err := time.Unmarshal(data); err != nil {
 			t.Fatalf("Failed to unmarshal output: '%v': %v", input, err)
 		}
-		if !reflect.DeepEqual(input, time) {
+		if input.Equal(&time) {
 			t.Errorf("Marshal->Unmarshal is not idempotent: '%v' vs '%v'", input, time)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR changes reflect.DeepEqual to use Equal because reflection is not required in this case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
