### PR TITLE
Automated cherry pick of #62751: Bump GLBC manifest to v1.1.1

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.0.1
+  name: l7-lb-controller-v1.1.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.0.1
+    version: v1.1.1
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.0.1
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.1
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Cherry pick of #62751 on release-1.10.

#62751: Bump GLBC manifest to v1.1.1