### PR TITLE
Automated cherry pick of #62464: avoid dobule RLock() in cpumanager

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -56,9 +56,6 @@ func (s *stateMemory) GetDefaultCPUSet() cpuset.CPUSet {
 }
 
 func (s *stateMemory) GetCPUSetOrDefault(containerID string) cpuset.CPUSet {
-	s.RLock()
-	defer s.RUnlock()
-
 	if res, ok := s.GetCPUSet(containerID); ok {
 		return res
 	}


### PR DESCRIPTION
Cherry pick of #62464 on release-1.8.

#62464: avoid dobule RLock() in cpumanager