### PR TITLE
[GCE] Ingress HTTP2 e2e test

### DIFF
--- a/cluster/gce/manifests/e2e-image-puller.manifest
+++ b/cluster/gce/manifests/e2e-image-puller.manifest
@@ -34,7 +34,7 @@ spec:
       k8s.gcr.io/busybox:1.24
       k8s.gcr.io/dnsutils:e2e
       k8s.gcr.io/e2e-net-amd64:1.0
-      k8s.gcr.io/echoserver:1.6
+      k8s.gcr.io/echoserver:1.10
       k8s.gcr.io/eptest:0.1
       k8s.gcr.io/fakegitserver:0.1
       k8s.gcr.io/galera-install:0.1

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -1612,7 +1612,7 @@ func generateBacksideHTTPSDeploymentSpec() *extensions.Deployment {
 					Containers: []v1.Container{
 						{
 							Name:  "echoheaders-https",
-							Image: "k8s.gcr.io/echoserver:1.9",
+							Image: "k8s.gcr.io/echoserver:1.10",
 							Ports: []v1.ContainerPort{{
 								ContainerPort: 8443,
 								Name:          "echo-443",

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -564,6 +564,119 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 		})
 	})
 
+	Describe("GCE [Slow] [Feature:HTTP2]", func() {
+		var gceController *framework.GCEIngressController
+
+		// Platform specific setup
+		BeforeEach(func() {
+			framework.SkipUnlessProviderIs("gce", "gke")
+			By("Initializing gce controller")
+			gceController = &framework.GCEIngressController{
+				Ns:     ns,
+				Client: jig.Client,
+				Cloud:  framework.TestContext.CloudConfig,
+			}
+			err := gceController.Init()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Platform specific cleanup
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				framework.DescribeIng(ns)
+			}
+			if jig.Ingress == nil {
+				By("No ingress created, no cleanup necessary")
+				return
+			}
+			By("Deleting ingress")
+			jig.TryDeleteIngress()
+
+			By("Cleaning up cloud resources")
+			Expect(gceController.CleanupGCEIngressController()).NotTo(HaveOccurred())
+		})
+
+		It("should be able to switch between HTTPS and HTTP2 modes", func() {
+			By("Create a basic HTTP2 ingress")
+			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "http2"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(true)
+
+			address, err := jig.WaitForIngressAddress(jig.Client, jig.Ingress.Namespace, jig.Ingress.Name, framework.LoadBalancerPollTimeout)
+
+			By(fmt.Sprintf("Polling on address %s and verify the backend is serving HTTP2", address))
+			timeoutClient := &http.Client{Timeout: framework.IngressReqTimeout}
+			err = wait.PollImmediate(framework.LoadBalancerPollInterval, framework.LoadBalancerPollTimeout, func() (bool, error) {
+				resp, err := framework.SimpleGET(timeoutClient, fmt.Sprintf("http://%s", address), "")
+				if err != nil {
+					framework.Logf("SimpleGET failed: %v", err)
+					return false, nil
+				}
+				if !strings.Contains(resp, "request_version=2") {
+					return false, fmt.Errorf("request wasn't served by HTTP2, response body: %s", resp)
+				}
+				if !strings.Contains(resp, "request_scheme=https") {
+					return false, fmt.Errorf("request wasn't served by HTTPS, response body: %s", resp)
+				}
+				framework.Logf("Poll succeeded, request was served by HTTP2")
+				return true, nil
+			})
+			Expect(err).NotTo(HaveOccurred(), "Failed to get HTTP2")
+
+			By("Switch backend service to use HTTPS")
+			svcList, err := f.ClientSet.CoreV1().Services(ns).List(metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, svc := range svcList.Items {
+				svc.Annotations[framework.ServiceApplicationProtocolKey] = `{"http2":"HTTPS"}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(&svc)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			resp := ""
+			err = wait.PollImmediate(framework.LoadBalancerPollInterval, framework.LoadBalancerPollTimeout, func() (bool, error) {
+				resp, err = framework.SimpleGET(timeoutClient, fmt.Sprintf("http://%s", address), "")
+				if err != nil {
+					framework.Logf("SimpleGET failed: %v", err)
+					return false, nil
+				}
+				if !strings.Contains(resp, "request_version=1.1") {
+					framework.Logf("Waiting for transition to HTTP/1")
+					return false, nil
+				}
+				framework.Logf("Poll succeeded, request was served by HTTP")
+				return true, nil
+			})
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get HTTP, response body: %v", resp))
+
+			By("Switch backend service to use HTTP2")
+			svcList, err = f.ClientSet.CoreV1().Services(ns).List(metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, svc := range svcList.Items {
+				svc.Annotations[framework.ServiceApplicationProtocolKey] = `{"http2":"HTTP2"}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(&svc)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			timeoutClient = &http.Client{Timeout: framework.IngressReqTimeout}
+			err = wait.PollImmediate(framework.LoadBalancerPollInterval, framework.LoadBalancerPollTimeout, func() (bool, error) {
+				resp, err = framework.SimpleGET(timeoutClient, fmt.Sprintf("http://%s", address), "")
+				if err != nil {
+					framework.Logf("SimpleGET failed: %v", err)
+					return false, nil
+				}
+				if !strings.Contains(resp, "request_version=2") {
+					framework.Logf("Waiting for transition to HTTP/2")
+					return false, nil
+				}
+				if !strings.Contains(resp, "request_scheme=https") {
+					return false, nil
+				}
+				framework.Logf("Poll succeeded, request was served by HTTP2")
+				return true, nil
+			})
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get HTTP2, response body: %v", resp))
+		})
+	})
+
 	Describe("GCE [Slow] [Feature:kubemci]", func() {
 		var gceController *framework.GCEIngressController
 		var ipName, ipAddress string

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -440,7 +440,7 @@ func generateScaleTestBackendDeploymentSpec(numReplicas int32) *extensions.Deplo
 					Containers: []v1.Container{
 						{
 							Name:  scaleTestBackendName,
-							Image: "gcr.io/google_containers/echoserver:1.6",
+							Image: "gcr.io/google_containers/echoserver:1.10",
 							Ports: []v1.ContainerPort{{ContainerPort: 8080}},
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: k8s.gcr.io/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.10
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/test/e2e/testing-manifests/ingress/http2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/ing.yaml
@@ -1,0 +1,9 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echomap
+spec:
+  # kubemci requires a default backend.
+  backend:
+    serviceName: echoheaders
+    servicePort: 443

--- a/test/e2e/testing-manifests/ingress/http2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/rc.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: echoheaders
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: echoheaders
+    spec:
+      containers:
+      - name: echoheaders
+        image: k8s.gcr.io/echoserver:1.10
+        ports:
+        - containerPort: 8443

--- a/test/e2e/testing-manifests/ingress/http2/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+      service.alpha.kubernetes.io/app-protocols: '{"http2":"HTTP2"}'
+  name: echoheaders
+  labels:
+    app: echoheaders
+spec:
+  type: NodePort
+  ports:
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+    name: http2
+  selector:
+    app: echoheaders

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/google_containers/echoserver:1.6
+        image: gcr.io/google_containers/echoserver:1.10
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/static-ip-2/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip-2/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: k8s.gcr.io/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.10
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: k8s.gcr.io/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.10
         ports:
         - containerPort: 8080

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -57,7 +57,7 @@ var (
 	CudaVectorAdd            = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0", true}
 	Dnsutils                 = ImageConfig{e2eRegistry, "dnsutils", "1.0", true}
 	DNSMasq                  = ImageConfig{gcRegistry, "k8s-dns-dnsmasq", "1.14.5", true}
-	EchoServer               = ImageConfig{gcRegistry, "echoserver", "1.6", false}
+	EchoServer               = ImageConfig{gcRegistry, "echoserver", "1.10", false}
 	EntrypointTester         = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0", true}
 	E2ENet                   = ImageConfig{gcRegistry, "e2e-net", "1.0", true}
 	Fakegitserver            = ImageConfig{e2eRegistry, "fakegitserver", "1.0", true}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds e2e test for bringing up an HTTP2 Ingress, converting it to HTTPS, then back to HTTP2
- Update echoserver image to 1.10

**Release note**:
```release-note
NONE
```
