### PR TITLE
Fix a bug that headless service without ports fails to have endpoint created.

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -753,7 +753,7 @@ func TestSyncEndpointsHeadlessService(t *testing.T) {
 		},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "1.2.3.4", NodeName: &emptyNodeName, TargetRef: &v1.ObjectReference{Kind: "Pod", Name: "pod0", Namespace: ns}}},
-			Ports:     []v1.EndpointPort{{Port: 0, Protocol: "TCP"}},
+			Ports:     []v1.EndpointPort{},
 		}},
 	})
 	endpointsHandler.ValidateRequestCount(t, 1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes/kubernetes/pull/47250. Headless service without ports fails to have corresponding endpoint created because endpoint controller deliberately attaches a dummy endpointPort with portNum=0, which will fail API validation check. Error as below:
```
endpoints_controller.go:375] Error syncing endpoints for service "default/XXX": Endpoints "XXX" is invalid: subsets[0].ports[0].port: Invalid value: 0: must be between 1 and 65535, inclusive
```

This PR makes endpoint controller not attach the dummy endpointPort for headless service.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55158, fixes #62440 

**Special notes for your reviewer**:
cc @xiangpengzhao 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug that headless service without ports fails to have endpoint created.
```
