### PR TITLE
make a simple dynamic client that is easy to use

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -303,7 +303,7 @@ func (gc *GarbageCollector) isDangling(reference metav1.OwnerReference, item *no
 	// TODO: It's only necessary to talk to the API server if the owner node
 	// is a "virtual" node. The local graph could lag behind the real
 	// status, but in practice, the difference is small.
-	owner, err = client.Resource(resource, item.identity.Namespace).Get(reference.Name, metav1.GetOptions{})
+	owner, err = client.Resource(resource, resourceDefaultNamespace(resource, item.identity.Namespace)).Get(reference.Name, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
 		gc.absentOwnerCache.Add(reference.UID)

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -686,9 +686,13 @@ func TestOrphanDependentsFailure(t *testing.T) {
 		},
 	}
 	err := gc.orphanDependents(objectReference{}, dependents)
-	expected := `the server reported a conflict (patch pods pod)`
+	expected := `the server reported a conflict`
 	if err == nil || !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error contains text %s, got %v", expected, err)
+		if err != nil {
+			t.Errorf("expected error contains text %q, got %q", expected, err.Error())
+		} else {
+			t.Errorf("expected error contains text %q, got nil", expected)
+		}
 	}
 }
 

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -135,7 +135,7 @@ func listWatcher(client dynamic.Interface, resource schema.GroupVersionResource)
 			// namespaces if it's namespace scoped, so leave
 			// APIResource.Namespaced as false is all right.
 			apiResource := metav1.APIResource{Name: resource.Resource}
-			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
+			return client.
 				Resource(&apiResource, metav1.NamespaceAll).
 				List(options)
 		},
@@ -145,7 +145,7 @@ func listWatcher(client dynamic.Interface, resource schema.GroupVersionResource)
 			// namespaces if it's namespace scoped, so leave
 			// APIResource.Namespaced as false is all right.
 			apiResource := metav1.APIResource{Name: resource.Resource}
-			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
+			return client.
 				Resource(&apiResource, metav1.NamespaceAll).
 				Watch(options)
 		},

