### PR TITLE
e2e: Update CSI provisioner to v0.2.1 container

### DIFF
--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -40,7 +40,7 @@ import (
 const (
 	csiHostPathPluginImage      string = "quay.io/k8scsi/hostpathplugin:v0.2.0"
 	csiExternalAttacherImage    string = "quay.io/k8scsi/csi-attacher:v0.2.0"
-	csiExternalProvisionerImage string = "quay.io/k8scsi/csi-provisioner:v0.2.0"
+	csiExternalProvisionerImage string = "quay.io/k8scsi/csi-provisioner:v0.2.1"
 	csiDriverRegistrarImage     string = "quay.io/k8scsi/driver-registrar:v0.2.0"
 )
 


### PR DESCRIPTION
Update the csi-provisioner to [v0.2.1](https://github.com/kubernetes-csi/external-provisioner/releases/tag/v0.2.1)

**What this PR does / why we need it**:
Fixes CSI [flaky tests](https://k8s-testgrid.appspot.com/sig-storage#gce-flaky&width=5)
Fixes #61782

