### PR TITLE
Make integration test etcd store unique

### DIFF
--- a/test/integration/examples/BUILD
+++ b/test/integration/examples/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//pkg/master:go_default_library",
         "//pkg/master/reconcilers:go_default_library",
         "//test/integration/framework:go_default_library",
+        "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/integration/examples/setup_test.go
+++ b/test/integration/examples/setup_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pborman/uuid"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -86,6 +88,7 @@ func startTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 	kubeAPIServerOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
 	kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
 	kubeAPIServerOptions.InsecureServing.BindPort = 0
+	kubeAPIServerOptions.Etcd.StorageConfig.Prefix = path.Join("/", uuid.New(), "registry")
 	kubeAPIServerOptions.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURL()}
 	kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
 	kubeAPIServerOptions.Authentication.RequestHeader.UsernameHeaders = []string{"X-Remote-User"}


### PR DESCRIPTION
Ensures each test gets a distinct spot in etcd to avoid cross-test pollution

Fixes flakes seen in the etcd_storage_path_test


```release-note
NONE
```