### PR TITLE
Stop() for Ticker to enable leak-free code

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -419,13 +419,15 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 
 func (m *managerImpl) waitForPodsCleanup(podCleanedUpFunc PodCleanedUpFunc, pods []*v1.Pod) {
 	timeout := m.clock.NewTimer(podCleanupTimeout)
-	tick := m.clock.Tick(podCleanupPollFreq)
+	defer timeout.Stop()
+	ticker := m.clock.NewTicker(podCleanupPollFreq)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-timeout.C():
 			glog.Warningf("eviction manager: timed out waiting for pods %s to be cleaned up", format.Pods(pods))
 			return
-		case <-tick:
+		case <-ticker.C():
 			for i, pod := range pods {
 				if !podCleanedUpFunc(pod) {
 					break

--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
@@ -21,6 +21,18 @@ import (
 	"time"
 )
 
+var (
+	_ = Clock(RealClock{})
+	_ = Clock(&FakeClock{})
+	_ = Clock(&IntervalClock{})
+
+	_ = Timer(&realTimer{})
+	_ = Timer(&fakeTimer{})
+
+	_ = Ticker(&realTicker{})
+	_ = Ticker(&fakeTicker{})
+)
+
 func TestFakeClock(t *testing.T) {
 	startTime := time.Now()
 	tc := NewFakeClock(startTime)
@@ -110,13 +122,13 @@ func TestFakeTick(t *testing.T) {
 	if tc.HasWaiters() {
 		t.Errorf("unexpected waiter?")
 	}
-	oneSec := tc.Tick(time.Second)
+	oneSec := tc.NewTicker(time.Second).C()
 	if !tc.HasWaiters() {
 		t.Errorf("unexpected lack of waiter?")
 	}
 
-	oneOhOneSec := tc.Tick(time.Second + time.Millisecond)
-	twoSec := tc.Tick(2 * time.Second)
+	oneOhOneSec := tc.NewTicker(time.Second + time.Millisecond).C()
+	twoSec := tc.NewTicker(2 * time.Second).C()
 	select {
 	case <-oneSec:
 		t.Errorf("unexpected channel read")

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limitting_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limitting_queue_test.go
@@ -30,7 +30,7 @@ func TestRateLimitingQueue(t *testing.T) {
 	delayingQueue := &delayingType{
 		Interface:       New(),
 		clock:           fakeClock,
-		heartbeat:       fakeClock.Tick(maxWait),
+		heartbeat:       fakeClock.NewTicker(maxWait),
 		stopCh:          make(chan struct{}),
 		waitingForAddCh: make(chan *waitFor, 1000),
 		metrics:         newRetryMetrics(""),

--- a/test/images/logs-generator/logs_generator.go
+++ b/test/images/logs-generator/logs_generator.go
@@ -62,10 +62,11 @@ func generateLogs(linesTotal int, duration time.Duration) {
 	delay := duration / time.Duration(linesTotal)
 	rand.Seed(time.Now().UnixNano())
 
-	tick := time.Tick(delay)
+	ticker := time.NewTicker(delay)
+	defer ticker.Stop()
 	for id := 0; id < linesTotal; id++ {
 		glog.Info(generateLogLine(id))
-		<-tick
+		<-ticker.C
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I wanted to use the clock package but the `Ticker` without a `Stop()` method is a deal breaker for me.

**Release note**:
```release-note
NONE
```
/kind enhancement
/sig api-machinery