### PR TITLE
authz: nodes should not be able to delete themselves

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -105,7 +105,7 @@ func NodeRules() []rbac.PolicyRule {
 		// Use the NodeRestriction admission plugin to limit a node to creating/updating its own API object.
 		rbac.NewRule("create", "get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 		rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
-		rbac.NewRule("update", "patch", "delete").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
 		// TODO: restrict to the bound node as creator in the NodeRestrictions admission plugin
 		rbac.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1067,7 +1067,6 @@ items:
     resources:
     - nodes
     verbs:
-    - delete
     - patch
     - update
   - apiGroups:

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -418,7 +418,8 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, createNode2MirrorPodEviction(node2Client))
 	expectAllowed(t, createNode2(node2Client))
 	expectAllowed(t, updateNode2Status(node2Client))
-	expectAllowed(t, deleteNode2(node2Client))
+	// cleanup node
+	expectAllowed(t, deleteNode2(superuserClient))
 
 	// create a pod as an admin to add object references
 	expectAllowed(t, createNode2NormalPod(superuserClient))
@@ -508,8 +509,10 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, unsetNode2ConfigSource(superuserClient))
 	// node2 can no longer get the configmap after it is unassigned as its config source
 	expectForbidden(t, getConfigMapConfigSource(node2Client))
+	// node should not be able to delete itself
+	expectForbidden(t, deleteNode2(node2Client))
 	// clean up node2
-	expectAllowed(t, deleteNode2(node2Client))
+	expectAllowed(t, deleteNode2(superuserClient))
 
 	//TODO(mikedanese): integration test node restriction of TokenRequest
 }


### PR DESCRIPTION
@kubernetes/sig-auth-pr-reviews 

legacy release note (removed because this was reverted in https://github.com/kubernetes/kubernetes/pull/63712):
```
kubelets are no longer allowed to delete their own Node API object. Prior to 1.11, in rare circumstances related to cloudprovider node ID changes, kubelets would attempt to delete/recreate their Node object at startup. If a legacy kubelet encounters this situation, a cluster admin can remove the Node object:
* `kubectl delete node/<nodeName>`
or grant self-deletion permission explicitly:
* `kubectl create clusterrole self-deleting-nodes --verb=delete --resource=nodes`
* `kubectl create clusterrolebinding self-deleting-nodes --clusterrole=self-deleting-nodes --group=system:nodes`
```

```release-note
NONE
```