### PR TITLE
Prepull etcd before an upgrade

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -87,7 +87,7 @@ func (d *DaemonSetPrepuller) DeleteFunc(component string) error {
 
 // PrepullImagesInParallel creates DaemonSets synchronously but waits in parallel for the images to pull
 func PrepullImagesInParallel(kubePrepuller Prepuller, timeout time.Duration) error {
-	componentsToPrepull := constants.MasterComponents
+	componentsToPrepull := append(constants.MasterComponents, constants.Etcd)
 	fmt.Printf("[upgrade/prepull] Will prepull images for components %v\n", componentsToPrepull)
 
 	timeoutChan := time.After(timeout)


### PR DESCRIPTION
If kubeadm ever has to upgrade etcd it should prepull the image so
there is less downtime during the upgrade when etcd versions change.

Fixes kubernetes/kubeadm#669

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:

This PR Prepulls the etcd image during a `kubeadm upgrade apply`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes kubernetes/kubeadm#669

**Special notes for your reviewer**:

constants.MasterComponents was not changed because it is used in many places where etcd does not need to be nor should it be a part of this slice.

**Release note**:
```release-note
NONE
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews