### PR TITLE
apimachinery: expose ObjectReflectDiff print limits to callers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -79,6 +79,10 @@ func ObjectGoPrintDiff(a, b interface{}) string {
 }
 
 func ObjectReflectDiff(a, b interface{}) string {
+	return ObjectReflectDiffN(a, b, 80)
+}
+
+func ObjectReflectDiffN(a, b interface{}, n int) string {
 	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
 	if vA.Type() != vB.Type() {
 		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
@@ -91,8 +95,8 @@ func ObjectReflectDiff(a, b interface{}) string {
 	for _, d := range diffs {
 		out = append(out,
 			fmt.Sprintf("%s:", d.path),
-			limit(fmt.Sprintf("  a: %#v", d.a), 80),
-			limit(fmt.Sprintf("  b: %#v", d.b), 80),
+			limit(fmt.Sprintf("  a: %#v", d.a), n),
+			limit(fmt.Sprintf("  b: %#v", d.b), n),
 		)
 	}
 	return strings.Join(out, "\n")


### PR DESCRIPTION
When using `ObjectReflectDiff()` on objects with long string fields, the
80 character limit on diffs will commonly hide the actual difference
between the fields and require that the dev change which diff function
is used to see what the issue was. This defeats the purpose of printing
the diff between objects. Without refactoring how a diff is presented,
the issue can be worked around by exposing the print limit and allowing
it to be extended.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>


```release-note
NONE
```

Example bad output from today's diff API:

```
--- FAIL: TestProwJobToPod (0.01s)
	podspec_test.go:331: expected pod:
		
		object.Spec.Containers[0].Env[4].Value:
		  a: "{\"args\":[\"/bin/thing\",\"some\",\"args\"],\"timeout\":7200000000000,\"g
		  b: "{\"args\":[\"/bin/thing\",\"some\",\"args\"],\"timeout\":7200000000000,\"g
FAIL
```