### PR TITLE
Changes kubeadm upgrade plan output & strategy

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -115,33 +115,32 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 			fmt.Fprintln(w, "")
 		}
 
-		fmt.Fprintf(w, "Upgrade to the latest %s:\n", upgrade.Description)
-		fmt.Fprintln(w, "")
-		fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
-		fmt.Fprintf(tabw, "API Server\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
-		fmt.Fprintf(tabw, "Controller Manager\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
-		fmt.Fprintf(tabw, "Scheduler\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
-		fmt.Fprintf(tabw, "Kube Proxy\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
-		if features.Enabled(featureGates, features.CoreDNS) {
-			fmt.Fprintf(tabw, "CoreDNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
-		} else {
-			fmt.Fprintf(tabw, "Kube DNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
-		}
-		fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
-
-		// The tabwriter should be flushed at this stage as we have now put in all the required content for this time. This is required for the tabs' size to be correct.
-		tabw.Flush()
-		fmt.Fprintln(w, "")
-		fmt.Fprintln(w, "You can now apply the upgrade by executing the following command:")
-		fmt.Fprintln(w, "")
-		fmt.Fprintf(w, "\tkubeadm upgrade apply %s\n", upgrade.After.KubeVersion)
-		fmt.Fprintln(w, "")
-
 		if upgrade.Before.KubeadmVersion != upgrade.After.KubeadmVersion {
-			fmt.Fprintf(w, "Note: Before you can perform this upgrade, you have to update kubeadm to %s.\n", upgrade.After.KubeadmVersion)
+			fmt.Fprintf(w, "Note: In order to show accurate upgrade versions, please use kubeadm version %s.\n", upgrade.After.KubeadmVersion)
+		} else {
+			fmt.Fprintf(w, "Upgrade to the latest %s:\n", upgrade.Description)
 			fmt.Fprintln(w, "")
-		}
+			fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
+			fmt.Fprintf(tabw, "API Server\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
+			fmt.Fprintf(tabw, "Controller Manager\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
+			fmt.Fprintf(tabw, "Scheduler\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
+			fmt.Fprintf(tabw, "Kube Proxy\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
 
+			if features.Enabled(featureGates, features.CoreDNS) {
+				fmt.Fprintf(tabw, "CoreDNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
+			} else {
+				fmt.Fprintf(tabw, "Kube DNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
+			}
+			fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+
+			// The tabwriter should be flushed at this stage as we have now put in all the required content for this time. This is required for the tabs' size to be correct.
+			tabw.Flush()
+			fmt.Fprintln(w, "")
+			fmt.Fprintln(w, "You can now apply the upgrade by executing the following command:")
+			fmt.Fprintln(w, "")
+			fmt.Fprintf(w, "\tkubeadm upgrade apply %s\n", upgrade.After.KubeVersion)
+		}
+		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "_____________________________________________________________________")
 		fmt.Fprintln(w, "")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -146,20 +146,13 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 			// If the cluster version is lower than the newest patch version, we should inform about the possible upgrade
 			if patchUpgradePossible(clusterVersion, patchVersion) {
 
-				// The kubeadm version has to be upgraded to the latest patch version
-				newKubeadmVer := patchVersionStr
-				if kubeadmVersion.AtLeast(patchVersion) {
-					// In this case, the kubeadm CLI version is new enough. Don't display an update suggestion for kubeadm by making .NewKubeadmVersion equal .CurrentKubeadmVersion
-					newKubeadmVer = kubeadmVersionStr
-				}
-
 				upgrades = append(upgrades, Upgrade{
 					Description: description,
 					Before:      beforeState,
 					After: ClusterState{
 						KubeVersion:    patchVersionStr,
 						DNSVersion:     dns.GetDNSVersion(patchVersion, ActiveDNSAddon(featureGates)),
-						KubeadmVersion: newKubeadmVer,
+						KubeadmVersion: patchVersionStr,
 						EtcdVersion:    getSuggestedEtcdVersion(patchVersionStr),
 						// KubeletVersions is unset here as it is not used anywhere in .After
 					},


### PR DESCRIPTION
kubeadm will not guess at versions of components if it is not
the same version it is guessing for.

kubeadm no longer supports upgrading patch versions of previous minor versions.

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**: This PR changes the output of kubeadm plan and encourages users to get the correct version of kubeadm for upgrading.

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubeadm#739

**Special notes for your reviewer**:

This might require discussion or rewording. I'm ok if this doesn't go through, but we will want something like this in the not so distant future.

**Release note**:

```release-note
NONE
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
