### PR TITLE
Custom metrics autoscaling e2e adapter tests

### DIFF
--- a/test/e2e/autoscaling/BUILD
+++ b/test/e2e/autoscaling/BUILD
@@ -11,6 +11,8 @@ go_library(
         "autoscaling_timer.go",
         "cluster_autoscaler_scalability.go",
         "cluster_size_autoscaling.go",
+        "custom_metrics_adapter_autoscaling.go",
+        "custom_metrics_autoscaling_utils.go",
         "custom_metrics_stackdriver_autoscaling.go",
         "dns_autoscaling.go",
         "framework.go",
@@ -19,6 +21,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/autoscaling",
     deps = [
         "//pkg/apis/core:go_default_library",
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/test/e2e/autoscaling/custom_metrics_adapter_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_adapter_autoscaling.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/instrumentation/monitoring"
+
+	. "github.com/onsi/ginkgo"
+)
+
+const (
+	adapterServiceName = "custom-metrics-apiserver:http"
+	adapterNamespace   = "custom-metrics"
+	adapterDummyPod    = "adapter-dummy-pod"
+)
+
+var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from API Server Adapter)", func() {
+
+	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
+	targetRefGVK := schema.FromAPIVersionAndKind("apps/v1", "StatefulSet")
+
+	It("should scale down with Custom Metric of type Pod from API Server [Feature:CustomMetricsAdapterAutoscaling]", func() {
+		initialReplicas := 2
+		metricValue := int64(100)
+		metricTarget := 2 * metricValue
+
+		metricValues := []TestMetricValue{
+			{
+				resourceName: dummyDeploymentName + "-0",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: metricValue,
+				},
+			},
+			{
+				resourceName: dummyDeploymentName + "-1",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: metricValue,
+				},
+			},
+		}
+
+		tc := CustomMetricAdapterTestCase{
+			framework:       f,
+			kubeClient:      f.ClientSet,
+			initialPodCount: 2,
+			scaledPodCount:  1,
+			metricValues:    metricValues,
+			deployment:      monitoring.SimpleDummyStatefulSet(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas)),
+			hpa:             simplePodsHPA(f.Namespace.ObjectMeta.Name, dummyDeploymentName, targetRefGVK, metricTarget),
+		}
+		tc.Run()
+	})
+
+	It("should scale down with Custom Metric of type Object from API Server while ignoring other metrics [Feature:CustomMetricsAdapterAutoscaling]", func() {
+		initialReplicas := 2
+		metricValue := int64(100)
+		metricTarget := 2 * metricValue
+
+		metricValues := []TestMetricValue{
+			{
+				resourceName: adapterDummyPod,
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: metricValue,
+				},
+			},
+			{
+				resourceName: dummyDeploymentName + "-0",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: int64(0),
+				},
+			},
+			{
+				resourceName: dummyDeploymentName + "-1",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: int64(0),
+				},
+			},
+		}
+
+		tc := CustomMetricAdapterTestCase{
+			framework:       f,
+			kubeClient:      f.ClientSet,
+			initialPodCount: 3,
+			scaledPodCount:  2,
+			metricValues:    metricValues,
+			deployment:      monitoring.SimpleDummyStatefulSet(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas)),
+			pod:             monitoring.DummyPod(adapterDummyPod, f.Namespace.ObjectMeta.Name, adapterDummyPod, monitoring.CustomMetricName, metricValue),
+			hpa:             objectHPA(f.Namespace.ObjectMeta.Name, adapterDummyPod, dummyDeploymentName, targetRefGVK, schema.ParseGroupKind("Pod"), metricTarget),
+		}
+		tc.Run()
+	})
+
+	It("should scale down with Custom Metric of type Object from API Server [Feature:CustomMetricsAdapterAutoscaling]", func() {
+		initialReplicas := 2
+		metricValue := int64(100)
+		metricTarget := 2 * metricValue
+
+		metricValues := []TestMetricValue{
+			{
+				resourceName: adapterDummyPod,
+				resourceType: schema.ParseGroupResource("services"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: metricValue,
+				},
+			},
+		}
+
+		// Don't actually create the object, to check the non-pod object case. Custom API should still work
+		tc := CustomMetricAdapterTestCase{
+			framework:       f,
+			kubeClient:      f.ClientSet,
+			initialPodCount: 2,
+			scaledPodCount:  1,
+			metricValues:    metricValues,
+			deployment:      monitoring.SimpleDummyStatefulSet(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas)),
+			hpa:             objectHPA(f.Namespace.ObjectMeta.Name, adapterDummyPod, dummyDeploymentName, targetRefGVK, schema.ParseGroupKind("Service"), metricTarget),
+		}
+		tc.Run()
+	})
+
+	It("should scale up with Custom Metric of type Pod from API Server [Feature:CustomMetricsAdapterAutoscaling]", func() {
+		initialReplicas := 1
+		metricValue := int64(200)
+		metricTarget := int64(0.5 * float64(metricValue))
+
+		metricValues := []TestMetricValue{
+			{
+				resourceName: dummyDeploymentName + "-0",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					monitoring.CustomMetricName: metricValue,
+				},
+			},
+		}
+
+		tc := CustomMetricAdapterTestCase{
+			framework:       f,
+			kubeClient:      f.ClientSet,
+			initialPodCount: 1,
+			scaledPodCount:  2,
+			metricValues:    metricValues,
+			deployment:      monitoring.SimpleDummyStatefulSet(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas)),
+			hpa:             simplePodsHPA(f.Namespace.ObjectMeta.Name, dummyDeploymentName, targetRefGVK, metricTarget),
+		}
+		tc.Run()
+	})
+
+	It("should scale up with 2 Custom Metrics of type Pod from API Server [Feature:CustomMetricsAdapterAutoscaling]", func() {
+		initialReplicas := 1
+		// metric 1 would cause a scale down, if not for metric 2
+		metric1Value := int64(100)
+		metric1Target := 2 * metric1Value
+		// metric2 should cause a scale up
+		metric2Value := int64(200)
+		metric2Target := int64(0.5 * float64(metric2Value))
+
+		metricTargets := map[string]int64{"metric1": metric1Target, "metric2": metric2Target}
+
+		metricValues := []TestMetricValue{
+			{
+				resourceName: dummyDeploymentName + "-0",
+				resourceType: schema.ParseGroupResource("pods"),
+				metrics: map[string]int64{
+					"metric1": metric1Value,
+					"metric2": metric2Value,
+				},
+			},
+		}
+
+		tc := CustomMetricAdapterTestCase{
+			framework:       f,
+			kubeClient:      f.ClientSet,
+			initialPodCount: 1,
+			scaledPodCount:  2,
+			metricValues:    metricValues,
+			deployment:      monitoring.SimpleDummyStatefulSet(dummyDeploymentName, f.Namespace.ObjectMeta.Name, int32(initialReplicas)),
+			hpa:             podsHPA(f.Namespace.ObjectMeta.Name, dummyDeploymentName, targetRefGVK, metricTargets),
+		}
+		tc.Run()
+	})
+})
+
+type CustomMetricAdapterTestCase struct {
+	framework       *framework.Framework
+	hpa             *autoscaling.HorizontalPodAutoscaler
+	kubeClient      clientset.Interface
+	deployment      *appsv1.StatefulSet
+	pod             *corev1.Pod
+	metricValues    []TestMetricValue
+	initialPodCount int
+	scaledPodCount  int
+}
+
+type TestMetricValue struct {
+	resourceName string
+	resourceType schema.GroupResource
+	metrics      map[string]int64
+}
+
+func (tc *CustomMetricAdapterTestCase) WriteMetric(resource schema.GroupResource, name, metric string, value int64) {
+	// Get custom-metrics adapter service
+	proxyRequest, err := framework.GetServicesProxyRequest(tc.kubeClient, tc.kubeClient.CoreV1().RESTClient().Post())
+	if err != nil {
+		framework.Failf("Failed to make custom metric service proxy request: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
+	defer cancel()
+
+	// Build custom-metric request
+	path := fmt.Sprintf("/write-metrics/namespaces/%s/%s/%s/%s", tc.framework.Namespace.ObjectMeta.Name, resource.String(), name, metric)
+	body := fmt.Sprintf(`{"Value":%d}`, value)
+
+	// Make request to custom-metrics service
+	req := proxyRequest.Namespace(adapterNamespace).
+		Context(ctx).
+		Name(adapterServiceName).
+		Suffix(path).
+		SetHeader("Content-Type", "application/json").
+		Body([]byte(body))
+	framework.Logf("Request URL: %v", req.URL())
+	_, err = req.DoRaw()
+	if err != nil {
+		framework.Failf("Failed to make custom metric POST request: %v", err)
+	}
+}
+
+func (tc *CustomMetricAdapterTestCase) Run() {
+	err := monitoring.CreateCustomAdapter(monitoring.AdapterForCustomMetrics)
+	if err != nil {
+		framework.Failf("Failed to set up: %v", err)
+	}
+	defer monitoring.CleanupCustomAdapter(monitoring.AdapterForCustomMetrics, adapterNamespace, tc.kubeClient, 15*time.Minute)
+
+	// Run application that will be scaled based on metrics
+	err = createStatefulSetsToScale(tc.framework, tc.kubeClient, tc.deployment, tc.pod)
+	if err != nil {
+		framework.Failf("Failed to create dummy deployment pod: %v", err)
+	}
+	defer cleanupStatefulSetsToScale(tc.framework, tc.kubeClient, tc.deployment, tc.pod)
+
+	// Wait for the statefulset to run
+	waitForReplicas(tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.initialPodCount, metav1.ListOptions{})
+
+	// Write custom metric value for each resource in statefulset
+	for _, testMetrics := range tc.metricValues {
+		for metric, value := range testMetrics.metrics {
+			tc.WriteMetric(testMetrics.resourceType, testMetrics.resourceName, metric, value)
+		}
+	}
+
+	// Autoscale the deployment
+	_, err = tc.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Create(tc.hpa)
+	if err != nil {
+		framework.Failf("Failed to create HPA: %v", err)
+	}
+	defer tc.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(tc.framework.Namespace.ObjectMeta.Name).Delete(tc.hpa.ObjectMeta.Name, &metav1.DeleteOptions{})
+
+	waitForReplicas(tc.framework.Namespace.ObjectMeta.Name, tc.kubeClient, 15*time.Minute, tc.scaledPodCount, metav1.ListOptions{})
+}

--- a/test/e2e/autoscaling/custom_metrics_autoscaling_utils.go
+++ b/test/e2e/autoscaling/custom_metrics_autoscaling_utils.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscaling "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/instrumentation/monitoring"
+)
+
+func createDeploymentToScale(f *framework.Framework, cs clientset.Interface, deployment *extensions.Deployment, pod *corev1.Pod) error {
+	if deployment != nil {
+		_, err := cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Create(deployment)
+		if err != nil {
+			return err
+		}
+	}
+	if pod != nil {
+		_, err := cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Create(pod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupDeploymentsToScale(f *framework.Framework, cs clientset.Interface, deployment *extensions.Deployment, pod *corev1.Pod) {
+	if deployment != nil {
+		_ = cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Delete(deployment.ObjectMeta.Name, &metav1.DeleteOptions{})
+	}
+	if pod != nil {
+		_ = cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
+	}
+}
+
+func createStatefulSetsToScale(f *framework.Framework, cs clientset.Interface, deployment *appsv1.StatefulSet, pod *corev1.Pod) error {
+	if deployment != nil {
+		_, err := cs.Apps().StatefulSets(f.Namespace.ObjectMeta.Name).Create(deployment)
+		if err != nil {
+			return err
+		}
+	}
+	if pod != nil {
+		_, err := cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Create(pod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupStatefulSetsToScale(f *framework.Framework, cs clientset.Interface, deployment *appsv1.StatefulSet, pod *corev1.Pod) {
+	if deployment != nil {
+		_ = cs.Apps().StatefulSets(f.Namespace.ObjectMeta.Name).Delete(deployment.ObjectMeta.Name, &metav1.DeleteOptions{})
+	}
+	if pod != nil {
+		_ = cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{})
+	}
+}
+
+func simplePodsHPA(namespace, targetRefName string, targetRefGroupVersionKind schema.GroupVersionKind, metricTarget int64) *autoscaling.HorizontalPodAutoscaler {
+	return podsHPA(namespace, targetRefName, targetRefGroupVersionKind, map[string]int64{monitoring.CustomMetricName: metricTarget})
+}
+
+func podsHPA(namespace string, targetRefName string, targetGroupVersionKind schema.GroupVersionKind, metricTargets map[string]int64) *autoscaling.HorizontalPodAutoscaler {
+	var minReplicas int32 = 1
+	metrics := []autoscaling.MetricSpec{}
+	for metric, target := range metricTargets {
+		metrics = append(metrics, autoscaling.MetricSpec{
+			Type: autoscaling.PodsMetricSourceType,
+			Pods: &autoscaling.PodsMetricSource{
+				MetricName:         metric,
+				TargetAverageValue: *resource.NewQuantity(target, resource.DecimalSI),
+			},
+		})
+	}
+	return &autoscaling.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-metrics-pods-hpa",
+			Namespace: namespace,
+		},
+		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+			Metrics:     metrics,
+			MaxReplicas: 3,
+			MinReplicas: &minReplicas,
+			ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+				APIVersion: targetGroupVersionKind.GroupVersion().String(),
+				Kind:       targetGroupVersionKind.Kind,
+				Name:       targetRefName,
+			},
+		},
+	}
+}
+
+func objectHPA(namespace, podName string, targetRefName string, targetGroupVersionKind schema.GroupVersionKind, metricGroupKind schema.GroupKind, metricTarget int64) *autoscaling.HorizontalPodAutoscaler {
+	var minReplicas int32 = 1
+	return &autoscaling.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-metrics-objects-hpa",
+			Namespace: namespace,
+		},
+		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+			Metrics: []autoscaling.MetricSpec{
+				{
+					Type: autoscaling.ObjectMetricSourceType,
+					Object: &autoscaling.ObjectMetricSource{
+						MetricName: monitoring.CustomMetricName,
+						Target: autoscaling.CrossVersionObjectReference{
+							Kind: metricGroupKind.String(),
+							Name: podName,
+						},
+						TargetValue: *resource.NewQuantity(metricTarget, resource.DecimalSI),
+					},
+				},
+			},
+			MaxReplicas: 3,
+			MinReplicas: &minReplicas,
+			ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+				APIVersion: targetGroupVersionKind.GroupVersion().String(),
+				Kind:       targetGroupVersionKind.Kind,
+				Name:       targetRefName,
+			},
+		},
+	}
+}
+
+type externalMetricTarget struct {
+	value     int64
+	isAverage bool
+}
+
+func externalHPA(namespace string, metricTargets map[string]externalMetricTarget) *autoscaling.HorizontalPodAutoscaler {
+	var minReplicas int32 = 1
+	metricSpecs := []autoscaling.MetricSpec{}
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"resource.type": "gke_container"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "resource.labels.namespace_id",
+				Operator: metav1.LabelSelectorOpIn,
+				// TODO(bskiba): change default to real namespace name once it is available
+				// from Stackdriver.
+				Values: []string{"default", "dummy"},
+			},
+			{
+				Key:      "resource.labels.pod_id",
+				Operator: metav1.LabelSelectorOpExists,
+				Values:   []string{},
+			},
+		},
+	}
+	for metric, target := range metricTargets {
+		var metricSpec autoscaling.MetricSpec
+		metricSpec = autoscaling.MetricSpec{
+			Type: autoscaling.ExternalMetricSourceType,
+			External: &autoscaling.ExternalMetricSource{
+				MetricName:     "custom.googleapis.com|" + metric,
+				MetricSelector: selector,
+			},
+		}
+		if target.isAverage {
+			metricSpec.External.TargetAverageValue = resource.NewQuantity(target.value, resource.DecimalSI)
+		} else {
+			metricSpec.External.TargetValue = resource.NewQuantity(target.value, resource.DecimalSI)
+		}
+		metricSpecs = append(metricSpecs, metricSpec)
+	}
+	hpa := &autoscaling.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-metrics-external-hpa",
+			Namespace: namespace,
+		},
+		Spec: autoscaling.HorizontalPodAutoscalerSpec{
+			Metrics:     metricSpecs,
+			MaxReplicas: 3,
+			MinReplicas: &minReplicas,
+			ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+				APIVersion: "extensions/v1beta1",
+				Kind:       "Deployment",
+				Name:       dummyDeploymentName,
+			},
+		},
+	}
+
+	return hpa
+}
+
+// waitForReplicas waits for the total number of pods selected by listOptions in the namespace to match desiredReplicas
+func waitForReplicas(namespace string, cs clientset.Interface, timeout time.Duration, desiredReplicas int, listOptions metav1.ListOptions) {
+	interval := 20 * time.Second
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pods, err := cs.Core().Pods(namespace).List(listOptions)
+		if err != nil {
+			framework.Failf("Failed to get pod count for %s: %v", namespace, err)
+		}
+		replicas := len(pods.Items)
+		framework.Logf("waiting for %d replicas (current: %d)", desiredReplicas, replicas)
+		return replicas == desiredReplicas, nil // Expected number of replicas found. Exit.
+	})
+	if err != nil {
+		framework.Failf("Timeout waiting %v for %v replicas", timeout, desiredReplicas)
+	}
+}

