### PR TITLE
Automated cherry pick of #56474

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
@@ -469,7 +469,7 @@ func (c *BlobDiskController) getDiskCount(SAName string) (int, error) {
 }
 
 func (c *BlobDiskController) getAllStorageAccounts() (map[string]*storageAccountState, error) {
-	accountListResult, err := c.common.cloud.StorageAccountClient.List()
+	accountListResult, err := c.common.cloud.StorageAccountClient.ListByResourceGroup(c.common.resourceGroup)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #56474 on release-1.8.

#56474: use ListByResourceGroup instead of List()