### PR TITLE
Fix dockershim CreateContainer error handling.

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -140,7 +140,10 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 	}
 
 	hc := createConfig.HostConfig
-	ds.updateCreateConfig(&createConfig, config, sandboxConfig, podSandboxID, securityOptSeparator, apiVersion)
+	err = ds.updateCreateConfig(&createConfig, config, sandboxConfig, podSandboxID, securityOptSeparator, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update container create config: %v", err)
+	}
 	// Set devices for container.
 	devices := make([]dockercontainer.DeviceMapping, len(config.Devices))
 	for i, device := range config.Devices {


### PR DESCRIPTION
Found this bug in CRI validation test https://github.com/kubernetes-incubator/cri-tools/pull/282.

In https://github.com/kubernetes/kubernetes/pull/52077, we expect container creation to return error if `RunAsGroup` is specified without `RunAsUser` or `RunAsUsername`. However, the error returned is not handled.

@krmayankk This is only a corner case. Does this worth cherry-pick into 1.10?
@kubernetes/sig-node-bugs 

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix dockershim CreateContainer error handling
```
