### PR TITLE
Add support to resize Portworx volume

### DIFF
--- a/pkg/volume/portworx/BUILD
+++ b/pkg/volume/portworx/BUILD
@@ -15,6 +15,7 @@ go_test(
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/util/testing:go_default_library",
     ],

--- a/pkg/volume/portworx/portworx_test.go
+++ b/pkg/volume/portworx/portworx_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -106,7 +107,7 @@ func (fake *fakePortworxManager) UnmountVolume(c *portworxVolumeUnmounter, mount
 	return nil
 }
 
-func (fake *fakePortworxManager) CreateVolume(c *portworxVolumeProvisioner) (volumeID string, volumeSizeGB int, labels map[string]string, err error) {
+func (fake *fakePortworxManager) CreateVolume(c *portworxVolumeProvisioner) (volumeID string, volumeSizeGB int64, labels map[string]string, err error) {
 	labels = make(map[string]string)
 	labels["fakeportworxmanager"] = "yes"
 	return PortworxTestVolume, 100, labels, nil
@@ -116,6 +117,10 @@ func (fake *fakePortworxManager) DeleteVolume(cd *portworxVolumeDeleter) error {
 	if cd.volumeID != PortworxTestVolume {
 		return fmt.Errorf("Deleter got unexpected volume name: %s", cd.volumeID)
 	}
+	return nil
+}
+
+func (fake *fakePortworxManager) ResizeVolume(spec *volume.Spec, newSize resource.Quantity, volumeHost volume.VolumeHost) error {
 	return nil
 }
 

--- a/plugin/pkg/admission/storage/persistentvolume/resize/admission.go
+++ b/plugin/pkg/admission/storage/persistentvolume/resize/admission.go
@@ -149,7 +149,7 @@ func (pvcr *persistentVolumeClaimResize) allowResize(pvc, oldPvc *api.Persistent
 
 // checkVolumePlugin checks whether the volume plugin supports resize
 func (pvcr *persistentVolumeClaimResize) checkVolumePlugin(pv *api.PersistentVolume) bool {
-	if pv.Spec.Glusterfs != nil || pv.Spec.Cinder != nil || pv.Spec.RBD != nil {
+	if pv.Spec.Glusterfs != nil || pv.Spec.Cinder != nil || pv.Spec.RBD != nil || pv.Spec.PortworxVolume != nil {
 		return true
 	}
 


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**:

This PR adds support in the Portworx volume plugin to expand an existing PVC.

**Which issue(s) this PR fixes**:

Closes #62305

**Release note**:

```release-note
Add support to resize Portworx volumes.
```
