### PR TITLE
Pass 2: k8s GCR vanity URL

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -62,7 +62,7 @@ DOCKERIZED_BINARIES = {
 
 [docker_bundle(
     name = binary,
-    # TODO(thockin): remove the google_containers name after release 1.10.
+    # TODO(thockin): remove the google_containers name after release 1.11.
     images = {
         "k8s.gcr.io/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal",
         "gcr.io/google_containers/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal",

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -285,7 +285,7 @@ function kube::release::create_docker_images_for_server() {
     mkdir -p "${images_dir}"
 
     local -r docker_registry="k8s.gcr.io"
-    # TODO(thockin): Remove all traces of this after 1.10 release.
+    # TODO(thockin): Remove all traces of this after 1.11 release.
     # The following is the old non-indirected registry name.  To ease the
     # transition to the new name (above), we are double-tagging saved images.
     local -r deprecated_registry="gcr.io/google_containers"

--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: fluentd-gcp-scaler
       containers:
       - name: fluentd-gcp-scaler
-        image: gcr.io/google-containers/fluentd-gcp-scaler:0.3
+        image: k8s.gcr.io/fluentd-gcp-scaler:0.3
         command:
           - /scaler.sh
           - --ds-name=fluentd-gcp-v3.0.0

--- a/hack/testdata/deployment-label-change3.yaml
+++ b/hack/testdata/deployment-label-change3.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -440,7 +440,7 @@ func generateScaleTestBackendDeploymentSpec(numReplicas int32) *extensions.Deplo
 					Containers: []v1.Container{
 						{
 							Name:  scaleTestBackendName,
-							Image: "gcr.io/google_containers/echoserver:1.10",
+							Image: "k8s.gcr.io/echoserver:1.10",
 							Ports: []v1.ContainerPort{{ContainerPort: 8080}},
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -21,6 +21,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"fmt"
+	"strings"
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
@@ -34,8 +37,6 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
-	"strings"
-	"time"
 )
 
 const (
@@ -333,7 +334,7 @@ func newPodTemplate(labels map[string]string) *v1.PodTemplateSpec {
 				// and prints the entire file to stdout.
 				{
 					Name:    "busybox",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "k8s.gcr.io/busybox",
 					Command: []string{"sh", "-c"},
 					Args: []string{
 						"echo ${POD_NAME} >> /mnt/data/regional-pd/pods.txt;" +

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/google_containers/echoserver:1.10
+        image: k8s.gcr.io/echoserver:1.10
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Also push out the old URL deprecation since we have not started the community transition yet and there are some instances of it still floating about.

```release-note
NONE
```
