### PR TITLE
make describers more generic from the CLI

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -89,7 +89,6 @@ go_library(
         "//pkg/kubectl/util/term:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//pkg/printers:go_default_library",
-        "//pkg/printers/internalversion:go_default_library",
         "//pkg/util/interrupt:go_default_library",
         "//pkg/util/taints:go_default_library",
         "//pkg/version:go_default_library",

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -26,13 +26,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/printers"
-	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 )
 
 var (
@@ -75,11 +73,6 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 		ShowEvents: true,
 	}
 
-	// TODO: this should come from the factory, and may need to be loaded from the server, and so is probably
-	//   going to have to be removed
-	validArgs := printersinternal.DescribableResources()
-	argAliases := kubectl.ResourceAliases(validArgs)
-
 	cmd := &cobra.Command{
 		Use: "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		DisableFlagsInUseLine: true,
@@ -90,8 +83,6 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)
 			cmdutil.CheckErr(err)
 		},
-		ValidArgs:  validArgs,
-		ArgAliases: argAliases,
 	}
 	usage := "containing the resource to describe"
 	cmdutil.AddFilenameOptionFlags(cmd, options, usage)

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -164,16 +164,12 @@ func (f *ring1Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (
 }
 
 func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (printers.Describer, error) {
-	clientset, err := f.clientAccessFactory.ClientSet()
-	if err != nil {
-		return nil, err
-	}
-	externalclientset, err := f.clientAccessFactory.KubernetesClientSet()
+	clientConfig, err := f.clientAccessFactory.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
 	// try to get a describer
-	if describer, ok := printersinternal.DescriberFor(mapping.GroupVersionKind.GroupKind(), clientset, externalclientset); ok {
+	if describer, ok := printersinternal.DescriberFor(mapping.GroupVersionKind.GroupKind(), clientConfig); ok {
 		return describer, nil
 	}
 	// if this is a kind we don't have a describer for yet, go generic if possible

--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -107,6 +107,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 


### PR DESCRIPTION
I've made this change very small so the intent and explanation make sense to people.

Clients are not generic.  Client**Configs** are generic.  We faced this distinction in the apiserver and it took us a little to hurdle it.  When you try to provide a generic example or function, you need to provide Client**Config**, not a kube clientset.  The reason is that the code you're calling may have generated their own clientset, may want to use a dynamic one, or may want to a simple restclient.  As we seek to make `kubectl` primitives more generally applicable, this is an example we'll want to follow.  I suspect we'll be making more changes along these veins as we tease out the generic pieces of `kubectl ` to make a friendly CLI library.


@kubernetes/sig-cli-maintainers 

/hold

Holding for a few days to make sure that people have time to read and digest.

```release-note
NONE
```