### PR TITLE
Fix failed e2e tests for dns configmap

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -35,8 +35,9 @@ type dnsFederationsConfigMapTest struct {
 
 var _ = SIGDescribe("DNS configMap federations", func() {
 
+	t := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
+
 	It("should be able to change federation configuration [Slow][Serial]", func() {
-		t := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
 		t.c = t.f.ClientSet
 		t.run()
 	})
@@ -220,15 +221,21 @@ func (t *dnsPtrFwdTest) run() {
 
 var _ = SIGDescribe("DNS configMap nameserver", func() {
 
-	It("should be able to change stubDomain configuration [Slow][Serial]", func() {
+	Context("Change stubDomain", func() {
 		nsTest := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
-		nsTest.c = nsTest.f.ClientSet
-		nsTest.run()
+
+		It("should be able to change stubDomain configuration [Slow][Serial]", func() {
+			nsTest.c = nsTest.f.ClientSet
+			nsTest.run()
+		})
 	})
 
-	It("should forward PTR records lookup to upstream nameserver [Slow][Serial]", func() {
+	Context("Forward PTR lookup", func() {
 		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDnsTestCommon()}
-		fwdTest.c = fwdTest.f.ClientSet
-		fwdTest.run()
+
+		It("should forward PTR records lookup to upstream nameserver [Slow][Serial]", func() {
+			fwdTest.c = fwdTest.f.ClientSet
+			fwdTest.run()
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix DNS configMap e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62490 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
