### PR TITLE
make mikedanese owner of CertRotation features

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -66,7 +66,7 @@ const (
 	// to take advantage of NoExecute Taints and Tolerations.
 	TaintBasedEvictions utilfeature.Feature = "TaintBasedEvictions"
 
-	// owner: @jcbsmpsn
+	// owner: @mikedanese
 	// alpha: v1.7
 	//
 	// Gets a server certificate for the kubelet from the Certificate Signing
@@ -74,8 +74,8 @@ const (
 	// certificate as expiration approaches.
 	RotateKubeletServerCertificate utilfeature.Feature = "RotateKubeletServerCertificate"
 
-	// owner: @jcbsmpsn
-	// alpha: v1.7
+	// owner: @mikedanese
+	// beta: v1.8
 	//
 	// Automatically renews the client certificate used for communicating with
 	// the API server as the certificate approaches expiration.


### PR DESCRIPTION
I've taken these features over from @jcbsmpsn 
```release-note
NONE
```
@kubernetes/sig-auth-pr-reviews 