### PR TITLE
Usage based priority function for default scheduler

### DIFF
--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//vendor/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -272,6 +272,14 @@ const (
 	// A node which has closer cpu,memory utilization and volume count is favoured by scheduler
 	// while making decisions.
 	BalanceAttachedNodeVolumes utilfeature.Feature = "BalanceAttachedNodeVolumes"
+
+	// owner: @ravig
+	// alpha: v1.11
+	//
+	// UsageBasedScheduling allows the scheduler to take exact CPU, memory usage on node while making scheduling
+	// decisions. As of now, this is feature is limited to best effort pods. Also note that this is dependent on
+	// metrics-server and when enabled will have detrimental effect on performance of scheduler.
+	UsageBasedScheduling utilfeature.Feature = "UsageBasedScheduling"
 )
 
 func init() {
@@ -319,6 +327,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	RunAsGroup:                                  {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeSubpath:                               {Default: true, PreRelease: utilfeature.GA},
 	BalanceAttachedNodeVolumes:                  {Default: false, PreRelease: utilfeature.Alpha},
+	UsageBasedScheduling:                        {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -13,6 +13,7 @@ go_library(
         "image_locality.go",
         "interpod_affinity.go",
         "least_requested.go",
+        "least_used_based_on_metrics.go",
         "metadata.go",
         "most_requested.go",
         "node_affinity.go",
@@ -43,6 +44,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 
@@ -53,6 +55,7 @@ go_test(
         "image_locality_test.go",
         "interpod_affinity_test.go",
         "least_requested_test.go",
+        "least_used_based_on_metrics_test.go",
         "metadata_test.go",
         "most_requested_test.go",
         "node_affinity_test.go",
@@ -75,7 +78,12 @@ go_test(
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/algorithm/priorities/least_used_based_on_metrics.go
+++ b/pkg/scheduler/algorithm/priorities/least_used_based_on_metrics.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
+	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
+	resourceclient "k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
+)
+
+// Note: Least used based on metrics priority function ensures that the node which has least current cpu utilization
+// gets pods. We use metrics-server for getting the utilization information.
+
+// usageDataOnNode contains the resource metrics client used to get node info.
+type usageDataOnNode struct {
+	metricsNodeClient priorityutil.MetricsClient
+}
+
+// NewLeastUsedNodeBasedOnMetrics returns leastUsagePriorityMap needed.
+func NewLeastUsedNodeBasedOnMetrics(metricsClient *resourceclient.MetricsV1beta1Client) (algorithm.PriorityMapFunction, algorithm.PriorityReduceFunction) {
+	metricsNodeClient := priorityutil.NewRESTMetricsClient(metricsClient)
+	currentUsage := &usageDataOnNode{
+		metricsNodeClient: metricsNodeClient,
+	}
+	return currentUsage.leastUsagePriorityMap, nil
+}
+
+// getScore checks if there is any other node which has less cpu utilization when compared to current node. If there is,
+// the score for current node becomes 0 or else it returns 10 meaning current node is least utilized node in the cluster.
+func getScore(currentNodeCPUUtil int64, nodeUtilInfo priorityutil.NodeMetricsInfo) int {
+	for _, info := range nodeUtilInfo {
+		if info < currentNodeCPUUtil {
+			// There is a node which has utilization less than current one. So, this node gets a score of 0.
+			return int(0)
+		}
+	}
+	return int(10)
+}
+
+// LeastUsagePriorityMap is a priority function that finds the node with least utilization in the cluster. We rely on
+// metrics-server to get information related to all the nodes in the cluster. Following are possible scenarios
+// - If there is a node in the cluster which has less less utilization than the current node, it gets a 0.
+// - Else, the current node has the least utilization in the cluster and it gets a score of 10.
+func (u *usageDataOnNode) leastUsagePriorityMap(pod *v1.Pod, meta interface{}, nodeInfo *schedulercache.NodeInfo) (schedulerapi.HostPriority, error) {
+	node := nodeInfo.Node()
+	if node == nil {
+		return schedulerapi.HostPriority{}, fmt.Errorf("Node not found")
+	}
+	var nodeUtilInfo = make(priorityutil.NodeMetricsInfo)
+	if priorityMeta, ok := meta.(*priorityMetadata); ok {
+		nodeUtilInfo = priorityMeta.nodeUtilInfo
+
+	} else {
+		glog.V(5).Infof("Falling back to computing usage data from metrics")
+		nodeUtilInfo = getNodeUtilizationInfo(u.metricsNodeClient)
+	}
+	if len(nodeUtilInfo) == 0 {
+		// It's ok even if we don't get the node utilization score. There is a very good chance metrics-server is warming up
+		// So let us return a score of 0 for every node.
+		return schedulerapi.HostPriority{Host: node.Name, Score: int(0)}, nil
+	}
+	currentNodeCPUUtil := nodeUtilInfo[node.Name]
+	score := getScore(currentNodeCPUUtil, nodeUtilInfo)
+	glog.V(5).Infof("The least used node based on metrics score is %v for the node %v for pod %v", score, node.Name, pod.Name)
+	return schedulerapi.HostPriority{
+		Host:  node.Name,
+		Score: score,
+	}, nil
+}

--- a/pkg/scheduler/algorithm/priorities/least_used_based_on_metrics_test.go
+++ b/pkg/scheduler/algorithm/priorities/least_used_based_on_metrics_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	core "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/pkg/features"
+	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
+	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsfake "k8s.io/metrics/pkg/client/clientset_generated/clientset/fake"
+	resourceclient "k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
+)
+
+type nodeUsage struct {
+	nodeName    string
+	cpuUsage    resource.Quantity
+	memoryUsage resource.Quantity
+}
+
+func getNewNodeMetrics() []nodeUsage {
+	nodeMetricsList := make([]nodeUsage, 0)
+	for i := 0; i < 3; i++ {
+		nodeMetric := nodeUsage{}
+		nodeMetric.nodeName = fmt.Sprintf("node-%d", i)
+		// This ensures that 3rd node has highest utilization.
+		nodeMetric.cpuUsage = resource.MustParse(fmt.Sprintf("%dm", 1000+(i*100)))
+		nodeMetric.memoryUsage = resource.MustParse("0")
+		nodeMetricsList = append(nodeMetricsList, nodeMetric)
+	}
+	return nodeMetricsList
+}
+
+func TestNewLeastUsedResourceBasedOnMetrics(t *testing.T) {
+	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%s=true", features.UsageBasedScheduling))
+	cpuOnly := v1.PodSpec{
+		NodeName: "machine1",
+		Containers: []v1.Container{
+			{
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1000m"),
+						v1.ResourceMemory: resource.MustParse("0"),
+					},
+				},
+			},
+			{
+				Resources: v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2000m"),
+						v1.ResourceMemory: resource.MustParse("0"),
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		pod               *v1.Pod
+		nodes             []*v1.Node
+		expectedNodeScore schedulerapi.HostPriorityList
+		metricsClient     *resourceclient.MetricsV1beta1Client
+		test              string
+	}{
+		{
+			pod:               &v1.Pod{Spec: cpuOnly},
+			nodes:             []*v1.Node{makeNode("node-0", 4000, 10000), makeNode("node-1", 4000, 0), makeNode("node-2", 4000, 0)},
+			expectedNodeScore: []schedulerapi.HostPriority{{Host: "node-0", Score: 10}, {Host: "node-1", Score: 0}, {Host: "node-2", Score: 0}},
+			test:              "pod with cpu only request. The 1st node has least utilization, so it should have highest score.",
+		},
+	}
+	fakeMetricsClient := &metricsfake.Clientset{}
+	fakeMetricsClient.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+
+		nodeMetrics := &metricsapi.NodeMetricsList{}
+		for _, nm := range getNewNodeMetrics() {
+			nodeMetric := metricsapi.NodeMetrics{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nm.nodeName,
+				},
+				Timestamp: metav1.Time{Time: time.Now()},
+				Usage: v1.ResourceList{
+					v1.ResourceCPU:    nm.cpuUsage,
+					v1.ResourceMemory: nm.memoryUsage,
+				},
+			}
+			nodeMetrics.Items = append(nodeMetrics.Items, nodeMetric)
+		}
+		return true, nodeMetrics, nil
+	})
+
+	for _, test := range tests {
+		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+		currentUsage := &usageDataOnNode{
+			metricsNodeClient: priorityutil.NewRESTMetricsClient(fakeMetricsClient.MetricsV1beta1()),
+		}
+		list, err := priorityFunction(currentUsage.leastUsagePriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(test.expectedNodeScore, list) {
+			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedNodeScore, list)
+		}
+	}
+	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%s=false", features.UsageBasedScheduling))
+}

--- a/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -157,7 +157,7 @@ func TestPriorityMetadata(t *testing.T) {
 		schedulertesting.FakeServiceLister([]*v1.Service{}),
 		schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 		schedulertesting.FakeReplicaSetLister([]*extensions.ReplicaSet{}),
-		schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
+		schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}), nil)
 	for _, test := range tests {
 		ptData := mataDataProducer(test.pod, nil)
 		if !reflect.DeepEqual(test.expected, ptData) {

--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -351,7 +351,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			schedulertesting.FakeServiceLister(test.services),
 			schedulertesting.FakeControllerLister(test.rcs),
 			schedulertesting.FakeReplicaSetLister(test.rss),
-			schedulertesting.FakeStatefulSetLister(test.sss))
+			schedulertesting.FakeStatefulSetLister(test.sss), nil)
 		mataData := mataDataProducer(test.pod, nodeNameToInfo)
 
 		ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, mataData)
