### PR TITLE
Separate pod priority from preemption

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -381,6 +381,8 @@ type SchedulerServer struct {
 	HealthzServer *http.Server
 	// MetricsServer is optional.
 	MetricsServer *http.Server
+	// Disable pod preemption or not.
+	DisablePreemption bool
 }
 
 // NewSchedulerServer creates a runnable SchedulerServer from configuration.
@@ -445,6 +447,7 @@ func NewSchedulerServer(config *componentconfig.KubeSchedulerConfiguration, mast
 		LeaderElection:                 leaderElectionConfig,
 		HealthzServer:                  healthzServer,
 		MetricsServer:                  metricsServer,
+		DisablePreemption:              config.DisablePreemption,
 	}, nil
 }
 
@@ -659,6 +662,7 @@ func (s *SchedulerServer) SchedulerConfig() (*scheduler.Config, error) {
 		storageClassInformer,
 		s.HardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		s.DisablePreemption,
 	)
 
 	source := s.AlgorithmSource
@@ -716,5 +720,7 @@ func (s *SchedulerServer) SchedulerConfig() (*scheduler.Config, error) {
 	}
 	// Additional tweaks to the config produced by the configurator.
 	config.Recorder = s.Recorder
+
+	config.DisablePreemption = s.DisablePreemption
 	return config, nil
 }

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -111,6 +111,9 @@ type KubeSchedulerConfiguration struct {
 	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
 	// DEPRECATED: This is no longer used.
 	FailureDomains string
+
+	// DisablePreemption disables the pod preemption feature.
+	DisablePreemption bool
 }
 
 // KubeSchedulerLeaderElectionConfiguration expands LeaderElectionConfiguration

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -106,6 +106,9 @@ type KubeSchedulerConfiguration struct {
 
 	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
 	FailureDomains string `json:"failureDomains"`
+
+	// DisablePreemption disables the pod preemption feature.
+	DisablePreemption bool `json:"disablePreemption"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -309,6 +309,7 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_componentconfig_KubeSche
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.FailureDomains = in.FailureDomains
+	out.DisablePreemption = in.DisablePreemption
 	return nil
 }
 
@@ -334,6 +335,7 @@ func autoConvert_componentconfig_KubeSchedulerConfiguration_To_v1alpha1_KubeSche
 	out.EnableProfiling = in.EnableProfiling
 	out.EnableContentionProfiling = in.EnableContentionProfiling
 	out.FailureDomains = in.FailureDomains
+	out.DisablePreemption = in.DisablePreemption
 	return nil
 }
 

--- a/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
@@ -579,6 +579,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			informerFactory.Storage().V1().StorageClasses(),
 			v1.DefaultHardPodAffinitySymmetricWeight,
 			enableEquivalenceCache,
+			false,
 		).CreateFromConfig(policy); err != nil {
 			t.Errorf("%s: Error constructing: %v", v, err)
 			continue

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -506,7 +506,18 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		}
 		queue := NewSchedulingQueue()
 		scheduler := NewGenericScheduler(
-			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyPriorityMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{}, false)
+			cache,
+			nil,
+			queue,
+			test.predicates,
+			algorithm.EmptyPredicateMetadataProducer,
+			test.prioritizers,
+			algorithm.EmptyPriorityMetadataProducer,
+			extenders,
+			nil,
+			schedulertesting.FakePersistentVolumeClaimLister{},
+			false,
+			false)
 		podIgnored := &v1.Pod{}
 		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -98,6 +98,7 @@ type genericScheduler struct {
 	cachedNodeInfoMap        map[string]*schedulercache.NodeInfo
 	volumeBinder             *volumebinder.VolumeBinder
 	pvcLister                corelisters.PersistentVolumeClaimLister
+	disablePreemption        bool
 }
 
 // Schedule tries to schedule the given pod to one of the nodes in the node list.
@@ -1107,7 +1108,9 @@ func NewGenericScheduler(
 	extenders []algorithm.SchedulerExtender,
 	volumeBinder *volumebinder.VolumeBinder,
 	pvcLister corelisters.PersistentVolumeClaimLister,
-	alwaysCheckAllPredicates bool) algorithm.ScheduleAlgorithm {
+	alwaysCheckAllPredicates bool,
+	disablePreemption bool,
+) algorithm.ScheduleAlgorithm {
 	return &genericScheduler{
 		cache:                    cache,
 		equivalenceCache:         eCache,
@@ -1121,5 +1124,6 @@ func NewGenericScheduler(
 		volumeBinder:             volumeBinder,
 		pvcLister:                pvcLister,
 		alwaysCheckAllPredicates: alwaysCheckAllPredicates,
+		disablePreemption:        disablePreemption,
 	}
 }

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -409,7 +409,18 @@ func TestGenericScheduler(t *testing.T) {
 		pvcLister := schedulertesting.FakePersistentVolumeClaimLister(pvcs)
 
 		scheduler := NewGenericScheduler(
-			cache, nil, NewSchedulingQueue(), test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyPriorityMetadataProducer, []algorithm.SchedulerExtender{}, nil, pvcLister, test.alwaysCheckAllPredicates)
+			cache,
+			nil,
+			NewSchedulingQueue(),
+			test.predicates,
+			algorithm.EmptyPredicateMetadataProducer,
+			test.prioritizers,
+			algorithm.EmptyPriorityMetadataProducer,
+			[]algorithm.SchedulerExtender{},
+			nil,
+			pvcLister,
+			test.alwaysCheckAllPredicates,
+			false)
 		machine, err := scheduler.Schedule(test.pod, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 
 		if !reflect.DeepEqual(err, test.wErr) {
@@ -1323,7 +1334,18 @@ func TestPreempt(t *testing.T) {
 			extenders = append(extenders, extender)
 		}
 		scheduler := NewGenericScheduler(
-			cache, nil, NewSchedulingQueue(), map[string]algorithm.FitPredicate{"matches": algorithmpredicates.PodFitsResources}, algorithm.EmptyPredicateMetadataProducer, []algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}}, algorithm.EmptyPriorityMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{}, false)
+			cache,
+			nil,
+			NewSchedulingQueue(),
+			map[string]algorithm.FitPredicate{"matches": algorithmpredicates.PodFitsResources},
+			algorithm.EmptyPredicateMetadataProducer,
+			[]algorithm.PriorityConfig{{Function: numericPriority, Weight: 1}},
+			algorithm.EmptyPriorityMetadataProducer,
+			extenders,
+			nil,
+			schedulertesting.FakePersistentVolumeClaimLister{},
+			false,
+			false)
 		// Call Preempt and check the expected results.
 		node, victims, _, err := scheduler.Preempt(test.pod, schedulertesting.FakeNodeLister(makeNodeList(nodeNames)), error(&FitError{Pod: test.pod, FailedPredicates: failedPredMap}))
 		if err != nil {

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -46,7 +46,10 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
-const enableEquivalenceCache = true
+const (
+	enableEquivalenceCache = true
+	disablePodPreemption   = false
+)
 
 func TestCreate(t *testing.T) {
 	handler := utiltesting.FakeHandler{
@@ -533,6 +536,7 @@ func newConfigFactory(client *clientset.Clientset, hardPodAffinitySymmetricWeigh
 		informerFactory.Storage().V1().StorageClasses(),
 		hardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		disablePodPreemption,
 	)
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -548,6 +548,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 		[]algorithm.SchedulerExtender{},
 		nil,
 		schedulertesting.FakePersistentVolumeClaimLister{},
+		false,
 		false)
 	bindingChan := make(chan *v1.Binding, 1)
 	errChan := make(chan error, 1)
@@ -596,6 +597,7 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		[]algorithm.SchedulerExtender{},
 		nil,
 		schedulertesting.FakePersistentVolumeClaimLister{},
+		false,
 		false)
 	bindingChan := make(chan *v1.Binding, 2)
 	configurator := &FakeConfigurator{

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -63,7 +63,7 @@ type TestContext struct {
 	scheduler              *scheduler.Scheduler
 }
 
-// createConfiguratorWithPodInformer create a configurator for scheduler with given informer factory, custom name and  pod informer.
+// createConfiguratorWithPodInformer creates a configurator for scheduler.
 func createConfiguratorWithPodInformer(
 	schedulerName string,
 	clientSet clientset.Interface,
@@ -116,7 +116,14 @@ func initTestMaster(t *testing.T, nsPrefix string, admission admission.Interface
 	}
 
 	// 2. Create kubeclient
-	context.clientSet = clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Groups[v1.GroupName].GroupVersion()}})
+	context.clientSet = clientset.NewForConfigOrDie(
+		&restclient.Config{
+			QPS: -1, Host: s.URL,
+			ContentConfig: restclient.ContentConfig{
+				GroupVersion: testapi.Groups[v1.GroupName].GroupVersion(),
+			},
+		},
+	)
 	return &context
 }
 
@@ -128,6 +135,21 @@ func initTestScheduler(
 	controllerCh chan struct{},
 	setPodInformer bool,
 	policy *schedulerapi.Policy,
+) *TestContext {
+	// Pod preemption is enabled by default scheduler configuration, but preemption only happens when PodPriority
+	// feature gate is enabled at the same time.
+	return initTestSchedulerWithOptions(t, context, controllerCh, setPodInformer, policy, false)
+}
+
+// initTestSchedulerWithOptions initializes a test environment and creates a scheduler with default
+// configuration and other options.
+func initTestSchedulerWithOptions(
+	t *testing.T,
+	context *TestContext,
+	controllerCh chan struct{},
+	setPodInformer bool,
+	policy *schedulerapi.Policy,
+	disablePreemption bool,
 ) *TestContext {
 	// Enable EnableEquivalenceClassCache for all integration tests.
 	defer utilfeaturetesting.SetFeatureGateDuringTest(
@@ -167,19 +189,29 @@ func initTestScheduler(
 		context.schedulerConfig.StopEverything = controllerCh
 	}
 
+	// set DisablePreemption option
+	context.schedulerConfig.DisablePreemption = disablePreemption
+
 	// set setPodInformer if provided.
 	if setPodInformer {
 		go podInformer.Informer().Run(context.schedulerConfig.StopEverything)
 	}
 
 	eventBroadcaster := record.NewBroadcaster()
-	context.schedulerConfig.Recorder = eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: v1.DefaultSchedulerName})
-	eventBroadcaster.StartRecordingToSink(&clientv1core.EventSinkImpl{Interface: context.clientSet.CoreV1().Events("")})
+	context.schedulerConfig.Recorder = eventBroadcaster.NewRecorder(
+		legacyscheme.Scheme,
+		v1.EventSource{Component: v1.DefaultSchedulerName},
+	)
+	eventBroadcaster.StartRecordingToSink(&clientv1core.EventSinkImpl{
+		Interface: context.clientSet.CoreV1().Events(""),
+	})
 
 	context.informerFactory.Start(context.schedulerConfig.StopEverything)
 	context.informerFactory.WaitForCacheSync(context.schedulerConfig.StopEverything)
 
-	context.scheduler, err = scheduler.NewFromConfigurator(&scheduler.FakeConfigurator{Config: context.schedulerConfig}, nil...)
+	context.scheduler, err = scheduler.NewFromConfigurator(&scheduler.FakeConfigurator{
+		Config: context.schedulerConfig},
+		nil...)
 	if err != nil {
 		t.Fatalf("Couldn't create scheduler: %v", err)
 	}
@@ -191,6 +223,13 @@ func initTestScheduler(
 // configuration.
 func initTest(t *testing.T, nsPrefix string) *TestContext {
 	return initTestScheduler(t, initTestMaster(t, nsPrefix, nil), nil, true, nil)
+}
+
+// initTestDisablePreemption initializes a test environment and creates master and scheduler with default
+// configuration but with pod preemption disabled.
+func initTestDisablePreemption(t *testing.T, nsPrefix string) *TestContext {
+	return initTestSchedulerWithOptions(
+		t, initTestMaster(t, nsPrefix, nil), nil, true, nil, true)
 }
 
 // cleanupTest deletes the scheduler and the test namespace. It should be called
@@ -206,7 +245,8 @@ func cleanupTest(t *testing.T, context *TestContext) {
 
 // waitForReflection waits till the passFunc confirms that the object it expects
 // to see is in the store. Used to observe reflected events.
-func waitForReflection(t *testing.T, nodeLister corelisters.NodeLister, key string, passFunc func(n interface{}) bool) error {
+func waitForReflection(t *testing.T, nodeLister corelisters.NodeLister, key string,
+	passFunc func(n interface{}) bool) error {
 	nodes := []*v1.Node{}
 	err := wait.Poll(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
 		n, err := nodeLister.Get(key)
@@ -345,7 +385,8 @@ func createPausePod(cs clientset.Interface, p *v1.Pod) (*v1.Pod, error) {
 // createPausePodWithResource creates a pod with "Pause" image and the given
 // resources and returns its pointer and error status. The resource list can be
 // nil.
-func createPausePodWithResource(cs clientset.Interface, podName string, nsName string, res *v1.ResourceList) (*v1.Pod, error) {
+func createPausePodWithResource(cs clientset.Interface, podName string,
+	nsName string, res *v1.ResourceList) (*v1.Pod, error) {
 	var conf pausePodConfig
 	if res == nil {
 		conf = pausePodConfig{
@@ -439,7 +480,8 @@ func podUnschedulable(c clientset.Interface, podNamespace, podName string) wait.
 			return false, nil
 		}
 		_, cond := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
-		return cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == v1.PodReasonUnschedulable, nil
+		return cond != nil && cond.Status == v1.ConditionFalse &&
+			cond.Reason == v1.PodReasonUnschedulable, nil
 	}
 }
 
@@ -481,7 +523,8 @@ func cleanupPods(cs clientset.Interface, t *testing.T, pods []*v1.Pod) {
 		}
 	}
 	for _, p := range pods {
-		if err := wait.Poll(time.Second, wait.ForeverTestTimeout, podDeleted(cs, p.Namespace, p.Name)); err != nil {
+		if err := wait.Poll(time.Second, wait.ForeverTestTimeout,
+			podDeleted(cs, p.Namespace, p.Name)); err != nil {
 			t.Errorf("error while waiting for pod  %v/%v to get deleted: %v", p.Namespace, p.Name, err)
 		}
 	}

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -85,6 +85,7 @@ func createConfiguratorWithPodInformer(
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		false,
 	)
 }
 

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -112,5 +112,6 @@ func createSchedulerConfigurator(
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		false,
 	)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Users request to split priority and preemption feature gate so they can use priority separately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62068 

**Special notes for your reviewer**:

~~I kept use `ENABLE_POD_PRIORITY` as ENV name for gce cluster scripts for backward compatibility reason. Please let me know if other approach is preffered.~~

~~This is a potential **break change** as existing clusters will be affected, we may need to include this in 1.11 maybe?~~

TODO: update this doc https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/

[Update] Usage: in config file for scheduler:
```yaml
apiVersion: componentconfig/v1alpha1
kind: KubeSchedulerConfiguration
...
disablePreemption: true
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Split PodPriority and PodPreemption feature gate
```
