### PR TITLE
CSI - Update to apply fsGroup volume ownership

### DIFF
--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -141,7 +141,8 @@ func TestMounterSetUp(t *testing.T) {
 	}
 
 	// Mounter.SetUp()
-	if err := csiMounter.SetUp(nil); err != nil {
+	fsGroup := int64(2000)
+	if err := csiMounter.SetUp(&fsGroup); err != nil {
 		t.Fatalf("mounter.Setup failed: %v", err)
 	}
 	path := csiMounter.GetPath()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR correctly fixes the CSI internal driver to apply fsGroup volume ownership value during mount.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62413 

```release-note
NONE
```
