### PR TITLE
Fix IP-alias subnet creation logic

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1731,12 +1731,6 @@ function create-subnetworks() {
     --region ${REGION} \
     ${IP_ALIAS_SUBNETWORK} 2>/dev/null)
   if [[ -z ${subnet} ]]; then
-    # Only allow auto-creation for default subnets
-    if [[ ${IP_ALIAS_SUBNETWORK} != ${INSTANCE_PREFIX}-subnet-default ]]; then
-      echo "${color_red}Subnetwork ${NETWORK}:${IP_ALIAS_SUBNETWORK} does not exist${color_norm}"
-      exit 1
-    fi
-
     echo "Creating subnet ${NETWORK}:${IP_ALIAS_SUBNETWORK}"
     gcloud beta compute networks subnets create \
       ${IP_ALIAS_SUBNETWORK} \


### PR DESCRIPTION
Follows https://github.com/kubernetes/kubernetes/pull/62172

This fixes the failures happening when using ip-alias with custom network. The subnet name shouldn't be checked against the default value during creation, but just created if not present (as it's name can be different than default based on the value of `KUBE_GCE_IP_ALIAS_SUBNETWORK`).

/cc @wojtek-t 

```release-note
NONE
```