### PR TITLE
Automated cherry pick of #62611: Fix machineID getting for vmss nodes when using instance

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -167,6 +167,10 @@ func (az *Cloud) InstanceID(ctx context.Context, name types.NodeName) (string, e
 		}
 		ssName, instanceID, err := extractVmssVMName(metadataName)
 		if err != nil {
+			if err == ErrorNotVmssInstance {
+				// Compose machineID for standard Node.
+				return az.getStandardMachineID(nodeName), nil
+			}
 			return "", err
 		}
 		// Compose instanceID based on ssName and instanceID for vmss instance.


### PR DESCRIPTION
Cherry pick of #62611 on release-1.10.

#62611: Fix machineID getting for vmss nodes when using instance