### PR TITLE
Fix __kubectl_filedir to perform file and directory completion

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -246,7 +246,7 @@ __kubectl_filedir() {
 		if [[ ! "${w}" = "${cur}"* ]]; then
 			continue
 		fi
-		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+		if eval "[[ \"\${w}\" = *${1:+".$1"} || -d \"\${w}\" ]]"; then
 			qw="$(__kubectl_quote "${w}")"
 			if [ -d "${w}" ]; then
 				COMPREPLY+=("${qw}/")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR fixes `__kubectl_filedir` to perform file and directory completion.

```
$ __kubectl_filedir && echo "${COMPREPLY[@]}" && unset COMPREPLY
api/ build/ BUILD.bazel CHANGELOG-1.10.md CHANGELOG-1.2.md CHANGELOG-1.3.md CHANGELOG-1.4.md CHANGELOG-1.5.md CHANGELOG-1.6.md CHANGELOG-1.7.md CHANGELOG-1.8.md CHANGELOG-1.9.md CHANGELOG.md cluster/ cmd/ code-of-conduct.md CONTRIBUTING.md docs/ examples/ Godeps/ hack/ labels.yaml LICENSE logo/ Makefile Makefile.generated_files _output/ OWNERS OWNERS_ALIASES pkg/ plugin/ README.md staging/ SUPPORT.md test/ third_party/ _tmp/ translations/ vendor/ WORKSPACE
```

Currently, it performs directory completion only.

```
$ __kubectl_filedir && echo "${COMPREPLY[@]}" && unset COMPREPLY
api/ build/ cluster/ cmd/ docs/ examples/ Godeps/ hack/ logo/ _output/ pkg/ plugin/ staging/ test/ third_party/ _tmp/ translations/ vendor/
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: @sttts 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
