### PR TITLE
CRI: update documents for container logpath

### DIFF
--- a/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go
+++ b/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go
@@ -744,7 +744,7 @@ type PodSandboxConfig struct {
 	// structured logs, systemd-journald journal files, gRPC trace files, etc.
 	// E.g.,
 	//     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
-	//     ContainerConfig.LogPath = `containerName_Instance#.log`
+	//     ContainerConfig.LogPath = `containerName/Instance#.log`
 	//
 	// WARNING: Log management and how kubelet should interface with the
 	// container logs are under active discussion in
@@ -1790,7 +1790,7 @@ type ContainerConfig struct {
 	// the log (STDOUT and STDERR) on the host.
 	// E.g.,
 	//     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
-	//     ContainerConfig.LogPath = `containerName_Instance#.log`
+	//     ContainerConfig.LogPath = `containerName/Instance#.log`
 	//
 	// WARNING: Log management and how kubelet should interface with the
 	// container logs are under active discussion in

--- a/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
+++ b/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
@@ -307,7 +307,7 @@ message PodSandboxConfig {
     // structured logs, systemd-journald journal files, gRPC trace files, etc.
     // E.g.,
     //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
-    //     ContainerConfig.LogPath = `containerName_Instance#.log`
+    //     ContainerConfig.LogPath = `containerName/Instance#.log`
     //
     // WARNING: Log management and how kubelet should interface with the
     // container logs are under active discussion in
@@ -686,7 +686,7 @@ message ContainerConfig {
     // the log (STDOUT and STDERR) on the host.
     // E.g.,
     //     PodSandboxConfig.LogDirectory = `/var/log/pods/<podUID>/`
-    //     ContainerConfig.LogPath = `containerName_Instance#.log`
+    //     ContainerConfig.LogPath = `containerName/Instance#.log`
     //
     // WARNING: Log management and how kubelet should interface with the
     // container logs are under active discussion in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The container log path has been changed from  `containername_attempt#.log` to `containername/attempt#.log` in #59906. This PR updates CRI documents for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CRI: update documents for container logpath. The container log path has been changed from containername_attempt#.log to containername/attempt#.log 
```
