### PR TITLE
Automated cherry pick of #61890: Specify DHCP domain for hostname

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -121,6 +121,7 @@ type RouterOpts struct {
 type MetadataOpts struct {
 	SearchOrder    string     `gcfg:"search-order"`
 	RequestTimeout MyDuration `gcfg:"request-timeout"`
+	DHCPDomain     string     `gcfg:"dhcp-domain"`
 }
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
@@ -233,6 +234,7 @@ func configFromEnv() (cfg Config, ok bool) {
 			cfg.Global.TrustID != "")
 
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
+	cfg.Metadata.DHCPDomain = "novalocal"
 	cfg.BlockStorage.BSVersion = "auto"
 
 	return
@@ -250,6 +252,7 @@ func readConfig(config io.Reader) (Config, error) {
 	cfg.BlockStorage.TrustDevicePath = false
 	cfg.BlockStorage.IgnoreVolumeAZ = false
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
+	cfg.Metadata.DHCPDomain = "novalocal"
 
 	err := gcfg.ReadInto(&cfg, config)
 	return cfg, err

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
@@ -60,7 +61,11 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
-	return types.NodeName(md.Hostname), nil
+	domain := "." + i.opts.DHCPDomain
+	if i.opts.DHCPDomain != "" && strings.HasSuffix(md.Hostname, domain) {
+		return types.NodeName(strings.TrimSuffix(md.Hostname, domain)), nil
+	}
+	return types.NodeName(strings.Split(md.Hostname, ".")[0]), nil
 }
 
 // AddSSHKeyToAllInstances is not implemented for OpenStack


### PR DESCRIPTION
Cherry pick of #61890 on release-1.10.

#61890: Specify DHCP domain for hostname

```release-note
Fixing bug in openstack cloud provider when picking up hostname from metadata service or config drive. If the hostname has a custom domain, we should remove the domain before we use the hostname as the node name in kubernetes.
```
