### PR TITLE
Revert "gce: move etcd dir cleanup to manifests"

### DIFF
--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -1,4 +1,14 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-empty-dir-cleanup
+  namespace: kube-system
+  labels:
+    k8s-app: etcd-empty-dir-cleanup
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: etcd-empty-dir-cleanup
@@ -9,6 +19,7 @@ metadata:
     k8s-app: etcd-empty-dir-cleanup
 spec:
   priorityClassName: system-node-critical
+  serviceAccountName: etcd-empty-dir-cleanup
   hostNetwork: true
   dnsPolicy: Default
   containers:

--- a/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-binding.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gce:podsecuritypolicy:etcd-empty-dir-cleanup
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gce:podsecuritypolicy:etcd-empty-dir-cleanup
+subjects:
+- kind: ServiceAccount
+  name: etcd-empty-dir-cleanup
+  namespace: kube-system

--- a/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-role.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gce:podsecuritypolicy:etcd-empty-dir-cleanup
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - gce.etcd-empty-dir-cleanup
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/podsecuritypolicies/etcd-empty-dir-cleanup-psp.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: gce.etcd-empty-dir-cleanup
+  annotations:
+    kubernetes.io/description: 'Policy used by the etcd-empty-dir-cleanup addon.'
+    # TODO: etcd-empty-dir-cleanup should run with the default seccomp profile
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # 'runtime/default' is already the default, but must be filled in on the
+    # pod to pass admission.
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  privileged: false
+  volumes:
+  - 'secret'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/cluster/gce/gci/BUILD
+++ b/cluster/gce/gci/BUILD
@@ -10,7 +10,7 @@ go_test(
     ],
     data = [
         ":scripts-test-data",
-        "//cluster/gce/manifests",
+        "//cluster/gce/manifests:manifests-test-data",
     ],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1323,8 +1323,7 @@ function prepare-etcd-manifest {
 }
 
 function start-etcd-empty-dir-cleanup-pod {
-  local -r src_file="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/etcd-empty-dir-cleanup.yaml"
-  cp "${src_file}" "/etc/kubernetes/manifests"
+  cp "${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml" "/etc/kubernetes/manifests"
 }
 
 # Starts etcd server pod (and etcd-events pod if needed).

--- a/cluster/gce/manifests/BUILD
+++ b/cluster/gce/manifests/BUILD
@@ -5,18 +5,30 @@ load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "gce-master-manifests",
-    srcs = [":manifests"],
-    mode = "0644",
-)
-
-filegroup(
-    name = "manifests",
     srcs = [
         "abac-authz-policy.jsonl",
         "cluster-autoscaler.manifest",
         "e2e-image-puller.manifest",
         "etcd.manifest",
-        "etcd-empty-dir-cleanup.yaml",
+        "glbc.manifest",
+        "kms-plugin-container.manifest",
+        "kube-addon-manager.yaml",
+        "kube-apiserver.manifest",
+        "kube-controller-manager.manifest",
+        "kube-proxy.manifest",
+        "kube-scheduler.manifest",
+        "rescheduler.manifest",
+    ],
+    mode = "0644",
+)
+
+filegroup(
+    name = "manifests-test-data",
+    srcs = [
+        "abac-authz-policy.jsonl",
+        "cluster-autoscaler.manifest",
+        "e2e-image-puller.manifest",
+        "etcd.manifest",
         "glbc.manifest",
         "kms-plugin-container.manifest",
         "kube-addon-manager.yaml",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/63134

This reverts commit ae73bed1d0b9a299b06fc762d513b9b734ea4ce7.

```release-note
NONE
```

/cc @wojtek-t 