### PR TITLE
Wait longer in pod cleanup

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2077,11 +2077,6 @@ func AssertCleanup(ns string, selectors ...string) {
 		nsArg = fmt.Sprintf("--namespace=%s", ns)
 	}
 
-	backoff := wait.Backoff{
-		Duration: 5 * time.Second,
-		Factor:   2,
-		Steps:    3,
-	}
 	var e error
 	verifyCleanupFunc := func() (bool, error) {
 		e = nil
@@ -2099,7 +2094,7 @@ func AssertCleanup(ns string, selectors ...string) {
 		}
 		return true, nil
 	}
-	err := wait.ExponentialBackoff(backoff, verifyCleanupFunc)
+	err := wait.PollImmediate(500*time.Millisecond, 1*time.Minute, verifyCleanupFunc)
 	if err != nil {
 		Failf(e.Error())
 	}


### PR DESCRIPTION
I've checked the [garbage collector tests](https://github.com/kubernetes/kubernetes/blob/827b3d77cde4a5d28bea5b2adece154d198ef85d/test/e2e/apimachinery/garbage_collector.go#L557) and usually they're waiting up to a minute to clean the resources. So I'm proposing to use that same values when waiting for the pod cleanup. I was not able to reproduce the problem locally, but from reading the logs it looks like the problem might be with just the timing nothing else. 

Related to #61484

/assign @Liujingfang1 @mengqiy 