### PR TITLE
add statefulset scaling permission to admins, editors, and viewers

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -236,7 +236,8 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(Read...).Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbac.NewRule("impersonate").Groups(legacyGroup).Resources("serviceaccounts").RuleOrDie(),
 
-				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources("statefulsets",
+				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources(
+					"statefulsets", "statefulsets/scale",
 					"daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback",
 					"replicasets", "replicasets/scale").RuleOrDie(),
@@ -275,7 +276,8 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(Read...).Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 				rbac.NewRule("impersonate").Groups(legacyGroup).Resources("serviceaccounts").RuleOrDie(),
 
-				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources("statefulsets",
+				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources(
+					"statefulsets", "statefulsets/scale",
 					"daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback",
 					"replicasets", "replicasets/scale").RuleOrDie(),
@@ -307,7 +309,8 @@ func ClusterRoles() []rbac.ClusterRole {
 				// indicator of which namespaces you have access to.
 				rbac.NewRule(Read...).Groups(legacyGroup).Resources("namespaces").RuleOrDie(),
 
-				rbac.NewRule(Read...).Groups(appsGroup).Resources("statefulsets",
+				rbac.NewRule(Read...).Groups(appsGroup).Resources(
+					"statefulsets", "statefulsets/scale",
 					"daemonsets",
 					"deployments", "deployments/scale",
 					"replicasets", "replicasets/scale").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -137,6 +137,7 @@ items:
     - replicasets
     - replicasets/scale
     - statefulsets
+    - statefulsets/scale
     verbs:
     - create
     - delete
@@ -329,6 +330,7 @@ items:
     - replicasets
     - replicasets/scale
     - statefulsets
+    - statefulsets/scale
     verbs:
     - create
     - delete
@@ -471,6 +473,7 @@ items:
     - replicasets
     - replicasets/scale
     - statefulsets
+    - statefulsets/scale
     verbs:
     - get
     - list


### PR DESCRIPTION
StatefulSets are missing scale permissions, so users can't scale them.


```release-note
fix permissions to allow statefulset scaling for admins, editors, and viewers
```