@@ -586,7 +586,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 			schedulertesting.FakeServiceLister(test.services),
 			schedulertesting.FakeControllerLister(test.rcs),
 			schedulertesting.FakeReplicaSetLister(test.rss),
-			schedulertesting.FakeStatefulSetLister(test.sss))
+			schedulertesting.FakeStatefulSetLister(test.sss), nil)
 		mataData := mataDataProducer(test.pod, nodeNameToInfo)
 		ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, mataData)
 		list, err := ttp(test.pod, nodeNameToInfo, makeLabeledNodeList(labeledNodes))
@@ -771,7 +771,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 			schedulertesting.FakeServiceLister(test.services),
 			schedulertesting.FakeControllerLister(rcs),
 			schedulertesting.FakeReplicaSetLister(rss),
-			schedulertesting.FakeStatefulSetLister(sss))
+			schedulertesting.FakeStatefulSetLister(sss), nil)
 		mataData := mataDataProducer(test.pod, nodeNameToInfo)
 		ttp := priorityFunction(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, mataData)
 		list, err := ttp(test.pod, nodeNameToInfo, makeLabeledNodeList(test.nodes))

--- a/pkg/scheduler/algorithm/priorities/util/BUILD
+++ b/pkg/scheduler/algorithm/priorities/util/BUILD
@@ -34,10 +34,13 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util",
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/algorithm/priorities/util/util.go
+++ b/pkg/scheduler/algorithm/priorities/util/util.go
@@ -17,9 +17,37 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"github.com/golang/glog"
+	"time"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	resourceclient "k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
 )
