### PR TITLE
add crds for shortname for customresourcedefinition in ValidResourceTypeList

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -251,7 +251,7 @@ func ValidResourceTypeList(f ClientAccessFactory) string {
 			* configmaps (aka 'cm')
 			* controllerrevisions
 			* cronjobs
-			* customresourcedefinition (aka 'crd')
+			* customresourcedefinitions (aka 'crd','crds')
 			* daemonsets (aka 'ds')
 			* deployments (aka 'deploy')
 			* endpoints (aka 'ep')


### PR DESCRIPTION
**What this PR does / why we need it**:
add crds for shortname for customresourcedefinition in ValidResourceTypeList
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
```
kubectl api-resources
NAME                              SHORTNAMES   APIGROUP                       NAMESPACED   KIND
validatingwebhookconfigurations                admissionregistration.k8s.io   false        ValidatingWebhookConfiguration
customresourcedefinitions         crd,crds     apiextensions.k8s.io           false        CustomResourceDefinition
apiservices                                    apiregistration.k8s.io         false        APIService
controllerrevisions                            apps                           true         ControllerRevision
```

```
kubectl get --help
Valid resource types include:
  * all
  * certificatesigningrequests (aka 'csr')
  * clusterrolebindings
  * clusterroles
  * componentstatuses (aka 'cs')
  * configmaps (aka 'cm')
  * controllerrevisions
  * cronjobs
  * customresourcedefinition (aka 'crd')
  * daemonsets (aka 'ds')
```

```
// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
func (r *REST) ShortNames() []string {
	return []string{"crd", "crds"}
}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
