### PR TITLE
Bump minimum required go version to 1.10.1

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -326,7 +326,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.9.1
+  minimum_go_version=go1.10.1
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     kube::log::usage_from_stdin <<EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
**What this PR does / why we need it**:
We have supported go1.10.x for a few weeks now (#60597). CI has all been updated. This enforces it as the new minimum go version required go k8s >=1.11

**Release note**:
No release note, as #60597 already had one.
```release-note
NONE
```
