### PR TITLE
Remove need for server connections for dry-run create

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -2387,11 +2387,12 @@ run_secrets_test() {
   create_and_use_new_namespace
   kube::log::status "Testing secrets"
 
-  # Ensure dry run succeeds and includes kind, apiVersion and data
-  output_message=$(kubectl create secret generic test --from-literal=key1=value1 --dry-run -o yaml)
+  # Ensure dry run succeeds and includes kind, apiVersion and data, and doesn't require a server connection
+  output_message=$(kubectl create secret generic test --from-literal=key1=value1 --dry-run -o yaml --server=example.com --v=6)
   kube::test::if_has_string "${output_message}" 'kind: Secret'
   kube::test::if_has_string "${output_message}" 'apiVersion: v1'
   kube::test::if_has_string "${output_message}" 'key1: dmFsdWUx'
+  kube::test::if_has_not_string "${output_message}" 'example.com'
 
   ### Create a new namespace
   # Pre-condition: the test-secrets namespace does not exist

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -315,34 +315,34 @@ func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, o
 		return err
 	}
 	mapper, typer := f.Object()
-	gvks, _, err := typer.ObjectKinds(obj)
-	if err != nil {
-		return err
-	}
-	gvk := gvks[0]
-	mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
-	if err != nil {
-		return err
-	}
-	client, err := f.ClientForMapping(mapping)
-	if err != nil {
-		return err
-	}
-	resourceMapper := &resource.Mapper{
-		ObjectTyper:  typer,
-		RESTMapper:   mapper,
-		ClientMapper: resource.ClientMapperFunc(f.ClientForMapping),
-	}
-	info, err := resourceMapper.InfoForObject(obj, nil)
-	if err != nil {
-		return err
-	}
-	if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, cmdutil.InternalVersionJSONEncoder()); err != nil {
-		return err
-	}
-	obj = info.Object
-
 	if !options.DryRun {
+		gvks, _, err := typer.ObjectKinds(obj)
+		if err != nil {
+			return err
+		}
+		gvk := gvks[0]
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
+		if err != nil {
+			return err
+		}
+		client, err := f.ClientForMapping(mapping)
+		if err != nil {
+			return err
+		}
+		resourceMapper := &resource.Mapper{
+			ObjectTyper:  typer,
+			RESTMapper:   mapper,
+			ClientMapper: resource.ClientMapperFunc(f.ClientForMapping),
+		}
+		info, err := resourceMapper.InfoForObject(obj, nil)
+		if err != nil {
+			return err
+		}
+		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+			return err
+		}
+		obj = info.Object
+
 		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
 		if err != nil {
 			return err
@@ -354,7 +354,7 @@ func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, o
 	}
 
 	if useShortOutput := options.OutputFormat == "name"; useShortOutput || len(options.OutputFormat) == 0 {
-		cmdutil.PrintSuccess(useShortOutput, out, info.Object, options.DryRun, "created")
+		cmdutil.PrintSuccess(useShortOutput, out, obj, options.DryRun, "created")
 		return nil
 	}
 


### PR DESCRIPTION
when running create commands in --dry-run mode, we don't need a server connection or restmapper information

```release-note
NONE
```