### PR TITLE
migrate kubelet --cloud-config to kubelet.config.k8s.io

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -92,10 +92,6 @@ type KubeletFlags struct {
 	// +optional
 	CloudProvider string
 
-	// cloudConfigFile is the path to the cloud provider configuration file.
-	// +optional
-	CloudConfigFile string
-
 	// rootDirectory is the directory path to place kubelet files (volume
 	// mounts,etc).
 	RootDirectory string
@@ -362,7 +358,6 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
 
 	fs.StringVar(&f.CloudProvider, "cloud-provider", f.CloudProvider, "The provider for cloud services. Specify empty string for running with no cloud provider. If set, the cloud provider determines the name of the node (consult cloud provider documentation to determine if and how the hostname is used).")
-	fs.StringVar(&f.CloudConfigFile, "cloud-config", f.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 
 	fs.StringVar(&f.RootDirectory, "root-dir", f.RootDirectory, "Directory path for managing kubelet files (volume mounts,etc).")
 
@@ -438,6 +433,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 		mainfs.AddFlagSet(fs)
 	}()
 
+	fs.StringVar(&c.CloudConfigFile, "cloud-config", c.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
 	fs.BoolVar(&c.FailSwapOn, "fail-swap-on", c.FailSwapOn, "Makes the Kubelet fail to start if swap is enabled on the node. ")
 	fs.BoolVar(&c.FailSwapOn, "experimental-fail-swap-on", c.FailSwapOn, "DEPRECATED: please use --fail-swap-on instead.")
 

--- a/pkg/kubelet/apis/kubeletconfig/helpers.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers.go
@@ -21,6 +21,7 @@ package kubeletconfig
 // passing the configuration to the application. This method must be kept up to date as new fields are added.
 func KubeletConfigurationPathRefs(kc *KubeletConfiguration) []*string {
 	paths := []*string{}
+	paths = append(paths, &kc.CloudConfigFile)
 	paths = append(paths, &kc.StaticPodPath)
 	paths = append(paths, &kc.Authentication.X509.ClientCAFile)
 	paths = append(paths, &kc.TLSCertFile)

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -128,6 +128,7 @@ func TestAllPrimitiveFieldPaths(t *testing.T) {
 var (
 	// KubeletConfiguration fields that contain file paths. If you update this, also update KubeletConfigurationPathRefs!
 	kubeletConfigurationPathFieldPaths = sets.NewString(
+		"CloudConfigFile",
 		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
 		"TLSCertFile",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -62,6 +62,8 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta
 
+	// cloudConfigFile is the path to the cloud provider configuration file.
+	CloudConfigFile string
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	StaticPodPath string

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -62,6 +62,10 @@ const (
 type KubeletConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// cloudConfigFile is the path to the cloud provider configuration file.
+	// Default: ""
+	// +optional
+	CloudConfigFile string `json:"cloudConfigFile,omitempty"`
 	// staticPodPath is the path to the directory containing local (static) pods to
 	// run, or the path to a single static pod file.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.conversion.go
@@ -206,6 +206,7 @@ func Convert_kubeletconfig_KubeletAuthorization_To_v1beta1_KubeletAuthorization(
 }
 
 func autoConvert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(in *KubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
+	out.CloudConfigFile = in.CloudConfigFile
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency
@@ -331,6 +332,7 @@ func Convert_v1beta1_KubeletConfiguration_To_kubeletconfig_KubeletConfiguration(
 }
 
 func autoConvert_kubeletconfig_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in *kubeletconfig.KubeletConfiguration, out *KubeletConfiguration, s conversion.Scope) error {
+	out.CloudConfigFile = in.CloudConfigFile
 	out.StaticPodPath = in.StaticPodPath
 	out.SyncFrequency = in.SyncFrequency
 	out.FileCheckFrequency = in.FileCheckFrequency


### PR DESCRIPTION
**What this PR does / why we need it**:
migrate kubelet --cloud-config to kubelet.config.k8s.io

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61677 

**Special notes for your reviewer**:
@mtaufen 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Kubelet's --cloud-config flag can now be set via the kubelet.config.k8s.io/v1beta1 API by specifying the KubeletConfiguration.CloudConfigFile field.
```

/sig node
