### PR TITLE
migrate kubelet --kubeconfig to kubelet.config.k8s.io

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -52,7 +52,6 @@ const defaultRootDir = "/var/lib/kubelet"
 // In general, please try to avoid adding flags or configuration fields,
 // we already have a confusingly large amount of them.
 type KubeletFlags struct {
-	KubeConfig          string
 	BootstrapKubeconfig string
 	RotateCertificates  bool
 
@@ -336,7 +335,6 @@ func (f *KubeletFlags) AddFlags(fs *pflag.FlagSet) {
 	f.addOSFlags(fs)
 
 	fs.StringVar(&f.KubeletConfigFile, "config", f.KubeletConfigFile, "The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. Command-line flags override configuration from this file.")
-	fs.StringVar(&f.KubeConfig, "kubeconfig", f.KubeConfig, "Path to a kubeconfig file, specifying how to connect to the API server. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
 
 	fs.MarkDeprecated("experimental-bootstrap-kubeconfig", "Use --bootstrap-kubeconfig")
 	fs.StringVar(&f.BootstrapKubeconfig, "experimental-bootstrap-kubeconfig", f.BootstrapKubeconfig, "deprecated: use --bootstrap-kubeconfig")
@@ -441,6 +439,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		mainfs.AddFlagSet(fs)
 	}()
 
+	fs.StringVar(&c.KubeConfig, "kubeconfig", c.KubeConfig, "Path to a kubeconfig file, specifying how to connect to the API server. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
 	fs.BoolVar(&c.FailSwapOn, "fail-swap-on", c.FailSwapOn, "Makes the Kubelet fail to start if swap is enabled on the node. ")
 	fs.BoolVar(&c.FailSwapOn, "experimental-fail-swap-on", c.FailSwapOn, "DEPRECATED: please use --fail-swap-on instead.")
 	fs.MarkDeprecated("experimental-fail-swap-on", "This flag is deprecated and will be removed in future releases. please use --fail-swap-on instead.")

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -44,6 +44,8 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta
 
+	// Path to a kubeconfig file, specifying how to connect to the API server.
+	KubeConfig string
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	StaticPodPath string

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -44,6 +44,8 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// Path to a kubeconfig file, specifying how to connect to the API server.
+	KubeConfig string `json:"kubeConfig,omitempty"`
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	// Default: ""

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
@@ -141,6 +141,7 @@ func Convert_kubeletconfig_KubeletAuthorization_To_v1beta1_KubeletAuthorization(
 }
 
 func autoConvert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(in *KubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
+	out.KubeConfig = in.KubeConfig
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
@@ -262,6 +263,7 @@ func Convert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(
 }
 
 func autoConvert_kubeletconfig_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in *kubeletconfig.KubeletConfiguration, out *KubeletConfiguration, s conversion.Scope) error {
+	out.KubeConfig = in.KubeConfig
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency


### PR DESCRIPTION
**What this PR does / why we need it**:
migrate kubeconfig to kubelet.config.k8s.io

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61662 

**Special notes for your reviewer**:
@mtaufen 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Kubelet's --kubeconfig flag can now be set via the kubelet.config.k8s.io/v1beta1 API by specifying the KubeletConfiguration.KubeConfig field.
```
