### PR TITLE
Fix wrong usage of kubelet option

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -264,7 +264,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--kubeconfig", kubeconfigPath,
 		"--root-dir", KubeletRootDirectory,
 		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
-		"--allow-privileged", "true",
+		"--allow-privileged=true",
 	)
 
 	// Apply test framework feature gates by default. This could also be overridden
@@ -354,7 +354,7 @@ func addKubeletConfigFlags(cmdArgs *[]string, kc *kubeletconfig.KubeletConfigura
 	fs := pflag.NewFlagSet("kubelet", pflag.ExitOnError)
 	options.AddKubeletConfigFlags(fs, kc)
 	for _, name := range flags {
-		*cmdArgs = append(*cmdArgs, "--"+name, fs.Lookup(name).Value.String())
+		*cmdArgs = append(*cmdArgs, fmt.Sprintf("--%s=%s", name, fs.Lookup(name).Value.String()))
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

"--allow-privileged true" is incorrect usage of boolean option.
It means setting '--allow-priviledged' to its default value plus
non-existing subcommand 'true'.

"--allow-privileged false" is even more confusing as it sets
allow-priviledged flag to its default value 'true'

This is true for any boolean command line option.

Fixed this by using correct syntax --allow-priviledged=true

**Special notes for your reviewer**:
This is a show-stopper for PR #61833 

**Release note**:

```release-note
NONE
```