### PR TITLE
allow higher burst for discovery

### DIFF
--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -109,6 +109,11 @@ func (f *discoveryFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface
 		return nil, err
 	}
 
+	// The more groups you have, the more discovery requests you need to make.
+	// given 25 groups (our groups + a few custom resources) with one-ish version each, discovery needs to make 50 requests
+	// double it just so we don't end up here again for a while.  This config is only used for discovery.
+	cfg.Burst = 100
+
 	if f.cacheDir != "" {
 		wt := cfg.WrapTransport
 		cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
Discovery makes a lot of consecutive (maybe someday parallel) calls.  One for every group and another for every version.  Add a few CRDs and it's pretty easy to get to 50 calls. 

This targets the burst on kubectl's discovery client only.