### PR TITLE
Use OWNERS filters to give approval to ixdy for Bazel build changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,29 @@
-reviewers:
-  - brendandburns
-  - dchen1107
-  - jbeda
-  - lavalamp
-  - smarterclayton
-  - thockin
-approvers:
-  - bgrant0607
-  - brendandburns
-  - dchen1107
-  - jbeda
-  - monopole # To move code per kubernetes/community#598
-  - lavalamp
-  - smarterclayton
-  - thockin
-  - wojtek-t
+filters:
+  ".*":
+    reviewers:
+      - brendandburns
+      - dchen1107
+      - jbeda
+      - lavalamp
+      - smarterclayton
+      - thockin
+    approvers:
+      - bgrant0607
+      - brendandburns
+      - dchen1107
+      - jbeda
+      - monopole # To move code per kubernetes/community#598
+      - lavalamp
+      - smarterclayton
+      - thockin
+      - wojtek-t
+
+  # Bazel build infrastructure changes often touch files throughout the tree
+  "\.bzl$":
+    reviewers:
+      - ixdy
+    approvers:
+      - ixdy
+  "BUILD(\.bazel)?$":
+    approvers:
+      - ixdy


### PR DESCRIPTION
**What this PR does / why we need it**: Bazel updates tend to affect a bunch of `BUILD` files throughout the tree. Rather than getting @thockin to rubber-stamp these all the time, give me the power to approve? I already have appoval over `build/` and `hack/`, which is related to these files.

Happy to add other owners here too, though I don't know who else wants to own.

Previously: https://github.com/kubernetes/kubernetes/pull/45245, https://github.com/kubernetes/kubernetes/pull/45855

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @cjwagner @thockin 
/cc @fejta @mikedanese @BenTheElder 
