### PR TITLE
juju: Use k8s.gcr.io url for arm64 ingress image

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -735,7 +735,7 @@ def launch_default_ingress_controller():
                 "docker.io/cdkbot/nginx-ingress-controller-s390x:0.9.0-beta.13"
         elif context['arch'] == 'arm64':
             context['ingress_image'] = \
-                "gcr.io/google-containers/nginx-ingress-controller-arm64:0.9.0-beta.15" # noqa
+                "k8s.gcr.io/nginx-ingress-controller-arm64:0.9.0-beta.15"
         else:
             context['ingress_image'] = \
                 "k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.15" # noqa


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the kubernetes-worker charm to point to k8s.gcr.io for the nginx-ingress-controller-arm64 image. This should have no impact on functionality today, but as I understand it, we're all standardizing on k8s.gcr.io to allow for future changes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
