### PR TITLE
adding scenarios for namespace apigroup

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -679,6 +679,7 @@ staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
 staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller
 staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1
 test/e2e
+test/e2e/api
 test/e2e/apimachinery
 test/e2e/apps
 test/e2e/auth

--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -12,6 +12,7 @@ go_test(
     embed = [":go_default_library"],
     tags = ["e2e"],
     deps = [
+        "//test/e2e/api:go_default_library",
         "//test/e2e/apimachinery:go_default_library",
         "//test/e2e/apps:go_default_library",
         "//test/e2e/auth:go_default_library",
@@ -95,6 +96,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//test/e2e/api:all-srcs",
         "//test/e2e/apimachinery:all-srcs",
         "//test/e2e/apps:all-srcs",
         "//test/e2e/auth:all-srcs",

--- a/test/e2e/api/BUILD
+++ b/test/e2e/api/BUILD
@@ -18,7 +18,9 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )
 

--- a/test/e2e/api/BUILD
+++ b/test/e2e/api/BUILD
@@ -1,37 +1,36 @@
 package(default_visibility = ["//visibility:public"])
 
-	load(
-	    "@io_bazel_rules_go//go:def.bzl",
-	    "go_library",
-	)
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
 
-	go_library(
-	    name = "go_default_library",
-	    srcs = ["namespaces.go"],
-	    importpath = "k8s.io/kubernetes/test/e2e/api",
-	    visibility = ["//visibility:private"],
-	    deps = [
-			 "//vendor/k8s.io/api/core/v1:go_default_library",
-			 "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-			"//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
-		
-		"//test/e2e/framework:go_default_library",
-		
-		"//vendor/github.com/onsi/ginkgo:go_default_library",
-		"//vendor/github.com/onsi/gomega:go_default_library",
-	    ],
-	)
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "namespaces.go",
+        "framework.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/e2e/api",
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)
 
-	filegroup(
-	    name = "package-srcs",
-	    srcs = glob(["**"]),
-	    tags = ["automanaged"],
-	    visibility = ["//visibility:private"],
-	)
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
 
-	filegroup(
-	    name = "all-srcs",
-	    srcs = [":package-srcs"],
-	    tags = ["automanaged"],
-	    visibility = ["//visibility:public"],
-	)
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/e2e/api/BUILD
+++ b/test/e2e/api/BUILD
@@ -8,17 +8,17 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
-        "namespaces.go",
         "framework.go",
+        "namespaces.go",
     ],
     importpath = "k8s.io/kubernetes/test/e2e/api",
     deps = [
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
     ],
 )
 

--- a/test/e2e/api/BUILD
+++ b/test/e2e/api/BUILD
@@ -1,0 +1,37 @@
+package(default_visibility = ["//visibility:public"])
+
+	load(
+	    "@io_bazel_rules_go//go:def.bzl",
+	    "go_library",
+	)
+
+	go_library(
+	    name = "go_default_library",
+	    srcs = ["namespaces.go"],
+	    importpath = "k8s.io/kubernetes/test/e2e/api",
+	    visibility = ["//visibility:private"],
+	    deps = [
+			 "//vendor/k8s.io/api/core/v1:go_default_library",
+			 "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+			"//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+		
+		"//test/e2e/framework:go_default_library",
+		
+		"//vendor/github.com/onsi/ginkgo:go_default_library",
+		"//vendor/github.com/onsi/gomega:go_default_library",
+	    ],
+	)
+
+	filegroup(
+	    name = "package-srcs",
+	    srcs = glob(["**"]),
+	    tags = ["automanaged"],
+	    visibility = ["//visibility:private"],
+	)
+
+	filegroup(
+	    name = "all-srcs",
+	    srcs = [":package-srcs"],
+	    tags = ["automanaged"],
+	    visibility = ["//visibility:public"],
+	)

--- a/test/e2e/api/framework.go
+++ b/test/e2e/api/framework.go
@@ -18,6 +18,7 @@ package api
 
 import "github.com/onsi/ginkgo"
 
