### PR TITLE
Automated cherry pick of #63033: Fix bash command for liveness probes in the metadata agents.

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
@@ -47,7 +47,7 @@ spec:
           exec:
             command:
               - /bin/bash
-              - c
+              - -c
               - |
                 if [[ -f /var/run/metadata-agent/health/unhealthy ]]; then
                   exit 1;
@@ -110,7 +110,7 @@ spec:
           exec:
             command:
               - /bin/bash
-              - c
+              - -c
               - |
                 if [[ -f /var/run/metadata-agent/health/unhealthy ]]; then
                   exit 1;


### PR DESCRIPTION
Cherry pick of #63033 on release-1.10.

#63033: Fix bash command for liveness probes in the metadata agents.