### PR TITLE
remove self linker from group info

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/BUILD
@@ -14,7 +14,6 @@ go_library(
     importpath = "k8s.io/apimachinery/pkg/apimachinery",
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
@@ -150,11 +150,8 @@ func (gmf *GroupMetaFactory) Register(m *registered.APIRegistrationManager, sche
 		gmf.GroupArgs.AddInternalObjectsToScheme(scheme)
 	}
 
-	accessor := meta.NewAccessor()
-
 	groupMeta := &apimachinery.GroupMeta{
 		GroupVersions:   externalVersions,
-		SelfLinker:      runtime.SelfLinker(accessor),
 		RootScopedKinds: gmf.GroupArgs.RootScopedKinds,
 	}
 	groupMeta.RESTMapper = gmf.newRESTMapper(scheme, externalVersions, groupMeta)

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/types.go
@@ -18,7 +18,6 @@ package apimachinery
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -29,12 +28,6 @@ type GroupMeta struct {
 	GroupVersions []schema.GroupVersion
 
 	RootScopedKinds sets.String
-
-	// SelfLinker can set or get the SelfLink field of all API types.
-	// TODO: when versioning changes, make this part of each API definition.
-	// TODO(lavalamp): Combine SelfLinker & ResourceVersioner interfaces, force all uses
-	// to go through the InterfacesFor method below.
-	SelfLinker runtime.SelfLinker
 
 	// RESTMapper provides the default mapping between REST paths and the objects declared in a Scheme and all known
 	// versions.

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -98,6 +98,7 @@ go_library(
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/emicklei/go-restful-swagger12"
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apimachinery"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -422,7 +423,7 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		UnsafeConvertor: runtime.UnsafeObjectConvertor(apiGroupInfo.Scheme),
 		Defaulter:       apiGroupInfo.Scheme,
 		Typer:           apiGroupInfo.Scheme,
-		Linker:          apiGroupInfo.GroupMeta.SelfLinker,
+		Linker:          runtime.SelfLinker(meta.NewAccessor()),
 		RootScopedKinds: apiGroupInfo.GroupMeta.RootScopedKinds,
 
 		Admit:                        s.admissionControl,


### PR DESCRIPTION
The self-link is related to RESTStorage, not to the scheme/codec.  Also, no one every customized it.  This moves it to the single point of use and retains the override potential.

@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```