### PR TITLE
introduce non-cached implementation of String in Quantity

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -600,16 +600,22 @@ func (q *Quantity) Neg() {
 const int64QuantityExpectedBytes = 18
 
 // String formats the Quantity as a string, caching the result if not calculated.
-// String is an expensive operation and caching this result significantly reduces the cost of
-// normal parse / marshal operations on Quantity.
 func (q *Quantity) String() string {
 	if len(q.s) == 0 {
-		result := make([]byte, 0, int64QuantityExpectedBytes)
-		number, suffix := q.CanonicalizeBytes(result)
-		number = append(number, suffix...)
-		q.s = string(number)
+		q.s = q.AString()
 	}
 	return q.s
+}
+
+// AString formats the Quantity as a string, dynamically calculating the result.
+// AString is an expensive operation and caching this result significantly reduces the cost of
+// normal parse / marshal operations on Quantity. If caching is desired, please use the
+// original String function above.
+func (q *Quantity) AString() string {
+	result := make([]byte, 0, int64QuantityExpectedBytes)
+	number, suffix := q.CanonicalizeBytes(result)
+	number = append(number, suffix...)
+	return string(number)
 }
 
 // MarshalJSON implements the json.Marshaller interface.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -729,6 +729,21 @@ func TestQuantityString(t *testing.T) {
 	}
 }
 
+// TestQuantityAString that quantity doesn't cache the string value it computes.
+func TestQuantityAString(t *testing.T) {
+	q := MustParse("100Gi")
+
+	// MustParse could potentially cache the string value, so set it back to an empty string.
+	q.s = ""
+	if expected, actual := "100Gi", q.AString(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+
+	if q.s != "" {
+		t.Errorf("'quantity.s' was modified. Expected '', actual '%v'", q.s)
+	}
+}
+
 func TestQuantityParseEmit(t *testing.T) {
 	table := []struct {
 		in     string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The current implementation of `String()` in `resource.Quantity` mutates the `Quantity` struct by [setting](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L610) it's `s` field with the calculated string value; as a form of caching.

For thread safety reasons, this might not be the desired behaviour for certain programs. Instead of making the function thread-safe, I've moved the `String` calculation to a separate function while keeping the original function structurally the same. This new function is called `AString` and is exposed outside of the package.

**Which issue(s) this PR fixes** *
Not sure if any exist for this.

**Special notes for your reviewer**:

**Release note**:
NONE