### PR TITLE
pkg/kubelet: do not print device status on each node sync

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -592,7 +592,6 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 		devicePluginCapacity, devicePluginAllocatable, removedDevicePlugins = kl.containerManager.GetDevicePluginResourceCapacity()
 		if devicePluginCapacity != nil {
 			for k, v := range devicePluginCapacity {
-				glog.V(2).Infof("Update capacity for %s to %d", k, v.Value())
 				node.Status.Capacity[k] = v
 			}
 		}
@@ -637,7 +636,6 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 	}
 	if devicePluginAllocatable != nil {
 		for k, v := range devicePluginAllocatable {
-			glog.V(2).Infof("Update allocatable for %s to %d", k, v.Value())
 			node.Status.Allocatable[k] = v
 		}
 	}


### PR DESCRIPTION
Devices status were printed on each node status sync (10s by default),
it was the only place in setNodeStatusMachineInfo that was doing so.

In addition, the values "allocatable" and "capacity" are known to be
confusing for users, this periodic logging might be mistaken for an
actual problem with the devices or the device plugin itself.

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>

I don't think there is a lot of value in keeping these lines (even at a lower log level), what do you think?

/sig node

/area hw-accelerators

/cc @jiayingz @RenaudWasTaken

```release-note
NONE
```
