### PR TITLE
fix "kubectl create --raw"

### DIFF
--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -264,12 +264,16 @@ func (o *CreateOptions) raw(f cmdutil.Factory) error {
 		}
 	}
 	// TODO post content with stream.  Right now it ignores body content
-	bytes, err := restClient.Post().RequestURI(o.Raw).Body(data).DoRaw()
+	result := restClient.Post().RequestURI(o.Raw).Body(data).Do()
+	if err := result.Error(); err != nil {
+		return err
+	}
+	body, err := result.Raw()
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(o.Out, "%v", string(bytes))
+	fmt.Fprintf(o.Out, "%v", string(body))
 	return nil
 }
 


### PR DESCRIPTION
Before this change:
```
$ kubectl create -f  pod.json --raw=https://172.16.29.130:443/api/v1/namespaces/default/pods  --as=tom --as-group=aaaaa
Error from server (Forbidden): unknown
```

After this change:
```
$ kubectl create -f pod.json --raw=https://172.16.29.130:443/api/v1/namespaces/default/pods  --as=tom --as-group=aaaaa
Error from server (Forbidden): pods is forbidden: User "tom" cannot create pods in the namespace "default"
```

/assign @soltysh 
**Release note**:

```release-note
NONE
```
