### PR TITLE
Report node DNS info with --node-ip

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -191,7 +191,6 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 			glog.Errorf("Specified Node IP not found in cloudprovider")
 			return
 		}
-		nodeAddresses = []v1.NodeAddress{*nodeIP}
 	}
 	newNode := node.DeepCopy()
 	newNode.Status.Addresses = nodeAddresses

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -854,7 +854,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 	assert.Equal(t, 1, len(fnh.UpdatedNodes), "Node was not updated")
 	assert.Equal(t, "node0", fnh.UpdatedNodes[0].Name, "Node was not updated")
-	assert.Equal(t, 1, len(fnh.UpdatedNodes[0].Status.Addresses), "Node status unexpectedly updated")
+	assert.Equal(t, 3, len(fnh.UpdatedNodes[0].Status.Addresses), "Node status unexpectedly updated")
 
 	cloudNodeController.Run()
 
@@ -862,7 +862,7 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 
 	updatedNodes := fnh.GetUpdatedNodesCopy()
 
-	assert.Equal(t, 1, len(updatedNodes[0].Status.Addresses), 1, "Node Addresses not correctly updated")
+	assert.Equal(t, 3, len(updatedNodes[0].Status.Addresses), "Node Addresses not correctly updated")
 	assert.Equal(t, "10.0.0.1", updatedNodes[0].Status.Addresses[0].Address, "Node Addresses not correctly updated")
 }
 

--- a/pkg/kubelet/apis/well_known_annotations.go
+++ b/pkg/kubelet/apis/well_known_annotations.go
@@ -19,7 +19,7 @@ package apis
 const (
 	// When kubelet is started with the "external" cloud provider, then
 	// it sets this annotation on the node to denote an ip address set from the
-	// cmd line flag. This ip is verified with the cloudprovider as valid by
+	// cmd line flag (--node-ip). This ip is verified with the cloudprovider as valid by
 	// the cloud-controller-manager
 	AnnotationProvidedIPAddr = "alpha.kubernetes.io/provided-node-ip"
 )

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -521,6 +521,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		containerManager:     kubeDeps.ContainerManager,
 		containerRuntimeName: containerRuntime,
 		nodeIP:               parsedNodeIP,
+		nodeIPValidator:      validateNodeIP,
 		clock:                clock.RealClock{},
 		enableControllerAttachDetach:            kubeCfg.EnableControllerAttachDetach,
 		iptClient:                               utilipt.New(utilexec.New(), utildbus.New(), utilipt.ProtocolIpv4),
@@ -1069,6 +1070,9 @@ type Kubelet struct {
 
 	// If non-nil, use this IP address for the node
 	nodeIP net.IP
+
+	// use this function to validate the kubelet nodeIP
+	nodeIPValidator func(net.IP) error
 
 	// If non-nil, this is a unique identifier for the node in an external database, eg. cloudprovider
 	providerID string


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds `ExternalDNS`, `InternalDNS`, and `ExternalIP` info for kubelets with the `--nodeip` flag enabled. 

**Which issue(s) this PR fixes** 
Fixes #63158

**Special notes for your reviewer**:

I added a field to the Kubelet to make IP validation more testable (`validateNodeIP` relies on the `net` package and the IP address of the host that is executing the test.) I also converted the test to use a table so new cases could be added more easily.

**Release Notes**
```release-note
Report node DNS info with --node-ip flag
```

@andrewsykim
@nckturner 

/sig node
/sig network