### PR TITLE
Update kazel to include openapi tag detection fix

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
-	"GoVersion": "go1.9",
+	"GoVersion": "go1.10",
 	"GodepVersion": "v80",
 	"Packages": [
 		"github.com/onsi/ginkgo/ginkgo",
@@ -2080,7 +2080,7 @@
 		},
 		{
 			"ImportPath": "github.com/kubernetes/repo-infra/kazel",
-			"Rev": "2a736b4fba317cf3038e3cbd06899b544b875fae"
+			"Rev": "d9bb9fdc907665c61c228baa64fed9b91c7dc1b0"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api",

--- a/pkg/generated/openapi/BUILD
+++ b/pkg/generated/openapi/BUILD
@@ -17,7 +17,6 @@ openapi_library(
         "pkg/kubelet/apis/kubeletconfig/v1beta1",
         "pkg/proxy/apis/kubeproxyconfig/v1alpha1",
         "pkg/version",
-        "vendor/github.com/kubernetes/repo-infra/kazel",
     ],
     tags = ["automanaged"],
     vendor_prefix = openapi_vendor_prefix,

--- a/vendor/github.com/kubernetes/repo-infra/kazel/BUILD
+++ b/vendor/github.com/kubernetes/repo-infra/kazel/BUILD
@@ -1,18 +1,4 @@
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
-    "go_library",
-)
-
-go_binary(
-    name = "kazel",
-    embed = [":go_default_library"],
-    tags = ["automanaged"],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -24,11 +10,17 @@ go_library(
         "sourcerer.go",
     ],
     importpath = "github.com/kubernetes/repo-infra/kazel",
-    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
     deps = [
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
+)
+
+go_binary(
+    name = "kazel",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/vendor/github.com/kubernetes/repo-infra/kazel/generator.go
+++ b/vendor/github.com/kubernetes/repo-infra/kazel/generator.go
@@ -17,19 +17,23 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
 
 const (
-	openAPIGenTag = "// +k8s:openapi-gen"
+	openAPITagName = "openapi-gen"
+	staging        = "staging/src/"
+)
 
-	staging = "staging/src/"
+var (
+	// Generator tags are specified using the format "// +k8s:name=value"
+	genTagRe = regexp.MustCompile(`//\s*\+k8s:([^\s=]+)(?:=(\S+))\s*\n`)
 )
 
 // walkGenerated updates the rule for kubernetes' OpenAPI generated file.
@@ -75,8 +79,12 @@ func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			if bytes.Contains(b, []byte(openAPIGenTag)) {
-				includeMe = true
+			matches := genTagRe.FindAllSubmatch(b, -1)
+			for _, m := range matches {
+				if len(m) >= 2 && string(m[1]) == openAPITagName {
+					includeMe = true
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: includes the fix from https://github.com/kubernetes/repo-infra/issues/67 for https://github.com/kubernetes/repo-infra/issues/66, which was discovered in @thockin's PR https://github.com/kubernetes/kubernetes/pull/57600/files#r178665554.

**Special notes for your reviewer**: I'm not sure what's up with the large list of comment diffs in `Godeps.json`; it looks like the `git describe` strings were (unintentionally?) truncated in @brendanburns's PR https://github.com/kubernetes/kubernetes/pull/61955.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @brendanburns @thockin @mikedanese 
