### PR TITLE
add dry-run flag as field in create PrintFlags

### DIFF
--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -104,7 +104,6 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		"Only relevant if --edit=true. Defaults to the line ending native to your platform.")
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddRecordFlag(cmd)
-	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&options.Raw, "raw", options.Raw, "Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.")
@@ -161,10 +160,8 @@ func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
 }
 
 func (o *CreateOptions) Complete(cmd *cobra.Command) error {
-	o.DryRun = cmdutil.GetDryRunFlag(cmd)
-
-	if o.DryRun {
-		o.PrintFlags.Complete("%s (dry run)")
+	if o.PrintFlags.DryRun != nil {
+		o.DryRun = *o.PrintFlags.DryRun
 	}
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
@@ -341,9 +338,6 @@ func (o *CreateSubcommandOptions) Complete(cmd *cobra.Command, args []string, ge
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
 
-	if o.DryRun {
-		o.PrintFlags.Complete("%s (dry run)")
-	}
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/create/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create/create_clusterrole.go
@@ -83,7 +83,6 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringSliceVar(&c.Verbs, "verb", c.Verbs, "Verb that applies to the resources contained in the rule")
 	cmd.Flags().StringSliceVar(&c.NonResourceURLs, "non-resource-url", c.NonResourceURLs, "A partial url that user should have access to.")
 	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")

--- a/pkg/kubectl/cmd/create/create_job.go
+++ b/pkg/kubectl/cmd/create/create_job.go
@@ -80,7 +80,6 @@ func NewCmdCreateJob(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().String("from", "", "The name of the resource to create a Job from (only cronjob is supported).")
 
 	return cmd
@@ -104,13 +103,13 @@ func (c *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	}
 	c.Client = clientset.BatchV1()
 	c.Builder = f.NewBuilder()
-	c.DryRun = cmdutil.GetDryRunFlag(cmd)
 	c.Cmd = cmd
 	c.OutputFormat = cmdutil.GetFlagString(cmd, "output")
 
-	if c.DryRun {
-		c.PrintFlags.Complete("%s (dry run)")
+	if c.PrintFlags.DryRun != nil {
+		c.DryRun = *c.PrintFlags.DryRun
 	}
+
 	printer, err := c.PrintFlags.ToPrinter()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/create/create_role.go
+++ b/pkg/kubectl/cmd/create/create_role.go
@@ -140,7 +140,6 @@ func NewCmdCreateRole(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringSliceVar(&c.Verbs, "verb", c.Verbs, "Verb that applies to the resources contained in the rule")
 	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
 	cmd.Flags().StringArrayVar(&c.ResourceNames, "resource-name", c.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
@@ -204,9 +203,6 @@ func (c *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 	c.DryRun = cmdutil.GetDryRunFlag(cmd)
 	c.OutputFormat = cmdutil.GetFlagString(cmd, "output")
 
-	if c.DryRun {
-		c.PrintFlags.Complete("%s (dry run)")
-	}
 	printer, err := c.PrintFlags.ToPrinter()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -432,7 +432,6 @@ func AddApplyAnnotationVarFlags(cmd *cobra.Command, applyAnnotation *bool) {
 // TODO: need to take a pass at other generator commands to use this set of flags
 func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
 	cmd.Flags().String("generator", defaultGenerator, "The name of the API generator to use.")
-	AddDryRunFlag(cmd)
 }
 
 type ValidateOptions struct {


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Wires the `--dry-run` flag through the `create` subcommand PrintFlags struct.

cc @soltysh 
