### PR TITLE
GCE: Fix ILB issue updating backend services

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -563,6 +563,9 @@ func (gce *GCECloud) ensureInternalBackendServiceGroups(name string, igLinks []s
 		return nil
 	}
 
+	// Set the backend service's backends to the updated list.
+	bs.Backends = backends
+
 	glog.V(2).Infof("ensureInternalBackendServiceGroups: updating backend service %v", name)
 	if err := gce.UpdateRegionBackendService(bs, gce.region); err != nil {
 		return err
@@ -575,8 +578,7 @@ func shareBackendService(svc *v1.Service) bool {
 	return GetLoadBalancerAnnotationBackendShare(svc) && !v1_service.RequestsOnlyLocalTraffic(svc)
 }
 
-func backendsFromGroupLinks(igLinks []string) []*compute.Backend {
-	var backends []*compute.Backend
+func backendsFromGroupLinks(igLinks []string) (backends []*compute.Backend) {
 	for _, igLink := range igLinks {
 		backends = append(backends, &compute.Backend{
 			Group: igLink,

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -52,20 +52,22 @@ const (
 )
 
 type TestClusterValues struct {
-	ProjectID   string
-	Region      string
-	ZoneName    string
-	ClusterID   string
-	ClusterName string
+	ProjectID         string
+	Region            string
+	ZoneName          string
+	SecondaryZoneName string
+	ClusterID         string
+	ClusterName       string
 }
 
 func DefaultTestClusterValues() TestClusterValues {
 	return TestClusterValues{
-		ProjectID:   "test-project",
-		Region:      "us-central1",
-		ZoneName:    "us-central1-b",
-		ClusterID:   "test-cluster-id",
-		ClusterName: "Test Cluster Name",
+		ProjectID:         "test-project",
+		Region:            "us-central1",
+		ZoneName:          "us-central1-b",
+		SecondaryZoneName: "us-central1-c",
+		ClusterID:         "test-cluster-id",
+		ClusterName:       "Test Cluster Name",
 	}
 }
 


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62878
`ensureInternalBackendServiceGroups` would sync the instance groups with the latest nodes, and update the backend service's list of backends if necessary. However, the list of backends on the backend service was not set before calling the GCP API.

`updateInternalLoadBalancerNodes` does very little above `ensureInternalBackendServiceGroups`, so I'm just combining the unit tests into one.

**Special notes for your reviewer**:
/assign MrHohn
cc @agau4779 

**Release note**:
```release-note
GCE: Fix for internal load balancer management resulting in backend services with outdated instance group links.
```
