### PR TITLE
Kubeadm upgrade migrate

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "register.go",
         "types.go",
+        "upgrade.go",
         "zz_generated.conversion.go",
         "zz_generated.deepcopy.go",
         "zz_generated.defaults.go",
@@ -52,12 +53,18 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",
+        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/scheme:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1beta1:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
+        "//pkg/util/version:go_default_library",
+        "//vendor/github.com/json-iterator/go:go_default_library",
+        "//vendor/github.com/ugorji/go/codec:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -76,4 +83,15 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["upgrade_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/util/version:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+    ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/testdata/kubeadm196.yaml
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/testdata/kubeadm196.yaml
@@ -1,0 +1,62 @@
+api:
+  advertiseAddress: 172.31.93.180
+  bindPort: 6443
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /etc/kubernetes/pki
+cloudProvider: aws
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: gcr.io/google_containers
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: 192.168.0.0/16
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates: ""
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpTimeoutMilliseconds: 250ms
+kubeletConfiguration: {}
+kubernetesVersion: v1.9.6
+networking:
+  dnsDomain: cluster.local
+  podSubnet: 192.168.0.0/16
+  serviceSubnet: 10.96.0.0/12
+nodeName: ip-172-31-93-180.ec2.internal
+token: 8d69af.cd3e1c58f6228dfc
+tokenTTL: 24h0m0s
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	versionutil "k8s.io/kubernetes/pkg/util/version"
+)
+
+const test196 = "testdata/kubeadm196.yaml"
+
+func TestUpgrade(t *testing.T) {
+	testYAML, err := ioutil.ReadFile(test196)
+	if err != nil {
+		t.Fatalf("couldn't read test data: %v", err)
+	}
+
+	decoded, err := LoadYAML(testYAML)
+	if err != nil {
+		t.Fatalf("couldn't unmarshal test yaml: %v", err)
+	}
+
+	var obj MasterConfiguration
+	if err := Migrate(decoded, version190, version1100, &obj); err != nil {
+		t.Fatalf("couldn't decode migrated object: %v", err)
+	}
+}
+
+func TestProxyFeatureListToMap(t *testing.T) {
+
+	cases := []struct {
+		name         string
+		featureGates string
+		expected     map[string]interface{}
+		shouldError  bool
+	}{
+		{
+			name:         "multiple features",
+			featureGates: "feature1=true,feature2=false",
+			expected: map[string]interface{}{
+				"feature1": true,
+				"feature2": false,
+			},
+		},
+		{
+			name:         "single feature",
+			featureGates: "feature1=true",
+			expected: map[string]interface{}{
+				"feature1": true,
+			},
+		},
+		{
+			name:         "single feature",
+			featureGates: "",
+			expected:     map[string]interface{}{},
+		},
+		{
+			name:         "malformed string",
+			featureGates: "test,",
+			shouldError:  true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			cfg := map[string]interface{}{
+				"kubeProxy": map[string]interface{}{
+					"config": map[string]interface{}{
+						"featureGates": testCase.featureGates,
+					},
+				},
+			}
+
+			err := proxyFeatureListToMap(cfg)
+			if testCase.shouldError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			gates, ok, err := unstructured.NestedMap(cfg, "kubeProxy", "config", "featureGates")
+			if !ok {
+				t.Errorf("missing map keys in nested map")
+			}
+			if err != nil {
+				t.Errorf("unexpected error in map: %v", err)
+			}
+
+			if len(testCase.expected) != len(gates) {
+				t.Errorf("expected feature gate size %d, got %d", len(testCase.expected), len(gates))
+			}
+
+			for k, v := range testCase.expected {
+				gateVal, ok := gates[k]
+				if !ok {
+					t.Errorf("featureGates missing key %q", k)
+					continue
+				}
+
+				if v != gateVal {
+					t.Errorf("expected value %v, got %v", v, gateVal)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldApply(t *testing.T) {
+	minFrom := versionutil.MustParseGeneric("1.9.0")
+	maxTo := versionutil.MustParseGeneric("1.10.0")
+
+	testCases := []struct {
+		name     string
+		from     string
+		to       string
+		expected bool
+	}{
+		{
+			name:     "in range",
+			from:     "1.9.6",
+			to:       "1.10.1",
+			expected: true,
+		},
+		{
+			name:     "min too low",
+			from:     "1.8.0",
+			to:       "1.10.1",
+			expected: false,
+		},
+		{
+			name:     "min too high",
+			from:     "1.10.0",
+			to:       "1.10.0",
+			expected: false,
+		},
+		{
+			name:     "max too low",
+			from:     "1.9.6",
+			to:       "1.9.7",
+			expected: false,
+		},
+		{
+			name:     "max too high",
+			from:     "1.9.6",
+			to:       "1.11.1",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			from, err := versionutil.ParseGeneric(testCase.from)
+			if err != nil {
+				t.Fatalf("couldn't parse from %q: %v", testCase.from, err)
+			}
+
+			to, err := versionutil.ParseGeneric(testCase.to)
+			if err != nil {
+				t.Fatalf("couldn't parse to %q: %v", testCase.to, err)
+			}
+
+			actual := shouldApply(minFrom, from, maxTo, to)
+			if actual != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, actual)
+			}
+		})
+	}
+
+}

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
@@ -86,8 +87,11 @@ func NewCmdApply(parentFlags *cmdUpgradeFlags) *cobra.Command {
 				cfg, err := upgrade.FetchConfigurationFromFile(flags.parent.cfgPath)
 				kubeadmutil.CheckErr(err)
 
-				if cfg.KubernetesVersion != "" {
-					flags.newK8sVersionStr = cfg.KubernetesVersion
+				version, _, err := unstructured.NestedString(cfg, "kubernetesVersion")
+				kubeadmutil.CheckErr(err)
+
+				if version != "" {
+					flags.newK8sVersionStr = version
 				}
 			}
 

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+	versionutil "k8s.io/kubernetes/pkg/util/version"
 )
 
 // upgradeVariables holds variables needed for performing an upgrade or planning to do so
@@ -60,7 +61,23 @@ func enforceRequirements(flags *cmdUpgradeFlags, dryRun bool, newK8sVersion stri
 	}
 
 	// Fetch the configuration from a file or ConfigMap and validate it
-	cfg, err := upgrade.FetchConfiguration(client, os.Stdout, flags.cfgPath)
+	cfgMap, err := upgrade.FetchConfiguration(client, os.Stdout, flags.cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+	}
+
+	versionGetter := upgrade.NewKubeVersionGetter(client, os.Stdout)
+	_, oldK8sVersion, err := versionGetter.ClusterVersion()
+	if err != nil {
+		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+	}
+
+	newK8sVersionParsed, err := versionutil.ParseGeneric(newK8sVersion)
+	if err != nil {
+		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+	}
+
+	cfg, err := upgrade.LoadConfigMap(cfgMap, oldK8sVersion, newK8sVersionParsed)
 	if err != nil {
 		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
 	}
@@ -84,7 +101,7 @@ func enforceRequirements(flags *cmdUpgradeFlags, dryRun bool, newK8sVersion stri
 		client: client,
 		cfg:    cfg,
 		// Use a real version getter interface that queries the API server, the kubeadm client and the Kubernetes CI system for latest versions
-		versionGetter: upgrade.NewKubeVersionGetter(client, os.Stdout),
+		versionGetter: versionGetter,
 		// Use the waiter conditionally based on the dryrunning variable
 		waiter: getWaiter(dryRun, client),
 	}, nil

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -44,7 +44,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When kubeadm 1.10 came out, it inadvertently introduced a backwards incompatible config change. Because the kubeadm `MasterConfiguration` is written by the old version of kubeadm and read by the new one, this incompatibility causes the upgrade to fail.

To mitigate this, I've written a simple transform that operates on a map-based version of the config. This map is mutated to make it compatible with the new structure, then serialised to JSON and deserialised by the usual APIMachinery

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [kubeadm#744](https://github.com/kubernetes/kubeadm/issues/744#issuecomment-379045823L)

**Special notes for your reviewer**:

I'm happy to move around where the code lives, I was not sure where to put it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes configuration error when upgrading kubeadm from 1.9 to 1.10+
```
