### PR TITLE
migrate kubelet --cert-dir to kubelet.config.k8s.io

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -83,11 +83,6 @@ type KubeletFlags struct {
 	// Container-runtime-specific options.
 	config.ContainerRuntimeOptions
 
-	// certDirectory is the directory where the TLS certs are located (by
-	// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
-	// are provided, this flag will be ignored.
-	CertDirectory string
-
 	// cloudProvider is the provider for cloud services.
 	// +optional
 	CloudProvider string
@@ -218,7 +213,6 @@ func NewKubeletFlags() *KubeletFlags {
 	return &KubeletFlags{
 		EnableServer:                        true,
 		ContainerRuntimeOptions:             *NewContainerRuntimeOptions(),
-		CertDirectory:                       "/var/lib/kubelet/pki",
 		RootDirectory:                       defaultRootDir,
 		MasterServiceNamespace:              metav1.NamespaceDefault,
 		MaxContainerCount:                   -1,
@@ -358,9 +352,6 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.StringVar(&f.ProviderID, "provider-id", f.ProviderID, "Unique identifier for identifying the node in a machine database, i.e cloudprovider")
 
-	fs.StringVar(&f.CertDirectory, "cert-dir", f.CertDirectory, "The directory where the TLS certs are located. "+
-		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
-
 	fs.StringVar(&f.CloudProvider, "cloud-provider", f.CloudProvider, "The provider for cloud services. Specify empty string for running with no cloud provider. If set, the cloud provider determines the name of the node (consult cloud provider documentation to determine if and how the hostname is used).")
 	fs.StringVar(&f.CloudConfigFile, "cloud-config", f.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 
@@ -438,6 +429,8 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		mainfs.AddFlagSet(fs)
 	}()
 
+	fs.StringVar(&c.CertDirectory, "cert-dir", c.CertDirectory, "The directory where the TLS certs are located. "+
+		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
 	fs.BoolVar(&c.FailSwapOn, "fail-swap-on", c.FailSwapOn, "Makes the Kubelet fail to start if swap is enabled on the node. ")
 	fs.BoolVar(&c.FailSwapOn, "experimental-fail-swap-on", c.FailSwapOn, "DEPRECATED: please use --fail-swap-on instead.")
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -956,7 +956,6 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 		kubeServer.NodeIP,
 		kubeServer.ProviderID,
 		kubeServer.CloudProvider,
-		kubeServer.CertDirectory,
 		kubeServer.RootDirectory,
 		kubeServer.RegisterNode,
 		kubeServer.RegisterWithTaints,

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -787,8 +787,8 @@ func getNodeName(cloud cloudprovider.Interface, hostname string) (types.NodeName
 // certificate and key file are generated. Returns a configured server.TLSOptions object.
 func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletConfiguration) (*server.TLSOptions, error) {
 	if !kc.ServerTLSBootstrap && kc.TLSCertFile == "" && kc.TLSPrivateKeyFile == "" {
-		kc.TLSCertFile = path.Join(kf.CertDirectory, "kubelet.crt")
-		kc.TLSPrivateKeyFile = path.Join(kf.CertDirectory, "kubelet.key")
+		kc.TLSCertFile = path.Join(kc.CertDirectory, "kubelet.crt")
+		kc.TLSPrivateKeyFile = path.Join(kc.CertDirectory, "kubelet.key")
 
 		canReadCertAndKey, err := certutil.CanReadCertAndKey(kc.TLSCertFile, kc.TLSPrivateKeyFile)
 		if err != nil {
@@ -1029,7 +1029,6 @@ func CreateAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeIP string,
 	providerID string,
 	cloudProvider string,
-	certDirectory string,
 	rootDirectory string,
 	registerNode bool,
 	registerWithTaints []api.Taint,
@@ -1063,7 +1062,6 @@ func CreateAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeIP,
 		providerID,
 		cloudProvider,
-		certDirectory,
 		rootDirectory,
 		registerNode,
 		registerWithTaints,

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -43,6 +43,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.Authorization.Webhook.CacheAuthorizedTTL = metav1.Duration{Duration: 5 * time.Minute}
 			obj.Authorization.Webhook.CacheUnauthorizedTTL = metav1.Duration{Duration: 30 * time.Second}
 			obj.Address = "0.0.0.0"
+			obj.CertDirectory = "/var/lib/kubelet/pki"
 			obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}
 			obj.RuntimeRequestTimeout = metav1.Duration{Duration: 2 * time.Minute}
 			obj.CPUCFSQuota = true

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -62,6 +62,10 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta
 
+	// certDirectory is the directory where the TLS certs are located (by
+	// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
+	// are provided, this flag will be ignored.
+	CertDirectory string
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	StaticPodPath string

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -62,6 +62,10 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// certDirectory is the directory where the TLS certs are located (by
+	// default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile
+	// are provided, this flag will be ignored.
+	CertDirectory string `json:"certDirectory,omitempty"`
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
@@ -206,6 +206,7 @@ func Convert_kubeletconfig_KubeletAuthorization_To_v1beta1_KubeletAuthorization(
 }
 
 func autoConvert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(in *KubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
+	out.CertDirectory = in.CertDirectory
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
@@ -332,6 +333,7 @@ func Convert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(
 }
 
 func autoConvert_kubeletconfig_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in *kubeletconfig.KubeletConfiguration, out *KubeletConfiguration, s conversion.Scope) error {
+	out.CertDirectory = in.CertDirectory
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -37,15 +37,15 @@ import (
 
 // NewKubeletServerCertificateManager creates a certificate manager for the kubelet when retrieving a server certificate
 // or returns an error.
-func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress, certDirectory string) (certificate.Manager, error) {
+func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress) (certificate.Manager, error) {
 	var certSigningRequestClient clientcertificates.CertificateSigningRequestInterface
 	if kubeClient != nil && kubeClient.CertificatesV1beta1() != nil {
 		certSigningRequestClient = kubeClient.CertificatesV1beta1().CertificateSigningRequests()
 	}
 	certificateStore, err := certificate.NewFileStore(
 		"kubelet-server",
-		certDirectory,
-		certDirectory,
+		kubeCfg.CertDirectory,
+		kubeCfg.CertDirectory,
 		kubeCfg.TLSCertFile,
 		kubeCfg.TLSPrivateKeyFile)
 	if err != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -204,7 +204,6 @@ type Builder func(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeIP string,
 	providerID string,
 	cloudProvider string,
-	certDirectory string,
 	rootDirectory string,
 	registerNode bool,
 	registerWithTaints []api.Taint,
@@ -329,7 +328,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeIP string,
 	providerID string,
 	cloudProvider string,
-	certDirectory string,
 	rootDirectory string,
 	registerNode bool,
 	registerWithTaints []api.Taint,
@@ -735,7 +733,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
 
 	if kubeCfg.ServerTLSBootstrap && kubeDeps.TLSOptions != nil && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
-		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, klet.getLastObservedNodeAddresses, certDirectory)
+		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, klet.getLastObservedNodeAddresses)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize certificate manager: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
migrate kubelet --cert-dir to kubelet.config.k8s.io

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61679

**Special notes for your reviewer**:
@mtaufen 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Kubelet's --cert-dir flag can now be set via the kubelet.config.k8s.io/v1beta1 API by specifying the KubeletConfiguration.CertDirectory field.
```

/sig node