+
+// NodeMetricsInfo contains node metric values as a map from node names to metric values (the metric values are expected
+// to be the metric as a milli-value). As of now, we are focusing on CPU.
+type NodeMetricsInfo map[string]int64
+
+// MetricsClient knows how to query a remote interface to retrieve node-level resource metrics.
+type MetricsClient interface {
+	// GetResourceMetric gets the given resource metric (and an associated oldest timestamp)
+	// for all nodes in the cluster.
+	GetResourceMetric() (NodeMetricsInfo, time.Time, error)
+}
+
+// resourceMetricsClient contains a client to NodeMetricsGetter.
+type resourceMetricsClient struct {
+	client resourceclient.NodeMetricsesGetter
+}
+
+// restMetricsClient is a client which supports fetching metrics from both the resource metrics API. This could be
+// extended for custom metrics as well.
+type restMetricsClient struct {
+	*resourceMetricsClient
+}
 
 // GetControllerRef gets pod's owner controller reference from a pod object.
 func GetControllerRef(pod *v1.Pod) *metav1.OwnerReference {
@@ -33,4 +61,37 @@ func GetControllerRef(pod *v1.Pod) *metav1.OwnerReference {
 		}
 	}
 	return nil
+}
+
+// NewRESTMetricsClient returns a metricsClient.
+func NewRESTMetricsClient(resourceClient resourceclient.NodeMetricsesGetter) MetricsClient {
+	return &restMetricsClient{
+		&resourceMetricsClient{resourceClient},
+	}
+}
+
+// populateNodeMetricsInfo returns a map of nodes with their CPU usages.
+func populateNodeMetricsInfo(metrics *v1beta1.NodeMetricsList) NodeMetricsInfo {
+	nodeMetrics := NodeMetricsInfo{}
+	for _, m := range metrics.Items {
+		nodeMetrics[m.Name] = m.Usage.Cpu().MilliValue()
+	}
+	return nodeMetrics
+}
+
+// GetResourceMetric gets the given resource metric (and an associated oldest timestamp)
+// for all pods matching the specified selector in the given namespace
+func (c *resourceMetricsClient) GetResourceMetric() (NodeMetricsInfo, time.Time, error) {
+	metrics, err := c.client.NodeMetricses().List(metav1.ListOptions{})
+	if err != nil {
+		glog.V(5).Infof("unable to fetch metrics from API: %v", err)
+		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from API: %v", err)
+	}
+
+	if len(metrics.Items) == 0 {
+		return nil, time.Time{}, fmt.Errorf("no metrics returned from metric-server")
+	}
+	nodeMetricsInfo := populateNodeMetricsInfo(metrics)
+	timestamp := metrics.Items[0].Timestamp.Time
+	return nodeMetricsInfo, timestamp, nil
 }

