### PR TITLE
GCE Cloud Provider: Update ExternalTrafficPolicy on LoadBalancer Service without downtime

### DIFF
--- a/pkg/cloudprovider/providers/gce/cloud/gen.go
+++ b/pkg/cloudprovider/providers/gce/cloud/gen.go
@@ -12178,7 +12178,9 @@ type TargetPools interface {
 	List(ctx context.Context, region string, fl *filter.F) ([]*ga.TargetPool, error)
 	Insert(ctx context.Context, key *meta.Key, obj *ga.TargetPool) error
 	Delete(ctx context.Context, key *meta.Key) error
+	AddHealthCheck(context.Context, *meta.Key, *ga.TargetPoolsAddHealthCheckRequest) error
 	AddInstance(context.Context, *meta.Key, *ga.TargetPoolsAddInstanceRequest) error
+	RemoveHealthCheck(context.Context, *meta.Key, *ga.TargetPoolsRemoveHealthCheckRequest) error
 	RemoveInstance(context.Context, *meta.Key, *ga.TargetPoolsRemoveInstanceRequest) error
 }
 
@@ -12215,12 +12217,14 @@ type MockTargetPools struct {
 	// order to add your own logic. Return (true, _, _) to prevent the normal
 	// execution flow of the mock. Return (false, nil, nil) to continue with
 	// normal mock behavior/ after the hook function executes.
-	GetHook            func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, *ga.TargetPool, error)
-	ListHook           func(ctx context.Context, region string, fl *filter.F, m *MockTargetPools) (bool, []*ga.TargetPool, error)
-	InsertHook         func(ctx context.Context, key *meta.Key, obj *ga.TargetPool, m *MockTargetPools) (bool, error)
-	DeleteHook         func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, error)
-	AddInstanceHook    func(context.Context, *meta.Key, *ga.TargetPoolsAddInstanceRequest, *MockTargetPools) error
-	RemoveInstanceHook func(context.Context, *meta.Key, *ga.TargetPoolsRemoveInstanceRequest, *MockTargetPools) error
+	GetHook               func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, *ga.TargetPool, error)
+	ListHook              func(ctx context.Context, region string, fl *filter.F, m *MockTargetPools) (bool, []*ga.TargetPool, error)
+	InsertHook            func(ctx context.Context, key *meta.Key, obj *ga.TargetPool, m *MockTargetPools) (bool, error)
+	DeleteHook            func(ctx context.Context, key *meta.Key, m *MockTargetPools) (bool, error)
+	AddHealthCheckHook    func(context.Context, *meta.Key, *ga.TargetPoolsAddHealthCheckRequest, *MockTargetPools) error
+	AddInstanceHook       func(context.Context, *meta.Key, *ga.TargetPoolsAddInstanceRequest, *MockTargetPools) error
+	RemoveHealthCheckHook func(context.Context, *meta.Key, *ga.TargetPoolsRemoveHealthCheckRequest, *MockTargetPools) error
+	RemoveInstanceHook    func(context.Context, *meta.Key, *ga.TargetPoolsRemoveInstanceRequest, *MockTargetPools) error
 
 	// X is extra state that can be used as part of the mock. Generated code
 	// will not use this field.
@@ -12369,10 +12373,26 @@ func (m *MockTargetPools) Obj(o *ga.TargetPool) *MockTargetPoolsObj {
 	return &MockTargetPoolsObj{o}
 }
 
+// AddHealthCheck is a mock for the corresponding method.
+func (m *MockTargetPools) AddHealthCheck(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsAddHealthCheckRequest) error {
+	if m.AddHealthCheckHook != nil {
+		return m.AddHealthCheckHook(ctx, key, arg0, m)
+	}
+	return nil
+}
+
 // AddInstance is a mock for the corresponding method.
 func (m *MockTargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsAddInstanceRequest) error {
 	if m.AddInstanceHook != nil {
 		return m.AddInstanceHook(ctx, key, arg0, m)
+	}
+	return nil
+}
+
+// RemoveHealthCheck is a mock for the corresponding method.
+func (m *MockTargetPools) RemoveHealthCheck(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsRemoveHealthCheckRequest) error {
+	if m.RemoveHealthCheckHook != nil {
+		return m.RemoveHealthCheckHook(ctx, key, arg0, m)
 	}
 	return nil
 }
