### PR TITLE
Fix qosReserved json tag (lowercase qos, instead of uppercase QOS)

### DIFF
--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -260,7 +260,7 @@ type KubeletConfiguration struct {
 	// Requires the QOSReserved feature gate to be enabled.
 	// Default: nil
 	// +optional
-	QOSReserved map[string]string `json:"QOSReserved,omitempty"`
+	QOSReserved map[string]string `json:"qosReserved,omitempty"`
 	// runtimeRequestTimeout is the timeout for all runtime requests except long running
 	// requests - pull, logs, exec and attach.
 	// Default: "2m"


### PR DESCRIPTION
The API conventions specify that json keys should start with a lowercase
character, and if the key starts with an initialism, all characters in
the initialism should be lowercase. See `tlsCipherSuites` as an example.

API Conventions:
https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md

>All letters in the acronym should have the same case, using the
>appropriate case for the situation. For example, at the beginning
>of a field name, the acronym should be all lowercase, such as "httpGet".

Follow up to: https://github.com/kubernetes/kubernetes/pull/62925

```release-note
NONE
```

@sjenning @derekwaynecarr 
