### PR TITLE
Add Establishing Controller to avoid race between Established condition and CRs actually served

### DIFF
--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -35,6 +35,7 @@ func createAPIExtensionsConfig(
 	externalInformers kubeexternalinformers.SharedInformerFactory,
 	pluginInitializers []admission.PluginInitializer,
 	commandOptions *options.ServerRunOptions,
+	masterCount int,
 ) (*apiextensionsapiserver.Config, error) {
 	// make a shallow copy to let us twiddle a few things
 	// most of the config actually remains the same.  We only need to mess with a couple items related to the particulars of the apiextensions
@@ -69,6 +70,7 @@ func createAPIExtensionsConfig(
 		},
 		ExtraConfig: apiextensionsapiserver.ExtraConfig{
 			CRDRESTOptionsGetter: apiextensionscmd.NewCRDRESTOptionsGetter(etcdOptions),
+			MasterCount:          masterCount,
 		},
 	}
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -165,7 +165,7 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 	}
 
 	// If additional API servers are added, they should be gated.
-	apiExtensionsConfig, err := createAPIExtensionsConfig(*kubeAPIServerConfig.GenericConfig, versionedInformers, pluginInitializer, completedOptions.ServerRunOptions)
+	apiExtensionsConfig, err := createAPIExtensionsConfig(*kubeAPIServerConfig.GenericConfig, versionedInformers, pluginInitializer, completedOptions.ServerRunOptions, completedOptions.MasterCount)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/BUILD
@@ -44,6 +44,7 @@ filegroup(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server:all-srcs",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:all-srcs",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/controller/establish:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/controller/finalizer:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/controller/status:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/BUILD
@@ -1,39 +1,18 @@
-package(default_visibility = ["//visibility:public"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-    "go_test",
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["naming_controller_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-    ],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["naming_controller.go"],
-    importpath = "k8s.io/apiextensions-apiserver/pkg/controller/status",
+    srcs = ["establishing_controller.go"],
+    importpath = "k8s.io/apiextensions-apiserver/pkg/controller/establish",
+    visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
@@ -51,4 +30,5 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish/establishing_controller.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package establish
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	client "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion"
+	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion"
+	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion"
+)
+
+// EstablishingController controls how and when CRD is established.
+type EstablishingController struct {
+	crdClient client.CustomResourceDefinitionsGetter
+	crdLister listers.CustomResourceDefinitionLister
+	crdSynced cache.InformerSynced
+
+	// To allow injection for testing.
+	syncFn func(key string) error
+
+	queue workqueue.RateLimitingInterface
+}
+
+// NewEstablishingController creates new EstablishingController.
+func NewEstablishingController(crdInformer informers.CustomResourceDefinitionInformer,
+	crdClient client.CustomResourceDefinitionsGetter) *EstablishingController {
+	ec := &EstablishingController{
+		crdClient: crdClient,
+		crdLister: crdInformer.Lister(),
+		crdSynced: crdInformer.Informer().HasSynced,
+		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crdEstablishing"),
+	}
+
+	ec.syncFn = ec.sync
+
+	return ec
+}
+
+// QueueCRD adds CRD into the establishing queue.
+func (ec *EstablishingController) QueueCRD(key string, timeout time.Duration) {
+	ec.queue.AddAfter(key, timeout)
+}
+
+// Run starts the EstablishingController.
+func (ec *EstablishingController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer ec.queue.ShutDown()
+
+	glog.Infof("Starting EstablishingController")
+	defer glog.Infof("Shutting down EstablishingController")
+
+	if !cache.WaitForCacheSync(stopCh, ec.crdSynced) {
+		return
+	}
+
+	// only start one worker thread since its a slow moving API
+	go wait.Until(ec.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (ec *EstablishingController) runWorker() {
+	for ec.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem deals with one key off the queue.
+// It returns false when it's time to quit.
+func (ec *EstablishingController) processNextWorkItem() bool {
+	key, quit := ec.queue.Get()
+	if quit {
+		return false
+	}
+	defer ec.queue.Done(key)
+
+	err := ec.syncFn(key.(string))
+	if err == nil {
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+	ec.queue.AddRateLimited(key)
+
+	return true
+}
+
+// sync is used to turn CRDs into the Established state.
+func (ec *EstablishingController) sync(key string) error {
+	cachedCRD, err := ec.crdLister.Get(key)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !apiextensions.IsCRDConditionTrue(cachedCRD, apiextensions.NamesAccepted) ||
+		apiextensions.IsCRDConditionTrue(cachedCRD, apiextensions.Established) {
+		return nil
+	}
+
+	crd := cachedCRD.DeepCopy()
+	establishedCondition := apiextensions.CustomResourceDefinitionCondition{
+		Type:    apiextensions.Established,
+		Status:  apiextensions.ConditionTrue,
+		Reason:  "InitialNamesAccepted",
+		Message: "the initial names have been accepted",
+	}
+	apiextensions.SetCRDCondition(crd, establishedCondition)
+
+	// Update server with new CRD condition.
+	_, err = ec.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
@@ -95,19 +95,17 @@ var acceptedCondition = apiextensions.CustomResourceDefinitionCondition{
 	Message: "no conflicts found",
 }
 
-func nameConflictCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
-	return apiextensions.CustomResourceDefinitionCondition{
-		Type:    apiextensions.NamesAccepted,
-		Status:  apiextensions.ConditionFalse,
-		Reason:  reason,
-		Message: message,
-	}
+var notAcceptedCondition = apiextensions.CustomResourceDefinitionCondition{
+	Type:    apiextensions.NamesAccepted,
+	Status:  apiextensions.ConditionFalse,
+	Reason:  "NotAccepted",
+	Message: "not all names are accepted",
 }
 
-var establishedCondition = apiextensions.CustomResourceDefinitionCondition{
+var installingCondition = apiextensions.CustomResourceDefinitionCondition{
 	Type:    apiextensions.Established,
-	Status:  apiextensions.ConditionTrue,
-	Reason:  "InitialNamesAccepted",
+	Status:  apiextensions.ConditionFalse,
+	Reason:  "Installing",
 	Message: "the initial names have been accepted",
 }
 
@@ -116,6 +114,15 @@ var notEstablishedCondition = apiextensions.CustomResourceDefinitionCondition{
 	Status:  apiextensions.ConditionFalse,
 	Reason:  "NotAccepted",
 	Message: "not all names are accepted",
+}
+
+func nameConflictCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
+	return apiextensions.CustomResourceDefinitionCondition{
+		Type:    apiextensions.NamesAccepted,
+		Status:  apiextensions.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	}
 }
 
 func TestSync(t *testing.T) {
@@ -136,7 +143,7 @@ func TestSync(t *testing.T) {
 				Plural: "alfa",
 			},
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
 			name: "different groups",
@@ -146,7 +153,7 @@ func TestSync(t *testing.T) {
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
 			name: "conflict plural to singular",
@@ -206,7 +213,7 @@ func TestSync(t *testing.T) {
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
 			name: "merge on conflicts",
@@ -248,7 +255,7 @@ func TestSync(t *testing.T) {
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
 			name: "no conflicts on self, remove shortname",
@@ -264,44 +271,44 @@ func TestSync(t *testing.T) {
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1"),
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
-			name:     "established before with true condition",
-			in:       newCRD("alfa.bravo.com").Condition(establishedCondition).NewOrDie(),
+			name:     "installing before with true condition",
+			in:       newCRD("alfa.bravo.com").Condition(acceptedCondition).NewOrDie(),
 			existing: []*apiextensions.CustomResourceDefinition{},
 			expectedNames: apiextensions.CustomResourceDefinitionNames{
 				Plural: "alfa",
 			},
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
-			name:     "not established before with false condition",
-			in:       newCRD("alfa.bravo.com").Condition(notEstablishedCondition).NewOrDie(),
+			name:     "not installing before with false condition",
+			in:       newCRD("alfa.bravo.com").Condition(notAcceptedCondition).NewOrDie(),
 			existing: []*apiextensions.CustomResourceDefinition{},
 			expectedNames: apiextensions.CustomResourceDefinitionNames{
 				Plural: "alfa",
 			},
 			expectedNameConflictCondition: acceptedCondition,
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  installingCondition,
 		},
 		{
-			name: "conflicting, established before with true condition",
+			name: "conflicting, installing before with true condition",
 			in: newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
-				Condition(establishedCondition).
+				Condition(acceptedCondition).
 				NewOrDie(),
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
 			},
 			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
 			expectedNameConflictCondition: nameConflictCondition("PluralConflict", `"alfa" is already in use`),
-			expectedEstablishedCondition:  establishedCondition,
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
-			name: "conflicting, not established before with false condition",
+			name: "conflicting, not installing before with false condition",
 			in: newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
-				Condition(notEstablishedCondition).
+				Condition(notAcceptedCondition).
 				NewOrDie(),
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
@@ -322,7 +329,7 @@ func TestSync(t *testing.T) {
 			crdLister:        listers.NewCustomResourceDefinitionLister(crdIndexer),
 			crdMutationCache: cache.NewIntegerResourceVersionMutationCache(crdIndexer, crdIndexer, 60*time.Second, false),
 		}
-		actualNames, actualNameConflictCondition, actualEstablishedCondition := c.calculateNamesAndConditions(tc.in)
+		actualNames, actualNameConflictCondition, establishedCondition := c.calculateNamesAndConditions(tc.in)
 
 		if e, a := tc.expectedNames, actualNames; !reflect.DeepEqual(e, a) {
 			t.Errorf("%v expected %v, got %#v", tc.name, e, a)
@@ -330,7 +337,7 @@ func TestSync(t *testing.T) {
 		if e, a := tc.expectedNameConflictCondition, actualNameConflictCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
 			t.Errorf("%v expected %v, got %v", tc.name, e, a)
 		}
-		if e, a := tc.expectedEstablishedCondition, actualEstablishedCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
+		if e, a := tc.expectedEstablishedCondition, establishedCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
 			t.Errorf("%v expected %v, got %v", tc.name, e, a)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: If you create CR shorty after CRD, it can happen that it returns error that CRD doesn't exists, even if it exists and is Established. This implements the Establishing Controller, is used to Establish CRD once we're sure it's ready and CRs are served. For more details, check issue #62725.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62725 

```release-note
Add Establishing Controller on CRDs to avoid race between Established condition and CRs actually served. In HA setups, the Established condition is delayed by 5 seconds.
```

/sig api-machinery
/area custom-resources
/cc sttts deads2k