### PR TITLE
init annotations if it is nil to fix kubemci e2e test failures

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -1627,6 +1627,9 @@ func (j *IngressTestJig) SetUpBacksideHTTPSIngress(cs clientset.Interface, names
 	}
 	ingToCreate := generateBacksideHTTPSIngressSpec(namespace)
 	if staticIPName != "" {
+		if ingToCreate.Annotations == nil {
+			ingToCreate.Annotations = map[string]string{}
+		}
 		ingToCreate.Annotations[IngressStaticIPKey] = staticIPName
 	}
 	ingCreated, err := j.runCreate(ingToCreate)


### PR DESCRIPTION
Initializing ingress.annotations before setting an annotation to fix `assignment to entry in nil map` error.

Relevant Logs: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubemci-ingress-conformance/1035/build-log.txt
```
I0331 21:01:42.915] [91m[1mâ€¢! Panic [43.203 seconds][0m
I0331 21:01:42.915] [sig-network] Loadbalancing: L7
I0331 21:01:42.916] [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:22[0m
I0331 21:01:42.916]   GCE [Slow] [Feature:kubemci]
I0331 21:01:42.916]   [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:578[0m
I0331 21:01:42.917]     [91m[1mshould create ingress with backend HTTPS [It][0m
I0331 21:01:42.917]     [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:636[0m
I0331 21:01:42.917] 
I0331 21:01:42.918]     [91m[1mTest Panicked[0m
I0331 21:01:42.918]     [91massignment to entry in nil map[0m
I0331 21:01:42.918]     /usr/local/go/src/runtime/panic.go:491
I0331 21:01:42.919] 
I0331 21:01:42.919]     [91mFull Stack Trace[0m
I0331 21:01:42.919]     	/usr/local/go/src/runtime/panic.go:491 +0x283
I0331 21:01:42.920]     k8s.io/kubernetes/test/e2e/framework.(*IngressTestJig).SetUpBacksideHTTPSIngress(0xc420fe6840, 0x63514e0, 0xc42092ec30, 0xc420374da0, 0x17, 0xc4217a7650, 0x2c, 0x0, 0x0, 0x0, ...)
I0331 21:01:42.920]     	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/ingress_utils.go:1630 +0x86b
I0331 21:01:42.920]     k8s.io/kubernetes/test/e2e/network.executeBacksideBacksideHTTPSTest(0xc4211d1040, 0xc420fe6840, 0xc4217a7650, 0x2c)
I0331 21:01:42.921]     	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:746 +0xbe
I0331 21:01:42.921]     k8s.io/kubernetes/test/e2e/network.glob..func6.4.5()
I0331 21:01:42.921]     	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/ingress.go:637 +0x4b
I0331 21:01:42.922]     k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc4213ad440, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
I0331 21:01:42.922]     	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:332 +0x219
I0331 21:01:42.922]     k8s.io/kubernetes/test/e2e.TestE2E(0xc42092e1e0)
I0331 21:01:42.922]     	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:48 +0x2b
I0331 21:01:42.923]     testing.tRunner(0xc42092e1e0, 0x41a1c50)
I0331 21:01:42.923]     	/usr/local/go/src/testing/testing.go:746 +0xd0
I0331 21:01:42.923]     created by testing.(*T).Run
I0331 21:01:42.923]     	/usr/local/go/src/testing/testing.go:789 +0x2de
```

```release-note
NONE
```

cc @MrHohn @G-Harmon @csbell 
