### PR TITLE
migrate the kubelet --bootstrap-checkpoint-path to kubelet.config.k8s.io

### DIFF
--- a/pkg/scheduler/util/BUILD
+++ b/pkg/scheduler/util/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//pkg/apis/scheduling:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
@@ -300,6 +302,118 @@ func TestHostPortInfo_Check(t *testing.T) {
 		}
 		if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
 			t.Errorf("%v failed, expected %t; got %t", test.desc, test.expect, !test.expect)
+		}
+	}
+}
+
+func TestGetContainerPorts(t *testing.T) {
+	tests := []struct {
+		pod1     *v1.Pod
+		pod2     *v1.Pod
+		expected []*v1.ContainerPort
+	}{
+		{
+			pod1: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 8001,
+									Protocol:      v1.ProtocolTCP,
+								},
+								{
+									ContainerPort: 8002,
+									Protocol:      v1.ProtocolTCP,
+								},
+							},
+						},
+						{
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 8003,
+									Protocol:      v1.ProtocolTCP,
+								},
+								{
+									ContainerPort: 8004,
+									Protocol:      v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+			pod2: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 8011,
+									Protocol:      v1.ProtocolTCP,
+								},
+								{
+									ContainerPort: 8012,
+									Protocol:      v1.ProtocolTCP,
+								},
+							},
+						},
+						{
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 8013,
+									Protocol:      v1.ProtocolTCP,
+								},
+								{
+									ContainerPort: 8014,
+									Protocol:      v1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*v1.ContainerPort{
+				{
+					ContainerPort: 8001,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8002,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8003,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8004,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8011,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8012,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8013,
+					Protocol:      v1.ProtocolTCP,
+				},
+				{
+					ContainerPort: 8014,
+					Protocol:      v1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result := GetContainerPorts(test.pod1, test.pod2)
+		if !reflect.DeepEqual(test.expected, result) {
+			t.Errorf("Got different result than expected.\nDifference detected on:\n%s", diff.ObjectGoPrintSideBySide(test.expected, result))
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
migrate the bootstrap-checkpoint-path to kubelet.config.k8s.io

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61681

**Special notes for your reviewer**:
I will do the migrations left if this is acceptable.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Kubelet's --bootstrap-checkpoint-path flag can now be set via the kubelet.config.k8s.io/v1beta1 API by specifying the KubeletConfiguration.BootstrapCheckpointPath field.
```
