### PR TITLE
use standard interface functions for printers

### DIFF
--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -117,7 +117,7 @@ type EnvOptions struct {
 	From              string
 	Prefix            string
 
-	PrintObj func(runtime.Object) error
+	PrintObj printers.ResourcePrinterFunc
 
 	Builder *resource.Builder
 	Infos   []*resource.Info
@@ -226,9 +226,7 @@ func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
-	o.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, o.Out)
-	}
+	o.PrintObj = printer.PrintObj
 
 	if o.List && len(o.Output) > 0 {
 		return cmdutil.UsageErrorf(o.Cmd, "--list and --output may not be specified together")
@@ -437,7 +435,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
+			if err := o.PrintObj(patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -456,7 +454,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 			return fmt.Errorf("at least one environment variable must be provided")
 		}
 
-		if err := o.PrintObj(info.AsVersioned()); err != nil {
+		if err := o.PrintObj(info.AsVersioned(), o.Out); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -53,7 +53,7 @@ type ImageOptions struct {
 	Cmd          *cobra.Command
 	ResolveImage func(in string) (string, error)
 
-	PrintObj func(runtime.Object) error
+	PrintObj printers.ResourcePrinterFunc
 
 	UpdatePodSpecForObject func(obj runtime.Object, fn func(*v1.PodSpec) error) (bool, error)
 	Resources              []string
@@ -136,9 +136,7 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		return err
 	}
 
-	o.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, o.Out)
-	}
+	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -258,7 +256,7 @@ func (o *ImageOptions) Run() error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
+			if err := o.PrintObj(patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -283,7 +281,7 @@ func (o *ImageOptions) Run() error {
 
 		info.Refresh(obj, true)
 
-		if err := o.PrintObj(info.AsVersioned()); err != nil {
+		if err := o.PrintObj(info.AsVersioned(), o.Out); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -79,7 +79,7 @@ type ResourcesOptions struct {
 
 	DryRun bool
 
-	PrintObj func(runtime.Object) error
+	PrintObj printers.ResourcePrinterFunc
 
 	Limits               string
 	Requests             string
@@ -155,9 +155,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	if err != nil {
 		return err
 	}
-	o.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, o.Out)
-	}
+	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -262,7 +260,7 @@ func (o *ResourcesOptions) Run() error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObj(patch.Info.AsVersioned()); err != nil {
+			if err := o.PrintObj(patch.Info.AsVersioned(), o.Out); err != nil {
 				return err
 			}
 			continue
@@ -285,7 +283,7 @@ func (o *ResourcesOptions) Run() error {
 		}
 		info.Refresh(obj, true)
 
-		if err := o.PrintObj(info.AsVersioned()); err != nil {
+		if err := o.PrintObj(info.AsVersioned(), o.Out); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -73,7 +73,7 @@ type serviceAccountConfig struct {
 	infos                  []*resource.Info
 	serviceAccountName     string
 
-	PrintObj func(runtime.Object) error
+	PrintObj printers.ResourcePrinterFunc
 }
 
 // NewCmdServiceAccount returns the "set serviceaccount" command.
@@ -127,9 +127,7 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	if err != nil {
 		return err
 	}
-	saConfig.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, saConfig.out)
-	}
+	saConfig.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -180,7 +178,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			continue
 		}
 		if saConfig.local || saConfig.dryRun {
-			if err := saConfig.PrintObj(patch.Info.AsVersioned()); err != nil {
+			if err := saConfig.PrintObj(patch.Info.AsVersioned(), saConfig.out); err != nil {
 				return err
 			}
 			continue
@@ -199,7 +197,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 			}
 		}
 
-		if err := saConfig.PrintObj(info.AsVersioned()); err != nil {
+		if err := saConfig.PrintObj(info.AsVersioned(), saConfig.out); err != nil {
 			return err
 		}
 	}

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -74,7 +74,7 @@ type SubjectOptions struct {
 	Groups          []string
 	ServiceAccounts []string
 
-	PrintObj func(obj runtime.Object) error
+	PrintObj printers.ResourcePrinterFunc
 }
 
 func NewCmdSubject(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
@@ -124,9 +124,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
-	o.PrintObj = func(obj runtime.Object) error {
-		return printer.PrintObj(obj, o.Out)
-	}
+	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -251,7 +249,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.PrintObj(info.Object); err != nil {
+			if err := o.PrintObj(info.Object, o.Out); err != nil {
 				return err
 			}
 			continue
@@ -264,7 +262,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 		info.Refresh(obj, true)
 
-		return o.PrintObj(info.AsVersioned())
+		return o.PrintObj(info.AsVersioned(), o.Out)
 	}
 	return utilerrors.NewAggregate(allErrs)
 }


### PR DESCRIPTION
Updates the printObj funcs to be the standard resource printer interface we have.

@kubernetes/sig-cli-misc 