### PR TITLE
 Add `snapfactor` storageclass parameter for GlusterFS provisioner.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -253,13 +253,14 @@ func TestParseClassParameters(t *testing.T) {
 			nil,   // secret
 			false, // expect error
 			&provisionerConfig{
-				url:         "https://localhost:8080",
-				user:        "admin",
-				userKey:     "password",
-				secretValue: "password",
-				gidMin:      2000,
-				gidMax:      2147483647,
-				volumeType:  gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				user:               "admin",
+				userKey:            "password",
+				secretValue:        "password",
+				gidMin:             2000,
+				gidMax:             2147483647,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 		{
@@ -273,14 +274,15 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:             "https://localhost:8080",
-				user:            "admin",
-				secretName:      "mysecret",
-				secretNamespace: "default",
-				secretValue:     "mypassword",
-				gidMin:          2000,
-				gidMax:          2147483647,
-				volumeType:      gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				user:               "admin",
+				secretName:         "mysecret",
+				secretNamespace:    "default",
+				secretValue:        "mypassword",
+				gidMin:             2000,
+				gidMax:             2147483647,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 		{
@@ -292,10 +294,11 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     2000,
-				gidMax:     2147483647,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				gidMin:             2000,
+				gidMax:             2147483647,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 		{
@@ -429,10 +432,11 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     4000,
-				gidMax:     2147483647,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             2147483647,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 		{
@@ -445,10 +449,11 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     2000,
-				gidMax:     5000,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				gidMin:             2000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 		{
@@ -462,10 +467,11 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     4000,
-				gidMax:     5000,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 3}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 
@@ -481,10 +487,11 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     4000,
-				gidMax:     5000,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "replicate", Replicate: gapi.ReplicaDurability{Replica: 4}, Disperse: gapi.DisperseDurability{Data: 0, Redundancy: 0}},
+				thinPoolSnapFactor: float32(1.0),
 			},
 		},
 
@@ -500,10 +507,31 @@ func TestParseClassParameters(t *testing.T) {
 			&secret,
 			false, // expect error
 			&provisionerConfig{
-				url:        "https://localhost:8080",
-				gidMin:     4000,
-				gidMax:     5000,
-				volumeType: gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
+				thinPoolSnapFactor: float32(1.0),
+			},
+		},
+		{
+			"valid snapfactor: 50",
+			map[string]string{
+				"resturl":         "https://localhost:8080",
+				"restauthenabled": "false",
+				"gidMin":          "4000",
+				"gidMax":          "5000",
+				"volumetype":      "disperse:4:2",
+				"snapfactor":      "50",
+			},
+			&secret,
+			false, // expect error
+			&provisionerConfig{
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
+				thinPoolSnapFactor: float32(50),
 			},
 		},
 		{
@@ -545,6 +573,28 @@ func TestParseClassParameters(t *testing.T) {
 				"resturl":         "https://localhost:8080",
 				"restauthenabled": "false",
 				"volumetype":      "replicate:-1000",
+			},
+			&secret,
+			true, // expect error
+			nil,
+		},
+		{
+			"invalid thinPoolSnapFactor: value out of range",
+			map[string]string{
+				"resturl":         "https://localhost:8080",
+				"restauthenabled": "false",
+				"snapfactor":      "0.5",
+			},
+			&secret,
+			true, // expect error
+			nil,
+		},
+		{
+			"invalid thinPoolSnapFactor: value out of range",
+			map[string]string{
+				"resturl":         "https://localhost:8080",
+				"restauthenabled": "false",
+				"snapfactor":      "120",
 			},
 			&secret,
 			true, // expect error


### PR DESCRIPTION
    This patch add a new parameter called `snapfactor` to glusterfs
    storageclass. This is an optional parameter and value should
    fall into the range of 1-100. When set the thin pool calculation
    respect this snapfactor and create a thinpool accordingly.
    


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
