### PR TITLE
Fix: when privileged is set correctly in charms

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -372,9 +372,6 @@ def start_worker(kube_api, kube_control, auth_control, cni):
     creds = db.get('credentials')
     data_changed('kube-control.creds', creds)
 
-    # set --allow-privileged flag for kubelet
-    set_privileged()
-
     create_config(random.choice(servers), creds)
     configure_kubelet(dns, ingress_ip)
     configure_kube_proxy(servers, cluster_cidr)
@@ -626,8 +623,8 @@ def configure_kubelet(dns, ingress_ip):
     if (dns['enable-kube-dns']):
         kubelet_opts['cluster-dns'] = dns['sdn-ip']
 
-    privileged = is_state('kubernetes-worker.privileged')
-    kubelet_opts['allow-privileged'] = 'true' if privileged else 'false'
+    # set --allow-privileged flag for kubelet
+    kubelet_opts['allow-privileged'] = set_privileged()
 
     if is_state('kubernetes-worker.gpu.enabled'):
         hookenv.log('Adding '
@@ -865,8 +862,10 @@ def remove_nrpe_config(nagios=None):
 
 
 def set_privileged():
-    """Update the allow-privileged flag for kubelet.
-
+    """Return 'true' if privileged containers are needed.
+    This is when a) the user requested them
+                 b) user does not care (auto) and GPUs are available in a pre
+                    1.9 era
     """
     privileged = hookenv.config('allow-privileged').lower()
     gpu_needs_privileged = (is_state('kubernetes-worker.gpu.enabled') and
@@ -880,6 +879,8 @@ def set_privileged():
         remove_state('kubernetes-worker.gpu.enabled')
         # No need to restart kubernetes (set the restart-needed state)
         # because set-privileged is already in the restart path
+
+    return privileged
 
 
 @when('config.changed.allow-privileged')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Privileged flag is not correctly set in juju charms causing validation test to fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/538

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
