### PR TITLE
Add vikaschoudhary16 to the approvers in device manager

### DIFF
--- a/pkg/kubelet/cm/devicemanager/OWNERS
+++ b/pkg/kubelet/cm/devicemanager/OWNERS
@@ -1,7 +1,7 @@
 approvers:
 - jiayingz
 - vishh
+- vikaschoudhary16
 reviewers:
 - mindprince
 - RenaudWasTaken
-- vikaschoudhary16


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to volunteer in the device manager as an approver. I have been working dedicatedly in the device manager since very beginning and, i think, made considerable contributions in getting it graduated to beta. 

**List of my activities in Device Manager**:
Authored:
- Node-level Checkpointing manager: Migrate dockershim and device plugin manager checkpointing #56040
- Call Dial in blocking mode #58319
- Invoke preStart RPC call before container start, if desired by plugin #58282
- Remove redundant sleep from ReRegistration unit test case #57610
- Fix a race in the endpoint.go #57591
- Add unit test for endpoint allocate #58941
- Fix device manager to scan resources.Requests #57278
- Device plugin stub: Take device health dynamically #57267
- Modify endpoint unregister handling #60296
- Handle Unhealthy devices #57266
- Unit test device plugin handler Start() #55698
- Refactor TestPodContainerDeviceAllocation for extensiblity/readability #55692
- Use file store utility for device plugin checkpointing #55382

Authored but not merged yet:
- Add probe based mechanism and Use it in Device Manager #58755
- Add New Resource API proposal #782
- https://docs.google.com/document/d/1dtHpGY-gPe9sY7zzMGnm8Ywo09zJfNH-E1KEALFV39s/edit#heading=h.7fe6spexljh6
- [[PUBLIC] Network Devices Support Proposal](https://docs.google.com/document/d/1TpYqgmJQOctm1oexQRo0cGNb9oyk0vozhmhr6myY99M/edit#heading=h.9skhj6jwr20r)

Reviewed PRs:
- Fixes the races around devicemanager Allocate() and endpoint deletion. #60856
- avoid race condition in device manager startup/shutdown: close socket #59861
- Fix all GPUs exposed when the limit of "nvidia.com/gpu" == 0 #59698
- avoid race condition in device manager and plugin startup/shutdown: wait for goroutines #60034
- Create pkg/kubelet/apis/deviceplugin/v1beta1 directory. #59588
- devicemanager testing: dynamically choose tmp dir #59489
- Add annotations to the device plugin API #58172
- [DevicePlugin] Rework pod-devices module #56398
- Refactor Device Plugin Registration #52616
- Stub Device Plugin refactor: 600x speedup #52612
- Update device plugin document to show NVIDIA device plugin #6721
- Support for resource quota on extended resources #57302
- Rename package deviceplugin => devicemanager. #56870
- Re-uses device plugin resources allocated to init containers. #56818
- Prohibit requesting device plugin resources in init-containers #56659
- Add a paragraph on device plugin upgrade in device plugin doc. #6501
- Update device plugin proposal doc to match 1.9 device plugin changes. #1447
- Extends deviceplugin to gracefully handle full device plugin lifecycle. #55088
- Add stub device plugin for conformance e2e test #54792
- Implementation of the Device Plugin Manager #50482
- Deviceplugin jiayingz #51209
- Device Plugin Design Proposal #695

Issues that I involved with:
- Support device plugin advertised timeouts #58866
- Device plugin checkpointing should be more reliable #54088
- Devices are not re-used when paired with init containers #56022
- Device Plugin Race #56026
- Device manager only considers extended resource limits when allocating devices. #57276
- deviceplugin unit test failure #58281
- [DevicePlugin] Should we retry when ListAndWatch gRPC call failed? #58372
- [DevicePlugin] Change the multiple Allocate call to a single Pod Admit call #59370
- [DevicePlugin] Support Unlimited Resources #59380
- Kubelet device plugin APIs: Deallocate #59110
- Kubelet device plugin to pass additional information about Pods to Allocate call #59109


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
/cc @jiayingz @vishh @derekwaynecarr @dchen1107 @ConnorDoyle @RenaudWasTaken @jeremyeder 