### PR TITLE
fix 1.10 change log typo

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -324,7 +324,7 @@ kind: KubeProxyConfiguration
 
 * The `PodSecurityPolicy` API has been moved to the `policy/v1beta1` API group. The `PodSecurityPolicy` API in the `extensions/v1beta1` API group is deprecated and will be removed in a future release. Authorizations for using pod security policy resources should change to reference the `policy` API group after upgrading to 1.11. ([#54933](https://github.com/kubernetes/kubernetes/pull/54933), [@php-coder](https://github.com/php-coder))
 
-* Add `--enable-admission-plugin` `--disable-admission-plugin` flags and deprecate `--admission-control`. When using the separate flag, the order in which they're specified doesn't matter.  ([#58123](https://github.com/kubernetes/kubernetes/pull/58123), [@hzxuzhonghu](https://github.com/hzxuzhonghu))
+* Add `--enable-admission-plugins` `--disable-admission-plugins` flags and deprecate `--admission-control`. When using the separate flag, the order in which they're specified doesn't matter.  ([#58123](https://github.com/kubernetes/kubernetes/pull/58123), [@hzxuzhonghu](https://github.com/hzxuzhonghu))
 
 * The kubelet  --docker-disable-shared-pid flag, which runs docker containers with a process namespace that is shared between all containers in a pod, is now deprecated and will be removed in a future release. It is replaced by `v1.Pod.Spec.ShareProcessNamespace`, which configures this behavior. This field is alpha and can be enabled with --feature-gates=PodShareProcessNamespace=true. ([#58093](https://github.com/kubernetes/kubernetes/pull/58093), [@verb](https://github.com/verb))
 
@@ -1833,7 +1833,7 @@ filename | sha256 hash
 * Bump GCE metadata proxy to v0.1.9 to pick up security fixes. ([#58221](https://github.com/kubernetes/kubernetes/pull/58221), [@ihmccreery](https://github.com/ihmccreery))
 * kubeadm now supports CIDR notations in NO_PROXY environment variable ([#53895](https://github.com/kubernetes/kubernetes/pull/53895), [@kad](https://github.com/kad))
 * kubeadm now accept `--apiserver-extra-args`, `--controller-manager-extra-args` and `--scheduler-extra-args` to override / specify additional flags for control plane components ([#58080](https://github.com/kubernetes/kubernetes/pull/58080), [@simonferquel](https://github.com/simonferquel))
-* Add `--enable-admission-plugin` `--disable-admission-plugin` flags and deprecate `--admission-control`. ([#58123](https://github.com/kubernetes/kubernetes/pull/58123), [@hzxuzhonghu](https://github.com/hzxuzhonghu))
+* Add `--enable-admission-plugins` `--disable-admission-plugins` flags and deprecate `--admission-control`. ([#58123](https://github.com/kubernetes/kubernetes/pull/58123), [@hzxuzhonghu](https://github.com/hzxuzhonghu))
     * Afterwards, don't care about the orders specified in the flags.
 * "ExternalTrafficLocalOnly" has been removed from feature gate. It has been a GA feature since v1.7. ([#56948](https://github.com/kubernetes/kubernetes/pull/56948), [@MrHohn](https://github.com/MrHohn))
 * GCP: allow a master to not include a metadata concealment firewall rule (if it's not running the metadata proxy). ([#58104](https://github.com/kubernetes/kubernetes/pull/58104), [@ihmccreery](https://github.com/ihmccreery))

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
@@ -53,7 +53,7 @@ func TestEnabledPluginNames(t *testing.T) {
 			setDefaultOffPlugins:      sets.NewString(),
 		},
 
-		// scenario 3: use default off plugins and specified by enable-admission-plugin with RecommendedPluginOrder
+		// scenario 3: use default off plugins and specified by enable-admission-plugins with RecommendedPluginOrder
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginB", "pluginC", "pluginD"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
@@ -61,7 +61,7 @@ func TestEnabledPluginNames(t *testing.T) {
 			setEnablePlugins:          []string{"pluginD", "pluginC"},
 		},
 
-		// scenario 4: use default off plugins and specified by disable-admission-plugin with RecommendedPluginOrder
+		// scenario 4: use default off plugins and specified by disable-admission-plugins with RecommendedPluginOrder
 		{
 			expectedPluginNames:       []string{"pluginB"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
@@ -69,7 +69,7 @@ func TestEnabledPluginNames(t *testing.T) {
 			setDisablePlugins:         []string{"pluginA"},
 		},
 
-		// scenario 5: use default off plugins and specified by enable-admission-plugin and disable-admission-plugin with RecommendedPluginOrder
+		// scenario 5: use default off plugins and specified by enable-admission-plugins and disable-admission-plugins with RecommendedPluginOrder
 		{
 			expectedPluginNames:       []string{"pluginA", "pluginC"},
 			setRecommendedPluginOrder: []string{"pluginA", "pluginB", "pluginC", "pluginD"},
@@ -142,39 +142,39 @@ func TestValidate(t *testing.T) {
 			expectedResult: true,
 		},
 
-		// scenario 1: set both `--enable-admission-plugin` `--disable-admission-plugin`
+		// scenario 1: set both `--enable-admission-plugins` `--disable-admission-plugins`
 		{
 			setEnablePlugins:  []string{"pluginA", "pluginB"},
 			setDisablePlugins: []string{"pluginC"},
 			expectedResult:    true,
 		},
 
-		// scenario 2: set invalid `--enable-admission-plugin` `--disable-admission-plugin`
+		// scenario 2: set invalid `--enable-admission-plugins` `--disable-admission-plugins`
 		{
 			setEnablePlugins:  []string{"pluginA", "pluginB"},
 			setDisablePlugins: []string{"pluginB"},
 			expectedResult:    false,
 		},
 
-		// scenario 3: set only invalid `--enable-admission-plugin`
+		// scenario 3: set only invalid `--enable-admission-plugins`
 		{
 			setEnablePlugins: []string{"pluginA", "pluginE"},
 			expectedResult:   false,
 		},
 
-		// scenario 4: set only invalid `--disable-admission-plugin`
+		// scenario 4: set only invalid `--disable-admission-plugins`
 		{
 			setDisablePlugins: []string{"pluginA", "pluginE"},
 			expectedResult:    false,
 		},
 
-		// scenario 5: set valid `--enable-admission-plugin`
+		// scenario 5: set valid `--enable-admission-plugins`
 		{
 			setEnablePlugins: []string{"pluginA", "pluginB"},
 			expectedResult:   true,
 		},
 
-		// scenario 6: set valid `--disable-admission-plugin`
+		// scenario 6: set valid `--disable-admission-plugins`
 		{
 			setDisablePlugins: []string{"pluginA"},
 			expectedResult:    true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Thanks to @christianhuening, find typo about `enable-admission-plugins` and `disable-admission-plugins`
They are plural.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
