### PR TITLE
Revert "git: Use VolumeHost.GetExec() to execute stuff in volume plugins"

### DIFF
--- a/pkg/volume/git_repo/BUILD
+++ b/pkg/volume/git_repo/BUILD
@@ -14,12 +14,12 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/volume/git_repo",
     deps = [
-        "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 
@@ -28,13 +28,14 @@ go_test(
     srcs = ["git_repo_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/empty_dir:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/exec/testing:go_default_library",
     ],
 )
 

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -24,10 +24,10 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/utils/exec"
 )
 
 // This is the primary entrypoint for volume plugins.
@@ -100,8 +100,7 @@ func (plugin *gitRepoPlugin) NewMounter(spec *volume.Spec, pod *v1.Pod, opts vol
 		source:   spec.Volume.GitRepo.Repository,
 		revision: spec.Volume.GitRepo.Revision,
 		target:   spec.Volume.GitRepo.Directory,
-		mounter:  plugin.host.GetMounter(plugin.GetPluginName()),
-		exec:     plugin.host.GetExec(plugin.GetPluginName()),
+		exec:     exec.New(),
 		opts:     opts,
 	}, nil
 }
@@ -150,8 +149,7 @@ type gitRepoVolumeMounter struct {
 	source   string
 	revision string
 	target   string
-	mounter  mount.Interface
-	exec     mount.Exec
+	exec     exec.Interface
 	opts     volume.VolumeOptions
 }
 
@@ -197,7 +195,7 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	if len(b.target) != 0 {
 		args = append(args, b.target)
 	}
-	if output, err := b.execGit(args, dir); err != nil {
+	if output, err := b.execCommand("git", args, dir); err != nil {
 		return fmt.Errorf("failed to exec 'git %s': %s: %v",
 			strings.Join(args, " "), output, err)
 	}
@@ -227,10 +225,10 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return fmt.Errorf("unexpected directory contents: %v", files)
 	}
 
-	if output, err := b.execGit([]string{"checkout", b.revision}, subdir); err != nil {
+	if output, err := b.execCommand("git", []string{"checkout", b.revision}, subdir); err != nil {
 		return fmt.Errorf("failed to exec 'git checkout %s': %s: %v", b.revision, output, err)
 	}
-	if output, err := b.execGit([]string{"reset", "--hard"}, subdir); err != nil {
+	if output, err := b.execCommand("git", []string{"reset", "--hard"}, subdir); err != nil {
 		return fmt.Errorf("failed to exec 'git reset --hard': %s: %v", output, err)
 	}
 
@@ -244,10 +242,10 @@ func (b *gitRepoVolumeMounter) getMetaDir() string {
 	return path.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedNameForDisk(gitRepoPluginName)), b.volName)
 }
 
-func (b *gitRepoVolumeMounter) execGit(args []string, dir string) ([]byte, error) {
-	// run git -C <dir> <args>
-	fullArgs := append([]string{"-C", dir}, args...)
-	return b.exec.Run("git", fullArgs...)
+func (b *gitRepoVolumeMounter) execCommand(command string, args []string, dir string) ([]byte, error) {
+	cmd := b.exec.Command(command, args...)
+	cmd.SetDir(dir)
+	return cmd.CombinedOutput()
 }
 
 // gitRepoVolumeUnmounter cleans git repo volumes.


### PR DESCRIPTION
This reverts commit c578542ad7fac65a1b6c8c020dd1b5a99b4fe76c (PR #51098). The PR added support for containerized git, on the other hand it required git 1.8.5. This breaks git volumes on older distros (CentOS 7, Ubuntu 14.04) that have old git.

Git volumes are getting deprecated (https://github.com/kubernetes/kubernetes/issues/60999) so we should restore it to the last working state and not touch it any longer.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
gitRepo volumes in pods no longer require git 1.8.5 or newer, older git versions are supported too now.
```

I'd like to cherry-pick it into 1.10.

/sig storage