### PR TITLE
remove confusing flexibility for metadata interpretation

### DIFF
--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -417,16 +417,6 @@ func (g TestGroup) Converter() runtime.ObjectConvertor {
 	return interfaces.ObjectConvertor
 }
 
-// MetadataAccessor returns the MetadataAccessor for the API version to test against,
-// as set by the KUBE_TEST_API env var.
-func (g TestGroup) MetadataAccessor() meta.MetadataAccessor {
-	interfaces, err := legacyscheme.Registry.GroupOrDie(g.externalGroupVersion.Group).InterfacesFor(g.externalGroupVersion)
-	if err != nil {
-		panic(err)
-	}
-	return interfaces.MetadataAccessor
-}
-
 // SelfLink returns a self link that will appear to be for the version Version().
 // 'resource' should be the resource path, e.g. "pods" for the Pod type. 'name' should be
 // empty for lists.

--- a/pkg/apis/core/install/BUILD
+++ b/pkg/apis/core/install/BUILD
@@ -28,7 +28,7 @@ go_test(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/apis/core/install/install_test.go
+++ b/pkg/apis/core/install/install_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,18 +30,8 @@ import (
 )
 
 func TestResourceVersioner(t *testing.T) {
-	g, err := legacyscheme.Registry.Group(v1.GroupName)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	intf, err := g.DefaultInterfacesFor(v1.SchemeGroupVersion)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	accessor := intf.MetadataAccessor
-
 	pod := internal.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "10"}}
-	version, err := accessor.ResourceVersion(&pod)
+	version, err := meta.NewAccessor().ResourceVersion(&pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,7 +40,7 @@ func TestResourceVersioner(t *testing.T) {
 	}
 
 	podList := internal.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}}
-	version, err = accessor.ResourceVersion(&podList)
+	version, err = meta.NewAccessor().ResourceVersion(&podList)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,12 +109,12 @@ func TestRESTMapper(t *testing.T) {
 		}
 
 		rc := &internal.ReplicationController{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-		name, err := mapping.MetadataAccessor.Name(rc)
+		name, err := meta.NewAccessor().Name(rc)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if name != "foo" {
-			t.Errorf("unable to retrieve object meta with: %v", mapping.MetadataAccessor)
+			t.Errorf("bad name: %q", name)
 		}
 	}
 }

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -149,7 +149,7 @@ func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) 
 				return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%s\nfrom server for:", info.String()), info.Source, err)
 			}
 		}
-		originalBuf, err := kubectl.GetOriginalConfiguration(info.Mapping, info.Object)
+		originalBuf, err := kubectl.GetOriginalConfiguration(info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%s\nfrom server for:", info.String()), info.Source, err)
 		}

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -119,7 +119,7 @@ func (o *ViewLastAppliedOptions) Complete(cmd *cobra.Command, f cmdutil.Factory,
 			return err
 		}
 
-		configString, err := kubectl.GetOriginalConfiguration(info.Mapping, info.Object)
+		configString, err := kubectl.GetOriginalConfiguration(info.Object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -187,7 +187,7 @@ func (o *AutoscaleOptions) RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *c
 			return cmdutil.PrintObject(cmd, object, out)
 		}
 
-		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), hpa, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), hpa.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return err
 		}
 

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/auth"
@@ -378,3 +379,5 @@ func deprecatedAlias(deprecatedVersion string, cmd *cobra.Command) *cobra.Comman
 	cmd.Hidden = true
 	return cmd
 }
+
+var metadataAccessor = meta.NewAccessor()

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -237,7 +237,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return cmdutil.AddSourceToErr("creating", info.Source, err)
 		}
 
@@ -412,7 +412,7 @@ func RunCreateSubcommand(f cmdutil.Factory, options *CreateSubcommandOptions) er
 		if err != nil {
 			return err
 		}
-		if err := kubectl.CreateOrUpdateAnnotation(options.CreateAnnotation, info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(options.CreateAnnotation, info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return err
 		}
 

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -289,7 +289,7 @@ func (o *ExposeServiceOptions) RunExpose(f cmdutil.Factory, out io.Writer, cmd *
 			cmdutil.PrintSuccess(false, out, info.Object, true, "exposed")
 			return nil
 		}
-		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return err
 		}
 

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -219,7 +219,7 @@ func (o *ReplaceOptions) Run() error {
 			return err
 		}
 
