### PR TITLE
accelerators: remove Accelerators from feature gates

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -631,9 +631,9 @@ def configure_kubelet(dns, ingress_ip):
 
     if is_state('kubernetes-worker.gpu.enabled'):
         hookenv.log('Adding '
-                    '--feature-gates=Accelerators=true,DevicePlugins=true '
+                    '--feature-gates=DevicePlugins=true '
                     'to kubelet')
-        kubelet_opts['feature-gates'] = 'Accelerators=true,DevicePlugins=true'
+        kubelet_opts['feature-gates'] = 'DevicePlugins=true'
 
     configure_kubernetes_service('kubelet', kubelet_opts, 'kubelet-extra-args')
 

--- a/cluster/kubemark/gce/config-default.sh
+++ b/cluster/kubemark/gce/config-default.sh
@@ -120,10 +120,6 @@ fi
 # Optional: set feature gates
 FEATURE_GATES="${KUBE_FEATURE_GATES:-ExperimentalCriticalPodAnnotation=true}"
 
-if [[ ! -z "${NODE_ACCELERATORS}" ]]; then
-    FEATURE_GATES="${FEATURE_GATES},Accelerators=true"
-fi
-
 # Enable a simple "AdvancedAuditing" setup for testing.
 ENABLE_APISERVER_ADVANCED_AUDIT="${ENABLE_APISERVER_ADVANCED_AUDIT:-false}"
 


### PR DESCRIPTION
Passing this flag is preventing clusters from coming up:

```
server.go:165] unrecognized key: Accelerators
```