### PR TITLE
Add `volumenameprefix` tests for glusterfs dynamic provisioner.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -534,6 +534,29 @@ func TestParseClassParameters(t *testing.T) {
 				thinPoolSnapFactor: float32(50),
 			},
 		},
+
+		{
+			"valid volumenameprefix: dept-dev",
+			map[string]string{
+				"resturl":          "https://localhost:8080",
+				"restauthenabled":  "false",
+				"gidMin":           "4000",
+				"gidMax":           "5000",
+				"volumetype":       "disperse:4:2",
+				"snapfactor":       "50",
+				"volumenameprefix": "dept-dev",
+			},
+			&secret,
+			false, // expect error
+			&provisionerConfig{
+				url:                "https://localhost:8080",
+				gidMin:             4000,
+				gidMax:             5000,
+				volumeType:         gapi.VolumeDurabilityInfo{Type: "disperse", Replicate: gapi.ReplicaDurability{Replica: 0}, Disperse: gapi.DisperseDurability{Data: 4, Redundancy: 2}},
+				thinPoolSnapFactor: float32(50),
+				volumeNamePrefix:   "dept-dev",
+			},
+		},
 		{
 			"invalid volumetype (disperse) parameter",
 			map[string]string{
@@ -584,6 +607,28 @@ func TestParseClassParameters(t *testing.T) {
 				"resturl":         "https://localhost:8080",
 				"restauthenabled": "false",
 				"snapfactor":      "0.5",
+			},
+			&secret,
+			true, // expect error
+			nil,
+		},
+		{
+			"invalid volumenameprefix: string starting with '_'",
+			map[string]string{
+				"resturl":          "https://localhost:8080",
+				"restauthenabled":  "false",
+				"volumenameprefix": "_",
+			},
+			&secret,
+			true, // expect error
+			nil,
+		},
+		{
+			"invalid volumenameprefix: string with '_'",
+			map[string]string{
+				"resturl":          "https://localhost:8080",
+				"restauthenabled":  "false",
+				"volumenameprefix": "qe_dept",
 			},
 			&secret,
 			true, // expect error


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
