### PR TITLE
Increase CPU limit to 1000 millicores to support 100kb/s throughput.

### DIFF
--- a/cluster/addons/fluentd-gcp/scaler-deployment.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-deployment.yaml
@@ -31,6 +31,6 @@ spec:
         - name: MEMORY_REQUEST
           value: 200Mi
         - name: CPU_LIMIT
-          value: 300m
+          value: 1000m
         - name: MEMORY_LIMIT
           value: 500Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
The e2e tests for fluentd in gke are failing due to conservative CPU limits for the logging agent. After doing some research we have determined that 1 core is necessary to achieve 100kb/s throughput.

**Release note:**
```release-note
[fluentd-gcp addon] Increase CPU limit for fluentd to 1 core to achieve 100kb/s throughput.
```