### PR TITLE
[prometheus addon] Use secure kubelet port

### DIFF
--- a/cluster/addons/prometheus/prometheus-configmap.yaml
+++ b/cluster/addons/prometheus/prometheus-configmap.yaml
@@ -37,11 +37,11 @@ data:
       relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
-      - source_labels: [__address__]
-        action: replace
-        target_label: __address__
-        regex: ([^:;]+):(\d+)
-        replacement: ${1}:10255
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
     - job_name: kubernetes-nodes-cadvisor
       kubernetes_sd_configs:
@@ -49,11 +49,13 @@ data:
       relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
-      - source_labels: [__address__]
-        action: replace
-        target_label: __address__
-        regex: ([^:;]+):(\d+)
-        replacement: ${1}:4194
+      - target_label: __metrics_path__
+        replacement: /metrics/cadvisor
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
     - job_name: kubernetes-service-endpoints
       kubernetes_sd_configs:

--- a/cluster/addons/prometheus/prometheus-rbac.yaml
+++ b/cluster/addons/prometheus/prometheus-rbac.yaml
@@ -19,6 +19,7 @@ rules:
       - ""
     resources:
       - nodes
+      - nodes/metrics
       - services
       - endpoints
       - pods


### PR DESCRIPTION
This PR changes port used by prometheus server to kubelet secure port. To access endpoints for metrics it adds "nodes/metrics" resource to rbac.
Previously it was not possible to authorize to kubelet in GCP, because Token Auth was disabled.
PR that enabled Token Auth in GCP https://github.com/kubernetes/kubernetes/pull/58178
```release-note
NONE
```
/cc @brancz @kawych
