### PR TITLE
Update addon manifests to use policy/v1beta1

### DIFF
--- a/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-role.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-role.yaml
@@ -8,7 +8,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.etcd-empty-dir-cleanup
   resources:

--- a/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.etcd-empty-dir-cleanup

--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp-role.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp-role.yaml
@@ -8,7 +8,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.event-exporter
   resources:

--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/event-exporter-psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.event-exporter

--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp-role.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp-role.yaml
@@ -8,7 +8,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.fluentd-gcp
   resources:

--- a/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp.yaml
+++ b/cluster/addons/fluentd-gcp/podsecuritypolicies/fluentd-gcp-psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.fluentd-gcp

--- a/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder-role.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder-role.yaml
@@ -11,7 +11,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.persistent-volume-binder
   resources:

--- a/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/persistent-volume-binder.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.persistent-volume-binder

--- a/cluster/gce/addons/podsecuritypolicies/privileged-role.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/privileged-role.yaml
@@ -7,7 +7,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.privileged
   resources:

--- a/cluster/gce/addons/podsecuritypolicies/privileged.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/privileged.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.privileged

--- a/cluster/gce/addons/podsecuritypolicies/unprivileged-addon-role.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/unprivileged-addon-role.yaml
@@ -8,7 +8,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - extensions
+  - policy
   resourceNames:
   - gce.unprivileged-addon
   resources:

--- a/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: gce.unprivileged-addon


### PR DESCRIPTION
**What this PR does / why we need it:**
This is a part of the PSP migration from extensions to policy API group. This PR updates addon manifests to use policy/v1beta1 and grant permissions in policy API group.

**Which issue(s) this PR fixes:**
Addressed to https://github.com/kubernetes/features/issues/5