### PR TITLE
avoid dobule RLock() in cpumanager

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -56,9 +56,6 @@ func (s *stateMemory) GetDefaultCPUSet() cpuset.CPUSet {
 }
 
 func (s *stateMemory) GetCPUSetOrDefault(containerID string) cpuset.CPUSet {
-	s.RLock()
-	defer s.RUnlock()
-
 	if res, ok := s.GetCPUSet(containerID); ok {
 		return res
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We met a deadlock when removing pod.
kubelet keeps logging:
```
Pod "xxxx" is terminated, but some containers are still running 
```
After debug, we found it stuck in `SetDefaultCPUSet` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cpumanager/policy_static.go#L184)  while another goroutine are calling `GetCPUSetOrDefault` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cpumanager/cpu_manager.go#L256).

According  golang/go#15418, It is not safe to double RLock a RWMutex.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

none

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
removed unsafe double RLock in cpumanager
```
