### PR TITLE
kazel: skip third_party/etcd.*

### DIFF
--- a/build/root/.kazelcfg.json
+++ b/build/root/.kazelcfg.json
@@ -1,7 +1,8 @@
 {
 	"GoPrefix": "k8s.io/kubernetes",
 	"SkippedPaths": [
-		"^_.*"
+		"^_.*",
+		"^third_party/etcd.*"
 	],
 	"AddSourcesRules": true,
 	"K8sOpenAPIGen": true

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -4,8 +4,13 @@ licenses(["notice"])
 
 filegroup(
     name = "package-srcs",
-    srcs = glob(["**"]),
-    tags = ["automanaged"],
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "etcd*/**",
+            "etcd*.tar.gz",
+        ],
+    ),
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: fixes the issue encountered in https://github.com/kubernetes/kubernetes/pull/62151#discussion_r179322174.

Basically, we git ignore anything under `third_party/etcd.*`, but if a `BUILD` file ends up in there somehow, it'll confuse kazel and generate invalid entries in top-level `BUILD` files that we do check in. We can avoid this issue by instructing kazel to ignore these directories.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @mikedanese @thockin @BenTheElder 
