### PR TITLE
Ensure expected load balancer is selected for Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -199,7 +199,8 @@ func (az *Cloud) getServiceLoadBalancer(service *v1.Service, clusterName string,
 
 	// check if the service already has a load balancer
 	if existingLBs != nil {
-		for _, existingLB := range existingLBs {
+		for i := range existingLBs {
+			existingLB := existingLBs[i]
 			if strings.EqualFold(*existingLB.Name, defaultLBName) {
 				defaultLB = &existingLB
 			}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Azure cloud provider is always selecting the last element of LB list. The reason is: getServiceLoadBalancer() refers the pointer of an local variable within for loop:

https://github.com/kubernetes/kubernetes/blob/e7ed9b408adaaec1e5ddfc167fc18b6aaeca425f/pkg/cloudprovider/providers/azure/azure_loadbalancer.go#L202-L206

This is a common mistake as golang is actually reusing same variable within the loop. This PR fixes this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62449

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure expected load balancer is selected for Azure
```

/sig azure
/kind bug