### PR TITLE
Ignore resourceversion field when creating resource object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -18,7 +18,6 @@ package etcd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -122,9 +121,6 @@ func (h *etcdHelper) Create(ctx context.Context, key string, obj, out runtime.Ob
 	trace.Step("Object encoded")
 	if err != nil {
 		return err
-	}
-	if version, err := h.versioner.ObjectResourceVersion(obj); err == nil && version != 0 {
-		return errors.New("resourceVersion may not be set on objects to be created")
 	}
 	if err := h.versioner.PrepareObjectForStorage(obj); err != nil {
 		return fmt.Errorf("PrepareObjectForStorage returned an error: %v", err)
@@ -532,7 +528,7 @@ func (h *etcdHelper) GuaranteedUpdate(
 
 		// Since update object may have a resourceVersion set, we need to clear it here.
 		if err := h.versioner.PrepareObjectForStorage(ret); err != nil {
-			return errors.New("resourceVersion cannot be set on objects store in etcd")
+			return fmt.Errorf("PrepareObjectForStorage failed: %v", err)
 		}
 
 		newBodyData, err := runtime.Encode(h.codec, ret)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -149,9 +148,6 @@ func (s *store) Get(ctx context.Context, key string, resourceVersion string, out
 
 // Create implements storage.Interface.Create.
 func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
-	if version, err := s.versioner.ObjectResourceVersion(obj); err == nil && version != 0 {
-		return errors.New("resourceVersion should not be set on objects to be created")
-	}
 	if err := s.versioner.PrepareObjectForStorage(obj); err != nil {
 		return fmt.Errorf("PrepareObjectForStorage failed: %v", err)
 	}


### PR DESCRIPTION
As `PrepareObjectForStorage` will cleanup resource version, so no need to fail creating with resource version is not 0. We can just ignore the resourceversion.
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L152-L157

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
