### PR TITLE
Accurately matches field values of HTTPExtender.preemptVerb

### DIFF
--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -116,7 +116,7 @@ func (h *HTTPExtender) IsIgnorable() bool {
 // SupportsPreemption returns if a extender support preemption.
 // A extender should have preempt verb defined and enabled its own node cache.
 func (h *HTTPExtender) SupportsPreemption() bool {
-	return len(h.preemptVerb) > 0
+	return h.preemptVerb == "preempt"
 }
 
 // ProcessPreemption returns filtered candidate nodes and victims after running preemption logic in extender.

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -539,3 +539,32 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 func createNode(name string) *v1.Node {
 	return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
+
+func TestHTTPExtenderSupportsPreemption(t *testing.T) {
+	tests := []struct {
+		name        string
+		preemptVerb string
+		want        bool
+	}{
+		{
+			name:        "test 1",
+			preemptVerb: "preempt",
+			want:        true,
+		},
+		{
+			name:        "test 2",
+			preemptVerb: "not-preempt",
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HTTPExtender{
+				preemptVerb: tt.preemptVerb,
+			}
+			if got := h.SupportsPreemption(); got != tt.want {
+				t.Errorf("HTTPExtender.SupportsPreemption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
/kind bug
An error may occur when the passed in is not the string `preempt`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
