### PR TITLE
Fix user visible files creation for windows

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -230,7 +230,7 @@ func validatePayload(payload map[string]FileProjection) (map[string]FileProjecti
 			return nil, err
 		}
 
-		cleanPayload[path.Clean(k)] = content
+		cleanPayload[filepath.Clean(k)] = content
 	}
 
 	return cleanPayload, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix user visible files creation for windows. Without this, [createUserVisibleFiles](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/atomic_writer.go#L415:24) will get linkname with subpath included, and then symlink will fail. This is because "/" is used in pod spec (e.g. `"new/path/data-1"`) while "\" is used on Windows to get linkname. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62338

**Special notes for your reviewer**:

Should also be cherry-picked to old releases.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix user visible files creation for windows
```
