### PR TITLE
kubectl stops rendering List as suffix kind name for CRD resources

### DIFF
--- a/pkg/kubectl/cmd/util/openapi/validation/validation.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"errors"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -54,7 +53,7 @@ func (v *SchemaValidation) ValidateBytes(data []byte) error {
 		return utilerrors.NewAggregate(errs)
 	}
 
-	if strings.HasSuffix(gvk.Kind, "List") {
+	if (gvk == schema.GroupVersionKind{Version: "v1", Kind: "List"}) {
 		return utilerrors.NewAggregate(v.validateList(obj))
 	}
 

--- a/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
@@ -394,4 +394,16 @@ items:
 `))
 		Expect(err.Error()).To(Equal("[kind not set, apiVersion not set]"))
 	})
+
+	It("is fine with crd resource with List as a suffix kind name, which may not be a list of resources", func() {
+		err := validator.ValidateBytes([]byte(`
+apiVersion: fake.com/v1
+kind: FakeList
+metadata:
+  name: fake
+spec:
+  foo: bar
+`))
+		Expect(err).To(BeNil())
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`List` should not be treated as suffix when validating CRD objects.
Removing this validation won't break anything.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62410

**Special notes for your reviewer**:
/assign liggitt deads2k 
/cc nikhita soltysh 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl stops rendering List as suffix kind name for CRD resources
```
