### PR TITLE
Automated cherry pick of #61609: Cleanup CRD/CR confusion in webhook e2e tests #62350: Fix flaky crd e2e tests

### DIFF
--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -46,29 +46,29 @@ import (
 )
 
 const (
-	secretName                   = "sample-webhook-secret"
-	deploymentName               = "sample-webhook-deployment"
-	serviceName                  = "e2e-test-webhook"
-	roleBindingName              = "webhook-auth-reader"
-	webhookConfigName            = "e2e-test-webhook-config"
-	mutatingWebhookConfigName    = "e2e-test-mutating-webhook-config"
-	skipNamespaceLabelKey        = "skip-webhook-admission"
-	skipNamespaceLabelValue      = "yes"
-	skippedNamespaceName         = "exempted-namesapce"
-	disallowedPodName            = "disallowed-pod"
-	disallowedConfigMapName      = "disallowed-configmap"
-	allowedConfigMapName         = "allowed-configmap"
-	crdName                      = "e2e-test-webhook-crd"
-	crdKind                      = "E2e-test-webhook-crd"
-	crWebhookConfigName          = "e2e-test-webhook-config-cr"
-	crdWebhookConfigName         = "e2e-test-webhook-config-crd"
-	crMutatingWebhookConfigName  = "e2e-test-mutating-webhook-config-cr"
-	crdAPIGroup                  = "webhook-crd-test.k8s.io"
-	crdAPIVersion                = "v1"
-	webhookFailClosedConfigName  = "e2e-test-webhook-fail-closed"
-	failNamespaceLabelKey        = "fail-closed-webhook"
-	failNamespaceLabelValue      = "yes"
-	failNamespaceName            = "fail-closed-namesapce"
+	secretName                  = "sample-webhook-secret"
+	deploymentName              = "sample-webhook-deployment"
+	serviceName                 = "e2e-test-webhook"
+	roleBindingName             = "webhook-auth-reader"
+	webhookConfigName           = "e2e-test-webhook-config"
+	mutatingWebhookConfigName   = "e2e-test-mutating-webhook-config"
+	skipNamespaceLabelKey       = "skip-webhook-admission"
+	skipNamespaceLabelValue     = "yes"
+	skippedNamespaceName        = "exempted-namesapce"
+	disallowedPodName           = "disallowed-pod"
+	disallowedConfigMapName     = "disallowed-configmap"
+	allowedConfigMapName        = "allowed-configmap"
+	crdName                     = "e2e-test-webhook-crd"
+	crdKind                     = "E2e-test-webhook-crd"
+	crWebhookConfigName         = "e2e-test-webhook-config-cr"
+	crdWebhookConfigName        = "e2e-test-webhook-config-crd"
+	crMutatingWebhookConfigName = "e2e-test-mutating-webhook-config-cr"
+	crdAPIGroup                 = "webhook-crd-test.k8s.io"
+	crdAPIVersion               = "v1"
+	webhookFailClosedConfigName = "e2e-test-webhook-fail-closed"
+	failNamespaceLabelKey       = "fail-closed-webhook"
+	failNamespaceLabelValue     = "yes"
+	failNamespaceName           = "fail-closed-namesapce"
 )
 
 var serverWebhookVersion = utilversion.MustParseSemantic("v1.8.0")
@@ -1035,7 +1035,7 @@ func testCRDDenyWebhook(f *framework.Framework) {
 	}
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name + "s." + group,
+			Name: name + "s." + group,
 			Labels: map[string]string{
 				"webhook-e2e-test": "webhook-disallow",
 			},

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -62,13 +62,15 @@ const (
 	crdKind                      = "E2e-test-webhook-crd"
 	crWebhookConfigName          = "e2e-test-webhook-config-cr"
 	crdWebhookConfigName         = "e2e-test-webhook-config-crd"
-	crdMutatingWebhookConfigName = "e2e-test-mutating-webhook-config-crd"
+	crMutatingWebhookConfigName  = "e2e-test-mutating-webhook-config-cr"
 	crdAPIGroup                  = "webhook-crd-test.k8s.io"
 	crdAPIVersion                = "v1"
 	webhookFailClosedConfigName  = "e2e-test-webhook-fail-closed"
 	failNamespaceLabelKey        = "fail-closed-webhook"
 	failNamespaceLabelValue      = "yes"
 	failNamespaceName            = "fail-closed-namesapce"
+	disallowedCrdLabelKey        = "disallowed-crd"
+	disallowedCrdLabelValue      = "yes"
 )
 
 var serverWebhookVersion = utilversion.MustParseSemantic("v1.8.0")
