### PR TITLE
GCE: Bump GLBC manifest to v1.1.1

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.1.0
+  name: l7-lb-controller-v1.1.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.1.0
+    version: v1.1.1
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.0
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.1
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
**Special notes for your reviewer**:
/assign bowei
/cc bowei
/cc rramkumar1

**Release note**:
```release-note
GCE: Bump GLBC version to 1.1.1 - fixing an issue of handling multiple certs with identical certificates
```
