### PR TITLE
Automated cherry pick of #61357: add udev to hyperkube and bump versions

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -95,10 +95,10 @@ docker_pull(
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:fc1b461367730660ac5a40c1eb2d1b23221829acf8a892981c12361383b3742b",
-    registry = "gcr.io",
-    repository = "google-containers/debian-hyperkube-base-amd64",
-    tag = "0.8",  # ignored, but kept here for documentation
+    digest = "sha256:cc782ed16599000ca4c85d47ec6264753747ae1e77520894dca84b104a7621e2",
+    registry = "k8s.gcr.io",
+    repository = "debian-hyperkube-base-amd64",
+    tag = "0.10",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.8
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
Cherry pick of #61357 on release-1.9.

#61357: add udev to hyperkube and bump versions