### PR TITLE
Automated cherry pick of #61713: kubectl: fix a panic when createGeneratedObject failed

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -276,14 +276,14 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 
 	params["env"] = cmdutil.GetFlagStringArray(cmd, "env")
 
-	allErrs := []error{}
 	var runObjectMap = map[string]*RunObject{}
 	runObject, err := createGeneratedObject(f, cmd, generator, names, params, cmdutil.GetFlagString(cmd, "overrides"), namespace)
 	if err != nil {
-		allErrs = append(allErrs, err)
+		return err
 	} else {
 		runObjectMap[generatorName] = runObject
 	}
+	allErrs := []error{}
 	if cmdutil.GetFlagBool(cmd, "expose") {
 		serviceGenerator := cmdutil.GetFlagString(cmd, "service-generator")
 		if len(serviceGenerator) == 0 {

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -276,12 +276,12 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 
 	params["env"] = cmdutil.GetFlagStringArray(cmd, "env")
 
-	var runObjectMap = map[string]*RunObject{}
+	var createdObjects = []*RunObject{}
 	runObject, err := createGeneratedObject(f, cmd, generator, names, params, cmdutil.GetFlagString(cmd, "overrides"), namespace)
 	if err != nil {
 		return err
 	} else {
-		runObjectMap[generatorName] = runObject
+		createdObjects = append(createdObjects, runObject)
 	}
 	allErrs := []error{}
 	if cmdutil.GetFlagBool(cmd, "expose") {
@@ -293,7 +293,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 		if err != nil {
 			allErrs = append(allErrs, err)
 		} else {
-			runObjectMap[generatorName] = serviceRunObject
+			createdObjects = append(createdObjects, serviceRunObject)
 		}
 	}
 
@@ -345,7 +345,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 		}
 
 		if remove {
-			for _, obj := range runObjectMap {
+			for _, obj := range createdObjects {
 				namespace, err = obj.Mapping.MetadataAccessor.Namespace(obj.Object)
 				if err != nil {
 					return err


### PR DESCRIPTION
Cherry pick of #61713 on release-1.10.

#61713: kubectl: fix a panic when createGeneratedObject failed

**Release note**:
```release-note
Fix `kubectl run` panic as errors of generated objects were not propagated
```