### PR TITLE
root OWNERS: escape backslashes in filters

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -19,11 +19,11 @@ filters:
       - wojtek-t
 
   # Bazel build infrastructure changes often touch files throughout the tree
-  "\.bzl$":
+  "\\.bzl$":
     reviewers:
       - ixdy
     approvers:
       - ixdy
-  "BUILD(\.bazel)?$":
+  "BUILD(\\.bazel)?$":
     approvers:
       - ixdy


### PR DESCRIPTION
**What this PR does / why we need it**: I didn't properly test my change in #62484, and now the OWNERS file is failing to parse:
```console
$ yq '.' OWNERS
yq: Error running jq: ScannerError: while scanning a double-quoted scalar
  in "OWNERS", line 22, column 3
found unknown escape character '.'
  in "OWNERS", line 22, column 5.
```
(The approval bot is similarly having trouble parsing.)

@cjwagner suspects the backslashes need to be escaped, and that indeed seems to work:
```console
$ yq '.' OWNERS
{
  "filters": {
    ".*": {
      "reviewers": [
        "brendandburns",
        "dchen1107",
        "jbeda",
        "lavalamp",
        "smarterclayton",
        "thockin"
      ],
      "approvers": [
        "bgrant0607",
        "brendandburns",
        "dchen1107",
        "jbeda",
        "monopole",
        "lavalamp",
        "smarterclayton",
        "thockin",
        "wojtek-t"
      ]
    },
    "\\.bzl$": {
      "reviewers": [
        "ixdy"
      ],
      "approvers": [
        "ixdy"
      ]
    },
    "BUILD(\\.bazel)?$": {
      "approvers": [
        "ixdy"
      ]
    }
  }
}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @cjwagner 
cc @cblecker @smarterclayton @bgrant0607 