### PR TITLE
Make UnstructuredContent return contents without mutating the source

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -2133,14 +2133,14 @@ URL:	http://localhost
 				"name":              "MyName",
 				"namespace":         "MyNamespace",
 				"creationTimestamp": "2017-04-01T00:00:00Z",
-				"resourceVersion":   123,
+				"resourceVersion":   int64(123),
 				"uid":               "00000000-0000-0000-0000-000000000001",
 				"dummy3":            "present",
 			},
 			"items": []interface{}{
 				map[string]interface{}{
 					"itemBool": true,
-					"itemInt":  42,
+					"itemInt":  int64(42),
 				},
 			},
 			"url":    "http://localhost",

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -2133,14 +2133,14 @@ URL:	http://localhost
 				"name":              "MyName",
 				"namespace":         "MyNamespace",
 				"creationTimestamp": "2017-04-01T00:00:00Z",
-				"resourceVersion":   int64(123),
+				"resourceVersion":   123,
 				"uid":               "00000000-0000-0000-0000-000000000001",
 				"dummy3":            "present",
 			},
 			"items": []interface{}{
 				map[string]interface{}{
 					"itemBool": true,
-					"itemInt":  int64(42),
+					"itemInt":  42,
 				},
 			},
 			"url":    "http://localhost",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "helpers_test.go",
         "unstructured_list_test.go",
