### PR TITLE
handle DeletedFinalStateUnknown objects in attachDetachController

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -433,7 +433,19 @@ func (adc *attachDetachController) podUpdate(oldObj, newObj interface{}) {
 
 func (adc *attachDetachController) podDelete(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
-	if pod == nil || !ok {
+	if !ok {
+		tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.V(2).Infof("Couldn't get object from tombstone %+v", obj)
+			return
+		}
+		pod, ok = tombstone.Obj.(*v1.Pod)
+		if !ok {
+			glog.V(2).Infof("tombstone contained object that is not a pod %+v", obj)
+			return
+		}
+	}
+	if pod == nil {
 		return
 	}
 
@@ -471,7 +483,19 @@ func (adc *attachDetachController) nodeUpdate(oldObj, newObj interface{}) {
 
 func (adc *attachDetachController) nodeDelete(obj interface{}) {
 	node, ok := obj.(*v1.Node)
-	if node == nil || !ok {
+	if !ok {
+		tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.V(2).Infof("Couldn't get object from tombstone %+v", obj)
+			return
+		}
+		node, ok = tombstone.Obj.(*v1.Node)
+		if !ok {
+			glog.V(2).Infof("tombstone contained object that is not a node %+v", obj)
+			return
+		}
+	}
+	if node == nil {
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
handle DeletedFinalStateUnknown objects in attachDetachController
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
```
// DeletedFinalStateUnknown is placed into a DeltaFIFO in the case where
// an object was deleted but the watch deletion event was missed. In this
// case we don't know the final "resting" state of the object, so there's
// a chance the included `Obj` is stale.
type DeletedFinalStateUnknown struct {
	Key string
	Obj interface{}
}
```
**Special notes for your reviewer**:
ref [61925](https://github.com/kubernetes/kubernetes/pull/61925/files)
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