@@ -12526,6 +12546,39 @@ func (g *GCETargetPools) Delete(ctx context.Context, key *meta.Key) error {
 	return err
 }
 
+// AddHealthCheck is a method on GCETargetPools.
+func (g *GCETargetPools) AddHealthCheck(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsAddHealthCheckRequest) error {
+	glog.V(5).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		glog.V(2).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "ga", "TargetPools")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "AddHealthCheck",
+		Version:   meta.Version("ga"),
+		Service:   "TargetPools",
+	}
+	glog.V(5).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		glog.V(4).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.GA.TargetPools.AddHealthCheck(projectID, key.Region, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		glog.V(4).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	glog.V(4).Infof("GCETargetPools.AddHealthCheck(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
 // AddInstance is a method on GCETargetPools.
 func (g *GCETargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsAddInstanceRequest) error {
 	glog.V(5).Infof("GCETargetPools.AddInstance(%v, %v, ...): called", ctx, key)
@@ -12556,6 +12609,39 @@ func (g *GCETargetPools) AddInstance(ctx context.Context, key *meta.Key, arg0 *g
 	}
 	err = g.s.WaitForCompletion(ctx, op)
 	glog.V(4).Infof("GCETargetPools.AddInstance(%v, %v, ...) = %+v", ctx, key, err)
+	return err
+}
+
+// RemoveHealthCheck is a method on GCETargetPools.
+func (g *GCETargetPools) RemoveHealthCheck(ctx context.Context, key *meta.Key, arg0 *ga.TargetPoolsRemoveHealthCheckRequest) error {
+	glog.V(5).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...): called", ctx, key)
+
+	if !key.Valid() {
+		glog.V(2).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...): key is invalid (%#v)", ctx, key, key)
+		return fmt.Errorf("invalid GCE key (%+v)", key)
+	}
+	projectID := g.s.ProjectRouter.ProjectID(ctx, "ga", "TargetPools")
+	rk := &RateLimitKey{
+		ProjectID: projectID,
+		Operation: "RemoveHealthCheck",
+		Version:   meta.Version("ga"),
+		Service:   "TargetPools",
+	}
+	glog.V(5).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...): projectID = %v, rk = %+v", ctx, key, projectID, rk)
+
+	if err := g.s.RateLimiter.Accept(ctx, rk); err != nil {
+		glog.V(4).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...): RateLimiter error: %v", ctx, key, err)
+		return err
+	}
+	call := g.s.GA.TargetPools.RemoveHealthCheck(projectID, key.Region, key.Name, arg0)
+	call.Context(ctx)
+	op, err := call.Do()
+	if err != nil {
+		glog.V(4).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...) = %+v", ctx, key, err)
+		return err
+	}
+	err = g.s.WaitForCompletion(ctx, op)
+	glog.V(4).Infof("GCETargetPools.RemoveHealthCheck(%v, %v, ...) = %+v", ctx, key, err)
 	return err
 }
 

