### PR TITLE
Enable bypassing online checks in kubeadm upgrade plan

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -87,7 +87,7 @@ func enforceRequirements(flags *cmdUpgradeFlags, dryRun bool, newK8sVersion stri
 		client: client,
 		cfg:    cfg,
 		// Use a real version getter interface that queries the API server, the kubeadm client and the Kubernetes CI system for latest versions
-		versionGetter: upgrade.NewKubeVersionGetter(client, os.Stdout),
+		versionGetter: upgrade.NewOfflineVersionGetter(upgrade.NewKubeVersionGetter(client, os.Stdout), newK8sVersion),
 		// Use the waiter conditionally based on the dryrunning variable
 		waiter: getWaiter(dryRun, client),
 	}, nil


### PR DESCRIPTION
Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:

This PR makes `kubeadm upgrade plan` a little nicer to use in an air gapped environment. `kubeadm upgrade plan` now accepts a version and returns that instead of checking the internet.

**Which issue(s) this PR fixes**:

Fixes kubernetes/kubeadm#698

**Special notes for your reviewer**:

I also cleaned up the tests for this section of code by adding formal names for table tests and using `t.Run`.

**Release note**:

```release-note
`kubeadm upgrade plan` now accepts a version which improves the UX nicer in air-gapped environments.
```
