### PR TITLE
Automated cherry pick of #61375 #61124 upstream release 1.10

### DIFF
--- a/pkg/controller/nodeipam/ipam/BUILD
+++ b/pkg/controller/nodeipam/ipam/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cloud_cidr_allocator_test.go",
         "controller_test.go",
         "range_allocator_test.go",
         "timeout_test.go",

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -69,6 +69,12 @@ const (
 
 	// cidrUpdateRetries is the no. of times a NodeSpec update will be retried before dropping it.
 	cidrUpdateRetries = 3
+
+	// updateRetryTimeout is the time to wait before requeing a failed node for retry
+	updateRetryTimeout = 100 * time.Millisecond
+
+	// updateMaxRetries is the max retries for a failed node
+	updateMaxRetries = 10
 )
 
 // CIDRAllocator is an interface implemented by things that know how

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func hasNodeInProcessing(ca *cloudCIDRAllocator, name string) bool {
+	ca.lock.Lock()
+	defer ca.lock.Unlock()
+
+	_, found := ca.nodesInProcessing[name]
+	return found
+}
+
+func TestBoundedRetries(t *testing.T) {
+	clientSet := fake.NewSimpleClientset()
+	updateChan := make(chan string, 1) // need to buffer as we are using only on go routine
+	stopChan := make(chan struct{})
+	sharedInfomer := informers.NewSharedInformerFactory(clientSet, 1*time.Hour)
+	ca := &cloudCIDRAllocator{
+		client:            clientSet,
+		nodeUpdateChannel: updateChan,
+		nodeLister:        sharedInfomer.Core().V1().Nodes().Lister(),
+		nodesSynced:       sharedInfomer.Core().V1().Nodes().Informer().HasSynced,
+		nodesInProcessing: map[string]*nodeProcessingInfo{},
+	}
+	go ca.worker(stopChan)
+	nodeName := "testNode"
+	ca.AllocateOrOccupyCIDR(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	})
+	for hasNodeInProcessing(ca, nodeName) {
+		// wait for node to finish processing (should terminate and not time out)
+	}
+}

--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -174,14 +174,15 @@ func (c *Controller) onAdd(node *v1.Node) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if syncer, ok := c.syncers[node.Name]; !ok {
+	syncer, ok := c.syncers[node.Name]
+	if !ok {
 		syncer = c.newSyncer(node.Name)
 		c.syncers[node.Name] = syncer
 		go syncer.Loop(nil)
 	} else {
 		glog.Warningf("Add for node %q that already exists", node.Name)
-		syncer.Update(node)
 	}
+	syncer.Update(node)
 
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Backport of stability fixes on IPAM controller to 1.10.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61363, Fixes #61124 

**Special notes for your reviewer**:
These are already merged on master, backport to 1.10 branch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Backport of stability fixes on IPAM controller to 1.10.
```
