### PR TITLE
[WIP] refactor fake dynamic client: avoid type assertion which may panic

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/fake/BUILD
+++ b/staging/src/k8s.io/client-go/dynamic/fake/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     importpath = "k8s.io/client-go/dynamic/fake",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The force type-assertion in `obj.(*unstructured.UnstructuredList).Items` will cause panic when I'm trying to reuse the inner `testing.Fake` from the fake clientset. AFAIK, the fake client is storing objects as their original kind e.g. `v1.Configmap, v1beta1.ReplicaSetl`.. but yet the dynamic client is trying to read it as the unstructured type. 

This PR is a workround for avoiding panics which may destroy the goroutine. Trying to to a conversion before putting items into list.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
