### PR TITLE
Fix kubeadm upgrade ignores HighAvailability feature gate

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -70,14 +70,17 @@ func enforceRequirements(flags *cmdUpgradeFlags, dryRun bool, newK8sVersion stri
 		cfg.KubernetesVersion = newK8sVersion
 	}
 
+	// If features gates are passed to the command line, use it (otherwise use featureGates from configuration)
+	if flags.featureGatesString != "" {
+		cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, flags.featureGatesString)
+		if err != nil {
+			return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
+		}
+	}
+
 	// If the user told us to print this information out; do it!
 	if flags.printConfig {
 		printConfiguration(cfg, os.Stdout)
-	}
-
-	cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, flags.featureGatesString)
-	if err != nil {
-		return nil, fmt.Errorf("[upgrade/config] FATAL: %v", err)
 	}
 
 	return &upgradeVariables{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes https://github.com/kubernetes/kubeadm/issues/731

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/731

**Special notes for your reviewer**:
The problem is a regression introduced by [#55952](https://github.com/kubernetes/kubernetes/pull/55952) which added a --feature-gates 
flag to `kubeadm upgrade`, to be used for updating feature gates during the upgrade process (so it is update + upgrade). 

The original implementation always override the actual feature gates with the flag value, even when the flag is not set; this PR fixes this behaviour making `kubeadm upgrade` considers the flag value only if set, otherwise actual feature gates will be preserved.

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/sig-cluster-lifecycle-bugs 

**Release note**:
```release-note
Fixed #731 kubeadm upgrade ignores HighAvailability feature gate
```
