### PR TITLE
eliminate alwaysAdmit admission in apiserver test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -71,18 +71,6 @@ import (
 	"k8s.io/apiserver/pkg/server/filters"
 )
 
-// alwaysAdmit is an implementation of admission.Interface which always says yes to an admit request.
-// It is useful in tests and when using kubernetes in an open manner.
-type alwaysAdmit struct{}
-
-func (alwaysAdmit) Admit(a admission.Attributes) (err error) {
-	return nil
-}
-
-func (alwaysAdmit) Handles(operation admission.Operation) bool {
-	return true
-}
-
 type alwaysMutatingDeny struct{}
 
 func (alwaysMutatingDeny) Admit(a admission.Attributes) (err error) {
@@ -233,7 +221,6 @@ func init() {
 
 	mapper = nsMapper
 	namespaceMapper = nsMapper
-	admissionControl = alwaysAdmit{}
 
 	scheme.AddFieldLabelConversionFunc(grouplessGroupVersion.String(), "Simple",
 		func(label, value string) (string, string, error) {
@@ -260,11 +247,6 @@ type defaultAPIServer struct {
 
 // uses the default settings
 func handle(storage map[string]rest.Storage) http.Handler {
-	return handleInternal(storage, admissionControl, selfLinker, nil)
-}
-
-// tests using the new namespace scope mechanism
-func handleNamespaced(storage map[string]rest.Storage) http.Handler {
 	return handleInternal(storage, admissionControl, selfLinker, nil)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

alwaysAdmit is of no meaning, previously if not specify an admission plugin, it will panic, but now since we add protection `if admit != nil`. So can safely remove it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
