### PR TITLE
test/e2e/storage: replace path with filepath

### DIFF
--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"path"
+	"path/filepath"
 
 	"time"
 
@@ -74,7 +74,7 @@ func testFlexVolume(driver string, cs clientset.Interface, config framework.Volu
 // controller-manager if 'restart' is true.
 func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath string, restart bool) {
 	flexDir := getFlexDir(c, node, vendor, driver)
-	flexFile := path.Join(flexDir, driver)
+	flexFile := filepath.Join(flexDir, driver)
 
 	host := ""
 	if node != nil {
@@ -146,7 +146,7 @@ func getFlexDir(c clientset.Interface, node *v1.Node, vendor, driver string) str
 			}
 		}
 	}
-	flexDir := path.Join(volumePluginDir, fmt.Sprintf("/%s~%s/", vendor, driver))
+	flexDir := filepath.Join(volumePluginDir, fmt.Sprintf("/%s~%s/", vendor, driver))
 	return flexDir
 }
 
@@ -210,8 +210,8 @@ var _ = utils.SIGDescribe("Flexvolumes [Disruptive]", func() {
 		driver := "dummy"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver), true /* restart */)
+		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(cs, &node, "k8s", driverInstallAs, filepath.Join(driverDir, driver), true /* restart */)
 
 		testFlexVolume(driverInstallAs, cs, config, f)
 
@@ -228,10 +228,10 @@ var _ = utils.SIGDescribe("Flexvolumes [Disruptive]", func() {
 		driver := "dummy-attachable"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver), true /* restart */)
-		By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
-		installFlex(cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver), true /* restart */)
+		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(cs, &node, "k8s", driverInstallAs, filepath.Join(driverDir, driver), true /* restart */)
+		By(fmt.Sprintf("installing flexvolume %s on master as %s", filepath.Join(driverDir, driver), driverInstallAs))
+		installFlex(cs, nil, "k8s", driverInstallAs, filepath.Join(driverDir, driver), true /* restart */)
 
 		testFlexVolume(driverInstallAs, cs, config, f)
 
@@ -250,8 +250,8 @@ var _ = utils.SIGDescribe("Flexvolumes [Disruptive]", func() {
 		driver := "dummy"
 		driverInstallAs := driver + "-" + suffix
 
-		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(cs, &node, "k8s", driverInstallAs, path.Join(driverDir, driver), false /* restart */)
+		By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(cs, &node, "k8s", driverInstallAs, filepath.Join(driverDir, driver), false /* restart */)
 
 		testFlexVolume(driverInstallAs, cs, config, f)
 

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -412,7 +412,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 		BeforeEach(func() {
 			setupStorageClass(config, &immediateMode)
 			setupLocalVolumeProvisioner(config)
-			volumePath = path.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
+			volumePath = filepath.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
 			setupLocalVolumeProvisionerMountPoint(config, volumePath, config.node0)
 		})
 
@@ -492,7 +492,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			createProvisionerDaemonset(config)
 
 			By("Creating a volume in discovery directory")
-			dynamicVolumePath := path.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
+			dynamicVolumePath := filepath.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
 			setupLocalVolumeProvisionerMountPoint(config, dynamicVolumePath, config.node0)
 
 			By("Waiting for the PersistentVolume to be created")
@@ -561,7 +561,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				By(fmt.Sprintf("Setting up local volumes on node %q", node.Name))
 				paths := []string{}
 				for j := 0; j < volsPerNode; j++ {
-					volumePath := path.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
+					volumePath := filepath.Join(config.discoveryDir, fmt.Sprintf("vol-%v", string(uuid.NewUUID())))
 					setupLocalVolumeProvisionerMountPoint(config, volumePath, &config.nodes[i])
 					paths = append(paths, volumePath)
 				}

--- a/test/e2e/storage/volume_io.go
+++ b/test/e2e/storage/volume_io.go
@@ -30,7 +30,7 @@ package storage
 import (
 	"fmt"
 	"math"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -186,8 +186,8 @@ func deleteFile(pod *v1.Pod, fpath string) {
 // Note: `fsizes` values are enforced to each be at least `minFileSize` and a multiple of `minFileSize`
 //   bytes.
 func testVolumeIO(f *framework.Framework, cs clientset.Interface, config framework.VolumeTestConfig, volsrc v1.VolumeSource, podSecContext *v1.PodSecurityContext, file string, fsizes []int64) (err error) {
-	dir := path.Join("/opt", config.Prefix, config.Namespace)
-	dd_input := path.Join(dir, "dd_if")
+	dir := filepath.Join("/opt", config.Prefix, config.Namespace)
+	dd_input := filepath.Join(dir, "dd_if")
 	writeBlk := strings.Repeat("abcdefghijklmnopqrstuvwxyz123456", 32) // 1KiB value
 	loopCnt := minFileSize / int64(len(writeBlk))
 	// initContainer cmd to create and fill dd's input file. The initContainer is used to create
@@ -229,7 +229,7 @@ func testVolumeIO(f *framework.Framework, cs clientset.Interface, config framewo
 		if math.Mod(float64(fsize), float64(minFileSize)) != 0 {
 			fsize = fsize/minFileSize + minFileSize
 		}
-		fpath := path.Join(dir, fmt.Sprintf("%s-%d", file, fsize))
+		fpath := filepath.Join(dir, fmt.Sprintf("%s-%d", file, fsize))
 		if err = writeToFile(clientPod, fpath, dd_input, fsize); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR replaces usage of `path` with `filepath` as it uses OS-specific path separators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62916 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
