### PR TITLE
Add resource type completion for explain

### DIFF
--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -76,9 +76,10 @@ func NewCmdExplain(parent string, f cmdutil.Factory, streams genericclioptions.I
 	cmd := &cobra.Command{
 		Use: "explain RESOURCE",
 		DisableFlagsInUseLine: true,
-		Short:   i18n.T("Documentation of resources"),
-		Long:    explainLong + "\n\n" + cmdutil.SuggestApiResources(parent),
-		Example: explainExamples,
+		Short:     i18n.T("Documentation of resources"),
+		Long:      explainLong + "\n\n" + cmdutil.SuggestApiResources(parent),
+		Example:   explainExamples,
+		ValidArgs: cmdutil.AllResourceList(f),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd))
 			cmdutil.CheckErr(o.Validate(args))

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -251,3 +251,27 @@ func ValidArgList(f ClientAccessFactory) []string {
 
 	return validArgs
 }
+
+// AllResourceList returns list of all resource names discovered.
+func AllResourceList(f ClientAccessFactory) []string {
+	discoveryclient, err := f.DiscoveryClient()
+	if err != nil {
+		return []string{}
+	}
+
+	// Always request fresh data from the server
+	discoveryclient.Invalidate()
+
+	lists, err := discoveryclient.ServerPreferredResources()
+	if err != nil {
+		return []string{}
+	}
+
+	resources := []string{}
+	for _, list := range lists {
+		for _, resource := range list.APIResources {
+			resources = append(resources, resource.Name)
+		}
+	}
+	return resources
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR supports completion for resource type list of kubectl explain.
After this, resource list could be completed by `kubectl explain [TAB][TAB]`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Fixes https://github.com/kubernetes/kubernetes/issues/63173
