### PR TITLE
Fixes kubeadm upgrade plan output

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -104,7 +104,7 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 					firstPrinted = true
 					continue
 				}
-				fmt.Fprintf(tabw, "\t\t%d x %s\t%s\n", nodeCount, oldVersion, upgrade.After.KubeVersion)
+				fmt.Fprintf(tabw, "\t%d x %s\t%s\n", nodeCount, oldVersion, upgrade.After.KubeVersion)
 			}
 			// We should flush the writer here at this stage; as the columns will now be of the right size, adjusted to the above content
 			tabw.Flush()

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -332,6 +332,53 @@ _____________________________________________________________________
 
 `),
 		},
+		{
+			upgrades: []upgrade.Upgrade{
+				{
+					Description: "version in the v1.9 series",
+					Before: upgrade.ClusterState{
+						KubeVersion: "v1.9.2",
+						KubeletVersions: map[string]uint16{
+							"v1.9.2": 1,
+							"v1.9.3": 2,
+						},
+						KubeadmVersion: "v1.9.2",
+						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
+					},
+					After: upgrade.ClusterState{
+						KubeVersion:    "v1.9.3",
+						KubeadmVersion: "v1.9.3",
+						DNSVersion:     "1.14.8",
+						EtcdVersion:    "3.1.12",
+					},
+				},
+			},
+			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
+COMPONENT   CURRENT      AVAILABLE
+Kubelet     1 x v1.9.2   v1.9.3
+            2 x v1.9.3   v1.9.3
+
+Upgrade to the latest version in the v1.9 series:
+
+COMPONENT            CURRENT   AVAILABLE
+API Server           v1.9.2    v1.9.3
+Controller Manager   v1.9.2    v1.9.3
+Scheduler            v1.9.2    v1.9.3
+Kube Proxy           v1.9.2    v1.9.3
+Kube DNS             1.14.5    1.14.8
+Etcd                 3.0.17    3.1.12
+
+You can now apply the upgrade by executing the following command:
+
+	kubeadm upgrade apply v1.9.3
+
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.3.
+
+_____________________________________________________________________
+
+`),
+		},
 	}
 	for _, rt := range tests {
 		rt.buf = bytes.NewBufferString("")


### PR DESCRIPTION
Closes kubernetes/kubeadm#713

Aligns `kubeadm upgrade plan` output when kubelets have different versions.

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This PR fixes the output of `kubeadm upgrade plan` when kubelets have different versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#713

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
