### PR TITLE
Fix kubelet flags.

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -55,12 +55,6 @@ func (a *args) String() string {
 
 // Set function of flag.Value
 func (a *args) Set(value string) error {
-	// Someone else is calling flag.Parse after the flags are parsed in the
-	// test framework. Use this to avoid the flag being parsed twice.
-	// TODO(random-liu): Figure out who is parsing the flags.
-	if flag.Parsed() {
-		return nil
-	}
 	// Note that we assume all white space in flag string is separating fields
 	na := strings.Fields(value)
 	*a = append(*a, na...)


### PR DESCRIPTION
pflag now sets golang flag `Parsed` before parsing flags https://github.com/spf13/pflag/commit/1ce0cc6db4029d97571db82f85092fccedb572ce. With that, all kubelet flags setting will be skipped.

We initially added `flag.Parsed` check to work around a issue that flags are parsed twice, thus kubelet flags are appended twice.

However, it doesn't seem to be the case now. I removed the `Parsed` check, and kubelet flags are only appended once.
```
/tmp/node-e2e-20180416T200912/kubelet --kubeconfig /tmp/node-e2e-20180416T200912/kubeconfig --root-dir /var/lib/kubelet --v 4 --logtostderr --allow-privileged true --network-plugin=kubenet --cni-bin-dir /tmp/node-e2e-20180416T200912/cni/bin --cni-conf-dir /tmp/node-e2e-20180416T200912/cni/net.d --hostname-override test-cos-beta-66-10452-53-0 --container-runtime docker --container-runtime-endpoint unix:///var/run/dockershim.sock --config /tmp/node-e2e-20180416T200912/kubelet-config --experimental-mounter-path=/tmp/node-e2e-20180416T200912/mounter --experimental-kernel-memcg-notification=true --runtime-cgroups=/system.slice/docker.service
```

This PR removes the unnecessary `Parsed` check to fix the test. @mtaufen 

/cc @kubernetes/sig-node-pr-reviews 
Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
