### PR TITLE
fix the issue that default azure disk fsypte(ext4) does not work on Windows

### DIFF
--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -35,7 +35,6 @@ import (
 )
 
 const (
-	defaultFSType                   = "ext4"
 	defaultStorageAccountType       = storage.StandardLRS
 	defaultAzureDiskKind            = v1.AzureSharedBlobDisk
 	defaultAzureDataDiskCachingMode = v1.AzureDataDiskCachingNone
@@ -106,14 +105,6 @@ func getVolumeSource(spec *volume.Spec) (*v1.AzureDiskVolumeSource, error) {
 	}
 
 	return nil, fmt.Errorf("azureDisk - Spec does not reference an Azure disk volume type")
-}
-
-func normalizeFsType(fsType string) string {
-	if fsType == "" {
-		return defaultFSType
-	}
-
-	return fsType
 }
 
 func normalizeKind(kind string) (v1.AzureDataDiskKind, error) {

--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -121,7 +121,6 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	}
 
 	// normalize values
-	fsType = normalizeFsType(fsType)
 	skuName, err := normalizeStorageAccountType(storageAccountType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[This line of code](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/azure_dd/azure_provision.go#L124) will set default fstype as `ext4` which is not applicable for Windows disk.
This PR remove the default fstype setting from master side.
We should leave fstype in master as what it is, and let client side(kubelet) decide the default fstype:
 - Linux: ext4, see [default fstype setting code in linux](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/azure_dd/azure_common_linux.go#L189)
 - Windows: NTFS, see [default fstype setting code in Windows](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/azure_dd/azure_common_windows.go#L108)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62247

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix the issue that default azure disk fsypte(ext4) does not work on Windows
```

/sig azure
/sig windows
@feiskyer @karataliu 