### PR TITLE
modify the log output in kuberuntime_manager.go

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -509,7 +509,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
 			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
-				message := fmt.Sprintf("Container %+v is dead, but RestartPolicy says that we should restart it.", container)
+				message := fmt.Sprintf("Container %q in pod %q is dead, but RestartPolicy says that we should restart it.", container.Name, pod.Name)
 				glog.Info(message)
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
sometime, if there is many config for container, the log looks cluttered like below, and there is not pod information.
`Container {Name:operate Image:172.20.128.25:6666/flavor-20180412001353/operate:v1.0 Command:[] Args:[] WorkingDir: Ports:[{Name: HostPort:0 ContainerPort:8206 Protocol:TCP HostIP:}] EnvFrom:[] Env:[{Name:language Value:CH ValueFrom:nil} {Name:log Value:3 ValueFrom:nil} {Name:version_no Value:V5.16.10.28B001 ValueFrom:nil} {Name:kafka_host Value:broker1-director:29992,broker2-director:29993,broker3-director:29994 ValueFrom:nil} {Name:mq_host Value:rabbitmq-director ValueFrom:nil} {Name:gateway_host Value:inner-router-flavor-20180412001353 ValueFrom:nil} {Name:cassandra_host Value:cassandra1-director,cassandra2-director,cassandra3-director ValueFrom:nil} {Name:es_host Value:es1-director,es2-director,es3-director ValueFrom:nil} {Name:zk_host Value:zookeeper-director ValueFrom:nil} {Name:etcd_host Value:etcd-director ValueFrom:nil} {Name:north_external_vip Value:1.2.3.4 ValueFrom:nil} {Name:south_external_vip Value:1.2.3.4ValueFrom:nil} {Name:IS_AC_TEST Value:True ValueFrom:nil} {Name:language Value: ValueFrom:nil} {Name:log Value: ValueFrom:nil} {Name:open_ms_uuid Value:******ValueFrom:nil} {Name:openpalette_container_name Value:operate ValueFrom:nil} {Name:openpalette_srv_uuid Value:7e2e2696-067f-4075-b3ae-1ebdb22bc112 ValueFrom:nil} {Name:DBCONF Value:ip=172.20.128.23:3000 ValueFrom:nil} {Name:OPENPALETTE_MYSQL_ADDRESS Value:commsrv_rdb57_server ValueFrom:nil} {Name:OPENPALETTE_MYSQL_PORT Value:4551 ValueFrom:nil} {Name:OPENPALETTE_MYSQL_DBNAME Value:db_930968eeff1f42a89777f696827f8ebd ValueFrom:nil} {Name:OPENPALETTE_MYSQL_USERNAME Value:Ur0B2NLipRT1Pv ValueFrom:nil} {Name:OPENPALETTE_MYSQL_PASSWORD Value:wM1DTutOlN_0Zx ValueFrom:nil} {Name:TZ Value:Asia/Shanghai ValueFrom:nil} {Name:OPENPALETTE_NAMESPACE Value:flavor-20180412001353 ValueFrom:nil} {Name:OPENPALETTE_MSB_IP Value:172.20.96.23 ValueFrom:nil} {Name:OPENPALETTE_MSB_PORT Value:10081 ValueFrom:nil}] Resources:{Limits:map[memory:{i:{value:2147483648 scale:0} d:{Dec:<nil>} l:[] s:2Gi Format:BinarySI}] Requests:map[pod.alpha.kubernetes.io/opaque-int-resource-hugepage:{i:{value:0 scale:0} d:{Dec:<nil>} l:[0] s:0 Format:DecimalSI} pod.alpha.kubernetes.io/opaque-int-resource-affinityCPU:{i:{value:0 scale:0} d:{Dec:<nil>} l:[0] s:0 Format:DecimalSI} memory:{i:{value:268435456 scale:0} d:{Dec:<nil>} l:[268435456] s: Format:BinarySI} pod.alpha.kubernetes.io/opaque-int-resource-c0-capacity:{i:{value:0 scale:0} d:{Dec:<nil>} l:[0] s:0 Format:DecimalSI}]} VolumeMounts:[{Name:logpath ReadOnly:false MountPath:/var/zte-log SubPath:} {Name:clock-zone ReadOnly:false MountPath:/usr/share/zoneinfo SubPath:} {Name:default-token-n95rf ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath:}] LivenessProbe:&Probe{Handler:Handler{Exec:nil,HTTPGet:&HTTPGetAction{Path:/api/v2.0/operateService/system/health,Port:8206,Host:,Scheme:HTTP,HTTPHeaders:[{Content-Type application/json}],},TCPSocket:nil,},InitialDelaySeconds:600,TimeoutSeconds:60,PeriodSeconds:10,SuccessThreshold:1,FailureThreshold:3,} ReadinessProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:Always SecurityContext:&SecurityContext{Capabilities:nil,Privileged:*false,SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,ReadOnlyRootFilesystem:nil,} Stdin:false StdinOnce:false TTY:false} is dead, but RestartPolicy says that we should restart it.`

merge this pr , the log is simpler and better to debug
`kuberuntime_manager.go:513] Container "nginx" in pod "nginx-v2-6hsh5" is dead, but RestartPolicy says that we should restart it.`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
