### PR TITLE
[prometheus addon] Add readme

### DIFF
--- a/cluster/addons/prometheus/README.md
+++ b/cluster/addons/prometheus/README.md
@@ -1,0 +1,5 @@
+# Prometheus Add-on
+
+This add-on is an experimental configuration of k8s monitoring using Prometheus used for e2e tests.
+
+For production use check out more mature setups like [Prometheus Operator](https://github.com/coreos/prometheus-operator) and [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus).


### PR DESCRIPTION
This PR adds README file that warns users about it's intended use, and redirects to more mature projects.

```release-note
NONE
```
/cc @brancz 
