### PR TITLE
kuberuntime: logs: reduce logging level on waitLogs msg

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs.go
+++ b/pkg/kubelet/kuberuntime/logs/logs.go
@@ -380,7 +380,7 @@ func waitLogs(id string, w *fsnotify.Watcher, runtimeService internalapi.Runtime
 			}
 			// Only keep following container log when it is running.
 			if s.State != runtimeapi.ContainerState_CONTAINER_RUNNING {
-				glog.Errorf("Container %q is not running (state=%q)", id, s.State)
+				glog.V(5).Infof("Container %q is not running (state=%q)", id, s.State)
 				// Do not return error because it's normal that the container stops
 				// during waiting.
 				return false, nil


### PR DESCRIPTION
Lots of occurrences of this msg coming from `waitLogs()`:
```
E0411 13:17:04.589338    7645 logs.go:383] Container "4fbf541ed1900c4670216a6a1ecf752cd07ac430f5547c5497fbc4b78e564b78" is not running (state="CONTAINER_EXITED")
E0411 14:02:18.168502    7645 logs.go:383] Container "dba4c535666d05310889965418592727047320743a233e226e2266b399836150" is not running (state="CONTAINER_EXITED")
E0411 14:02:41.342645    7645 logs.go:383] Container "a946289b36fe3c375c29dce020005424f3b980237892253d42b8bd8bfb595756" is not running (state="CONTAINER_EXITED")
E0411 14:02:49.907317    7645 logs.go:383] Container "e1d6014330e7422c03ae6db501d4fb296a4501355517cb60e2f910f54741361d" is not running (state="CONTAINER_EXITED")
```
Added in https://github.com/kubernetes/kubernetes/pull/55140

This message prints whenever something is watching the log when the container dies.

The comment right after the error msg say "this is normal" and thus should not be logged at Error level.

@derekwaynecarr @feiskyer @Random-Liu 
