### PR TITLE
GCE: Fix ILB issue updating backend services

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -563,6 +563,9 @@ func (gce *GCECloud) ensureInternalBackendServiceGroups(name string, igLinks []s
 		return nil
 	}
 
+	// Set the backend service's backends to the updated list.
+	bs.Backends = backends
+
 	glog.V(2).Infof("ensureInternalBackendServiceGroups: updating backend service %v", name)
 	if err := gce.UpdateRegionBackendService(bs, gce.region); err != nil {
 		return err


### PR DESCRIPTION
Cherrypick of #62885 on release-1.10.

#62885 GCE: Fix ILB issue updating backend services 

This is not an automated cherrypick as HEAD fix contained unit test changes and unit tests don't exist at this version.

**Release note**:
```release-note
GCE: Fix for internal load balancer management resulting in backend services with outdated instance group links.
```
