### PR TITLE
Remove KUBE_API_VERSIONS

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -139,7 +139,10 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		go func() {
 			// let the CRD controller process the initial set of CRDs before starting the autoregistration controller.
 			// this prevents the autoregistration controller's initial sync from deleting APIServices for CRDs that still exist.
-			crdRegistrationController.WaitForInitialSync()
+			// we only need to do this if CRDs are enabled on this server.  We can't use discovery because we are the source for discovery.
+			if aggregatorConfig.GenericConfig.MergedResourceConfig.AnyVersionForGroupEnabled("apiextensions.k8s.io") {
+				crdRegistrationController.WaitForInitialSync()
+			}
 			autoRegistrationController.Run(5, context.StopCh)
 		}()
 		return nil

--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//cmd/controller-manager/app/options:go_default_library",
         "//cmd/kube-controller-manager/app/config:go_default_library",
         "//cmd/kube-controller-manager/app/options:go_default_library",
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/authentication/install:go_default_library",
         "//pkg/apis/authorization/install:go_default_library",

--- a/cmd/kube-controller-manager/app/import_known_versions.go
+++ b/cmd/kube-controller-manager/app/import_known_versions.go
@@ -20,9 +20,6 @@ package app
 
 // These imports are the API groups the client will support.
 import (
-	"fmt"
-
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
 	_ "k8s.io/kubernetes/pkg/apis/authorization/install"
@@ -38,9 +35,3 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/settings/install"
 	_ "k8s.io/kubernetes/pkg/apis/storage/install"
 )
-
-func init() {
-	if missingVersions := legacyscheme.Registry.ValidateEnvRequestedVersions(); len(missingVersions) != 0 {
-		panic(fmt.Sprintf("KUBE_API_VERSIONS contains versions that are not installed: %q.", missingVersions))
-	}
-}

--- a/hack/test-update-storage-objects.sh
+++ b/hack/test-update-storage-objects.sh
@@ -40,7 +40,6 @@ ETCD_PORT=${ETCD_PORT:-2379}
 ETCD_PREFIX=${ETCD_PREFIX:-randomPrefix}
 API_PORT=${API_PORT:-8080}
 API_HOST=${API_HOST:-127.0.0.1}
-KUBE_API_VERSIONS=""
 RUNTIME_CONFIG=""
 
 ETCDCTL=$(which etcdctl)
