### PR TITLE
Fix kubectl describe cronjob

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4034,6 +4034,8 @@ run_job_tests() {
   kubectl run pi --schedule="59 23 31 2 *" --namespace=test-jobs --generator=cronjob/v1beta1 "--image=$IMAGE_PERL" --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(20)' "${kube_flags[@]}"
   # Post-Condition: assertion object exists
   kube::test::get_object_assert 'cronjob/pi --namespace=test-jobs' "{{$id_field}}" 'pi'
+  kubectl get cronjob/pi --namespace=test-jobs
+  kubectl describe cronjob/pi --namespace=test-jobs
 
   ### Create a job in dry-run mode
   output_message=$(kubectl create job test-job --from=cronjob/pi --dry-run=true --namespace=test-jobs -o name)
@@ -4046,6 +4048,8 @@ run_job_tests() {
   kubectl create job test-job --from=cronjob/pi --namespace=test-jobs
   # Post-Condition: assertion object exists
   kube::test::get_object_assert 'job/test-job --namespace=test-jobs' "{{$id_field}}" 'test-job'
+  kubectl get job/test-job --namespace=test-jobs
+  kubectl describe job/test-job --namespace=test-jobs
   #Clean up
   kubectl delete job test-job --namespace=test-jobs
   kubectl delete cronjob pi --namespace=test-jobs

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -166,16 +166,14 @@ func (f *ring1Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (
 func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (printers.Describer, error) {
 	clientset, err := f.clientAccessFactory.ClientSet()
 	if err != nil {
-		// if we can't make a client for this group/version, go generic if possible
-		if genericDescriber, genericErr := genericDescriber(f.clientAccessFactory, mapping); genericErr == nil {
-			return genericDescriber, nil
-		}
-		// otherwise return the original error
 		return nil, err
 	}
-
+	externalclientset, err := f.clientAccessFactory.KubernetesClientSet()
+	if err != nil {
+		return nil, err
+	}
 	// try to get a describer
-	if describer, ok := printersinternal.DescriberFor(mapping.GroupVersionKind.GroupKind(), clientset); ok {
+	if describer, ok := printersinternal.DescriberFor(mapping.GroupVersionKind.GroupKind(), clientset, externalclientset); ok {
 		return describer, nil
 	}
 	// if this is a kind we don't have a describer for yet, go generic if possible

--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -106,7 +106,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )
 

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -1312,7 +1312,7 @@ func TestDescribeDeployment(t *testing.T) {
 			},
 		},
 	})
-	d := DeploymentDescriber{fake, versionedFake.ExtensionsV1beta1()}
+	d := DeploymentDescriber{fake, versionedFake}
 	out, err := d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -1934,7 +1934,7 @@ func TestDescribeEvents(t *testing.T) {
 					Replicas: utilpointer.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{},
 				},
-			}).ExtensionsV1beta1(),
+			}),
 		},
 		"EndpointsDescriber": &EndpointsDescriber{
 			fake.NewSimpleClientset(&api.Endpoints{


### PR DESCRIPTION
CronJob describer was attempting to use the internal batch clientset, which speaks to the batch/v1 API group. CronJobs do not exist in that API group.