@@ -100,7 +102,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		// Note that in 1.9 we will have backwards incompatible change to
 		// admission webhooks, so the image will be updated to 1.9 sometime in
 		// the development 1.9 cycle.
-		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v2", context)
+		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v1", context)
 	})
 	AfterEach(func() {
 		cleanWebhookTest(client, namespaceName)
@@ -117,7 +119,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		defer crdCleanup()
 		registerWebhookForCustomResource(f, context)
 		defer client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(crWebhookConfigName, nil)
-		testCRDWebhook(f, dynamicClient)
+		testCustomResourceWebhook(f, dynamicClient)
 	})
 
 	It("Should unconditionally reject operations on fail closed webhook", func() {
@@ -138,12 +140,12 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		testMutatingPodWebhook(f)
 	})
 
-	It("Should mutate crd", func() {
+	It("Should mutate custom resource", func() {
 		crdCleanup, dynamicClient := createCRD(f)
 		defer crdCleanup()
-		registerMutatingWebhookForCRD(f, context)
-		defer client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(crdMutatingWebhookConfigName, nil)
-		testMutatingCRDWebhook(f, dynamicClient)
+		registerMutatingWebhookForCustomResource(f, context)
+		defer client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(crMutatingWebhookConfigName, nil)
+		testMutatingCustomResourceWebhook(f, dynamicClient)
 	})
 
 	It("Should deny crd creation", func() {
@@ -824,16 +826,17 @@ func createCRD(f *framework.Framework) (func(), dynamic.ResourceInterface) {
 
 func registerWebhookForCustomResource(f *framework.Framework, context *certContext) {
 	client := f.ClientSet
-	By("Registering the crd webhook via the AdmissionRegistration API")
+	By("Registering the custom resource webhook via the AdmissionRegistration API")
 
 	namespace := f.Namespace.Name
+	configName := crWebhookConfigName
 	_, err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(&v1beta1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crWebhookConfigName,
+			Name: configName,
 		},
 		Webhooks: []v1beta1.Webhook{
 			{
-				Name: "deny-unwanted-crd-data.k8s.io",
+				Name: "deny-unwanted-custom-resource-data.k8s.io",
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
@@ -846,31 +849,32 @@ func registerWebhookForCustomResource(f *framework.Framework, context *certConte
 					Service: &v1beta1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/crd"),
+						Path:      strPtr("/custom-resource"),
 					},
 					CABundle: context.signingCert,
 				},
 			},
 		},
 	})
-	framework.ExpectNoError(err, "registering crd webhook config %s with namespace %s", webhookConfigName, namespace)
+	framework.ExpectNoError(err, "registering custom resource webhook config %s with namespace %s", configName, namespace)
 
 	// The webhook configuration is honored in 1s.
 	time.Sleep(10 * time.Second)
 }
 
-func registerMutatingWebhookForCRD(f *framework.Framework, context *certContext) {
+func registerMutatingWebhookForCustomResource(f *framework.Framework, context *certContext) {
 	client := f.ClientSet
-	By("Registering the mutating webhook for crd via the AdmissionRegistration API")
+	By("Registering the mutating webhook for a custom resource via the AdmissionRegistration API")
 
 	namespace := f.Namespace.Name
+	configName := crMutatingWebhookConfigName
 	_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(&v1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: crdMutatingWebhookConfigName,
+			Name: configName,
 		},
 		Webhooks: []v1beta1.Webhook{
 			{
-				Name: "mutate-crd-data-stage-1.k8s.io",
+				Name: "mutate-custom-resource-data-stage-1.k8s.io",
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
@@ -883,13 +887,13 @@ func registerMutatingWebhookForCRD(f *framework.Framework, context *certContext)
 					Service: &v1beta1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-crd"),
+						Path:      strPtr("/mutating-custom-resource"),
 					},
 					CABundle: context.signingCert,
 				},
 			},
 			{
-				Name: "mutate-crd-data-stage-2.k8s.io",
+				Name: "mutate-custom-resource-data-stage-2.k8s.io",
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
@@ -902,20 +906,20 @@ func registerMutatingWebhookForCRD(f *framework.Framework, context *certContext)
 					Service: &v1beta1.ServiceReference{
 						Namespace: namespace,
 						Name:      serviceName,
-						Path:      strPtr("/mutating-crd"),
+						Path:      strPtr("/mutating-custom-resource"),
 					},
 					CABundle: context.signingCert,
 				},
 			},
 		},
 	})
