### PR TITLE
Setup fsGroup for local volumes correctly

### DIFF
--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -1383,6 +1383,19 @@ func TestParseMountInfo(t *testing.T) {
 187 23 0:58 / /var/lib/kubelet/pods/1fc5ea21-eff4-11e7-ac80-0e858b8eaf40/volumes/kubernetes.io~nfs/nfs2 rw,relatime shared:96 - nfs4 172.18.4.223:/srv/nfs2 rw,vers=4.0,rsize=524288,wsize=524288,namlen=255,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=172.18.4.223,local_lock=none,addr=172.18.4.223
 188 24 0:58 / /var/lib/kubelet/pods/43219158-e5e1-11e7-a392-0e858b8eaf40/volume-subpaths/nfs1/subpath1/0 rw,relatime shared:89 - nfs4 172.18.4.223:/srv/nfs/foo rw,vers=4.0,rsize=524288,wsize=524288,namlen=255,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=172.18.4.223,local_lock=none,addr=172.18.4.223
 347 60 0:71 / /var/lib/kubelet/pods/13195d46-f9fa-11e7-bbf1-5254007a695a/volumes/kubernetes.io~nfs/vol2 rw,relatime shared:170 - nfs 172.17.0.3:/exports/2 rw,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=172.17.0.3,mountvers=3,mountport=20048,mountproto=udp,local_lock=none,addr=172.17.0.3
+222 24 253:0 /tmp/src /mnt/dst rw,relatime shared:1 - ext4 /dev/mapper/vagrant--vg-root rw,errors=remount-ro,data=ordered
+28 18 0:24 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755
+29 28 0:25 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+31 28 0:27 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:13 - cgroup cgroup rw,cpuset
+32 28 0:28 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:14 - cgroup cgroup rw,cpu,cpuacct
+33 28 0:29 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,freezer
+34 28 0:30 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,net_cls,net_prio
+35 28 0:31 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:17 - cgroup cgroup rw,pids
+36 28 0:32 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,devices
+37 28 0:33 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:19 - cgroup cgroup rw,hugetlb
+38 28 0:34 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:20 - cgroup cgroup rw,blkio
+39 28 0:35 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,memory
+40 28 0:36 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,perf_event
 `
 	tempDir, filename, err := writeFile(info)
 	if err != nil {
@@ -1392,17 +1405,103 @@ func TestParseMountInfo(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		mountPoint   string
+		id           int
 		expectedInfo mountInfo
 	}{
 		{
 			"simple bind mount",
-			"/var/lib/kubelet",
+			189,
 			mountInfo{
-				mountPoint:   "/var/lib/kubelet",
-				optional:     []string{"shared:30"},
-				mountOptions: []string{"rw", "relatime"},
-				superOptions: []string{"rw", "commit=30", "data=ordered"},
+				id:             189,
+				parentID:       80,
+				majorMinor:     "8:1",
+				root:           "/var/lib/kubelet",
+				source:         "/dev/sda1",
+				mountPoint:     "/var/lib/kubelet",
+				optionalFields: []string{"shared:30"},
+				fsType:         "ext4",
+				mountOptions:   []string{"rw", "relatime"},
+				superOptions:   []string{"rw", "commit=30", "data=ordered"},
+			},
+		},
+		{
+			"bind mount a directory",
+			222,
+			mountInfo{
+				id:             222,
+				parentID:       24,
+				majorMinor:     "253:0",
+				root:           "/tmp/src",
+				source:         "/dev/mapper/vagrant--vg-root",
+				mountPoint:     "/mnt/dst",
+				optionalFields: []string{"shared:1"},
+				fsType:         "ext4",
+				mountOptions:   []string{"rw", "relatime"},
+				superOptions:   []string{"rw", "errors=remount-ro", "data=ordered"},
+			},
+		},
+		{
+			"more than one optional fields",
+			224,
+			mountInfo{
+				id:             224,
+				parentID:       62,
+				majorMinor:     "253:0",
+				root:           "/var/lib/docker/devicemapper/test/shared",
+				source:         "/dev/mapper/ssd-root",
+				mountPoint:     "/var/lib/docker/devicemapper/test/shared",
+				optionalFields: []string{"master:1", "shared:44"},
+				fsType:         "ext4",
+				mountOptions:   []string{"rw", "relatime"},
+				superOptions:   []string{"rw", "seclabel", "data=ordered"},
+			},
+		},
+		{
+			"cgroup-mountpoint",
+			28,
+			mountInfo{
+				id:             28,
+				parentID:       18,
+				majorMinor:     "0:24",
+				root:           "/",
+				source:         "tmpfs",
+				mountPoint:     "/sys/fs/cgroup",
+				optionalFields: []string{"shared:9"},
+				fsType:         "tmpfs",
+				mountOptions:   []string{"ro", "nosuid", "nodev", "noexec"},
+				superOptions:   []string{"ro", "mode=755"},
+			},
+		},
+		{
+			"cgroup-subsystem-systemd-mountpoint",
+			29,
+			mountInfo{
+				id:             29,
+				parentID:       28,
+				majorMinor:     "0:25",
+				root:           "/",
+				source:         "cgroup",
+				mountPoint:     "/sys/fs/cgroup/systemd",
+				optionalFields: []string{"shared:10"},
+				fsType:         "cgroup",
+				mountOptions:   []string{"rw", "nosuid", "nodev", "noexec", "relatime"},
+				superOptions:   []string{"rw", "xattr", "release_agent=/lib/systemd/systemd-cgroups-agent", "name=systemd"},
+			},
+		},
+		{
+			"cgroup-subsystem-cpuset-mountpoint",
+			31,
+			mountInfo{
+				id:             31,
+				parentID:       28,
+				majorMinor:     "0:27",
+				root:           "/",
+				source:         "cgroup",
+				mountPoint:     "/sys/fs/cgroup/cpuset",
+				optionalFields: []string{"shared:13"},
+				fsType:         "cgroup",
+				mountOptions:   []string{"rw", "nosuid", "nodev", "noexec", "relatime"},
+				superOptions:   []string{"rw", "cpuset"},
 			},
 		},
 	}
@@ -1415,7 +1514,7 @@ func TestParseMountInfo(t *testing.T) {
 	for _, test := range tests {
 		found := false
 		for _, info := range infos {
-			if info.mountPoint == test.mountPoint {
+			if info.id == test.id {
 				found = true
 				if !reflect.DeepEqual(info, test.expectedInfo) {
 					t.Errorf("Test case %q:\n expected: %+v\n got:      %+v", test.name, test.expectedInfo, info)
@@ -1424,7 +1523,7 @@ func TestParseMountInfo(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("Test case %q: mountPoint %s not found", test.name, test.mountPoint)
+			t.Errorf("Test case %q: mountPoint %d not found", test.name, test.id)
 		}
 	}
 }
@@ -1916,4 +2015,154 @@ func isOperationNotPermittedError(err error) bool {
 		return true
 	}
 	return false
+}
+
+func TestSearchMountPoints(t *testing.T) {
+	base := `
+19 25 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
+20 25 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:12 - proc proc rw
+21 25 0:6 / /dev rw,nosuid,relatime shared:2 - devtmpfs udev rw,size=4058156k,nr_inodes=1014539,mode=755
+22 21 0:14 / /dev/pts rw,nosuid,noexec,relatime shared:3 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+23 25 0:19 / /run rw,nosuid,noexec,relatime shared:5 - tmpfs tmpfs rw,size=815692k,mode=755
+25 0 252:0 / / rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro,data=ordered
+26 19 0:12 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:8 - securityfs securityfs rw
+27 21 0:21 / /dev/shm rw,nosuid,nodev shared:4 - tmpfs tmpfs rw
+28 23 0:22 / /run/lock rw,nosuid,nodev,noexec,relatime shared:6 - tmpfs tmpfs rw,size=5120k
+29 19 0:23 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - tmpfs tmpfs ro,mode=755
+30 29 0:24 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,xattr,release_agent=/lib/systemd/systemd-cgroups-agent,name=systemd
+31 19 0:25 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:11 - pstore pstore rw
+32 29 0:26 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:13 - cgroup cgroup rw,devices
+33 29 0:27 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:14 - cgroup cgroup rw,freezer
+34 29 0:28 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,pids
+35 29 0:29 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,blkio
+36 29 0:30 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:17 - cgroup cgroup rw,memory
+37 29 0:31 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,perf_event
+38 29 0:32 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:19 - cgroup cgroup rw,hugetlb
+39 29 0:33 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:20 - cgroup cgroup rw,cpu,cpuacct
+40 29 0:34 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,cpuset
+41 29 0:35 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,net_cls,net_prio
+58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordere
+`
+
+	testcases := []struct {
+		name         string
+		source       string
+		mountInfos   string
+		expectedRefs []string
+		expectedErr  error
+	}{
+		{
+			"dir",
+			"/mnt/disks/vol1",
+			base,
+			nil,
+			nil,
+		},
+		{
+			"dir-used",
+			"/mnt/disks/vol1",
+			base + `
+56 25 252:0 /mnt/disks/vol1 /var/lib/kubelet/pods/1890aef5-5a60-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro,data=ordered
+57 25 0:45 / /mnt/disks/vol rw,relatime shared:36 - tmpfs tmpfs rw
+`,
+			[]string{"/var/lib/kubelet/pods/1890aef5-5a60-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test"},
+			nil,
+		},
+		{
+			"tmpfs-vol",
+			"/mnt/disks/vol1",
+			base + `120 25 0:76 / /mnt/disks/vol1 rw,relatime shared:41 - tmpfs vol1 rw,size=10000k
+`,
+			nil,
+			nil,
+		},
+		{
+			"tmpfs-vol-used-by-two-pods",
+			"/mnt/disks/vol1",
+			base + `120 25 0:76 / /mnt/disks/vol1 rw,relatime shared:41 - tmpfs vol1 rw,size=10000k
+196 25 0:76 / /var/lib/kubelet/pods/ade3ac21-5a5b-11e8-8559-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-8f263585 rw,relatime shared:41 - tmpfs vol1 rw,size=10000k
+228 25 0:76 / /var/lib/kubelet/pods/ac60532d-5a5b-11e8-8559-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-8f263585 rw,relatime shared:41 - tmpfs vol1 rw,size=10000k
+`,
+			[]string{
+				"/var/lib/kubelet/pods/ade3ac21-5a5b-11e8-8559-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-8f263585",
+				"/var/lib/kubelet/pods/ac60532d-5a5b-11e8-8559-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-8f263585",
+			},
+			nil,
+		},
+		{
+			"tmpfs-subdir-used-indirectly-via-bindmount-dir-by-one-pod",
+			"/mnt/vol1/foo",
+			base + `177 25 0:46 / /mnt/data rw,relatime shared:37 - tmpfs data rw
+190 25 0:46 /vol1 /mnt/vol1 rw,relatime shared:37 - tmpfs data rw
+191 25 0:46 /vol2 /mnt/vol2 rw,relatime shared:37 - tmpfs data rw
+62 25 0:46 /vol1/foo /var/lib/kubelet/pods/e25f2f01-5b06-11e8-8694-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test rw,relatime shared:37 - tmpfs data rw
+`,
+			[]string{"/var/lib/kubelet/pods/e25f2f01-5b06-11e8-8694-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test"},
+			nil,
+		},
+		{
+			"dir-bindmounted",
+			"/mnt/disks/vol2",
+			base + `342 25 252:0 /mnt/disks/vol2 /mnt/disks/vol2 rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro,data=ordered
+`,
+			nil,
+			nil,
+		},
+		{
+			"dir-bindmounted-used-by-one-pod",
+			"/mnt/disks/vol2",
+			base + `342 25 252:0 /mnt/disks/vol2 /mnt/disks/vol2 rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro,data=ordered
+77 25 252:0 /mnt/disks/vol2 /var/lib/kubelet/pods/f30dc360-5a5d-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-1fb30a1c rw,relatime shared:1 - ext4 /dev/mapper/ubuntu--vg-root rw,errors=remount-ro,data=ordered
+`,
+			[]string{"/var/lib/kubelet/pods/f30dc360-5a5d-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-1fb30a1c"},
+			nil,
+		},
+		{
+			"blockfs",
+			"/mnt/disks/blkvol1",
+			base + `58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+`,
+			nil,
+			nil,
+		},
+		{
+			"blockfs-used-by-one-pod",
+			"/mnt/disks/blkvol1",
+			base + `58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+62 25 7:1 / /var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+`,
+			[]string{"/var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test"},
+			nil,
+		},
+		{
+			"blockfs-used-by-two-pods",
+			"/mnt/disks/blkvol1",
+			base + `58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+62 25 7:1 / /var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+95 25 7:1 / /var/lib/kubelet/pods/4854a48b-5a64-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordered
+`,
+			[]string{"/var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test",
+				"/var/lib/kubelet/pods/4854a48b-5a64-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test"},
+			nil,
+		},
+	}
+	tmpFile, err := ioutil.TempFile("", "test-get-filetype")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+	for _, v := range testcases {
+		tmpFile.Truncate(0)
+		tmpFile.Seek(0, 0)
+		tmpFile.WriteString(v.mountInfos)
+		tmpFile.Sync()
+		refs, err := searchMountPoints(v.source, tmpFile.Name())
+		if !reflect.DeepEqual(refs, v.expectedRefs) {
+			t.Errorf("test %q: expected Refs: %#v, got %#v", v.name, v.expectedRefs, refs)
+		}
+		if !reflect.DeepEqual(err, v.expectedErr) {
+			t.Errorf("test %q: expected err: %v, got %v", v.name, v.expectedErr, err)
+		}
+	}
 }

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -333,7 +333,7 @@ func (mounter *NsenterMounter) GetMountRefs(pathname string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return getMountRefsByDev(mounter, hostpath)
+	return searchMountPoints(hostpath, procMountInfoPath)
 }
 
 func (mounter *NsenterMounter) GetFSGroup(pathname string) (int64, error) {

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -290,14 +290,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				})
 
 				It("should set fsGroup for one pod", func() {
-					skipTypes := sets.NewString(
-						string(DirectoryBindMountedLocalVolumeType),
-						string(DirectoryLinkBindMountedLocalVolumeType),
-					)
-					if skipTypes.Has(string(testVolType)) {
-						// TODO(cofyc): Test it when bug is fixed.
-						framework.Skipf("Skipped when volume type is %v", testVolType)
-					}
 					By("Checking fsGroup is set")
 					pod := createPodWithFsGroupTest(config, testVol, 1234, 1234)
 					By("Deleting pod")
@@ -305,14 +297,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				})
 
 				It("should set same fsGroup for two pods simultaneously", func() {
-					skipTypes := sets.NewString(
-						string(DirectoryBindMountedLocalVolumeType),
-						string(DirectoryLinkBindMountedLocalVolumeType),
-					)
-					if skipTypes.Has(string(testVolType)) {
-						// TODO(cofyc): Test it when bug is fixed.
-						framework.Skipf("Skipped when volume type is %v", testVolType)
-					}
 					fsGroup := int64(1234)
 					By("Create first pod and check fsGroup is set")
 					pod1 := createPodWithFsGroupTest(config, testVol, fsGroup, fsGroup)
@@ -325,14 +309,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				})
 
 				It("should set different fsGroup for second pod if first pod is deleted", func() {
-					skipTypes := sets.NewString(
-						string(DirectoryBindMountedLocalVolumeType),
-						string(DirectoryLinkBindMountedLocalVolumeType),
-					)
-					if skipTypes.Has(string(testVolType)) {
-						// TODO(cofyc): Test it when bug is fixed.
-						framework.Skipf("Skipped when volume type is %v", testVolType)
-					}
 					fsGroup1, fsGroup2 := int64(1234), int64(4321)
 					By("Create first pod and check fsGroup is set")
 					pod1 := createPodWithFsGroupTest(config, testVol, fsGroup1, fsGroup1)
@@ -346,16 +322,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				})
 
 				It("should not set different fsGroups for two pods simultaneously", func() {
-					skipTypes := sets.NewString(
-						string(DirectoryLocalVolumeType),
-						string(DirectoryLinkLocalVolumeType),
-						string(DirectoryBindMountedLocalVolumeType),
-						string(DirectoryLinkBindMountedLocalVolumeType),
-					)
-					if skipTypes.Has(string(testVolType)) {
-						// TODO(cofyc): Test it when bug is fixed.
-						framework.Skipf("Skipped when volume type is %v", testVolType)
-					}
 					fsGroup1, fsGroup2 := int64(1234), int64(4321)
 					By("Create first pod and check fsGroup is set")
 					pod1 := createPodWithFsGroupTest(config, testVol, fsGroup1, fsGroup1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This pr fixes fsGroup check in local volume in containerized kubelet. Except this, it also fixes fsGroup check when volume source is a normal directory whether kubelet is running on the host or in a container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61741 

**Special notes for your reviewer**:

Bind mounts are detected in `/proc/mounts`, but it does not contain root of mount for bind mounts. So `mount.GetMountRefsByDev()` cannot get all references if source is a normal directory. e.g.

```
# mkdir /tmp/src /mnt/dst
# mount --bind /tmp/src /tmp/src # required by local-volume-provisioner, see https://github.com/kubernetes-incubator/external-storage/pull/499
# mount --bind /tmp/src /mnt/dst
# grep -P 'src|dst' /proc/mounts 
tmpfs /tmp/src tmpfs rw,nosuid,nodev,noatime,size=4194304k 0 0
tmpfs /mnt/dst tmpfs rw,nosuid,nodev,noatime,size=4194304k 0 0
# grep -P 'src|dst' /proc/self/mountinfo 
234 409 0:42 /src /tmp/src rw,nosuid,nodev,noatime shared:30 - tmpfs tmpfs rw,size=4194304k
235 24 0:42 /src /mnt/dst rw,nosuid,nodev,noatime shared:30 - tmpfs tmpfs rw,size=4194304k
```

We need to compare root of mount and device in this case.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```