### PR TITLE
Automated cherry pick of #62168: fix typo that redefines variable and breaks code

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -372,7 +372,7 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 	nbdToolsFound := false
 
 	if !mapped {
-		nbdToolsFound := checkRbdNbdTools(b.exec)
+		nbdToolsFound = checkRbdNbdTools(b.exec)
 		if nbdToolsFound {
 			devicePath, mapped = waitForPath(b.Pool, b.Image, 1 /*maxRetries*/, true /*useNbdDriver*/)
 		}


### PR DESCRIPTION
Cherry pick of #62168 on release-1.10.

#62168: fix typo that redefines variable and breaks code