### PR TITLE
Set default sorting order for kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -370,10 +370,14 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		return err
 	}
 	var sorter *kubectl.RuntimeSort
-	if o.Sort && len(objs) > 1 {
-		// TODO: questionable
-		if sorter, err = kubectl.SortObjects(cmdutil.InternalVersionDecoder(), objs, sorting); err != nil {
-			return err
+	if len(objs) > 1 {
+		if o.Sort {
+			// TODO: questionable
+			if sorter, err = kubectl.SortObjects(cmdutil.InternalVersionDecoder(), objs, sorting); err != nil {
+				return err
+			}
+		} else {
+			sorter, err = kubectl.SortObjects(cmdutil.InternalVersionDecoder(), objs, "{.lastTimestamp}")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

By default the output of 'kubectl get' is not sorted,
which could be inconvenient for users in some cases.

For example 'kubectl get events' output looks better if
sorted by 'LAST SEEN' column as users usually more interested
in the latest events.
    
Sorting 'kubectl get' output by {.lastTimestamp} if applicable should solve this.

```release-note
NONE
```