### PR TITLE
Bump GLBC version and remove Unreleased tag from tests

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.0.1
+  name: l7-lb-controller-v1.1.0
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.0.1
+    version: v1.1.0
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.0.1
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.0
     livenessProbe:
       httpGet:
         path: /healthz

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -311,7 +311,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			executeBacksideBacksideHTTPSTest(f, jig, "")
 		})
 
-		It("should support multiple TLS certs [Unreleased]", func() {
+		It("should support multiple TLS certs", func() {
 			By("Creating an ingress with no certs.")
 			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "multiple-certs"), ns, map[string]string{
 				framework.IngressStaticIPKey: ns,
@@ -418,8 +418,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			// TODO(nikhiljindal): Check the instance group annotation value and verify with a multizone cluster.
 		})
 
-		// TODO (gau): Remove [Unreleased] label once HTTP2 is in the next Ingress release
-		It("should be able to switch between HTTPS and HTTP2 modes [Unreleased]", func() {
+		It("should be able to switch between HTTPS and HTTP2 modes", func() {
 			httpsScheme := "request_scheme=https"
 
 			By("Create a basic HTTP2 ingress")


### PR DESCRIPTION
/assign rramkumar1
/cc mrhohn

**Release note**:
```release-note
GCE: Bump GLBC version to 1.1.0 - supporting multiple certificates and HTTP2
```
