### PR TITLE
Provide a more ideal example for scheduler extender policy.

### DIFF
--- a/examples/scheduler-policy-config-with-extender.json
+++ b/examples/scheduler-policy-config-with-extender.json
@@ -1,19 +1,6 @@
 {
 "kind" : "Policy",
 "apiVersion" : "v1",
-"predicates" : [
-	{"name" : "PodFitsHostPorts"},
-	{"name" : "PodFitsResources"},
-	{"name" : "NoDiskConflict"},
-	{"name" : "MatchNodeSelector"},
-	{"name" : "HostName"}
-	],
-"priorities" : [
-	{"name" : "LeastRequestedPriority", "weight" : 1},
-	{"name" : "BalancedResourceAllocation", "weight" : 1},
-	{"name" : "ServiceSpreadingPriority", "weight" : 1},
-	{"name" : "EqualPriority", "weight" : 1}
-	],
 "extenders" : [
 	{
         "urlPrefix": "http://127.0.0.1:12346/scheduler",
@@ -24,7 +11,5 @@
         "enableHttps": false,
         "nodeCacheCapable": false
 	}
-    ],
-"hardPodAffinitySymmetricWeight" : 10,
-"alwaysCheckAllPredicates" : false
+    ]
 }


### PR DESCRIPTION
We now use default predicates/priorities if they are unspecified in the policy
config (#59363).

The other example in ./scheduler-policy-config.json shows how to use priorities
and predicates.

Let's use this example to show how to use extenders. When you are using
extenders you don't necessarily want to mess with priorities and predicates
(#45188).

```release-note
NONE
```
