### PR TITLE
Fix extra-log flag for node e2e.

### DIFF
--- a/test/e2e_node/services/logs.go
+++ b/test/e2e_node/services/logs.go
@@ -44,12 +44,6 @@ func (l *logFiles) String() string {
 
 // Set function of flag.Value
 func (l *logFiles) Set(value string) error {
-	// Someone else is calling flag.Parse after the flags are parsed in the
-	// test framework. Use this to avoid the flag being parsed twice.
-	// TODO(random-liu): Figure out who is parsing the flags.
-	if flag.Parsed() {
-		return nil
-	}
 	var log LogFileData
 	if err := json.Unmarshal([]byte(value), &log); err != nil {
 		return err


### PR DESCRIPTION
Similar with https://github.com/kubernetes/kubernetes/pull/62670.

Without this, test-infra can't collect extra logs, such as contianerd log.

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
