### PR TITLE
Init Kubelet runtime cache before dependent stats provider

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -652,6 +652,12 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.containerRuntime = runtime
 	klet.runner = runtime
 
+	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime)
+	if err != nil {
+		return nil, err
+	}
+	klet.runtimeCache = runtimeCache
+
 	if cadvisor.UsingLegacyCadvisorStats(containerRuntime, remoteRuntimeEndpoint) {
 		klet.StatsProvider = stats.NewCadvisorStatsProvider(
 			klet.cadvisor,
@@ -780,11 +786,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		experimentalCheckNodeCapabilitiesBeforeMount,
 		keepTerminatedPodVolumes)
 
-	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime)
-	if err != nil {
-		return nil, err
-	}
-	klet.runtimeCache = runtimeCache
 	klet.reasonCache = NewReasonCache()
 	klet.workQueue = queue.NewBasicWorkQueue(klet.clock)
 	klet.podWorkers = newPodWorkers(klet.syncPod, kubeDeps.Recorder, klet.workQueue, klet.resyncInterval, backOffPeriod, klet.podCache)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes sure the kubelet runtime cache is initiated before the stats providers, that depend on it.

Nil pointer dereference occurs when accessing the container stats via the Kubelet API, using the `/{namespace}/{podName}/{uid}/{containerName}` path, that returns 503 as a result:

```
Apr 11 15:08:30 minikube kubelet[3104]: I0411 15:08:30.596209    3104 logs.go:49] http: panic serving 192.168.64.20:47110: runtime error: invalid memory address or nil pointer dereference
Apr 11 15:08:30 minikube kubelet[3104]: goroutine 44964 [running]:
Apr 11 15:08:30 minikube kubelet[3104]: net/http.(*conn).serve.func1(0xc421b16be0)
Apr 11 15:08:30 minikube kubelet[3104]:         /usr/local/go/src/net/http/server.go:1697 +0xd0
Apr 11 15:08:30 minikube kubelet[3104]: panic(0x334ec60, 0x5a1dd80)
Apr 11 15:08:30 minikube kubelet[3104]:         /usr/local/go/src/runtime/panic.go:491 +0x283
Apr 11 15:08:30 minikube kubelet[3104]: k8s.io/kubernetes/pkg/kubelet/stats.(*StatsProvider).GetContainerInfo(0xc420b364b0, 0xc420e514d0, 0x2c, 0xc420bd9a20, 0x20, 0xc4213388dd, 0x17, 0xc420a37b80, 0x0, 0x0, ...)
Apr 11 15:08:30 minikube kubelet[3104]:         /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/stats/stats_provider.go:146 +0x93
Apr 11 15:08:30 minikube kubelet[3104]: k8s.io/kubernetes/pkg/kubelet/server/stats.(*handler).handlePodContainer(0xc420b8cb40, 0xc42070b380, 0xc4214237a0)
Apr 11 15:08:30 minikube kubelet[3104]:         /workspace/anago-v1.10.0-rc.1.9+fc32d2f3698e36/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/server/stats/handler.go:257 +0x6b9
Apr 11 15:08:30 minikube kubelet[3104]: k8s.io/kubernetes/pkg/kubelet/server/stats.(*handler).(k8s.io/kubernetes/pkg/kubelet/server/stats.handlePodContainer)-fm(0xc42070b380, 0xc4214237a0)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #56297

**Release note**:

```release-note
Fix nil pointer dereference when accessing the container stats Kubelet endpoint
```

/sig instrumentation
