### PR TITLE
Fix bash command for liveness probes in the metadata agents.

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
@@ -50,7 +50,7 @@ spec:
           exec:
             command:
               - /bin/bash
-              - c
+              - -c
               - |
                 if [[ -f /var/run/metadata-agent/health/unhealthy ]]; then
                   exit 1;
@@ -113,7 +113,7 @@ spec:
           exec:
             command:
               - /bin/bash
-              - c
+              - -c
               - |
                 if [[ -f /var/run/metadata-agent/health/unhealthy ]]; then
                   exit 1;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves an error in the way that the bash liveness probe is defined.

**Release note**:
```release-note
Fix the liveness probe to use `/bin/bash -c` instead of `/bin/bash c`.
```