-		if err := kubectl.CreateOrUpdateAnnotation(o.createAnnotation, info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(o.createAnnotation, info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return cmdutil.AddSourceToErr("replacing", info.Source, err)
 		}
 
@@ -315,7 +315,7 @@ func (o *ReplaceOptions) forceReplace() error {
 			return err
 		}
 
-		if err := kubectl.CreateOrUpdateAnnotation(o.createAnnotation, info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(o.createAnnotation, info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return err
 		}
 

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -532,7 +532,7 @@ func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []s
 	if isList {
 		// the resourceVersion of list objects is ~now but won't return
 		// an initial watch event
-		rv, err = mapping.MetadataAccessor.ResourceVersion(obj)
+		rv, err = meta.NewAccessor().ResourceVersion(obj)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -110,7 +111,7 @@ func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []stri
 	if err != nil {
 		return err
 	}
-	rv, err := mapping.MetadataAccessor.ResourceVersion(obj)
+	rv, err := meta.NewAccessor().ResourceVersion(obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -451,12 +451,12 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 
 func (o *RunOptions) removeCreatedObjects(f cmdutil.Factory, createdObjects []*RunObject) error {
 	for _, obj := range createdObjects {
-		namespace, err := obj.Mapping.MetadataAccessor.Namespace(obj.Object)
+		namespace, err := metadataAccessor.Namespace(obj.Object)
 		if err != nil {
 			return err
 		}
 		var name string
-		name, err = obj.Mapping.MetadataAccessor.Name(obj.Object)
+		name, err = metadataAccessor.Name(obj.Object)
 		if err != nil {
 			return err
 		}
@@ -687,7 +687,7 @@ func (o *RunOptions) createGeneratedObject(f cmdutil.Factory, cmd *cobra.Command
 			return nil, err
 		}
 
-		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 			return nil, err
 		}
 

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -205,8 +205,7 @@ func AddToScheme(scheme *runtime.Scheme) (meta.RESTMapper, runtime.Codec) {
 	codec := codecs.LegacyCodec(UnlikelyGV)
 	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{UnlikelyGV, ValidVersionGV}, func(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: meta.NewAccessor(),
+			ObjectConvertor: scheme,
 		}, versionErrIfFalse(version == ValidVersionGV || version == UnlikelyGV)
 	})
 	for _, gv := range []schema.GroupVersion{UnlikelyGV, ValidVersionGV} {
@@ -442,8 +441,7 @@ func (f *TestFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 			// provide typed objects for these two versions
 			case ValidVersionGV, UnlikelyGV:
 				return &meta.VersionInterfaces{
-					ObjectConvertor:  scheme.Scheme,
-					MetadataAccessor: meta.NewAccessor(),
+					ObjectConvertor: scheme.Scheme,
 				}, nil
 				// otherwise fall back to the legacy scheme
 			default:

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -362,7 +362,7 @@ func (o *EditOptions) Run() error {
 		}
 		var annotationInfos []*resource.Info
 		for i := range infos {
-			data, err := kubectl.GetOriginalConfiguration(infos[i].Mapping, infos[i].Object)
+			data, err := kubectl.GetOriginalConfiguration(infos[i].Object)
 			if err != nil {
 				return err
 			}
@@ -625,7 +625,7 @@ func (o *EditOptions) visitAnnotation(annotationVisitor resource.Visitor) error 
 	err := annotationVisitor.Visit(func(info *resource.Info, incomingErr error) error {
 		// put configuration annotation in "updates"
 		if o.ApplyAnnotation {
-			if err := kubectl.CreateOrUpdateAnnotation(true, info, cmdutil.InternalVersionJSONEncoder()); err != nil {
+			if err := kubectl.CreateOrUpdateAnnotation(true, info.Object, cmdutil.InternalVersionJSONEncoder()); err != nil {
 				return err
 			}
 		}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -502,7 +502,7 @@ func UpdateObject(info *resource.Info, codec runtime.Codec, updateFn func(runtim
 	}
 
 	// Update the annotation used by kubectl apply
-	if err := kubectl.UpdateApplyAnnotation(info, codec); err != nil {
+	if err := kubectl.UpdateApplyAnnotation(info.Object, codec); err != nil {
 		return nil, err
 	}
 
@@ -515,15 +515,6 @@ func UpdateObject(info *resource.Info, codec runtime.Codec, updateFn func(runtim
 
 func GetDryRunFlag(cmd *cobra.Command) bool {
 	return GetFlagBool(cmd, "dry-run")
-}
-
-// ContainsChangeCause checks if input resource info contains change-cause annotation.
-func ContainsChangeCause(info *resource.Info) bool {
-	annotations, err := info.Mapping.MetadataAccessor.Annotations(info.Object)
-	if err != nil {
-		return false
-	}
-	return len(annotations[kubectl.ChangeCauseAnnotation]) > 0
 }
 
 // GetResourcesAndPairs retrieves resources and "KEY=VALUE or KEY-" pair args from given args

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+var metadataAccessor = meta.NewAccessor()
+
 // Helper provides methods for retrieving or mutating a RESTful
 // resource.
 type Helper struct {
@@ -34,9 +36,6 @@ type Helper struct {
 	Resource string
 	// A RESTClient capable of mutating this resource.
 	RESTClient RESTClient
-	// An interface for reading or writing the resource version of this
-	// type.
-	Versioner runtime.ResourceVersioner
 	// True if the resource type is scoped to namespaces
 	NamespaceScoped bool
 }
@@ -46,7 +45,6 @@ func NewHelper(client RESTClient, mapping *meta.RESTMapping) *Helper {
 	return &Helper{
 		Resource:        mapping.Resource,
 		RESTClient:      client,
-		Versioner:       mapping.MetadataAccessor,
 		NamespaceScoped: mapping.Scope.Name() == meta.RESTScopeNameNamespace,
 	}
 }
@@ -113,13 +111,13 @@ func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.Delet
 func (m *Helper) Create(namespace string, modify bool, obj runtime.Object) (runtime.Object, error) {
 	if modify {
 		// Attempt to version the object based on client logic.
-		version, err := m.Versioner.ResourceVersion(obj)
+		version, err := metadataAccessor.ResourceVersion(obj)
 		if err != nil {
 			// We don't know how to clear the version on this object, so send it to the server as is
 			return m.createResource(m.RESTClient, m.Resource, namespace, obj)
 		}
 		if version != "" {
-			if err := m.Versioner.SetResourceVersion(obj, ""); err != nil {
+			if err := metadataAccessor.SetResourceVersion(obj, ""); err != nil {
 				return nil, err
 			}
 		}
@@ -145,7 +143,7 @@ func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Obj
 	c := m.RESTClient
 
 	// Attempt to version the object based on client logic.
-	version, err := m.Versioner.ResourceVersion(obj)
+	version, err := metadataAccessor.ResourceVersion(obj)
 	if err != nil {
 		// We don't know how to version this object, so send it to the server as is
 		return m.replaceResource(c, m.Resource, namespace, name, obj)
@@ -157,11 +155,11 @@ func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Obj
 			// The object does not exist, but we want it to be created
 			return m.replaceResource(c, m.Resource, namespace, name, obj)
 		}
-		serverVersion, err := m.Versioner.ResourceVersion(serverObj)
+		serverVersion, err := metadataAccessor.ResourceVersion(serverObj)
 		if err != nil {
 			return nil, err
 		}
-		if err := m.Versioner.SetResourceVersion(obj, serverVersion); err != nil {
+		if err := metadataAccessor.SetResourceVersion(obj, serverVersion); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -211,7 +211,6 @@ func TestHelperCreate(t *testing.T) {
 		}
 		modifier := &Helper{
 			RESTClient:      client,
-			Versioner:       metaAccessor,
 			NamespaceScoped: true,
 		}
 		_, err := modifier.Create("bar", test.Modify, test.Object)
@@ -568,7 +567,6 @@ func TestHelperReplace(t *testing.T) {
 		}
 		modifier := &Helper{
 			RESTClient:      client,
-			Versioner:       metaAccessor,
 			NamespaceScoped: test.NamespaceScoped,
 		}
 		_, err := modifier.Replace(test.Namespace, "foo", test.Overwrite, test.Object)

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -65,9 +65,9 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 		return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 	}
 
-	name, _ := mapping.MetadataAccessor.Name(obj)
-	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
-	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
+	name, _ := metadataAccessor.Name(obj)
+	namespace, _ := metadataAccessor.Namespace(obj)
+	resourceVersion, _ := metadataAccessor.ResourceVersion(obj)
 
 	return &Info{
 		Client:  client,
@@ -105,9 +105,9 @@ func (m *Mapper) InfoForObject(obj runtime.Object, preferredGVKs []schema.GroupV
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 	}
-	name, _ := mapping.MetadataAccessor.Name(obj)
-	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
-	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
+	name, _ := metadataAccessor.Name(obj)
+	namespace, _ := metadataAccessor.Namespace(obj)
+	resourceVersion, _ := metadataAccessor.ResourceVersion(obj)
 	return &Info{
 		Client:  client,
 		Mapping: mapping,
@@ -198,7 +198,6 @@ func (m relaxedMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*me
 	if err != nil && meta.IsNoMatchError(err) && len(versions) > 0 {
 		return &meta.RESTMapping{
 			GroupVersionKind: gk.WithVersion(versions[0]),
-			MetadataAccessor: meta.NewAccessor(),
 			Scope:            meta.RESTScopeRoot,
 			ObjectConvertor:  identityConvertor{},
 		}, nil
@@ -211,7 +210,6 @@ func (m relaxedMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]
 		return []*meta.RESTMapping{
 			{
 				GroupVersionKind: gk.WithVersion(versions[0]),
-				MetadataAccessor: meta.NewAccessor(),
 				Scope:            meta.RESTScopeRoot,
 				ObjectConvertor:  identityConvertor{},
 			},

--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -88,9 +88,8 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 			}
 			return err
 		}
-		accessor := r.Mapping.MetadataAccessor
-		resourceVersion, _ := accessor.ResourceVersion(list)
-		nextContinueToken, _ := accessor.Continue(list)
+		resourceVersion, _ := metadataAccessor.ResourceVersion(list)
+		nextContinueToken, _ := metadataAccessor.Continue(list)
 		info := &Info{
 			Client:  r.Client,
 			Mapping: r.Mapping,

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -118,7 +118,7 @@ func (i *Info) Get() (err error) {
 		return err
 	}
 	i.Object = obj
-	i.ResourceVersion, _ = i.Mapping.MetadataAccessor.ResourceVersion(obj)
+	i.ResourceVersion, _ = metadataAccessor.ResourceVersion(obj)
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (i *Info) Get() (err error) {
 // the Object will be updated even if name, namespace, or resourceVersion
 // attributes cannot be loaded from the object.
 func (i *Info) Refresh(obj runtime.Object, ignoreError bool) error {
-	name, err := i.Mapping.MetadataAccessor.Name(obj)
+	name, err := metadataAccessor.Name(obj)
 	if err != nil {
 		if !ignoreError {
 			return err
@@ -134,7 +134,7 @@ func (i *Info) Refresh(obj runtime.Object, ignoreError bool) error {
 	} else {
 		i.Name = name
 	}
-	namespace, err := i.Mapping.MetadataAccessor.Namespace(obj)
+	namespace, err := metadataAccessor.Namespace(obj)
 	if err != nil {
 		if !ignoreError {
 			return err
@@ -142,7 +142,7 @@ func (i *Info) Refresh(obj runtime.Object, ignoreError bool) error {
 	} else {
 		i.Namespace = namespace
 	}
-	version, err := i.Mapping.MetadataAccessor.ResourceVersion(obj)
+	version, err := metadataAccessor.ResourceVersion(obj)
 	if err != nil {
 		if !ignoreError {
 			return err
@@ -617,7 +617,7 @@ func UpdateObjectNamespace(info *Info, err error) error {
 		return err
 	}
 	if info.Object != nil {
-		return info.Mapping.MetadataAccessor.SetNamespace(info.Object, info.Namespace)
+		return metadataAccessor.SetNamespace(info.Object, info.Namespace)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -26,7 +26,6 @@ import (
 // VersionInterfaces contains the interfaces one should use for dealing with types of a particular version.
 type VersionInterfaces struct {
 	runtime.ObjectConvertor
-	MetadataAccessor
 }
 
 type ListMetaAccessor interface {
@@ -113,7 +112,6 @@ type RESTMapping struct {
 	Scope RESTScope
 
 	runtime.ObjectConvertor
-	MetadataAccessor
 }
 
 // RESTMapper allows clients to map resources to kind, and map kind and version

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -536,8 +536,7 @@ func (m *DefaultRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string
 			GroupVersionKind: gvk,
 			Scope:            scope,
 
-			ObjectConvertor:  interfaces.ObjectConvertor,
-			MetadataAccessor: interfaces.MetadataAccessor,
+			ObjectConvertor: interfaces.ObjectConvertor,
 		})
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -44,7 +44,7 @@ var validAccessor = resourceAccessor{}
 var validConvertor = fakeConvertor{}
 
 func fakeInterfaces(version schema.GroupVersion) (*VersionInterfaces, error) {
-	return &VersionInterfaces{ObjectConvertor: validConvertor, MetadataAccessor: validAccessor}, nil
+	return &VersionInterfaces{ObjectConvertor: validConvertor}, nil
 }
 
 var unmatchedErr = errors.New("no version")
@@ -577,8 +577,8 @@ func TestRESTMapperRESTMapping(t *testing.T) {
 			t.Errorf("%d: unexpected resource: %#v", i, mapping)
 		}
 
-		if mapping.MetadataAccessor == nil || mapping.ObjectConvertor == nil {
-			t.Errorf("%d: missing codec and accessor: %#v", i, mapping)
+		if mapping.ObjectConvertor == nil {
+			t.Errorf("%d: missing codec: %#v", i, mapping)
 		}
 
 		groupVersion := testCase.ExpectedGroupVersion
@@ -727,8 +727,8 @@ func TestRESTMapperRESTMappings(t *testing.T) {
 			if mapping.Resource != exp.Resource {
 				t.Errorf("%d - %d: unexpected resource: %#v", i, j, mapping)
 			}
-			if mapping.MetadataAccessor == nil || mapping.ObjectConvertor == nil {
-				t.Errorf("%d - %d: missing codec and accessor: %#v", i, j, mapping)
+			if mapping.ObjectConvertor == nil {
+				t.Errorf("%d - %d: missing codec: %#v", i, j, mapping)
 			}
 			if mapping.GroupVersionKind != exp.GroupVersionKind {
 				t.Errorf("%d - %d: unexpected GroupVersionKind: %#v", i, j, mapping)

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/unstructured.go
@@ -28,8 +28,7 @@ func InterfacesForUnstructuredConversion(parent VersionInterfacesFunc) VersionIn
 	return func(version schema.GroupVersion) (*VersionInterfaces, error) {
 		if i, err := parent(version); err == nil {
 			return &VersionInterfaces{
-				ObjectConvertor:  i.ObjectConvertor,
-				MetadataAccessor: NewAccessor(),
+				ObjectConvertor: i.ObjectConvertor,
 			}, nil
 		}
 		return InterfacesForUnstructured(version)
@@ -41,7 +40,6 @@ func InterfacesForUnstructuredConversion(parent VersionInterfacesFunc) VersionIn
 // other conversions.
 func InterfacesForUnstructured(schema.GroupVersion) (*VersionInterfaces, error) {
 	return &VersionInterfaces{
-		ObjectConvertor:  &unstructured.UnstructuredObjectConverter{},
-		MetadataAccessor: NewAccessor(),
+		ObjectConvertor: &unstructured.UnstructuredObjectConverter{},
 	}, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
@@ -224,8 +224,7 @@ func (gmf *GroupMetaFactory) Enable(m *registered.APIRegistrationManager, scheme
 		if err := groupMeta.AddVersionInterfaces(
 			schema.GroupVersion{Group: gvf.GroupName, Version: gvf.VersionName},
 			&meta.VersionInterfaces{
-				ObjectConvertor:  scheme,
-				MetadataAccessor: accessor,
+				ObjectConvertor: scheme,
 			},
 		); err != nil {
 			return err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -147,23 +147,19 @@ func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error)
 	switch version {
 	case testGroupVersion:
 		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: accessor,
+			ObjectConvertor: scheme,
 		}, nil
 	case newGroupVersion:
 		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: accessor,
+			ObjectConvertor: scheme,
 		}, nil
 	case grouplessGroupVersion:
 		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: accessor,
+			ObjectConvertor: scheme,
 		}, nil
 	case testGroup2Version:
 		return &meta.VersionInterfaces{
-			ObjectConvertor:  scheme,
-			MetadataAccessor: accessor,
+			ObjectConvertor: scheme,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported storage version: %s (valid: %v)", version, groupVersions)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -155,8 +155,7 @@ func TestInstallAPIGroups(t *testing.T) {
 
 		interfacesFor := func(version schema.GroupVersion) (*meta.VersionInterfaces, error) {
 			return &meta.VersionInterfaces{
-				ObjectConvertor:  scheme,
-				MetadataAccessor: meta.NewAccessor(),
+				ObjectConvertor: scheme,
 			}, nil
 		}
 

--- a/staging/src/k8s.io/client-go/dynamic/BUILD
+++ b/staging/src/k8s.io/client-go/dynamic/BUILD
@@ -14,6 +14,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/client-go/dynamic/dynamic_util.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamic_util.go
@@ -26,15 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// VersionInterfaces provides an object converter and metadata
-// accessor appropriate for use with unstructured objects.
-func VersionInterfaces(schema.GroupVersion) (*meta.VersionInterfaces, error) {
-	return &meta.VersionInterfaces{
-		ObjectConvertor:  &unstructured.UnstructuredObjectConverter{},
-		MetadataAccessor: meta.NewAccessor(),
-	}, nil
-}
-
 // NewDiscoveryRESTMapper returns a RESTMapper based on discovery information.
 func NewDiscoveryRESTMapper(resources []*metav1.APIResourceList, versionFunc meta.VersionInterfacesFunc) (*meta.DefaultRESTMapper, error) {
 	rm := meta.NewDefaultRESTMapper(nil, versionFunc)

--- a/staging/src/k8s.io/client-go/dynamic/dynamic_util_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamic_util_test.go
@@ -19,7 +19,9 @@ package dynamic
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -43,7 +45,7 @@ func TestDiscoveryRESTMapper(t *testing.T) {
 		Kind:    "test_kind",
 	}
 
-	mapper, err := NewDiscoveryRESTMapper(resources, VersionInterfaces)
+	mapper, err := NewDiscoveryRESTMapper(resources, versionInterfaces)
 	if err != nil {
 		t.Fatalf("unexpected error creating mapper: %s", err)
 	}
@@ -76,4 +78,12 @@ func TestDiscoveryRESTMapper(t *testing.T) {
 			t.Errorf("KindFor(%#v) = %#v; want %#v", res, got, gvk)
 		}
 	}
+}
+
+// VersionInterfaces provides an object converter and metadata
+// accessor appropriate for use with unstructured objects.
+func versionInterfaces(schema.GroupVersion) (*meta.VersionInterfaces, error) {
+	return &meta.VersionInterfaces{
+		ObjectConvertor: &unstructured.UnstructuredObjectConverter{},
+	}, nil
 }

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -970,11 +970,11 @@ func (c *allClient) destroy(obj runtime.Object, mapping *meta.RESTMapping) error
 		return err
 	}
 	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
-	name, err := mapping.MetadataAccessor.Name(obj)
+	name, err := meta.NewAccessor().Name(obj)
 	if err != nil {
 		return err
 	}
-	ns, err := mapping.MetadataAccessor.Namespace(obj)
+	ns, err := meta.NewAccessor().Namespace(obj)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Metadata accessors are coded in.  This means that we don't need to inject flexibility, the flexibility is already present based on what your code relies up.  This removes the per-individual resource injection which simplifies all calling code.

intersection of @kubernetes/sig-api-machinery-pr-reviews @kubernetes/sig-cli-maintainers 

```release-note
NONE
```