### PR TITLE
Automated cherry pick of #62909: Manage Metadata Agent Config with Addon Manager

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
@@ -12,6 +12,9 @@ kind: ConfigMap
 metadata:
   name: metadata-agent-config
   namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
 data:
   node_level.conf: |-
     KubernetesUseWatch: true


### PR DESCRIPTION
Cherry pick of #62909 on release-1.10.

#62909: Manage Metadata Agent Config with Addon Manager

**Release note**:
```release-note
Fix error where config map for Metadata Agent was not created by addon manager.
```