### PR TITLE
[GCE] Remove parallel 

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestGetLoadBalancer(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -52,8 +50,6 @@ func TestGetLoadBalancer(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -70,8 +66,6 @@ func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerCreatesInternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -88,8 +82,6 @@ func TestEnsureLoadBalancerCreatesInternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletesExistingInternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -110,8 +102,6 @@ func TestEnsureLoadBalancerDeletesExistingInternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletesExistingExternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -133,8 +123,6 @@ func TestEnsureLoadBalancerDeletesExistingExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletedDeletesExternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -152,8 +140,6 @@ func TestEnsureLoadBalancerDeletedDeletesExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletedDeletesInternalLb(t *testing.T) {
-	t.Parallel()
-
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the parallel from the Loadbalancer tests. Looks like one mock method modifies a singleton variable, hence the tests currently cannot be run in parallel. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62601 

**Release note**:
```release-note
NONE
```
