### PR TITLE
Add apiservices to ValidResourceTypeList

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -244,6 +244,7 @@ func ValidResourceTypeList(f ClientAccessFactory) string {
 	return templates.LongDesc(`Valid resource types include:
 	
 			* all
+			* apiservices
 			* certificatesigningrequests (aka 'csr')
 			* clusterrolebindings
 			* clusterroles


### PR DESCRIPTION
This patch makes a tiny change by adding apiservices to
ValidResourceTypeList.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Currently `kubectl get -h`, `kubectl describe -h` does not show `apiservices` as a valid resource types.

**Special notes for your reviewer**:

- `kubectl explain apiservices` does not support `apiservices` but it is another issue reported in https://github.com/kubernetes/kubernetes/issues/49465
- If `apiservices` is not added by design due to staging, please feel close to this patch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
