### PR TITLE
Update build documentation about memory required to build Kubernetes on osx to 4.5G

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -6,7 +6,7 @@ Building Kubernetes is easy if you take advantage of the containerized build env
 
 1. Docker, using one of the following configurations:
   * **macOS** You can either use Docker for Mac or docker-machine. See installation instructions [here](https://docs.docker.com/docker-for-mac/).
-     **Note**: You will want to set the Docker VM to have at least 3GB of initial memory or building will likely fail. (See: [#11852]( http://issue.k8s.io/11852)).
+     **Note**: You will want to set the Docker VM to have at least 4.5GB of initial memory or building will likely fail. (See: [#11852]( http://issue.k8s.io/11852)).
   * **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.
   * **Remote Docker engine** Use a big machine in the cloud to build faster. This is a little trickier so look at the section later on.
 2. **Optional** [Google Cloud SDK](https://developers.google.com/cloud/sdk/)


### PR DESCRIPTION
**What this PR does / why we need it**:

To build Kubernetes on osx you now need at least 4.5G of memory configured for Docker.

**Which issue(s) this PR fixes**:
Fixes #62218

**Special notes for your reviewer**:

On an osx I experimented configuring Docker at 0.5GB memory increments. I found that I was unable to successfully build Kubernetes (`make quick-release`) on osx when I configured Docker with 4GB of memory. I was able to build kubernetes after configuring 4.5GB.

**Release note**:
```release-note
NONE
```
