### PR TITLE
Kubeadm: Update comments and UT to remove /66 restriction

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -275,9 +275,6 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 // If the pod network size is /113 or larger, the node CIDR will be set to the same
 // size and this will be rejected later in validation.
 //
-// NOTE: Currently, the pod network must be /66 or larger. It is not reflected here,
-// but a smaller value will fail later validation.
-//
 // NOTE: Currently, the design allows a maximum of 64K nodes. This algorithm splits
 // the available bits to maximize the number used for nodes, but still have the node
 // CIDR be a multiple of eight.

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -823,14 +823,19 @@ func TestCalcNodeCidrSize(t *testing.T) {
 			expectedPrefix: "104",
 		},
 		{
-			name:           "V6: Largest subnet currently supported",
-			podSubnet:      "2001:db8::/66",
-			expectedPrefix: "80",
-		},
-		{
 			name:           "V6: For /64 pod net, use /80",
 			podSubnet:      "2001:db8::/64",
 			expectedPrefix: "80",
+		},
+		{
+			name:           "V6: For /48 pod net, use /64",
+			podSubnet:      "2001:db8::/48",
+			expectedPrefix: "64",
+		},
+		{
+			name:           "V6: For /32 pod net, use /48",
+			podSubnet:      "2001:db8::/32",
+			expectedPrefix: "48",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION

**What this PR does / why we need it**:
The comments in cmd/kubeadm/app/phases/controlplane/manifests.go mention the
IPv6 /66 restriction, and the UT also refers to this.
This restriction was removed in PR#60089
This removes those comments and updates the UT

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62806 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note-none

```