@@ -51,13 +50,12 @@ DISABLE_ADMISSION_PLUGINS="ServiceAccount,NamespaceLifecycle,LimitRanger,Mutatin
 function startApiServer() {
   local storage_versions=${1:-""}
   local storage_media_type=${2:-""}
-  kube::log::status "Starting kube-apiserver with KUBE_API_VERSIONS: ${KUBE_API_VERSIONS}"
-  kube::log::status "                        and storage-media-type: ${storage_media_type}"
-  kube::log::status "                            and runtime-config: ${RUNTIME_CONFIG}"
-  kube::log::status "                 and storage-version overrides: ${storage_versions}"
+  kube::log::status "Starting kube-apiserver with..."
+  kube::log::status "                        storage-media-type: ${storage_media_type}"
+  kube::log::status "                            runtime-config: ${RUNTIME_CONFIG}"
+  kube::log::status "                 storage-version overrides: ${storage_versions}"
 
-  KUBE_API_VERSIONS="${KUBE_API_VERSIONS}" \
-    "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
+  "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver" \
     --insecure-bind-address="${API_HOST}" \
     --bind-address="${API_HOST}" \
     --insecure-port="${API_PORT}" \
@@ -120,8 +118,7 @@ KUBE_NEW_STORAGE_VERSIONS="storage.k8s.io/v1"
 # but KUBE_OLD_API_VERSION is the latest (storage) version.
 # Additionally use KUBE_STORAGE_MEDIA_TYPE_JSON for storage encoding.
 #######################################################
-KUBE_API_VERSIONS="v1,autoscaling/v1,${KUBE_OLD_API_VERSION},${KUBE_NEW_API_VERSION}"
-RUNTIME_CONFIG="api/all=false,api/v1=true,${KUBE_OLD_API_VERSION}=true,${KUBE_NEW_API_VERSION}=true"
+RUNTIME_CONFIG="api/all=false,api/v1=true,apiregistration.k8s.io/v1=true,${KUBE_OLD_API_VERSION}=true,${KUBE_NEW_API_VERSION}=true"
 startApiServer ${KUBE_OLD_STORAGE_VERSIONS} ${KUBE_STORAGE_MEDIA_TYPE_JSON}
 
 
@@ -155,8 +152,7 @@ killApiServer
 # Still use KUBE_STORAGE_MEDIA_TYPE_JSON for storage encoding.
 #######################################################
 
-KUBE_API_VERSIONS="v1,autoscaling/v1,${KUBE_NEW_API_VERSION},${KUBE_OLD_API_VERSION}"
-RUNTIME_CONFIG="api/all=false,api/v1=true,${KUBE_OLD_API_VERSION}=true,${KUBE_NEW_API_VERSION}=true"
+RUNTIME_CONFIG="api/all=false,api/v1=true,apiregistration.k8s.io/v1=true,${KUBE_OLD_API_VERSION}=true,${KUBE_NEW_API_VERSION}=true"
 startApiServer ${KUBE_NEW_STORAGE_VERSIONS} ${KUBE_STORAGE_MEDIA_TYPE_JSON}
 
 # Update etcd objects, so that will now be stored in the new api version.
@@ -186,8 +182,7 @@ killApiServer
 # However, change storage encoding to KUBE_STORAGE_MEDIA_TYPE_PROTOBUF.
 #######################################################
 
-KUBE_API_VERSIONS="v1,autoscaling/v1,${KUBE_NEW_API_VERSION}"
-RUNTIME_CONFIG="api/all=false,api/v1=true,${KUBE_NEW_API_VERSION}=true"
+RUNTIME_CONFIG="api/all=false,api/v1=true,apiregistration.k8s.io/v1=true,${KUBE_NEW_API_VERSION}=true"
 
 # This seems to reduce flakiness.
 sleep 1

--- a/pkg/api/legacyscheme/scheme.go
+++ b/pkg/api/legacyscheme/scheme.go
@@ -17,8 +17,6 @@ limitations under the License.
 package legacyscheme
 
 import (
-	"os"
-
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -26,7 +24,7 @@ import (
 
 // Registry is an instance of an API registry.  This is an interim step to start removing the idea of a global
 // API registry.
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
 // NOTE: If you are copying this file to start a new api group, STOP! Copy the

--- a/pkg/client/clientset_generated/internalclientset/scheme/register.go
+++ b/pkg/client/clientset_generated/internalclientset/scheme/register.go
@@ -19,8 +19,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +46,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/kubeapiserver/options/storage_versions.go
+++ b/pkg/kubeapiserver/options/storage_versions.go
@@ -101,7 +101,6 @@ func (s *StorageSerializationOptions) AddFlags(fs *pflag.FlagSet) {
 		"In the case where objects are moved from one group to the other, "+
 		"you may specify the format \"group1=group2/v1beta1,group3/v1beta1,...\". "+
 		"You only need to pass the groups you wish to change from the defaults. "+
-		"It defaults to a list of preferred versions of all registered groups, "+
-		"which is derived from the KUBE_API_VERSIONS environment variable.")
+		"It defaults to a list of preferred versions of all known groups.")
 
 }

--- a/pkg/kubectl/scheme/scheme.go
+++ b/pkg/kubectl/scheme/scheme.go
@@ -17,8 +17,6 @@ limitations under the License.
 package scheme
 
 import (
-	"os"
-
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,7 +27,7 @@ import (
 // All kubectl code should eventually switch to use this Registry and Scheme instead of the global ones.
 
 // Registry is an instance of an API registry.
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 // Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
 var Scheme = runtime.NewScheme()

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -19,7 +19,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/master",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/admission/install:go_default_library",
         "//pkg/apis/admissionregistration/install:go_default_library",
         "//pkg/apis/apps/install:go_default_library",

--- a/pkg/master/import_known_versions.go
+++ b/pkg/master/import_known_versions.go
@@ -18,10 +18,6 @@ package master
 
 // These imports are the API groups the API server will support.
 import (
-	"fmt"
-
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-
 	_ "k8s.io/kubernetes/pkg/apis/admission/install"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
@@ -42,9 +38,3 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/settings/install"
 	_ "k8s.io/kubernetes/pkg/apis/storage/install"
 )
-
-func init() {
-	if missingVersions := legacyscheme.Registry.ValidateEnvRequestedVersions(); len(missingVersions) != 0 {
-		panic(fmt.Sprintf("KUBE_API_VERSIONS contains versions that are not installed: %q.", missingVersions))
-	}
-}

--- a/plugin/pkg/admission/eventratelimit/config.go
+++ b/plugin/pkg/admission/eventratelimit/config.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +30,7 @@ import (
 )
 
 var (
-	registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+	registry = registered.NewAPIRegistrationManager()
 	scheme   = runtime.NewScheme()
 	codecs   = serializer.NewCodecFactory(scheme)
 )

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +31,7 @@ import (
 )
 
 var (
-	registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+	registry = registered.NewAPIRegistrationManager()
 	scheme   = runtime.NewScheme()
 	codecs   = serializer.NewCodecFactory(scheme)
 )

--- a/plugin/pkg/admission/resourcequota/config.go
+++ b/plugin/pkg/admission/resourcequota/config.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +30,7 @@ import (
 )
 
 var (
-	registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+	registry = registered.NewAPIRegistrationManager()
 	scheme   = runtime.NewScheme()
 	codecs   = serializer.NewCodecFactory(scheme)
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/scheme/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/scheme/register.go
@@ -19,8 +19,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +31,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})

--- a/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
@@ -49,7 +49,7 @@ type InstallFunc func(registry *registered.APIRegistrationManager, scheme *runti
 // RoundTripTestForAPIGroup is convenient to call from your install package to make sure that a "bare" install of your group provides
 // enough information to round trip
 func RoundTripTestForAPIGroup(t *testing.T, installFn InstallFunc, fuzzingFuncs fuzzer.FuzzerFuncs) {
-	registry := registered.NewOrDie("")
+	registry := registered.NewAPIRegistrationManager()
 	scheme := runtime.NewScheme()
 	installFn(registry, scheme)
 
@@ -70,7 +70,7 @@ func RoundTripTestForScheme(t *testing.T, scheme *runtime.Scheme, fuzzingFuncs f
 // RoundTripProtobufTestForAPIGroup is convenient to call from your install package to make sure that a "bare" install of your group provides
 // enough information to round trip
 func RoundTripProtobufTestForAPIGroup(t *testing.T, installFn InstallFunc, fuzzingFuncs fuzzer.FuzzerFuncs) {
-	registry := registered.NewOrDie("")
+	registry := registered.NewAPIRegistrationManager()
 	scheme := runtime.NewScheme()
 	installFn(registry, scheme)
 

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
@@ -138,9 +138,6 @@ func (gmf *GroupMetaFactory) Register(m *registered.APIRegistrationManager, sche
 
 	externalVersions := []schema.GroupVersion{}
 	for _, v := range gmf.prioritizedVersionList {
-		if !m.IsAllowedVersion(v) {
-			continue
-		}
 		externalVersions = append(externalVersions, v)
 		gmf.VersionArgs[v.Version].AddToScheme(scheme)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/BUILD
@@ -21,7 +21,6 @@ go_library(
     srcs = ["registered.go"],
     importpath = "k8s.io/apimachinery/pkg/apimachinery/registered",
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered_test.go
@@ -56,10 +56,7 @@ func TestAllPreferredGroupVersions(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		m, err := NewAPIRegistrationManager("")
-		if err != nil {
-			t.Fatalf("Unexpected failure to make a manager: %v", err)
-		}
+		m := NewAPIRegistrationManager()
 		for _, groupMeta := range testCase.groupMetas {
 			m.RegisterGroup(groupMeta)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	registry = registered.NewOrDie("")
+	registry = registered.NewAPIRegistrationManager()
 	scheme   = runtime.NewScheme()
 	codecs   = serializer.NewCodecFactory(scheme)
 )

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -166,7 +166,7 @@ func newFakeAPIResourceConfigSource() *serverstore.ResourceConfig {
 }
 
 func newFakeRegistry() *registered.APIRegistrationManager {
-	registry := registered.NewOrDie("")
+	registry := registered.NewAPIRegistrationManager()
 
 	registry.RegisterGroup(apimachinery.GroupMeta{
 		GroupVersion:  apiv1.SchemeGroupVersion,

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package storage
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -35,7 +34,7 @@ import (
 var (
 	v1GroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
 
-	registry       = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+	registry       = registered.NewAPIRegistrationManager()
 	scheme         = runtime.NewScheme()
 	codecs         = serializer.NewCodecFactory(scheme)
 	parameterCodec = runtime.NewParameterCodec(scheme)
@@ -116,7 +115,7 @@ func TestConfigurableStorageFactory(t *testing.T) {
 }
 
 func TestUpdateEtcdOverrides(t *testing.T) {
-	registry := registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+	registry := registered.NewAPIRegistrationManager()
 	exampleinstall.Install(registry, scheme)
 
 	testCases := []struct {

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -70,25 +70,6 @@ var (
 	retryBackoff  = time.Duration(500) * time.Millisecond
 )
 
-// TestDisabledGroupVersion ensures that requiring a group version works as expected
-func TestDisabledGroupVersion(t *testing.T) {
-	gv := schema.GroupVersion{Group: "webhook.util.k8s.io", Version: "v1"}
-	gvs := []schema.GroupVersion{gv}
-	registry := registered.NewOrDie(gv.String())
-	_, err := NewGenericWebhook(registry, scheme.Codecs, "/some/path", gvs, retryBackoff)
-
-	if err == nil {
-		t.Errorf("expected an error")
-	} else {
-		aErrMsg := err.Error()
-		eErrMsg := fmt.Sprintf("webhook plugin requires enabling extension resource: %s", gv)
-
-		if aErrMsg != eErrMsg {
-			t.Errorf("unexpected error message mismatch:\n  Expected: %s\n  Actual:   %s", eErrMsg, aErrMsg)
-		}
-	}
-}
-
 // TestKubeConfigFile ensures that a kube config file, regardless of validity, is handled properly
 func TestKubeConfigFile(t *testing.T) {
 	badCAPath := "/tmp/missing/ca.pem"
@@ -277,7 +258,7 @@ func TestKubeConfigFile(t *testing.T) {
 			if err == nil {
 				defer os.Remove(kubeConfigFile)
 
-				_, err = NewGenericWebhook(registered.NewOrDie(""), scheme.Codecs, kubeConfigFile, groupVersions, retryBackoff)
+				_, err = NewGenericWebhook(registered.NewAPIRegistrationManager(), scheme.Codecs, kubeConfigFile, groupVersions, retryBackoff)
 			}
 
 			return err
@@ -300,7 +281,7 @@ func TestKubeConfigFile(t *testing.T) {
 // TestMissingKubeConfigFile ensures that a kube config path to a missing file is handled properly
 func TestMissingKubeConfigFile(t *testing.T) {
 	kubeConfigPath := "/some/missing/path"
-	_, err := NewGenericWebhook(registered.NewOrDie(""), scheme.Codecs, kubeConfigPath, groupVersions, retryBackoff)
+	_, err := NewGenericWebhook(registered.NewAPIRegistrationManager(), scheme.Codecs, kubeConfigPath, groupVersions, retryBackoff)
 
 	if err == nil {
 		t.Errorf("creating the webhook should had failed")
@@ -412,7 +393,7 @@ func TestTLSConfig(t *testing.T) {
 
 			defer os.Remove(configFile)
 
-			wh, err := NewGenericWebhook(registered.NewOrDie(""), scheme.Codecs, configFile, groupVersions, retryBackoff)
+			wh, err := NewGenericWebhook(registered.NewAPIRegistrationManager(), scheme.Codecs, configFile, groupVersions, retryBackoff)
 
 			if err == nil {
 				err = wh.RestClient.Get().Do().Error()
@@ -477,7 +458,7 @@ func TestRequestTimeout(t *testing.T) {
 
 	var requestTimeout = 10 * time.Millisecond
 
-	wh, err := newGenericWebhook(registered.NewOrDie(""), scheme.Codecs, configFile, groupVersions, retryBackoff, requestTimeout)
+	wh, err := newGenericWebhook(registered.NewAPIRegistrationManager(), scheme.Codecs, configFile, groupVersions, retryBackoff, requestTimeout)
 	if err != nil {
 		t.Fatalf("failed to create the webhook: %v", err)
 	}
@@ -563,7 +544,7 @@ func TestWithExponentialBackoff(t *testing.T) {
 
 	defer os.Remove(configFile)
 
-	wh, err := NewGenericWebhook(registered.NewOrDie(""), scheme.Codecs, configFile, groupVersions, retryBackoff)
+	wh, err := NewGenericWebhook(registered.NewAPIRegistrationManager(), scheme.Codecs, configFile, groupVersions, retryBackoff)
 
 	if err != nil {
 		t.Fatalf("failed to create the webhook: %v", err)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
@@ -38,7 +38,7 @@ import (
 
 // NOTE: Copied from webhook backend to register auditv1beta1 to scheme
 var (
-	registry = registered.NewOrDie("")
+	registry = registered.NewAPIRegistrationManager()
 )
 
 func init() {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
@@ -45,7 +45,7 @@ var (
 	//
 	// Can we make these passable to NewGenericWebhook?
 	// TODO(audit): figure out a general way to let the client choose their preferred version
-	registry = registered.NewOrDie("")
+	registry = registered.NewAPIRegistrationManager()
 )
 
 func init() {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -116,7 +116,7 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(token string) (user.Info, 
 // authentication/v1beta1. We construct a registry that acknowledges
 // authentication/v1beta1 as an enabled version to pass a check enforced in
 // NewGenericWebhook.
-var registry = registered.NewOrDie("")
+var registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	registry.RegisterVersions(groupVersions)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -238,7 +238,7 @@ func convertToSARExtra(extra map[string][]string) map[string]authorization.Extra
 // authorization/v1beta1. We construct a registry that acknowledges
 // authorization/v1beta1 as an enabled version to pass a check enforced in
 // NewGenericWebhook.
-var registry = registered.NewOrDie("")
+var registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	registry.RegisterVersions(groupVersions)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme/register.go
@@ -19,8 +19,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -34,7 +32,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
@@ -89,14 +89,13 @@ func (g *GenScheme) GenerateType(c *generator.Context, t *types.Type, w io.Write
 		"allGroupVersions":                 allGroupVersions,
 		"allInstallGroups":                 allInstallGroups,
 		"customRegister":                   false,
-		"osGetenv":                         c.Universe.Function(types.Name{Package: "os", Name: "Getenv"}),
 		"runtimeNewParameterCodec":         c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "NewParameterCodec"}),
 		"runtimeNewScheme":                 c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "NewScheme"}),
 		"serializerNewCodecFactory":        c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/serializer", Name: "NewCodecFactory"}),
 		"runtimeScheme":                    c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Scheme"}),
 		"schemaGroupVersion":               c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersion"}),
 		"metav1AddToGroupVersion":          c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "AddToGroupVersion"}),
-		"registeredNewOrDie":               c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/apimachinery/registered", Name: "NewOrDie"}),
+		"registeredNew":                    c.Universe.Function(types.Name{Package: "k8s.io/apimachinery/pkg/apimachinery/registered", Name: "NewAPIRegistrationManager"}),
 		"registeredAPIRegistrationManager": c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apimachinery/registered", Name: "APIRegistrationManager"}),
 	}
 	globals := map[string]string{
@@ -137,7 +136,7 @@ var $.ParameterCodec$ = $.runtimeNewParameterCodec|raw$($.Scheme$)
 `
 
 var registryRegistration = `
-var $.Registry$ = $.registeredNewOrDie|raw$($.osGetenv|raw$("KUBE_API_VERSIONS"))
+var $.Registry$ = $.registeredNew|raw$()
 
 func init() {
 	$.metav1AddToGroupVersion|raw$($.Scheme$, $.schemaGroupVersion|raw${Version: "v1"})

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/scheme.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/scheme.go
@@ -35,7 +35,7 @@ var (
 	Codecs = serializer.NewCodecFactory(Scheme)
 	// Registry is an instance of an API registry.  This is an interim step to start removing the idea of a global
 	// API registry.
-	Registry = registered.NewOrDie("")
+	Registry = registered.NewAPIRegistrationManager()
 )
 
 func init() {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme/register.go
@@ -19,8 +19,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +31,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})

--- a/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	registry = registered.NewOrDie("")
+	registry = registered.NewAPIRegistrationManager()
 	Scheme   = runtime.NewScheme()
 	Codecs   = serializer.NewCodecFactory(Scheme)
 )

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/scheme/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/scheme/register.go
@@ -19,8 +19,6 @@ limitations under the License.
 package scheme
 
 import (
-	os "os"
-
 	registered "k8s.io/apimachinery/pkg/apimachinery/registered"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +31,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
-var Registry = registered.NewOrDie(os.Getenv("KUBE_API_VERSIONS"))
+var Registry = registered.NewAPIRegistrationManager()
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/63102

KUBE_API_VERSIONS is an attempt to control the available serialization of types. It pre-dates the idea that we'll have separate schemes, so it's not a thing that makes sense anymore.

Server-side we've had a very clear message about breaks in the logs for a year "KUBE_API_VERSIONS is only for testing. Things will break.".

Client-side it became progressively more broken as we moved to generic types for CRUD more than a year ago. What is registered doesn't matter when everything is unstructured.

We should remove this piece of legacy since it doesn't behave predictable server-side or client-side.

@smarterclayton @lavalamp
@kubernetes/sig-api-machinery-bugs 

```release-note
KUBE_API_VERSIONS is no longer respected.  It was used for testing, but runtime-config is the proper flag to set.
```

