### PR TITLE
Add contribex to github template owners

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - castrojo
+  - cblecker
+  - grodrigues3
+  - parispittman
+  - Phillels
+approvers:
+  - castrojo
+  - cblecker
+  - grodrigues3
+  - parispittman
+  - Phillels


### PR DESCRIPTION
**What this PR does / why we need it**:
The `.github/` folder doesn't have an OWNERS file. These templates fall under contribex, so this would add an OWNERS file to this folder.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
