### PR TITLE
kubectl get CRD resources with --server-print=true column name error

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
@@ -42,7 +42,7 @@ var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 func New(extensions spec.Extensions) (rest.TableConvertor, error) {
 	headers := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
-		{Name: "Created At", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
+		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 	}
 	c := &convertor{
 		headers: headers,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Here's a bunch of kubectl get command execution and their outputs.
my-crd is the user-define CRD resource.
1. 
```
kubectl get pod --all-namespaces --server-print=true

NAMESPACE   NAME    READY   STATUS  RESTARTS   AGE
test-ns    test-pod  1/1    running     1      15m

```
2. 
```
kubectl get my-crd --all-namespaces --server-print=false

NAMESPACE   NAME      AGE
test-ns    test-crd    21m
```

3.
```
kubectl get my-crd --all-namespaces --server-print=true

NAMESPACE   NAME        CREATED AT
test-ns    test-crd         21m
```

Here's the problem
1. Example 3 isn't consistent with example 1 and 2
2. CREATED AT 21m doesn't make sense

This patch fix this.




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
