### PR TITLE
fix issue that hostpath.type does not work on Windows 

### DIFF
--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -219,9 +219,9 @@ func (mounter *Mounter) GetFileType(pathname string) (FileType, error) {
 		return FileTypeBlockDev, nil
 	case syscall.S_IFCHR:
 		return FileTypeCharDev, nil
-	case syscall.S_IFDIR:
+	case syscall.FILE_ATTRIBUTE_DIRECTORY:
 		return FileTypeDirectory, nil
-	case syscall.S_IFREG:
+	case syscall.FILE_ATTRIBUTE_NORMAL:
 		return FileTypeFile, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
hostpath.type as `DirectoryOrCreate` does not work on windows, there will be mount failed error, this PR fixed this issue.

```
---
apiVersion: v1
kind: Pod
metadata:
  name: aspnet-hostpath
spec:
  containers:
  - image: microsoft/aspnet
    name: aspnet-hostpath
    volumeMounts:
    - name: test-volume
      mountPath: '/azure'
  nodeSelector:
    beta.kubernetes.io/os: windows
  volumes:
  - name: test-volume
    hostPath:
      path: 'c:\var\lib\kublet\test'
      type: DirectoryOrCreate
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62121

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix issue that hostpath.type does not work on Windows 
```
@dixudx 

/sig storage
/sig windows
