### PR TITLE
[prometheus addon] Add OWNERS file

### DIFF
--- a/cluster/addons/prometheus/OWNERS
+++ b/cluster/addons/prometheus/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- kawych
+- piosz
+- serathius
+- brancz
+reviewers:
+- kawych
+- piosz
+- serathius
+- brancz
+


### PR DESCRIPTION
This PR adds owners from sig-instrumentation to prometheus addon

```release-note
NONE
```
cc @piosz @brancz @kawych