### PR TITLE
Automated cherry pick of #62919: Fix vSphere Cloud Provider to handle upgrade from k8s version less than v1.9.4 to v1.9.4+

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/cloudprovider/providers/vsphere/vclib:go_default_library",
         "//pkg/cloudprovider/providers/vsphere/vclib/diskmanagers:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/vmware/govmomi:go_default_library",
         "//vendor/github.com/vmware/govmomi/vim25:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -76,7 +76,11 @@ func (nm *NodeManager) DiscoverNode(node *v1.Node) error {
 	var globalErr *error
 
 	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
-	nodeUUID := GetUUIDFromProviderID(node.Spec.ProviderID)
+	nodeUUID, err := GetNodeUUID(node)
+	if err != nil {
+		glog.Errorf("Node Discovery failed to get node uuid for node %s with error: %v", node.Name, err)
+		return err
+	}
 
 	glog.V(4).Infof("Discovering node %s with uuid %s", node.ObjectMeta.Name, nodeUUID)
 

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -600,7 +600,8 @@ func (vs *VSphere) InstanceExistsByProviderID(providerID string) (bool, error) {
 		return false, err
 	}
 	for _, node := range nodes {
-		if node.VMUUID == GetUUIDFromProviderID(providerID) {
+		// ProviderID is UUID for nodes v1.9.3+
+		if node.VMUUID == GetUUIDFromProviderID(providerID) || node.NodeName == providerID {
 			nodeName = node.NodeName
 			break
 		}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -32,14 +32,14 @@ import (
 
 	"fmt"
 
-	"path/filepath"
-
 	"github.com/vmware/govmomi/vim25/mo"
 
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers"
+	"k8s.io/kubernetes/pkg/util/version"
+	"path/filepath"
 )
 
 const (
@@ -539,7 +539,13 @@ func (vs *VSphere) checkDiskAttached(ctx context.Context, nodes []k8stypes.NodeN
 			return nodesToRetry, err
 		}
 
-		nodeUUID := strings.ToLower(GetUUIDFromProviderID(node.Spec.ProviderID))
+		nodeUUID, err := GetNodeUUID(&node)
+		if err != nil {
+			glog.Errorf("Node Discovery failed to get node uuid for node %s with error: %v", node.Name, err)
+			return nodesToRetry, err
+		}
+		nodeUUID = strings.ToLower(nodeUUID)
+
 		glog.V(9).Infof("Verifying volume for node %s with nodeuuid %q: %s", nodeName, nodeUUID, vmMoMap)
 		vclib.VerifyVolumePathsForVM(vmMoMap[nodeUUID], nodeVolumes[nodeName], convertToString(nodeName), attached)
 	}
@@ -608,4 +614,33 @@ func GetVMUUID() (string, error) {
 
 func GetUUIDFromProviderID(providerID string) string {
 	return strings.TrimPrefix(providerID, ProviderPrefix)
+}
+
+func IsUUIDSupportedNode(node *v1.Node) (bool, error) {
+	newVersion, err := version.ParseSemantic("v1.9.4")
+	if err != nil {
+		glog.Errorf("Failed to determine whether node %+v is old with error %v", node, err)
+		return false, err
+	}
+	nodeVersion, err := version.ParseSemantic(node.Status.NodeInfo.KubeletVersion)
+	if err != nil {
+		glog.Errorf("Failed to determine whether node %+v is old with error %v", node, err)
+		return false, err
+	}
+	if nodeVersion.LessThan(newVersion) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func GetNodeUUID(node *v1.Node) (string, error) {
+	oldNode, err := IsUUIDSupportedNode(node)
+	if err != nil {
+		glog.Errorf("Failed to get node UUID for node %+v with error %v", node, err)
+		return "", err
+	}
+	if oldNode {
+		return node.Status.NodeInfo.SystemUUID, nil
+	}
+	return GetUUIDFromProviderID(node.Spec.ProviderID), nil
 }


### PR DESCRIPTION
Cherry pick of #62919 on release-1.9.

#62919: Fix vSphere Cloud Provider to handle upgrade from k8s version less than v1.9.4 to v1.9.4+

```release-note
Fix in vSphere Cloud Provider to handle upgrades from kubernetes version less than v1.9.4 to v1.9.4 and above.
```
