### PR TITLE
Fully resolve tmpdir in verify-bazel.sh, since it might be a symlink on macOS

### DIFF
--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -31,7 +31,7 @@ fi
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
-_tmpdir="$(mktemp -d -t verify-bazel.XXXXXX)"
+_tmpdir="$(kube::realpath $(mktemp -d -t verify-bazel.XXXXXX))"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 
 _tmp_gopath="${_tmpdir}/go"

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -35,7 +35,7 @@ kube::util::ensure_godep_version
 
 if [[ -z ${TMP_GOPATH:-} ]]; then
   # Create a nice clean place to put our new godeps
-  _tmpdir="$(mktemp -d -t gopath.XXXXXX)"
+  _tmpdir="$(kube::realpath $(mktemp -d -t gopath.XXXXXX))"
 else
   # reuse what we might have saved previously
   _tmpdir="${TMP_GOPATH}"


### PR DESCRIPTION
**What this PR does / why we need it**: Apparently the system tmpdir is inside a symlink on macOS, which confuses gazelle's symlink logic. By resolving this symlink to the absolute path, we can avoid the issue. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61986

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @cblecker 
cc @patrikerdes