--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -19,9 +19,11 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/test/e2e/instrumentation/monitoring",
     deps = [
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
@@ -108,11 +108,11 @@ func testCustomMetrics(f *framework.Framework, kubeClient clientset.Interface, c
 	}
 	defer CleanupDescriptors(gcmService, projectId)
 
-	err = CreateAdapter(adapterDeployment)
+	err = CreateStackdriverAdapter(adapterDeployment)
 	if err != nil {
 		framework.Failf("Failed to set up: %s", err)
 	}
-	defer CleanupAdapter(adapterDeployment)
+	defer CleanupStackdriverAdapter(adapterDeployment)
 
 	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(HPAPermissions)
 	if err != nil {
@@ -155,11 +155,11 @@ func testExternalMetrics(f *framework.Framework, kubeClient clientset.Interface,
 	defer CleanupDescriptors(gcmService, projectId)
 
 	// Both deployments - for old and new resource model - expose External Metrics API.
-	err = CreateAdapter(AdapterForOldResourceModel)
+	err = CreateStackdriverAdapter(AdapterForOldResourceModel)
 	if err != nil {
 		framework.Failf("Failed to set up: %s", err)
 	}
-	defer CleanupAdapter(AdapterForOldResourceModel)
+	defer CleanupStackdriverAdapter(AdapterForOldResourceModel)
 
 	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(HPAPermissions)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates E2E tests for autoscaling using a custom metrics API server adapter (see: https://github.com/damemi/k8s-e2e-adapter/) which accepts a POST request to set specific metrics for resources in the custom metrics API. This reduces dependence on Stackdriver for autoscaling tests.

Note that this doesn't add tests for external metrics with the custom metrics adapter yet.

Also makes some minor refactors to the existing Stackdriver autoscaling tests, mainly just to rearrange common code between the new tests and the Stackdriver tests. 

**Special notes for your reviewer**: This will obviously depend on getting an image for the e2e-metrics-adapter I linked above into the test suite, in order to write the custom metrics. I am not sure what the process for that is, and this PR may need to be updated to reflect any changes in references to the service that image uses. All of which I'm willing to work on

**Release note**:
```release-note
NONE
```

/assign @DirectXMan12 