### PR TITLE
fluentd-elasticsearch addon: allow graceful shutdown in fluentd-es image.

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
@@ -20,4 +20,4 @@
 # For systems without journald
 mkdir -p /var/log/journal
 
-/usr/local/bin/fluentd $@
+exec /usr/local/bin/fluentd $@


### PR DESCRIPTION
This PR contains an optimisation to the fluentd-elasticsearch addon. Restarting fluentd pods took unnecessarily long because the start script in the image did not support propagating signals to the actual fluentd process. This patch fixes this behaviour.

