### PR TITLE
fix typo that redefines variable and breaks code

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -374,7 +374,7 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 	nbdToolsFound := false
 
 	if !mapped {
-		nbdToolsFound := checkRbdNbdTools(b.exec)
+		nbdToolsFound = checkRbdNbdTools(b.exec)
 		if nbdToolsFound {
 			devicePath, mapped = waitForPath(b.Pool, b.Image, 1 /*maxRetries*/, true /*useNbdDriver*/)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug in `rbd_util.go`, where a variable is overriden in `if` scope.

**Which issue(s) this PR fixes**
Fixes #32266

**Special notes for your reviewer**:
This is related to the PR: https://github.com/kubernetes/kubernetes/pull/58916 This can not work, as the variable `nbdToolsFound` is changed only in local scope of `if` and is always `false` outside.

**Release note**:
```release-note
Fixed bug in rbd-nbd utility when nbd is used.
```