+// Creating a description for api testing
 func SIGDescribe(text string, body func()) bool {
 	return ginkgo.Describe("[sig-api] "+text, body)
 }

--- a/test/e2e/api/framework.go
+++ b/test/e2e/api/framework.go
@@ -18,7 +18,7 @@ package api
 
 import "github.com/onsi/ginkgo"
 
-// Creating a description for api testing
+// SIGDescribe is a method for labeling api-rest-like operations on kubernates api
 func SIGDescribe(text string, body func()) bool {
 	return ginkgo.Describe("[sig-api] "+text, body)
 }

--- a/test/e2e/api/framework.go
+++ b/test/e2e/api/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-api] "+text, body)
+}

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("api-namespaces", func() {
 		     2) post it
 		     3) check that the newly created namespace is brought when get by name is invoked.
 		     4) check that the newly created namespace appears on the list.
-		     5) delete the namespace, waiting until 
+		     5) delete the namespace, waiting until finished.
 		     6) check that the newly created namespace is NOT brought when get by name is invoked.
 		     7) check that the newly created namespace does NOT appear on the list.
 		*/

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("api-namespaces", func() {
 		     6) check that the newly created namespace is NOT brought when get by name is invoked.
 		     7) check that the newly created namespace does NOT appear on the list.
 		*/
