### PR TITLE
stop defaulting kubeconfig to http://localhost:8080

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4776,7 +4776,7 @@ runTests() {
     exit 1
   fi
   kube::log::status "Checking kubectl version"
-  kubectl version
+  KUBERNETES_MASTER=http://127.0.0.1:${API_PORT} kubectl version
 
   # Generate a random namespace name, based on the current time (to make
   # debugging slightly easier) and a random number. Don't use `date +%N`

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -36,22 +36,13 @@ import (
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
 	// DEPRECATED will be replaced
-	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
+	ClusterDefaults = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
 	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
 		ClusterDefaults: ClusterDefaults,
 	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
 )
-
-// getDefaultServer returns a default setting for DefaultClientConfig
-// DEPRECATED
-func getDefaultServer() string {
-	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
-		return server
-	}
-	return "http://localhost:8080"
-}
 
 // ClientConfig is used to make it easy to get an api server client
 type ClientConfig interface {


### PR DESCRIPTION
This default was made pre-1.0 to ease the transition to kubeconfig files.  It only works when run locally against a server using a deprecated flag and the functionality can be reproduced in such an environment by setting `KUBERNETES_MASTER`.

@kubernetes/sig-api-machinery-pr-reviews @liggitt @caesarxuchao I think it's time.

```release-note
`kubectl` no longer defaults to `http://localhost:8080`.  Set `KUBERNETES_MASTER` if you were relying on that behavior.
```