### PR TITLE
Automated cherry pick of #62887: Fix ILB issue updating backend services

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -567,6 +567,9 @@ func (gce *GCECloud) ensureInternalBackendServiceGroups(name string, igLinks []s
 		return nil
 	}
 
+	// Set the backend service's backends to the updated list.
+	bs.Backends = backends
+
 	glog.V(2).Infof("ensureInternalBackendServiceGroups: updating backend service %v", name)
 	if err := gce.UpdateRegionBackendService(bs, gce.region); err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #62887 on release-1.9.

#62887: Fix ILB issue updating backend services

**Release note**:
```release-note
GCE: Fix for internal load balancer management resulting in backend services with outdated instance group links.
```