### PR TITLE
Add label to flag this as cluster service

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -26,6 +26,7 @@ metadata:
   name: system:kube-dns-autoscaler
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: true
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -48,6 +49,7 @@ metadata:
   name: system:kube-dns-autoscaler
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: true
 subjects:
   - kind: ServiceAccount
     name: kube-dns-autoscaler


### PR DESCRIPTION
I just found out, that most cluster services use this label. As we are trying to determine objects not managed by the user, but the cluster itself it is forcing us to make explicit checks just for this.
The suggestion is to just label ClusterRole and ClusterRoleBinding correctly.

**What this PR does / why we need it**:
Makes the dns-horizontal-autoscaler labeled in a consistent way

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