--- a/pkg/cloudprovider/providers/gce/cloud/meta/meta.go
+++ b/pkg/cloudprovider/providers/gce/cloud/meta/meta.go
@@ -363,6 +363,8 @@ var AllServices = []*ServiceInfo{
 		additionalMethods: []string{
 			"AddInstance",
 			"RemoveInstance",
+			"AddHealthCheck",
+			"RemoveHealthCheck",
 		},
 	},
 	{

--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -92,6 +92,66 @@ func RemoveInstanceHook(ctx context.Context, key *meta.Key, req *ga.TargetPoolsR
 	return nil
 }
 
+// AddHealthCheckHook mocks adding healthcheck to MockTargetPools.
+func AddHealthCheckHook(ctx context.Context, key *meta.Key, req *ga.TargetPoolsAddHealthCheckRequest, m *cloud.MockTargetPools) error {
+	pool, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in TargetPools", key.String()),
+		}
+	}
+
+	for _, hc := range req.HealthChecks {
+		pool.HealthChecks = append(pool.HealthChecks, hc.HealthCheck)
+	}
+
+	return nil
+}
+
+// RemoveHealthCheckHook mocks removing healthcheck from MockTargetPools.
+func RemoveHealthCheckHook(ctx context.Context, key *meta.Key, req *ga.TargetPoolsRemoveHealthCheckRequest, m *cloud.MockTargetPools) error {
+	pool, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in TargetPools", key.String()),
+		}
+	}
+
+	for _, hcToRemove := range req.HealthChecks {
+		for i, hc := range pool.HealthChecks {
+			if hcToRemove.HealthCheck == hc {
+				// Delete health check from pool.HealthChecks without preserving order
+				pool.HealthChecks[i] = pool.HealthChecks[len(pool.HealthChecks)-1]
+				pool.HealthChecks = pool.HealthChecks[:len(pool.HealthChecks)-1]
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// UpdateHTTPHealthCheckHook defines the hook for updating a HttpHealthCheck. It
+// replaces the object with the same key in the mock with the updated object.
+func UpdateHTTPHealthCheckHook(ctx context.Context, key *meta.Key, obj *ga.HttpHealthCheck, m *cloud.MockHttpHealthChecks) error {
+	_, err := m.Get(ctx, key)
+	if err != nil {
+		return &googleapi.Error{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("Key: %s was not found in HealthChecks", key.String()),
+		}
+	}
+
+	obj.Name = key.Name
+	projectID := m.ProjectRouter.ProjectID(ctx, "ga", "httpHealthChecks")
+	obj.SelfLink = cloud.SelfLink(meta.VersionGA, projectID, "httpHealthChecks", key)
+
+	m.Objects[*key] = &cloud.MockHttpHealthChecksObj{Obj: obj}
+	return nil
+}
+
 func convertAndInsertAlphaForwardingRule(key *meta.Key, obj gceObject, mRules map[meta.Key]*cloud.MockForwardingRulesObj, version meta.Version, projectID string) (bool, error) {
 	if !key.Valid() {
 		return false, fmt.Errorf("invalid GCE key (%+v)", key)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -210,26 +210,28 @@ func (gce *GCECloud) ensureExternalLoadBalancer(clusterName, clusterID string, a
 		glog.V(4).Infof("ensureExternalLoadBalancer(%s): Service needs local traffic health checks on: %d%s.", lbRefStr, healthCheckNodePort, path)
 		if hcLocalTrafficExisting == nil {
 			// This logic exists to detect a transition for non-OnlyLocal to OnlyLocal service
-			// turn on the tpNeedsRecreation flag to delete/recreate fwdrule/tpool updating the
-			// target pool to use local traffic health check.
+			// and update health checks for the target pool to use local traffic health check.
 			glog.V(2).Infof("ensureExternalLoadBalancer(%s): Updating from nodes health checks to local traffic health checks.", lbRefStr)
 			if supportsNodesHealthCheck {
 				hcToDelete = makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
 			}
-			tpNeedsRecreation = true
 		}
-		hcToCreate = makeHttpHealthCheck(loadBalancerName, path, healthCheckNodePort)
+		// If the target pool needs to be recreaed or is in a transition from
+		// non-OnlyLocal to Onlylocal service, a new heath check will be required.
+		if tpNeedsRecreation || hcLocalTrafficExisting == nil {
+			hcToCreate = makeHttpHealthCheck(loadBalancerName, path, healthCheckNodePort)
+		}
 	} else {
 		glog.V(4).Infof("ensureExternalLoadBalancer(%s): Service needs nodes health checks.", lbRefStr)
 		if hcLocalTrafficExisting != nil {
 			// This logic exists to detect a transition from OnlyLocal to non-OnlyLocal service
-			// and turn on the tpNeedsRecreation flag to delete/recreate fwdrule/tpool updating the
-			// target pool to use nodes health check.
+			// and create/delete health checks from the target pool.
 			glog.V(2).Infof("ensureExternalLoadBalancer(%s): Updating from local traffic health checks to nodes health checks.", lbRefStr)
 			hcToDelete = hcLocalTrafficExisting
-			tpNeedsRecreation = true
 		}
-		if supportsNodesHealthCheck {
+		// If the target pool needs to be recreaed or is in a transition from
+		// Onlylocal to non-OnlyLocal service, a new heath check will be required.
+		if (tpNeedsRecreation || hcLocalTrafficExisting != nil) && supportsNodesHealthCheck {
 			hcToCreate = makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
 		}
 	}
@@ -350,6 +352,52 @@ func (gce *GCECloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID st
 	return nil
 }
 
+func (gce *GCECloud) deleteHealthCheckAndFirewall(service *v1.Service, name, clusterID string, hcName string) error {
+	serviceName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	lbRefStr := fmt.Sprintf("%v(%v)", name, serviceName)
+
+	// Check whether it is nodes health check, which has different name from the load-balancer.
+	isNodesHealthCheck := hcName != name
+	if isNodesHealthCheck {
+		// Lock to prevent deleting necessary nodes health check before it gets attached
+		// to target pool.
+		gce.sharedResourceLock.Lock()
+		defer gce.sharedResourceLock.Unlock()
+	}
+	glog.Infof("deleteHealthCheckAndFirewall(%v): Deleting health check %v.", lbRefStr, hcName)
+	if err := gce.DeleteHttpHealthCheck(hcName); err != nil {
+		// Delete nodes health checks will fail if any other target pool is using it.
+		if isInUsedByError(err) {
+			glog.V(4).Infof("deleteHealthCheckAndFirewall(%v): Health check %v is in used: %v.", lbRefStr, hcName, err)
+			return nil
+		} else if !isHTTPErrorCode(err, http.StatusNotFound) {
+			glog.Warningf("deleteHealthCheckAndFirewall(%v): Failed to delete health check %v: %v.", lbRefStr, hcName, err)
+			return err
+		}
+		// StatusNotFound could happen when:
+		// - This is the first attempt but we pass in a healthcheck that is already deleted
+		//   to prevent leaking.
+		// - This is the first attempt but user manually deleted the heathcheck.
+		// - This is a retry and in previous round we failed to delete the healthcheck firewall
+		//   after deleted the healthcheck.
+		// We continue to delete the healthcheck firewall to prevent leaking.
+		glog.V(4).Infof("deleteHealthCheckAndFirewall(%v): Health check %v is already deleted.", lbRefStr, hcName)
+	}
+	// If health check is deleted without error, it means no load-balancer is using it.
+	// So we should delete the health check firewall as well.
+	fwName := MakeHealthCheckFirewallName(clusterID, hcName, isNodesHealthCheck)
+	glog.Infof("deleteHealthCheckAndFirewall(%v): Deleting health check firewall %v.", lbRefStr, fwName)
+	if err := ignoreNotFound(gce.DeleteFirewall(fwName)); err != nil {
+		if isForbidden(err) && gce.OnXPN() {
+			glog.V(4).Infof("deleteHealthCheckAndFirewall(%v): Do not have permission to delete firewall rule %v (on XPN). Raising event.", lbRefStr, fwName)
+			gce.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, gce.NetworkProjectID()))
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func (gce *GCECloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name, region, clusterID string, hcNames ...string) error {
 	serviceName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
 	lbRefStr := fmt.Sprintf("%v(%v)", name, serviceName)
@@ -363,48 +411,7 @@ func (gce *GCECloud) DeleteExternalTargetPoolAndChecks(service *v1.Service, name
 
 	// Deletion of health checks is allowed only after the TargetPool reference is deleted
 	for _, hcName := range hcNames {
-		if err := func() error {
-			// Check whether it is nodes health check, which has different name from the load-balancer.
-			isNodesHealthCheck := hcName != name
-			if isNodesHealthCheck {
-				// Lock to prevent deleting necessary nodes health check before it gets attached
-				// to target pool.
-				gce.sharedResourceLock.Lock()
-				defer gce.sharedResourceLock.Unlock()
-			}
-			glog.Infof("DeleteExternalTargetPoolAndChecks(%v): Deleting health check %v.", lbRefStr, hcName)
-			if err := gce.DeleteHttpHealthCheck(hcName); err != nil {
-				// Delete nodes health checks will fail if any other target pool is using it.
-				if isInUsedByError(err) {
-					glog.V(4).Infof("DeleteExternalTargetPoolAndChecks(%v): Health check %v is in used: %v.", lbRefStr, hcName, err)
-					return nil
-				} else if !isHTTPErrorCode(err, http.StatusNotFound) {
-					glog.Warningf("DeleteExternalTargetPoolAndChecks(%v): Failed to delete health check %v: %v.", lbRefStr, hcName, err)
-					return err
-				}
-				// StatusNotFound could happen when:
-				// - This is the first attempt but we pass in a healthcheck that is already deleted
-				//   to prevent leaking.
-				// - This is the first attempt but user manually deleted the heathcheck.
-				// - This is a retry and in previous round we failed to delete the healthcheck firewall
-				//   after deleted the healthcheck.
-				// We continue to delete the healthcheck firewall to prevent leaking.
-				glog.V(4).Infof("DeleteExternalTargetPoolAndChecks(%v): Health check %v is already deleted.", lbRefStr, hcName)
-			}
-			// If health check is deleted without error, it means no load-balancer is using it.
-			// So we should delete the health check firewall as well.
-			fwName := MakeHealthCheckFirewallName(clusterID, hcName, isNodesHealthCheck)
-			glog.Infof("DeleteExternalTargetPoolAndChecks(%v): Deleting health check firewall %v.", lbRefStr, fwName)
-			if err := ignoreNotFound(gce.DeleteFirewall(fwName)); err != nil {
-				if isForbidden(err) && gce.OnXPN() {
-					glog.V(4).Infof("DeleteExternalTargetPoolAndChecks(%v): Do not have permission to delete firewall rule %v (on XPN). Raising event.", lbRefStr, fwName)
-					gce.raiseFirewallChangeNeededEvent(service, FirewallToGCloudDeleteCmd(fwName, gce.NetworkProjectID()))
-					return nil
-				}
-				return err
-			}
-			return nil
-		}(); err != nil {
+		if err := gce.deleteHealthCheckAndFirewall(service, name, clusterID, hcName); err != nil {
 			return err
 		}
 	}
@@ -477,6 +484,7 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 		}
 		glog.Infof("ensureTargetPoolAndHealthCheck(%s): Deleted target pool.", lbRefStr)
 	}
+
 	// Once we've deleted the resources (if necessary), build them back up (or for
 	// the first time if they're new).
 	if tpNeedsRecreation {
@@ -500,6 +508,56 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 			glog.Infof("ensureTargetPoolAndHealthCheck(%s): Updated target pool (with %d hosts).", lbRefStr, len(hosts)-maxTargetPoolCreateInstances)
 		}
 	} else if tpExists {
+		if hcToDelete != nil || hcToCreate != nil {
+			// Check if this target pool needs a new health check or delete an existing one.
+			pool, err := gce.GetTargetPool(loadBalancerName, gce.region)
+			if err != nil {
+				return err
+			}
+			if hcToDelete != nil {
+				for _, hc := range pool.HealthChecks {
+					if getHealthCheckNameFromLink(hc) == hcToDelete.Name {
+						healthchecks := []*compute.HealthCheckReference{{HealthCheck: hc}}
+						if err := gce.RemoveHealthChecksFromTargetPool(loadBalancerName, gce.region, healthchecks); err != nil {
+							return fmt.Errorf("failed to remove healthcheck from target pool for load balancer (%s): %v", lbRefStr, err)
+						}
+						if err := gce.deleteHealthCheckAndFirewall(svc, loadBalancerName, clusterID, hcToDelete.Name); err != nil {
+							return fmt.Errorf("failed to delete healthcheck for load balancer (%s): %v", lbRefStr, err)
+						}
+						// Mark that hcToDelete has been deleted.
+						hcToDelete = nil
+						break
+					}
+				}
+				if hcToDelete != nil {
+					glog.Errorf("Trying to delete a healthcheck which is not referred by the load balancer (%s): %s", lbRefStr, hcToDelete.Name)
+				}
+			}
+
+			if hcToCreate != nil {
+				for _, hc := range pool.HealthChecks {
+					if getHealthCheckNameFromLink(hc) == hcToCreate.Name {
+						glog.Warningf("Healthcheck to be created is already referred by the load balancer (%s): %s. Will update this hc instead.", lbRefStr, hcToCreate.Name)
+						if err := gce.UpdateHttpHealthCheck(hcToCreate); err != nil {
+							return fmt.Errorf("Failed to update http health check %v for load balancer (%s)", hcToCreate.Name, lbRefStr)
+						}
+						hcToCreate = nil
+						break
+					}
+				}
+				if hcToCreate != nil {
+					hcCreated, err := gce.createHealthCheckAndFirewall(svc, loadBalancerName, serviceName.String(), ipAddressToUse, gce.region, clusterID, hosts, hcToCreate)
+					if err != nil {
+						return err
+					}
+					healthchecks := []*compute.HealthCheckReference{{HealthCheck: hcCreated.SelfLink}}
+					if err := gce.AddHealthChecksToTargetPool(loadBalancerName, gce.region, healthchecks); err != nil {
+						return fmt.Errorf("failed to add healthcheck to target pool for load balancer (%s): %v", lbRefStr, err)
+					}
+				}
+			}
+		}
+
 		// Ensure hosts are updated even if there is no other changes required on target pool.
 		if err := gce.updateTargetPool(loadBalancerName, hosts); err != nil {
 			return fmt.Errorf("failed to update target pool for load balancer (%s): %v", lbRefStr, err)
@@ -509,27 +567,35 @@ func (gce *GCECloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation 
 	return nil
 }
 
+func (gce *GCECloud) createHealthCheckAndFirewall(svc *v1.Service, name, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hc *compute.HttpHealthCheck) (*compute.HttpHealthCheck, error) {
+	// Check whether it is nodes health check, which has different name from the load-balancer.
+	isNodesHealthCheck := hc.Name != name
+	if isNodesHealthCheck {
+		// Lock to prevent necessary nodes health check / firewall gets deleted.
+		gce.sharedResourceLock.Lock()
+		defer gce.sharedResourceLock.Unlock()
+	}
+
+	if err := gce.ensureHttpHealthCheckFirewall(svc, serviceName, ipAddress, region, clusterID, hosts, hc.Name, int32(hc.Port), isNodesHealthCheck); err != nil {
+		return nil, err
+	}
+	var err error
+	hcRequestPath, hcPort := hc.RequestPath, hc.Port
+	if hc, err = gce.ensureHttpHealthCheck(hc.Name, hc.RequestPath, int32(hc.Port)); err != nil || hc == nil {
+		return nil, fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", name, hcPort, hcRequestPath, err)
+	}
+	return hc, nil
+}
+
 func (gce *GCECloud) createTargetPoolAndHealthCheck(svc *v1.Service, name, serviceName, ipAddress, region, clusterID string, hosts []*gceInstance, hc *compute.HttpHealthCheck) error {
 	// health check management is coupled with targetPools to prevent leaks. A
 	// target pool is the only thing that requires a health check, so we delete
 	// associated checks on teardown, and ensure checks on setup.
 	hcLinks := []string{}
 	if hc != nil {
-		// Check whether it is nodes health check, which has different name from the load-balancer.
-		isNodesHealthCheck := hc.Name != name
-		if isNodesHealthCheck {
-			// Lock to prevent necessary nodes health check / firewall gets deleted.
-			gce.sharedResourceLock.Lock()
-			defer gce.sharedResourceLock.Unlock()
-		}
-
-		if err := gce.ensureHttpHealthCheckFirewall(svc, serviceName, ipAddress, region, clusterID, hosts, hc.Name, int32(hc.Port), isNodesHealthCheck); err != nil {
+		hc, err := gce.createHealthCheckAndFirewall(svc, name, serviceName, ipAddress, region, clusterID, hosts, hc)
+		if err != nil {
 			return err
-		}
-		var err error
-		hcRequestPath, hcPort := hc.RequestPath, hc.Port
-		if hc, err = gce.ensureHttpHealthCheck(hc.Name, hc.RequestPath, int32(hc.Port)); err != nil || hc == nil {
-			return fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", name, hcPort, hcRequestPath, err)
 		}
 		hcLinks = append(hcLinks, hc.SelfLink)
 	}
@@ -619,6 +685,14 @@ func makeHttpHealthCheck(name, path string, port int32) *compute.HttpHealthCheck
 		HealthyThreshold:   gceHcHealthyThreshold,
 		UnhealthyThreshold: gceHcUnhealthyThreshold,
 	}
+}
+
+func getHealthCheckNameFromLink(url string) string {
+	parts := strings.Split(url, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
 }
 
 func (gce *GCECloud) ensureHttpHealthCheck(name, path string, port int32) (hc *compute.HttpHealthCheck, err error) {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -309,6 +309,67 @@ func TestEnsureExternalLoadBalancer(t *testing.T) {
 	assertExternalLbResources(t, gce, svc, vals, nodeNames)
 }
 
+func TestHealthCheckChangesWhenServiceSwitchLocality(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	nodeName := "test-node-1"
+
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	svc := fakeLoadbalancerService("")
+	svc.Spec.HealthCheckNodePort = 10086
+
+	nodes, err := createAndInsertNodes(gce, []string{nodeName}, vals.ZoneName)
+
+	status, err := gce.ensureExternalLoadBalancer(
+		vals.ClusterName,
+		vals.ClusterID,
+		svc,
+		nil,
+		nodes,
+	)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, status.Ingress)
+
+	lbName := cloudprovider.GetLoadBalancerName(svc)
+	hcName := MakeNodesHealthCheckName(vals.ClusterID)
+
+	// Check that TargetPool is created
+	pool, err := gce.GetTargetPool(lbName, gce.region)
+	require.NoError(t, err)
+	assert.Equal(t, lbName, pool.Name)
+	assert.NotEmpty(t, pool.HealthChecks)
+	assert.Equal(t, 1, len(pool.Instances))
+
+	// Check that node HealthCheck is created
+	healthcheck, err := gce.GetHttpHealthCheck(hcName)
+	require.NoError(t, err)
+	assert.Equal(t, hcName, healthcheck.Name)
+	assert.Equal(t, GetNodesHealthCheckPort(), int32(healthcheck.Port))
+
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	status, err = gce.ensureExternalLoadBalancer(
+		vals.ClusterName,
+		vals.ClusterID,
+		svc,
+		nil,
+		nodes,
+	)
+	assert.NoError(t, err)
+	pool, err = gce.GetTargetPool(lbName, gce.region)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(pool.Instances))
+
+	// Check that a new HealthCheck is created and the old one is deleted
+	healthcheck, err = gce.GetHttpHealthCheck(hcName)
+	assert.Error(t, err)
+	assert.Nil(t, healthcheck)
+
+	healthcheck, err = gce.GetHttpHealthCheck(lbName)
+	assert.Equal(t, lbName, healthcheck.Name)
+	assert.Equal(t, svc.Spec.HealthCheckNodePort, int32(healthcheck.Port))
+}
+
 func TestUpdateExternalLoadBalancer(t *testing.T) {
 	t.Parallel()
 
@@ -841,6 +902,64 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	assert.NoError(t, err)
 	pool, err = gce.GetTargetPool(lbName, region)
 	assert.Equal(t, 1, len(pool.Instances))
+}
+
+func TestEnsureTargetPoolMaintainsReferenceToHealthCheck(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+
+	svc := fakeLoadbalancerService("")
+
+	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
+	require.NoError(t, err)
+	status, err := gce.ensureExternalLoadBalancer(
+		vals.ClusterName,
+		vals.ClusterID,
+		svc,
+		nil,
+		nodes,
+	)
+	require.NotNil(t, status)
+	require.NoError(t, err)
+
+	hostNames := nodeNames(nodes)
+	hosts, err := gce.getInstancesByNames(hostNames)
+	clusterID := vals.ClusterID
+
+	ipAddr := status.Ingress[0].IP
+	lbName := cloudprovider.GetLoadBalancerName(svc)
+	region := vals.Region
+
+	// Should be able to create health check
+	err = gce.ensureTargetPoolAndHealthCheck(true, true, svc, lbName, clusterID, ipAddr, hosts, makeHttpHealthCheck("hc_a", "/healthz_a", 10086), nil)
+	assert.NoError(t, err)
+	pool, err := gce.GetTargetPool(lbName, region)
+	require.NotNil(t, pool)
+	assert.Equal(t, 1, len(pool.HealthChecks))
+	assert.Equal(t, "hc_a", getHealthCheckNameFromLink(pool.HealthChecks[0]))
+	hc, err := gce.GetHttpHealthCheck("hc_a")
+	require.NotNil(t, hc)
+	assert.Equal(t, "/healthz_a", hc.RequestPath)
+
+	// Should be able to update healthcheck the hcToCreate is already referred by the target pool
+	err = gce.ensureTargetPoolAndHealthCheck(true, false, svc, lbName, clusterID, ipAddr, hosts, makeHttpHealthCheck("hc_a", "/healthz_a_2", 10086), nil)
+	assert.NoError(t, err)
+	hc, err = gce.GetHttpHealthCheck("hc_a")
+	require.NotNil(t, hc)
+	assert.Equal(t, "/healthz_a_2", hc.RequestPath)
+
+	// Should be able to update healthcheck the hcToCreate is already referred by the target pool
+	err = gce.ensureTargetPoolAndHealthCheck(true, false, svc, lbName, clusterID, ipAddr, hosts, nil, makeHttpHealthCheck("hc_a", "/healthz_a_2", 10086))
+	assert.NoError(t, err)
+	pool, err = gce.GetTargetPool(lbName, region)
+	assert.Equal(t, 0, len(pool.HealthChecks))
+	hc, err = gce.GetHttpHealthCheck("hc_a")
+	assert.Nil(t, hc)
+
+	// Should not crash when the health check doesn't exists.
+	err = gce.ensureTargetPoolAndHealthCheck(true, false, svc, lbName, clusterID, ipAddr, hosts, nil, makeHttpHealthCheck("hc_a", "/healthz_a_2", 10086))
+	assert.NoError(t, err)
 }
 
 func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -131,6 +131,8 @@ func fakeGCECloud(vals TestClusterValues) (*GCECloud, error) {
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	c.MockTargetPools.AddInstanceHook = mock.AddInstanceHook
 	c.MockTargetPools.RemoveInstanceHook = mock.RemoveInstanceHook
+	c.MockTargetPools.AddHealthCheckHook = mock.AddHealthCheckHook
+	c.MockTargetPools.RemoveHealthCheckHook = mock.RemoveHealthCheckHook
 	c.MockForwardingRules.InsertHook = mock.InsertFwdRuleHook
 	c.MockAddresses.InsertHook = mock.InsertAddressHook
 	c.MockAlphaAddresses.InsertHook = mock.InsertAlphaAddressHook
@@ -147,6 +149,7 @@ func fakeGCECloud(vals TestClusterValues) (*GCECloud, error) {
 
 	c.MockRegionBackendServices.UpdateHook = mock.UpdateRegionBackendServiceHook
 	c.MockHealthChecks.UpdateHook = mock.UpdateHealthCheckHook
+	c.MockHttpHealthChecks.UpdateHook = mock.UpdateHTTPHealthCheckHook
 	c.MockFirewalls.UpdateHook = mock.UpdateFirewallHook
 
 	keyGA := meta.GlobalKey("key-ga")

--- a/pkg/cloudprovider/providers/gce/gce_targetpool.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetpool.go
@@ -64,3 +64,21 @@ func (gce *GCECloud) RemoveInstancesFromTargetPool(name, region string, instance
 	mc := newTargetPoolMetricContext("remove_instances", region)
 	return mc.Observe(gce.c.TargetPools().RemoveInstance(context.Background(), meta.RegionalKey(name, region), req))
 }
+
+// AddHealthCheckToTargetPool adds health checks by link to the TargetPool
+func (gce *GCECloud) AddHealthChecksToTargetPool(name, region string, hcRefs []*compute.HealthCheckReference) error {
+	req := &compute.TargetPoolsAddHealthCheckRequest{
+		HealthChecks: hcRefs,
+	}
+	mc := newTargetPoolMetricContext("add_healthchecks", region)
+	return mc.Observe(gce.c.TargetPools().AddHealthCheck(context.Background(), meta.RegionalKey(name, region), req))
+}
+
+// RemoveHealthCheckFromTargetPool removes health checks by link to the TargetPool
+func (gce *GCECloud) RemoveHealthChecksFromTargetPool(name, region string, hcRefs []*compute.HealthCheckReference) error {
+	req := &compute.TargetPoolsRemoveHealthCheckRequest{
+		HealthChecks: hcRefs,
+	}
+	mc := newTargetPoolMetricContext("remove_healthchecks", region)
+	return mc.Observe(gce.c.TargetPools().RemoveHealthCheck(context.Background(), meta.RegionalKey(name, region), req))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Prevent target pool recreation on updating ExternalTrafficPolicy for GCE provider to eliminate downtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #49425

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
