### PR TITLE
Getting error from GetFirewallRule and checking it to fix multicluster ingress test

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -864,12 +864,22 @@ func (cont *GCEIngressController) GetFirewallRuleName() string {
 }
 
 // GetFirewallRule returns the firewall used by the GCEIngressController.
+// Causes a fatal error incase of an error.
+// TODO: Rename this to GetFirewallRuleOrDie and similarly rename all other
+// methods here to be consistent with rest of the code in this repo.
 func (cont *GCEIngressController) GetFirewallRule() *compute.Firewall {
-	gceCloud := cont.Cloud.Provider.(*gcecloud.GCECloud)
-	fwName := cont.GetFirewallRuleName()
-	fw, err := gceCloud.GetFirewall(fwName)
+	fw, err := cont.GetFirewallRuleOrError()
 	Expect(err).NotTo(HaveOccurred())
 	return fw
+}
+
+// GetFirewallRule returns the firewall used by the GCEIngressController.
+// Returns an error if that fails.
+// TODO: Rename this to GetFirewallRule when the above method with that name is renamed.
+func (cont *GCEIngressController) GetFirewallRuleOrError() (*compute.Firewall, error) {
+	gceCloud := cont.Cloud.Provider.(*gcecloud.GCECloud)
+	fwName := cont.GetFirewallRuleName()
+	return gceCloud.GetFirewall(fwName)
 }
 
 func (cont *GCEIngressController) deleteFirewallRule(del bool) (msg string) {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -386,8 +386,8 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				framework.Failf("unexpected backend service, expected none, got: %v", gceController.ListGlobalBackendServices())
 			}
 			// Controller does not have a list command for firewall rule. We use get instead.
-			if gceController.GetFirewallRule() != nil {
-				framework.Failf("unexpected firewall rule, expected none got: %v", gceController.GetFirewallRule())
+			if fw, err := gceController.GetFirewallRuleOrError(); err == nil {
+				framework.Failf("unexpected nil error in getting firewall rule, expected firewall NotFound, got firewall: %v", fw)
 			}
 
 			// TODO(nikhiljindal): Check the instance group annotation value and verify with a multizone cluster.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/pull/61909#issuecomment-377704479

Adding a GetFirewallRuleOrError method that returns the error rather than failing and using that in our multicluster ingress test.

cc @nicksardo @MrHohn @G-Harmon @csbell 

```release-note
NONE
```
