### PR TITLE
hack/test-update-storage-objects.sh: don't build a binary that the script doesn't use

### DIFF
--- a/hack/test-update-storage-objects.sh
+++ b/hack/test-update-storage-objects.sh
@@ -97,7 +97,6 @@ function cleanup() {
 trap cleanup EXIT SIGINT
 
 make -C "${KUBE_ROOT}" WHAT=cmd/kube-apiserver
-make -C "${KUBE_ROOT}" WHAT=cluster/images/etcd/migrate
 
 kube::etcd::start
 echo "${ETCD_VERSION}" > "${ETCD_DIR}/version.txt"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes unused code that was building a binary that script doesn't use.

**Special notes for your reviewer**:
`hack/test-update-storage-objects.sh` used `attachlease` and `migrate-if-needed.sh` for performing etcd2 -> etcd3 migration. In the commit 39e5a56691 we stopped migrating data, but still built unused `attachlease` binary.

Later, in the dc4d92e154 commit, `migrate-if-needed.sh` was reimplemented in go and unused `attachlease` was replaced by `migrate` that also wasn't needed.
