### PR TITLE
[WIP] kubeadm: Refactor anonymous function to make it readable

### DIFF
--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -45,6 +45,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
+        "//cmd/kubeadm/app/util/pubkeypin:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/bootstrap/token/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/bootstrap/token/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -78,7 +78,7 @@ func validateAndLoadInsecureConfig(insecureClusterInfo *v1.ConfigMap, token *kub
 	}
 	detachedJWSToken, ok := insecureClusterInfo.Data[bootstrapapi.JWSSignatureKeyPrefix+token.ID]
 	if !ok || len(detachedJWSToken) == 0 {
-		return nil, fmt.Errorf("token id %q is invalid for this cluster or it has expired. Use \"kubeadm token create\" on the master node to creating a new valid token", tokenID)
+		return nil, fmt.Errorf("token id %q is invalid for this cluster or it has expired. Use \"kubeadm token create\" on the master node to creating a new valid token", token.ID)
 	}
 	if !bootstrap.DetachedTokenIsValid(detachedJWSToken, insecureKubeconfigString, token.ID, token.Secret) {
 		return nil, fmt.Errorf("failed to verify JWS signature of received cluster info object, can't trust this API Server")

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 	bootstrapapi "k8s.io/client-go/tools/bootstrap/token/api"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -39,6 +40,100 @@ import (
 
 // BootstrapUser defines bootstrap user name
 const BootstrapUser = "token-bootstrap-client"
+
+// fetchInsecureClusterInfo fetches the insecure bootstrap Kubeconfig and returns cluster name, client set and server
+// This is used while trying to connect to the endpoints for the first time
+func fetchInsecureClusterInfo(endpoint, cfgClusterName string) (string, *clientset.Clientset, string, error) {
+	masterEndpoint := fmt.Sprintf("https://%s", endpoint)
+	bootstrapConfig := kubeconfigutil.CreateBasic(masterEndpoint, cfgClusterName, BootstrapUser, []byte{})
+	bootstrapConfig.Clusters[cfgClusterName].InsecureSkipTLSVerify = true
+
+	clusterName := bootstrapConfig.Contexts[bootstrapConfig.CurrentContext].Cluster
+	server := bootstrapConfig.Clusters[clusterName].Server
+	client, err := kubeconfigutil.ToClientSet(bootstrapConfig)
+
+	return clusterName, client, server, err
+}
+
+// retrieveClusterInfo retrieves the cluster ConfigMap for a specific client
+func retrieveClusterInfo(client *clientset.Clientset) *v1.ConfigMap {
+	var clusterInfo *v1.ConfigMap
+	wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
+		var err error
+		clusterInfo, err = client.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		if err != nil {
+			fmt.Printf("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	return clusterInfo
+}
+
+// validateAndLoadInsecureConfig validates the MAC on the kubeconfig from the ConfigMap and loads it
+func validateAndLoadInsecureConfig(insecureClusterInfo *v1.ConfigMap, token *kubeadmapi.BootstrapTokenString) (*clientcmdapi.Config, error) {
+	insecureKubeconfigString, ok := insecureClusterInfo.Data[bootstrapapi.KubeConfigKey]
+	if !ok || len(insecureKubeconfigString) == 0 {
+		return nil, fmt.Errorf("there is no %s key in the %s ConfigMap. This API Server isn't set up for token bootstrapping, can't connect", bootstrapapi.KubeConfigKey, bootstrapapi.ConfigMapClusterInfo)
+	}
+	detachedJWSToken, ok := insecureClusterInfo.Data[bootstrapapi.JWSSignatureKeyPrefix+token.ID]
+	if !ok || len(detachedJWSToken) == 0 {
+		return nil, fmt.Errorf("token id %q is invalid for this cluster or it has expired. Use \"kubeadm token create\" on the master node to creating a new valid token", tokenID)
+	}
+	if !bootstrap.DetachedTokenIsValid(detachedJWSToken, insecureKubeconfigString, token.ID, token.Secret) {
+		return nil, fmt.Errorf("failed to verify JWS signature of received cluster info object, can't trust this API Server")
+	}
+	insecureKubeconfigBytes := []byte(insecureKubeconfigString)
+	insecureConfig, err := clientcmd.Load(insecureKubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse the kubeconfig file in the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
+	}
+	return insecureConfig, nil
+}
+
+// fetchSecureClient loads and validates the cluster CA against a pinned set and uses it to retrieve a secure client connection
+func fetchSecureClient(endpoint string, insecureConfig *clientcmdapi.Config, clusterName string, pubKeyPins *pubkeypin.Set) (*clientset.Clientset, error) {
+	// Load the cluster CA from the Config
+	if len(insecureConfig.Clusters) != 1 {
+		return nil, fmt.Errorf("expected the kubeconfig file in the %s configmap to have a single cluster, but it had %d", bootstrapapi.ConfigMapClusterInfo, len(insecureConfig.Clusters))
+	}
+	var clusterCABytes []byte
+	for _, cluster := range insecureConfig.Clusters {
+		clusterCABytes = cluster.CertificateAuthorityData
+	}
+	clusterCA, err := parsePEMCert(clusterCABytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cluster CA from the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
+
+	}
+
+	// Validate the cluster CA public key against the pinned set
+	err = pubKeyPins.Check(clusterCA)
+	if err != nil {
+		return nil, fmt.Errorf("cluster CA found in %s configmap is invalid: %v", bootstrapapi.ConfigMapClusterInfo, err)
+	}
+
+	// Now that we know the proported cluster CA, connect and validate with that CA
+	masterEndpoint := fmt.Sprintf("https://%s", endpoint)
+	secureBootstrapConfig := kubeconfigutil.CreateBasic(masterEndpoint, clusterName, BootstrapUser, clusterCABytes)
+	return kubeconfigutil.ToClientSet(secureBootstrapConfig)
+}
+
+// loadSecureConfig pulls the kubeconfig from the securely-obtained ConfigMap and validates that it's the same as what we found in the insecure ConfigMap
+func loadSecureConfig(secureClusterInfo, insecureClusterInfo *v1.ConfigMap) (*clientcmdapi.Config, error) {
+	secureKubeconfigBytes := []byte(secureClusterInfo.Data[bootstrapapi.KubeConfigKey])
+	insecureKubeconfigBytes := []byte(insecureClusterInfo.Data[bootstrapapi.KubeConfigKey])
+	if !bytes.Equal(secureKubeconfigBytes, insecureKubeconfigBytes) {
+		return nil, fmt.Errorf("the second kubeconfig from the %s configmap (using validated TLS) was different from the first", bootstrapapi.ConfigMapClusterInfo)
+	}
+
+	secureKubeconfig, err := clientcmd.Load(secureKubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse the kubeconfig file in the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
+	}
+
+	return secureKubeconfig, nil
+}
 
 // RetrieveValidatedClusterInfo connects to the API Server and tries to fetch the cluster-info ConfigMap
 // It then makes sure it can trust the API Server by looking at the JWS-signed tokens and (if cfg.DiscoveryTokenCACertHashes is not empty)
@@ -59,45 +154,16 @@ func RetrieveValidatedClusterInfo(cfg *kubeadmapi.NodeConfiguration) (*clientcmd
 	// The function below runs for every endpoint, and all endpoints races with each other.
 	// The endpoint that wins the race and completes the task first gets its kubeconfig returned below
 	baseKubeConfig, err := runForEndpointsAndReturnFirst(cfg.DiscoveryTokenAPIServers, cfg.DiscoveryTimeout.Duration, func(endpoint string) (*clientcmdapi.Config, error) {
-
-		insecureBootstrapConfig := buildInsecureBootstrapKubeConfig(endpoint, cfg.ClusterName)
-		clusterName := insecureBootstrapConfig.Contexts[insecureBootstrapConfig.CurrentContext].Cluster
-
-		insecureClient, err := kubeconfigutil.ToClientSet(insecureBootstrapConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		fmt.Printf("[discovery] Created cluster-info discovery client, requesting info from %q\n", insecureBootstrapConfig.Clusters[clusterName].Server)
+		clusterName, insecureClient, server, err := fetchInsecureClusterInfo(endpoint, cfg.ClusterName)
+		fmt.Printf("[discovery] Created cluster-info discovery client, requesting info from %q\n", server)
 
 		// Make an initial insecure connection to get the cluster-info ConfigMap
-		var insecureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			insecureClusterInfo, err = insecureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				fmt.Printf("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		insecureClusterInfo := retrieveClusterInfo(insecureClient)
 
 		// Validate the MAC on the kubeconfig from the ConfigMap and load it
-		insecureKubeconfigString, ok := insecureClusterInfo.Data[bootstrapapi.KubeConfigKey]
-		if !ok || len(insecureKubeconfigString) == 0 {
-			return nil, fmt.Errorf("there is no %s key in the %s ConfigMap. This API Server isn't set up for token bootstrapping, can't connect", bootstrapapi.KubeConfigKey, bootstrapapi.ConfigMapClusterInfo)
-		}
-		detachedJWSToken, ok := insecureClusterInfo.Data[bootstrapapi.JWSSignatureKeyPrefix+token.ID]
-		if !ok || len(detachedJWSToken) == 0 {
-			return nil, fmt.Errorf("token id %q is invalid for this cluster or it has expired. Use \"kubeadm token create\" on the master node to creating a new valid token", token.ID)
-		}
-		if !bootstrap.DetachedTokenIsValid(detachedJWSToken, insecureKubeconfigString, token.ID, token.Secret) {
-			return nil, fmt.Errorf("failed to verify JWS signature of received cluster info object, can't trust this API Server")
-		}
-		insecureKubeconfigBytes := []byte(insecureKubeconfigString)
-		insecureConfig, err := clientcmd.Load(insecureKubeconfigBytes)
+		insecureConfig, err := validateAndLoadInsecureConfig(insecureClusterInfo, token)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't parse the kubeconfig file in the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
+			return nil, err
 		}
 
 		// If no TLS root CA pinning was specified, we're done
@@ -106,79 +172,28 @@ func RetrieveValidatedClusterInfo(cfg *kubeadmapi.NodeConfiguration) (*clientcmd
 			return insecureConfig, nil
 		}
 
-		// Load the cluster CA from the Config
-		if len(insecureConfig.Clusters) != 1 {
-			return nil, fmt.Errorf("expected the kubeconfig file in the %s configmap to have a single cluster, but it had %d", bootstrapapi.ConfigMapClusterInfo, len(insecureConfig.Clusters))
-		}
-		var clusterCABytes []byte
-		for _, cluster := range insecureConfig.Clusters {
-			clusterCABytes = cluster.CertificateAuthorityData
-		}
-		clusterCA, err := parsePEMCert(clusterCABytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse cluster CA from the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
-
-		}
-
-		// Validate the cluster CA public key against the pinned set
-		err = pubKeyPins.Check(clusterCA)
-		if err != nil {
-			return nil, fmt.Errorf("cluster CA found in %s configmap is invalid: %v", bootstrapapi.ConfigMapClusterInfo, err)
-		}
-
-		// Now that we know the proported cluster CA, connect back a second time validating with that CA
-		secureBootstrapConfig := buildSecureBootstrapKubeConfig(endpoint, clusterCABytes, clusterName)
-		secureClient, err := kubeconfigutil.ToClientSet(secureBootstrapConfig)
+		// Load and validate cluster CA, connect back a second time validating with that CA
+		secureClient, err := fetchSecureClient(endpoint, insecureConfig, clusterName, pubKeyPins)
 		if err != nil {
 			return nil, err
 		}
 
-		fmt.Printf("[discovery] Requesting info from %q again to validate TLS against the pinned public key\n", insecureBootstrapConfig.Clusters[clusterName].Server)
-		var secureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			secureClusterInfo, err = secureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				fmt.Printf("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		fmt.Printf("[discovery] Requesting info from %q again to validate TLS against the pinned public key\n", server)
+		secureClusterInfo := retrieveClusterInfo(secureClient)
 
-		// Pull the kubeconfig from the securely-obtained ConfigMap and validate that it's the same as what we found the first time
-		secureKubeconfigBytes := []byte(secureClusterInfo.Data[bootstrapapi.KubeConfigKey])
-		if !bytes.Equal(secureKubeconfigBytes, insecureKubeconfigBytes) {
-			return nil, fmt.Errorf("the second kubeconfig from the %s configmap (using validated TLS) was different from the first", bootstrapapi.ConfigMapClusterInfo)
+		// Make sure the secure and insecure configs match and load the secure one
+		secureKubeconfig, err := loadSecureConfig(secureClusterInfo, insecureClusterInfo)
+		if err == nil {
+			fmt.Printf("[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server %q\n", endpoint)
 		}
 
-		secureKubeconfig, err := clientcmd.Load(secureKubeconfigBytes)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't parse the kubeconfig file in the %s configmap: %v", bootstrapapi.ConfigMapClusterInfo, err)
-		}
-
-		fmt.Printf("[discovery] Cluster info signature and contents are valid and TLS certificate validates against pinned roots, will use API Server %q\n", endpoint)
-		return secureKubeconfig, nil
+		return secureKubeconfig, err
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return kubeconfigutil.GetClusterFromKubeConfig(baseKubeConfig), nil
-}
-
-// buildInsecureBootstrapKubeConfig makes a KubeConfig object that connects insecurely to the API Server for bootstrapping purposes
-func buildInsecureBootstrapKubeConfig(endpoint, clustername string) *clientcmdapi.Config {
-	masterEndpoint := fmt.Sprintf("https://%s", endpoint)
-	bootstrapConfig := kubeconfigutil.CreateBasic(masterEndpoint, clustername, BootstrapUser, []byte{})
-	bootstrapConfig.Clusters[clustername].InsecureSkipTLSVerify = true
-	return bootstrapConfig
-}
-
-// buildSecureBootstrapKubeConfig makes a KubeConfig object that connects securely to the API Server for bootstrapping purposes (validating with the specified CA)
-func buildSecureBootstrapKubeConfig(endpoint string, caCert []byte, clustername string) *clientcmdapi.Config {
-	masterEndpoint := fmt.Sprintf("https://%s", endpoint)
-	bootstrapConfig := kubeconfigutil.CreateBasic(masterEndpoint, clustername, BootstrapUser, caCert)
-	return bootstrapConfig
 }
 
 // runForEndpointsAndReturnFirst loops the endpoints slice and let's the endpoints race for connecting to the master


### PR DESCRIPTION
Signed-off-by: Rostislav M. Georgiev <rostislavg@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is a simple refactoring of a [huge anonymous function](https://github.com/kubernetes/kubernetes/blob/7966265a515fbeccbbe9b8d7101e4f1f3382c624/cmd/kubeadm/app/discovery/token/token.go#L62-L162), contained in `RetrieveValidatedClusterInfo`.

I don't claim it's perfect, but it is a good start and any suggestions will be appreciated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @krousey
/assign @timothysc

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
