### PR TITLE
Fixes #49445 by adding additional annotation to define ELB security group (AWS)

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -142,8 +142,13 @@ const ServiceAnnotationLoadBalancerConnectionIdleTimeout = "service.beta.kuberne
 const ServiceAnnotationLoadBalancerCrossZoneLoadBalancingEnabled = "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"
 
 // ServiceAnnotationLoadBalancerExtraSecurityGroups is the annotation used
-// one the service to specify additional security groups to be added to ELB created
+// on the service to specify additional security groups to be added to ELB created
 const ServiceAnnotationLoadBalancerExtraSecurityGroups = "service.beta.kubernetes.io/aws-load-balancer-extra-security-groups"
+
+// ServiceAnnotationLoadBalancerSecurityGroups is the annotation used
+// on the service to specify the security groups to be added to ELB created. Differently from the annotation
+// "service.beta.kubernetes.io/aws-load-balancer-extra-security-groups", this replaces all other security groups previously assigned to the ELB.
+const ServiceAnnotationLoadBalancerSecurityGroups = "service.beta.kubernetes.io/aws-load-balancer-security-groups"
 
 // ServiceAnnotationLoadBalancerCertificate is the annotation used on the
 // service to request a secure listener. Value is a valid certificate ARN.
@@ -3158,7 +3163,8 @@ func getPortSets(annotation string) (ports *portSets) {
 // attached to ELB created by a service. List always consist of at least
 // 1 member which is an SG created for this service or a SG from the Global config.
 // Extra groups can be specified via annotation, as can extra tags for any
-// new groups.
+// new groups. The annotation "ServiceAnnotationLoadBalancerSecurityGroups" allows for
+// setting the security groups specified.
 func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, loadBalancerName string, annotations map[string]string) ([]string, error) {
 	var err error
 	var securityGroupID string
@@ -3175,7 +3181,20 @@ func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, load
 			return nil, err
 		}
 	}
-	sgList := []string{securityGroupID}
+
+	sgList := []string{}
+
+	for _, extraSG := range strings.Split(annotations[ServiceAnnotationLoadBalancerSecurityGroups], ",") {
+		extraSG = strings.TrimSpace(extraSG)
+		if len(extraSG) > 0 {
+			sgList = append(sgList, extraSG)
+		}
+	}
+
+	// If no Security Groups have been specified with the ServiceAnnotationLoadBalancerSecurityGroups annotation, we add the default one.
+	if len(sgList) == 0 {
+		sgList = append(sgList, securityGroupID)
+	}
 
 	for _, extraSG := range strings.Split(annotations[ServiceAnnotationLoadBalancerExtraSecurityGroups], ",") {
 		extraSG = strings.TrimSpace(extraSG)

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1179,6 +1179,38 @@ func TestLBExtraSecurityGroupsAnnotation(t *testing.T) {
 	}
 }
 
+func TestLBSecurityGroupsAnnotation(t *testing.T) {
+	awsServices := newMockedFakeAWSServices(TestClusterId)
+	c, _ := newAWSCloud(CloudConfig{}, awsServices)
+
+	sg1 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000001"}
+	sg2 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000002"}
+	sg3 := map[string]string{ServiceAnnotationLoadBalancerSecurityGroups: "sg-000001, sg-000002"}
+
+	tests := []struct {
+		name string
+
+		annotations map[string]string
+		expectedSGs []string
+	}{
+		{"SG specified", sg1, []string{sg1[ServiceAnnotationLoadBalancerSecurityGroups]}},
+		{"Multiple SGs specified", sg3, []string{sg1[ServiceAnnotationLoadBalancerSecurityGroups], sg2[ServiceAnnotationLoadBalancerSecurityGroups]}},
+	}
+
+	awsServices.ec2.(*MockedFakeEC2).expectDescribeSecurityGroups(TestClusterId, "k8s-elb-aid", "cluster.test")
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serviceName := types.NamespacedName{Namespace: "default", Name: "myservice"}
+
+			sgList, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
+			assert.NoError(t, err, "buildELBSecurityGroupList failed")
+			assert.True(t, sets.NewString(test.expectedSGs...).Equal(sets.NewString(sgList...)),
+				"Security Groups expected=%q , returned=%q", test.expectedSGs, sgList)
+		})
+	}
+}
+
 // Test that we can add a load balancer tag
 func TestAddLoadBalancerTags(t *testing.T) {
 	loadBalancerName := "test-elb"


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes #49445 by changing the way the SG are applied to AWS ELBs: previously, an ELB would always have a default SG, either a pre-created one or an ad hoc one that always allowed `0.0.0.0/0` even if an annotation with a different security would be specified. This PR changes that by having the "extra" SG be the only one applied when it is specified as this is the way most of the people use AWS anyways: they predefine Security Groups with rules that work with them and they want to be applied. 
It would would be probably worth considering changing the name of the annotation as this change of behaviour doesn't really make it "extra". 

**Which issue(s) this PR fixes** :
Fixes #49445

**Special notes for your reviewer**:
Please advise how to build and test this on AWS to do an integration test, I don't have prior experience with that.

**Release note**:

```release-note
Adds `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation to set the security groups to the AWS ELB to be the only ones specified in the annotation in case this is present (does not add `0.0.0.0/0`). 
```


/cc @justinsb @chrislovecnm  what do you think? 
