### PR TITLE
Timeout on instances.NodeAddresses cloud provider request

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -432,7 +432,36 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		// to the cloud provider?
 		// TODO(justinsb): We can if CurrentNodeName() was actually CurrentNode() and returned an interface
 		// TODO: If IP addresses couldn't be fetched from the cloud provider, should kubelet fallback on the other methods for getting the IP below?
-		nodeAddresses, err := instances.NodeAddresses(context.TODO(), kl.nodeName)
+		var nodeAddresses []v1.NodeAddress
+		var err error
+
+		// Make sure the instances.NodeAddresses returns even if the cloud provider API hangs for a long time
+		func() {
+			kl.cloudproviderRequestMux.Lock()
+			if len(kl.cloudproviderRequestParallelism) > 0 {
+				kl.cloudproviderRequestMux.Unlock()
+				return
+			}
+			kl.cloudproviderRequestParallelism <- 0
+			kl.cloudproviderRequestMux.Unlock()
+
+			go func() {
+				nodeAddresses, err = instances.NodeAddresses(context.TODO(), kl.nodeName)
+
+				kl.cloudproviderRequestMux.Lock()
+				<-kl.cloudproviderRequestParallelism
+				kl.cloudproviderRequestMux.Unlock()
+
+				kl.cloudproviderRequestSync <- 0
+			}()
+		}()
+
+		select {
+		case <-kl.cloudproviderRequestSync:
+		case <-time.After(kl.cloudproviderRequestTimeout):
+			err = fmt.Errorf("Timeout after %v", kl.cloudproviderRequestTimeout)
+		}
+
 		if err != nil {
 			return fmt.Errorf("failed to get node address from cloud provider: %v", err)
 		}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -192,6 +192,9 @@ func TestNodeStatusWithCloudProviderNodeIP(t *testing.T) {
 		Err: nil,
 	}
 	kubelet.cloud = fakeCloud
+	kubelet.cloudproviderRequestParallelism = make(chan int, 1)
+	kubelet.cloudproviderRequestSync = make(chan int)
+	kubelet.cloudproviderRequestTimeout = 10 * time.Second
 
 	kubelet.setNodeAddress(&existingNode)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In cases the cloud provider does not respond before the node gets evicted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
stop kubelet to cloud provider integration potentially wedging kubelet sync loop
```
