### PR TITLE
wire printflags through set commands

### DIFF
--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -215,13 +215,17 @@ func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	o.Resources = resources
 	o.Cmd = cmd
 
-	o.PrintFlags.Complete(o.DryRun)
-
+	if o.DryRun {
+		// TODO(juanvallejo): This can be cleaned up even further by creating
+		// a PrintFlags struct that binds the --dry-run flag, and whose
+		// ToPrinter method returns a printer that understands how to print
+		// this success message.
+		o.PrintFlags.Complete("%s (dry run)")
+	}
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
 	}
-
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -74,7 +74,7 @@ func TestSetEnvLocal(t *testing.T) {
 	opts := EnvOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -123,7 +123,7 @@ func TestSetMultiResourcesEnvLocal(t *testing.T) {
 	opts := EnvOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -514,7 +514,7 @@ func TestSetEnvRemote(t *testing.T) {
 			opts := EnvOptions{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -127,7 +127,9 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	o.ResolveImage = f.ResolveImage
 	o.Cmd = cmd
 
-	o.PrintFlags.Complete(o.DryRun)
+	if o.DryRun {
+		o.PrintFlags.Complete("%s (dry run)")
+	}
 
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
@@ -250,15 +252,15 @@ func (o *ImageOptions) Run() error {
 			continue
 		}
 
+		// no changes
+		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
+			continue
+		}
+
 		if o.Local || o.DryRun {
 			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
 				return err
 			}
-			continue
-		}
-
-		// no changes
-		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
 			continue
 		}
 

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,12 +38,13 @@ import (
 type ImageOptions struct {
 	resource.FilenameOptions
 
+	PrintFlags *printers.PrintFlags
+
 	Infos        []*resource.Info
 	Selector     string
 	Out          io.Writer
 	Err          io.Writer
 	DryRun       bool
-	ShortOutput  bool
 	All          bool
 	Record       bool
 	Output       string
@@ -49,6 +52,8 @@ type ImageOptions struct {
 	Local        bool
 	Cmd          *cobra.Command
 	ResolveImage func(in string) (string, error)
+
+	PrintObj func(runtime.Object) error
 
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
@@ -81,6 +86,8 @@ var (
 
 func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	options := &ImageOptions{
+		PrintFlags: printers.NewPrintFlags("image updated"),
+
 		Out: out,
 		Err: err,
 	}
@@ -98,7 +105,8 @@ func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 		},
 	}
 
-	cmdutil.AddPrinterFlags(cmd)
+	options.PrintFlags.AddFlags(cmd)
+
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmd.Flags().BoolVar(&options.All, "all", options.All, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
@@ -112,13 +120,23 @@ func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 
 func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
-	o.ShortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
 	o.Record = cmdutil.GetRecordFlag(cmd)
 	o.ChangeCause = f.Command(cmd, false)
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.ResolveImage = f.ResolveImage
 	o.Cmd = cmd
+
+	o.PrintFlags.Complete(o.DryRun)
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -232,15 +250,15 @@ func (o *ImageOptions) Run() error {
 			continue
 		}
 
-		// no changes
-		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
+		if o.Local || o.DryRun {
+			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
+				return err
+			}
 			continue
 		}
 
-		if o.Local || o.DryRun {
-			if err := cmdutil.PrintObject(o.Cmd, patch.Info.AsVersioned(), o.Out); err != nil {
-				return err
-			}
+		// no changes
+		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
 			continue
 		}
 
@@ -263,13 +281,9 @@ func (o *ImageOptions) Run() error {
 
 		info.Refresh(obj, true)
 
-		if len(o.Output) > 0 {
-			if err := cmdutil.PrintObject(o.Cmd, info.AsVersioned(), o.Out); err != nil {
-				return err
-			}
-			continue
+		if err := o.PrintObj(info.AsVersioned()); err != nil {
+			return err
 		}
-		cmdutil.PrintSuccess(o.ShortOutput, o.Out, info.Object, o.DryRun, "image updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
@@ -61,14 +63,23 @@ func TestImageLocal(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
+	outputFormat := "name"
+
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdImage(tf, buf, buf)
 	cmd.SetOutput(buf)
-	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
-	opts := ImageOptions{FilenameOptions: resource.FilenameOptions{
-		Filenames: []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}},
+	opts := ImageOptions{
+		PrintFlags: &printers.PrintFlags{
+			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+			OutputFormat: &outputFormat,
+		},
+		FilenameOptions: resource.FilenameOptions{
+			Filenames: []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}},
 		Out:   buf,
 		Local: true}
 	err := opts.Complete(tf, cmd, []string{"cassandra=thingy"})
@@ -87,6 +98,11 @@ func TestImageLocal(t *testing.T) {
 }
 
 func TestSetImageValidation(t *testing.T) {
+	printFlags := &printers.PrintFlags{
+		JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+		NamePrintFlags:     printers.NewNamePrintFlags("", false),
+	}
+
 	testCases := []struct {
 		name         string
 		imageOptions *ImageOptions
@@ -94,13 +110,14 @@ func TestSetImageValidation(t *testing.T) {
 	}{
 		{
 			name:         "test resource < 1 and filenames empty",
-			imageOptions: &ImageOptions{},
+			imageOptions: &ImageOptions{PrintFlags: printFlags},
 			expectErr:    "[one or more resources must be specified as <resource> <name> or <resource>/<name>, at least one image update is required]",
 		},
 		{
 			name: "test containerImages < 1",
 			imageOptions: &ImageOptions{
-				Resources: []string{"a", "b", "c"},
+				PrintFlags: printFlags,
+				Resources:  []string{"a", "b", "c"},
 
 				FilenameOptions: resource.FilenameOptions{
 					Filenames: []string{"testFile"},
@@ -111,7 +128,8 @@ func TestSetImageValidation(t *testing.T) {
 		{
 			name: "test containerImages > 1 and all containers are already specified by *",
 			imageOptions: &ImageOptions{
-				Resources: []string{"a", "b", "c"},
+				PrintFlags: printFlags,
+				Resources:  []string{"a", "b", "c"},
 				FilenameOptions: resource.FilenameOptions{
 					Filenames: []string{"testFile"},
 				},
@@ -125,7 +143,8 @@ func TestSetImageValidation(t *testing.T) {
 		{
 			name: "success case",
 			imageOptions: &ImageOptions{
-				Resources: []string{"a", "b", "c"},
+				PrintFlags: printFlags,
+				Resources:  []string{"a", "b", "c"},
 				FilenameOptions: resource.FilenameOptions{
 					Filenames: []string{"testFile"},
 				},
@@ -166,14 +185,23 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
+	outputFormat := "name"
+
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdImage(tf, buf, buf)
 	cmd.SetOutput(buf)
-	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
-	opts := ImageOptions{FilenameOptions: resource.FilenameOptions{
-		Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
+	opts := ImageOptions{
+		PrintFlags: &printers.PrintFlags{
+			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+			OutputFormat: &outputFormat,
+		},
+		FilenameOptions: resource.FilenameOptions{
+			Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
 		Out:   buf,
 		Local: true}
 	err := opts.Complete(tf, cmd, []string{"*=thingy"})
@@ -552,11 +580,21 @@ func TestSetImageRemote(t *testing.T) {
 				}),
 				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
+
+			outputFormat := "yaml"
+
 			out := new(bytes.Buffer)
 			cmd := NewCmdImage(tf, out, out)
 			cmd.SetOutput(out)
-			cmd.Flags().Set("output", "yaml")
+			cmd.Flags().Set("output", outputFormat)
 			opts := ImageOptions{
+				PrintFlags: &printers.PrintFlags{
+					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+					OutputFormat: &outputFormat,
+				},
+
 				Out:   out,
 				Local: false}
 			err := opts.Complete(tf, cmd, input.args)

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -74,7 +74,7 @@ func TestImageLocal(t *testing.T) {
 	opts := ImageOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -100,7 +100,7 @@ func TestImageLocal(t *testing.T) {
 func TestSetImageValidation(t *testing.T) {
 	printFlags := &printers.PrintFlags{
 		JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-		NamePrintFlags:     printers.NewNamePrintFlags("", false),
+		NamePrintFlags:     printers.NewNamePrintFlags(""),
 	}
 
 	testCases := []struct {
@@ -196,7 +196,7 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 	opts := ImageOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -590,7 +590,7 @@ func TestSetImageRemote(t *testing.T) {
 			opts := ImageOptions{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 
@@ -61,6 +63,8 @@ var (
 type ResourcesOptions struct {
 	resource.FilenameOptions
 
+	PrintFlags *printers.PrintFlags
+
 	Infos             []*resource.Info
 	Out               io.Writer
 	Err               io.Writer
@@ -72,6 +76,10 @@ type ResourcesOptions struct {
 	ChangeCause       string
 	Local             bool
 	Cmd               *cobra.Command
+
+	DryRun bool
+
+	PrintObj func(runtime.Object) error
 
 	Limits               string
 	Requests             string
@@ -85,6 +93,8 @@ type ResourcesOptions struct {
 // pod templates are selected by default.
 func NewResourcesOptions(out io.Writer, errOut io.Writer) *ResourcesOptions {
 	return &ResourcesOptions{
+		PrintFlags: printers.NewPrintFlags("resource requirements updated"),
+
 		Out:               out,
 		Err:               errOut,
 		ContainerSelector: "*",
@@ -112,7 +122,8 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 		},
 	}
 
-	cmdutil.AddPrinterFlags(cmd)
+	options.PrintFlags.AddFlags(cmd)
+
 	//usage := "Filename, directory, or URL to a file identifying the resource to get from the server"
 	//kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	usage := "identifying the resource to get from a server."
@@ -135,6 +146,18 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	o.Record = cmdutil.GetRecordFlag(cmd)
 	o.ChangeCause = f.Command(cmd, false)
 	o.Cmd = cmd
+	o.DryRun = cmdutil.GetDryRunFlag(o.Cmd)
+
+	o.PrintFlags.Complete(o.DryRun)
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
+	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -238,8 +261,8 @@ func (o *ResourcesOptions) Run() error {
 			continue
 		}
 
-		if o.Local || cmdutil.GetDryRunFlag(o.Cmd) {
-			if err := cmdutil.PrintObject(o.Cmd, patch.Info.AsVersioned(), o.Out); err != nil {
+		if o.Local || o.DryRun {
+			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
 				return err
 			}
 			continue
@@ -262,14 +285,9 @@ func (o *ResourcesOptions) Run() error {
 		}
 		info.Refresh(obj, true)
 
-		shortOutput := o.Output == "name"
-		if len(o.Output) > 0 && !shortOutput {
-			if err := cmdutil.PrintObject(o.Cmd, info.AsVersioned(), o.Out); err != nil {
-				return err
-			}
-			continue
+		if err := o.PrintObj(info.AsVersioned()); err != nil {
+			return err
 		}
-		cmdutil.PrintSuccess(shortOutput, o.Out, info.Object, false, "resource requirements updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -148,13 +148,13 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	o.Cmd = cmd
 	o.DryRun = cmdutil.GetDryRunFlag(o.Cmd)
 
-	o.PrintFlags.Complete(o.DryRun)
-
+	if o.DryRun {
+		o.PrintFlags.Complete("%s (dry run)")
+	}
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
 	}
-
 	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}

--- a/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/pkg/kubectl/cmd/set/set_resources_test.go
@@ -73,7 +73,7 @@ func TestResourcesLocal(t *testing.T) {
 	opts := ResourcesOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -127,7 +127,7 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 	opts := ResourcesOptions{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -508,7 +508,7 @@ func TestSetResourcesRemote(t *testing.T) {
 			opts := ResourcesOptions{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},

--- a/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/pkg/kubectl/cmd/set/set_resources_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
@@ -60,14 +62,23 @@ func TestResourcesLocal(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
+	outputFormat := "name"
+
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdResources(tf, buf, buf)
 	cmd.SetOutput(buf)
-	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
-	opts := ResourcesOptions{FilenameOptions: resource.FilenameOptions{
-		Filenames: []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}},
+	opts := ResourcesOptions{
+		PrintFlags: &printers.PrintFlags{
+			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+			OutputFormat: &outputFormat,
+		},
+		FilenameOptions: resource.FilenameOptions{
+			Filenames: []string{"../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml"}},
 		Out:               buf,
 		Local:             true,
 		Limits:            "cpu=200m,memory=512Mi",
@@ -105,14 +116,23 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
+	outputFormat := "name"
+
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdResources(tf, buf, buf)
 	cmd.SetOutput(buf)
-	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
 
-	opts := ResourcesOptions{FilenameOptions: resource.FilenameOptions{
-		Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
+	opts := ResourcesOptions{
+		PrintFlags: &printers.PrintFlags{
+			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+			OutputFormat: &outputFormat,
+		},
+		FilenameOptions: resource.FilenameOptions{
+			Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
 		Out:               buf,
 		Local:             true,
 		Limits:            "cpu=200m,memory=512Mi",
@@ -478,11 +498,21 @@ func TestSetResourcesRemote(t *testing.T) {
 				}),
 				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
+
+			outputFormat := "yaml"
+
 			buf := new(bytes.Buffer)
 			cmd := NewCmdResources(tf, buf, buf)
 			cmd.SetOutput(buf)
-			cmd.Flags().Set("output", "yaml")
+			cmd.Flags().Set("output", outputFormat)
 			opts := ResourcesOptions{
+				PrintFlags: &printers.PrintFlags{
+					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+					OutputFormat: &outputFormat,
+				},
+
 				Out:               buf,
 				Limits:            "cpu=200m,memory=512Mi",
 				ContainerSelector: "*"}

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -120,13 +120,13 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	saConfig.updatePodSpecForObject = f.UpdatePodSpecForObject
 	saConfig.cmd = cmd
 
-	saConfig.PrintFlags.Complete(saConfig.dryRun)
-
+	if saConfig.dryRun {
+		saConfig.PrintFlags.Complete("%s (dry run)")
+	}
 	printer, err := saConfig.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
 	}
-
 	saConfig.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, saConfig.out)
 	}

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/api/core/v1"
@@ -54,6 +56,8 @@ var (
 
 // serviceAccountConfig encapsulates the data required to perform the operation.
 type serviceAccountConfig struct {
+	PrintFlags *printers.PrintFlags
+
 	fileNameOptions        resource.FilenameOptions
 	out                    io.Writer
 	err                    io.Writer
@@ -68,11 +72,15 @@ type serviceAccountConfig struct {
 	updatePodSpecForObject func(runtime.Object, func(*v1.PodSpec) error) (bool, error)
 	infos                  []*resource.Info
 	serviceAccountName     string
+
+	PrintObj func(runtime.Object) error
 }
 
 // NewCmdServiceAccount returns the "set serviceaccount" command.
 func NewCmdServiceAccount(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	saConfig := &serviceAccountConfig{
+		PrintFlags: printers.NewPrintFlags("serviceaccount updated"),
+
 		out: out,
 		err: err,
 	}
@@ -89,7 +97,8 @@ func NewCmdServiceAccount(f cmdutil.Factory, out, err io.Writer) *cobra.Command 
 			cmdutil.CheckErr(saConfig.Run())
 		},
 	}
-	cmdutil.AddPrinterFlags(cmd)
+
+	saConfig.PrintFlags.AddFlags(cmd)
 
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &saConfig.fileNameOptions, usage)
@@ -110,6 +119,17 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	saConfig.output = cmdutil.GetFlagString(cmd, "output")
 	saConfig.updatePodSpecForObject = f.UpdatePodSpecForObject
 	saConfig.cmd = cmd
+
+	saConfig.PrintFlags.Complete(saConfig.dryRun)
+
+	printer, err := saConfig.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	saConfig.PrintObj = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, saConfig.out)
+	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -151,6 +171,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 		})
 		return runtime.Encode(cmdutil.InternalVersionJSONEncoder(), info.Object)
 	}
+
 	patches := CalculatePatches(saConfig.infos, cmdutil.InternalVersionJSONEncoder(), patchFn)
 	for _, patch := range patches {
 		info := patch.Info
@@ -159,7 +180,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			continue
 		}
 		if saConfig.local || saConfig.dryRun {
-			if err := cmdutil.PrintObject(saConfig.cmd, patch.Info.AsVersioned(), saConfig.out); err != nil {
+			if err := saConfig.PrintObj(patch.Info.AsVersioned()); err != nil {
 				return err
 			}
 			continue
@@ -177,13 +198,10 @@ func (saConfig *serviceAccountConfig) Run() error {
 				}
 			}
 		}
-		if len(saConfig.output) > 0 {
-			if err := cmdutil.PrintObject(saConfig.cmd, info.AsVersioned(), saConfig.out); err != nil {
-				return err
-			}
-			continue
+
+		if err := saConfig.PrintObj(info.AsVersioned()); err != nil {
+			return err
 		}
-		cmdutil.PrintSuccess(saConfig.shortOutput, saConfig.out, info.Object, saConfig.dryRun, "serviceaccount updated")
 	}
 	return utilerrors.NewAggregate(patchErrs)
 }

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -92,7 +92,7 @@ func TestSetServiceAccountLocal(t *testing.T) {
 			saConfig := serviceAccountConfig{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},
@@ -136,7 +136,7 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 	opts := serviceAccountConfig{
 		PrintFlags: &printers.PrintFlags{
 			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+			NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 			OutputFormat: &outputFormat,
 		},
@@ -380,7 +380,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 			saConfig := serviceAccountConfig{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},
@@ -427,7 +427,7 @@ func TestServiceAccountValidation(t *testing.T) {
 			saConfig := &serviceAccountConfig{
 				PrintFlags: &printers.PrintFlags{
 					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
-					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+					NamePrintFlags:     printers.NewNamePrintFlags(""),
 
 					OutputFormat: &outputFormat,
 				},

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -25,6 +25,8 @@ import (
 	"path"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
@@ -77,15 +79,25 @@ func TestSetServiceAccountLocal(t *testing.T) {
 					return nil, nil
 				}),
 			}
+
+			outputFormat := "yaml"
+
 			tf.Namespace = "test"
 			out := new(bytes.Buffer)
 			cmd := NewCmdServiceAccount(tf, out, out)
 			cmd.SetOutput(out)
-			cmd.Flags().Set("output", "yaml")
+			cmd.Flags().Set("output", outputFormat)
 			cmd.Flags().Set("local", "true")
 			testapi.Default = testapi.Groups[input.apiGroup]
-			saConfig := serviceAccountConfig{fileNameOptions: resource.FilenameOptions{
-				Filenames: []string{input.yaml}},
+			saConfig := serviceAccountConfig{
+				PrintFlags: &printers.PrintFlags{
+					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+					OutputFormat: &outputFormat,
+				},
+				fileNameOptions: resource.FilenameOptions{
+					Filenames: []string{input.yaml}},
 				out:   out,
 				local: true}
 			err := saConfig.Complete(tf, cmd, []string{serviceAccount})
@@ -114,13 +126,22 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
+	outputFormat := "name"
+
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdServiceAccount(tf, buf, buf)
 	cmd.SetOutput(buf)
-	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("local", "true")
-	opts := serviceAccountConfig{fileNameOptions: resource.FilenameOptions{
-		Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
+	opts := serviceAccountConfig{
+		PrintFlags: &printers.PrintFlags{
+			JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+			NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+			OutputFormat: &outputFormat,
+		},
+		fileNameOptions: resource.FilenameOptions{
+			Filenames: []string{"../../../../test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml"}},
 		out:   buf,
 		local: true}
 
@@ -349,11 +370,21 @@ func TestSetServiceAccountRemote(t *testing.T) {
 				}),
 				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
+
+			outputFormat := "yaml"
+
 			out := new(bytes.Buffer)
 			cmd := NewCmdServiceAccount(tf, out, out)
 			cmd.SetOutput(out)
-			cmd.Flags().Set("output", "yaml")
+			cmd.Flags().Set("output", outputFormat)
 			saConfig := serviceAccountConfig{
+				PrintFlags: &printers.PrintFlags{
+					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+					OutputFormat: &outputFormat,
+				},
+
 				out:   out,
 				local: false}
 			err := saConfig.Complete(tf, cmd, input.args)
@@ -385,12 +416,22 @@ func TestServiceAccountValidation(t *testing.T) {
 					return nil, nil
 				}),
 			}
+
+			outputFormat := ""
+
 			tf.Namespace = "test"
 			out := bytes.NewBuffer([]byte{})
 			cmd := NewCmdServiceAccount(tf, out, out)
 			cmd.SetOutput(out)
 
-			saConfig := &serviceAccountConfig{}
+			saConfig := &serviceAccountConfig{
+				PrintFlags: &printers.PrintFlags{
+					JSONYamlPrintFlags: printers.NewJSONYamlPrintFlags(),
+					NamePrintFlags:     printers.NewNamePrintFlags("", false),
+
+					OutputFormat: &outputFormat,
+				},
+			}
 			err := saConfig.Complete(tf, cmd, input.args)
 			assert.EqualError(t, err, input.errorString)
 		})

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -74,7 +74,7 @@ type SubjectOptions struct {
 	Groups          []string
 	ServiceAccounts []string
 
-	PrintObject func(obj runtime.Object) error
+	PrintObj func(obj runtime.Object) error
 }
 
 func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
@@ -117,14 +117,14 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 
-	o.PrintFlags.Complete(o.DryRun)
-
+	if o.DryRun {
+		o.PrintFlags.Complete("%s (dry run)")
+	}
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
 	}
-
-	o.PrintObject = func(obj runtime.Object) error {
+	o.PrintObj = func(obj runtime.Object) error {
 		return printer.PrintObj(obj, o.Out)
 	}
 
@@ -251,7 +251,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObject(info.Object); err != nil {
+			if err := o.PrintObj(info.Object); err != nil {
 				return err
 			}
 			continue
@@ -264,7 +264,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 		info.Refresh(obj, true)
 
-		return o.PrintObject(info.AsVersioned())
+		return o.PrintObj(info.AsVersioned())
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/printers"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +56,8 @@ type updateSubjects func(existings []rbac.Subject, targets []rbac.Subject) (bool
 // SubjectOptions is the start of the data required to perform the operation. As new fields are added, add them here instead of
 // referencing the cmd.Flags
 type SubjectOptions struct {
+	PrintFlags *printers.PrintFlags
+
 	resource.FilenameOptions
 
 	Infos             []*resource.Info
@@ -70,11 +74,13 @@ type SubjectOptions struct {
 	Groups          []string
 	ServiceAccounts []string
 
-	PrintObject func(obj runtime.Object, out io.Writer) error
+	PrintObject func(obj runtime.Object) error
 }
 
 func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &SubjectOptions{
+		PrintFlags: printers.NewPrintFlags("subjects updated"),
+
 		Out: out,
 		Err: errOut,
 	}
@@ -92,7 +98,8 @@ func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 		},
 	}
 
-	cmdutil.AddPrinterFlags(cmd)
+	options.PrintFlags.AddFlags(cmd)
+
 	usage := "the resource to update the subjects"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmd.Flags().BoolVar(&options.All, "all", options.All, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
@@ -109,8 +116,16 @@ func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Co
 func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
-	o.PrintObject = func(obj runtime.Object, out io.Writer) error {
-		return cmdutil.PrintObject(cmd, obj, out)
+
+	o.PrintFlags.Complete(o.DryRun)
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObject = func(obj runtime.Object) error {
+		return printer.PrintObj(obj, o.Out)
 	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
@@ -236,7 +251,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObject(info.Object, o.Out); err != nil {
+			if err := o.PrintObject(info.Object); err != nil {
 				return err
 			}
 			continue
@@ -249,11 +264,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 		info.Refresh(obj, true)
 
-		shortOutput := o.Output == "name"
-		if len(o.Output) > 0 && !shortOutput {
-			return o.PrintObject(info.AsVersioned(), o.Out)
-		}
-		cmdutil.PrintSuccess(shortOutput, o.Out, info.Object, false, "subjects updated")
+		return o.PrintObject(info.AsVersioned())
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/printers/flags.go
+++ b/pkg/printers/flags.go
@@ -45,8 +45,8 @@ type PrintFlags struct {
 	OutputFormat *string
 }
 
-func (f *PrintFlags) Complete(dryRun bool) error {
-	f.NamePrintFlags.DryRun = dryRun
+func (f *PrintFlags) Complete(messageTemplate string) error {
+	f.NamePrintFlags.Operation = fmt.Sprintf(messageTemplate, f.NamePrintFlags.Operation)
 	return nil
 }
 
@@ -80,6 +80,6 @@ func NewPrintFlags(operation string) *PrintFlags {
 		OutputFormat: &outputFormat,
 
 		JSONYamlPrintFlags: NewJSONYamlPrintFlags(),
-		NamePrintFlags:     NewNamePrintFlags(operation, false),
+		NamePrintFlags:     NewNamePrintFlags(operation),
 	}
 }

--- a/pkg/printers/name_flags.go
+++ b/pkg/printers/name_flags.go
@@ -31,10 +31,6 @@ import (
 // a resource's fully-qualified Kind.group/name, or a successful
 // message about that resource if an Operation is provided.
 type NamePrintFlags struct {
-	// DryRun indicates whether the "(dry run)" message
-	// should be appended to the finalized "successful"
-	// message printed about an action on an object.
-	DryRun bool
 	// Operation describes the name of the action that
 	// took place on an object, to be included in the
 	// finalized "successful" message.
@@ -51,10 +47,6 @@ func (f *NamePrintFlags) ToPrinter(outputFormat string) (ResourcePrinter, error)
 		Operation: f.Operation,
 		Typer:     scheme.Scheme,
 		Decoders:  decoders,
-	}
-
-	if f.DryRun {
-		namePrinter.Operation = namePrinter.Operation + " (dry run)"
 	}
 
 	outputFormat = strings.ToLower(outputFormat)
@@ -75,9 +67,8 @@ func (f *NamePrintFlags) AddFlags(c *cobra.Command) {}
 
 // NewNamePrintFlags returns flags associated with
 // --name printing, with default values set.
-func NewNamePrintFlags(operation string, dryRun bool) *NamePrintFlags {
+func NewNamePrintFlags(operation string) *NamePrintFlags {
 	return &NamePrintFlags{
 		Operation: operation,
-		DryRun:    dryRun,
 	}
 }

--- a/pkg/printers/name_flags_test.go
+++ b/pkg/printers/name_flags_test.go
@@ -50,12 +50,6 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 			expectedOutput: "pod/foo",
 		},
 		{
-			name:           "empty output format and an operation prints success message with dry run",
-			operation:      "patched",
-			dryRun:         true,
-			expectedOutput: "pod/foo patched (dry run)",
-		},
-		{
 			name:          "operation and no valid \"name\" output does not match a printer",
 			operation:     "patched",
 			outputFormat:  "invalid",
@@ -83,7 +77,6 @@ func TestNamePrinterSupportsExpectedFormats(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			printFlags := printers.NamePrintFlags{
 				Operation: tc.operation,
-				DryRun:    tc.dryRun,
 			}
 
 			p, err := printFlags.ToPrinter(tc.outputFormat)

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -42,7 +42,7 @@ func GetStandardPrinter(typer runtime.ObjectTyper, encoder runtime.Encoder, deco
 		printer = p
 
 	case "name":
-		nameFlags := NewNamePrintFlags("", false)
+		nameFlags := NewNamePrintFlags("")
 		namePrinter, err := nameFlags.ToPrinter(format)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

~~Depends on https://github.com/kubernetes/kubernetes/pull/62139
Opening now to test with CI~~

Wires PrintFlags through all `kubectl set` commands.

cc @soltysh @deads2k 