### PR TITLE
Prevent nodes from updating taints

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -338,6 +338,12 @@ func (c *nodePlugin) admitNode(nodeName string, a admission.Attributes) error {
 		if node.Spec.ConfigSource != nil && !apiequality.Semantic.DeepEqual(node.Spec.ConfigSource, oldNode.Spec.ConfigSource) {
 			return admission.NewForbidden(a, fmt.Errorf("cannot update configSource to a new non-nil configSource"))
 		}
+
+		// Don't allow a node to update its own taints. This would allow a node to remove or modify its
+		// taints in a way that would let it steer disallowed workloads to itself.
+		if !apiequality.Semantic.DeepEqual(node.Spec.Taints, oldNode.Spec.Taints) {
+			return admission.NewForbidden(a, fmt.Errorf("cannot modify taints"))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Prevents kubelets from modifying or removing taints on update.

Nodes can set taints when they register themselves, but do not update/remove those taints after creation (that is done by the node controller based on reported node conditions).

xref https://github.com/kubernetes/community/pull/911 https://github.com/kubernetes/features/issues/279

/sig node
/sig auth
/sig scheduling

/assign @mikedanese @k82cn

```release-note
The NodeRestriction admission plugin now prevents kubelets from modifying/removing taints applied to their Node API object.
```