### PR TITLE
Fix typo in kubectl --all-containers flag usage

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -228,7 +228,7 @@ func (o LogsOptions) Validate() error {
 		return errors.New("unexpected logs options object")
 	}
 	if o.AllContainers && len(logsOptions.Container) > 0 {
-		return fmt.Errorf("--all-containers=true should not be specifiled with container name %s", logsOptions.Container)
+		return fmt.Errorf("--all-containers=true should not be specified with container name %s", logsOptions.Container)
 	}
 	if errs := validation.ValidatePodLogOptions(logsOptions); len(errs) > 0 {
 		return errs.ToAggregate()

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -140,7 +140,7 @@ func TestValidateLogFlags(t *testing.T) {
 			name:     "container name combined with --all-containers",
 			flags:    map[string]string{"all-containers": "true"},
 			args:     []string{"my-pod", "my-container"},
-			expected: "--all-containers=true should not be specifiled with container",
+			expected: "--all-containers=true should not be specified with container",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This pull requests fixes a typo in kubectl usage for the flag --all-containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
