### PR TITLE
Fix ingress util for setting TLS spec

### DIFF
--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -97,7 +97,7 @@ func (t *IngressUpgradeTest) Setup(f *framework.Framework) {
 		framework.IngressStaticIPKey:  t.ipName,
 		framework.IngressAllowHTTPKey: "false",
 	}, map[string]string{})
-	t.jig.AddHTTPS("tls-secret", "ingress.test.com")
+	t.jig.SetHTTPS("tls-secret", "ingress.test.com")
 
 	By("waiting for Ingress to come up with ip: " + t.ip)
 	framework.ExpectNoError(framework.PollURL(fmt.Sprintf("https://%v/%v", t.ip, path), host, framework.LoadBalancerPollTimeout, t.jig.PollInterval, t.httpClient, false))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with ingress TLS testing.  For most tests, we want to only provide one certificate and verify it's being served. In some tests (including a conformance test), a new certificate was added; but only the first certificate was asserted. 

This is because the multi-TLS test uses `WaitForIngressWithCert()` while the other tests use `WaitForGivenIngressWithTimeout`.

**Special notes for your reviewer**:
/assign rramkumar1
/cc rramkumar1

**Release note**:
```release-note
NONE
```
