### PR TITLE
[flake] Fix govet failures in pull-kubernetes-verify test

### DIFF
--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -199,7 +199,13 @@ func SetupNVIDIAGPUNode(f *framework.Framework, setupResourceGatherer bool) *fra
 	var rsgather *framework.ContainerResourceGatherer
 	if setupResourceGatherer {
 		framework.Logf("Starting ResourceUsageGather for the created DaemonSet pods.")
-		rsgather, err = framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{false, false, 2 * time.Second, 2 * time.Second, true}, pods)
+		rsgather, err = framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{
+			InKubemark:                  false,
+			MasterOnly:                  false,
+			ResourceDataGatheringPeriod: 2 * time.Second,
+			ProbeDuration:               2 * time.Second,
+			PrintVerboseLogs:            true,
+		}, pods)
 		framework.ExpectNoError(err, "creating ResourceUsageGather for the daemonset pods")
 		go rsgather.StartGatheringData()
 	}

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -134,7 +134,7 @@ type ImageConfig struct {
 
 type Accelerator struct {
 	Type  string `json:"type,omitempty"`
-	Count int64  `json:"count, omitempty"`
+	Count int64  `json:"count,omitempty"`
 }
 
 type Resources struct {
@@ -142,19 +142,19 @@ type Resources struct {
 }
 
 type GCEImage struct {
-	Image      string `json:"image, omitempty"`
-	ImageDesc  string `json:"image_description, omitempty"`
+	Image      string `json:"image,omitempty"`
+	ImageDesc  string `json:"image_description,omitempty"`
 	Project    string `json:"project"`
 	Metadata   string `json:"metadata"`
-	ImageRegex string `json:"image_regex, omitempty"`
+	ImageRegex string `json:"image_regex,omitempty"`
 	// Defaults to using only the latest image. Acceptable values are [0, # of images that match the regex).
 	// If the number of existing previous images is lesser than what is desired, the test will use that is available.
-	PreviousImages int `json:"previous_images, omitempty"`
+	PreviousImages int `json:"previous_images,omitempty"`
 
-	Machine   string    `json:"machine, omitempty"`
-	Resources Resources `json:"resources, omitempty"`
+	Machine   string    `json:"machine,omitempty"`
+	Resources Resources `json:"resources,omitempty"`
 	// This test is for benchmark (no limit verification, more result log, node name has format 'machine-image-uuid') if 'Tests' is non-empty.
-	Tests []string `json:"tests, omitempty"`
+	Tests []string `json:"tests,omitempty"`
 }
 
 type internalImageConfig struct {

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -666,7 +666,7 @@ func TestUpdateNodeObjects(t *testing.T) {
 		go func(lister int) {
 			w, err := c.Nodes().Watch(metav1.ListOptions{})
 			if err != nil {
-				fmt.Printf("[watch:%d] error: %v", k, err)
+				fmt.Printf("[watch:%d] error: %v", lister, err)
 				return
 			}
 			i := 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Found in test flake:
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/60476/pull-kubernetes-verify/84571/
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/61918/pull-kubernetes-verify/84576/

```
# k8s.io/kubernetes/test/e2e_node/runner/remote
test/e2e_node/runner/remote/run_remote.go:137: struct field tag `json:"count, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:145: struct field tag `json:"image, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:146: struct field tag `json:"image_description, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:149: struct field tag `json:"image_regex, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:152: struct field tag `json:"previous_images, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:154: struct field tag `json:"machine, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:155: struct field tag `json:"resources, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
test/e2e_node/runner/remote/run_remote.go:157: struct field tag `json:"tests, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value
# k8s.io/kubernetes/test/e2e/scheduling
test/e2e/scheduling/nvidia-gpus.go:202: k8s.io/kubernetes/test/e2e/framework.ResourceGathererOptions composite literal uses unkeyed fields
# k8s.io/kubernetes/test/integration/master
test/integration/master/synthetic_master_test.go:669: loop variable k captured by func literal
make[1]: *** [vet] Error 1
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
There are also gofmt flakes, but `gofmt` doesn't consider them as failures locally. Weird. I don't fix them in this PR.
```
diff -u ./pkg/security/podsecuritypolicy/provider_test.go.orig ./pkg/security/podsecuritypolicy/provider_test.go
--- ./pkg/security/podsecuritypolicy/provider_test.go.orig	2018-04-03 02:36:51.195878570 +0000
+++ ./pkg/security/podsecuritypolicy/provider_test.go	2018-04-03 02:36:51.195878570 +0000
@@ -1017,7 +1017,7 @@
 		},
 		Spec: api.PodSpec{
 			SecurityContext: &api.PodSecurityContext{
-			// fill in for test cases
+				// fill in for test cases
 			},
 			Containers: []api.Container{
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
