### PR TITLE
Bug 1541476 - Pods in crash loop backoff can't be deleted until the crash loop backoff period expires

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -713,7 +713,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.containerLogManager = logs.NewStubContainerLogManager()
 	}
 
-	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
+	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, klet)
 
 	if kubeCfg.ServerTLSBootstrap && kubeDeps.TLSOptions != nil && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
 		var (

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -216,7 +216,7 @@ func newTestKubeletWithImageList(
 	configMapManager := configmap.NewSimpleConfigMapManager(kubelet.kubeClient)
 	kubelet.configMapManager = configMapManager
 	kubelet.podManager = kubepod.NewBasicPodManager(fakeMirrorClient, kubelet.secretManager, kubelet.configMapManager, podtest.NewMockCheckpointManager())
-	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{})
+	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{})
 
 	kubelet.containerRuntime = fakeRuntime
 	kubelet.runtimeCache = containertest.NewFakeRuntimeCache(kubelet.containerRuntime)

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -103,7 +103,7 @@ func newTestManager() *manager {
 	// Add test pod to pod manager, so that status manager can get the pod from pod manager if needed.
 	podManager.AddPod(getTestPod())
 	m := NewManager(
-		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}),
+		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{}),
 		results.NewManager(),
 		nil, // runner
 		refManager,

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -118,7 +118,7 @@ func TestDoProbe(t *testing.T) {
 			}
 
 			// Clean up.
