### PR TITLE
Use a []string for CgroupName, which is a more accurate internal representation

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -18,119 +18,105 @@ limitations under the License.
 
 package cm
 
-import "testing"
+import (
+	"path"
+	"testing"
+)
 
-func TestLibcontainerAdapterAdaptToSystemd(t *testing.T) {
+func TestCgroupNameToSystemdBasename(t *testing.T) {
 	testCases := []struct {
-		input    string
+		input    CgroupName
 		expected string
 	}{
 		{
-			input:    "/",
-			expected: "-.slice",
+			input:    RootCgroupName,
+			expected: "/",
 		},
 		{
-			input:    "/system.slice",
+			input:    NewCgroupName(RootCgroupName, "system"),
 			expected: "system.slice",
 		},
 		{
-			input:    "/system.slice/Burstable",
+			input:    NewCgroupName(RootCgroupName, "system", "Burstable"),
 			expected: "system-Burstable.slice",
 		},
 		{
-			input:    "/Burstable.slice/Burstable-pod_123.slice",
+			input:    NewCgroupName(RootCgroupName, "Burstable", "pod-123"),
 			expected: "Burstable-pod_123.slice",
 		},
 		{
-			input:    "/test.slice/test-a.slice/test-a-b.slice",
+			input:    NewCgroupName(RootCgroupName, "test", "a", "b"),
 			expected: "test-a-b.slice",
 		},
 		{
-			input:    "/test.slice/test-a.slice/test-a-b.slice/Burstable",
+			input:    NewCgroupName(RootCgroupName, "test", "a", "b", "Burstable"),
 			expected: "test-a-b-Burstable.slice",
 		},
 		{
-			input:    "/Burstable",
+			input:    NewCgroupName(RootCgroupName, "Burstable"),
 			expected: "Burstable.slice",
 		},
 		{
-			input:    "/Burstable/pod_123",
-			expected: "Burstable-pod_123.slice",
-		},
-		{
-			input:    "/BestEffort/pod_6c1a4e95-6bb6-11e6-bc26-28d2444e470d",
+			input:    NewCgroupName(RootCgroupName, "BestEffort", "pod-6c1a4e95-6bb6-11e6-bc26-28d2444e470d"),
 			expected: "BestEffort-pod_6c1a4e95_6bb6_11e6_bc26_28d2444e470d.slice",
 		},
 	}
 	for _, testCase := range testCases {
-		f := newLibcontainerAdapter(libcontainerSystemd)
-		if actual := f.adaptName(CgroupName(testCase.input), false); actual != testCase.expected {
+		if actual := path.Base(testCase.input.ToSystemd()); actual != testCase.expected {
 			t.Errorf("Unexpected result, input: %v, expected: %v, actual: %v", testCase.input, testCase.expected, actual)
 		}
 	}
 }
 
-func TestLibcontainerAdapterAdaptToSystemdAsCgroupFs(t *testing.T) {
+func TestCgroupNameToSystemd(t *testing.T) {
 	testCases := []struct {
-		input    string
+		input    CgroupName
 		expected string
 	}{
 		{
-			input:    "/",
+			input:    RootCgroupName,
 			expected: "/",
 		},
 		{
-			input:    "/Burstable",
+			input:    NewCgroupName(RootCgroupName, "Burstable"),
 			expected: "/Burstable.slice",
 		},
 		{
-			input:    "/Burstable/pod_123",
+			input:    NewCgroupName(RootCgroupName, "Burstable", "pod-123"),
 			expected: "/Burstable.slice/Burstable-pod_123.slice",
 		},
 		{
-			input:    "/BestEffort/pod_6c1a4e95-6bb6-11e6-bc26-28d2444e470d",
+			input:    NewCgroupName(RootCgroupName, "BestEffort", "pod-6c1a4e95-6bb6-11e6-bc26-28d2444e470d"),
 			expected: "/BestEffort.slice/BestEffort-pod_6c1a4e95_6bb6_11e6_bc26_28d2444e470d.slice",
 		},
 		{
-			input:    "/kubepods",
+			input:    NewCgroupName(RootCgroupName, "kubepods"),
 			expected: "/kubepods.slice",
 		},
 	}
 	for _, testCase := range testCases {
-		f := newLibcontainerAdapter(libcontainerSystemd)
-		if actual := f.adaptName(CgroupName(testCase.input), true); actual != testCase.expected {
+		if actual := testCase.input.ToSystemd(); actual != testCase.expected {
 			t.Errorf("Unexpected result, input: %v, expected: %v, actual: %v", testCase.input, testCase.expected, actual)
 		}
 	}
 }
 
-func TestLibcontainerAdapterNotAdaptToSystemd(t *testing.T) {
-	cgroupfs := newLibcontainerAdapter(libcontainerCgroupfs)
-	otherAdatper := newLibcontainerAdapter(libcontainerCgroupManagerType("test"))
-
+func TestCgroupNameToCgroupfs(t *testing.T) {
 	testCases := []struct {
-		input    string
+		input    CgroupName
 		expected string
 	}{
 		{
-			input:    "/",
+			input:    RootCgroupName,
 			expected: "/",
 		},
 		{
-			input:    "/Burstable",
+			input:    NewCgroupName(RootCgroupName, "Burstable"),
 			expected: "/Burstable",
-		},
-		{
-			input:    "",
-			expected: "",
 		},
 	}
 	for _, testCase := range testCases {
-		if actual := cgroupfs.adaptName(CgroupName(testCase.input), true); actual != testCase.expected {
-			t.Errorf("Unexpected result, input: %v, expected: %v, actual: %v", testCase.input, testCase.expected, actual)
-		}
-
-		if actual := otherAdatper.adaptName(CgroupName(testCase.input), true); actual != testCase.expected {
+		if actual := testCase.input.ToCgroupfs(); actual != testCase.expected {
 			t.Errorf("Unexpected result, input: %v, expected: %v, actual: %v", testCase.input, testCase.expected, actual)
 		}
 	}

--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -63,23 +63,33 @@ func (m *unsupportedCgroupManager) Pids(_ CgroupName) []int {
 }
 
 func (m *unsupportedCgroupManager) CgroupName(name string) CgroupName {
-	return ""
+	return CgroupName([]string{})
 }
 
 func (m *unsupportedCgroupManager) ReduceCPULimits(cgroupName CgroupName) error {
 	return nil
 }
 
-func ConvertCgroupFsNameToSystemd(cgroupfsName string) (string, error) {
-	return "", nil
+var RootCgroupName = CgroupName([]string{})
+
+func NewCgroupName(base CgroupName, components ...string) CgroupName {
+	return CgroupName(append(base, components...))
 }
 
-func ConvertCgroupNameToSystemd(cgroupName CgroupName, outputToCgroupFs bool) string {
+func (cgroupName CgroupName) ToSystemd() string {
 	return ""
 }
 
-func RevertFromSystemdToCgroupStyleName(name string) string {
+func ParseSystemdToCgroupName(name string) CgroupName {
+	return nil
+}
+
+func (cgroupName CgroupName) ToCgroupfs() string {
 	return ""
+}
+
+func ParseCgroupfsToCgroupName(name string) CgroupName {
+	return nil
 }
 
 func IsSystemdStyleName(name string) bool {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -123,7 +123,7 @@ type containerManagerImpl struct {
 	capacity v1.ResourceList
 	// Absolute cgroupfs path to a cgroup that Kubelet needs to place all pods under.
 	// This path include a top level container for enforcing Node Allocatable.
-	cgroupRoot string
+	cgroupRoot CgroupName
 	// Event recorder interface.
 	recorder record.EventRecorder
 	// Interface for QoS cgroup management
@@ -223,7 +223,8 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 	capacity = cadvisor.CapacityFromMachineInfo(machineInfo)
 
-	cgroupRoot := nodeConfig.CgroupRoot
+	// Turn CgroupRoot from a string (in cgroupfs path format) to internal CgroupName
+	cgroupRoot := ParseCgroupfsToCgroupName(nodeConfig.CgroupRoot)
 	cgroupManager := NewCgroupManager(subsystems, nodeConfig.CgroupDriver)
 	// Check if Cgroup-root actually exists on the node
 	if nodeConfig.CgroupsPerQOS {
@@ -236,13 +237,13 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		// of note, we always use the cgroupfs driver when performing this check since
 		// the input is provided in that format.
 		// this is important because we do not want any name conversion to occur.
-		if !cgroupManager.Exists(CgroupName(cgroupRoot)) {
+		if !cgroupManager.Exists(cgroupRoot) {
 			return nil, fmt.Errorf("invalid configuration: cgroup-root %q doesn't exist: %v", cgroupRoot, err)
 		}
 		glog.Infof("container manager verified user specified cgroup-root exists: %v", cgroupRoot)
 		// Include the top level cgroup for enforcing node allocatable into cgroup-root.
 		// This way, all sub modules can avoid having to understand the concept of node allocatable.
-		cgroupRoot = path.Join(cgroupRoot, defaultNodeAllocatableCgroupName)
+		cgroupRoot = NewCgroupName(cgroupRoot, defaultNodeAllocatableCgroupName)
 	}
 	glog.Infof("Creating Container Manager object based on Node Config: %+v", nodeConfig)
 
@@ -305,7 +306,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 		}
 	}
 	return &podContainerManagerNoop{
-		cgroupRoot: CgroupName(cm.cgroupRoot),
+		cgroupRoot: cm.cgroupRoot,
 	}
 }
 
@@ -503,7 +504,7 @@ func (cm *containerManagerImpl) GetNodeConfig() NodeConfig {
 
 // GetPodCgroupRoot returns the literal cgroupfs value for the cgroup containing all pods.
 func (cm *containerManagerImpl) GetPodCgroupRoot() string {
-	return cm.cgroupManager.Name(CgroupName(cm.cgroupRoot))
+	return cm.cgroupManager.Name(cm.cgroupRoot)
 }
 
 func (cm *containerManagerImpl) GetMountedSubsystems() *CgroupSubsystems {

--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -42,7 +42,7 @@ const (
 //createNodeAllocatableCgroups creates Node Allocatable Cgroup when CgroupsPerQOS flag is specified as true
 func (cm *containerManagerImpl) createNodeAllocatableCgroups() error {
 	cgroupConfig := &CgroupConfig{
-		Name: CgroupName(cm.cgroupRoot),
+		Name: cm.cgroupRoot,
 		// The default limits for cpu shares can be very low which can lead to CPU starvation for pods.
 		ResourceParameters: getCgroupConfig(cm.capacity),
 	}
@@ -71,7 +71,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	glog.V(4).Infof("Attempting to enforce Node Allocatable with config: %+v", nc)
 
 	cgroupConfig := &CgroupConfig{
-		Name:               CgroupName(cm.cgroupRoot),
+		Name:               cm.cgroupRoot,
 		ResourceParameters: getCgroupConfig(nodeAllocatable),
 	}
 
@@ -88,7 +88,8 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	// Pod Evictions are expected to bring down memory usage to below Node Allocatable limits.
 	// Until evictions happen retry cgroup updates.
 	// Update limits on non root cgroup-root to be safe since the default limits for CPU can be too low.
-	if cm.cgroupRoot != "/" {
+	// Check if cgroupRoot is set to a non-empty value (empty would be the root container)
+	if len(cm.cgroupRoot) > 0 {
 		go func() {
 			for {
 				err := cm.cgroupManager.Update(cgroupConfig)
@@ -105,7 +106,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	// Now apply kube reserved and system reserved limits if required.
 	if nc.EnforceNodeAllocatable.Has(kubetypes.SystemReservedEnforcementKey) {
 		glog.V(2).Infof("Enforcing System reserved on cgroup %q with limits: %+v", nc.SystemReservedCgroupName, nc.SystemReserved)
-		if err := enforceExistingCgroup(cm.cgroupManager, nc.SystemReservedCgroupName, nc.SystemReserved); err != nil {
+		if err := enforceExistingCgroup(cm.cgroupManager, ParseCgroupfsToCgroupName(nc.SystemReservedCgroupName), nc.SystemReserved); err != nil {
 			message := fmt.Sprintf("Failed to enforce System Reserved Cgroup Limits on %q: %v", nc.SystemReservedCgroupName, err)
 			cm.recorder.Event(nodeRef, v1.EventTypeWarning, events.FailedNodeAllocatableEnforcement, message)
 			return fmt.Errorf(message)
@@ -114,7 +115,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	}
 	if nc.EnforceNodeAllocatable.Has(kubetypes.KubeReservedEnforcementKey) {
 		glog.V(2).Infof("Enforcing kube reserved on cgroup %q with limits: %+v", nc.KubeReservedCgroupName, nc.KubeReserved)
-		if err := enforceExistingCgroup(cm.cgroupManager, nc.KubeReservedCgroupName, nc.KubeReserved); err != nil {
+		if err := enforceExistingCgroup(cm.cgroupManager, ParseCgroupfsToCgroupName(nc.KubeReservedCgroupName), nc.KubeReserved); err != nil {
 			message := fmt.Sprintf("Failed to enforce Kube Reserved Cgroup Limits on %q: %v", nc.KubeReservedCgroupName, err)
 			cm.recorder.Event(nodeRef, v1.EventTypeWarning, events.FailedNodeAllocatableEnforcement, message)
 			return fmt.Errorf(message)
@@ -125,9 +126,9 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 }
 
 // enforceExistingCgroup updates the limits `rl` on existing cgroup `cName` using `cgroupManager` interface.
-func enforceExistingCgroup(cgroupManager CgroupManager, cName string, rl v1.ResourceList) error {
+func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.ResourceList) error {
 	cgroupConfig := &CgroupConfig{
-		Name:               CgroupName(cName),
+		Name:               cName,
 		ResourceParameters: getCgroupConfig(rl),
 	}
 	glog.V(4).Infof("Enforcing limits on cgroup %q with %d cpu shares and %d bytes of memory", cName, cgroupConfig.ResourceParameters.CpuShares, cgroupConfig.ResourceParameters.Memory)

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -35,7 +35,7 @@ func (m *podContainerManagerStub) EnsureExists(_ *v1.Pod) error {
 }
 
 func (m *podContainerManagerStub) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {
-	return "", ""
+	return nil, ""
 }
 
 func (m *podContainerManagerStub) Destroy(_ CgroupName) error {

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -18,7 +18,6 @@ package cm
 
 import (
 	"fmt"
-	"path"
 	"strings"
 	"sync"
 	"time"
@@ -60,17 +59,17 @@ type qosContainerManagerImpl struct {
 	qosReserved        map[v1.ResourceName]int64
 }
 
-func NewQOSContainerManager(subsystems *CgroupSubsystems, cgroupRoot string, nodeConfig NodeConfig, cgroupManager CgroupManager) (QOSContainerManager, error) {
+func NewQOSContainerManager(subsystems *CgroupSubsystems, cgroupRoot CgroupName, nodeConfig NodeConfig, cgroupManager CgroupManager) (QOSContainerManager, error) {
 	if !nodeConfig.CgroupsPerQOS {
 		return &qosContainerManagerNoop{
-			cgroupRoot: CgroupName(cgroupRoot),
+			cgroupRoot: cgroupRoot,
 		}, nil
 	}
 
 	return &qosContainerManagerImpl{
 		subsystems:    subsystems,
 		cgroupManager: cgroupManager,
-		cgroupRoot:    CgroupName(cgroupRoot),
+		cgroupRoot:    cgroupRoot,
 		qosReserved:   nodeConfig.QOSReserved,
 	}, nil
 }
@@ -81,23 +80,20 @@ func (m *qosContainerManagerImpl) GetQOSContainersInfo() QOSContainersInfo {
 
 func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceList, activePods ActivePodsFunc) error {
 	cm := m.cgroupManager
-	rootContainer := string(m.cgroupRoot)
-	if !cm.Exists(CgroupName(rootContainer)) {
-		return fmt.Errorf("root container %s doesn't exist", rootContainer)
+	rootContainer := m.cgroupRoot
+	if !cm.Exists(rootContainer) {
+		return fmt.Errorf("root container %v doesn't exist", rootContainer)
 	}
 
 	// Top level for Qos containers are created only for Burstable
 	// and Best Effort classes
-	qosClasses := map[v1.PodQOSClass]string{
-		v1.PodQOSBurstable:  path.Join(rootContainer, strings.ToLower(string(v1.PodQOSBurstable))),
-		v1.PodQOSBestEffort: path.Join(rootContainer, strings.ToLower(string(v1.PodQOSBestEffort))),
+	qosClasses := map[v1.PodQOSClass]CgroupName{
+		v1.PodQOSBurstable:  NewCgroupName(rootContainer, strings.ToLower(string(v1.PodQOSBurstable))),
+		v1.PodQOSBestEffort: NewCgroupName(rootContainer, strings.ToLower(string(v1.PodQOSBestEffort))),
 	}
 
 	// Create containers for both qos classes
 	for qosClass, containerName := range qosClasses {
-		// get the container's absolute name
-		absoluteContainerName := CgroupName(containerName)
-
 		resourceParameters := &ResourceConfig{}
 		// the BestEffort QoS class has a statically configured minShares value
 		if qosClass == v1.PodQOSBestEffort {
@@ -107,7 +103,7 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 
 		// containerConfig object stores the cgroup specifications
 		containerConfig := &CgroupConfig{
-			Name:               absoluteContainerName,
+			Name:               containerName,
 			ResourceParameters: resourceParameters,
 		}
 
@@ -117,7 +113,7 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 		}
 
 		// check if it exists
-		if !cm.Exists(absoluteContainerName) {
+		if !cm.Exists(containerName) {
 			if err := cm.Create(containerConfig); err != nil {
 				return fmt.Errorf("failed to create top level %v QOS cgroup : %v", qosClass, err)
 			}
@@ -279,11 +275,11 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
 
 	qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
 		v1.PodQOSBurstable: {
-			Name:               CgroupName(m.qosContainersInfo.Burstable),
+			Name:               m.qosContainersInfo.Burstable,
 			ResourceParameters: &ResourceConfig{},
 		},
 		v1.PodQOSBestEffort: {
-			Name:               CgroupName(m.qosContainersInfo.BestEffort),
+			Name:               m.qosContainersInfo.BestEffort,
 			ResourceParameters: &ResourceConfig{},
 		},
 	}

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -38,7 +38,9 @@ type ResourceConfig struct {
 }
 
 // CgroupName is the abstract name of a cgroup prior to any driver specific conversion.
-type CgroupName string
+// It is specified as a list of strings from its individual components, such as:
+// {"kubepods", "burstable", "pod1234-abcd-5678-efgh"}
+type CgroupName []string
 
 // CgroupConfig holds the cgroup configuration information.
 // This is common object which is used to specify
@@ -78,7 +80,7 @@ type CgroupManager interface {
 	Exists(name CgroupName) bool
 	// Name returns the literal cgroupfs name on the host after any driver specific conversions.
 	// We would expect systemd implementation to make appropriate name conversion.
-	// For example, if we pass /foo/bar
+	// For example, if we pass {"foo", "bar"}
 	// then systemd should convert the name to something like
 	// foo.slice/foo-bar.slice
 	Name(name CgroupName) string
@@ -94,9 +96,9 @@ type CgroupManager interface {
 
 // QOSContainersInfo stores the names of containers per qos
 type QOSContainersInfo struct {
-	Guaranteed string
-	BestEffort string
-	Burstable  string
+	Guaranteed CgroupName
+	BestEffort CgroupName
+	Burstable  CgroupName
 }
 
 // PodContainerManager stores and manages pod level containers

--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -85,7 +85,6 @@ go_library(
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/checkpointmanager/checksum:go_default_library",
         "//pkg/kubelet/checkpointmanager/errors:go_default_library",
-        "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockershim/cm:go_default_library",
         "//pkg/kubelet/dockershim/libdocker:go_default_library",

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -255,9 +255,14 @@ func isPodManagedContainer(cinfo *cadvisorapiv2.ContainerInfo) bool {
 func getCadvisorPodInfoFromPodUID(podUID types.UID, infos map[string]cadvisorapiv2.ContainerInfo) *cadvisorapiv2.ContainerInfo {
 	for key, info := range infos {
 		if cm.IsSystemdStyleName(key) {
-			key = cm.RevertFromSystemdToCgroupStyleName(key)
+			// Convert to internal cgroup name and take the last component only.
+			internalCgroupName := cm.ParseSystemdToCgroupName(key)
+			key = internalCgroupName[len(internalCgroupName)-1]
+		} else {
+			// Take last component only.
+			key = path.Base(key)
 		}
-		if cm.GetPodCgroupNameSuffix(podUID) == path.Base(key) {
+		if cm.GetPodCgroupNameSuffix(podUID) == key {
 			return &info
 		}
 	}

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -19,7 +19,6 @@ package e2e_node
 import (
 	"fmt"
 	"os/exec"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -38,14 +37,14 @@ import (
 )
 
 // makePodToVerifyHugePages returns a pod that verifies specified cgroup with hugetlb
-func makePodToVerifyHugePages(cgroupName cm.CgroupName, hugePagesLimit resource.Quantity) *apiv1.Pod {
+func makePodToVerifyHugePages(baseName string, hugePagesLimit resource.Quantity) *apiv1.Pod {
 	// convert the cgroup name to its literal form
 	cgroupFsName := ""
-	cgroupName = cm.CgroupName(path.Join(defaultNodeAllocatableCgroup, string(cgroupName)))
+	cgroupName := cm.NewCgroupName(cm.RootCgroupName, defaultNodeAllocatableCgroup, baseName)
 	if framework.TestContext.KubeletConfig.CgroupDriver == "systemd" {
-		cgroupFsName = cm.ConvertCgroupNameToSystemd(cgroupName, true)
+		cgroupFsName = cgroupName.ToSystemd()
 	} else {
-		cgroupFsName = string(cgroupName)
+		cgroupFsName = cgroupName.ToCgroupfs()
 	}
 
 	// this command takes the expected value and compares it against the actual value for the pod cgroup hugetlb.2MB.limit_in_bytes
@@ -184,7 +183,7 @@ func runHugePagesTests(f *framework.Framework) {
 		})
 		podUID := string(pod.UID)
 		By("checking if the expected hugetlb settings were applied")
-		verifyPod := makePodToVerifyHugePages(cm.CgroupName("pod"+podUID), resource.MustParse("50Mi"))
+		verifyPod := makePodToVerifyHugePages("pod"+podUID, resource.MustParse("50Mi"))
 		f.PodClient().Create(verifyPod)
 		err := framework.WaitForPodSuccessInNamespace(f.ClientSet, verifyPod.Name, f.Namespace.Name)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -21,7 +21,6 @@ package e2e_node
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -99,8 +98,8 @@ func getAllocatableLimits(cpu, memory string, capacity v1.ResourceList) (*resour
 }
 
 const (
-	kubeReservedCgroup   = "/kube_reserved"
-	systemReservedCgroup = "/system_reserved"
+	kubeReservedCgroup   = "kube_reserved"
+	systemReservedCgroup = "system_reserved"
 )
 
 func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error {
@@ -115,13 +114,13 @@ func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error
 func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
 	// Create kube reserved cgroup
 	cgroupConfig := &cm.CgroupConfig{
-		Name: cm.CgroupName(kubeReservedCgroup),
+		Name: cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup),
 	}
 	if err := createIfNotExists(cgroupManager, cgroupConfig); err != nil {
 		return err
 	}
 	// Create system reserved cgroup
-	cgroupConfig.Name = cm.CgroupName(systemReservedCgroup)
+	cgroupConfig.Name = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
 
 	return createIfNotExists(cgroupManager, cgroupConfig)
 }
@@ -129,12 +128,12 @@ func createTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error 
 func destroyTemporaryCgroupsForReservation(cgroupManager cm.CgroupManager) error {
 	// Create kube reserved cgroup
 	cgroupConfig := &cm.CgroupConfig{
-		Name: cm.CgroupName(kubeReservedCgroup),
+		Name: cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup),
 	}
 	if err := cgroupManager.Destroy(cgroupConfig); err != nil {
 		return err
 	}
-	cgroupConfig.Name = cm.CgroupName(systemReservedCgroup)
+	cgroupConfig.Name = cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
 	return cgroupManager.Destroy(cgroupConfig)
 }
 
@@ -173,8 +172,9 @@ func runTest(f *framework.Framework) error {
 	// Set new config and current config.
 	currentConfig := newCfg
 
-	expectedNAPodCgroup := path.Join(currentConfig.CgroupRoot, "kubepods")
-	if !cgroupManager.Exists(cm.CgroupName(expectedNAPodCgroup)) {
+	expectedNAPodCgroup := cm.ParseCgroupfsToCgroupName(currentConfig.CgroupRoot)
+	expectedNAPodCgroup = cm.NewCgroupName(expectedNAPodCgroup, "kubepods")
+	if !cgroupManager.Exists(expectedNAPodCgroup) {
 		return fmt.Errorf("Expected Node Allocatable Cgroup Does not exist")
 	}
 	// TODO: Update cgroupManager to expose a Status interface to get current Cgroup Settings.
@@ -218,30 +218,32 @@ func runTest(f *framework.Framework) error {
 		return nil
 	}, time.Minute, 5*time.Second).Should(BeNil())
 
-	if !cgroupManager.Exists(cm.CgroupName(kubeReservedCgroup)) {
+	kubeReservedCgroupName := cm.NewCgroupName(cm.RootCgroupName, kubeReservedCgroup)
+	if !cgroupManager.Exists(kubeReservedCgroupName) {
 		return fmt.Errorf("Expected kube reserved cgroup Does not exist")
 	}
 	// Expect CPU shares on kube reserved cgroup to equal it's reservation which is `100m`.
 	kubeReservedCPU := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceCPU)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], kubeReservedCgroup, "cpu.shares"), int64(cm.MilliCPUToShares(kubeReservedCPU.MilliValue())), 10); err != nil {
+	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupManager.Name(kubeReservedCgroupName), "cpu.shares"), int64(cm.MilliCPUToShares(kubeReservedCPU.MilliValue())), 10); err != nil {
 		return err
 	}
 	// Expect Memory limit kube reserved cgroup to equal configured value `100Mi`.
 	kubeReservedMemory := resource.MustParse(currentConfig.KubeReserved[string(v1.ResourceMemory)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], kubeReservedCgroup, "memory.limit_in_bytes"), kubeReservedMemory.Value(), 0); err != nil {
+	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], cgroupManager.Name(kubeReservedCgroupName), "memory.limit_in_bytes"), kubeReservedMemory.Value(), 0); err != nil {
 		return err
 	}
-	if !cgroupManager.Exists(cm.CgroupName(systemReservedCgroup)) {
+	systemReservedCgroupName := cm.NewCgroupName(cm.RootCgroupName, systemReservedCgroup)
+	if !cgroupManager.Exists(systemReservedCgroupName) {
 		return fmt.Errorf("Expected system reserved cgroup Does not exist")
 	}
 	// Expect CPU shares on system reserved cgroup to equal it's reservation which is `100m`.
 	systemReservedCPU := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceCPU)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], systemReservedCgroup, "cpu.shares"), int64(cm.MilliCPUToShares(systemReservedCPU.MilliValue())), 10); err != nil {
+	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["cpu"], cgroupManager.Name(systemReservedCgroupName), "cpu.shares"), int64(cm.MilliCPUToShares(systemReservedCPU.MilliValue())), 10); err != nil {
 		return err
 	}
 	// Expect Memory limit on node allocatable cgroup to equal allocatable.
 	systemReservedMemory := resource.MustParse(currentConfig.SystemReserved[string(v1.ResourceMemory)])
-	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], systemReservedCgroup, "memory.limit_in_bytes"), systemReservedMemory.Value(), 0); err != nil {
+	if err := expectFileValToEqual(filepath.Join(subsystems.MountPoints["memory"], cgroupManager.Name(systemReservedCgroupName), "memory.limit_in_bytes"), systemReservedMemory.Value(), 0); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This is purely a refactoring and should bring no essential change in behavior.

It does clarify the cgroup handling code quite a bit.

It is preparation for further changes we might want to do in the cgroup hierarchy. (But it's useful on its own, so even if we don't do any, it should still be considered.)

**Special notes for your reviewer**:

The slice of strings more precisely captures the hierarchic nature of the cgroup paths we use to represent pods and their groupings.

It also ensures we're reducing the chances of passing an incorrect path format to a cgroup driver that requires a different path naming, since now explicit conversions are always needed.

The new constructor `NewCgroupName` starts from an existing `CgroupName`, which enforces a hierarchy where a root is always needed. It also performs checking on the component names to ensure invalid characters ("/" and "_") are not in use.

A `RootCgroupName` for the top of the cgroup hierarchy tree is introduced.

This refactor results in a net reduction of around 30 lines of code,
mainly with the demise of ConvertCgroupNameToSystemd which had fairly
complicated logic in it and was doing just too many things.

There's a small TODO in a helper `updateSystemdCgroupInfo` that was introduced to make this commit possible. That logic really belongs in libcontainer, I'm planning to send a PR there to include it there. (The API already takes a field with that information, only that field is only processed in cgroupfs and not systemd driver, we should fix that.)

Tested: By running the e2e-node tests on both Ubuntu 16.04 (with cgroupfs driver) and CentOS 7 (with systemd driver.)

**NOTE**: I only tested this with dockershim, we should double-check that this works with the CRI endpoints too, both in cgroupfs and systemd modes.

/assign @derekwaynecarr 
/assign @dashpole 
/assign @Random-Liu 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
