### PR TITLE
authn: tokenreview should operatate of authenticator.Token

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -101,6 +101,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/discovery:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -48,6 +48,7 @@ import (
 	storageapiv1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -158,6 +159,10 @@ type ExtraConfig struct {
 
 	ServiceAccountIssuer       serviceaccount.TokenGenerator
 	ServiceAccountAPIAudiences []string
+
+	// TokenAuthenticator is seperatored from the rest of the authenticator stack
+	// for use in the TokenReview registry.
+	TokenAuthenticator authenticator.Token
 }
 
 type Config struct {
@@ -332,7 +337,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	// TODO: describe the priority all the way down in the RESTStorageProviders and plumb it back through the various discovery
 	// handlers that we have.
 	restStorageProviders := []RESTStorageProvider{
-		authenticationrest.RESTStorageProvider{Authenticator: c.GenericConfig.Authentication.Authenticator},
+		authenticationrest.RESTStorageProvider{Authenticator: c.ExtraConfig.TokenAuthenticator},
 		authorizationrest.RESTStorageProvider{Authorizer: c.GenericConfig.Authorization.Authorizer, RuleResolver: c.GenericConfig.RuleResolver},
 		autoscalingrest.RESTStorageProvider{},
 		batchrest.RESTStorageProvider{},

--- a/pkg/registry/authentication/rest/storage_authentication.go
+++ b/pkg/registry/authentication/rest/storage_authentication.go
@@ -30,7 +30,7 @@ import (
 )
 
 type RESTStorageProvider struct {
-	Authenticator authenticator.Request
+	Authenticator authenticator.Token
 }
 
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {

--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -18,7 +18,6 @@ package tokenreview
 
 import (
 	"fmt"
-	"net/http"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,10 +28,10 @@ import (
 )
 
 type REST struct {
-	tokenAuthenticator authenticator.Request
+	tokenAuthenticator authenticator.Token
 }
 
-func NewREST(tokenAuthenticator authenticator.Request) *REST {
+func NewREST(tokenAuthenticator authenticator.Token) *REST {
 	return &REST{tokenAuthenticator: tokenAuthenticator}
 }
 
@@ -58,11 +57,7 @@ func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, createV
 		return tokenReview, nil
 	}
 
-	// create a header that contains nothing but the token
-	fakeReq := &http.Request{Header: http.Header{}}
-	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
-
-	tokenUser, ok, err := r.tokenAuthenticator.AuthenticateRequest(fakeReq)
+	tokenUser, ok, err := r.tokenAuthenticator.AuthenticateToken(tokenReview.Spec.Token)
 	tokenReview.Status.Authenticated = ok
 	if err != nil {
 		tokenReview.Status.Error = err.Error()


### PR DESCRIPTION
This allows us to expand the authenticator.Token interface without
touching the other authenticators.

@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```
