### PR TITLE
[GCE] Parallelize GCE loadbalancer tests

### DIFF
--- a/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
+++ b/pkg/cloudprovider/providers/gce/cloud/mock/mock.go
@@ -123,26 +123,37 @@ func convertAndInsertAlphaForwardingRule(key *meta.Key, obj gceObject, mRules ma
 // InsertFwdRuleHook mocks inserting a ForwardingRule. ForwardingRules are
 // expected to default to Premium tier if no NetworkTier is specified.
 func InsertFwdRuleHook(ctx context.Context, key *meta.Key, obj *ga.ForwardingRule, m *cloud.MockForwardingRules) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionGA, "forwardingRules")
 	return convertAndInsertAlphaForwardingRule(key, obj, m.Objects, meta.VersionGA, projectID)
 }
 
 // InsertBetaFwdRuleHook mocks inserting a BetaForwardingRule.
 func InsertBetaFwdRuleHook(ctx context.Context, key *meta.Key, obj *beta.ForwardingRule, m *cloud.MockForwardingRules) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionBeta, "forwardingRules")
 	return convertAndInsertAlphaForwardingRule(key, obj, m.Objects, meta.VersionBeta, projectID)
 }
 
 // InsertAlphaFwdRuleHook mocks inserting an AlphaForwardingRule.
 func InsertAlphaFwdRuleHook(ctx context.Context, key *meta.Key, obj *alpha.ForwardingRule, m *cloud.MockForwardingRules) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionAlpha, "forwardingRules")
 	return convertAndInsertAlphaForwardingRule(key, obj, m.Objects, meta.VersionAlpha, projectID)
 }
 
-// Used to assign Addresses with no IP a unique IP address
-var ipCounter = 1
+// AddressAttributes maps from Address key to a map of Instances
+type AddressAttributes struct {
+	IPCounter int // Used to assign Addresses with no IP a unique IP address
+}
 
-func convertAndInsertAlphaAddress(key *meta.Key, obj gceObject, mAddrs map[meta.Key]*cloud.MockAddressesObj, version meta.Version, projectID string) (bool, error) {
+func convertAndInsertAlphaAddress(key *meta.Key, obj gceObject, mAddrs map[meta.Key]*cloud.MockAddressesObj, version meta.Version, projectID string, addressAttrs AddressAttributes) (bool, error) {
 	if !key.Valid() {
 		return false, fmt.Errorf("invalid GCE key (%+v)", key)
 	}
@@ -197,8 +208,8 @@ func convertAndInsertAlphaAddress(key *meta.Key, obj gceObject, mAddrs map[meta.
 	}
 
 	if addr.Address == "" {
-		addr.Address = fmt.Sprintf("1.2.3.%d", ipCounter)
-		ipCounter++
+		addr.Address = fmt.Sprintf("1.2.3.%d", addressAttrs.IPCounter)
+		addressAttrs.IPCounter++
 	}
 
 	// Set the default values for the Alpha fields.
@@ -212,21 +223,30 @@ func convertAndInsertAlphaAddress(key *meta.Key, obj gceObject, mAddrs map[meta.
 
 // InsertAddressHook mocks inserting an Address.
 func InsertAddressHook(ctx context.Context, key *meta.Key, obj *ga.Address, m *cloud.MockAddresses) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionGA, "addresses")
-	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionGA, projectID)
+	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionGA, projectID, m.X.(AddressAttributes))
 }
 
 // InsertBetaAddressHook mocks inserting a BetaAddress.
 func InsertBetaAddressHook(ctx context.Context, key *meta.Key, obj *beta.Address, m *cloud.MockAddresses) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionBeta, "addresses")
