### PR TITLE
Set the default operational state for dummy interfaces to up

### DIFF
--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -82,10 +82,11 @@ func (h *netlinkHandle) EnsureDummyDevice(devName string) (bool, error) {
 		// found dummy device
 		return true, nil
 	}
-	dummy := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{Name: devName},
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: devName}}
+	if err := h.LinkAdd(dummy); err != nil {
+		return false, err
 	}
-	return false, h.LinkAdd(dummy)
+	return false, h.LinkSetUp(dummy)
 }
 
 // DeleteDummyDevice is part of interface.


### PR DESCRIPTION
**What this PR does / why we need it**:

Created dummy interfaces are `DOWN` by default (at least on the `4.15.10` kernel I was testing). This means it does not receive traffic on the host.

This breaks IPVS at least in the host network.

This patch tries to always bring the interface up.
It stayed in the `UNKNOWN` state afterwards but received traffic (thus making `ipvs` happy).

```release-note
dummy interfaces generated by kubernetes are brought up by default
```