### PR TITLE
fc, flexvolume: replace path with filepath

### DIFF
--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -134,18 +133,18 @@ func scsiHostRescan(io ioHandler) {
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/fc/target-lun-0
 func makePDNameInternal(host volume.VolumeHost, wwns []string, lun string, wwids []string) string {
 	if len(wwns) != 0 {
-		return path.Join(host.GetPluginDir(fcPluginName), wwns[0]+"-lun-"+lun)
+		return filepath.Join(host.GetPluginDir(fcPluginName), wwns[0]+"-lun-"+lun)
 	} else {
-		return path.Join(host.GetPluginDir(fcPluginName), wwids[0])
+		return filepath.Join(host.GetPluginDir(fcPluginName), wwids[0])
 	}
 }
 
 // make a directory like /var/lib/kubelet/plugins/kubernetes.io/fc/volumeDevices/target-lun-0
 func makeVDPDNameInternal(host volume.VolumeHost, wwns []string, lun string, wwids []string) string {
 	if len(wwns) != 0 {
-		return path.Join(host.GetVolumeDevicePluginDir(fcPluginName), wwns[0]+"-lun-"+lun)
+		return filepath.Join(host.GetVolumeDevicePluginDir(fcPluginName), wwns[0]+"-lun-"+lun)
 	} else {
-		return path.Join(host.GetVolumeDevicePluginDir(fcPluginName), wwids[0])
+		return filepath.Join(host.GetVolumeDevicePluginDir(fcPluginName), wwids[0])
 	}
 }
 
@@ -334,7 +333,7 @@ func (util *FCUtil) DetachBlockFCDisk(c fcDiskUnmapper, mapPath, devicePath stri
 	}
 	for _, fi := range fis {
 		if strings.Contains(fi.Name(), volumeInfo) {
-			devicePath = path.Join(searchPath, fi.Name())
+			devicePath = filepath.Join(searchPath, fi.Name())
 			glog.V(5).Infof("fc: updated devicePath: %s", devicePath)
 			break
 		}

--- a/pkg/volume/flexvolume/flexvolume_test.go
+++ b/pkg/volume/flexvolume/flexvolume_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"text/template"
 
@@ -131,12 +131,12 @@ func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, e
 	if vendorName != "" {
 		vendoredName = fmt.Sprintf("%s~%s", vendorName, plugName)
 	}
-	pluginDir := path.Join(tmpDir, vendoredName)
+	pluginDir := filepath.Join(tmpDir, vendoredName)
 	err := os.MkdirAll(pluginDir, 0777)
 	if err != nil {
 		t.Errorf("Failed to create plugin: %v", err)
 	}
-	pluginExec := path.Join(pluginDir, plugName)
+	pluginExec := filepath.Join(pluginDir, plugName)
 	f, err := os.Create(pluginExec)
 	if err != nil {
 		t.Errorf("Failed to install plugin")
@@ -148,7 +148,7 @@ func installPluginUnderTest(t *testing.T, vendorName, plugName, tmpDir string, e
 	if execTemplateData == nil {
 		execTemplateData = &map[string]interface{}{
 			"DevicePath": "/dev/sdx",
-			"OutputFile": path.Join(pluginDir, plugName+".out"),
+			"OutputFile": filepath.Join(pluginDir, plugName+".out"),
 		}
 	}
 

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -18,7 +18,7 @@ package flexvolume
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -65,7 +65,7 @@ type PluginFactory interface {
 type pluginFactory struct{}
 
 func (pluginFactory) NewFlexVolumePlugin(pluginDir, name string) (volume.VolumePlugin, error) {
-	execPath := path.Join(pluginDir, name)
+	execPath := filepath.Join(pluginDir, name)
 
 	driverName := utilstrings.UnescapePluginName(name)
 
@@ -102,7 +102,7 @@ func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
 func (plugin *flexVolumePlugin) getExecutable() string {
 	parts := strings.Split(plugin.driverName, "/")
 	execName := parts[len(parts)-1]
-	execPath := path.Join(plugin.execPath, execName)
+	execPath := filepath.Join(plugin.execPath, execName)
 	if runtime.GOOS == "windows" {
 		execPath = util.GetWindowsPath(execPath)
 	}
@@ -274,6 +274,6 @@ func (plugin *flexVolumePlugin) getDeviceMountPath(spec *volume.Spec) (string, e
 		return "", fmt.Errorf("GetVolumeName failed from getDeviceMountPath: %s", err)
 	}
 
-	mountsDir := path.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts")
-	return path.Join(mountsDir, volumeName), nil
+	mountsDir := filepath.Join(plugin.host.GetPluginDir(flexVolumePluginName), plugin.driverName, "mounts")
+	return filepath.Join(mountsDir, volumeName), nil
 }

--- a/pkg/volume/flexvolume/probe_test.go
+++ b/pkg/volume/flexvolume/probe_test.go
@@ -18,7 +18,7 @@ package flexvolume
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -70,8 +70,8 @@ func TestProberAddRemoveDriver(t *testing.T) {
 
 	// add driver
 	const driverName2 = "fake-driver2"
-	driverPath := path.Join(pluginDir, driverName2)
-	executablePath := path.Join(driverPath, driverName2)
+	driverPath := filepath.Join(pluginDir, driverName2)
+	executablePath := filepath.Join(driverPath, driverName2)
 	installDriver(driverName2, fs)
 	watcher.TriggerEvent(fsnotify.Create, driverPath)
 	watcher.TriggerEvent(fsnotify.Create, executablePath)
@@ -94,7 +94,7 @@ func TestProberAddRemoveDriver(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call probe after a non-driver file is added in a subdirectory. should return 1 event.
-	fp := path.Join(driverPath, "dummyfile")
+	fp := filepath.Join(driverPath, "dummyfile")
 	fs.Create(fp)
 	watcher.TriggerEvent(fsnotify.Create, fp)
 
@@ -114,7 +114,7 @@ func TestProberAddRemoveDriver(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call probe after a subdirectory is added in a driver directory. should return 1 event.
-	subdirPath := path.Join(driverPath, "subdir")
+	subdirPath := filepath.Join(driverPath, "subdir")
 	fs.Create(subdirPath)
 	watcher.TriggerEvent(fsnotify.Create, subdirPath)
 
@@ -195,7 +195,7 @@ func TestRemovePluginDir(t *testing.T) {
 	// Arrange
 	driverPath, fs, watcher, _ := initTestEnvironment(t)
 	fs.RemoveAll(pluginDir)
-	watcher.TriggerEvent(fsnotify.Remove, path.Join(driverPath, driverName))
+	watcher.TriggerEvent(fsnotify.Remove, filepath.Join(driverPath, driverName))
 	watcher.TriggerEvent(fsnotify.Remove, driverPath)
 	watcher.TriggerEvent(fsnotify.Remove, pluginDir)
 
@@ -215,7 +215,7 @@ func TestNestedDriverDir(t *testing.T) {
 
 	// test add testDriverName
 	testDriverName := "testDriverName"
-	testDriverPath := path.Join(pluginDir, testDriverName)
+	testDriverPath := filepath.Join(pluginDir, testDriverName)
 	fs.MkdirAll(testDriverPath, 0666)
 	watcher.TriggerEvent(fsnotify.Create, testDriverPath)
 	// Assert
@@ -226,7 +226,7 @@ func TestNestedDriverDir(t *testing.T) {
 	basePath := testDriverPath
 	for i := 0; i < 10; i++ {
 		subdirName := "subdirName"
-		subdirPath := path.Join(basePath, subdirName)
+		subdirPath := filepath.Join(basePath, subdirName)
 		fs.MkdirAll(subdirPath, 0666)
 		watcher.TriggerEvent(fsnotify.Create, subdirPath)
 		// Assert
@@ -245,9 +245,9 @@ func TestProberMultipleEvents(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		newDriver := fmt.Sprintf("multi-event-driver%d", 1)
 		installDriver(newDriver, fs)
-		driverPath := path.Join(pluginDir, newDriver)
+		driverPath := filepath.Join(pluginDir, newDriver)
 		watcher.TriggerEvent(fsnotify.Create, driverPath)
-		watcher.TriggerEvent(fsnotify.Create, path.Join(driverPath, newDriver))
+		watcher.TriggerEvent(fsnotify.Create, filepath.Join(driverPath, newDriver))
 	}
 
 	// Act
@@ -283,9 +283,9 @@ func TestProberError(t *testing.T) {
 
 // Installs a mock driver (an empty file) in the mock fs.
 func installDriver(driverName string, fs utilfs.Filesystem) {
-	driverPath := path.Join(pluginDir, driverName)
+	driverPath := filepath.Join(pluginDir, driverName)
 	fs.MkdirAll(driverPath, 0666)
-	fs.Create(path.Join(driverPath, driverName))
+	fs.Create(filepath.Join(driverPath, driverName))
 }
 
 // Initializes mocks, installs a single driver in the mock fs, then initializes prober.
@@ -302,7 +302,7 @@ func initTestEnvironment(t *testing.T) (
 		fs:        fs,
 		factory:   fakePluginFactory{error: false},
 	}
-	driverPath = path.Join(pluginDir, driverName)
+	driverPath = filepath.Join(pluginDir, driverName)
 	installDriver(driverName, fs)
 	prober.Init()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR replaces usage of `path` with `filepath` as it uses OS-specific path separators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62916 

**Special notes for your reviewer**:
This PR addresses the following volume plugins:
- `pkg/volume/fc`
- `pkg/volume/flexvolume`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
