### PR TITLE
Fix NPD preload.

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -197,15 +197,15 @@ function install-node-problem-detector {
       local -r npd_version="${DEFAULT_NPD_VERSION}"
       local -r npd_sha1="${DEFAULT_NPD_SHA1}"
   fi
+  local -r npd_tar="node-problem-detector-${npd_version}.tar.gz"
 
-  if is-preloaded "node-problem-detector" "${npd_sha1}"; then
+  if is-preloaded "${npd_tar}" "${npd_sha1}"; then
     echo "node-problem-detector is preloaded."
     return
   fi
 
   echo "Downloading node problem detector."
   local -r npd_release_path="https://storage.googleapis.com/kubernetes-release"
-  local -r npd_tar="node-problem-detector-${npd_version}.tar.gz"
   download-or-bust "${npd_sha1}" "${npd_release_path}/node-problem-detector/${npd_tar}"
   local -r npd_dir="${KUBE_HOME}/node-problem-detector"
   mkdir -p "${npd_dir}"


### PR DESCRIPTION
Fix NPD preload.

NPD preload information is:
```
node-problem-detector-v0.4.1.tar.gz,a57a3fe64cab8a18ec654f5cef0aec59dae62568
```

@shiliangxue Do we need to cherrypick this?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
