### PR TITLE
Automated cherry pick of #61715: Increase cpu/mem thresholds for c-m in density test

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -167,8 +167,8 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 		if numNodes <= 100 {
 			apiserverCPU = 1.8
 			apiserverMem = 1700 * (1024 * 1024)
-			controllerCPU = 0.5
-			controllerMem = 500 * (1024 * 1024)
+			controllerCPU = 0.6
+			controllerMem = 530 * (1024 * 1024)
 			schedulerCPU = 0.4
 			schedulerMem = 180 * (1024 * 1024)
 		}


### PR DESCRIPTION
Cherry pick of #61715 on release-1.10.

#61715: Increase cpu/mem thresholds for c-m in density test

```release-note
NONE
```