### PR TITLE
Don't log when error returned

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/settings/internalversion:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/storage/internalversion:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internalclientset
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -246,7 +245,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -74,7 +73,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package clientset
 
 import (
-	glog "github.com/golang/glog"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -74,7 +73,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internalclientset
 
 import (
-	glog "github.com/golang/glog"
 	apiextensionsinternalversion "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -66,7 +65,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/client-go/kubernetes/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/BUILD
@@ -14,7 +14,6 @@ go_library(
     ],
     importpath = "k8s.io/client-go/kubernetes",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	admissionregistrationv1alpha1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
@@ -518,7 +517,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internalversion
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -78,7 +77,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -94,7 +93,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -94,7 +93,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -83,7 +83,6 @@ func (g *genClientset) GenerateType(c *generator.Context, t *types.Type, w io.Wr
 		"NewDiscoveryClientForConfigOrDie":     c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClientForConfigOrDie"}),
 		"NewDiscoveryClient":                   c.Universe.Function(types.Name{Package: "k8s.io/client-go/discovery", Name: "NewDiscoveryClient"}),
 		"flowcontrolNewTokenBucketRateLimiter": c.Universe.Function(types.Name{Package: "k8s.io/client-go/util/flowcontrol", Name: "NewTokenBucketRateLimiter"}),
-		"glogErrorf":                           c.Universe.Function(types.Name{Package: "github.com/golang/glog", Name: "Errorf"}),
 	}
 	sw.Do(clientsetInterface, m)
 	sw.Do(clientsetTemplate, m)
@@ -163,7 +162,6 @@ $range .allGroups$    cs.$.LowerCaseGroupGoName$$.Version$, err =$.PackageAlias$
 $end$
 	cs.DiscoveryClient, err = $.NewDiscoveryClientForConfig|raw$(&configShallowCopy)
 	if err!=nil {
-		$.glogErrorf|raw$("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package clientset
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -86,7 +85,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internalclientset
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -66,7 +65,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     importpath = "k8s.io/metrics/pkg/client/clientset_generated/clientset",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package clientset
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -86,7 +85,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "k8s.io/sample-apiserver/pkg/client/clientset/internalversion",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package internalversion
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -66,7 +65,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "k8s.io/sample-apiserver/pkg/client/clientset/versioned",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -74,7 +73,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/BUILD
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "k8s.io/sample-controller/pkg/client/clientset/versioned",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-controller/pkg/client/clientset/versioned/clientset.go
@@ -19,7 +19,6 @@ limitations under the License.
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -74,7 +73,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Both logging and returning an error is an antipattern. If the caller wants it logged they will log it. And in this case it will be logged twice which is very confusing for debugging.

**Release note**:
```release-note
NONE
```
/kind cleanup
/sig api-machinery