### PR TITLE
remove discovery injection from factory

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -113,13 +113,10 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/rest/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -118,8 +118,6 @@ type ClientAccessFactory interface {
 	// LabelsForObject returns the labels associated with the provided object
 	LabelsForObject(object runtime.Object) (map[string]string, error)
 
-	// Returns internal flagset
-	FlagSet() *pflag.FlagSet
 	// Command will stringify and return all environment arguments ie. a command run by a client
 	// using the factory.
 	Command(cmd *cobra.Command, showSecrets bool) string

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -32,11 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apiserver/pkg/util/flag"
 	manualfake "k8s.io/client-go/rest/fake"
 	testcore "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -46,23 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/categories"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
-
-func TestNewFactoryDefaultFlagBindings(t *testing.T) {
-	factory := NewFactory(nil)
-
-	if !factory.FlagSet().HasFlags() {
-		t.Errorf("Expected flags, but didn't get any")
-	}
-}
-
-func TestNewFactoryNoFlagBindings(t *testing.T) {
-	clientConfig := clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})
-	factory := NewFactory(clientConfig)
-
-	if factory.FlagSet().HasFlags() {
-		t.Errorf("Expected zero flags, but got %v", factory.FlagSet())
-	}
-}
 
 func TestPortsForObject(t *testing.T) {
 	f := NewFactory(nil)
@@ -208,18 +188,6 @@ func TestCanBeExposed(t *testing.T) {
 		if !test.expectErr && err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-	}
-}
-
-func TestFlagUnderscoreRenaming(t *testing.T) {
-	factory := NewFactory(nil)
-
-	factory.FlagSet().SetNormalizeFunc(flag.WordSepNormalizeFunc)
-	factory.FlagSet().Bool("valid_flag", false, "bool value")
-
-	// In case of failure of this test check this PR: spf13/pflag#23
-	if factory.FlagSet().Lookup("valid_flag").Name != "valid-flag" {
-		t.Fatalf("Expected flag name to be valid-flag, got %s", factory.FlagSet().Lookup("valid_flag").Name)
 	}
 }
 


### PR DESCRIPTION
We added this shim when cached discovery was a contentious thing to give ourselves flexibility.  It is no longer contentious and this removes a layer of complexity we no longer need.

@kubernetes/sig-cli-maintainers 
@soltysh @juanvallejo 

```release-note
NONE
```