### PR TITLE
delete the duplicate 'update.Pod' para in err log

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -183,7 +183,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan UpdatePodOptions) {
 		}
 		if err != nil {
 			// IMPORTANT: we do not log errors here, the syncPodFn is responsible for logging errors
-			glog.Errorf("Error syncing pod %s (%q), skipping: %v", update.Pod.UID, format.Pod(update.Pod), err)
+			glog.Errorf("Error syncing pod %s, skipping: %v", format.Pod(update.Pod), err)
 		}
 		p.wrapUp(update.Pod.UID, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To make the err log more concise
before this pr:
`E0410 20:31:10.398648   16373 pod_workers.go:186] Error syncing pod 0ab2798b-3cbb-11e8-bbaa-002dc92800b3 ("nginx-mlxgc_default(0ab2798b-3cbb-11e8-bbaa-002dc92800b3)"), skipping: failed to "StartContainer" for "nginx" with CrashLoopBackOff: "Back-off 10s restarting failed container=nginx pod=nginx-mlxgc_default(0ab2798b-3cbb-11e8-bbaa-002dc92800b3)"`

after:
`E0410 20:33:41.293646   19445 pod_workers.go:186] Error syncing pod nginx-nnf6s_default(5afd412b-3cbb-11e8-bbaa-002dc92800b3), skipping: failed to "StartContainer" for "nginx" with CrashLoopBackOff: "Back-off 20s restarting failed container=nginx pod=nginx-nnf6s_default(5afd412b-3cbb-11e8-bbaa-002dc92800b3)"`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
