### PR TITLE
Change Capacity log verbosity in status update

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -592,7 +592,9 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 		devicePluginCapacity, devicePluginAllocatable, removedDevicePlugins = kl.containerManager.GetDevicePluginResourceCapacity()
 		if devicePluginCapacity != nil {
 			for k, v := range devicePluginCapacity {
-				glog.V(2).Infof("Update capacity for %s to %d", k, v.Value())
+				if old, ok := node.Status.Capacity[k]; !ok || old.Value() != v.Value() {
+					glog.V(2).Infof("Update capacity for %s to %d", k, v.Value())
+				}
 				node.Status.Capacity[k] = v
 			}
 		}
@@ -635,9 +637,12 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 		}
 		node.Status.Allocatable[k] = value
 	}
+
 	if devicePluginAllocatable != nil {
 		for k, v := range devicePluginAllocatable {
-			glog.V(2).Infof("Update allocatable for %s to %d", k, v.Value())
+			if old, ok := node.Status.Allocatable[k]; !ok || old.Value() != v.Value() {
+				glog.V(2).Infof("Update allocatable for %s to %d", k, v.Value())
+			}
 			node.Status.Allocatable[k] = v
 		}
 	}


### PR DESCRIPTION
*What this PR does / why we need it:*

While in production we noticed that the log verbosity for the Capacity field in the node status was to high.
This log message is called for every device plugin resource at every update.

A proposed solution is to tune it down from V(2) to V(5). In a normal setting you'll be able to see the effect by looking at the node status.

Release note:
```
NONE
```

/sig node
/area hw-accelerators
/assign @vikaschoudhary16 @jiayingz @vishh 