### PR TITLE
Enable kubeadm to configure auditing webhook

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -118,9 +118,11 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				},
 			}
 			obj.AuditPolicyConfiguration = kubeadm.AuditPolicyConfiguration{
-				Path:      "foo",
-				LogDir:    "/foo",
-				LogMaxAge: utilpointer.Int32Ptr(0),
+				Path:                  "foo",
+				LogDir:                "/foo",
+				LogMaxAge:             utilpointer.Int32Ptr(0),
+				WebhookConfigPath:     "foo",
+				WebhookInitialBackoff: "30s",
 			}
 		},
 		func(obj *kubeadm.NodeConfiguration, c fuzz.Continue) {

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -310,6 +310,10 @@ type AuditPolicyConfiguration struct {
 	LogDir string
 	// LogMaxAge is the number of days logs will be stored for. 0 indicates forever.
 	LogMaxAge *int32
+	// WebhookConfigPath is the local path to webhook policy.
+	WebhookConfigPath string
+	// WebhookInitialBackoff is the time to wait (in seconds) before retrying the first failed request.
+	WebhookInitialBackoff string //defaults to 10s if not provided
 	//TODO(chuckha) add other options for audit policy.
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -295,5 +295,9 @@ type AuditPolicyConfiguration struct {
 	LogDir string `json:"logDir"`
 	// LogMaxAge is the number of days logs will be stored for. 0 indicates forever.
 	LogMaxAge *int32 `json:"logMaxAge,omitempty"`
+	// WebhookConfigPath is the local path to webhook policy.
+	WebhookConfigPath string `json:"webhookConfigPath,omitempty"`
+	// WebhookInitialBackoff is the time to wait (in seconds) before retrying the first failed request.
+	WebhookInitialBackoff string `json:"webhookInitialBackoff,omitempty"`
 	//TODO(chuckha) add other options for audit policy.
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -93,6 +93,8 @@ func autoConvert_v1alpha1_AuditPolicyConfiguration_To_kubeadm_AuditPolicyConfigu
 	out.Path = in.Path
 	out.LogDir = in.LogDir
 	out.LogMaxAge = (*int32)(unsafe.Pointer(in.LogMaxAge))
+	out.WebhookConfigPath = in.WebhookConfigPath
+	out.WebhookInitialBackoff = in.WebhookInitialBackoff
 	return nil
 }
 
@@ -105,6 +107,8 @@ func autoConvert_kubeadm_AuditPolicyConfiguration_To_v1alpha1_AuditPolicyConfigu
 	out.Path = in.Path
 	out.LogDir = in.LogDir
 	out.LogMaxAge = (*int32)(unsafe.Pointer(in.LogMaxAge))
+	out.WebhookConfigPath = in.WebhookConfigPath
+	out.WebhookInitialBackoff = in.WebhookInitialBackoff
 	return nil
 }
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -319,6 +319,13 @@ func (i *Init) Run(out io.Writer) error {
 				return fmt.Errorf("error creating default audit policy %q [%v]", i.cfg.AuditPolicyConfiguration.Path, err)
 			}
 		}
