### PR TITLE
Use 'docker/default' as default seccomp profile for unprivileged PodSecurityPolicy

### DIFF
--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gce.event-exporter
   annotations:
     kubernetes.io/description: 'Policy used by the event-exporter addon.'
-    # TODO: event-exporter should run with the default seccomp profile
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,docker/default'
     # 'runtime/default' is already the default, but must be filled in on the
     # pod to pass admission.
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp.yaml
@@ -4,8 +4,8 @@ metadata:
   name: gce.fluentd-gcp
   annotations:
     kubernetes.io/description: 'Policy used by the fluentd-gcp addon.'
-    # TODO: fluentd-gcp should run with the default seccomp profile
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,docker/default'
     # 'runtime/default' is already the default, but must be filled in on the
     # pod to pass admission.
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder.yaml
@@ -5,8 +5,8 @@ metadata:
   annotations:
     kubernetes.io/description: 'Policy used by the persistent-volume-binder
       (a.k.a. persistentvolume-controller) to run recycler pods.'
-    # TODO: This should use the default seccomp profile.
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,docker/default'
   labels:
     kubernetes.io/cluster-service: 'true'
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
@@ -7,8 +7,8 @@ metadata:
       privilege necessary to run non-privileged kube-system pods. This policy is
       not intended for use outside of kube-system, and may include further
       restrictions in the future.'
-    # TODO: Addons should use the default seccomp profile.
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,docker/default'
     # 'runtime/default' is already the default, but must be filled in on the
     # pod to pass admission.
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR sets the default seccomp profile for unprivileged PodSecurityPolicy to 'docker/default'. This PR is a followup of [#62662](https://github.com/kubernetes/kubernetes/pull/62662). We are using 'docker/default' instead of 'runtime/default' in addons in order to handle node version skew. When default seccomp profile is applied later, we can remove those annotations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #39845

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
