### PR TITLE
Automated cherry pick of #62075: Update GLBC manifest to v1.0.1

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.8-alpha.2
+  name: l7-lb-controller-v1.0.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v0.9.8-alpha.2
+    version: v1.0.1
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:1.0.0
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.0.1
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Cherry pick of #62075 on release-1.10.

#62075: Update GLBC manifest to v1.0.1