### PR TITLE
Register Prometheus etcdmetrics only for apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -18,12 +18,12 @@ package metrics
 
 import (
 	"bufio"
-	//"fmt"
 	"net"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -32,6 +32,13 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// resettableCollector is the interface implemented by prometheus.MetricVec
+// that can be used by Prometheus to collect metrics and reset their values.
+type resettableCollector interface {
+	prometheus.Collector
+	Reset()
+}
 
 var (
 	// TODO(a-robinson): Add unit tests for the handling of these metrics once
@@ -96,6 +103,16 @@ var (
 		[]string{"requestKind"},
 	)
 	kubectlExeRegexp = regexp.MustCompile(`^.*((?i:kubectl\.exe))`)
+
+	metrics = []resettableCollector{
+		requestCounter,
+		longRunningRequestGauge,
+		requestLatencies,
+		requestLatenciesSummary,
+		responseSizes,
+		DroppedRequests,
+		currentInflightRequests,
+	}
 )
 
 const (
@@ -105,15 +122,22 @@ const (
 	MutatingKind = "mutating"
 )
 
-func init() {
-	// Register all metrics.
-	prometheus.MustRegister(requestCounter)
-	prometheus.MustRegister(longRunningRequestGauge)
-	prometheus.MustRegister(requestLatencies)
-	prometheus.MustRegister(requestLatenciesSummary)
-	prometheus.MustRegister(responseSizes)
-	prometheus.MustRegister(DroppedRequests)
-	prometheus.MustRegister(currentInflightRequests)
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		for _, metric := range metrics {
+			prometheus.MustRegister(metric)
+		}
+	})
+}
+
+// Reset all metrics.
+func Reset() {
+	for _, metric := range metrics {
+		metric.Reset()
+	}
 }
 
 func UpdateInflightRequestMetrics(nonmutating, mutating int) {
@@ -168,13 +192,6 @@ func MonitorRequest(req *http.Request, verb, resource, subresource, scope, conte
 	if verb == "GET" || verb == "LIST" {
 		responseSizes.WithLabelValues(reportedVerb, resource, subresource, scope).Observe(float64(respSize))
 	}
-}
-
-func Reset() {
-	requestCounter.Reset()
-	requestLatencies.Reset()
-	requestLatenciesSummary.Reset()
-	responseSizes.Reset()
 }
 
 // InstrumentRouteFunc works like Prometheus' InstrumentHandlerFunc but wraps

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -32,6 +32,7 @@ type DefaultMetrics struct{}
 
 // Install adds the DefaultMetrics handler
 func (m DefaultMetrics) Install(c *mux.PathRecorderMux) {
+	register()
 	c.Handle("/metrics", prometheus.Handler())
 }
 
@@ -41,6 +42,7 @@ type MetricsWithReset struct{}
 
 // Install adds the MetricsWithReset handler
 func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
+	register()
 	defaultMetricsHandler := prometheus.Handler().ServeHTTP
 	c.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "DELETE" {
@@ -51,4 +53,10 @@ func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 		}
 		defaultMetricsHandler(w, req)
 	})
+}
+
+// register apiserver and etcd metrics
+func register() {
+	apimetrics.Register()
+	etcdmetrics.Register()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -101,10 +101,6 @@ type etcdHelper struct {
 	cache utilcache.Cache
 }
 
-func init() {
-	metrics.Register()
-}
-
 // Implements storage.Interface.
 func (h *etcdHelper) Versioner() storage.Versioner {
 	return h.versioner


### PR DESCRIPTION
Removed automatic registration with `init` funciton and use `Register` function to register metrics for etcd storage only when requested.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Prevents leaking etcd metrics to other k8s components

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially #63004

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
