### PR TITLE
add NoMatch cases in TestSetMatches

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -156,10 +156,9 @@ func TestSetMatches(t *testing.T) {
 	expectMatchDirect(t, Set{"baz": "blah"}, labelset)
 	expectMatchDirect(t, Set{"foo": "bar", "baz": "blah"}, labelset)
 
-	//TODO: bad values not handled for the moment in SelectorFromSet
-	//expectNoMatchDirect(t, Set{"foo": "=blah"}, labelset)
-	//expectNoMatchDirect(t, Set{"baz": "=bar"}, labelset)
-	//expectNoMatchDirect(t, Set{"foo": "=bar", "foobar": "bar", "baz": "blah"}, labelset)
+	expectNoMatchDirect(t, Set{"foo": "lah"}, labelset)
+	expectNoMatchDirect(t, Set{"baz": "new"}, labelset)
+	expectNoMatchDirect(t, Set{"foo": "far", "foobar": "bar", "baz": "blah"}, labelset)
 }
 
 func TestNilMapIsValid(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
add NoMatch cases in TestSetMatches
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
```
r, err := NewRequirement(label, selection.Equals, []string{value})
if err == nil {
	requirements = append(requirements, *r)
} else {
	return internalSelector{}
}
```
when the value or key of Set is invalid, the func SelectorFromSet will return `internalSelector{}`, in such case, any lable will match the selector.such as`Set{"baz": "=bar"}`. Is it reasonable？Should we add an err in func SelectorFromSet return?
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
