### PR TITLE
git_repo, gce_pd, flocker: replace path with filepath

### DIFF
--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -19,7 +19,7 @@ package flocker
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/golang/glog"
@@ -82,7 +82,7 @@ func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
 }
 
 func makeGlobalFlockerPath(datasetUUID string) string {
-	return path.Join(defaultMountPath, datasetUUID)
+	return filepath.Join(defaultMountPath, datasetUUID)
 }
 
 func (p *flockerPlugin) Init(host volume.VolumeHost) error {

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -19,7 +19,6 @@ package gce_pd
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -93,7 +92,7 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName ty
 		}
 	}
 
-	return path.Join(diskByIdPath, diskGooglePrefix+pdName), nil
+	return filepath.Join(diskByIdPath, diskGooglePrefix+pdName), nil
 }
 
 func (attacher *gcePersistentDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
@@ -247,7 +246,7 @@ func (plugin *gcePersistentDiskPlugin) NewDetacher() (volume.Detacher, error) {
 // Callers are responsible for thread safety between concurrent attach and detach
 // operations.
 func (detacher *gcePersistentDiskDetacher) Detach(volumeName string, nodeName types.NodeName) error {
-	pdName := path.Base(volumeName)
+	pdName := filepath.Base(volumeName)
 
 	attached, err := detacher.gceDisks.DiskIsAttached(pdName, nodeName)
 	if err != nil {

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -19,7 +19,7 @@ package gce_pd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/golang/glog"
@@ -347,7 +347,7 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func makeGlobalPDName(host volume.VolumeHost, devName string) string {
-	return path.Join(host.GetPluginDir(gcePersistentDiskPluginName), mount.MountsInGlobalPDPath, devName)
+	return filepath.Join(host.GetPluginDir(gcePersistentDiskPluginName), mount.MountsInGlobalPDPath, devName)
 }
 
 func (b *gcePersistentDiskMounter) GetPath() string {

--- a/pkg/volume/gce_pd/gce_pd_block.go
+++ b/pkg/volume/gce_pd/gce_pd_block.go
@@ -18,7 +18,6 @@ package gce_pd
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 
@@ -158,7 +157,7 @@ func (pd *gcePersistentDisk) GetGlobalMapPath(spec *volume.Spec) (string, error)
 	if err != nil {
 		return "", err
 	}
-	return path.Join(pd.plugin.host.GetVolumeDevicePluginDir(gcePersistentDiskPluginName), string(volumeSource.PDName)), nil
+	return filepath.Join(pd.plugin.host.GetVolumeDevicePluginDir(gcePersistentDiskPluginName), string(volumeSource.PDName)), nil
 }
 
 // GetPodDeviceMapPath returns pod device map path and volume name

--- a/pkg/volume/gce_pd/gce_pd_block_test.go
+++ b/pkg/volume/gce_pd/gce_pd_block_test.go
@@ -18,7 +18,7 @@ package gce_pd
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -47,7 +47,7 @@ func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
 
 	//Bad Path
 	badspec, err := getVolumeSpecFromGlobalMapPath("")
@@ -102,8 +102,8 @@ func TestGetPodAndPluginMapPaths(t *testing.T) {
 	//deferred clean up
 	defer os.RemoveAll(tmpVDir)
 
-	expectedGlobalPath := path.Join(tmpVDir, testGlobalPath)
-	expectedPodPath := path.Join(tmpVDir, testPodPath)
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
+	expectedPodPath := filepath.Join(tmpVDir, testPodPath)
 
 	spec := getTestVolume(false, tmpVDir, true /*isBlock*/)
 	plugMgr := volume.VolumePluginMgr{}

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -19,7 +19,7 @@ package gce_pd
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -123,7 +123,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Got a nil Mounter")
 	}
 
-	volPath := path.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~gce-pd/vol1")
+	volPath := filepath.Join(tmpDir, "pods/poduid/volumes/kubernetes.io~gce-pd/vol1")
 	path := mounter.GetPath()
 	if path != volPath {
 		t.Errorf("Got unexpected path: %s", path)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -18,7 +18,6 @@ package gce_pd
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -299,8 +298,8 @@ func verifyAllPathsRemoved(devicePaths []string) (bool, error) {
 // Returns list of all /dev/disk/by-id/* paths for given PD.
 func getDiskByIdPaths(pdName string, partition string) []string {
 	devicePaths := []string{
-		path.Join(diskByIdPath, diskGooglePrefix+pdName),
-		path.Join(diskByIdPath, diskScsiGooglePrefix+pdName),
+		filepath.Join(diskByIdPath, diskGooglePrefix+pdName),
+		filepath.Join(diskByIdPath, diskScsiGooglePrefix+pdName),
 	}
 
 	if partition != "" {

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -19,7 +19,7 @@ package git_repo
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -216,10 +216,10 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	switch {
 	case b.target == ".":
 		// if target dir is '.', use the current dir
-		subdir = path.Join(dir)
+		subdir = filepath.Join(dir)
 	case len(files) == 1:
 		// if target is not '.', use the generated folder
-		subdir = path.Join(dir, files[0].Name())
+		subdir = filepath.Join(dir, files[0].Name())
 	default:
 		// if target is not '.', but generated many files, it's wrong
 		return fmt.Errorf("unexpected directory contents: %v", files)
@@ -239,7 +239,7 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func (b *gitRepoVolumeMounter) getMetaDir() string {
-	return path.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedNameForDisk(gitRepoPluginName)), b.volName)
+	return filepath.Join(b.plugin.host.GetPodPluginDir(b.podUID, utilstrings.EscapeQualifiedNameForDisk(gitRepoPluginName)), b.volName)
 }
 
 func (b *gitRepoVolumeMounter) execCommand(command string, args []string, dir string) ([]byte, error) {

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -327,7 +327,7 @@ func doTestSetUp(scenario struct {
 		if expected.cmd[1] == "clone" {
 			fakeOutputs = append(fakeOutputs, func() ([]byte, error) {
 				// git clone, it creates new dir/files
-				os.MkdirAll(path.Join(fcmd.Dirs[0], expected.dir), 0750)
+				os.MkdirAll(filepath.Join(fcmd.Dirs[0], expected.dir), 0750)
 				return []byte{}, nil
 			})
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR replaces usage of `path` with `filepath` as it uses OS-specific path separators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62916 

**Special notes for your reviewer**:
This PR addresses the following volume plugins:
- `pkg/volume/git_repo`
- `pkg/volume/gce_pd`
- `pkg/volume/flocker`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
