### PR TITLE
-Fix the name could cause a conflict if an object with the same name …

### DIFF
--- a/pkg/scheduler/factory/cache_comparer.go
+++ b/pkg/scheduler/factory/cache_comparer.go
@@ -117,12 +117,12 @@ func (c compareStrategy) ComparePods(pods, waitingPods []*v1.Pod, nodeinfos map[
 func (c compareStrategy) ComparePdbs(pdbs []*policy.PodDisruptionBudget, pdbCache map[string]*policy.PodDisruptionBudget) (missed, redundant []string) {
 	actual := []string{}
 	for _, pdb := range pdbs {
-		actual = append(actual, string(pdb.Name))
+		actual = append(actual, string(pdb.UID))
 	}
 
 	cached := []string{}
-	for pdbName := range pdbCache {
-		cached = append(cached, pdbName)
+	for pdbUID := range pdbCache {
+		cached = append(cached, pdbUID)
 	}
 
 	return compareStrings(actual, cached)

--- a/pkg/scheduler/factory/cache_comparer_test.go
+++ b/pkg/scheduler/factory/cache_comparer_test.go
@@ -202,17 +202,17 @@ func TestComparePdbs(t *testing.T) {
 
 	for _, test := range tests {
 		pdbs := []*policy.PodDisruptionBudget{}
-		for _, name := range test.actual {
+		for _, uid := range test.actual {
 			pdb := &policy.PodDisruptionBudget{}
-			pdb.Name = name
+			pdb.UID = types.UID(uid)
 			pdbs = append(pdbs, pdb)
 		}
 
 		cache := make(map[string]*policy.PodDisruptionBudget)
-		for _, name := range test.cached {
+		for _, uid := range test.cached {
 			pdb := &policy.PodDisruptionBudget{}
-			pdb.Name = name
-			cache[name] = pdb
+			pdb.UID = types.UID(uid)
+			cache[uid] = pdb
 		}
 
 		m, r := compare.ComparePdbs(pdbs, cache)

--- a/pkg/scheduler/schedulercache/cache.go
+++ b/pkg/scheduler/schedulercache/cache.go
@@ -432,7 +432,7 @@ func (cache *schedulerCache) AddPDB(pdb *policy.PodDisruptionBudget) error {
 	defer cache.mu.Unlock()
 
 	// Unconditionally update cache.
-	cache.pdbs[pdb.Name] = pdb
+	cache.pdbs[string(pdb.UID)] = pdb
 	return nil
 }
 
@@ -444,7 +444,7 @@ func (cache *schedulerCache) RemovePDB(pdb *policy.PodDisruptionBudget) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	delete(cache.pdbs, pdb.Name)
+	delete(cache.pdbs, string(pdb.UID))
 	return nil
 }
 

--- a/pkg/scheduler/schedulercache/cache_test.go
+++ b/pkg/scheduler/schedulercache/cache_test.go
@@ -1137,13 +1137,14 @@ func setupCacheWithAssumedPods(b *testing.B, podNum int, assumedTime time.Time) 
 	return cache
 }
 
-func makePDB(name, namespace string, labels map[string]string, minAvailable int) *v1beta1.PodDisruptionBudget {
+func makePDB(name, namespace string, uid types.UID, labels map[string]string, minAvailable int) *v1beta1.PodDisruptionBudget {
 	intstrMin := intstr.FromInt(minAvailable)
 	pdb := &v1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 			Labels:    labels,
+			UID:       uid,
 		},
 		Spec: v1beta1.PodDisruptionBudgetSpec{
 			MinAvailable: &intstrMin,
@@ -1158,14 +1159,14 @@ func makePDB(name, namespace string, labels map[string]string, minAvailable int)
 func TestPDBOperations(t *testing.T) {
 	ttl := 10 * time.Second
 	testPDBs := []*v1beta1.PodDisruptionBudget{
-		makePDB("pdb0", "ns1", map[string]string{"tkey1": "tval1"}, 3),
-		makePDB("pdb1", "ns1", map[string]string{"tkey1": "tval1", "tkey2": "tval2"}, 1),
-		makePDB("pdb2", "ns3", map[string]string{"tkey3": "tval3", "tkey2": "tval2"}, 10),
+		makePDB("pdb0", "ns1", "uid0", map[string]string{"tkey1": "tval1"}, 3),
+		makePDB("pdb1", "ns1", "uid1", map[string]string{"tkey1": "tval1", "tkey2": "tval2"}, 1),
+		makePDB("pdb2", "ns3", "uid2", map[string]string{"tkey3": "tval3", "tkey2": "tval2"}, 10),
 	}
 	updatedPDBs := []*v1beta1.PodDisruptionBudget{
-		makePDB("pdb0", "ns1", map[string]string{"tkey4": "tval4"}, 8),
-		makePDB("pdb1", "ns1", map[string]string{"tkey1": "tval1"}, 1),
-		makePDB("pdb2", "ns3", map[string]string{"tkey3": "tval3", "tkey1": "tval1", "tkey2": "tval2"}, 10),
+		makePDB("pdb0", "ns1", "uid0", map[string]string{"tkey4": "tval4"}, 8),
+		makePDB("pdb1", "ns1", "uid1", map[string]string{"tkey1": "tval1"}, 1),
+		makePDB("pdb2", "ns3", "uid2", map[string]string{"tkey3": "tval3", "tkey1": "tval1", "tkey2": "tval2"}, 10),
 	}
 	tests := []struct {
 		pdbsToAdd    []*v1beta1.PodDisruptionBudget
@@ -1225,7 +1226,7 @@ func TestPDBOperations(t *testing.T) {
 			found := false
 			// find it among the cached ones
 			for _, cpdb := range cachedPDBs {
-				if pdb.Name == cpdb.Name {
+				if pdb.UID == cpdb.UID {
 					found = true
 					if !reflect.DeepEqual(pdb, cpdb) {
 						t.Errorf("%v is not equal to %v", pdb, cpdb)
@@ -1234,7 +1235,7 @@ func TestPDBOperations(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Errorf("PDB with name '%v' was not found in the cache.", pdb.Name)
+				t.Errorf("PDB with uid '%v' was not found in the cache.", pdb.UID)
 			}
 
 		}

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -496,7 +497,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 	}
 }
 
-func mkMinAvailablePDB(name, namespace string, minAvailable int, matchLabels map[string]string) *policy.PodDisruptionBudget {
+func mkMinAvailablePDB(name, namespace string, uid types.UID, minAvailable int, matchLabels map[string]string) *policy.PodDisruptionBudget {
 	intMinAvailable := intstr.FromInt(minAvailable)
 	return &policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -546,7 +547,7 @@ func TestPDBInPreemption(t *testing.T) {
 			description: "A non-PDB violating pod is preempted despite its higher priority",
 			nodes:       []*nodeConfig{{name: "node-1", res: defaultNodeRes}},
 			pdbs: []*policy.PodDisruptionBudget{
-				mkMinAvailablePDB("pdb-1", context.ns.Name, 2, map[string]string{"foo": "bar"}),
+				mkMinAvailablePDB("pdb-1", context.ns.Name, types.UID("pdb-1-uid"), 2, map[string]string{"foo": "bar"}),
 			},
 			existingPods: []*v1.Pod{
 				initPausePod(context.clientSet, &pausePodConfig{
@@ -588,7 +589,7 @@ func TestPDBInPreemption(t *testing.T) {
 				{name: "node-2", res: defaultNodeRes},
 			},
 			pdbs: []*policy.PodDisruptionBudget{
-				mkMinAvailablePDB("pdb-1", context.ns.Name, 2, map[string]string{"foo": "bar"}),
+				mkMinAvailablePDB("pdb-1", context.ns.Name, types.UID("pdb-1-uid"), 2, map[string]string{"foo": "bar"}),
 			},
 			existingPods: []*v1.Pod{
 				initPausePod(context.clientSet, &pausePodConfig{
@@ -626,8 +627,8 @@ func TestPDBInPreemption(t *testing.T) {
 				{name: "node-3", res: defaultNodeRes},
 			},
 			pdbs: []*policy.PodDisruptionBudget{
-				mkMinAvailablePDB("pdb-1", context.ns.Name, 2, map[string]string{"foo1": "bar"}),
-				mkMinAvailablePDB("pdb-2", context.ns.Name, 2, map[string]string{"foo2": "bar"}),
+				mkMinAvailablePDB("pdb-1", context.ns.Name, types.UID("pdb-1-uid"), 2, map[string]string{"foo1": "bar"}),
+				mkMinAvailablePDB("pdb-2", context.ns.Name, types.UID("pdb-2-uid"), 2, map[string]string{"foo2": "bar"}),
 			},
 			existingPods: []*v1.Pod{
 				initPausePod(context.clientSet, &pausePodConfig{

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -671,6 +672,7 @@ func TestPDBCache(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: context.ns.Name,
 			Name:      "test-pdb",
+			UID:       types.UID("test-pdb-uid"),
 			Labels:    map[string]string{"tkey1": "tval1", "tkey2": "tval2"},
 		},
 		Spec: policy.PodDisruptionBudgetSpec{


### PR DESCRIPTION
…is created in a different namespace

**What this PR does / why we need it**:
/kind bug

Using the name could cause a conflict if an object with the same name is created in a different namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#62750

**Special notes for your reviewer**:
/assign @bsalamat 

**Release note**:
```
-Fix the name could cause a conflict if an object with the same name is created in a different namespace
```