### PR TITLE
Not validating front proxy CA Key when using External CA.

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -466,6 +466,7 @@ func TestUsingExternalCA(t *testing.T) {
 			setupFuncs: []func(cfg *kubeadmapi.MasterConfiguration) error{
 				CreatePKIAssets,
 				deleteCAKey,
+				deleteFrontProxyCAKey,
 			},
 			expected: true,
 		},
@@ -583,16 +584,17 @@ func TestValidateMethods(t *testing.T) {
 }
 
 func deleteCAKey(cfg *kubeadmapi.MasterConfiguration) error {
-	if err := os.Remove(filepath.Join(cfg.CertificatesDir, "ca.key")); err != nil {
-		return fmt.Errorf("failed removing ca.key: %v", err)
+	if err := os.Remove(filepath.Join(cfg.CertificatesDir, kubeadmconstants.CAKeyName)); err != nil {
+		return fmt.Errorf("failed removing %s: %v", kubeadmconstants.CAKeyName, err)
 	}
 	return nil
 }
 
-func assertIsCa(t *testing.T, cert *x509.Certificate) {
-	if !cert.IsCA {
-		t.Error("cert is not a valida CA")
+func deleteFrontProxyCAKey(cfg *kubeadmapi.MasterConfiguration) error {
+	if err := os.Remove(filepath.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyCAKeyName)); err != nil {
+		return fmt.Errorf("failed removing %s: %v", kubeadmconstants.FrontProxyCAKeyName, err)
 	}
+	return nil
 }
 
 func TestCreateCertificateFilesMethods(t *testing.T) {

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -967,10 +967,13 @@ func TestGetControllerManagerCommandExternalCA(t *testing.T) {
 			t.Errorf("failed creating pki assets: %v", err)
 		}
 
-		// delete ca.key if test.caKeyPresent is false
+		// delete ca.key and front-proxy-ca.key if test.caKeyPresent is false
 		if !test.caKeyPresent {
-			if err := os.Remove(filepath.Join(test.cfg.CertificatesDir, "ca.key")); err != nil {
-				t.Errorf("failed removing ca.key: %v", err)
+			if err := os.Remove(filepath.Join(test.cfg.CertificatesDir, kubeadmconstants.CAKeyName)); err != nil {
+				t.Errorf("failed removing %s: %v", kubeadmconstants.CAKeyName, err)
+			}
+			if err := os.Remove(filepath.Join(test.cfg.CertificatesDir, kubeadmconstants.FrontProxyCAKeyName)); err != nil {
+				t.Errorf("failed removing %s: %v", kubeadmconstants.FrontProxyCAKeyName, err)
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
"That the front ca key is not required as the front proxy client tls keypair can be managed by the third party." This PR don't validate the front CA Key but check if it already exists.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/752

**Special notes for your reviewer**:
@yanndegat @timothysc @stealthybox @fabriziopandini 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