--- a/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
@@ -579,6 +579,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			informerFactory.Storage().V1().StorageClasses(),
 			v1.DefaultHardPodAffinitySymmetricWeight,
 			enableEquivalenceCache,
+			nil,
 		).CreateFromConfig(policy); err != nil {
 			t.Errorf("%s: Error constructing: %v", v, err)
 			continue

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -637,7 +637,7 @@ func TestZeroRequest(t *testing.T) {
 			schedulertesting.FakeServiceLister([]*v1.Service{}),
 			schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
 			schedulertesting.FakeReplicaSetLister([]*extensions.ReplicaSet{}),
-			schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
+			schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}), nil)
 		mataData := mataDataProducer(test.pod, nodeNameToInfo)
 
 		list, err := PrioritizeNodes(

--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -88,6 +88,7 @@ go_library(
         "//vendor/k8s.io/client-go/listers/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/listers/storage/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -533,6 +533,7 @@ func newConfigFactory(client *clientset.Clientset, hardPodAffinitySymmetricWeigh
 		informerFactory.Storage().V1().StorageClasses(),
 		hardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		nil,
 	)
 }
 

--- a/pkg/scheduler/factory/plugins.go
+++ b/pkg/scheduler/factory/plugins.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
+	resourceclient "k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
 
 	"github.com/golang/glog"
 )
@@ -47,6 +48,7 @@ type PluginFactoryArgs struct {
 	StorageClassInfo               predicates.StorageClassInfo
 	VolumeBinder                   *volumebinder.VolumeBinder
 	HardPodAffinitySymmetricWeight int32
+	MetricsClient                  *resourceclient.MetricsV1beta1Client
 }
 
 // PriorityMetadataProducerFactory produces PriorityMetadataProducer from the given args.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/schedulercache"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
+	resourceclient "k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1"
 
 	"github.com/golang/glog"
 )
@@ -137,6 +138,9 @@ type Config struct {
 
 	// VolumeBinder handles PVC/PV binding for the pod.
 	VolumeBinder *volumebinder.VolumeBinder
+
+	// MetricsClient to get utilization for all nodes.
+	MetricsClient *resourceclient.MetricsV1beta1Client
 }
 
 // NewFromConfigurator returns a new scheduler that is created entirely by the Configurator.  Assumes Create() is implemented.
@@ -440,6 +444,7 @@ func (sched *Scheduler) scheduleOne() {
 
 	// Synchronously attempt to find a fit for the pod.
 	start := time.Now()
+
 	suggestedHost, err := sched.schedule(pod)
 	if err != nil {
 		// schedule() may have failed because the pod would not fit on any host, so we try to

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -84,6 +84,7 @@ func createConfiguratorWithPodInformer(
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		nil,
 	)
 }
 

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -112,5 +112,6 @@ func createSchedulerConfigurator(
 		informerFactory.Storage().V1().StorageClasses(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		nil,
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
 
- This PR introduces priority function for usage based scheduling in default scheduler. The node which has least CPU utilization currently will get a score of 10 and rest of the nodes in the cluster would get a score of 0.
- We need metrics-server to be deployed in the cluster to get node level metrics to while scheduling.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #18438
(I am not able to reopen the issue but this was closed by bot)

**Special notes for your reviewer**:
/cc @bsalamat @aveshagarwal @derekwaynecarr 

(Update : Added link for document. Those who are part sig-scheduling mailing list could access it. https://docs.google.com/document/d/1icbnfZlqiwvwEMp4_yThR-Y56XoxoLszxihYBq8P3j8/edit)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce usage based scheduling priority function.
```
