### PR TITLE
Restore enable disable resources for a groupVersion

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -80,8 +80,9 @@ func createAggregatorConfig(
 	etcdOptions.StorageConfig.Codec = aggregatorscheme.Codecs.LegacyCodec(v1beta1.SchemeGroupVersion, v1.SchemeGroupVersion)
 	genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
 
-	// override MergedResourceConfig with aggregator defaults and registry
-	if err := commandOptions.APIEnablement.ApplyTo(
+	// override genericConfig.MergedResourceConfig with aggregator defaults and registry
+	genericAPIEnablement := genericoptions.APIEnablementOptions{RuntimeConfig: commandOptions.APIEnablement.RuntimeConfig}
+	if err := genericAPIEnablement.ApplyTo(
 		&genericConfig,
 		aggregatorapiserver.DefaultAPIResourceConfigSource(),
 		aggregatorscheme.Registry); err != nil {

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -54,8 +54,9 @@ func createAPIExtensionsConfig(
 	etcdOptions.StorageConfig.Codec = apiextensionsapiserver.Codecs.LegacyCodec(v1beta1.SchemeGroupVersion)
 	genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
 
-	// override MergedResourceConfig with apiextensions defaults and registry
-	if err := commandOptions.APIEnablement.ApplyTo(
+	// override genericConfig.MergedResourceConfig with apiextensions defaults and registry
+	genericAPIEnablement := genericoptions.APIEnablementOptions{RuntimeConfig: commandOptions.APIEnablement.RuntimeConfig}
+	if err := genericAPIEnablement.ApplyTo(
 		&genericConfig,
 		apiextensionsapiserver.DefaultAPIResourceConfigSource(),
 		apiextensionsapiserver.Registry); err != nil {

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -51,7 +51,7 @@ type ServerRunOptions struct {
 	Authorization           *kubeoptions.BuiltInAuthorizationOptions
 	CloudProvider           *kubeoptions.CloudProviderOptions
 	StorageSerialization    *kubeoptions.StorageSerializationOptions
-	APIEnablement           *genericoptions.APIEnablementOptions
+	APIEnablement           *kubeoptions.APIEnablementOptions
 
 	AllowPrivileged           bool
 	EnableLogsHandler         bool
@@ -89,7 +89,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		Authorization:        kubeoptions.NewBuiltInAuthorizationOptions(),
 		CloudProvider:        kubeoptions.NewCloudProviderOptions(),
 		StorageSerialization: kubeoptions.NewStorageSerializationOptions(),
-		APIEnablement:        genericoptions.NewAPIEnablementOptions(),
+		APIEnablement:        kubeoptions.NewAPIEnablementOptions(),
 
 		EnableLogsHandler:      true,
 		EventTTL:               1 * time.Hour,

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -287,8 +287,10 @@ func TestAddFlags(t *testing.T) {
 			StorageVersions:        legacyscheme.Registry.AllPreferredGroupVersions(),
 			DefaultStorageVersions: legacyscheme.Registry.AllPreferredGroupVersions(),
 		},
-		APIEnablement: &apiserveroptions.APIEnablementOptions{
-			RuntimeConfig: utilflag.ConfigurationMap{},
+		APIEnablement: &kubeoptions.APIEnablementOptions{
+			GenericAPIEnablement: &apiserveroptions.APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{},
+			},
 		},
 		EnableLogsHandler:       false,
 		EnableAggregatorRouting: true,

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -288,9 +288,7 @@ func TestAddFlags(t *testing.T) {
 			DefaultStorageVersions: legacyscheme.Registry.AllPreferredGroupVersions(),
 		},
 		APIEnablement: &kubeoptions.APIEnablementOptions{
-			GenericAPIEnablement: &apiserveroptions.APIEnablementOptions{
-				RuntimeConfig: utilflag.ConfigurationMap{},
-			},
+			RuntimeConfig: utilflag.ConfigurationMap{},
 		},
 		EnableLogsHandler:       false,
 		EnableAggregatorRouting: true,

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -793,18 +793,8 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 	}
 
 	// TODO: remove when we stop supporting the legacy group version.
-	if s.APIEnablement.RuntimeConfig != nil {
-		for key, value := range s.APIEnablement.RuntimeConfig {
-			if key == "v1" || strings.HasPrefix(key, "v1/") ||
-				key == "api/v1" || strings.HasPrefix(key, "api/v1/") {
-				delete(s.APIEnablement.RuntimeConfig, key)
-				s.APIEnablement.RuntimeConfig["/v1"] = value
-			}
-			if key == "api/legacy" {
-				delete(s.APIEnablement.RuntimeConfig, key)
-			}
-		}
-	}
+	s.APIEnablement.ConvertLegacyGroup()
+
 	options.ServerRunOptions = s
 	return options, nil
 }

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -99,7 +99,7 @@ func StartTestServer(t Logger, customFlags []string, storageConfig *storagebacke
 	s.ServiceClusterIPRange.IP = net.IPv4(10, 0, 0, 0)
 	s.ServiceClusterIPRange.Mask = net.CIDRMask(16, 32)
 	s.Etcd.StorageConfig = *storageConfig
-	s.APIEnablement.RuntimeConfig.Set("api/all=true")
+	s.APIEnablement.GenericAPIEnablement.RuntimeConfig.Set("api/all=true")
 
 	fs.Parse(customFlags)
 	completedOptions, err := app.Complete(s)

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -99,7 +99,7 @@ func StartTestServer(t Logger, customFlags []string, storageConfig *storagebacke
 	s.ServiceClusterIPRange.IP = net.IPv4(10, 0, 0, 0)
 	s.ServiceClusterIPRange.Mask = net.CIDRMask(16, 32)
 	s.Etcd.StorageConfig = *storageConfig
-	s.APIEnablement.GenericAPIEnablement.RuntimeConfig.Set("api/all=true")
+	s.APIEnablement.RuntimeConfig.Set("api/all=true")
 
 	fs.Parse(customFlags)
 	completedOptions, err := app.Complete(s)

--- a/pkg/kubeapiserver/BUILD
+++ b/pkg/kubeapiserver/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -18,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/resourceconfig:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
     ],
 )
 
@@ -39,4 +41,18 @@ filegroup(
         "//pkg/kubeapiserver/server:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["default_storage_factory_builder_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
+    ],
 )

--- a/pkg/kubeapiserver/default_storage_factory_builder_test.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resourceconfig
+package kubeapiserver
 
 import (
 	"reflect"
@@ -28,7 +28,7 @@ import (
 	serverstore "k8s.io/apiserver/pkg/server/storage"
 )
 
-func TestParseRuntimeConfig(t *testing.T) {
+func TestMergeAPIResourceConfigs(t *testing.T) {
 	registry := newFakeRegistry()
 	extensionsGroupVersion := extensionsapiv1beta1.SchemeGroupVersion
 	apiv1GroupVersion := v1.SchemeGroupVersion
@@ -192,6 +192,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 			err: false,
 		},
 	}
+
 	for index, test := range testCases {
 		t.Log(registry.RegisteredGroupVersions())
 		actualDisablers, err := MergeAPIResourceConfigs(test.defaultResourceConfig(), test.runtimeConfig, registry)
@@ -203,7 +204,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 
 		expectedConfig := test.expectedAPIConfig()
 		if err == nil && !reflect.DeepEqual(actualDisablers, expectedConfig) {
-			t.Fatalf("%v: unexpected apiResourceDisablers. Actual: %v\n expected: %v", test.runtimeConfig, actualDisablers, expectedConfig)
+			t.Fatalf("case %v: unexpected apiResourceDisablers. Actual: %v\n expected: %v", index, actualDisablers.GroupVersionResourceConfigs, expectedConfig.GroupVersionResourceConfigs)
 		}
 	}
 }

--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "admission.go",
+        "api_enablement.go",
         "authentication.go",
         "authorization.go",
         "cloudprovider.go",
@@ -23,6 +24,7 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
         "//pkg/cloudprovider/providers:go_default_library",
+        "//pkg/kubeapiserver:go_default_library",
         "//pkg/kubeapiserver/authenticator:go_default_library",
         "//pkg/kubeapiserver/authorizer:go_default_library",
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
@@ -67,6 +69,8 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/validating:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/resourceconfig:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
@@ -90,6 +94,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "admission_test.go",
+        "api_enablement_test.go",
         "authorization_test.go",
         "storage_versions_test.go",
     ],
@@ -97,5 +102,6 @@ go_test(
     deps = [
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
     ],
 )

--- a/pkg/kubeapiserver/options/api_enablement.go
+++ b/pkg/kubeapiserver/options/api_enablement.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apiserver/pkg/server"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/server/resourceconfig"
+	serverstore "k8s.io/apiserver/pkg/server/storage"
+)
+
+// APIEnablementOptions holds the APIEnablement options.
+// It is a wrap of generic APIEnablementOptions.
+type APIEnablementOptions struct {
+	GenericAPIEnablement *genericoptions.APIEnablementOptions
+}
+
+func NewAPIEnablementOptions() *APIEnablementOptions {
+	return &APIEnablementOptions{
+		GenericAPIEnablement: genericoptions.NewAPIEnablementOptions(),
+	}
+}
+
+// AddFlags adds flags for a specific APIServer to the specified FlagSet
+func (s *APIEnablementOptions) AddFlags(fs *pflag.FlagSet) {
+	s.GenericAPIEnablement.AddFlags(fs)
+}
+
+// Validate verifies flags passed to kube-apiserver APIEnablementOptions.
+// It calls GenericAPIEnablement.Validate.
+func (s *APIEnablementOptions) Validate(registries ...genericoptions.GroupRegisty) []error {
+	if s == nil {
+		return nil
+	}
+
+	errors := s.GenericAPIEnablement.Validate(registries...)
+
+	return errors
+}
+
+// ApplyTo override MergedResourceConfig with defaults and registry
+func (s *APIEnablementOptions) ApplyTo(c *server.Config, defaultResourceConfig *serverstore.ResourceConfig, registry resourceconfig.GroupVersionRegistry) error {
+	if s == nil {
+		return nil
+	}
+
+	err := s.GenericAPIEnablement.ApplyTo(c, defaultResourceConfig, registry)
+
+	return err
+}
+
+// ConvertLegacyGroup remove useless "api/legacy" and convert the legacy group "v1".
+func (s *APIEnablementOptions) ConvertLegacyGroup() {
+	if s == nil || s.GenericAPIEnablement == nil {
+		return
+	}
+	overrides := s.GenericAPIEnablement.RuntimeConfig
+	// remove api/legacy, it is useless.
+	delete(overrides, "api/legacy")
+
+	for key := range overrides {
+		// HACK: Hack for "v1" legacy group version.
+		// Remove when we stop supporting the legacy group version.
+		if key == "v1" || strings.HasPrefix(key, "v1/") {
+			overrides["/"+key] = overrides[key]
+			delete(overrides, key)
+			continue
+		}
+
+		if key == "api/v1" {
+			overrides["/v1"] = overrides[key]
+			delete(overrides, key)
+			continue
+		}
+
+		if strings.HasPrefix(key, "api/v1/") {
+			tokens := strings.Split(key, "/")
+			if len(tokens) == 3 {
+				overrides["/v1"+"/"+tokens[2]] = overrides[key]
+				delete(overrides, key)
+			}
+		}
+	}
+}

--- a/pkg/kubeapiserver/options/api_enablement_test.go
+++ b/pkg/kubeapiserver/options/api_enablement_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"reflect"
+	"testing"
+
+	utilflag "k8s.io/apiserver/pkg/util/flag"
+)
+
+func TestConvertLegacyGroup(t *testing.T) {
+	testCases := []struct {
+		name            string
+		options         *APIEnablementOptions
+		expectedOptions *APIEnablementOptions
+	}{
+		{
+			name: "runtime-config with api/legacy",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"api/legacy": "",
+					"apps/v1":    "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"apps/v1": "",
+				},
+			},
+		},
+		{
+			name: "runtime-config with api/v1",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"api/v1":  "",
+					"apps/v1": "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"/v1":     "",
+					"apps/v1": "",
+				},
+			},
+		},
+		{
+			name: "runtime-config with api/v1",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"api/v1":  "",
+					"apps/v1": "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"/v1":     "",
+					"apps/v1": "",
+				},
+			},
+		},
+		{
+			name: "runtime-config with api/v1/pods",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"api/v1/pods": "",
+					"apps/v1":     "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"/v1/pods": "",
+					"apps/v1":  "",
+				},
+			},
+		},
+		{
+			name: "runtime-config with core v1",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"v1":      "",
+					"apps/v1": "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"/v1":     "",
+					"apps/v1": "",
+				},
+			},
+		},
+		{
+			name: "runtime-config with core v1/pods",
+			options: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"v1/pods": "",
+					"apps/v1": "",
+				},
+			},
+			expectedOptions: &APIEnablementOptions{
+				RuntimeConfig: utilflag.ConfigurationMap{
+					"/v1/pods": "",
+					"apps/v1":  "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc.options.ConvertLegacyGroup()
+		if !reflect.DeepEqual(tc.options, tc.expectedOptions) {
+			t.Errorf("%s: expected\n\t%#v, got \n\t%#v", tc.name, tc.expectedOptions, tc.options)
+		}
+	}
+}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -315,7 +315,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	// install legacy rest storage
-	if c.ExtraConfig.APIResourceConfigSource.VersionEnabled(apiv1.SchemeGroupVersion) {
+	if c.ExtraConfig.APIResourceConfigSource.AnyResourcesForVersionEnabled(apiv1.SchemeGroupVersion) {
 		legacyRESTStorageProvider := corerest.LegacyRESTStorageProvider{
 			StorageFactory:             c.ExtraConfig.StorageFactory,
 			ProxyTransport:             c.ExtraConfig.ProxyTransport,
@@ -405,7 +405,7 @@ func (m *Master) InstallAPIs(apiResourceConfigSource serverstorage.APIResourceCo
 
 	for _, restStorageBuilder := range restStorageProviders {
 		groupName := restStorageBuilder.GroupName()
-		if !apiResourceConfigSource.AnyVersionForGroupEnabled(groupName) {
+		if !apiResourceConfigSource.AnyResourcesForGroupEnabled(groupName) {
 			glog.V(1).Infof("Skipping disabled API group %q.", groupName)
 			continue
 		}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -348,8 +348,8 @@ func TestAPIVersionOfDiscoveryEndpoints(t *testing.T) {
 
 func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
 	config := DefaultAPIResourceConfigSource()
-	for gv, enable := range config.GroupVersionConfigs {
-		if enable && strings.Contains(gv.Version, "alpha") {
+	for gv, gvConfig := range config.GroupVersionResourceConfigs {
+		if gvConfig.Enable && strings.Contains(gv.Version, "alpha") {
 			t.Errorf("Alpha API version %s enabled by default", gv.String())
 		}
 	}

--- a/pkg/registry/admissionregistration/rest/storage_apiserver.go
+++ b/pkg/registry/admissionregistration/rest/storage_apiserver.go
@@ -37,11 +37,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(admissionregistrationv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(admissionregistrationv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[admissionregistrationv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = admissionregistrationv1alpha1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(admissionregistrationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(admissionregistrationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[admissionregistrationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = admissionregistrationv1beta1.SchemeGroupVersion
 	}
@@ -49,24 +49,26 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := admissionregistrationv1alpha1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	// initializerconfigurations
-	s := initializerconfigurationstorage.NewREST(restOptionsGetter)
-	storage["initializerconfigurations"] = s
-
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("initializerconfigurations")) {
+		s := initializerconfigurationstorage.NewREST(restOptionsGetter)
+		storage["initializerconfigurations"] = s
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := admissionregistrationv1beta1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	// validatingwebhookconfigurations
-	validatingStorage := validatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
-	storage["validatingwebhookconfigurations"] = validatingStorage
-
-	// mutatingwebhookconfigurations
-	mutatingStorage := mutatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
-	storage["mutatingwebhookconfigurations"] = mutatingStorage
-
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("validatingwebhookconfigurations")) {
+		s := validatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
+		storage["validatingwebhookconfigurations"] = s
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("mutatingwebhookconfigurations")) {
+		s := mutatingwebhookconfigurationstorage.NewREST(restOptionsGetter)
+		storage["mutatingwebhookconfigurations"] = s
+	}
 	return storage
 }
 

--- a/pkg/registry/apps/rest/storage_apps.go
+++ b/pkg/registry/apps/rest/storage_apps.go
@@ -40,15 +40,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(appsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(appsapiv1beta2.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1beta2.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1beta2.SchemeGroupVersion.Version] = p.v1beta2Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1beta2.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(appsapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(appsapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = appsapiv1.SchemeGroupVersion
 	}
@@ -57,91 +57,94 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := appsapiv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-
-	// deployments
-	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-	storage["deployments"] = deploymentStorage.Deployment
-	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/rollback"] = deploymentStorage.Rollback
-	storage["deployments/scale"] = deploymentStorage.Scale
-
-	// statefulsets
-	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-	storage["statefulsets"] = statefulSetStorage.StatefulSet
-	storage["statefulsets/status"] = statefulSetStorage.Status
-	storage["statefulsets/scale"] = statefulSetStorage.Scale
-
-	// controllerrevisions
-	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-	storage["controllerrevisions"] = historyStorage
-
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
+		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+		storage["deployments"] = deploymentStorage.Deployment
+		storage["deployments/status"] = deploymentStorage.Status
+		storage["deployments/rollback"] = deploymentStorage.Rollback
+		storage["deployments/scale"] = deploymentStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
+		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+		storage["statefulsets"] = statefulSetStorage.StatefulSet
+		storage["statefulsets/status"] = statefulSetStorage.Status
+		storage["statefulsets/scale"] = statefulSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
+		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+		storage["controllerrevisions"] = historyStorage
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta2Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := appsapiv1beta2.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-
-	// deployments
-	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-	storage["deployments"] = deploymentStorage.Deployment
-	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/scale"] = deploymentStorage.Scale
-
-	// statefulsets
-	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-	storage["statefulsets"] = statefulSetStorage.StatefulSet
-	storage["statefulsets/status"] = statefulSetStorage.Status
-	storage["statefulsets/scale"] = statefulSetStorage.Scale
-
-	// daemonsets
-	daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
-	storage["daemonsets"] = daemonSetStorage
-	storage["daemonsets/status"] = daemonSetStatusStorage
-
-	// replicasets
-	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-	storage["replicasets"] = replicaSetStorage.ReplicaSet
-	storage["replicasets/status"] = replicaSetStorage.Status
-	storage["replicasets/scale"] = replicaSetStorage.Scale
-
-	// controllerrevisions
-	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-	storage["controllerrevisions"] = historyStorage
-
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
+		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+		storage["deployments"] = deploymentStorage.Deployment
+		storage["deployments/status"] = deploymentStorage.Status
+		storage["deployments/scale"] = deploymentStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
+		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+		storage["statefulsets"] = statefulSetStorage.StatefulSet
+		storage["statefulsets/status"] = statefulSetStorage.Status
+		storage["statefulsets/scale"] = statefulSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
+		daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
+		storage["daemonsets"] = daemonSetStorage
+		storage["daemonsets/status"] = daemonSetStatusStorage
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
+		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+		storage["replicasets"] = replicaSetStorage.ReplicaSet
+		storage["replicasets/status"] = replicaSetStorage.Status
+		storage["replicasets/scale"] = replicaSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
+		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+		storage["controllerrevisions"] = historyStorage
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := appsapiv1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-
-	// deployments
-	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-	storage["deployments"] = deploymentStorage.Deployment
-	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/scale"] = deploymentStorage.Scale
-
-	// statefulsets
-	statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
-	storage["statefulsets"] = statefulSetStorage.StatefulSet
-	storage["statefulsets/status"] = statefulSetStorage.Status
-	storage["statefulsets/scale"] = statefulSetStorage.Scale
-
-	// daemonsets
-	daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
-	storage["daemonsets"] = daemonSetStorage
-	storage["daemonsets/status"] = daemonSetStatusStorage
-
-	// replicasets
-	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-	storage["replicasets"] = replicaSetStorage.ReplicaSet
-	storage["replicasets/status"] = replicaSetStorage.Status
-	storage["replicasets/scale"] = replicaSetStorage.Scale
-
-	// controllerrevisions
-	historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
-	storage["controllerrevisions"] = historyStorage
-
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
+		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+		storage["deployments"] = deploymentStorage.Deployment
+		storage["deployments/status"] = deploymentStorage.Status
+		storage["deployments/scale"] = deploymentStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("statefulsets")) {
+		statefulSetStorage := statefulsetstore.NewStorage(restOptionsGetter)
+		storage["statefulsets"] = statefulSetStorage.StatefulSet
+		storage["statefulsets/status"] = statefulSetStorage.Status
+		storage["statefulsets/scale"] = statefulSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
+		daemonSetStorage, daemonSetStatusStorage := daemonsetstore.NewREST(restOptionsGetter)
+		storage["daemonsets"] = daemonSetStorage
+		storage["daemonsets/status"] = daemonSetStatusStorage
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
+		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+		storage["replicasets"] = replicaSetStorage.ReplicaSet
+		storage["replicasets/status"] = replicaSetStorage.Status
+		storage["replicasets/scale"] = replicaSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("controllerrevisions")) {
+		historyStorage := controllerrevisionsstore.NewREST(restOptionsGetter)
+		storage["controllerrevisions"] = historyStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/authentication/rest/storage_authentication.go
+++ b/pkg/registry/authentication/rest/storage_authentication.go
@@ -43,11 +43,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authenticationv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(authenticationv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authenticationv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authenticationv1.SchemeGroupVersion
 	}
@@ -56,19 +56,29 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := authenticationv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// tokenreviews
-	tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
-	storage["tokenreviews"] = tokenReviewStorage
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1beta1.SchemeGroupVersion) {
+		if apiResourceConfigSource.ResourceEnabled(version.WithResource("tokenreviews")) {
+			tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
+			storage["tokenreviews"] = tokenReviewStorage
+		}
+	}
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := authenticationv1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// tokenreviews
-	tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
-	storage["tokenreviews"] = tokenReviewStorage
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authenticationv1.SchemeGroupVersion) {
+		if apiResourceConfigSource.ResourceEnabled(version.WithResource("tokenreviews")) {
+			tokenReviewStorage := tokenreview.NewREST(p.Authenticator)
+			storage["tokenreviews"] = tokenReviewStorage
+		}
+	}
 
 	return storage
 }

--- a/pkg/registry/authorization/rest/storage_authorization.go
+++ b/pkg/registry/authorization/rest/storage_authorization.go
@@ -46,12 +46,12 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(authorizationv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authorizationv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authorizationv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authorizationv1beta1.SchemeGroupVersion
 	}
 
-	if apiResourceConfigSource.VersionEnabled(authorizationv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(authorizationv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[authorizationv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = authorizationv1.SchemeGroupVersion
 	}
@@ -60,29 +60,41 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := authorizationv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// subjectaccessreviews
-	storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
-	// selfsubjectaccessreviews
-	storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
-	// localsubjectaccessreviews
-	storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
-	// selfsubjectrulesreviews
-	storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("subjectaccessreviews")) {
+		storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
+		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("localsubjectaccessreviews")) {
+		storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectrulesreviews")) {
+		storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
+	}
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := authorizationv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// subjectaccessreviews
-	storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
-	// selfsubjectaccessreviews
-	storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
-	// localsubjectaccessreviews
-	storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
-	// selfsubjectrulesreviews
-	storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("subjectaccessreviews")) {
+		storage["subjectaccessreviews"] = subjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectaccessreviews")) {
+		storage["selfsubjectaccessreviews"] = selfsubjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("localsubjectaccessreviews")) {
+		storage["localsubjectaccessreviews"] = localsubjectaccessreview.NewREST(p.Authorizer)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("selfsubjectrulesreviews")) {
+		storage["selfsubjectrulesreviews"] = selfsubjectrulesreview.NewREST(p.RuleResolver)
+	}
 
 	return storage
 }

--- a/pkg/registry/autoscaling/rest/storage_autoscaling.go
+++ b/pkg/registry/autoscaling/rest/storage_autoscaling.go
@@ -35,11 +35,11 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(autoscalingapiv2beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv2beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv2beta1.SchemeGroupVersion.Version] = p.v2beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv2beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(autoscalingapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[autoscalingapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = autoscalingapiv1.SchemeGroupVersion
 	}
@@ -48,22 +48,26 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// horizontalpodautoscalers
-	hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
-	storage["horizontalpodautoscalers"] = hpaStorage
-	storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+	version := autoscalingapiv1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("horizontalpodautoscalers")) {
+		hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
+		storage["horizontalpodautoscalers"] = hpaStorage
+		storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v2beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// horizontalpodautoscalers
-	hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
-	storage["horizontalpodautoscalers"] = hpaStorage
-	storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+	version := autoscalingapiv2beta1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("horizontalpodautoscalers")) {
+		hpaStorage, hpaStatusStorage := horizontalpodautoscalerstore.NewREST(restOptionsGetter)
+		storage["horizontalpodautoscalers"] = hpaStorage
+		storage["horizontalpodautoscalers/status"] = hpaStatusStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/batch/rest/storage_batch.go
+++ b/pkg/registry/batch/rest/storage_batch.go
@@ -37,15 +37,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(batchapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(batchapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(batchapiv2alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(batchapiv2alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[batchapiv2alpha1.SchemeGroupVersion.Version] = p.v2alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = batchapiv2alpha1.SchemeGroupVersion
 	}
@@ -54,32 +54,38 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// jobs
-	jobsStorage, jobsStatusStorage := jobstore.NewREST(restOptionsGetter)
-	storage["jobs"] = jobsStorage
-	storage["jobs/status"] = jobsStatusStorage
+	version := batchapiv1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("jobs")) {
+		jobsStorage, jobsStatusStorage := jobstore.NewREST(restOptionsGetter)
+		storage["jobs"] = jobsStorage
+		storage["jobs/status"] = jobsStatusStorage
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// cronjobs
-	cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
-	storage["cronjobs"] = cronJobsStorage
-	storage["cronjobs/status"] = cronJobsStatusStorage
+	version := batchapiv1beta1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("cronjobs")) {
+		cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
+		storage["cronjobs"] = cronJobsStorage
+		storage["cronjobs/status"] = cronJobsStatusStorage
+	}
 	return storage
 }
 
 func (p RESTStorageProvider) v2alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// cronjobs
-	cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
-	storage["cronjobs"] = cronJobsStorage
-	storage["cronjobs/status"] = cronJobsStatusStorage
+	version := batchapiv2alpha1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("cronjobs")) {
+		cronJobsStorage, cronJobsStatusStorage := cronjobstore.NewREST(restOptionsGetter)
+		storage["cronjobs"] = cronJobsStorage
+		storage["cronjobs/status"] = cronJobsStatusStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/certificates/rest/storage_certificates.go
+++ b/pkg/registry/certificates/rest/storage_certificates.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(certificatesapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(certificatesapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[certificatesapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = certificatesapiv1beta1.SchemeGroupVersion
 	}
@@ -43,13 +43,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// certificatesigningrequests
-	csrStorage, csrStatusStorage, csrApprovalStorage := certificatestore.NewREST(restOptionsGetter)
-	storage["certificatesigningrequests"] = csrStorage
-	storage["certificatesigningrequests/status"] = csrStatusStorage
-	storage["certificatesigningrequests/approval"] = csrApprovalStorage
+	version := certificatesapiv1beta1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("certificatesigningrequests")) {
+		csrStorage, csrStatusStorage, csrApprovalStorage := certificatestore.NewREST(restOptionsGetter)
+		storage["certificatesigningrequests"] = csrStorage
+		storage["certificatesigningrequests/status"] = csrStatusStorage
+		storage["certificatesigningrequests/approval"] = csrApprovalStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/events/rest/storage_events.go
+++ b/pkg/registry/events/rest/storage_events.go
@@ -38,7 +38,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(eventsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(eventsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[eventsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = eventsapiv1beta1.SchemeGroupVersion
 	}
@@ -47,11 +47,13 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// events
-	eventsStorage := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
-	storage["events"] = eventsStorage
+	version := eventsapiv1beta1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("events")) {
+		eventsStorage := eventstore.NewREST(restOptionsGetter, uint64(p.TTL.Seconds()))
+		storage["events"] = eventsStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -33,14 +33,15 @@ import (
 	pspstore "k8s.io/kubernetes/pkg/registry/policy/podsecuritypolicy/storage"
 )
 
-type RESTStorageProvider struct{}
+type RESTStorageProvider struct {
+}
 
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(extensions.GroupName, legacyscheme.Registry, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(extensionsapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(extensionsapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[extensionsapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = extensionsapiv1beta1.SchemeGroupVersion
 	}
@@ -49,6 +50,8 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := extensionsapiv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
 
 	// This is a dummy replication controller for scale subresource purposes.
@@ -57,35 +60,37 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	storage["replicationcontrollers"] = controllerStorage.ReplicationController
 	storage["replicationcontrollers/scale"] = controllerStorage.Scale
 
-	// daemonsets
-	daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
-	storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
-	storage["daemonsets/status"] = daemonSetStatusStorage
-
-	//deployments
-	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
-	storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
-	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/rollback"] = deploymentStorage.Rollback
-	storage["deployments/scale"] = deploymentStorage.Scale
-	// ingresses
-	ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
-	storage["ingresses"] = ingressStorage
-	storage["ingresses/status"] = ingressStatusStorage
-
-	// podsecuritypolicy
-	podSecurityPolicyStorage := pspstore.NewREST(restOptionsGetter)
-	storage["podSecurityPolicies"] = podSecurityPolicyStorage
-
-	// replicasets
-	replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
-	storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
-	storage["replicasets/status"] = replicaSetStorage.Status
-	storage["replicasets/scale"] = replicaSetStorage.Scale
-
-	// networkpolicies
-	networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
-	storage["networkpolicies"] = networkExtensionsStorage
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("daemonsets")) {
+		daemonSetStorage, daemonSetStatusStorage := daemonstore.NewREST(restOptionsGetter)
+		storage["daemonsets"] = daemonSetStorage.WithCategories(nil)
+		storage["daemonsets/status"] = daemonSetStatusStorage
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("deployments")) {
+		deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
+		storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
+		storage["deployments/status"] = deploymentStorage.Status
+		storage["deployments/rollback"] = deploymentStorage.Rollback
+		storage["deployments/scale"] = deploymentStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("ingresses")) {
+		ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)
+		storage["ingresses"] = ingressStorage
+		storage["ingresses/status"] = ingressStatusStorage
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("podsecuritypolicy")) || apiResourceConfigSource.ResourceEnabled(version.WithResource("podsecuritypolicies")) {
+		podSecurityPolicyStorage := pspstore.NewREST(restOptionsGetter)
+		storage["podSecurityPolicies"] = podSecurityPolicyStorage
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("replicasets")) {
+		replicaSetStorage := replicasetstore.NewStorage(restOptionsGetter)
+		storage["replicasets"] = replicaSetStorage.ReplicaSet.WithCategories(nil)
+		storage["replicasets/status"] = replicaSetStorage.Status
+		storage["replicasets/scale"] = replicaSetStorage.Scale
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("networkpolicies")) {
+		networkExtensionsStorage := networkpolicystore.NewREST(restOptionsGetter)
+		storage["networkpolicies"] = networkExtensionsStorage
+	}
 
 	return storage
 }

--- a/pkg/registry/networking/rest/storage_settings.go
+++ b/pkg/registry/networking/rest/storage_settings.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(networkingapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(networkingapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[networkingapiv1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = networkingapiv1.SchemeGroupVersion
 	}
@@ -43,11 +43,13 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// networkpolicies
-	networkPolicyStorage := networkpolicystore.NewREST(restOptionsGetter)
-	storage["networkpolicies"] = networkPolicyStorage
+	version := networkingapiv1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("networkpolicies")) {
+		networkPolicyStorage := networkpolicystore.NewREST(restOptionsGetter)
+		storage["networkpolicies"] = networkPolicyStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/policy/rest/storage_policy.go
+++ b/pkg/registry/policy/rest/storage_policy.go
@@ -35,7 +35,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(policyapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(policyapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[policyapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = policyapiv1beta1.SchemeGroupVersion
 	}
@@ -43,13 +43,18 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := policyapiv1beta1.SchemeGroupVersion
 	storage := map[string]rest.Storage{}
-	// poddisruptionbudgets
-	poddisruptionbudgetStorage, poddisruptionbudgetStatusStorage := poddisruptionbudgetstore.NewREST(restOptionsGetter)
-	storage["poddisruptionbudgets"] = poddisruptionbudgetStorage
-	storage["poddisruptionbudgets/status"] = poddisruptionbudgetStatusStorage
 
-	storage["podsecuritypolicies"] = pspstore.NewREST(restOptionsGetter)
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("poddisruptionbudgets")) {
+		poddisruptionbudgetStorage, poddisruptionbudgetStatusStorage := poddisruptionbudgetstore.NewREST(restOptionsGetter)
+		storage["poddisruptionbudgets"] = poddisruptionbudgetStorage
+		storage["poddisruptionbudgets/status"] = poddisruptionbudgetStatusStorage
+	}
+
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("podsecuritypolicies")) {
+		storage["podsecuritypolicies"] = pspstore.NewREST(restOptionsGetter)
+	}
 
 	return storage
 }

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -18,6 +18,7 @@ package rest
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -70,15 +71,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(rbacapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(rbacapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[rbacapiv1alpha1.SchemeGroupVersion.Version] = p.storage(rbacapiv1alpha1.SchemeGroupVersion, apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = rbacapiv1alpha1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(rbacapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(rbacapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[rbacapiv1beta1.SchemeGroupVersion.Version] = p.storage(rbacapiv1beta1.SchemeGroupVersion, apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = rbacapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(rbacapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(rbacapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[rbacapiv1.SchemeGroupVersion.Version] = p.storage(rbacapiv1.SchemeGroupVersion, apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = rbacapiv1.SchemeGroupVersion
 	}
@@ -87,31 +88,48 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) storage(version schema.GroupVersion, apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	rolesStorage := rolestore.NewREST(restOptionsGetter)
-	roleBindingsStorage := rolebindingstore.NewREST(restOptionsGetter)
-	clusterRolesStorage := clusterrolestore.NewREST(restOptionsGetter)
-	clusterRoleBindingsStorage := clusterrolebindingstore.NewREST(restOptionsGetter)
-
-	authorizationRuleResolver := rbacregistryvalidation.NewDefaultRuleResolver(
-		role.AuthorizerAdapter{Registry: role.NewRegistry(rolesStorage)},
-		rolebinding.AuthorizerAdapter{Registry: rolebinding.NewRegistry(roleBindingsStorage)},
-		clusterrole.AuthorizerAdapter{Registry: clusterrole.NewRegistry(clusterRolesStorage)},
-		clusterrolebinding.AuthorizerAdapter{Registry: clusterrolebinding.NewRegistry(clusterRoleBindingsStorage)},
+	once := new(sync.Once)
+	var (
+		authorizationRuleResolver  rbacregistryvalidation.AuthorizationRuleResolver
+		rolesStorage               rest.StandardStorage
+		roleBindingsStorage        rest.StandardStorage
+		clusterRolesStorage        rest.StandardStorage
+		clusterRoleBindingsStorage rest.StandardStorage
 	)
 
-	// roles
-	storage["roles"] = rolepolicybased.NewStorage(rolesStorage, authorizationRuleResolver)
+	initializeStorage := func() {
+		once.Do(func() {
+			rolesStorage = rolestore.NewREST(restOptionsGetter)
+			roleBindingsStorage = rolebindingstore.NewREST(restOptionsGetter)
+			clusterRolesStorage = clusterrolestore.NewREST(restOptionsGetter)
+			clusterRoleBindingsStorage = clusterrolebindingstore.NewREST(restOptionsGetter)
 
-	// rolebindings
-	storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, p.Authorizer, authorizationRuleResolver)
+			authorizationRuleResolver = rbacregistryvalidation.NewDefaultRuleResolver(
+				role.AuthorizerAdapter{Registry: role.NewRegistry(rolesStorage)},
+				rolebinding.AuthorizerAdapter{Registry: rolebinding.NewRegistry(roleBindingsStorage)},
+				clusterrole.AuthorizerAdapter{Registry: clusterrole.NewRegistry(clusterRolesStorage)},
+				clusterrolebinding.AuthorizerAdapter{Registry: clusterrolebinding.NewRegistry(clusterRoleBindingsStorage)},
+			)
+		})
+	}
 
-	// clusterroles
-	storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, authorizationRuleResolver)
-
-	// clusterrolebindings
-	storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, p.Authorizer, authorizationRuleResolver)
-
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("roles")) {
+		initializeStorage()
+		storage["roles"] = rolepolicybased.NewStorage(rolesStorage, authorizationRuleResolver)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("rolebindings")) {
+		initializeStorage()
+		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, p.Authorizer, authorizationRuleResolver)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterroles")) {
+		initializeStorage()
+		storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, authorizationRuleResolver)
+	}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterrolebindings")) {
+		initializeStorage()
+		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, p.Authorizer, authorizationRuleResolver)
+	}
 	return storage
 }
 

--- a/pkg/registry/scheduling/rest/storage_scheduling.go
+++ b/pkg/registry/scheduling/rest/storage_scheduling.go
@@ -46,7 +46,7 @@ var _ genericapiserver.PostStartHookProvider = RESTStorageProvider{}
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(scheduling.GroupName, legacyscheme.Registry, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
 
-	if apiResourceConfigSource.VersionEnabled(schedulingapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(schedulingapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[schedulingapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = schedulingapiv1alpha1.SchemeGroupVersion
 	}
@@ -55,11 +55,13 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// priorityclasses
-	priorityClassStorage := priorityclassstore.NewREST(restOptionsGetter)
-	storage["priorityclasses"] = priorityClassStorage
+	version := schedulingapiv1alpha1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("priorityclasses")) {
+		priorityClassStorage := priorityclassstore.NewREST(restOptionsGetter)
+		storage["priorityclasses"] = priorityClassStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/settings/rest/storage_settings.go
+++ b/pkg/registry/settings/rest/storage_settings.go
@@ -34,7 +34,7 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(settingsapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(settingsapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[settingsapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = settingsapiv1alpha1.SchemeGroupVersion
 	}
@@ -43,11 +43,13 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
-	storage := map[string]rest.Storage{}
-	// podpresets
-	podPresetStorage := podpresetstore.NewREST(restOptionsGetter)
-	storage["podpresets"] = podPresetStorage
+	version := settingsapiv1alpha1.SchemeGroupVersion
 
+	storage := map[string]rest.Storage{}
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("podpresets")) {
+		podPresetStorage := podpresetstore.NewREST(restOptionsGetter)
+		storage["podpresets"] = podPresetStorage
+	}
 	return storage
 }
 

--- a/pkg/registry/storage/rest/storage_storage.go
+++ b/pkg/registry/storage/rest/storage_storage.go
@@ -38,15 +38,15 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
-	if apiResourceConfigSource.VersionEnabled(storageapiv1alpha1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1alpha1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1alpha1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1beta1.SchemeGroupVersion
 	}
-	if apiResourceConfigSource.VersionEnabled(storageapiv1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1.SchemeGroupVersion
 	}
@@ -55,19 +55,27 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := storageapiv1alpha1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// volumeattachments
-	volumeAttachmentStorage := volumeattachmentstore.NewREST(restOptionsGetter)
-	storage["volumeattachments"] = volumeAttachmentStorage
+
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("volumeattachments")) {
+		volumeAttachmentStorage := volumeattachmentstore.NewREST(restOptionsGetter)
+		storage["volumeattachments"] = volumeAttachmentStorage
+	}
 
 	return storage
 }
 
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := storageapiv1beta1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// storageclasses
-	storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
-	storage["storageclasses"] = storageClassStorage
+
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("storageclasses")) {
+		storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
+		storage["storageclasses"] = storageClassStorage
+	}
 
 	// volumeattachments
 	volumeAttachmentStorage := volumeattachmentstore.NewREST(restOptionsGetter)
@@ -77,10 +85,14 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 }
 
 func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	version := storageapiv1.SchemeGroupVersion
+
 	storage := map[string]rest.Storage{}
-	// storageclasses
-	storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
-	storage["storageclasses"] = storageClassStorage
+
+	if apiResourceConfigSource.ResourceEnabled(version.WithResource("storageclasses")) {
+		storageClassStorage := storageclassstore.NewREST(restOptionsGetter)
+		storage["storageclasses"] = storageClassStorage
+	}
 
 	return storage
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -132,14 +132,12 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 
 	apiResourceConfig := c.GenericConfig.MergedResourceConfig
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(apiextensions.GroupName, Registry, Scheme, metav1.ParameterCodec, Codecs)
-	if apiResourceConfig.VersionEnabled(v1beta1.SchemeGroupVersion) {
+	if apiResourceConfig.AnyResourcesForVersionEnabled(v1beta1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1beta1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
-		// customresourcedefinitions
 		customResourceDefintionStorage := customresourcedefinition.NewREST(Scheme, c.GenericConfig.RESTOptionsGetter)
 		storage["customresourcedefinitions"] = customResourceDefintionStorage
 		storage["customresourcedefinitions/status"] = customresourcedefinition.NewStatusREST(Scheme, customResourceDefintionStorage)
-
 		apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = storage
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -13,20 +13,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
-    ],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["helpers_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -82,7 +82,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 		{
 			// disable resource
 			runtimeConfig: map[string]string{
-				"api/v1/pods": "false",
+				"/v1/pods": "false",
 			},
 			defaultResourceConfig: func() *serverstore.ResourceConfig {
 				config := newFakeAPIResourceConfigSource()
@@ -98,7 +98,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 		{
 			// Disable v1.
 			runtimeConfig: map[string]string{
-				"api/v1": "false",
+				"/v1": "false",
 			},
 			defaultResourceConfig: func() *serverstore.ResourceConfig {
 				return newFakeAPIResourceConfigSource()
@@ -147,7 +147,7 @@ func TestParseRuntimeConfig(t *testing.T) {
 		{
 			// cannot disable individual resource when version is not enabled.
 			runtimeConfig: map[string]string{
-				"api/v1/pods": "false",
+				"/v1/pods": "false",
 			},
 			defaultResourceConfig: func() *serverstore.ResourceConfig {
 				config := newFakeAPIResourceConfigSource()

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -58,14 +58,14 @@ func NewResourceConfig() *ResourceConfig {
 }
 
 func (o *ResourceConfig) DisableAll() {
-	for k := range o.GroupVersionConfigs {
-		o.GroupVersionConfigs[k] = false
+	for version := range o.GroupVersionResourceConfigs {
+		o.DisableVersions(version)
 	}
 }
 
 func (o *ResourceConfig) EnableAll() {
-	for k := range o.GroupVersionConfigs {
-		o.GroupVersionConfigs[k] = true
+	for version := range o.GroupVersionResourceConfigs {
+		o.EnableVersions(version)
 	}
 }
 
@@ -94,6 +94,31 @@ func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 		}
 
 		o.GroupVersionResourceConfigs[version].Enable = true
+	}
+}
+
+func (o *ResourceConfig) DisableResources(resources ...schema.GroupVersionResource) {
+	for _, resource := range resources {
+		version := resource.GroupVersion()
+		_, versionExists := o.GroupVersionResourceConfigs[version]
+		if !versionExists {
+			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
+		}
+
+		o.GroupVersionResourceConfigs[version].DisabledResources.Insert(resource.Resource)
+	}
+}
+
+func (o *ResourceConfig) EnableResources(resources ...schema.GroupVersionResource) {
+	for _, resource := range resources {
+		version := resource.GroupVersion()
+		_, versionExists := o.GroupVersionResourceConfigs[version]
+		if !versionExists {
+			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
+		}
+
+		o.GroupVersionResourceConfigs[version].EnabledResources.Insert(resource.Resource)
+		o.GroupVersionResourceConfigs[version].DisabledResources.Delete(resource.Resource)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -18,22 +18,43 @@ package storage
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// APIResourceConfigSource is the interface to determine which groups and versions are enabled
+// APIResourceConfigSource is the interface to determine which versions and resources are enabled
 type APIResourceConfigSource interface {
-	VersionEnabled(version schema.GroupVersion) bool
-	AnyVersionForGroupEnabled(group string) bool
+	AnyVersionOfResourceEnabled(resource schema.GroupResource) bool
+	ResourceEnabled(resource schema.GroupVersionResource) bool
+	AnyResourcesForVersionEnabled(version schema.GroupVersion) bool
+	AnyResourcesForGroupEnabled(group string) bool
+}
+
+// Specifies the overrides for various API group versions.
+// This can be used to enable/disable entire group versions or specific resources.
+type GroupVersionResourceConfig struct {
+	// Whether to enable or disable this entire group version.  This dominates any enablement check.
+	// Enable=true means the group version is enabled, and EnabledResources/DisabledResources are considered.
+	// Enable=false means the group version is disabled, and EnabledResources/DisabledResources are not considered.
+	Enable bool
+
+	// DisabledResources lists the resources that are specifically disabled for a group/version
+	// DisabledResources trumps EnabledResources
+	DisabledResources sets.String
+
+	// EnabledResources lists the resources that should be enabled by default.  This is a little
+	// unusual, but we need it for compatibility with old code for now.  An empty set means
+	// enable all, a non-empty set means that all other resources are disabled.
+	EnabledResources sets.String
 }
 
 var _ APIResourceConfigSource = &ResourceConfig{}
 
 type ResourceConfig struct {
-	GroupVersionConfigs map[schema.GroupVersion]bool
+	GroupVersionResourceConfigs map[schema.GroupVersion]*GroupVersionResourceConfig
 }
 
 func NewResourceConfig() *ResourceConfig {
-	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}}
+	return &ResourceConfig{GroupVersionResourceConfigs: map[schema.GroupVersion]*GroupVersionResourceConfig{}}
 }
 
 func (o *ResourceConfig) DisableAll() {
@@ -49,31 +70,83 @@ func (o *ResourceConfig) EnableAll() {
 }
 
 // DisableVersions disables the versions entirely.
+func NewGroupVersionResourceConfig() *GroupVersionResourceConfig {
+	return &GroupVersionResourceConfig{Enable: true, DisabledResources: sets.String{}, EnabledResources: sets.String{}}
+}
+
+// DisableVersions disables the versions entirely.  No resources (even those whitelisted in EnabledResources) will be enabled
 func (o *ResourceConfig) DisableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
-		o.GroupVersionConfigs[version] = false
+		_, versionExists := o.GroupVersionResourceConfigs[version]
+		if !versionExists {
+			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
+		}
+
+		o.GroupVersionResourceConfigs[version].Enable = false
 	}
 }
 
 func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
-		o.GroupVersionConfigs[version] = true
+		_, versionExists := o.GroupVersionResourceConfigs[version]
+		if !versionExists {
+			o.GroupVersionResourceConfigs[version] = NewGroupVersionResourceConfig()
+		}
+
+		o.GroupVersionResourceConfigs[version].Enable = true
 	}
 }
 
-func (o *ResourceConfig) VersionEnabled(version schema.GroupVersion) bool {
-	enabled, _ := o.GroupVersionConfigs[version]
-	if enabled {
-		return true
+// AnyResourcesForVersionEnabled only considers matches based on exactly group/resource lexical matching.  This means that
+// resource renames across versions are NOT considered to be the same resource by this method. You'll need to manually check
+// using the ResourceEnabled function.
+func (o *ResourceConfig) AnyVersionOfResourceEnabled(resource schema.GroupResource) bool {
+	for version := range o.GroupVersionResourceConfigs {
+		if version.Group != resource.Group {
+			continue
+		}
+
+		if o.ResourceEnabled(version.WithResource(resource.Resource)) {
+			return true
+		}
 	}
 
 	return false
 }
 
-func (o *ResourceConfig) AnyVersionForGroupEnabled(group string) bool {
-	for version := range o.GroupVersionConfigs {
+func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) bool {
+	versionOverride, versionExists := o.GroupVersionResourceConfigs[resource.GroupVersion()]
+	if !versionExists {
+		return false
+	}
+	if !versionOverride.Enable {
+		return false
+	}
+
+	if versionOverride.DisabledResources.Has(resource.Resource) {
+		return false
+	}
+
+	if len(versionOverride.EnabledResources) > 0 {
+		return versionOverride.EnabledResources.Has(resource.Resource)
+	}
+
+	return true
+}
+
+func (o *ResourceConfig) AnyResourcesForVersionEnabled(version schema.GroupVersion) bool {
+	versionOverride, versionExists := o.GroupVersionResourceConfigs[version]
+	if !versionExists {
+		return false
+	}
+
+	return versionOverride.Enable
+}
+
+func (o *ResourceConfig) AnyResourcesForGroupEnabled(group string) bool {
+	for version := range o.GroupVersionResourceConfigs {
 		if version.Group == group {
-			if o.VersionEnabled(version) {
+			if o.AnyResourcesForVersionEnabled(version) {
 				return true
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -32,18 +32,18 @@ func TestDisabledVersion(t *testing.T) {
 	config.DisableVersions(g1v1)
 	config.EnableVersions(g1v2, g2v1)
 
-	if config.VersionEnabled(g1v1) {
+	if config.AnyResourcesForVersionEnabled(g1v1) {
 		t.Errorf("expected disabled for %v, from %v", g1v1, config)
 	}
-	if !config.VersionEnabled(g1v2) {
+	if !config.AnyResourcesForVersionEnabled(g1v2) {
 		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
-	if !config.VersionEnabled(g2v1) {
+	if !config.AnyResourcesForVersionEnabled(g2v1) {
 		t.Errorf("expected enabled for %v, from %v", g1v1, config)
 	}
 }
 
-func TestAnyVersionForGroupEnabled(t *testing.T) {
+func TestAnyResourcesForGroupEnabled(t *testing.T) {
 	tests := []struct {
 		name      string
 		creator   func() APIResourceConfigSource
@@ -86,7 +86,7 @@ func TestAnyVersionForGroupEnabled(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if e, a := tc.expectedResult, tc.creator().AnyVersionForGroupEnabled(tc.testGroup); e != a {
+		if e, a := tc.expectedResult, tc.creator().AnyResourcesForGroupEnabled(tc.testGroup); e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -240,7 +240,7 @@ func getAllResourcesAlias(resource schema.GroupResource) schema.GroupResource {
 
 func (s *DefaultStorageFactory) getStorageGroupResource(groupResource schema.GroupResource) schema.GroupResource {
 	for _, potentialStorageResource := range s.Overrides[groupResource].cohabitatingResources {
-		if s.APIResourceConfigSource.AnyVersionForGroupEnabled(potentialStorageResource.Group) {
+		if s.APIResourceConfigSource.AnyVersionOfResourceEnabled(potentialStorageResource) {
 			return potentialStorageResource
 		}
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/rest/storage_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/rest/storage_apiservice.go
@@ -34,7 +34,7 @@ import (
 func NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) genericapiserver.APIGroupInfo {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(apiregistration.GroupName, aggregatorscheme.Registry, aggregatorscheme.Scheme, metav1.ParameterCodec, aggregatorscheme.Codecs)
 
-	if apiResourceConfigSource.VersionEnabled(v1beta1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(v1beta1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1beta1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
 		apiServiceREST := apiservicestorage.NewREST(aggregatorscheme.Scheme, restOptionsGetter)
@@ -43,7 +43,7 @@ func NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSourc
 		apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = storage
 	}
 
-	if apiResourceConfigSource.VersionEnabled(v1.SchemeGroupVersion) {
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(v1.SchemeGroupVersion) {
 		apiGroupInfo.GroupMeta.GroupVersion = v1.SchemeGroupVersion
 		storage := map[string]rest.Storage{}
 		apiServiceREST := apiservicestorage.NewREST(aggregatorscheme.Scheme, restOptionsGetter)

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -1127,5 +1127,8 @@ func diffMapKeys(a, b interface{}, stringer func(interface{}) string) []string {
 
 type allResourceSource struct{}
 
-func (*allResourceSource) AnyVersionForGroupEnabled(group string) bool     { return true }
-func (*allResourceSource) VersionEnabled(version schema.GroupVersion) bool { return true }
+func (*allResourceSource) AnyVersionOfResourceEnabled(resource schema.GroupResource) bool { return true }
+func (*allResourceSource) AllResourcesForVersionEnabled(version schema.GroupVersion) bool { return true }
+func (*allResourceSource) AnyResourcesForGroupEnabled(group string) bool                  { return true }
+func (*allResourceSource) ResourceEnabled(resource schema.GroupVersionResource) bool      { return true }
+func (*allResourceSource) AnyResourcesForVersionEnabled(version schema.GroupVersion) bool { return true }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Restores ability to enable/disable resource within an API GroupVersion individually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62116

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Restores ability to enable/disable resource within an API GroupVersion individually.
```
