### PR TITLE
Update GLBC manifest to v1.0.1

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.8-alpha.2
+  name: l7-lb-controller-v1.0.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v0.9.8-alpha.2
+    version: v1.0.1
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:1.0.0
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.0.1
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
**Release note**:
```release-note
GCE: Updates GLBC version to 1.0.1 which includes a fix which prevents multi-cluster ingress objects from creating full load balancers.
```

/assign @bowei  @nikhiljindal 
cc @csbell @rramkumar1 @freehan @MrHohn 