### PR TITLE
support simultaneous kubeadm --v and --config

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -356,7 +356,7 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 
 	mixedInvalidFlags := []string{}
 	flag.Visit(func(f *pflag.Flag) {
-		if f.Name == "config" || f.Name == "ignore-preflight-errors" || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" {
+		if f.Name == "config" || f.Name == "ignore-preflight-errors" || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" || f.Name == "v" {
 			// "--skip-*" flags or other whitelisted flags can be set with --config
 			return
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Providing -v and --config parameters to increase verbosity while providing a kubeadm.config results in an error rather than providing the requested verbosity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://github.com/kubernetes/kubeadm/issues/765

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
