### PR TITLE
Automated cherry pick of #57243: Register metav1 types into samplecontroller api scheme

### DIFF
--- a/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -47,5 +48,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Foo{},
 		&FooList{},
 	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
Fixes kubernetes/sample-controller#14

Cherry pick of #57243 on release-1.9.

#57243: Register metav1 types into samplecontroller api scheme

```release-note
Fix error message regarding conversion of `v1.ListOptions` to `samplecontroller.k8s.io/v1alpha1`.
```