### PR TITLE
Automated cherry pick of #61000: Split out the hostname when default dhcp_domain is used in

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
@@ -60,7 +61,7 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
-	return types.NodeName(md.Hostname), nil
+	return types.NodeName(strings.Split(md.Hostname, ".")[0]), nil
 }
 
 // AddSSHKeyToAllInstances is not implemented for OpenStack


### PR DESCRIPTION
Cherry pick of #61000 on release-1.10.

#61000: Split out the hostname when default dhcp_domain is used in