-	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionBeta, projectID)
+	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionBeta, projectID, m.X.(AddressAttributes))
 }
 
 // InsertAlphaAddressHook mocks inserting an Address. Addresses are expected to
 // default to Premium tier if no NetworkTier is specified.
 func InsertAlphaAddressHook(ctx context.Context, key *meta.Key, obj *alpha.Address, m *cloud.MockAlphaAddresses) (bool, error) {
+	m.Lock.Lock()
+	defer m.Lock.Unlock()
+
 	projectID := m.ProjectRouter.ProjectID(ctx, meta.VersionBeta, "addresses")
-	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionAlpha, projectID)
+	return convertAndInsertAlphaAddress(key, obj, m.Objects, meta.VersionAlpha, projectID, m.X.(AddressAttributes))
 }
 
 // InstanceGroupAttributes maps from InstanceGroup key to a map of Instances

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestEnsureStaticIP(t *testing.T) {
+	t.Parallel()
+
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
@@ -61,6 +63,8 @@ func TestEnsureStaticIP(t *testing.T) {
 }
 
 func TestEnsureStaticIPWithTier(t *testing.T) {
+	t.Parallel()
+
 	s, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
@@ -97,6 +101,8 @@ func TestEnsureStaticIPWithTier(t *testing.T) {
 }
 
 func TestVerifyRequestedIP(t *testing.T) {
+	t.Parallel()
+
 	lbRef := "test-lb"
 
 	for desc, tc := range map[string]struct {
@@ -152,6 +158,8 @@ func TestVerifyRequestedIP(t *testing.T) {
 }
 
 func TestCreateForwardingRuleWithTier(t *testing.T) {
+	t.Parallel()
+
 	// Common variables among the tests.
 	ports := []v1.ServicePort{{Name: "foo", Protocol: v1.ProtocolTCP, Port: int32(123)}}
 	target := "test-target-pool"
@@ -209,6 +217,8 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 }
 
 func TestDeleteAddressWithWrongTier(t *testing.T) {
+	t.Parallel()
+
 	lbRef := "test-lb"
 
 	s, err := fakeGCECloud(DefaultTestClusterValues())
@@ -284,6 +294,8 @@ func createExternalLoadBalancer(gce *GCECloud, apiService *v1.Service, nodeNames
 }
 
 func TestEnsureExternalLoadBalancer(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeNames := []string{"test-node-1"}
 
@@ -299,6 +311,8 @@ func TestEnsureExternalLoadBalancer(t *testing.T) {
 }
 
 func TestUpdateExternalLoadBalancer(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeName := "test-node-1"
 
@@ -355,6 +369,8 @@ func TestUpdateExternalLoadBalancer(t *testing.T) {
 }
 
 func TestEnsureExternalLoadBalancerDeleted(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -370,6 +386,8 @@ func TestEnsureExternalLoadBalancerDeleted(t *testing.T) {
 }
 
 func TestLoadBalancerWrongTierResourceDeletion(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -423,6 +441,8 @@ func TestLoadBalancerWrongTierResourceDeletion(t *testing.T) {
 }
 
 func TestEnsureExternalLoadBalancerFailsIfInvalidNetworkTier(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -442,6 +462,8 @@ func TestEnsureExternalLoadBalancerFailsIfInvalidNetworkTier(t *testing.T) {
 }
 
 func TestEnsureExternalLoadBalancerFailsWithNoNodes(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -453,6 +475,8 @@ func TestEnsureExternalLoadBalancerFailsWithNoNodes(t *testing.T) {
 }
 
 func TestForwardingRuleNeedsUpdate(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -535,6 +559,8 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 }
 
 func TestTargetPoolNeedsRecreation(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -581,6 +607,8 @@ func TestTargetPoolNeedsRecreation(t *testing.T) {
 }
 
 func TestFirewallNeedsUpdate(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -743,6 +771,8 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 }
 
 func TestDeleteWrongNetworkTieredResourcesSucceedsWhenNotFound(t *testing.T) {
+	t.Parallel()
+
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
@@ -751,6 +781,8 @@ func TestDeleteWrongNetworkTieredResourcesSucceedsWhenNotFound(t *testing.T) {
 }
 
 func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -833,6 +865,8 @@ func checkEvent(t *testing.T, recorder *record.FakeRecorder, expected string, sh
 }
 
 func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
+	t.Parallel()
+
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 	vals := DefaultTestClusterValues()
@@ -882,6 +916,8 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 }
 
 func TestEnsureExternalLoadBalancerDeletedSucceedsOnXPN(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
@@ -929,6 +965,8 @@ func newEnsureELBParams(nodes []*v1.Node, apiService *v1.Service) *EnsureELBPara
 // ensureExternalLoadBalancer, making sure the system won't panic when
 // exceptions raised by gce.
 func TestEnsureExternalLoadBalancerErrors(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	var params *EnsureELBParams
 

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -48,6 +48,8 @@ func createInternalLoadBalancer(gce *GCECloud, apiService *v1.Service, existingF
 }
 
 func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeNames := []string{"test-node-1"}
 
@@ -76,6 +78,8 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 }
 
 func TestEnsureInternalBackendServiceGroups(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeNames := []string{"test-node-1"}
 
@@ -110,6 +114,8 @@ func TestEnsureInternalBackendServiceGroups(t *testing.T) {
 }
 
 func TestEnsureInternalLoadBalancer(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeNames := []string{"test-node-1"}
 
@@ -124,6 +130,8 @@ func TestEnsureInternalLoadBalancer(t *testing.T) {
 }
 
 func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeNames := []string{"test-node-1"}
 
@@ -158,6 +166,8 @@ func TestEnsureInternalLoadBalancerWithExistingResources(t *testing.T) {
 }
 
 func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -233,6 +243,8 @@ func TestEnsureInternalLoadBalancerClearPreviousResources(t *testing.T) {
 }
 
 func TestUpdateInternalLoadBalancerBackendServices(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	nodeName := "test-node-1"
 
@@ -286,6 +298,8 @@ func TestUpdateInternalLoadBalancerBackendServices(t *testing.T) {
 }
 
 func TestUpdateInternalLoadBalancerNodes(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -316,6 +330,8 @@ func TestUpdateInternalLoadBalancerNodes(t *testing.T) {
 }
 
 func TestEnsureInternalLoadBalancerDeleted(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -331,6 +347,8 @@ func TestEnsureInternalLoadBalancerDeleted(t *testing.T) {
 }
 
 func TestEnsureInternalLoadBalancerDeletedTwiceDoesNotError(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestGetLoadBalancer(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -50,6 +52,8 @@ func TestGetLoadBalancer(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -66,6 +70,8 @@ func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerCreatesInternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -82,6 +88,8 @@ func TestEnsureLoadBalancerCreatesInternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletesExistingInternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -102,6 +110,8 @@ func TestEnsureLoadBalancerDeletesExistingInternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletesExistingExternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -123,6 +133,8 @@ func TestEnsureLoadBalancerDeletesExistingExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletedDeletesExternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
@@ -140,6 +152,8 @@ func TestEnsureLoadBalancerDeletedDeletesExternalLb(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeletedDeletesInternalLb(t *testing.T) {
+	t.Parallel()
+
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -125,6 +125,8 @@ func fakeGCECloud(vals TestClusterValues) (*GCECloud, error) {
 	c.MockForwardingRules.InsertHook = mock.InsertFwdRuleHook
 	c.MockAddresses.InsertHook = mock.InsertAddressHook
 	c.MockAlphaAddresses.InsertHook = mock.InsertAlphaAddressHook
+	c.MockAlphaAddresses.X = mock.AddressAttributes{}
+	c.MockAddresses.X = mock.AddressAttributes{}
 
 	c.MockInstanceGroups.X = mock.InstanceGroupAttributes{
 		InstanceMap: make(map[meta.Key]map[string]*compute.InstanceWithNamedPorts),


### PR DESCRIPTION
**What this PR does / why we need it**:
- Encapsulate IP counter in Mocks. Previously, ipCounter was a global int modified by multiple tests.
- Use mock-provided Lock before modifying resources.
- Parallelize loadbalancer tests.

```release-note
NONE
```
