### PR TITLE
Make FAIL_SWAP_ON warning message clear

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -141,7 +141,7 @@ fi
 
 # warn if users are running with swap allowed
 if [ "${FAIL_SWAP_ON}" == "false" ]; then
-    echo "WARNING : The kubelet is configured to not fail if swap is enabled; production deployments should disable swap."
+    echo "WARNING : The kubelet is configured to not fail even if swap is enabled; production deployments should disable swap."
 fi
 
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

When operating local-up-cluster.sh to prepare e2e tests, the warning
message can be output. This commit makes the message clear.

**Release note**: NONE