### PR TITLE
Use filepath.Clean() instead of path.Clean()

### DIFF
--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -19,6 +19,7 @@ package downwardapi
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -229,7 +230,7 @@ func CollectData(items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.Volu
 	data := make(map[string]volumeutil.FileProjection)
 	for _, fileInfo := range items {
 		var fileProjection volumeutil.FileProjection
-		fPath := path.Clean(fileInfo.Path)
+		fPath := filepath.Clean(fileInfo.Path)
 		if fileInfo.Mode != nil {
 			fileProjection.Mode = *fileInfo.Mode
 		} else {

--- a/pkg/volume/quobyte/quobyte_util.go
+++ b/pkg/volume/quobyte/quobyte_util.go
@@ -18,7 +18,8 @@ package quobyte
 
 import (
 	"net"
-	"path"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -101,7 +102,7 @@ func (mounter *quobyteMounter) pluginDirIsMounted(pluginDir string) (bool, error
 }
 
 func (mounter *quobyteMounter) correctTraillingSlash(regStr string) string {
-	return path.Clean(regStr) + "/"
+	return filepath.Clean(regStr) + string(os.PathSeparator)
 }
 
 func validateRegistry(registry string) bool {

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -804,7 +804,7 @@ func checkVolumeContents(targetDir, tcName string, payload map[string]FileProjec
 
 	cleanPathPayload := make(map[string]FileProjection, len(payload))
 	for k, v := range payload {
-		cleanPathPayload[path.Clean(k)] = v
+		cleanPathPayload[filepath.Clean(k)] = v
 	}
 
 	if !reflect.DeepEqual(cleanPathPayload, observedPayload) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Use filepath.Clean() instead of path.Clean() across `pkg/volume`. This could fix potential issues for windows containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
followup of #62375.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @msau42 