### PR TITLE
Add OWNERS file regexp filtered label rules to replace path-label munger.

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,9 +1,13 @@
-reviewers:
-  - brendandburns
-  - smarterclayton
-  - thockin
-approvers:
-  - brendandburns
-  - smarterclayton
-  - thockin
-  - pwittrock
+".*":
+	reviewers:
+	  - brendandburns
+	  - smarterclayton
+	  - thockin
+	approvers:
+	  - brendandburns
+	  - smarterclayton
+	  - thockin
+	  - pwittrock
+"^(getting-started-guides|admin|user-guide|devel|design|proposals)":
+	labels:
+	- kind/old-docs

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -1,44 +1,51 @@
-approvers:
-- erictune
-- lavalamp
-- smarterclayton
-- thockin
-- liggitt
-# - bgrant0607 # manual escalations only
-reviewers:
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- yujuhong
-- brendandburns
-- derekwaynecarr
-- caesarxuchao
-- vishh
-- mikedanese
-- liggitt
-- nikhiljindal
-- gmarek
-- erictune
-- pmorie
-- sttts
-- dchen1107
-- saad-ali
-- luxas
-- janetkuo
-- justinsb
-- pwittrock
-- ncdc
-- tallclair
-- yifan-gu
-- eparis
-- mwielgus
-- feiskyer
-- soltysh
-- piosz
-- dims
-- errordeveloper
-- madhusudancs
-- krousey
-- rootfs
-- jszczepkowski
+".*":
+	approvers:
+	- erictune
+	- lavalamp
+	- smarterclayton
+	- thockin
+	- liggitt
+	# - bgrant0607 # manual escalations only
+	reviewers:
+	- lavalamp
+	- smarterclayton
+	- wojtek-t
+	- deads2k
+	- yujuhong
+	- brendandburns
+	- derekwaynecarr
+	- caesarxuchao
+	- vishh
+	- mikedanese
+	- liggitt
+	- nikhiljindal
+	- gmarek
+	- erictune
+	- pmorie
+	- sttts
+	- dchen1107
+	- saad-ali
+	- luxas
+	- janetkuo
+	- justinsb
+	- pwittrock
+	- ncdc
+	- tallclair
+	- yifan-gu
+	- eparis
+	- mwielgus
+	- feiskyer
+	- soltysh
+	- piosz
+	- dims
+	- errordeveloper
+	- madhusudancs
+	- krousey
+	- rootfs
+	- jszczepkowski
+"^[^/]+/([^/]+/)?types\\.go$": # examples: foo/types.go, foo/bar/types.go
+	labels:
+	- kind/api-change
+"^[^/]+/([^/]+/)?register\\.go$": # examples: foo/register.go, foo/bar/register.go
+	labels:
+	- kind/new-api


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures OWNERS file regexp filtered label rules to automatically apply labels to PRs that touch certain files. This will replace the functionality provided by the `path-label` munger and configured in [this file](https://github.com/kubernetes/test-infra/blob/master/mungegithub/misc-mungers/deployment/kubernetes/path-label.txt).

/sig testing

```release-note
none
```