-	framework.ExpectNoError(err, "registering crd webhook config %s with namespace %s", crdMutatingWebhookConfigName, namespace)
+	framework.ExpectNoError(err, "registering custom resource webhook config %s with namespace %s", configName, namespace)
 
 	// The webhook configuration is honored in 1s.
 	time.Sleep(10 * time.Second)
 }
 
-func testCRDWebhook(f *framework.Framework, crdClient dynamic.ResourceInterface) {
+func testCustomResourceWebhook(f *framework.Framework, customResourceClient dynamic.ResourceInterface) {
 	By("Creating a custom resource that should be denied by the webhook")
 	crd := newCRDForAdmissionWebhookTest()
 	crInstance := &unstructured.Unstructured{
@@ -931,7 +935,7 @@ func testCRDWebhook(f *framework.Framework, crdClient dynamic.ResourceInterface)
 			},
 		},
 	}
-	_, err := crdClient.Create(crInstance)
+	_, err := customResourceClient.Create(crInstance)
 	Expect(err).NotTo(BeNil())
 	expectedErrMsg := "the custom resource contains unwanted data"
 	if !strings.Contains(err.Error(), expectedErrMsg) {
@@ -939,7 +943,7 @@ func testCRDWebhook(f *framework.Framework, crdClient dynamic.ResourceInterface)
 	}
 }
 
-func testMutatingCRDWebhook(f *framework.Framework, crdClient dynamic.ResourceInterface) {
+func testMutatingCustomResourceWebhook(f *framework.Framework, customResourceClient dynamic.ResourceInterface) {
 	By("Creating a custom resource that should be mutated by the webhook")
 	crd := newCRDForAdmissionWebhookTest()
 	cr := &unstructured.Unstructured{
@@ -955,7 +959,7 @@ func testMutatingCRDWebhook(f *framework.Framework, crdClient dynamic.ResourceIn
 			},
 		},
 	}
-	mutatedCR, err := crdClient.Create(cr)
+	mutatedCR, err := customResourceClient.Create(cr)
 	Expect(err).To(BeNil())
 	expectedCRData := map[string]interface{}{
 		"mutation-start":   "yes",
@@ -988,6 +992,15 @@ func registerValidatingWebhookForCRD(f *framework.Framework, context *certContex
 						Resources:   []string{"customresourcedefinitions"},
 					},
 				}},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      disallowedCrdLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{disallowedCrdLabelValue},
+						},
+					},
+				},
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
 						Namespace: namespace,
@@ -1027,7 +1040,10 @@ func testCRDDenyWebhook(f *framework.Framework) {
 		return
 	}
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: name + "s." + group},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name + "s." + group,
+			Labels: map[string]string{disallowedCrdLabelKey: disallowedCrdLabelValue},
+		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   group,
 			Version: apiVersion,

--- a/test/images/webhook/BUILD
+++ b/test/images/webhook/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v1 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v1

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v1 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v2 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v1
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.10v2

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	// TODO: try this library to see if it generates correct json patch
@@ -245,6 +246,37 @@ func admitCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse 
 	return &reviewResponse
 }
 
