### PR TITLE
Add validation when removing cluster-scope resources and providing namespace

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -5195,7 +5195,8 @@ runTests() {
     kube::test::get_object_assert 'clusterrolebindings -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-CRB:'
     kube::test::get_object_assert 'clusterroles -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-CR:'
 
-    kubectl delete "${kube_flags[@]}" rolebindings,role,clusterroles,clusterrolebindings -n some-other-random -l test-cmd=auth
+    kubectl delete "${kube_flags[@]}" clusterroles,clusterrolebindings -l test-cmd=auth
+    kubectl delete "${kube_flags[@]}" rolebindings,role -n some-other-random -l test-cmd=auth
   fi
 
   #####################


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr prevents use-cases such as `kubectl delete ns --all -n xyz` by verifying if a cluster-scope resource is provided with a namespace parameter.

@kubernetes/sig-cli-pr-reviews wdyt about this approach? 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add additional validation when removing cluster-scoped resources
```
