### PR TITLE
aggregate objs before printing in apply cmd

### DIFF
--- a/test/fixtures/pkg/kubectl/cmd/apply/cm.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/cm.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+items:
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test
+  data:
+    key1: apple
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test2
+  data:
+    key2: apple
+kind: ConfigMapList
+metadata: {}


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Aggregates all objects into a list before printing 

Fixes https://github.com/kubernetes/kubernetes/issues/58834

cc @soltysh 