-		framework.ConformanceIt("scenario: get: not-found > post > list : found > get by name: found-and-matches >  delete >  list: not-found > get: not-found", func() {
+		It("scenario: get: not-found > post > list : found > get by name: found-and-matches >  delete >  list: not-found > get: not-found", func() {
 			namespaceName :=
 				strings.Join([]string{"testbasename", string(uuid.NewUUID())}, "")
 
@@ -155,7 +155,7 @@ var _ = SIGDescribe("api-namespaces", func() {
 		     5) check that the newly created namespace is brought when get by name is invoked.
 		     6) delete the namespace.
 		*/
-		framework.ConformanceIt("scenario: get:not found > post >  get by name: found-and-matches >  patch  > get: found > delete", func() {
+		It("scenario: get:not found > post >  get by name: found-and-matches >  patch  > get: found > delete", func() {
 			namespaceName :=
 				strings.Join([]string{"testbasename", string(uuid.NewUUID())}, "")
 
@@ -280,6 +280,7 @@ func newDefaultVerifier() NamespaceVerifier {
 		verifyKind: func(namespace *v1.Namespace) {
 			Expect(namespace.TypeMeta.Kind).To(Equal(""))
 		},
+		
 		verifyAPIVersion: func(namespace *v1.Namespace) {
 			Expect(namespace.TypeMeta.APIVersion).To(Equal(""))
 		},
@@ -287,32 +288,30 @@ func newDefaultVerifier() NamespaceVerifier {
 		verifyName: func(namespace *v1.Namespace) {
 			Expect(namespace.ObjectMeta.Name).To(Equal(""))
 		},
+		
 		verifyGenerateName: func(namespace *v1.Namespace) {
 			Expect(namespace.ObjectMeta.GenerateName).To(Equal(""))
 		},
-
+		
 		verifySelfLink: func(namespace *v1.Namespace) {
-
 		},
+		
 		verifyUID: func(namespace *v1.Namespace) {
-			// TODO / Question
-			// How to work against UID? wanted to check is not empty
-			//Expect(len(strings.TrimSpace(namespace.ObjectMeta.UID)) != 0).To(BeTrue())
+			Expect(namespace.ObjectMeta.UID).NotTo(BeNil())
 		},
+		
 		verifyGeneration: func(namespace *v1.Namespace) {
-			By(fmt.Sprintf(">>>namespace.ObjectMeta.Generation:[%v]\n", namespace.ObjectMeta.Generation))
-			Expect(namespace.ObjectMeta.Generation).To(Equal(originalGeneration)) // this is brand new
+			Expect(namespace.ObjectMeta.Generation).To(Equal(originalGeneration))
 		},
 
 		verifyCreationTimestamp: func(namespace *v1.Namespace) {
 			Expect(namespace.ObjectMeta.CreationTimestamp).NotTo(BeNil())
 		},
+		
 		verifyDeletionTimestamp: func(namespace *v1.Namespace) {
-			// TODO / Question
-			// resolve Time package import
-			//var defaultDeletionTimestamp *Time = nil
-			//Expect(namespace.ObjectMeta.DeletionTimestamp).To(Equal(defaultDeletionTimestamp))
+			Expect(namespace.ObjectMeta.DeletionTimestamp).To(BeNil())
 		},
+		
 		verifyDeletionGracePeriodSeconds: func(namespace *v1.Namespace) {
 			var defaultDeletionGracePeriodSeconds *int64
 			Expect(namespace.ObjectMeta.DeletionGracePeriodSeconds).To(Equal(defaultDeletionGracePeriodSeconds))
@@ -321,16 +320,15 @@ func newDefaultVerifier() NamespaceVerifier {
 		verifyLabels: func(namespace *v1.Namespace) {
 			Expect(len(namespace.ObjectMeta.Labels)).To(Equal(0))
 		},
+		
 		verifyAnnotations: func(namespace *v1.Namespace) {
 			Expect(len(namespace.ObjectMeta.Annotations)).To(Equal(0))
 		},
-
+		
 		verifyInitializers: func(namespace *v1.Namespace) {
-			// TODO / Question
-			// resolve Initializers package import
-			//var defaultInitializers *Initializers = nil
-			//Expect(namespace.ObjectMeta.Initializers).To(Equal(defaultInitializers))
+			Expect(namespace.ObjectMeta.Initializers).To(BeNil())
 		},
+		
 		verifyFinalizers: func(namespace *v1.Namespace) {
 			Expect(len(namespace.ObjectMeta.Finalizers)).To(Equal(0))
 		},

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	namespacesRootUrl  string = "/api/v1/namespaces/"
+	namespacesRootURL  string = "/api/v1/namespaces/"
 	originalGeneration int64  = 0
 )
 
@@ -119,7 +119,7 @@ var _ = SIGDescribe("api-namespaces-create", func() {
 				Expect(namespace.ObjectMeta.Name).To(Equal(namespaceName)) // this should match our given namespaceName
 			}
 			v.verifySelfLink = func(namespace *v1.Namespace) {
-				expectedSelfLink := strings.Join([]string{namespacesRootUrl, namespaceName}, "")
+				expectedSelfLink := strings.Join([]string{namespacesRootURL, namespaceName}, "")
 				Expect(namespace.ObjectMeta.SelfLink).To(Equal(expectedSelfLink))
 			}
 			v.verifyAll(namespace)
@@ -176,7 +176,7 @@ var _ = SIGDescribe("api-namespaces-create", func() {
 				Expect(strings.HasPrefix(namespace.ObjectMeta.Name, generateName)).To(BeTrue())
 			}
 			v.verifySelfLink = func(namespace *v1.Namespace) {
-				expectedSelfLinkBase := strings.Join([]string{namespacesRootUrl, generateName}, "")
+				expectedSelfLinkBase := strings.Join([]string{namespacesRootURL, generateName}, "")
 				Expect(strings.HasPrefix(namespace.ObjectMeta.SelfLink, expectedSelfLinkBase)).To(BeTrue())
 			}
 			v.verifyAll(namespace)
@@ -217,7 +217,7 @@ var _ = SIGDescribe("api-namespaces-create", func() {
 				Expect(strings.HasPrefix(namespace.ObjectMeta.Name, generateName)).To(BeTrue())
 			}
 			v.verifySelfLink = func(namespace *v1.Namespace) {
-				expectedSelfLinkBase := strings.Join([]string{namespacesRootUrl, generateName}, "")
+				expectedSelfLinkBase := strings.Join([]string{namespacesRootURL, generateName}, "")
 				Expect(strings.HasPrefix(namespace.ObjectMeta.SelfLink, expectedSelfLinkBase)).To(BeTrue())
 			}
 			v.verifyLabels = func(namespace *v1.Namespace) {
@@ -229,11 +229,10 @@ var _ = SIGDescribe("api-namespaces-create", func() {
 })
 
 // VerifyFunc is a type meant to hold functions that operate on namespaces
-
 type VerifyFunc func(namespace *v1.Namespace)
 
-// NamespaceVerifier is an object meant to hold functions that operate on namespaces that will be later called to verify expectations.
-
+// NamespaceVerifier is an object meant to hold functions that operate on namespaces that will be
+//later called to verify expectations.
 type NamespaceVerifier struct {
 	verifyKind       VerifyFunc
 	verifyAPIVersion VerifyFunc
@@ -322,7 +321,7 @@ func newDefaultVerifier() NamespaceVerifier {
 			//Expect(namespace.ObjectMeta.DeletionTimestamp).To(Equal(defaultDeletionTimestamp))
 		},
 		verifyDeletionGracePeriodSeconds: func(namespace *v1.Namespace) {
-			var defaultDeletionGracePeriodSeconds *int64 = nil
+			var defaultDeletionGracePeriodSeconds *int64
 			Expect(namespace.ObjectMeta.DeletionGracePeriodSeconds).To(Equal(defaultDeletionGracePeriodSeconds))
 		},
 

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ var _ = SIGDescribe("api-namespaces-create", func() {
 		   Testname: api-namespaces-create-name-valid
 		   Description: Check that creating a namespace with valid name parameter succeeds.
 		*/
-		framework.ConformanceIt("creating a namespace with only (valid) name parameter should succed", func() {
+		framework.ConformanceIt("creating a namespace with only (valid) name parameter should succeed", func() {
 			namespaceName :=
 				strings.Join([]string{"testbasename", string(uuid.NewUUID())}, "")
 

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("api-namespaces", func() {
 		     2) post it
 		     3) check that the newly created namespace is brought when get by name is invoked.
 		     4) check that the newly created namespace appears on the list.
-		     5) delete the namespace.
+		     5) delete the namespace, waiting until 
 		     6) check that the newly created namespace is NOT brought when get by name is invoked.
 		     7) check that the newly created namespace does NOT appear on the list.
 		*/

--- a/test/e2e/api/namespaces.go
+++ b/test/e2e/api/namespaces.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	namespacesRootUrl  string = "/api/v1/namespaces/"
+	originalGeneration int64  = 0
+)
+
+var _ = SIGDescribe("api-namespaces-list", func() {
+	f := framework.NewDefaultFramework("api-namespaces-list")
+
+	Context("starting from an any environment (might be empty or not)", func() {
+		// explicitly not asking for a namespace not being created for the test
+		f.SkipNamespaceCreation = true
+
+		/*
+		   Testname: api-namespaces-list-default
+		   Description: Check that the namespaces returned match the expected well known default namespaces.
+		*/
+		framework.ConformanceIt("list with empty options should show built-in by default namespaces", func() {
+
+			defaultNamespaces := make(map[string]bool)
+			defaultNamespaces["default"] = false
+			defaultNamespaces["kube-system"] = false
+			defaultNamespaces["kube-public"] = false
+
+			By("Retrieving namespaces")
+			options := metav1.ListOptions{}
+			namespaces, err := f.ClientSet.CoreV1().Namespaces().List(options)
+			Expect(err).NotTo(HaveOccurred())
+
+			// checking default namespaces are present in the result
+			for _, namespace := range namespaces.Items {
+				_, present := defaultNamespaces[namespace.ObjectMeta.Name]
+				if present {
+					delete(defaultNamespaces, namespace.ObjectMeta.Name)
+				}
+			}
+			// if all were present, map should end up empty
+			Expect(len(defaultNamespaces)).To(Equal(0))
+		})
+	})
+
+})
+
+var _ = SIGDescribe("api-namespaces-create", func() {
+	f := framework.NewDefaultFramework("api-namespaces-create")
+
+	Context("starting from an any environment (might be empty or not)", func() {
+		// explicitly not asking for a namespace not being created for the test
+		f.SkipNamespaceCreation = true
+
+		/*
+		   Testname: api-namespaces-create-empty
+		   Description: Check that creating a namespace with empty parameters fails.
+		*/
+		framework.ConformanceIt("creating a namespace with empty parameters should fail", func() {
+			namespaceCreationData := &v1.Namespace{}
+			_, err := f.ClientSet.CoreV1().Namespaces().Create(namespaceCreationData)
+			Expect(err).To(HaveOccurred())
+		})
+
+		/*
+		   Testname: api-namespaces-create-name-valid
+		   Description: Check that creating a namespace with valid name parameter succeeds.
+		*/
+		framework.ConformanceIt("creating a namespace with only (valid) name parameter should succed", func() {
+			namespaceName :=
+				strings.Join([]string{"testbasename", string(uuid.NewUUID())}, "")
+
+			By(fmt.Sprintf(" creating namespaceName:[%v]\n", namespaceName))
+
+			namespaceCreationData := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+
+			namespace, err := f.ClientSet.CoreV1().Namespaces().Create(namespaceCreationData)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer func() {
+				err := f.ClientSet.CoreV1().Namespaces().Delete(namespace.ObjectMeta.Name, nil)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			v := newDefaultVerifier()
+			v.verifyName = func(namespace *v1.Namespace) {
+				Expect(namespace.ObjectMeta.Name).To(Equal(namespaceName)) // this should match our given namespaceName
+			}
+			v.verifySelfLink = func(namespace *v1.Namespace) {
+				expectedSelfLink := strings.Join([]string{namespacesRootUrl, namespaceName}, "")
+				Expect(namespace.ObjectMeta.SelfLink).To(Equal(expectedSelfLink))
+			}
+			v.verifyAll(namespace)
+
+		})
+
+		/*
+		   Testname: api-namespaces-create-generatename-invalid
+		   Description: Check that creating a namespace with invalid generatename parameter fails.
+		*/
+		framework.ConformanceIt("creating a namespace with invalid generateName (containing uppercase) should fail", func() {
+			generateName :=
+				strings.Join([]string{"thisHasUppercaseCharacters", string(uuid.NewUUID())}, "")
+
+			namespaceCreationData := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: generateName,
+					Name:         "",
+				},
+			}
+
+			_, err := f.ClientSet.CoreV1().Namespaces().Create(namespaceCreationData)
+			Expect(err).To(HaveOccurred())
+		})
+
+		/*
+		   Testname: api-namespaces-create-generatename-valid
+		   Description: Check that creating a namespace with valid generatename parameter succeeds.
+		*/
+		framework.ConformanceIt("creating a namespace with valid generateName (all lowercase)", func() {
+			generateName :=
+				strings.Join([]string{"lowercasecharacters", string(uuid.NewUUID())}, "")
+
+			namespaceCreationData := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: generateName,
+					Name:         "",
+				},
+			}
+
+			namespace, err := f.ClientSet.CoreV1().Namespaces().Create(namespaceCreationData)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer func() {
+				err := f.ClientSet.CoreV1().Namespaces().Delete(namespace.ObjectMeta.Name, nil)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			v := newDefaultVerifier()
+			v.verifyGenerateName = func(namespace *v1.Namespace) {
+				Expect(namespace.ObjectMeta.GenerateName).To(Equal(generateName))
+			}
+			v.verifyName = func(namespace *v1.Namespace) {
+				Expect(strings.HasPrefix(namespace.ObjectMeta.Name, generateName)).To(BeTrue())
+			}
+			v.verifySelfLink = func(namespace *v1.Namespace) {
+				expectedSelfLinkBase := strings.Join([]string{namespacesRootUrl, generateName}, "")
+				Expect(strings.HasPrefix(namespace.ObjectMeta.SelfLink, expectedSelfLinkBase)).To(BeTrue())
+			}
+			v.verifyAll(namespace)
+		})
+
+		/*
+		   Testname: api-namespaces-create-generatename-valid-labels
+		   Description: Check that creating a namespace with valid generatename and labels parameters succeeds.
+		*/
+		framework.ConformanceIt("creating a namespace with valid generateName (all lowercase) and labels set", func() {
+			generateName :=
+				strings.Join([]string{"lowercasecharacters", string(uuid.NewUUID())}, "")
+
+			labels := map[string]string{}
+			labels["e2e-run"] = string(uuid.NewUUID())
+
+			namespaceCreationData := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: generateName,
+					Name:         "",
+					Labels:       labels,
+				},
+			}
+
+			namespace, err := f.ClientSet.CoreV1().Namespaces().Create(namespaceCreationData)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer func() {
+				err := f.ClientSet.CoreV1().Namespaces().Delete(namespace.ObjectMeta.Name, nil)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			v := newDefaultVerifier()
+			v.verifyGenerateName = func(namespace *v1.Namespace) {
+				Expect(namespace.ObjectMeta.GenerateName).To(Equal(generateName))
+			}
+			v.verifyName = func(namespace *v1.Namespace) {
+				Expect(strings.HasPrefix(namespace.ObjectMeta.Name, generateName)).To(BeTrue())
+			}
+			v.verifySelfLink = func(namespace *v1.Namespace) {
+				expectedSelfLinkBase := strings.Join([]string{namespacesRootUrl, generateName}, "")
+				Expect(strings.HasPrefix(namespace.ObjectMeta.SelfLink, expectedSelfLinkBase)).To(BeTrue())
+			}
+			v.verifyLabels = func(namespace *v1.Namespace) {
+				Expect(namespace.ObjectMeta.Labels).To(Equal(labels))
+			}
+			v.verifyAll(namespace)
+		})
+	})
+})
+
+// VerifyFunc is a type meant to hold functions that operate on namespaces
+
+type VerifyFunc func(namespace *v1.Namespace)
+
+// NamespaceVerifier is an object meant to hold functions that operate on namespaces that will be later called to verify expectations.
+
+type NamespaceVerifier struct {
+	verifyKind       VerifyFunc
+	verifyAPIVersion VerifyFunc
+
+	verifyName         VerifyFunc
+	verifyGenerateName VerifyFunc
+
+	verifySelfLink VerifyFunc
+	verifyUID      VerifyFunc
+
+	verifyGeneration                 VerifyFunc
+	verifyCreationTimestamp          VerifyFunc
+	verifyDeletionTimestamp          VerifyFunc
+	verifyDeletionGracePeriodSeconds VerifyFunc
+
+	verifyLabels      VerifyFunc
+	verifyAnnotations VerifyFunc
+
+	verifyInitializers VerifyFunc
+	verifyFinalizers   VerifyFunc
+}
+
+// method invokeable from a namespaceVerifier object, that verifies all conditions by calling the functions
+func (verifier NamespaceVerifier) verifyAll(namespace *v1.Namespace) {
+	// Metadata
+	verifier.verifyKind(namespace)
+	verifier.verifyAPIVersion(namespace)
+
+	// ObjectMeta
+	verifier.verifyName(namespace)
+	verifier.verifyGenerateName(namespace)
+
+	verifier.verifySelfLink(namespace)
+	verifier.verifyUID(namespace)
+	verifier.verifyGeneration(namespace)
+
+	verifier.verifyCreationTimestamp(namespace)
+	verifier.verifyDeletionTimestamp(namespace)
+	verifier.verifyDeletionGracePeriodSeconds(namespace)
+
+	verifier.verifyLabels(namespace)
+	verifier.verifyAnnotations(namespace)
+
+	verifier.verifyInitializers(namespace)
+	verifier.verifyFinalizers(namespace)
+}
+
+// creation of a default verifier that helps us defining basic expectations throughout different scenarios.
+// Allows override of specific areas that we want to verify against
+func newDefaultVerifier() NamespaceVerifier {
+	v := NamespaceVerifier{
+
+		verifyKind: func(namespace *v1.Namespace) {
+			Expect(namespace.TypeMeta.Kind).To(Equal(""))
+		},
+		verifyAPIVersion: func(namespace *v1.Namespace) {
+			Expect(namespace.TypeMeta.APIVersion).To(Equal(""))
+		},
+
+		verifyName: func(namespace *v1.Namespace) {
+			Expect(namespace.ObjectMeta.Name).To(Equal(""))
+		},
+		verifyGenerateName: func(namespace *v1.Namespace) {
+			Expect(namespace.ObjectMeta.GenerateName).To(Equal(""))
+		},
+
+		verifySelfLink: func(namespace *v1.Namespace) {
+
+		},
+		verifyUID: func(namespace *v1.Namespace) {
+			// TODO / Question
+			// How to work against UID? wanted to check is not empty
+			//Expect(len(strings.TrimSpace(namespace.ObjectMeta.UID)) != 0).To(BeTrue())
+		},
+		verifyGeneration: func(namespace *v1.Namespace) {
+			Expect(namespace.ObjectMeta.Generation).To(Equal(originalGeneration)) // this is brand new
+		},
+
+		verifyCreationTimestamp: func(namespace *v1.Namespace) {
+			Expect(namespace.ObjectMeta.CreationTimestamp).NotTo(BeNil())
+		},
+		verifyDeletionTimestamp: func(namespace *v1.Namespace) {
+			// TODO / Question
+			// resolve Time package import
+			//var defaultDeletionTimestamp *Time = nil
+			//Expect(namespace.ObjectMeta.DeletionTimestamp).To(Equal(defaultDeletionTimestamp))
+		},
+		verifyDeletionGracePeriodSeconds: func(namespace *v1.Namespace) {
+			var defaultDeletionGracePeriodSeconds *int64 = nil
+			Expect(namespace.ObjectMeta.DeletionGracePeriodSeconds).To(Equal(defaultDeletionGracePeriodSeconds))
+		},
+
+		verifyLabels: func(namespace *v1.Namespace) {
+			Expect(len(namespace.ObjectMeta.Labels)).To(Equal(0))
+		},
+		verifyAnnotations: func(namespace *v1.Namespace) {
+			Expect(len(namespace.ObjectMeta.Annotations)).To(Equal(0))
+		},
+
+		verifyInitializers: func(namespace *v1.Namespace) {
+			// TODO / Question
+			// resolve Initializers package import
+			//var defaultInitializers *Initializers = nil
+			//Expect(namespace.ObjectMeta.Initializers).To(Equal(defaultInitializers))
+		},
+		verifyFinalizers: func(namespace *v1.Namespace) {
+			Expect(len(namespace.ObjectMeta.Finalizers)).To(Equal(0))
+		},
+	}
+	return v
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	// test sources
+	_ "k8s.io/kubernetes/test/e2e/api"
 	_ "k8s.io/kubernetes/test/e2e/apimachinery"
 	_ "k8s.io/kubernetes/test/e2e/apps"
 	_ "k8s.io/kubernetes/test/e2e/auth"


### PR DESCRIPTION
Adding testcases for namespaces api group
A) api-namespaces-scenario-get-post-delete-get:
1) check that the namespaceName does not already exist: get by name should not find it
2) post it
3) check that the newly created namespace is brought when get by name is invoked.
4) check that the newly created namespace appears on the list.
5) delete the namespace (waiting for it)
6) check that the newly created namespace is NOT brought when get by name is invoked.
7) check that the newly created namespace does NOT appear on the list.

B) api-namespaces-scenario-get-post-patch-get:
1) check that the namespaceName does not already exist: get by name should not find it
2) post it
3) check that the newly created namespace is brought when get by name is invoked.
4) patch the namespace using labels
5) check that the newly created namespace is brought when get by name is invoked.
6) delete the namespace.

**Special notes for your reviewer**:
Hi review team: 
This is one of my firsts PR. I'm thankful for guidance and advice. 

Placed the changes on a separate folder since i was not sure if i should place it under apimachinery directly, and  looking to learn and calibrate if this is ok.

Down below, created a struct named "NamespaceVerifier" that would let me hold "default expecations" and letting me override only the ones I am specifically looking for in the precise scenario.This would allow me to verify that the object returned makes sense (and not duplicate individual expect lines on each scenario).
Invoking verifyAll would run all the checks against the fields.

I placed some TODO comments with doubts regarding types.

Thanks a lot!