### PR TITLE
Remove unnecessary code in ingress upgrade logic

### DIFF
--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -177,11 +177,6 @@ func (t *IngressUpgradeTest) verify(f *framework.Framework, done <-chan struct{}
 	postUpgradeResourceStore := &GCPResourceStore{}
 	t.populateGCPResourceStore(postUpgradeResourceStore)
 
-	// Ignore compute.SslCertificates since we know it will change during an upgrade/downgrade.
-	// TODO(rramkumar): Remove this once glbc 1.1 is released.
-	t.resourceStore.SslList = nil
-	postUpgradeResourceStore.SslList = nil
-
 	framework.ExpectNoError(compareGCPResourceStores(t.resourceStore, postUpgradeResourceStore, func(v1 reflect.Value, v2 reflect.Value) error {
 		i1 := v1.Interface()
 		i2 := v2.Interface()


### PR DESCRIPTION
Now that 1.1 is released, fix the TODO.

/assign @nicksardo 

**Release note**:

```release-note
None
```