+		// Verify the AuditWebhookConfigFile (verify it exists if it was passed in)
+		if i.cfg.AuditPolicyConfiguration.WebhookConfigPath != "" {
+			// TODO(hh) ensure passed in audit webhook config is valid so users don't have to find the error in the api server log.
+			if _, err := os.Stat(i.cfg.AuditPolicyConfiguration.WebhookConfigPath); err != nil {
+				return fmt.Errorf("error getting file info for audit webhook config file %q [%v]", i.cfg.AuditPolicyConfiguration.WebhookConfigPath, err)
+			}
+		}
 	}
 
 	// Temporarily set cfg.CertificatesDir to the "real value" when writing controlplane manifests

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -249,6 +249,10 @@ const (
 	AuditPolicyDir = "audit"
 	// AuditPolicyFile is the name of the audit policy file itself
 	AuditPolicyFile = "audit.yaml"
+	// KubeAuditWebhookConfigVolumeName is the name of the volume that will contain the audit webhook config
+	KubeAuditWebhookConfigVolumeName = "audit-webhook-config"
+	// AuditWebhookConfigFile is the name of the audit webhook config file itself
+	AuditWebhookConfigFile = "webhook.yaml"
 	// AuditPolicyLogFile is the name of the file audit logs get written to
 	AuditPolicyLogFile = "audit.log"
 	// KubeAuditPolicyLogVolumeName is the name of the volume that will contain the audit logs
@@ -370,4 +374,9 @@ func GetDNSIP(svcSubnet string) (net.IP, error) {
 // GetStaticPodAuditPolicyFile returns the path to the audit policy file within a static pod
 func GetStaticPodAuditPolicyFile() string {
 	return filepath.Join(KubernetesDir, AuditPolicyDir, AuditPolicyFile)
+}
+
+// GetStaticPodAuditWebhookConfigFile returns the path to the audit webhook config file within a static pod
+func GetStaticPodAuditWebhookConfigFile() string {
+	return filepath.Join(KubernetesDir, AuditPolicyDir, AuditWebhookConfigFile)
 }

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -217,6 +217,12 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 		} else {
 			defaultArguments["audit-log-maxage"] = fmt.Sprintf("%d", *cfg.AuditPolicyConfiguration.LogMaxAge)
 		}
+		if cfg.AuditPolicyConfiguration.WebhookConfigPath != "" {
+			command = append(command, "--audit-webhook-config-file="+kubeadmconstants.GetStaticPodAuditWebhookConfigFile())
+		}
+		if cfg.AuditPolicyConfiguration.WebhookInitialBackoff != "" {
+			command = append(command, fmt.Sprintf("--audit-webhook-initial-backoff=%s", cfg.AuditPolicyConfiguration.WebhookInitialBackoff))
+		}
 	}
 
 	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.APIServerExtraArgs)...)

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -225,10 +225,12 @@ func TestGetAPIServerCommand(t *testing.T) {
 				Etcd:            kubeadmapi.Etcd{CertFile: "fiz", KeyFile: "faz"},
 				CertificatesDir: testCertsDir,
 				AuditPolicyConfiguration: kubeadmapi.AuditPolicyConfiguration{
-					Path:      "/foo/bar",
-					LogDir:    "/foo/baz",
-					LogMaxAge: utilpointer.Int32Ptr(10),
-				},
+					Path:                  "/foo/bar",
+					LogDir:                "/foo/baz",
+					LogMaxAge:             utilpointer.Int32Ptr(10),
+					WebhookConfigPath:     "/foo/bar/baz",
+					WebhookInitialBackoff: "30s",
+				}, // ignored without the feature gate
 			},
 			expected: []string{
 				"kube-apiserver",
@@ -416,6 +418,8 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--audit-policy-file=/etc/kubernetes/audit/audit.yaml",
 				"--audit-log-path=/var/log/kubernetes/audit/audit.log",
 				"--audit-log-maxage=0",
+				"--audit-webhook-config-file=/etc/kubernetes/audit/webhook.yaml",
+				"--audit-webhook-initial-backoff=30s",
 			},
 		},
 		{

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -58,6 +58,10 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	if features.Enabled(cfg.FeatureGates, features.Auditing) {
 		// Read-only mount for the audit policy file.
 		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditPolicyVolumeName, cfg.AuditPolicyConfiguration.Path, kubeadmconstants.GetStaticPodAuditPolicyFile(), true, &hostPathFile)
+		// Read-only mount for the audit webhook config file.
+		if cfg.AuditPolicyConfiguration.WebhookConfigPath != "" {
+			mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditWebhookConfigVolumeName, cfg.AuditPolicyConfiguration.WebhookConfigPath, kubeadmconstants.GetStaticPodAuditWebhookConfigFile(), true, &hostPathFile)
+		}
 		// Write mount for the audit logs.
 		mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeAuditPolicyLogVolumeName, cfg.AuditPolicyConfiguration.LogDir, kubeadmconstants.StaticPodAuditPolicyLogDir, false, &hostPathDirectoryOrCreate)
 	}

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -289,6 +289,15 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 			},
 		},
 	}
+	volMap[kubeadmconstants.KubeAPIServer]["audit"] = v1.Volume{
+		Name: "audit-webhook",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: "/foo/bar/buzz.yaml",
+				Type: &hostPathFile,
+			},
+		},
+	}
 	volMap[kubeadmconstants.KubeAPIServer]["audit-log"] = v1.Volume{
 		Name: "audit-log",
 		VolumeSource: v1.VolumeSource{
@@ -351,6 +360,11 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 	volMountMap[kubeadmconstants.KubeAPIServer]["audit"] = v1.VolumeMount{
 		Name:      "audit",
 		MountPath: "/etc/kubernetes/audit/audit.yaml",
+		ReadOnly:  true,
+	}
+	volMountMap[kubeadmconstants.KubeAPIServer]["audit"] = v1.VolumeMount{
+		Name:      "audit-webhook",
+		MountPath: "/etc/kubernetes/audit/webhook.yaml",
 		ReadOnly:  true,
 	}
 	volMountMap[kubeadmconstants.KubeAPIServer]["audit-log"] = v1.VolumeMount{
@@ -513,8 +527,9 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 				Etcd:            kubeadmapi.Etcd{},
 				FeatureGates:    map[string]bool{features.Auditing: true},
 				AuditPolicyConfiguration: kubeadmapi.AuditPolicyConfiguration{
-					Path:   "/foo/bar/baz.yaml",
-					LogDir: "/bar/foo",
+					Path:              "/foo/bar/baz.yaml",
+					LogDir:            "/bar/foo",
+					WebhookConfigPath: "/bar/foo/buzz.yaml",
 				},
 			},
 			vol:      volMap,


### PR DESCRIPTION
**What this PR does / why we need it**:

kubeadm should be able to configure an [audit webook backend](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#webhook-backend).

**Which issue(s) this PR fixes**

kubernetes/kubeadm/issues/759

**Special notes for your reviewer**:

First k8s PR, guidance welcome.

**Release note**:

```release-note
Enable kubeadm configuration of Auditing Webhook Backend
```
