### PR TITLE
Validate cgroups-per-qos for Windows

### DIFF
--- a/pkg/kubelet/apis/kubeletconfig/validation/BUILD
+++ b/pkg/kubelet/apis/kubeletconfig/validation/BUILD
@@ -8,7 +8,44 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["validation.go"],
+    srcs = [
+        "validation.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "validation_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "validation_windows.go",
+        ],
+        "//conditions:default": [],
+    }),
     importpath = "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/validation",
     deps = [
         "//pkg/features:go_default_library",

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation.go
@@ -118,5 +118,9 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: option %q specified for HairpinMode (--hairpin-mode). Valid options are %q, %q or %q",
 			kc.HairpinMode, kubeletconfig.HairpinNone, kubeletconfig.HairpinVeth, kubeletconfig.PromiscuousBridge))
 	}
+
+	if err := validateKubeletOSConfiguration(kc); err != nil {
+		allErrors = append(allErrors, err)
+	}
 	return utilerrors.NewAggregate(allErrors)
 }

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation_others.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation_others.go
@@ -1,0 +1,28 @@
+// +build !windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
+)
+
+// validateKubeletOSConfiguration validates os specific kubelet configuration and returns an error if it is invalid.
+func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) error {
+	return nil
+}

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation_windows.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation_windows.go
@@ -1,0 +1,42 @@
+// +build windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
+)
+
+// validateKubeletOSConfiguration validates os specific kubelet configuration and returns an error if it is invalid.
+func validateKubeletOSConfiguration(kc *kubeletconfig.KubeletConfiguration) error {
+	message := "invalid configuration: %v (%v) %v is not supported on Windows"
+	allErrors := []error{}
+
+	if kc.CgroupsPerQOS {
+		allErrors = append(allErrors, fmt.Errorf(message, "CgroupsPerQOS", "--cgroups-per-qos", kc.CgroupsPerQOS))
+	}
+
+	if len(kc.EnforceNodeAllocatable) > 0 {
+		allErrors = append(allErrors, fmt.Errorf(message, "EnforceNodeAllocatable", "--enforce-node-allocatable", kc.EnforceNodeAllocatable))
+	}
+
+	return utilerrors.NewAggregate(allErrors)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

cgroups-per-qos and enforce-node-allocatable is not supported on Windows, but kubelet allows it on Windows. And then Pods may stuck in terminating state because of it. Refer #61716.

This PR adds validation for them and make kubelet refusing to start in this case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61716

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fail fast if cgroups-per-qos is set on Windows
```