--- a/pkg/controller/namespace/deletion/BUILD
+++ b/pkg/controller/namespace/deletion/BUILD
@@ -31,7 +31,6 @@ go_test(
     srcs = ["namespaced_resources_deleter_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
@@ -173,14 +172,16 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 		defer srv.Close()
 
 		mockClient := fake.NewSimpleClientset(testInput.testNamespace)
-		clientPool := dynamic.NewClientPool(clientConfig, legacyscheme.Registry.RESTMapper(), dynamic.LegacyAPIPathResolverFunc)
+		dynamicClient, err := dynamic.NewForConfig(clientConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		fn := func() ([]*metav1.APIResourceList, error) {
 			return resources, nil
 		}
-		d := NewNamespacedResourcesDeleter(mockClient.Core().Namespaces(), clientPool, mockClient.Core(), fn, v1.FinalizerKubernetes, true)
-		err := d.Delete(testInput.testNamespace.Name)
-		if err != nil {
+		d := NewNamespacedResourcesDeleter(mockClient.Core().Namespaces(), dynamicClient, mockClient.Core(), fn, v1.FinalizerKubernetes, true)
+		if err := d.Delete(testInput.testNamespace.Name); err != nil {
 			t.Errorf("scenario %s - Unexpected error when synching namespace %v", scenario, err)
 		}
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -63,7 +63,7 @@ type NamespaceController struct {
 // NewNamespaceController creates a new NamespaceController
 func NewNamespaceController(
 	kubeClient clientset.Interface,
-	clientPool dynamic.ClientPool,
+	dynamicClient dynamic.DynamicInterface,
 	discoverResourcesFn func() ([]*metav1.APIResourceList, error),
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
@@ -72,7 +72,7 @@ func NewNamespaceController(
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "namespace"),
-		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(kubeClient.CoreV1().Namespaces(), clientPool, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken, true),
+		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(kubeClient.CoreV1().Namespaces(), dynamicClient, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken, true),
 	}
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -197,7 +197,7 @@ func genericDescriber(clientAccessFactory ClientAccessFactory, mapping *meta.RES
 	clientConfigCopy.GroupVersion = &gv
 
 	// used to fetch the resource
-	dynamicClient, err := dynamic.NewClient(&clientConfigCopy)
+	dynamicClient, err := dynamic.NewClient(&clientConfigCopy, gv)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
@@ -49,6 +49,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -58,6 +58,26 @@ func (obj *Unstructured) IsList() bool {
 	_, ok = field.([]interface{})
 	return ok
 }
+func (obj *Unstructured) ToList() (*UnstructuredList, error) {
+	if !obj.IsList() {
+		// return an empty list back
+		return &UnstructuredList{Object: obj.Object}, nil
+	}
+
+	ret := &UnstructuredList{}
+	ret.Object = obj.Object
+
+	err := obj.EachListItem(func(item runtime.Object) error {
+		castItem := item.(*Unstructured)
+		ret.Items = append(ret.Items, *castItem)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
 
 func (obj *Unstructured) EachListItem(fn func(runtime.Object) error) error {
 	field, ok := obj.Object["items"]

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["scheme.go"],
+    importpath = "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme/scheme.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstructuredscheme
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+// NewUnstructuredNegotiatedSerializer returns a simple, negotiated serializer
+func NewUnstructuredNegotiatedSerializer() runtime.NegotiatedSerializer {
+	return unstructuredNegotiatedSerializer{
+		scheme:  scheme,
+		typer:   NewUnstructuredObjectTyper(),
+		creator: NewUnstructuredCreator(),
+	}
+}
+
+type unstructuredNegotiatedSerializer struct {
+	scheme  *runtime.Scheme
+	typer   runtime.ObjectTyper
+	creator runtime.ObjectCreater
+}
+
+func (s unstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, s.creator, s.typer, false),
+				Framer:        json.Framer,
+			},
+		},
+		{
+			MediaType:     "application/yaml",
+			EncodesAsText: true,
+			Serializer:    json.NewYAMLSerializer(json.DefaultMetaFactory, s.creator, s.typer),
+		},
+	}
+}
+
+func (s unstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, encoder, nil, gv, nil)
+}
+
+func (s unstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(s.scheme, nil, decoder, nil, gv)
+}
+
+type unstructuredObjectTyper struct {
+}
+
+// NewUnstructuredObjectTyper returns an object typer that can deal with unstructured things
+func NewUnstructuredObjectTyper() runtime.ObjectTyper {
+	return unstructuredObjectTyper{}
+}
+
+func (t unstructuredObjectTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	// Delegate for things other than Unstructured.
+	if _, ok := obj.(runtime.Unstructured); !ok {
+		return nil, false, fmt.Errorf("cannot type %T", obj)
+	}
+	return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+}
+
+func (t unstructuredObjectTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}
+
+type unstructuredCreator struct{}
+
+// NewUnstructuredCreator returns a simple object creator that always returns an unstructured
+func NewUnstructuredCreator() runtime.ObjectCreater {
+	return unstructuredCreator{}
+}
+
+func (c unstructuredCreator) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	ret := &unstructured.Unstructured{}
+	ret.SetGroupVersionKind(kind)
+	return ret, nil
+}
+
+type unstructuredDefaulter struct {
+}
+
+// NewUnstructuredDefaulter returns defaulter suitable for unstructured types that doesn't default anything
+func NewUnstructuredDefaulter() runtime.ObjectDefaulter {
+	return unstructuredDefaulter{}
+}
+
+func (d unstructuredDefaulter) Default(in runtime.Object) {
+}

--- a/staging/src/k8s.io/client-go/dynamic/BUILD
+++ b/staging/src/k8s.io/client-go/dynamic/BUILD
@@ -30,25 +30,28 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "bad_debt.go",
         "client.go",
         "client_pool.go",
         "dynamic_util.go",
+        "scheme.go",
+        "simple.go",
     ],
     importpath = "k8s.io/client-go/dynamic",
     deps = [
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/conversion/queryparams:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/dynamic/bad_debt.go
+++ b/staging/src/k8s.io/client-go/dynamic/bad_debt.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+// dynamicCodec is a codec that wraps the standard unstructured codec
+// with special handling for Status objects.
+// Deprecated only used by test code and its wrong
+type dynamicCodec struct{}
+
+func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(data, gvk, obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := obj.(*metav1.Status); !ok && strings.ToLower(gvk.Kind) == "status" {
+		obj = &metav1.Status{}
+		err := json.Unmarshal(data, obj)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return obj, gvk, nil
+}
+
+func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
+	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
+}
+
+// ContentConfig returns a rest.ContentConfig for dynamic types.
+// Deprecated only used by test code and its wrong
+func ContentConfig() rest.ContentConfig {
+	var jsonInfo runtime.SerializerInfo
+	// TODO: scheme.Codecs here should become "pkg/apis/server/scheme" which is the minimal core you need
+	// to talk to a kubernetes server
+	for _, info := range scheme.Codecs.SupportedMediaTypes() {
+		if info.MediaType == runtime.ContentTypeJSON {
+			jsonInfo = info
+			break
+		}
+	}
+
+	jsonInfo.Serializer = dynamicCodec{}
+	jsonInfo.PrettySerializer = nil
+	return rest.ContentConfig{
+		AcceptContentTypes:   runtime.ContentTypeJSON,
+		ContentType:          runtime.ContentTypeJSON,
+		NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(jsonInfo),
+	}
+}

--- a/staging/src/k8s.io/client-go/dynamic/client.go
+++ b/staging/src/k8s.io/client-go/dynamic/client.go
@@ -20,37 +20,24 @@ limitations under the License.
 package dynamic
 
 import (
-	"encoding/json"
-	"errors"
-	"io"
-	"net/url"
 	"strings"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/conversion/queryparams"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/util/flowcontrol"
 )
 
 // Interface is a Kubernetes client that allows you to access metadata
 // and manipulate metadata of a Kubernetes API group.
 type Interface interface {
-	// GetRateLimiter returns the rate limiter for this client.
-	GetRateLimiter() flowcontrol.RateLimiter
 	// Resource returns an API interface to the specified resource for this client's
 	// group and version.  If resource is not a namespaced resource, then namespace
 	// is ignored.  The ResourceInterface inherits the parameter codec of this client.
 	Resource(resource *metav1.APIResource, namespace string) ResourceInterface
-	// ParameterCodec returns a client with the provided parameter codec.
-	ParameterCodec(parameterCodec runtime.ParameterCodec) Interface
 }
 
 // ResourceInterface is an API interface to a specific resource under a
@@ -77,303 +64,50 @@ type ResourceInterface interface {
 // Client is a Kubernetes client that allows you to access metadata
 // and manipulate metadata of a Kubernetes API group, and implements Interface.
 type Client struct {
-	cl             *restclient.RESTClient
-	parameterCodec runtime.ParameterCodec
+	version  schema.GroupVersion
+	delegate DynamicInterface
 }
 
 // NewClient returns a new client based on the passed in config. The
 // codec is ignored, as the dynamic client uses it's own codec.
-func NewClient(conf *restclient.Config) (*Client, error) {
-	// avoid changing the original config
-	confCopy := *conf
-	conf = &confCopy
-
-	contentConfig := ContentConfig()
-	contentConfig.GroupVersion = conf.GroupVersion
-	if conf.NegotiatedSerializer != nil {
-		contentConfig.NegotiatedSerializer = conf.NegotiatedSerializer
-	}
-	conf.ContentConfig = contentConfig
-
-	if conf.APIPath == "" {
-		conf.APIPath = "/api"
-	}
-
-	if len(conf.UserAgent) == 0 {
-		conf.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-
-	cl, err := restclient.RESTClientFor(conf)
+func NewClient(conf *restclient.Config, version schema.GroupVersion) (*Client, error) {
+	delegate, err := NewForConfig(conf)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{cl: cl}, nil
-}
-
-// GetRateLimiter returns rate limier.
-func (c *Client) GetRateLimiter() flowcontrol.RateLimiter {
-	return c.cl.GetRateLimiter()
+	return &Client{version: version, delegate: delegate}, nil
 }
 
 // Resource returns an API interface to the specified resource for this client's
 // group and version. If resource is not a namespaced resource, then namespace
 // is ignored. The ResourceInterface inherits the parameter codec of c.
 func (c *Client) Resource(resource *metav1.APIResource, namespace string) ResourceInterface {
-	return &ResourceClient{
-		cl:             c.cl,
-		resource:       resource,
-		ns:             namespace,
-		parameterCodec: c.parameterCodec,
-	}
-}
-
-// ParameterCodec returns a client with the provided parameter codec.
-func (c *Client) ParameterCodec(parameterCodec runtime.ParameterCodec) Interface {
-	return &Client{
-		cl:             c.cl,
-		parameterCodec: parameterCodec,
-	}
-}
-
-// ResourceClient is an API interface to a specific resource under a
-// dynamic client, and implements ResourceInterface.
-type ResourceClient struct {
-	cl             *restclient.RESTClient
-	resource       *metav1.APIResource
-	ns             string
-	parameterCodec runtime.ParameterCodec
-}
-
-func (rc *ResourceClient) parseResourceSubresourceName() (string, []string) {
-	var resourceName string
-	var subresourceName []string
-	if strings.Contains(rc.resource.Name, "/") {
-		resourceName = strings.Split(rc.resource.Name, "/")[0]
-		subresourceName = strings.Split(rc.resource.Name, "/")[1:]
-	} else {
-		resourceName = rc.resource.Name
+	resourceTokens := strings.SplitN(resource.Name, "/", 2)
+	subresource := ""
+	if len(resourceTokens) > 1 {
+		subresource = resourceTokens[1]
 	}
 
-	return resourceName, subresourceName
-}
-
-// List returns a list of objects for this resource.
-func (rc *ResourceClient) List(opts metav1.ListOptions) (runtime.Object, error) {
-	parameterEncoder := rc.parameterCodec
-	if parameterEncoder == nil {
-		parameterEncoder = defaultParameterEncoder
+	if len(namespace) == 0 {
+		return oldResourceShim(c.delegate.ClusterSubresource(c.version.WithResource(resourceTokens[0]), subresource))
 	}
-	return rc.cl.Get().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
-		Do().
-		Get()
+	return oldResourceShim(c.delegate.NamespacedSubresource(c.version.WithResource(resourceTokens[0]), subresource, namespace))
 }
 
-// Get gets the resource with the specified name.
-func (rc *ResourceClient) Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
-	parameterEncoder := rc.parameterCodec
-	if parameterEncoder == nil {
-		parameterEncoder = defaultParameterEncoder
-	}
-	result := new(unstructured.Unstructured)
-	resourceName, subresourceName := rc.parseResourceSubresourceName()
-	err := rc.cl.Get().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(resourceName).
-		SubResource(subresourceName...).
-		VersionedParams(&opts, parameterEncoder).
-		Name(name).
-		Do().
-		Into(result)
-	return result, err
+// the old interfaces used the wrong type for lists.  this fixes that
+func oldResourceShim(in DynamicResourceInterface) ResourceInterface {
+	return oldResourceShimType{DynamicResourceInterface: in}
 }
 
-// Delete deletes the resource with the specified name.
-func (rc *ResourceClient) Delete(name string, opts *metav1.DeleteOptions) error {
-	return rc.cl.Delete().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(rc.resource.Name).
-		Name(name).
-		Body(opts).
-		Do().
-		Error()
+type oldResourceShimType struct {
+	DynamicResourceInterface
 }
 
-// DeleteCollection deletes a collection of objects.
-func (rc *ResourceClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
-	parameterEncoder := rc.parameterCodec
-	if parameterEncoder == nil {
-		parameterEncoder = defaultParameterEncoder
-	}
-	return rc.cl.Delete().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(rc.resource.Name).
-		VersionedParams(&listOptions, parameterEncoder).
-		Body(deleteOptions).
-		Do().
-		Error()
+func (s oldResourceShimType) List(opts metav1.ListOptions) (runtime.Object, error) {
+	return s.DynamicResourceInterface.List(opts)
 }
 
-// Create creates the provided resource.
-func (rc *ResourceClient) Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	result := new(unstructured.Unstructured)
-	resourceName, subresourceName := rc.parseResourceSubresourceName()
-	req := rc.cl.Post().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(resourceName).
-		Body(obj)
-	if len(subresourceName) > 0 {
-		// If the provided resource is a subresource, the POST request should contain
-		// object name. Examples of subresources that support Create operation:
-		//	core/v1/pods/{name}/binding
-		//	core/v1/pods/{name}/eviction
-		//	extensions/v1beta1/deployments/{name}/rollback
-		//	apps/v1beta1/deployments/{name}/rollback
-		// NOTE: Currently our system assumes every subresource object has the same
-		//	 name as the parent resource object. E.g. a pods/binding object having
-		//	 metadada.name "foo" means pod "foo" is being bound. We may need to
-		//	 change this if we break the assumption in the future.
-		req = req.SubResource(subresourceName...).
-			Name(obj.GetName())
-	}
-	err := req.Do().
-		Into(result)
-	return result, err
+func (s oldResourceShimType) Patch(name string, pt types.PatchType, data []byte) (*unstructured.Unstructured, error) {
+	return s.DynamicResourceInterface.Patch(name, pt, data)
 }
-
-// Update updates the provided resource.
-func (rc *ResourceClient) Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	result := new(unstructured.Unstructured)
-	if len(obj.GetName()) == 0 {
-		return result, errors.New("object missing name")
-	}
-	resourceName, subresourceName := rc.parseResourceSubresourceName()
-	err := rc.cl.Put().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(resourceName).
-		SubResource(subresourceName...).
-		// NOTE: Currently our system assumes every subresource object has the same
-		//	 name as the parent resource object. E.g. a pods/binding object having
-		//	 metadada.name "foo" means pod "foo" is being bound. We may need to
-		//	 change this if we break the assumption in the future.
-		Name(obj.GetName()).
-		Body(obj).
-		Do().
-		Into(result)
-	return result, err
-}
-
-// Watch returns a watch.Interface that watches the resource.
-func (rc *ResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
-	parameterEncoder := rc.parameterCodec
-	if parameterEncoder == nil {
-		parameterEncoder = defaultParameterEncoder
-	}
-	opts.Watch = true
-	return rc.cl.Get().
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
-		Watch()
-}
-
-// Patch applies the patch and returns the patched resource.
-func (rc *ResourceClient) Patch(name string, pt types.PatchType, data []byte) (*unstructured.Unstructured, error) {
-	result := new(unstructured.Unstructured)
-	resourceName, subresourceName := rc.parseResourceSubresourceName()
-	err := rc.cl.Patch(pt).
-		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
-		Resource(resourceName).
-		SubResource(subresourceName...).
-		Name(name).
-		Body(data).
-		Do().
-		Into(result)
-	return result, err
-}
-
-// dynamicCodec is a codec that wraps the standard unstructured codec
-// with special handling for Status objects.
-type dynamicCodec struct{}
-
-func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
-	obj, gvk, err := unstructured.UnstructuredJSONScheme.Decode(data, gvk, obj)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if _, ok := obj.(*metav1.Status); !ok && strings.ToLower(gvk.Kind) == "status" {
-		obj = &metav1.Status{}
-		err := json.Unmarshal(data, obj)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	return obj, gvk, nil
-}
-
-func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
-	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
-}
-
-// ContentConfig returns a restclient.ContentConfig for dynamic types.
-func ContentConfig() restclient.ContentConfig {
-	var jsonInfo runtime.SerializerInfo
-	// TODO: scheme.Codecs here should become "pkg/apis/server/scheme" which is the minimal core you need
-	// to talk to a kubernetes server
-	for _, info := range scheme.Codecs.SupportedMediaTypes() {
-		if info.MediaType == runtime.ContentTypeJSON {
-			jsonInfo = info
-			break
-		}
-	}
-
-	jsonInfo.Serializer = dynamicCodec{}
-	jsonInfo.PrettySerializer = nil
-	return restclient.ContentConfig{
-		AcceptContentTypes:   runtime.ContentTypeJSON,
-		ContentType:          runtime.ContentTypeJSON,
-		NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(jsonInfo),
-	}
-}
-
-// paramaterCodec is a codec converts an API object to query
-// parameters without trying to convert to the target version.
-type parameterCodec struct{}
-
-func (parameterCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
-	return queryparams.Convert(obj)
-}
-
-func (parameterCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
-	return errors.New("DecodeParameters not implemented on dynamic parameterCodec")
-}
-
-var defaultParameterEncoder runtime.ParameterCodec = parameterCodec{}
-
-type versionedParameterEncoderWithV1Fallback struct{}
-
-func (versionedParameterEncoderWithV1Fallback) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
-	ret, err := scheme.ParameterCodec.EncodeParameters(obj, to)
-	if err != nil && runtime.IsNotRegisteredError(err) {
-		// fallback to v1
-		return scheme.ParameterCodec.EncodeParameters(obj, v1.SchemeGroupVersion)
-	}
-	return ret, err
-}
-
-func (versionedParameterEncoderWithV1Fallback) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
-	return errors.New("DecodeParameters not implemented on versionedParameterEncoderWithV1Fallback")
-}
-
-// VersionedParameterEncoderWithV1Fallback is useful for encoding query
-// parameters for custom resources. It tries to convert object to the
-// specified version before converting it to query parameters, and falls back to
-// converting to v1 if the object is not registered in the specified version.
-// For the record, currently API server always treats query parameters sent to a
-// custom resource endpoint as v1.
-var VersionedParameterEncoderWithV1Fallback runtime.ParameterCodec = versionedParameterEncoderWithV1Fallback{}

--- a/staging/src/k8s.io/client-go/dynamic/client_pool.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_pool.go
@@ -113,7 +113,7 @@ func (c *clientPoolImpl) ClientForGroupVersionKind(kind schema.GroupVersionKind)
 	// we need to make a client
 	conf.GroupVersion = &gv
 
-	dynamicClient, err := NewClient(conf)
+	dynamicClient, err := NewClient(conf, gv)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/dynamic/scheme.go
+++ b/staging/src/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+var watchJsonSerializerInfo = runtime.SerializerInfo{
+	MediaType:        "application/json",
+	EncodesAsText:    true,
+	Serializer:       json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+	PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, true),
+	StreamSerializer: &runtime.StreamSerializerInfo{
+		EncodesAsText: true,
+		Serializer:    json.NewSerializer(json.DefaultMetaFactory, watchScheme, watchScheme, false),
+		Framer:        json.Framer,
+	},
+}
+
+// watchNegotiatedSerializer is used to read the wrapper of the watch stream
+type watchNegotiatedSerializer struct{}
+
+var watchNegotiatedSerializerInstance = watchNegotiatedSerializer{}
+
+func (s watchNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{watchJsonSerializerInfo}
+}
+
+func (s watchNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s watchNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, encoder, nil, gv, nil)
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return versioning.NewDefaultingCodecForScheme(watchScheme, nil, decoder, nil, gv)
+}

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type DynamicInterface interface {
+	ClusterResource(resource schema.GroupVersionResource) DynamicResourceInterface
+	NamespacedResource(resource schema.GroupVersionResource, namespace string) DynamicResourceInterface
+
+	// Deprecated, this isn't how we want to do it
+	ClusterSubresource(resource schema.GroupVersionResource, subresource string) DynamicResourceInterface
+	// Deprecated, this isn't how we want to do it
+	NamespacedSubresource(resource schema.GroupVersionResource, subresource, namespace string) DynamicResourceInterface
+}
+
+type DynamicResourceInterface interface {
+	Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(name string, options metav1.GetOptions) (*unstructured.Unstructured, error)
+	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(opts metav1.ListOptions) (watch.Interface, error)
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error)
+}
+
+type dynamicClient struct {
+	client *rest.RESTClient
+}
+
+var _ DynamicInterface = &dynamicClient{}
+
+func NewForConfig(inConfig *rest.Config) (DynamicInterface, error) {
+	config := rest.CopyConfig(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client      *dynamicClient
+	namespace   string
+	resource    schema.GroupVersionResource
+	subresource string
+}
+
+func (c *dynamicClient) ClusterResource(resource schema.GroupVersionResource) DynamicResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+func (c *dynamicClient) NamespacedResource(resource schema.GroupVersionResource, namespace string) DynamicResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, namespace: namespace}
+}
+
+func (c *dynamicClient) ClusterSubresource(resource schema.GroupVersionResource, subresource string) DynamicResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, subresource: subresource}
+}
+func (c *dynamicClient) NamespacedSubresource(resource schema.GroupVersionResource, subresource, namespace string) DynamicResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, namespace: namespace, subresource: subresource}
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if len(c.subresource) > 0 {
+		return nil, fmt.Errorf("create not supported for subresources")
+	}
+
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.Post().AbsPath(c.makeURLSegments("")...).Body(outBytes).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.Put().AbsPath(c.makeURLSegments(accessor.GetName())...).Body(outBytes).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.Put().AbsPath(append(c.makeURLSegments(accessor.GetName()), "status")...).Body(obj).Do()
+	uncastObj, err := result.Get()
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.Delete().AbsPath(c.makeURLSegments(name)...).Body(deleteOptionsByte).Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	if len(c.subresource) > 0 {
+		return fmt.Errorf("deletecollection not supported for subresources")
+	}
+
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.Delete().AbsPath(c.makeURLSegments("")...).Body(deleteOptionsByte).SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).Do()
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments(name)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.subresource) > 0 {
+		return nil, fmt.Errorf("list not supported for subresources")
+	}
+
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	if len(c.subresource) > 0 {
+		return nil, fmt.Errorf("watch not supported for subresources")
+	}
+
+	internalGV := schema.GroupVersions{
+		{Group: c.resource.Group, Version: runtime.APIVersionInternal},
+		// always include the legacy group as a decoding target to handle non-error `Status` return types
+		{Group: "", Version: runtime.APIVersionInternal},
+	}
+	s := &rest.Serializers{
+		Encoder: watchNegotiatedSerializerInstance.EncoderForVersion(watchJsonSerializerInfo.Serializer, c.resource.GroupVersion()),
+		Decoder: watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV),
+
+		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
+			return watchNegotiatedSerializerInstance.DecoderToVersion(watchJsonSerializerInfo.Serializer, internalGV), nil
+		},
+		StreamingSerializer: watchJsonSerializerInfo.StreamSerializer.Serializer,
+		Framer:              watchJsonSerializerInfo.StreamSerializer.Framer,
+	}
+
+	wrappedDecoderFn := func(body io.ReadCloser) streaming.Decoder {
+		framer := s.Framer.NewFrameReader(body)
+		return streaming.NewDecoder(framer, s.StreamingSerializer)
+	}
+
+	opts.Watch = true
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		WatchWithSpecificDecoders(wrappedDecoderFn, unstructured.UnstructuredJSONScheme)
+}
+
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error) {
+	result := c.client.client.Patch(pt).AbsPath(append(c.makeURLSegments(name), subresources...)...).Body(data).Do()
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+
+		// subresources only work on things with names
+		if len(c.subresource) > 0 {
+			url = append(url, c.subresource)
+		}
+	} else {
+		if len(c.subresource) > 0 {
+			panic("somehow snuck a subresource and an empty name.  programmer error")
+		}
+	}
+
+	return url
+}

