### PR TITLE
Fix localport open with --nodeport-addresses specified

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -968,22 +968,18 @@ func (proxier *Proxier) syncProxyRules() {
 
 			lps := make([]utilproxy.LocalPort, 0)
 			for address := range addresses {
-				if utilproxy.IsZeroCIDR(address) {
-					lp := utilproxy.LocalPort{
-						Description: "nodePort for " + svcNameString,
-						IP:          "",
-						Port:        svcInfo.NodePort,
-						Protocol:    protocol,
-					}
-					lps = append(lps, lp)
-					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
-					break
-				}
 				lp := utilproxy.LocalPort{
 					Description: "nodePort for " + svcNameString,
 					IP:          address,
 					Port:        svcInfo.NodePort,
 					Protocol:    protocol,
+				}
+				if utilproxy.IsZeroCIDR(address) {
+					// Empty IP address means all
+					lp.IP = ""
+					lps = append(lps, lp)
+					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
+					break
 				}
 				lps = append(lps, lp)
 			}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -962,7 +962,7 @@ func (proxier *Proxier) syncProxyRules() {
 			// (because the socket might open but it would never work).
 			addresses, err := utilproxy.GetNodeAddresses(proxier.nodePortAddresses, proxier.networkInterfacer)
 			if err != nil {
-				glog.Errorf("Failed to get node ip address matching nodeport cidr")
+				glog.Errorf("Failed to get node ip address matching nodeport cidr: %v", err)
 				continue
 			}
 
@@ -976,6 +976,7 @@ func (proxier *Proxier) syncProxyRules() {
 						Protocol:    protocol,
 					}
 					lps = append(lps, lp)
+					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
 					break
 				}
 				lp := utilproxy.LocalPort{
@@ -987,6 +988,7 @@ func (proxier *Proxier) syncProxyRules() {
 				lps = append(lps, lp)
 			}
 
+			// For ports on node IPs, open the actual port and hold it.
 			for _, lp := range lps {
 				if proxier.portsMap[lp] != nil {
 					glog.V(4).Infof("Port %s was open before and is still needed", lp.String())

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -987,7 +987,7 @@ func (proxier *Proxier) syncProxyRules() {
 		if svcInfo.NodePort != 0 {
 			addresses, err := utilproxy.GetNodeAddresses(proxier.nodePortAddresses, proxier.networkInterfacer)
 			if err != nil {
-				glog.Errorf("Failed to get node ip address matching nodeport cidr")
+				glog.Errorf("Failed to get node ip address matching nodeport cidr: %v", err)
 				continue
 			}
 
@@ -1001,6 +1001,7 @@ func (proxier *Proxier) syncProxyRules() {
 						Protocol:    protocol,
 					}
 					lps = append(lps, lp)
+					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
 					break
 				}
 				lp := utilproxy.LocalPort{
@@ -1012,6 +1013,7 @@ func (proxier *Proxier) syncProxyRules() {
 				lps = append(lps, lp)
 			}
 
+			// For ports on node IPs, open the actual port and hold it.
 			for _, lp := range lps {
 				if proxier.portsMap[lp] != nil {
 					glog.V(4).Infof("Port %s was open before and is still needed", lp.String())

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -985,27 +985,50 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		if svcInfo.NodePort != 0 {
-			lp := utilproxy.LocalPort{
-				Description: "nodePort for " + svcNameString,
-				IP:          "",
-				Port:        svcInfo.NodePort,
-				Protocol:    protocol,
+			addresses, err := utilproxy.GetNodeAddresses(proxier.nodePortAddresses, proxier.networkInterfacer)
+			if err != nil {
+				glog.Errorf("Failed to get node ip address matching nodeport cidr")
+				continue
 			}
-			if proxier.portsMap[lp] != nil {
-				glog.V(4).Infof("Port %s was open before and is still needed", lp.String())
-				replacementPortsMap[lp] = proxier.portsMap[lp]
-			} else {
-				socket, err := proxier.portMapper.OpenLocalPort(&lp)
-				if err != nil {
-					glog.Errorf("can't open %s, skipping this nodePort: %v", lp.String(), err)
-					continue
+
+			lps := make([]utilproxy.LocalPort, 0)
+			for address := range addresses {
+				if utilproxy.IsZeroCIDR(address) {
+					lp := utilproxy.LocalPort{
+						Description: "nodePort for " + svcNameString,
+						IP:          "",
+						Port:        svcInfo.NodePort,
+						Protocol:    protocol,
+					}
+					lps = append(lps, lp)
+					break
 				}
-				if lp.Protocol == "udp" {
-					isIPv6 := utilnet.IsIPv6(svcInfo.ClusterIP)
-					conntrack.ClearEntriesForPort(proxier.exec, lp.Port, isIPv6, clientv1.ProtocolUDP)
+				lp := utilproxy.LocalPort{
+					Description: "nodePort for " + svcNameString,
+					IP:          address,
+					Port:        svcInfo.NodePort,
+					Protocol:    protocol,
 				}
-				replacementPortsMap[lp] = socket
-			} // We're holding the port, so it's OK to install ipvs rules.
+				lps = append(lps, lp)
+			}
+
+			for _, lp := range lps {
+				if proxier.portsMap[lp] != nil {
+					glog.V(4).Infof("Port %s was open before and is still needed", lp.String())
+					replacementPortsMap[lp] = proxier.portsMap[lp]
+				} else {
+					socket, err := proxier.portMapper.OpenLocalPort(&lp)
+					if err != nil {
+						glog.Errorf("can't open %s, skipping this nodePort: %v", lp.String(), err)
+						continue
+					}
+					if lp.Protocol == "udp" {
+						isIPv6 := utilnet.IsIPv6(svcInfo.ClusterIP)
+						conntrack.ClearEntriesForPort(proxier.exec, lp.Port, isIPv6, clientv1.ProtocolUDP)
+					}
+					replacementPortsMap[lp] = socket
+				} // We're holding the port, so it's OK to install ipvs rules.
+			}
 
 			// Nodeports need SNAT, unless they're local.
 			// ipset call
@@ -1038,11 +1061,6 @@ func (proxier *Proxier) syncProxyRules() {
 
 			// Build ipvs kernel routes for each node ip address
 			nodeIPs := make([]net.IP, 0)
-			addresses, err := utilproxy.GetNodeAddresses(proxier.nodePortAddresses, proxier.networkInterfacer)
-			if err != nil {
-				glog.Errorf("Failed to get node ip address matching nodeport cidr")
-				continue
-			}
 			for address := range addresses {
 				if !utilproxy.IsZeroCIDR(address) {
 					nodeIPs = append(nodeIPs, net.ParseIP(address))

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -993,22 +993,18 @@ func (proxier *Proxier) syncProxyRules() {
 
 			lps := make([]utilproxy.LocalPort, 0)
 			for address := range addresses {
-				if utilproxy.IsZeroCIDR(address) {
-					lp := utilproxy.LocalPort{
-						Description: "nodePort for " + svcNameString,
-						IP:          "",
-						Port:        svcInfo.NodePort,
-						Protocol:    protocol,
-					}
-					lps = append(lps, lp)
-					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
-					break
-				}
 				lp := utilproxy.LocalPort{
 					Description: "nodePort for " + svcNameString,
 					IP:          address,
 					Port:        svcInfo.NodePort,
 					Protocol:    protocol,
+				}
+				if utilproxy.IsZeroCIDR(address) {
+					// Empty IP address means all
+					lp.IP = ""
+					lps = append(lps, lp)
+					// If we encounter a zero CIDR, then there is no point in processing the rest of the addresses.
+					break
 				}
 				lps = append(lps, lp)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix localport open with --nodeport-addresses specified.

**Which issue(s) this PR fixes**:
Fixes #61953

**Special notes for your reviewer**:

@ephur

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Services can listen on same host ports on different interfaces with --nodeport-addresses specified
```
