### PR TITLE
Automated cherry pick of #63001: Bump kube-dns version for kubeadm upgrade

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -132,7 +132,7 @@ _____________________________________________________________________
 					After: upgrade.ClusterState{
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -148,7 +148,7 @@ API Server           v1.8.3    v1.9.0
 Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
-Kube DNS             1.14.5    1.14.7
+Kube DNS             1.14.5    1.14.10
 Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
@@ -193,7 +193,7 @@ _____________________________________________________________________
 					After: upgrade.ClusterState{
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -229,7 +229,7 @@ API Server           v1.8.3    v1.9.0
 Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
-Kube DNS             1.14.5    1.14.7
+Kube DNS             1.14.5    1.14.10
 Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
@@ -258,7 +258,7 @@ _____________________________________________________________________
 					After: upgrade.ClusterState{
 						KubeVersion:    "v1.9.0-beta.1",
 						KubeadmVersion: "v1.9.0-beta.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -274,7 +274,7 @@ API Server           v1.8.5    v1.9.0-beta.1
 Controller Manager   v1.8.5    v1.9.0-beta.1
 Scheduler            v1.8.5    v1.9.0-beta.1
 Kube Proxy           v1.8.5    v1.9.0-beta.1
-Kube DNS             1.14.5    1.14.7
+Kube DNS             1.14.5    1.14.10
 Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
@@ -303,7 +303,7 @@ _____________________________________________________________________
 					After: upgrade.ClusterState{
 						KubeVersion:    "v1.9.0-rc.1",
 						KubeadmVersion: "v1.9.0-rc.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -319,7 +319,7 @@ API Server           v1.8.5    v1.9.0-rc.1
 Controller Manager   v1.8.5    v1.9.0-rc.1
 Scheduler            v1.8.5    v1.9.0-rc.1
 Kube Proxy           v1.8.5    v1.9.0-rc.1
-Kube DNS             1.14.5    1.14.7
+Kube DNS             1.14.5    1.14.10
 Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:

--- a/cmd/kubeadm/app/phases/addons/dns/versions.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	kubeDNSv180AndAboveVersion = "1.14.5"
-	kubeDNSv190AndAboveVersion = "1.14.7"
+	kubeDNSv190AndAboveVersion = "1.14.10"
 
 	kubeDNSProbeSRV = "SRV"
 	kubeDNSProbeA   = "A"
@@ -33,7 +33,7 @@ const (
 // GetDNSVersion returns the right kube-dns version for a specific k8s version
 func GetDNSVersion(kubeVersion *version.Version, dns string) string {
 	// v1.8.0+ uses kube-dns 1.14.5
-	// v1.9.0+ uses kube-dns 1.14.7
+	// v1.9.0+ uses kube-dns 1.14.10
 	// v1.9.0+ uses CoreDNS  1.0.1
 
 	// In the future when the version is bumped at HEAD; add conditional logic to return the right versions

--- a/cmd/kubeadm/app/phases/addons/dns/versions_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions_test.go
@@ -53,7 +53,7 @@ func TestGetKubeDNSVersion(t *testing.T) {
 		},
 		{
 			k8sVersion: "v1.9.0",
-			expected:   "1.14.7",
+			expected:   "1.14.10",
 		},
 	}
 	for _, rt := range tests {

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package upgrade
 
 import (
-	"github.com/coreos/etcd/clientv3"
-	versionutil "k8s.io/kubernetes/pkg/util/version"
 	"reflect"
 	"testing"
+
+	"github.com/coreos/etcd/clientv3"
+	versionutil "k8s.io/kubernetes/pkg/util/version"
 )
 
 type fakeVersionGetter struct {
@@ -113,7 +114,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.8.3",
 						KubeadmVersion: "v1.8.3",
-						DNSVersion:     "1.14.5",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.0.17",
 					},
 				},
@@ -145,7 +146,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -195,7 +196,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.1",
 						KubeadmVersion: "v1.9.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -242,7 +243,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-alpha.2",
 						KubeadmVersion: "v1.9.0-alpha.2",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -269,13 +270,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 							"v1.8.5": 1,
 						},
 						KubeadmVersion: "v1.8.5",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.0.14",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-alpha.2",
 						KubeadmVersion: "v1.9.0-alpha.2",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -309,7 +310,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-beta.1",
 						KubeadmVersion: "v1.9.0-beta.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -343,7 +344,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-rc.1",
 						KubeadmVersion: "v1.9.0-rc.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -377,7 +378,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.6-rc.1",
 						KubeadmVersion: "v1.9.6-rc.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -411,7 +412,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-rc.1",
 						KubeadmVersion: "v1.9.0-rc.1",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},
@@ -429,7 +430,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-alpha.2",
 						KubeadmVersion: "v1.10.0-alpha.2",
-						DNSVersion:     "1.14.7",
+						DNSVersion:     "1.14.10",
 						EtcdVersion:    "3.1.11",
 					},
 				},


### PR DESCRIPTION
Cherry pick of #63001 on release-1.9.

#63001: Bump kube-dns version for kubeadm upgrade

**Release note**:

```release-note
NONE
```