### PR TITLE
juju: Revert "Bugfix for erroneous upgrade needed messaging ..."

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -85,22 +85,20 @@ def upgrade_charm():
     set_state('kubernetes-worker.restart-needed')
 
 
-def get_snap_resource_paths():
-    resources = ['kubectl', 'kubelet', 'kube-proxy']
-    return [hookenv.resource_get(resource) for resource in resources]
-
-
 def check_resources_for_upgrade_needed():
     hookenv.status_set('maintenance', 'Checking resources')
-    if any_file_changed(get_snap_resource_paths()):
+    resources = ['kubectl', 'kubelet', 'kube-proxy']
+    paths = [hookenv.resource_get(resource) for resource in resources]
+    if any_file_changed(paths):
         set_upgrade_needed()
 
 
 def set_upgrade_needed():
     set_state('kubernetes-worker.snaps.upgrade-needed')
     config = hookenv.config()
+    previous_channel = config.previous('channel')
     require_manual = config.get('require-manual-upgrade')
-    if not require_manual:
+    if previous_channel is None or not require_manual:
         set_state('kubernetes-worker.snaps.upgrade-specified')
 
 
@@ -136,34 +134,21 @@ def cleanup_pre_snap_services():
             os.remove(file)
 
 
-@when_not('kubernetes-worker.snap.resources-available')
-def check_snap_resources():
-    for path in get_snap_resource_paths():
-        if not path or not os.path.exists(path):
-            msg = 'Missing snap resources.'
-            hookenv.status_set('blocked', msg)
-            return
-    set_state('kubernetes-worker.snap.resources-available')
-    set_state('kubernetes-worker.snaps.upgrade-specified')
-
-
 @when('config.changed.channel')
 def channel_changed():
     set_upgrade_needed()
 
 
-@when('kubernetes-worker.snaps.upgrade-needed',
-      'kubernetes-worker.snap.resources-available')
+@when('kubernetes-worker.snaps.upgrade-needed')
 @when_not('kubernetes-worker.snaps.upgrade-specified')
 def upgrade_needed_status():
     msg = 'Needs manual upgrade, run the upgrade action'
     hookenv.status_set('blocked', msg)
 
 
-@when('kubernetes-worker.snap.resources-available',
-      'kubernetes-worker.snaps.upgrade-specified')
+@when('kubernetes-worker.snaps.upgrade-specified')
 def install_snaps():
-    any_file_changed(get_snap_resource_paths())
+    check_resources_for_upgrade_needed()
     channel = hookenv.config('channel')
     hookenv.status_set('maintenance', 'Installing kubectl snap')
     snap.install('kubectl', channel=channel, classic=True)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This reverts https://github.com/kubernetes/kubernetes/pull/60873, which made it where the kubernetes-worker charm always requires a resource to be attached. This newly introduced requirement is a blocker for some of our users, so we have to revert this.

This PR fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/545 but reintroduces https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/504. We can't really fix this in the charm, we'll have to get it fixed in juju instead.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
