### PR TITLE
Add back support for the --show-kind flag to the kubectl get command

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -154,9 +154,10 @@ func PrinterForOptions(options *printers.PrintOptions) (printers.ResourcePrinter
 
 	printer = maybeWrapSortingPrinter(printer, *options)
 
-	// wrap the printer in a versioning printer that understands when to convert and when not to convert
-	printer = printers.NewVersionedPrinter(printer, legacyscheme.Scheme, legacyscheme.Scheme, kubectlscheme.Versions...)
-
+	// wrap the printer in a versioning printer that understands when to convert and when not to convert, if it is generic
+	if printer.IsGeneric() {
+		printer = printers.NewVersionedPrinter(printer, legacyscheme.Scheme, legacyscheme.Scheme, kubectlscheme.Versions...)
+	}
 	return printer, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a regression to the `--show-kind` flag in kubectl v.1.10.0. This is a fix for that regression.

**Which issue(s) this PR fixes**:
Fixes  #61979

**Special notes for your reviewer**:
The problem was that all printers were wrapped in a VersionedPrinter. This made this check in get.go no longer work as expected:
```
if resourcePrinter, found := printer.(*printers.HumanReadablePrinter); found {
```
In my fix, only generic printers are wrapped in VersionedPrinter. (The VersionedPrinter does nothing if the printer is not generic, so I think this should be safe.) A HumanReadablePrinter is not generic, and won't be wrapped in a VersionedPrinter, and the check above will again work as expected.

**Release note**:
```release-note
Fixed regresion where `kubectl get all` and `kubectl get x --show-type` did not show the resource types
```
