### PR TITLE
Fixes incorrect atomic usage

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -399,7 +399,7 @@ func TestRoundTripRedirects(t *testing.T) {
 			var redirects int32 = 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if redirects < test.redirects {
-					redirects = atomic.AddInt32(&redirects, 1)
+					atomic.AddInt32(&redirects, 1)
 					http.Redirect(w, req, "redirect", http.StatusFound)
 					return
 				}


### PR DESCRIPTION
Fixes incorrect assignment for atomic increment.
NOTE: This will be a vet error in go version 1.10.
ERROR: "direct assignment to atomic value".
No other erroneous atomic assignments found.

```release-note
NONE
```
