### PR TITLE
add index to node-authorizer for high cardinality vertices

### DIFF
--- a/plugin/pkg/auth/authorizer/node/BUILD
+++ b/plugin/pkg/auth/authorizer/node/BUILD
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "graph_test.go",
+        "intset_test.go",
         "node_authorizer_test.go",
     ],
     embed = [":go_default_library"],
@@ -33,6 +34,7 @@ go_library(
     srcs = [
         "graph.go",
         "graph_populator.go",
+        "intset.go",
         "node_authorizer.go",
     ],
     importpath = "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node",

--- a/plugin/pkg/auth/authorizer/node/graph_test.go
+++ b/plugin/pkg/auth/authorizer/node/graph_test.go
@@ -42,6 +42,7 @@ func TestDeleteEdges_locked(t *testing.T) {
 			toName:      "node1",
 			start: func() *Graph {
 				g := NewGraph()
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap2")
 				nodeVertex := g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
 				configmapVertex := g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap1")
 				g.graph.SetEdge(newDestinationEdge(configmapVertex, nodeVertex, nodeVertex))
@@ -49,6 +50,7 @@ func TestDeleteEdges_locked(t *testing.T) {
 			}(),
 			expect: func() *Graph {
 				g := NewGraph()
+				g.getOrCreateVertex_locked(configMapVertexType, "namespace1", "configmap2")
 				g.getOrCreateVertex_locked(nodeVertexType, "", "node1")
 				return g
 			}(),

--- a/plugin/pkg/auth/authorizer/node/intset.go
+++ b/plugin/pkg/auth/authorizer/node/intset.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+// intSet maintains a set of ints, and supports promoting and culling the previous generation.
+// this allows tracking a large, mostly-stable set without constantly reallocating the entire set.
+type intSet struct {
+	currentGeneration byte
+	members           map[int]byte
+}
+
+func newIntSet() *intSet {
+	return &intSet{members: map[int]byte{}}
+}
+
+// has returns true if the specified int is in the set.
+// it is safe to call concurrently, but must not be called concurrently with any of the other methods.
+func (s *intSet) has(i int) bool {
+	if s == nil {
+		return false
+	}
+	_, present := s.members[i]
+	return present
+}
+
+// startNewGeneration begins a new generation.
+// it must be followed by a call to mark() for every member of the generation,
+// then a call to sweep() to remove members not present in the generation.
+// it is not thread-safe.
+func (s *intSet) startNewGeneration() {
+	s.currentGeneration++
+}
+
+// mark indicates the specified int belongs to the current generation.
+// it is not thread-safe.
+func (s *intSet) mark(i int) {
+	s.members[i] = s.currentGeneration
+}
+
+// sweep removes items not in the current generation.
+// it is not thread-safe.
+func (s *intSet) sweep() {
+	for k, v := range s.members {
+		if v != s.currentGeneration {
+			delete(s.members, k)
+		}
+	}
+}

--- a/plugin/pkg/auth/authorizer/node/intset_test.go
+++ b/plugin/pkg/auth/authorizer/node/intset_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntSet(t *testing.T) {
+	i := newIntSet()
+
+	assert.False(t, i.has(1))
+	assert.False(t, i.has(2))
+	assert.False(t, i.has(3))
+	assert.False(t, i.has(4))
+
+	i.startNewGeneration()
+	i.mark(1)
+	i.mark(2)
+	i.sweep()
+
+	assert.True(t, i.has(1))
+	assert.True(t, i.has(2))
+	assert.False(t, i.has(3))
+	assert.False(t, i.has(4))
+
+	i.startNewGeneration()
+	i.mark(2)
+	i.mark(3)
+	i.sweep()
+
+	assert.False(t, i.has(1))
+	assert.True(t, i.has(2))
+	assert.True(t, i.has(3))
+	assert.False(t, i.has(4))
+
+	i.startNewGeneration()
+	i.mark(3)
+	i.mark(4)
+	i.sweep()
+
+	assert.False(t, i.has(1))
+	assert.False(t, i.has(2))
+	assert.True(t, i.has(3))
+	assert.True(t, i.has(4))
+}

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -212,6 +212,11 @@ func (r *NodeAuthorizer) hasPathFrom(nodeName string, startingType vertexType, s
 		return false, fmt.Errorf("node %q cannot get unknown %s %s/%s", nodeName, vertexTypes[startingType], startingNamespace, startingName)
 	}
 
+	// Fast check to see if we know of a destination edge
+	if r.graph.destinationEdgeIndex[startingVertex.ID()].has(nodeVertex.ID()) {
+		return true, nil
+	}
+
 	found := false
 	traversal := &traverse.VisitingDepthFirst{
 		EdgeFilter: func(edge graph.Edge) bool {


### PR DESCRIPTION
follow-up to https://github.com/kubernetes/kubernetes/pull/62856#issuecomment-382788780

explores adding an index to high-cardinality vertices in the node authorizer to reduce CPU usage for high density namespaces

* first commit is a refactor only - cc @mtaufen 
* second commit adds an optional per-vertex index we can maintain when there are sufficient outgoing edges.

benchmark results:
* shared_secret_via_pod cases are ~1000x faster
* throughput on processing of graph modifications is 50% higher
* there is more variance on graph modifications requiring index updates (though the 100 index-impacting graph modifications per second might be a higher-than-realistic write rate)

data profile (5000 pods per namespace, assigned to 5000 nodes, shared service account and secret):
```
        opts := sampleDataOpts{
                // To simulate high replication in a small number of namespaces:
               nodes:       5000,
               namespaces:  10,
               podsPerNode: 10,
...
```

command:
```
$ go test ./plugin/pkg/auth/authorizer/node/  -bench Authorization  -benchmem -v 
```

before
```
BenchmarkAuthorization/allowed_node_configmap-8                                  557 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_configmap-8                                       539 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_secret_via_pod-8                                  605 ns/op   529 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_shared_secret_via_pod-8                        215974 ns/op   792 B/op   19 allocs/op      5000
BenchmarkAuthorization/disallowed_node_configmap-8                               823 ns/op   694 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_configmap-8                                    888 ns/op   691 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_secret_via_pod-8                               868 ns/op   694 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_shared_secret_via_pvc-8                       1216 ns/op   948 B/op   22 allocs/op   1000000
BenchmarkAuthorization/disallowed_pvc-8                                          918 ns/op   691 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_pv-8                                          1095 ns/op   839 B/op   19 allocs/op   2000000
BenchmarkAuthorization/disallowed_attachment_-_no_relationship-8                 867 ns/op   677 B/op   16 allocs/op   2000000
BenchmarkAuthorization/disallowed_attachment_-_feature_disabled-8                220 ns/op   208 B/op    2 allocs/op  10000000
BenchmarkAuthorization/allowed_attachment_-_feature_enabled-8                    687 ns/op   594 B/op   12 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_node_configmap-8                      656 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/contentious_allowed_configmap-8                           659 ns/op   529 B/op   11 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_secret_via_pod-8                      654 ns/op   529 B/op   11 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_shared_secret_via_pod-8            234308 ns/op  1022 B/op   22 allocs/op      5000
BenchmarkAuthorization/contentious_disallowed_node_configmap-8                  1118 ns/op   692 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_configmap-8                       1054 ns/op   692 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_secret_via_pod-8                  1059 ns/op   691 B/op   17 allocs/op   2000000
BenchmarkAuthorization/contentious_disallowed_shared_secret_via_pvc-8           1403 ns/op   949 B/op   22 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_pvc-8                             1058 ns/op   692 B/op   17 allocs/op   2000000
BenchmarkAuthorization/contentious_disallowed_pv-8                              1237 ns/op   838 B/op   19 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_attachment_-_no_relationship-8    1022 ns/op   676 B/op   16 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_attachment_-_feature_disabled-8    260 ns/op   209 B/op    2 allocs/op   5000000
BenchmarkAuthorization/contentious_allowed_attachment_-_feature_enabled-8        793 ns/op   594 B/op   12 allocs/op   2000000
--- BENCH: BenchmarkAuthorization
   node_authorizer_test.go:596: graph modifications during non-contention test: 0
   node_authorizer_test.go:593: graph modifications during contention test: 961
   node_authorizer_test.go:594: <1ms=774, <10ms=32, <25ms=14, <50ms=29, <100ms=62, <250ms=46, <500ms=2, <1000ms=1, >1000ms=1
```

after
```
BenchmarkAuthorization/allowed_node_configmap-8                                  629 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_configmap-8                                       641 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_secret_via_pod-8                                  591 ns/op   530 B/op   11 allocs/op   3000000
BenchmarkAuthorization/allowed_shared_secret_via_pod-8                           217 ns/op   160 B/op    1 allocs/op  10000000
BenchmarkAuthorization/disallowed_node_configmap-8                               912 ns/op   693 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_configmap-8                                    913 ns/op   694 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_secret_via_pod-8                               881 ns/op   691 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_shared_secret_via_pvc-8                       1271 ns/op   952 B/op   22 allocs/op   1000000
BenchmarkAuthorization/disallowed_pvc-8                                          903 ns/op   694 B/op   17 allocs/op   2000000
BenchmarkAuthorization/disallowed_pv-8                                          1024 ns/op   836 B/op   19 allocs/op   1000000
BenchmarkAuthorization/disallowed_attachment_-_no_relationship-8                1187 ns/op   678 B/op   16 allocs/op   2000000
BenchmarkAuthorization/disallowed_attachment_-_feature_disabled-8                250 ns/op   209 B/op    2 allocs/op  10000000
BenchmarkAuthorization/allowed_attachment_-_feature_enabled-8                    694 ns/op   594 B/op   12 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_node_configmap-8                      732 ns/op   530 B/op   11 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_configmap-8                           820 ns/op   530 B/op   11 allocs/op   2000000
BenchmarkAuthorization/contentious_allowed_secret_via_pod-8                     1082 ns/op   531 B/op   11 allocs/op   1000000
BenchmarkAuthorization/contentious_allowed_shared_secret_via_pod-8               274 ns/op   160 B/op    1 allocs/op   5000000
BenchmarkAuthorization/contentious_disallowed_node_configmap-8                  1332 ns/op   693 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_configmap-8                       1534 ns/op   693 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_secret_via_pod-8                  1077 ns/op   692 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_shared_secret_via_pvc-8           1976 ns/op   949 B/op   22 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_pvc-8                             1297 ns/op   694 B/op   17 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_pv-8                              1632 ns/op   837 B/op   19 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_attachment_-_no_relationship-8    1394 ns/op   677 B/op   16 allocs/op   1000000
BenchmarkAuthorization/contentious_disallowed_attachment_-_feature_disabled-8    320 ns/op   209 B/op    2 allocs/op   5000000
BenchmarkAuthorization/contentious_allowed_attachment_-_feature_enabled-8       1055 ns/op   595 B/op   12 allocs/op   2000000
--- BENCH: BenchmarkAuthorization
    node_authorizer_test.go:629: graph modifications during non-contention test: 0
    node_authorizer_test.go:626: graph modifications during contention test: 1424
    node_authorizer_test.go:627: <1ms=0, <10ms=569, <25ms=340, <50ms=145, <100ms=101, <250ms=160, <500ms=61, <1000ms=42, >1000ms=6
```

```release-note
NONE
```