--- a/test/e2e_node/services/BUILD
+++ b/test/e2e_node/services/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//cmd/kube-apiserver/app:go_default_library",
         "//cmd/kube-apiserver/app/options:go_default_library",
         "//cmd/kubelet/app/options:go_default_library",
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/controller/namespace:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -45,7 +45,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	client := clientset.NewForConfigOrDie(config)
-	dynamicClient, err := dynamic.NewClient(config)
+	dynamicClient, err := dynamic.NewClient(config, *gv)
 	_ = dynamicClient
 	if err != nil {
 		t.Fatalf("unexpected error creating dynamic client: %v", err)

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -153,7 +153,7 @@ func TestCRD(t *testing.T) {
 	barComConfig := *result.ClientConfig
 	barComConfig.GroupVersion = &schema.GroupVersion{Group: "cr.bar.com", Version: "v1"}
 	barComConfig.APIPath = "/apis"
-	barComClient, err := dynamic.NewClient(&barComConfig)
+	barComClient, err := dynamic.NewClient(&barComConfig, *barComConfig.GroupVersion)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
The dynamic client has annoyed me for the last time!  The existing one takes arguments at odd levels, requires lots of information to instantiate, does some weird pool thing, and uses unusual types.  This creates an interface like this:

```go

type DynamicInterface interface {
	ClusterResource(resource schema.GroupVersionResource) DynamicResourceInterface
	NamespacedResource(resource schema.GroupVersionResource, namespace string) DynamicResourceInterface
}

type DynamicResourceInterface interface {
	Create(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
	Update(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
	UpdateStatus(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
	Delete(name string, options *metav1.DeleteOptions) error
	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
	Get(name string, options metav1.GetOptions) (*unstructured.Unstructured, error)
	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
	Watch(opts metav1.ListOptions) (watch.Interface, error)
	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*unstructured.Unstructured, error)
}
```

You create it from just a `rest.Config`, no mapper, no path resolving func, no trying to set up codecs ahead of time, no unnecessary pool.  It just works.

I updated the namespace controller to use it and I updated the existing dynamic client to leverage it so that I get all their tests for "free".

@kubernetes/sig-api-machinery-pr-reviews 
@liggitt @smarterclayton @bparees @sttts @ironcladlou I know each of us has struggled with the dynamic client in our time.
@lavalamp @caesarxuchao This is vastly simplifying.  I'm eager to drop the old `ClientPool`.  client-go will technically have another incompatible semver this release.  I'm up for changing it in tree.


```release-note
client-go developers: the new dynamic client is easier to use and the old is deprecated, you must switch.
```