### PR TITLE
Migrating test images to gcr.io/kubernetes-e2e-test-images

### DIFF
--- a/cluster/gce/manifests/e2e-image-puller.manifest
+++ b/cluster/gce/manifests/e2e-image-puller.manifest
@@ -70,10 +70,10 @@ spec:
       k8s.gcr.io/update-demo:kitten
       k8s.gcr.io/update-demo:nautilus
       k8s.gcr.io/volume-ceph:0.1
-      k8s.gcr.io/volume-gluster:0.2
-      k8s.gcr.io/volume-iscsi:0.1
+      gcr.io/kubernetes-e2e-test-images/volume-gluster:0.2
+      gcr.io/kubernetes-e2e-test-images/volume-iscsi:0.1
       k8s.gcr.io/volume-nfs:0.8
-      k8s.gcr.io/volume-rbd:0.1
+      gcr.io/kubernetes-e2e-test-images/volume-rbd:0.1
       k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e
       gcr.io/google_samples/gb-redisslave:nonexistent
       ; do echo $(date '+%X') pulling $i; docker pull $i 1>/dev/null; done; exit 0;

--- a/cluster/gce/manifests/e2e-image-puller.manifest
+++ b/cluster/gce/manifests/e2e-image-puller.manifest
@@ -69,10 +69,10 @@ spec:
       k8s.gcr.io/test-webserver:e2e
       k8s.gcr.io/update-demo:kitten
       k8s.gcr.io/update-demo:nautilus
-      k8s.gcr.io/volume-ceph:0.1
+      gcr.io/kubernetes-e2e-test-images/volume-ceph:0.1
       gcr.io/kubernetes-e2e-test-images/volume-gluster:0.2
       gcr.io/kubernetes-e2e-test-images/volume-iscsi:0.1
-      k8s.gcr.io/volume-nfs:0.8
+      gcr.io/kubernetes-e2e-test-images/volume-nfs:0.8
       gcr.io/kubernetes-e2e-test-images/volume-rbd:0.1
       k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e
       gcr.io/google_samples/gb-redisslave:nonexistent

--- a/test/images/volumes-tester/ceph/Makefile
+++ b/test/images/volumes-tester/ceph/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.1
-PREFIX = staging-k8s.gcr.io
+PREFIX = gcr.io/kubernetes-e2e-test-images
 
 all: push
 

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.5
-PREFIX = staging-k8s.gcr.io
+PREFIX = gcr.io/kubernetes-e2e-test-images
 
 all: push
 

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.2
-PREFIX = staging-k8s.gcr.io
+PREFIX = gcr.io/kubernetes-e2e-test-images
 
 all: push
 

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.8
-PREFIX = staging-k8s.gcr.io
+PREFIX = gcr.io/kubernetes-e2e-test-images
 
 all: push
 

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.2
-PREFIX = staging-k8s.gcr.io
+PREFIX = gcr.io/kubernetes-e2e-test-images
 
 all: push
 

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -94,9 +94,9 @@ var (
 	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.0", true}
 	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0", true}
 	VolumeNFSServer     = ImageConfig{gcRegistry, "volume-nfs", "0.8", false}
-	VolumeISCSIServer   = ImageConfig{gcRegistry, "volume-iscsi", "0.2", false}
-	VolumeGlusterServer = ImageConfig{gcRegistry, "volume-gluster", "0.5", false}
-	VolumeRBDServer     = ImageConfig{gcRegistry, "volume-rbd", "0.2", false}
+	VolumeISCSIServer   = ImageConfig{e2eRegistry, "volume-iscsi", "0.2", false}
+	VolumeGlusterServer = ImageConfig{e2eRegistry, "volume-gluster", "0.5", false}
+	VolumeRBDServer     = ImageConfig{e2eRegistry, "volume-rbd", "0.2", false}
 )
 
 func GetE2EImage(image ImageConfig) string {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -93,7 +93,7 @@ var (
 	SDDummyExporter     = ImageConfig{gcRegistry, "sd-dummy-exporter", "v0.1.0", false}
 	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.0", true}
 	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0", true}
-	VolumeNFSServer     = ImageConfig{gcRegistry, "volume-nfs", "0.8", false}
+	VolumeNFSServer     = ImageConfig{e2eRegistry, "volume-nfs", "0.8", false}
 	VolumeISCSIServer   = ImageConfig{e2eRegistry, "volume-iscsi", "0.2", false}
 	VolumeGlusterServer = ImageConfig{e2eRegistry, "volume-gluster", "0.5", false}
 	VolumeRBDServer     = ImageConfig{e2eRegistry, "volume-rbd", "0.2", false}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently e2e test images are distributed between 2 different registry locations, k8s.gcr.io and gcr.io/kubernetes-e2e-test-images. This is part of a multi-step initiative to house all the images in gcr.io/kubernetes-e2e-test-images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62131

**Special notes for your reviewer**:
1. I am starting off with migrating images under k8s/test/images/volumes-tester. 
2. I did not move ceph and nfs images since they are marked for [deprecation and removal](https://github.com/kubernetes/kubernetes/tree/master/test/images/volumes-tester). Let me know if we want them moved as well.
3. I have made a copy of the images in gcr.io/kubernetes-e2e-test-images so the references are not broken post the PR merge. Will work on removing the images from k8s.gcr.io once this change sticks.

