### PR TITLE
A test we always skip should not be a conformance test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -38,7 +38,6 @@ test/e2e/common/container_probe.go: "should *not* be restarted with a exec \"cat
 test/e2e/common/container_probe.go: "should be restarted with a /healthz http liveness probe "
 test/e2e/common/container_probe.go: "should have monotonically increasing restart count  [Slow]"
 test/e2e/common/container_probe.go: "should *not* be restarted with a /healthz http liveness probe "
-test/e2e/common/container_probe.go: "should be restarted with a docker exec liveness probe with timeout "
 test/e2e/common/docker_containers.go: "should use the image defaults if command and args are blank "
 test/e2e/common/docker_containers.go: "should be able to override the image's default arguments (docker cmd) "
 test/e2e/common/docker_containers.go: "should be able to override the image's default command (docker entrypoint) "

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -276,7 +276,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure that the pod is restarted with a docker exec
 			liveness probe with timeout.
 	*/
-	framework.ConformanceIt("should be restarted with a docker exec liveness probe with timeout ", func() {
+	It("should be restarted with a docker exec liveness probe with timeout ", func() {
 		// TODO: enable this test once the default exec handler supports timeout.
 		framework.Skipf("The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API")
 		runLivenessTest(f, &v1.Pod{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We should not have a test marked Conformance when it is always skipped

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62217

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
