### PR TITLE
Adding traffic shaping support for CNI network driver

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/BUILD
+++ b/pkg/kubelet/dockershim/network/cni/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockershim/network:go_default_library",
+        "//pkg/util/bandwidth:go_default_library",
         "//vendor/github.com/containernetworking/cni/libcni:go_default_library",
         "//vendor/github.com/containernetworking/cni/pkg/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
+	"k8s.io/kubernetes/pkg/util/bandwidth"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -66,6 +67,22 @@ type cniPortMapping struct {
 	ContainerPort int32  `json:"containerPort"`
 	Protocol      string `json:"protocol"`
 	HostIP        string `json:"hostIP"`
+}
+
+// cniBandwidthEntry maps to the standard CNI bandwidth Capability
+// see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md and
+// https://github.com/containernetworking/plugins/blob/master/plugins/meta/bandwidth/README.md
+type cniBandwidthEntry struct {
+	// IngressRate is the bandwidth rate in bits per second for traffic through container. 0 for no limit. If ingressRate is set, ingressBurst must also be set
+	IngressRate int `json:"ingressRate,omitempty"`
+	// IngressBurst is the bandwidth burst in bits for traffic through container. 0 for no limit. If ingressBurst is set, ingressRate must also be set
+	// NOTE: it's not used for now and default to 0.
+	IngressBurst int `json:"ingressBurst,omitempty"`
+	// EgressRate is the bandwidth is the bandwidth rate in bits per second for traffic through container. 0 for no limit. If egressRate is set, egressBurst must also be set
+	EgressRate int `json:"egressRate,omitempty"`
+	// EgressBurst is the bandwidth burst in bits for traffic through container. 0 for no limit. If egressBurst is set, egressRate must also be set
+	// NOTE: it's not used for now and default to 0.
+	EgressBurst int `json:"egressBurst,omitempty"`
 }
 
 func SplitDirs(dirs string) []string {
@@ -217,13 +234,13 @@ func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubec
 
 	// Windows doesn't have loNetwork. It comes only with Linux
 	if plugin.loNetwork != nil {
-		if _, err = plugin.addToNetwork(plugin.loNetwork, name, namespace, id, netnsPath); err != nil {
+		if _, err = plugin.addToNetwork(plugin.loNetwork, name, namespace, id, netnsPath, annotations); err != nil {
 			glog.Errorf("Error while adding to cni lo network: %s", err)
 			return err
 		}
 	}
 
-	_, err = plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath)
+	_, err = plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, annotations)
 	if err != nil {
 		glog.Errorf("Error while adding to cni network: %s", err)
 		return err
@@ -243,11 +260,11 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 		glog.Warningf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
-	return plugin.deleteFromNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath)
+	return plugin.deleteFromNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil)
 }
 
-func (plugin *cniNetworkPlugin) addToNetwork(network *cniNetwork, podName string, podNamespace string, podSandboxID kubecontainer.ContainerID, podNetnsPath string) (cnitypes.Result, error) {
-	rt, err := plugin.buildCNIRuntimeConf(podName, podNamespace, podSandboxID, podNetnsPath)
+func (plugin *cniNetworkPlugin) addToNetwork(network *cniNetwork, podName string, podNamespace string, podSandboxID kubecontainer.ContainerID, podNetnsPath string, annotations map[string]string) (cnitypes.Result, error) {
+	rt, err := plugin.buildCNIRuntimeConf(podName, podNamespace, podSandboxID, podNetnsPath, annotations)
 	if err != nil {
 		glog.Errorf("Error adding network when building cni runtime conf: %v", err)
 		return nil, err
@@ -264,8 +281,8 @@ func (plugin *cniNetworkPlugin) addToNetwork(network *cniNetwork, podName string
 	return res, nil
 }
 
-func (plugin *cniNetworkPlugin) deleteFromNetwork(network *cniNetwork, podName string, podNamespace string, podSandboxID kubecontainer.ContainerID, podNetnsPath string) error {
-	rt, err := plugin.buildCNIRuntimeConf(podName, podNamespace, podSandboxID, podNetnsPath)
+func (plugin *cniNetworkPlugin) deleteFromNetwork(network *cniNetwork, podName string, podNamespace string, podSandboxID kubecontainer.ContainerID, podNetnsPath string, annotations map[string]string) error {
+	rt, err := plugin.buildCNIRuntimeConf(podName, podNamespace, podSandboxID, podNetnsPath, annotations)
 	if err != nil {
 		glog.Errorf("Error deleting network when building cni runtime conf: %v", err)
 		return err
@@ -283,7 +300,7 @@ func (plugin *cniNetworkPlugin) deleteFromNetwork(network *cniNetwork, podName s
 	return nil
 }
 
-func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string, podSandboxID kubecontainer.ContainerID, podNetnsPath string) (*libcni.RuntimeConf, error) {
+func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string, podSandboxID kubecontainer.ContainerID, podNetnsPath string, annotations map[string]string) (*libcni.RuntimeConf, error) {
 	glog.V(4).Infof("Got netns path %v", podNetnsPath)
 	glog.V(4).Infof("Using podns path %v", podNs)
 
@@ -319,6 +336,23 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 	}
 	rt.CapabilityArgs = map[string]interface{}{
 		"portMappings": portMappingsParam,
+	}
+
+	ingress, egress, err := bandwidth.ExtractPodBandwidthResources(annotations)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading pod bandwidth annotations: %v", err)
+	}
+	if ingress != nil || egress != nil {
+		bandwidthParam := cniBandwidthEntry{}
+		if ingress != nil {
+			bandwidthParam.IngressRate = int(ingress.Value() / 1000)
+			bandwidthParam.IngressBurst = 0 // default to no limit
+		}
+		if egress != nil {
+			bandwidthParam.EgressRate = int(egress.Value() / 1000)
+			bandwidthParam.EgressBurst = 0 // default to no limit
+		}
+		rt.CapabilityArgs["bandwidth"] = bandwidthParam
 	}
 
 	return rt, nil

--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -42,7 +42,7 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
-	result, err := plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath)
+	result, err := plugin.addToNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil)
 
 	glog.V(5).Infof("GetPodNetworkStatus result %+v", result)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adding traffic shaping support for CNI network driver - it's also a sub-task of kubenet deprecation work.

Design document is available here: https://github.com/kubernetes/community/pull/1893

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @freehan @jingax10 @caseydavenport @dcbw 

/sig network
/sig node

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support traffic shaping for CNI network driver
```

