### PR TITLE
Capture kernel logs in example fluentd.conf

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -367,6 +367,22 @@ data:
       read_from_head true
       tag node-problem-detector
     </source>
+    
+    <source>
+      @id kernel
+      @type systemd
+      filters [{ "_TRANSPORT": "kernel" }]
+      <storage>
+        @type local
+        persistent true
+      </storage>
+      <entry>
+        fields_strip_underscores true
+        fields_lowercase true
+      </entry>
+      read_from_head true
+      tag kernel
+    </source>
 
   forward.input.conf: |-
     # Takes the messages sent over TCP


### PR DESCRIPTION
I find it useful to have the kernel logs available for searching, for example that's the only place you can see processes killed when they hit memory limits.
