### PR TITLE
Show deprecated kube-apiserver flags

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -237,5 +237,4 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ServiceAccountSigningKeyFile, "service-account-signing-key-file", s.ServiceAccountSigningKeyFile, ""+
 		"Path to the file that contains the current private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. (Requires the 'TokenRequest' feature gate.)")
-
 }

--- a/pkg/kubeapiserver/options/admission.go
+++ b/pkg/kubeapiserver/options/admission.go
@@ -73,6 +73,7 @@ func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
 		"The order of plugins in which they are passed to this flag does not matter. "+
 		"Comma-delimited list of: "+strings.Join(a.GenericAdmission.Plugins.Registered(), ", ")+".")
 	fs.MarkDeprecated("admission-control", "Use --enable-admission-plugins or --disable-admission-plugins instead. Will be removed in a future version.")
+	fs.Lookup("admission-control").Hidden = false
 
 	a.GenericAdmission.AddFlags(fs)
 }

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -99,6 +99,7 @@ func (s *InsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IPVar(&s.BindAddress, "insecure-bind-address", s.BindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
 	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in a future version.")
+	fs.Lookup("insecure-bind-address").Hidden = false
 
 	fs.IntVar(&s.BindPort, "insecure-port", s.BindPort, ""+
 		"The port on which to serve unsecured, unauthenticated access. It is assumed "+
@@ -106,6 +107,7 @@ func (s *InsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"the cluster and that port 443 on the cluster's public address is proxied to this "+
 		"port. This is performed by nginx in the default setup. Set to zero to disable.")
 	fs.MarkDeprecated("insecure-port", "This flag will be removed in a future version.")
+	fs.Lookup("insecure-port").Hidden = false
 }
 
 // TODO: remove it until kops stop using `--address`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR unhides deprecated kube-apiserver flags, so that the deprecation notice is clearly visible in --help.

Fixes #62617

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