-			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(nil, nil, nil, nil), &statustest.FakePodDeletionSafetyProvider{})
+			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(nil, nil, nil, nil), &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{})
 			resultsManager(m, probeType).Remove(testContainerID)
 		}
 	}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -75,7 +75,7 @@ func TestRunOnce(t *testing.T) {
 		recorder:         &record.FakeRecorder{},
 		cadvisor:         cadvisor,
 		nodeInfo:         testNodeInfo{},
-		statusManager:    status.NewManager(nil, podManager, &statustest.FakePodDeletionSafetyProvider{}),
+		statusManager:    status.NewManager(nil, podManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{}),
 		podManager:       podManager,
 		os:               &containertest.FakeOS{},
 		containerRuntime: fakeRuntime,

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -77,7 +77,7 @@ func (m *manager) testSyncBatch() {
 func newTestManager(kubeClient clientset.Interface) *manager {
 	podManager := kubepod.NewBasicPodManager(podtest.NewFakeMirrorClient(), kubesecret.NewFakeManager(), kubeconfigmap.NewFakeManager(), podtest.NewMockCheckpointManager())
 	podManager.AddPod(getTestPod())
-	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}).(*manager)
+	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{}).(*manager)
 }
 
 func generateRandomMessage() string {

--- a/pkg/kubelet/status/testing/BUILD
+++ b/pkg/kubelet/status/testing/BUILD
@@ -7,7 +7,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["fake_pod_deletion_safety.go"],
+    srcs = [
+        "fake_pod_deletion_safety.go",
+        "fake_pod_try_cleanup.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/kubelet/status/testing",
     deps = ["//vendor/k8s.io/api/core/v1:go_default_library"],
 )

--- a/pkg/kubelet/status/testing/fake_pod_try_cleanup.go
+++ b/pkg/kubelet/status/testing/fake_pod_try_cleanup.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import "k8s.io/api/core/v1"
+
+type FakePodTryCleanupResourcesProvider struct{}
+
+func (f *FakePodTryCleanupResourcesProvider) PodTryCleanupResources(pod *v1.Pod, status v1.PodStatus) error {
+	return nil
+}

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -529,7 +529,7 @@ func createDswpWithVolume(t *testing.T, pv *v1.PersistentVolume, pvc *v1.Persist
 	fakeASW := cache.NewActualStateOfWorld("fake", fakeVolumePluginMgr)
 	fakeRuntime := &containertest.FakeRuntime{}
 
-	fakeStatusManager := status.NewManager(fakeClient, fakePodManager, &statustest.FakePodDeletionSafetyProvider{})
+	fakeStatusManager := status.NewManager(fakeClient, fakePodManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{})
 
 	dswp := &desiredStateOfWorldPopulator{
 		kubeClient:                fakeClient,

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -219,7 +219,7 @@ func newTestVolumeManager(tmpDir string, podManager kubepod.Manager, kubeClient 
 	plugMgr := &volume.VolumePluginMgr{}
 	// TODO (#51147) inject mock prober
 	plugMgr.InitPlugins([]volume.VolumePlugin{plug}, nil /* prober */, volumetest.NewFakeVolumeHost(tmpDir, kubeClient, nil))
-	statusManager := status.NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{})
+	statusManager := status.NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, &statustest.FakePodTryCleanupResourcesProvider{})
 
 	vm := NewVolumeManager(
 		true,


### PR DESCRIPTION
This is a WIP for bug 1541476/ https://github.com/kubernetes/kubernetes/issues/57865
The primary issue is that the pod terminate code checks whether there are any containers alive, and if there are, refuses to allow the pod to exit, so it stays around in terminating state until the GC runs every minute to clean up any stale containers and sandboxes.

I added a routine to attempt to clean up resources (specifically containers).  This has mostly solved the problem.  I ran two loops overnight, one with killing the pod after 7 seconds and one after 300 seconds.  The large majority of cases now exit within 4 seconds, with a small secondary bump at 10-12 seconds.  However, there were three cases (one in the 300 second loop and two in the 7 second loop) where the terminate time was long (42 and 54 seconds in the 7 second loop, 70 seconds in the 300 second loop, which is what I saw prior to my change).  So there's some case that's not taken care of that I'm trying to track down.  The histogram of times required for the pod to terminate looks like this:

```
    543 Pass 1009: |apod-1009   0/1       CrashLoopBackOff   1         7s| 1 seconds
   2185 Pass 1000: |apod-1000   0/1       CrashLoopBackOff   1         8s| 2 seconds
   2326 Pass 1007: |apod-1007   0/1       CrashLoopBackOff   1         7s| 3 seconds
    622 Pass 1016: |apod-1016   0/1       CrashLoopBackOff   1         7s| 4 seconds
     65 Pass 1104: |apod-1104   0/1       CrashLoopBackOff   1         7s| 5 seconds
     10 Pass 1015: |apod-1015   0/1       CrashLoopBackOff   1         7s| 6 seconds
      3 Pass 1889: |apod-1889   0/1       CrashLoopBackOff   1         7s| 7 seconds
      3 Pass 2589: |apod-2589   0/1       CrashLoopBackOff   1         8s| 8 seconds
      5 Pass 2261: |apod-2261   0/1       CrashLoopBackOff   1         8s| 9 seconds
     21 Pass 1186: |apod-1186   0/1       CrashLoopBackOff   1         7s| 10 seconds
    114 Pass 1017: |apod-1017   0/1       CrashLoopBackOff   1         7s| 11 seconds
     96 Pass 1131: |apod-1131   0/1       CrashLoopBackOff   1         7s| 12 seconds
      8 Pass 2472: |apod-2472   1/1       Running   0         8s| 13 seconds
      7 Pass 1781: |apod-1781   0/1       CrashLoopBackOff   1         7s| 14 seconds
      3 Pass 4502: |apod-4502   0/1       Error     1         7s| 15 seconds
      1 Pass 514: |apod-514   0/1       CrashLoopBackOff   1         7s| 42 seconds
      1 Pass 3278: |apod-3278   0/1       CrashLoopBackOff   1         8s| 54 seconds
```

Furthermore, I observed that even terminating the containers does not actually result in them immediately exiting; they stick around until the next GC cleans up their sandboxes.  This seems wrong to me, but at line 792 in kuberuntime_manager.go there's a comment that the sandbox is only stopped, and will be removed with the next garbage collect, indicating that this behavior is deliberate.  But I'd like to investigate why that is the case.

This is all going to take some time to investigate, so the question is whether I file a PR for what I have now (since it overwhelmingly improves the situation) or try to get to the bottom of the ~10% of the cases where it takes 10+ seconds and the tiny handful where it takes a GC cycle.  I can also investigate whether cleaning up the sandbox improves either case. 