+        "unstructured_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -82,7 +82,7 @@ func (obj *Unstructured) EachListItem(fn func(runtime.Object) error) error {
 
 func (obj *Unstructured) UnstructuredContent() map[string]interface{} {
 	if obj.Object == nil {
-		obj.Object = make(map[string]interface{})
+		return make(map[string]interface{})
 	}
 	return obj.Object
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
@@ -53,19 +53,21 @@ func (u *UnstructuredList) EachListItem(fn func(runtime.Object) error) error {
 }
 
 // UnstructuredContent returns a map contain an overlay of the Items field onto
-// the Object field. Items always overwrites overlay. Changing "items" in the
-// returned object will affect items in the underlying Items field, but changing
-// the "items" slice itself will have no effect.
-// TODO: expose SetUnstructuredContent on runtime.Unstructured that allows
-// items to be changed.
+// the Object field. Items always overwrites overlay.
 func (u *UnstructuredList) UnstructuredContent() map[string]interface{} {
-	out := u.Object
-	if out == nil {
-		out = make(map[string]interface{})
+	out := make(map[string]interface{}, len(u.Object)+1)
+
+	// shallow copy every property but items
+	for k, v := range u.Object {
+		if k == "items" {
+			continue
+		}
+		out[k] = v
 	}
+
 	items := make([]interface{}, len(u.Items))
 	for i, item := range u.Items {
-		items[i] = item.Object
+		items[i] = item.UnstructuredContent()
 	}
 	out["items"] = items
 	return out

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
@@ -57,11 +57,8 @@ func (u *UnstructuredList) EachListItem(fn func(runtime.Object) error) error {
 func (u *UnstructuredList) UnstructuredContent() map[string]interface{} {
 	out := make(map[string]interface{}, len(u.Object)+1)
 
-	// shallow copy every property but items
+	// shallow copy every property
 	for k, v := range u.Object {
-		if k == "items" {
-			continue
-		}
 		out[k] = v
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,9 @@ import (
 
 func TestNilUnstructuredContent(t *testing.T) {
 	var u Unstructured
+	uCopy := u.DeepCopy()
 	content := u.UnstructuredContent()
 	expContent := make(map[string]interface{})
 	assert.EqualValues(t, expContent, content)
+	assert.Equal(t, uCopy, &u)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstructured
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNilUnstructuredContent(t *testing.T) {
+	var u Unstructured
+	content := u.UnstructuredContent()
+	expContent := make(map[string]interface{})
+	assert.EqualValues(t, expContent, content)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -411,8 +411,7 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 	var u map[string]interface{}
 	var err error
 	if unstr, ok := obj.(Unstructured); ok {
-		// UnstructuredContent() mutates the object so we need to make a copy first
-		u = unstr.DeepCopyObject().(Unstructured).UnstructuredContent()
+		u = unstr.UnstructuredContent()
 	} else {
 		t := reflect.TypeOf(obj)
 		value := reflect.ValueOf(obj)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -446,9 +446,6 @@ func DeepCopyJSON(x map[string]interface{}) map[string]interface{} {
 // DeepCopyJSONValue deep copies the passed value, assuming it is a valid JSON representation i.e. only contains
 // types produced by json.Unmarshal().
 func DeepCopyJSONValue(x interface{}) interface{} {
-	if x == nil {
-		return nil
-	}
 	switch x := x.(type) {
 	case map[string]interface{}:
 		if x == nil {
@@ -470,7 +467,7 @@ func DeepCopyJSONValue(x interface{}) interface{} {
 			clone[i] = DeepCopyJSONValue(v)
 		}
 		return clone
-	case string, int64, bool, float64, encodingjson.Number:
+	case string, int64, bool, float64, nil, encodingjson.Number:
 		return x
 	default:
 		panic(fmt.Errorf("cannot deep copy %T", x))

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -446,20 +446,31 @@ func DeepCopyJSON(x map[string]interface{}) map[string]interface{} {
 // DeepCopyJSONValue deep copies the passed value, assuming it is a valid JSON representation i.e. only contains
 // types produced by json.Unmarshal().
 func DeepCopyJSONValue(x interface{}) interface{} {
+	if x == nil {
+		return nil
+	}
 	switch x := x.(type) {
 	case map[string]interface{}:
+		if x == nil {
+			// Typed nil - an interface{} that contains a type map[string]interface{} with a value of nil
+			return x
+		}
 		clone := make(map[string]interface{}, len(x))
 		for k, v := range x {
 			clone[k] = DeepCopyJSONValue(v)
 		}
 		return clone
 	case []interface{}:
+		if x == nil {
+			// Typed nil - an interface{} that contains a type []interface{} with a value of nil
+			return x
+		}
 		clone := make([]interface{}, len(x))
 		for i, v := range x {
 			clone[i] = DeepCopyJSONValue(v)
 		}
 		return clone
-	case string, int64, bool, float64, nil, encodingjson.Number:
+	case string, int64, bool, float64, encodingjson.Number:
 		return x
 	default:
 		panic(fmt.Errorf("cannot deep copy %T", x))

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -234,9 +234,9 @@ type Object interface {
 // to JSON allowed.
 type Unstructured interface {
 	Object
-	// UnstructuredContent returns a non-nil, mutable map of the contents of this object. Values may be
+	// UnstructuredContent returns a non-nil map with this object's contents. Values may be
 	// []interface{}, map[string]interface{}, or any primitive type. Contents are typically serialized to
-	// and from JSON.
+	// and from JSON. SetUnstructuredContent should be used to mutate the contents.
 	UnstructuredContent() map[string]interface{}
 	// SetUnstructuredContent updates the object content to match the provided map.
 	SetUnstructuredContent(map[string]interface{})

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
@@ -263,7 +263,7 @@ func (obj *Unstructured) EachListItem(fn func(runtime.Object) error) error {
 
 func (obj *Unstructured) UnstructuredContent() map[string]interface{} {
 	if obj.Object == nil {
-		obj.Object = make(map[string]interface{})
+		return make(map[string]interface{})
 	}
 	return obj.Object
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR solves the issues described in #56316

Before this change:

- A call to `UnstructuredContent()` potentially modified `Object`
- The values returned by `UnstructuredContent()` could be manipulated to modify the value in `Object`. Going through the history it looks like this behavior was added before the addition of `SetUnstructuredContent()`. IMO it makes more sense now to use `SetUnstructuredContent()` or make changes to the exposed `Object` property
- `UnstructuredList` did not implement the behavior described in the godoc. The godoc stated that the value returned should be mutable, but if u.Object == nil the map returned had no effect on Object

With this PR I'm proposing `UnstructuredContent()` returns the data without providing the contract of a mutable map. It also ensures all implementations of the `Unstructured` interface abide by the doc

**Which issue(s) this PR fixes**:
Fixes #56316

**Special notes for your reviewer**:
This PR continues work started in #57713.

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery
/cc sttts deads2k