### PR TITLE
mark APIServiceSpec.CABundle optional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -85395,7 +85395,6 @@
     "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
     "required": [
      "service",
-     "caBundle",
      "groupPriorityMinimum",
      "versionPriority"
     ],
@@ -85541,7 +85540,6 @@
     "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
     "required": [
      "service",
-     "caBundle",
      "groupPriorityMinimum",
      "versionPriority"
     ],

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
@@ -53,6 +53,7 @@ type APIServiceSpec struct {
 	// This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify bool
 	// CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
+	// +optional
 	CABundle []byte
 
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
@@ -89,6 +89,7 @@ message APIServiceSpec {
   optional bool insecureSkipTLSVerify = 4;
 
   // CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
+  // +optional
   optional bytes caBundle = 5;
 
   // GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -53,7 +53,8 @@ type APIServiceSpec struct {
 	// This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty" protobuf:"varint,4,opt,name=insecureSkipTLSVerify"`
 	// CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
-	CABundle []byte `json:"caBundle" protobuf:"bytes,5,opt,name=caBundle"`
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty" protobuf:"bytes,5,opt,name=caBundle"`
 
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.
 	// Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
@@ -89,6 +89,7 @@ message APIServiceSpec {
   optional bool insecureSkipTLSVerify = 4;
 
   // CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
+  // +optional
   optional bytes caBundle = 5;
 
   // GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -53,7 +53,8 @@ type APIServiceSpec struct {
 	// This is strongly discouraged.  You should use the CABundle instead.
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty" protobuf:"varint,4,opt,name=insecureSkipTLSVerify"`
 	// CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate.
-	CABundle []byte `json:"caBundle" protobuf:"bytes,5,opt,name=caBundle"`
+	// +optional
+	CABundle []byte `json:"caBundle,omitempty" protobuf:"bytes,5,opt,name=caBundle"`
 
 	// GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones.
 	// Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority.


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/60690#issuecomment-382842852
mark the caBundle field optional so openapi is accurate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
