### PR TITLE
cloud node controller: don't override all node addresses when validating node ip from kubelet

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -191,7 +191,6 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 			glog.Errorf("Specified Node IP not found in cloudprovider")
 			return
 		}
-		nodeAddresses = []v1.NodeAddress{*nodeIP}
 	}
 	newNode := node.DeepCopy()
 	newNode.Status.Addresses = nodeAddresses

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -854,7 +854,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 	assert.Equal(t, 1, len(fnh.UpdatedNodes), "Node was not updated")
 	assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
-	assert.Equal(t, 1, len(fnh.UpdatedNodes[0].Status.Addresses), "Node status unexpectedly updated")
+	assert.Equal(t, 3, len(fnh.UpdatedNodes[0].Status.Addresses), "Node status unexpectedly updated")
 
 	cloudNodeController.Run()
 
@@ -862,7 +862,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 	updatedNodes := fnh.GetUpdatedNodesCopy()
 
-	assert.Equal(t, 1, len(updatedNodes[0].Status.Addresses), 1, "Node Addresses not correctly updated")
+	assert.Equal(t, 3, len(updatedNodes[0].Status.Addresses), "Node Addresses not correctly updated")
 	assert.Equal(t, "10.0.0.1", updatedNodes[0].Status.Addresses[0].Address, "Node Addresses not correctly updated")
 }
 

--- a/pkg/kubelet/apis/well_known_annotations.go
+++ b/pkg/kubelet/apis/well_known_annotations.go
@@ -19,7 +19,7 @@ package apis
 const (
 	// When kubelet is started with the "external" cloud provider, then
 	// it sets this annotation on the node to denote an ip address set from the
-	// cmd line flag. This ip is verified with the cloudprovider as valid by
+	// cmd line flag (--node-ip). This ip is verified with the cloudprovider as valid by
 	// the cloud-controller-manager
 	AnnotationProvidedIPAddr = "alpha.kubernetes.io/provided-node-ip"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The current behaviour for node controller if a kubelet sets `--node-ip` is to override all other node address types. The correct behaviour is to validate if `--node-ip` is set as one of the node addresses, and error if it's not. 

related: https://github.com/kubernetes/kubernetes/issues/61921 

**Special notes for your reviewer**:

**Release note**:
```release-note
cloud node controller: don't override all node addresses when validating --node-ip from kubelet
```