+// Deny all crds with the label "webhook-e2e-test":"webhook-disallow"
+// This function expects all CRDs submitted to it to be apiextensions.k8s.io/v1beta1
+// TODO: When apiextensions.k8s.io/v1 is added we will need to update this function.
+func admitCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("admitting crd")
+	crdResource := metav1.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1beta1", Resource: "customresourcedefinitions"}
+	if ar.Request.Resource != crdResource {
+		err := fmt.Errorf("expect resource to be %s", crdResource)
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+
+	raw := ar.Request.Object.Raw
+	crd := apiextensionsv1beta1.CustomResourceDefinition{}
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(raw, nil, &crd); err != nil {
+		glog.Error(err)
+		return toAdmissionResponse(err)
+	}
+	reviewResponse := v1beta1.AdmissionResponse{}
+	reviewResponse.Allowed = true
+
+	if v, ok := crd.Labels["webhook-e2e-test"]; ok {
+		if v == "webhook-disallow" {
+			reviewResponse.Allowed = false
+			reviewResponse.Result = &metav1.Status{Message: "the crd contains unwanted label"}
+		}
+	}
+	return &reviewResponse
+}
+
 type admitFunc func(v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
 
 func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
@@ -262,6 +294,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 		return
 	}
 
+	glog.V(2).Info(fmt.Sprintf("handling request: %v", body))
 	var reviewResponse *v1beta1.AdmissionResponse
 	ar := v1beta1.AdmissionReview{}
 	deserializer := codecs.UniversalDeserializer()
@@ -271,6 +304,7 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 	} else {
 		reviewResponse = admit(ar)
 	}
+	glog.V(2).Info(fmt.Sprintf("sending response: %v", reviewResponse))
 
 	response := v1beta1.AdmissionReview{}
 	if reviewResponse != nil {
@@ -314,6 +348,10 @@ func serveMutateCustomResource(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, mutateCustomResource)
 }
 
+func serveCRD(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, admitCRD)
+}
+
 func main() {
 	var config Config
 	config.addFlags()
@@ -325,6 +363,7 @@ func main() {
 	http.HandleFunc("/mutating-configmaps", serveMutateConfigmaps)
 	http.HandleFunc("/custom-resource", serveCustomResource)
 	http.HandleFunc("/mutating-custom-resource", serveMutateCustomResource)
+	http.HandleFunc("/crd", serveCRD)
 	clientset := getClient()
 	server := &http.Server{
 		Addr:      ":443",

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -190,8 +190,8 @@ func mutateConfigmaps(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	return &reviewResponse
 }
 
-func mutateCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-	glog.V(2).Info("mutating crd")
+func mutateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("mutating custom resource")
 	cr := struct {
 		metav1.ObjectMeta
 		Data map[string]string
@@ -218,8 +218,8 @@ func mutateCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	return &reviewResponse
 }
 
-func admitCRD(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
-	glog.V(2).Info("admitting crd")
+func admitCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	glog.V(2).Info("admitting custom resource")
 	cr := struct {
 		metav1.ObjectMeta
 		Data map[string]string
@@ -306,12 +306,12 @@ func serveMutateConfigmaps(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, mutateConfigmaps)
 }
 
-func serveCRD(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, admitCRD)
+func serveCustomResource(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, admitCustomResource)
 }
 
-func serveMutateCRD(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, mutateCRD)
+func serveMutateCustomResource(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, mutateCustomResource)
 }
 
 func main() {
@@ -323,8 +323,8 @@ func main() {
 	http.HandleFunc("/mutating-pods", serveMutatePods)
 	http.HandleFunc("/configmaps", serveConfigmaps)
 	http.HandleFunc("/mutating-configmaps", serveMutateConfigmaps)
-	http.HandleFunc("/crd", serveCRD)
-	http.HandleFunc("/mutating-crd", serveMutateCRD)
+	http.HandleFunc("/custom-resource", serveCustomResource)
+	http.HandleFunc("/mutating-custom-resource", serveMutateCustomResource)
 	clientset := getClient()
 	server := &http.Server{
 		Addr:      ":443",


### PR DESCRIPTION
Cherry pick of #61609 #62350 on release-1.9.

#61609: Cleanup CRD/CR confusion in webhook e2e tests
#62350: Fix flaky crd e2e tests