### PR TITLE
export of get shouldn't include selfLink

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1577,8 +1577,8 @@ func TestExport(t *testing.T) {
 		t.Errorf("Expected: exported, saw: %s", itemOut.Other)
 	}
 
-	if !selfLinker.called {
-		t.Errorf("Never set self link")
+	if selfLinker.called {
+		t.Errorf("Shouldn't set self link")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If the export=true, we used the Export() function which set [selfLink="".](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L1209) But the setSelfLink ignore the export option and set the selfLink back.

Before fix:
```
# kubectl get namespaces default -oyaml --export=true
apiVersion: v1
kind: Namespace
metadata:
  creationTimestamp: null
  name: default
  selfLink: /api/v1/namespaces/default
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```
After:
```
# kubectl get namespaces default -oyaml --export=true
apiVersion: v1
kind: Namespace
metadata:
  creationTimestamp: null
  name: default
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
