### PR TITLE
Fix duplicate comment in iptables rule for non-local public-port rule

### DIFF
--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -1095,7 +1095,7 @@ func (proxier *Proxier) iptablesHostNodePortArgs(nodePort int, protocol api.Prot
 // Build a slice of iptables args for an from-non-local public-port rule.
 func (proxier *Proxier) iptablesNonLocalNodePortArgs(nodePort int, protocol api.Protocol, proxyIP net.IP, proxyPort int, service proxy.ServicePortName) []string {
 	args := iptablesCommonPortalArgs(nil, false, false, proxyPort, protocol, service)
-	args = append(args, "-m", "comment", "--comment", service.String(), "-m", "state", "--state", "NEW", "-j", "ACCEPT")
+	args = append(args, "-m", "state", "--state", "NEW", "-j", "ACCEPT")
 	return args
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When kubernetes creates an iptable rule for "from-non-local public-port"
rule the rule gets created with two identical comment section.

The function `iptablesNonLocalNodePortArgs` creates a list of arguments
for the rule from iptablesCommonPortalArgs function. This function
already appends the arguments for the rules comments and therefore does
not require appending the comment again.

**Special notes for your reviewer**:

I'm actually not a go programmer at all and have no idea how your tests work.
I doubt that my fix will require adjustements on tests but I'm not 100% sure.
If additional work is needed, I would be glad if someone could point it out to me so I can take care of it.

**Release note**:
```release-note
NONE
```
