### PR TITLE
`kubectl create {clusterrole,role}`'s `--resources` flag support asterisk to specify all resources

### DIFF
--- a/pkg/kubectl/cmd/create/create_role.go
+++ b/pkg/kubectl/cmd/create/create_role.go
@@ -204,6 +204,11 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		}
 		resource.Resource = parts[0]
 
+		if resource.Resource == "*" && len(parts) == 1 && len(sections) == 1 {
+			o.Resources = []ResourceOptions{*resource}
+			break
+		}
+
 		o.Resources = append(o.Resources, *resource)
 	}
 
@@ -278,6 +283,9 @@ func (o *CreateRoleOptions) validateResource() error {
 	for _, r := range o.Resources {
 		if len(r.Resource) == 0 {
 			return fmt.Errorf("resource must be specified if apiGroup/subresource specified")
+		}
+		if r.Resource == "*" {
+			return nil
 		}
 
 		resource := schema.GroupVersionResource{Resource: r.Resource, Group: r.Group}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `kubectl create (cluster)role`'s `--resources` flag does not support asterisk to specify all resources.

```
# kubectl create clusterrole superrole --verb=get  --resource=*
the server doesn't have a resource type "*"
```

As an user, we create a role with `--resources=*` sometimes, so this PR supports it.

Fixes https://github.com/kubernetes/kubernetes/issues/62989

**Special notes for your reviewer**:

- This patch does not support `--resource=*` for `SpecialVerbs` - e.g `kubectl create role foo --verb=impersonate  --resource=*`, because current code also does not support `kubectl create role foo --verb=impersonate  --resource=users,pods`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubectl create {clusterrole,role}`'s `--resources` flag supports asterisk to specify all resources.
```