### PR TITLE
Make priority rest mapper handle partial discovery results

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
@@ -54,12 +54,12 @@ func (m PriorityRESTMapper) String() string {
 
 // ResourceFor finds all resources, then passes them through the ResourcePriority patterns to find a single matching hit.
 func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
-	originalGVRs, err := m.Delegate.ResourcesFor(partiallySpecifiedResource)
-	if err != nil {
-		return schema.GroupVersionResource{}, err
+	originalGVRs, originalErr := m.Delegate.ResourcesFor(partiallySpecifiedResource)
+	if originalErr != nil && len(originalGVRs) == 0 {
+		return schema.GroupVersionResource{}, originalErr
 	}
 	if len(originalGVRs) == 1 {
-		return originalGVRs[0], nil
+		return originalGVRs[0], originalErr
 	}
 
 	remainingGVRs := append([]schema.GroupVersionResource{}, originalGVRs...)
@@ -77,7 +77,7 @@ func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource schema.GroupV
 			continue
 		case 1:
 			// one match, return
-			return matchedGVRs[0], nil
+			return matchedGVRs[0], originalErr
 		default:
 			// more than one match, use the matched hits as the list moving to the next pattern.
 			// this way you can have a series of selection criteria
@@ -90,12 +90,12 @@ func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource schema.GroupV
 
 // KindFor finds all kinds, then passes them through the KindPriority patterns to find a single matching hit.
 func (m PriorityRESTMapper) KindFor(partiallySpecifiedResource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	originalGVKs, err := m.Delegate.KindsFor(partiallySpecifiedResource)
-	if err != nil {
-		return schema.GroupVersionKind{}, err
+	originalGVKs, originalErr := m.Delegate.KindsFor(partiallySpecifiedResource)
+	if originalErr != nil && len(originalGVKs) == 0 {
+		return schema.GroupVersionKind{}, originalErr
 	}
 	if len(originalGVKs) == 1 {
-		return originalGVKs[0], nil
+		return originalGVKs[0], originalErr
 	}
 
 	remainingGVKs := append([]schema.GroupVersionKind{}, originalGVKs...)
@@ -113,7 +113,7 @@ func (m PriorityRESTMapper) KindFor(partiallySpecifiedResource schema.GroupVersi
 			continue
 		case 1:
 			// one match, return
-			return matchedGVKs[0], nil
+			return matchedGVKs[0], originalErr
 		default:
 			// more than one match, use the matched hits as the list moving to the next pattern.
 			// this way you can have a series of selection criteria
@@ -153,9 +153,9 @@ func kindMatches(pattern schema.GroupVersionKind, kind schema.GroupVersionKind) 
 }
 
 func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (mapping *RESTMapping, err error) {
-	mappings, err := m.Delegate.RESTMappings(gk, versions...)
-	if err != nil {
-		return nil, err
+	mappings, originalErr := m.Delegate.RESTMappings(gk, versions...)
+	if originalErr != nil && len(mappings) == 0 {
+		return nil, originalErr
 	}
 
 	// any versions the user provides take priority
@@ -187,7 +187,7 @@ func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string)
 			continue
 		case 1:
 			// one match, return
-			return matching[0], nil
+			return matching[0], originalErr
 		default:
 			// more than one match, use the matched hits as the list moving to the next pattern.
 			// this way you can have a series of selection criteria
@@ -195,7 +195,7 @@ func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string)
 		}
 	}
 	if len(remaining) == 1 {
-		return remaining[0], nil
+		return remaining[0], originalErr
 	}
 
 	var kinds []schema.GroupVersionKind

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
@@ -35,6 +35,30 @@ func TestPriorityRESTMapperResourceForErrorHandling(t *testing.T) {
 		err              string
 	}{
 		{
+			name:     "error",
+			delegate: fixedRESTMapper{err: errors.New("delegateError")},
+			err:      "delegateError",
+		},
+		{
+			name:     "single hit + error",
+			delegate: fixedRESTMapper{resourcesFor: []schema.GroupVersionResource{{Resource: "single-hit"}}, err: errors.New("delegateError")},
+			result:   schema.GroupVersionResource{Resource: "single-hit"},
+			err:      "delegateError",
+		},
+		{
+			name: "group selection + error",
+			delegate: fixedRESTMapper{resourcesFor: []schema.GroupVersionResource{
+				{Group: "one", Version: "a", Resource: "first"},
+				{Group: "two", Version: "b", Resource: "second"},
+			}, err: errors.New("delegateError")},
+			resourcePatterns: []schema.GroupVersionResource{
+				{Group: "one", Version: AnyVersion, Resource: AnyResource},
+			},
+			result: schema.GroupVersionResource{Group: "one", Version: "a", Resource: "first"},
+			err:    "delegateError",
+		},
+
+		{
 			name:     "single hit",
 			delegate: fixedRESTMapper{resourcesFor: []schema.GroupVersionResource{{Resource: "single-hit"}}},
 			result:   schema.GroupVersionResource{Resource: "single-hit"},
@@ -106,6 +130,10 @@ func TestPriorityRESTMapperResourceForErrorHandling(t *testing.T) {
 		if len(tc.err) == 0 && actualErr == nil {
 			continue
 		}
+		if len(tc.err) == 0 && actualErr != nil {
+			t.Errorf("%s: unexpected err: %v", tc.name, actualErr)
+			continue
+		}
 		if len(tc.err) > 0 && actualErr == nil {
 			t.Errorf("%s: missing expected err: %v", tc.name, tc.err)
 			continue
@@ -125,6 +153,30 @@ func TestPriorityRESTMapperKindForErrorHandling(t *testing.T) {
 		result       schema.GroupVersionKind
 		err          string
 	}{
+		{
+			name:     "error",
+			delegate: fixedRESTMapper{err: errors.New("delegateErr")},
+			err:      "delegateErr",
+		},
+		{
+			name:     "single hit + error",
+			delegate: fixedRESTMapper{kindsFor: []schema.GroupVersionKind{{Kind: "single-hit"}}, err: errors.New("delegateErr")},
+			result:   schema.GroupVersionKind{Kind: "single-hit"},
+			err:      "delegateErr",
+		},
+		{
+			name: "group selection + error",
+			delegate: fixedRESTMapper{kindsFor: []schema.GroupVersionKind{
+				{Group: "one", Version: "a", Kind: "first"},
+				{Group: "two", Version: "b", Kind: "second"},
+			}, err: errors.New("delegateErr")},
+			kindPatterns: []schema.GroupVersionKind{
+				{Group: "one", Version: AnyVersion, Kind: AnyKind},
+			},
+			result: schema.GroupVersionKind{Group: "one", Version: "a", Kind: "first"},
+			err:    "delegateErr",
+		},
+
 		{
 			name:     "single hit",
 			delegate: fixedRESTMapper{kindsFor: []schema.GroupVersionKind{{Kind: "single-hit"}}},
@@ -197,6 +249,10 @@ func TestPriorityRESTMapperKindForErrorHandling(t *testing.T) {
 		if len(tc.err) == 0 && actualErr == nil {
 			continue
 		}
+		if len(tc.err) == 0 && actualErr != nil {
+			t.Errorf("%s: unexpected err: %v", tc.name, actualErr)
+			continue
+		}
 		if len(tc.err) > 0 && actualErr == nil {
 			t.Errorf("%s: missing expected err: %v", tc.name, tc.err)
 			continue
@@ -246,6 +302,13 @@ func TestPriorityRESTMapperRESTMapping(t *testing.T) {
 			name:   "accept first failure",
 			mapper: PriorityRESTMapper{Delegate: MultiRESTMapper{fixedRESTMapper{err: errors.New("fail on this")}, fixedRESTMapper{mappings: []*RESTMapping{mapping1}}}},
 			input:  schema.GroupKind{Kind: "Foo"},
+			err:    errors.New("fail on this"),
+		},
+		{
+			name:   "result + error",
+			mapper: PriorityRESTMapper{Delegate: fixedRESTMapper{mappings: []*RESTMapping{mapping1}, err: errors.New("fail on this")}},
+			input:  schema.GroupKind{Kind: "Foo"},
+			result: mapping1,
 			err:    errors.New("fail on this"),
 		},
 		{


### PR DESCRIPTION
If the delegate restmapper returns partial results, let the priority restmapper find a prioritized entry and propagate the original error

```release-note
NONE
```