### PR TITLE
fix generated bindata

### DIFF
--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -13651,7 +13651,7 @@ msgstr "Imposta il current-context in un file kubeconfig"
 
 #: pkg/kubectl/cmd/describe.go:86
 msgid "Show details of a specific resource or group of resources"
-msgstr "Mostra i dettagli di una specifiche risorsa o un gruppo di risorse"
+msgstr "Mostra i dettagli di una specifica risorsa o un gruppo di risorse"
 
 #: pkg/kubectl/cmd/rollout/rollout_status.go:58
 msgid "Show the status of the rollout"


### PR DESCRIPTION
Changes in https://github.com/kubernetes/kubernetes/pull/60878/files cause test failure
e.g. log: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/61905/pull-kubernetes-verify/84901/

The failing test was complaining about 
```
   #: pkg/kubectl/cmd/describe.go:86
   msgid "Show details of a specific resource or group of resources"
  -msgstr "Mostra i dettagli di una specifiche risorsa o un gruppo di risorse"
  +msgstr "Mostra i dettagli di una specifica risorsa o un gruppo di risorse"
```
This failing test blocks all the change in `staging/`.

The change in this PR is generated by run `hack/generate-bindata.sh`

```release-note
NONE
```
