### PR TITLE
allow user to opt out some diffOptions when doing 2 way diff.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -136,11 +136,24 @@ func CreateTwoWayMergeMapPatch(original, modified JSONMap, dataStruct interface{
 	return CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified, schema, fns...)
 }
 
+// Make user be able to opt out.
+// A common option is disabling the $SetElementOrder directive and leave others as defaulted.
+// DiffOptions{
+//     SetElementOrder: false,
+// }
+func (o DiffOptions) CreateTwoWayMergeMapPatchWithOption(original, modified JSONMap, schema LookupPatchMeta, fns ...mergepatch.PreconditionFunc) (JSONMap, error) {
+	return o.createTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified, schema, fns...)
+}
+
 func CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified JSONMap, schema LookupPatchMeta, fns ...mergepatch.PreconditionFunc) (JSONMap, error) {
 	diffOptions := DiffOptions{
 		SetElementOrder: true,
 	}
-	patchMap, err := diffMaps(original, modified, schema, diffOptions)
+	return diffOptions.createTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified, schema, fns...)
+}
+
+func (o DiffOptions) createTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified JSONMap, schema LookupPatchMeta, fns ...mergepatch.PreconditionFunc) (JSONMap, error) {
+	patchMap, err := diffMaps(original, modified, schema, o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addresses the comment in https://github.com/kubernetes/kubernetes/pull/59284#issuecomment-378834336
It is quite common that people want to update a list and doesn't care about the ordering in the list.
Another use case is for updating the condition list in a pod in [Readiness++](https://docs.google.com/document/d/1VFZbc_IqPf_Msd-jul7LKTmGjvQ5qRldYOFV0lGqxf8/edit#).
This can also improve some performance by avoiding unnecessary patch directive.

```release-note
NONE
```

