### PR TITLE
Tag pkg_rpm rules as manual

### DIFF
--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -10,6 +10,7 @@ pkg_rpm(
         "//cmd/kubectl",
     ],
     spec_file = "kubectl.spec",
+    tags = ["manual"],
     version_file = "//build:os_package_version",
 )
 
@@ -22,6 +23,7 @@ pkg_rpm(
         "//cmd/kubelet",
     ],
     spec_file = "kubelet.spec",
+    tags = ["manual"],
     version_file = "//build:os_package_version",
 )
 
@@ -35,6 +37,7 @@ pkg_rpm(
         "//cmd/kubeadm",
     ],
     spec_file = "kubeadm.spec",
+    tags = ["manual"],
     version_file = "//build:os_package_version",
 )
 
@@ -46,6 +49,7 @@ pkg_rpm(
         "@kubernetes_cni//file",
     ],
     spec_file = "kubernetes-cni.spec",
+    tags = ["manual"],
     version_file = "//build:cni_package_version",
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: Mitigation step for #63108. Nothing depends on these rules yet, and tagging as manual prevents `make bazel-build` from building them, too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder 
/cc @sigma 