### PR TITLE
Create container name after dropped ":" and "@" both separately

### DIFF
--- a/pkg/kubectl/deployment.go
+++ b/pkg/kubectl/deployment.go
@@ -78,7 +78,8 @@ func buildPodSpec(images []string) v1.PodSpec {
 		// Remove any tag or hash
 		if strings.Contains(name, ":") {
 			name = strings.Split(name, ":")[0]
-		} else if strings.Contains(name, "@") {
+		}
+		if strings.Contains(name, "@") {
 			name = strings.Split(name, "@")[0]
 		}
 		podSpec.Containers = append(podSpec.Containers, v1.Container{Name: name, Image: imageString})

--- a/pkg/kubectl/deployment_test.go
+++ b/pkg/kubectl/deployment_test.go
@@ -37,7 +37,7 @@ func TestDeploymentBasicGenerate(t *testing.T) {
 		{
 			name:           "deployment name and images ok",
 			deploymentName: "images-name-ok",
-			images:         []string{"nn/image1", "registry/nn/image2", "nn/image3:tag", "nn/image4@digest"},
+			images:         []string{"nn/image1", "registry/nn/image2", "nn/image3:tag", "nn/image4@digest", "nn/image5@sha256:digest"},
 			expected: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "images-name-ok",
@@ -58,6 +58,7 @@ func TestDeploymentBasicGenerate(t *testing.T) {
 								{Name: "image2", Image: "registry/nn/image2"},
 								{Name: "image3", Image: "nn/image3:tag"},
 								{Name: "image4", Image: "nn/image4@digest"},
+								{Name: "image5", Image: "nn/image5@sha256:digest"},
 							},
 						},
 					},


### PR DESCRIPTION
When image has ":" after "@", kubectl create deployment fails due to
invalid container name.

This patch changes to create the container name after drooping ":" and
"@" both separately.

Fixes https://github.com/kubernetes/kubernetes/issues/62252

```release-note
NONE
```
