### PR TITLE
Set slave mount propagation for local provisioner

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -1337,6 +1337,8 @@ func createVolumeConfigMap(config *localTestConfig) {
 
 func createProvisionerDaemonset(config *localTestConfig) {
 	provisionerPrivileged := true
+	mountProp := v1.MountPropagationHostToContainer
+
 	provisioner := &extv1beta1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
@@ -1387,8 +1389,9 @@ func createProvisionerDaemonset(config *localTestConfig) {
 									MountPath: "/etc/provisioner/config/",
 								},
 								{
-									Name:      "local-disks",
-									MountPath: provisionerDefaultMountRoot,
+									Name:             "local-disks",
+									MountPath:        provisionerDefaultMountRoot,
+									MountPropagation: &mountProp,
 								},
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Explicitly set slave mount propagation instead of assuming it's the default mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
