### PR TITLE
fix WaitForAttach failure issue for azure disk

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -150,27 +150,36 @@ func (a *azureDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName ty
 
 func (a *azureDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {
 	var err error
-	lun, err := strconv.Atoi(devicePath)
-	if err != nil {
-		return "", fmt.Errorf("azureDisk - Wait for attach expect device path as a lun number, instead got: %s (%v)", devicePath, err)
-	}
 
 	volumeSource, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err
 	}
 
+	diskController, err := getDiskController(a.plugin.host)
+	if err != nil {
+		return "", err
+	}
+
+	nodeName := types.NodeName(a.plugin.host.GetHostName())
+	diskName := volumeSource.DiskName
+
+	glog.V(5).Infof("azureDisk - WaitForAttach: begin to GetDiskLun by diskName(%s), DataDiskURI(%s), nodeName(%s), devicePath(%s)",
+		diskName, volumeSource.DataDiskURI, nodeName, devicePath)
+	lun, err := diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)
+	if err != nil {
+		return "", err
+	}
+	glog.V(5).Infof("azureDisk - WaitForAttach: GetDiskLun succeeded, got lun(%v)", lun)
 	exec := a.plugin.host.GetExec(a.plugin.GetPluginName())
 
 	io := &osIOHandler{}
 	scsiHostRescan(io, exec)
 
-	diskName := volumeSource.DiskName
-	nodeName := a.plugin.host.GetHostName()
 	newDevicePath := ""
 
 	err = wait.Poll(1*time.Second, timeout, func() (bool, error) {
-		if newDevicePath, err = findDiskByLun(lun, io, exec); err != nil {
+		if newDevicePath, err = findDiskByLun(int(lun), io, exec); err != nil {
 			return false, fmt.Errorf("azureDisk - WaitForAttach ticker failed node (%s) disk (%s) lun(%v) err(%s)", nodeName, diskName, lun, err)
 		}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
From v1.10, `devicePath` will be updated due to following code change:
https://github.com/kubernetes/kubernetes/blob/568afb4ecca99bc3b54fddc20927b3713369d357/pkg/volume/util/operationexecutor/operation_generator.go#L517-L518

So in v1.10.0, MountVolume.WaitForAttach will fail in the azure disk remount, error logs would be like following:
```
MountVolume.WaitForAttach failed for volume "pvc-f1562ecb-3e5f-11e8-ab6b-000d3af9f967" : azureDisk - Wait for attach expect device path as a lun number, instead got: /dev/disk/azure/scsi1/lun1 (strconv.Atoi: parsing "/dev/disk/azure/scsi1/lun1": invalid syntax)
  Warning  FailedMount             1m (x10 over 21m)   kubelet, k8s-agentpool-66825246-0  Unable to mount volumes for pod  
```

This PR does not use `devicePath` anymore since it could be changed, instead, it use `diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)` to get disk LUN, this ARM api call would cost about 0.12s

The GCE disk won't have this issue since `devicePath` is not used in [WaitForAttach func](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/gce_pd/attacher.go#L133), while aws disk is also using `devicePath`  in [WaitForAttach func](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/aws_ebs/attacher.go#L145), I think there is potentical issue for aws_ebs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62540

**Special notes for your reviewer**:
should cherry-pick to v1.10

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix WaitForAttach failure issue for azure disk
```
/assign @feiskyer 
/sig azure

FYI @khenidak 