### PR TITLE
Eventratelimit aggregates all reject errors

### DIFF
--- a/plugin/pkg/admission/eventratelimit/BUILD
+++ b/plugin/pkg/admission/eventratelimit/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/github.com/hashicorp/golang-lru:go_default_library",

--- a/plugin/pkg/admission/eventratelimit/limitenforcer.go
+++ b/plugin/pkg/admission/eventratelimit/limitenforcer.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hashicorp/golang-lru"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/client-go/util/flowcontrol"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -99,7 +98,7 @@ func (enforcer *limitEnforcer) accept(attr admission.Attributes) error {
 	allow := rateLimiter.TryAccept()
 
 	if !allow {
-		return apierrors.NewTooManyRequestsError(fmt.Sprintf("limit reached on type %v for key %v", enforcer.limitType, key))
+		return fmt.Errorf("limit reached on type %v for key %v", enforcer.limitType, key)
 	}
 
 	return nil


### PR DESCRIPTION
Previously, Eventratelimit validates event by each limiter but only returns the last reject error. Which is not accurate, so here I aggregate each error.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
