### PR TITLE
Autocalculate ALLOWED_NOTREADY_NODES based on NUM_NODES

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -66,6 +66,10 @@ if [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
     NODE_ACCELERATORS=""
 fi
 
+# To avoid failing large tests due to some flakes in starting nodes, allow
+# for a small percentage of nodes to not start during cluster startup.
+ALLOWED_NOTREADY_NODES="${ALLOWED_NOTREADY_NODES:-$((NUM_NODES / 100))}"
+
 # By default a cluster will be started with the master and nodes
 # on Container-optimized OS (cos, previously known as gci). If
 # you are updating the os image versions, update this variable.


### PR DESCRIPTION
As an alternative for https://github.com/kubernetes/test-infra/pull/7698

/cc @wojtek-t

```release-note
NONE
```