### PR TITLE
Implements OIDC distributed claims.

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -60,6 +60,7 @@ type AuthenticatorConfig struct {
 	OIDCGroupsPrefix            string
 	OIDCSigningAlgs             []string
 	OIDCRequiredClaims          map[string]string
+	OIDCIssuersPerClaim         map[string][]string
 	ServiceAccountKeyFiles      []string
 	ServiceAccountLookup        bool
 	ServiceAccountIssuer        string
@@ -160,7 +161,7 @@ func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDe
 	// simply returns an error, the OpenID Connect plugin may query the provider to
 	// update the keys, causing performance hits.
 	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
-		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCUsernamePrefix, config.OIDCGroupsClaim, config.OIDCGroupsPrefix, config.OIDCSigningAlgs, config.OIDCRequiredClaims)
+		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCUsernamePrefix, config.OIDCGroupsClaim, config.OIDCGroupsPrefix, config.OIDCSigningAlgs, config.OIDCRequiredClaims, config.OIDCIssuersPerClaim)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -242,7 +243,7 @@ func newAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Token, e
 }
 
 // newAuthenticatorFromOIDCIssuerURL returns an authenticator.Token or an error.
-func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClaim, usernamePrefix, groupsClaim, groupsPrefix string, signingAlgs []string, requiredClaims map[string]string) (authenticator.Token, error) {
+func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClaim, usernamePrefix, groupsClaim, groupsPrefix string, signingAlgs []string, requiredClaims map[string]string, issuersPerClaim map[string][]string) (authenticator.Token, error) {
 	const noUsernamePrefix = "-"
 
 	if usernamePrefix == "" && usernameClaim != "email" {
@@ -268,6 +269,7 @@ func newAuthenticatorFromOIDCIssuerURL(issuerURL, clientID, caFile, usernameClai
 		GroupsPrefix:         groupsPrefix,
 		SupportedSigningAlgs: signingAlgs,
 		RequiredClaims:       requiredClaims,
+		IssuersPerClaim:      issuersPerClaim,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -66,6 +66,18 @@ type OIDCAuthenticationOptions struct {
 	GroupsPrefix   string
 	SigningAlgs    []string
 	RequiredClaims map[string]string
+
+	// Distributed claims configuration.
+	// See for details:
+	// http://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
+
+	// IssuersPerClaim lists, for each claim, the list of issuer URLs that are
+	// trusted to provide the respective distributed claim.  Only distributed
+	// claims with issuers as specified below will be resolved.
+	//
+	// Example:
+	// "groups" -> []string{"http://example1.com/foo","http://example2.com/bar"}
+	IssuersPerClaim map[string][]string
 }
 
 type PasswordFileAuthenticationOptions struct {
@@ -230,6 +242,9 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"A key=value pair that describes a required claim in the ID Token. "+
 			"If set, the claim is verified to be present in the ID Token with a matching value. "+
 			"Repeat this flag to specify multiple claims.")
+
+		fs.Var(flag.NewColonSeparatedMultimapStringString(&s.OIDC.IssuersPerClaim), "oidc-distributed-claims-issuers-per-claim", ""+
+			"A multimap that describes acceptable issuer URLs per each distributed claim.  Repeat this flag to specify multiple claims.")
 	}
 
 	if s.PasswordFile != nil {
@@ -306,6 +321,7 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.Au
 		ret.OIDCUsernamePrefix = s.OIDC.UsernamePrefix
 		ret.OIDCSigningAlgs = s.OIDC.SigningAlgs
 		ret.OIDCRequiredClaims = s.OIDC.RequiredClaims
+		ret.OIDCIssuersPerClaim = s.OIDC.IssuersPerClaim
 	}
 
 	if s.PasswordFile != nil {

--- a/staging/src/k8s.io/apiserver/pkg/util/flag/colon_separated_multimap_string_string_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/colon_separated_multimap_string_string_test.go
@@ -162,6 +162,15 @@ func TestSetColonSeparatedMultimapStringString(t *testing.T) {
 			NewColonSeparatedMultimapStringString(nil),
 			nil,
 			"no target (nil pointer to map[string][]string)"},
+		{"values with colons in them (e.g. URLs)",
+			[]string{"a:http://e11.com,a:http://e12.com,b:http://e22.com"},
+			NewColonSeparatedMultimapStringString(&nilMap),
+			&ColonSeparatedMultimapStringString{
+				initialized: true,
+				Multimap: &map[string][]string{
+					"a": {"http://e11.com", "http://e12.com"},
+					"b": {"http://e22.com"},
+				}}, ""},
 	}
 
 	for _, c := range cases {
@@ -183,7 +192,7 @@ func TestSetColonSeparatedMultimapStringString(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !reflect.DeepEqual(c.expect, c.start) {
-				t.Fatalf("expect %#v but got %#v", c.expect, c.start)
+				t.Fatalf("expect %v but got %v", c.expect, c.start)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/BUILD
@@ -8,6 +8,7 @@ load(
 
 go_test(
     name = "go_default_test",
+	size = "small",
     srcs = ["oidc_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -34,9 +34,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -46,6 +48,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	certutil "k8s.io/client-go/util/cert"
+)
+
+var (
+	// synchronizeVerifierForTest is a test hook that, if set to true, blocks
+	// token ID verifier initialization so that tests always have a verifier to
+	// use.
+	synchronizeVerifierForTest = false
 )
 
 type Options struct {
@@ -104,6 +113,92 @@ type Options struct {
 
 	// now is used for testing. It defaults to time.Now.
 	now func() time.Time
+
+	// IssuersPerClaim supports distributed claims.
+	//
+	// See for details:
+	// http://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
+	//
+	// Lists, for each claim, the list of issuer URLs that are
+	// trusted to provide the respective distributed claim.  Only distributed
+	// claims with issuers as specified below will be resolved.  This is done
+	// to reduce the chance that an authentication request goes to an address
+	// that we don't trust to issue distributed claims.
+	//
+	// Multiple issuers are supported so that it would be possible to rotate
+	// the issuers over time (with sufficient advance notice) without
+	// disrupting cluster operations, while it is expected that more than one
+	// issuer per claim is present only if the distributed claims source change
+	// is imminent.
+	//
+	// Example:
+	// "groups" -> []string{"http://example1.com/foo","http://example2.com/bar"}
+	IssuersPerClaim map[string][]string
+}
+
+// initVerifier creates a new ID token verifier for the given configuration and issuer URL.  On success, calls setVerifier with the
+// resulting verifier.  Returns true in case of success, or non-nil error in case of an irrecoverable error.
+func initVerifier(ctx context.Context, config *oidc.Config, iss string) (*oidc.IDTokenVerifier, error) {
+	provider, err := oidc.NewProvider(ctx, iss)
+	if err != nil {
+		return nil, fmt.Errorf("init verifier failed: %v", err)
+	}
+	return provider.Verifier(config), nil
+}
+
+// asyncIDTokenVerifier is an ID token verifier that allows async initialization
+// of the issuer check.  Must be passed by reference as it wraps sync.Mutex.
+type asyncIDTokenVerifier struct {
+	m sync.Mutex
+
+	// v is the ID token verifier initialized asynchronously.  It remains nil
+	// up until it is eventually initialized.
+	// Guarded by m
+	v *oidc.IDTokenVerifier
+}
+
+// newAsyncIDTokenVerifier creates a new asynchronous token verifier.  The
+// verifier is available immediately, but may remain uninitialized for some time
+// after creation.
+// TODO: newAuthenticator could use this as well.
+func newAsyncIDTokenVerifier(ctx context.Context, c *oidc.Config, iss string) *asyncIDTokenVerifier {
+	t := &asyncIDTokenVerifier{}
+
+	// Polls indefinitely in an attemt to initialize the distributed claims
+	// verifier, or until context canceled.
+	sync := make(chan struct{})
+	initFn := func() (done bool, err error) {
+		glog.V(10).Infof("oidc authenticator: attempting init: iss=%v", iss)
+		v, err := initVerifier(ctx, c, iss)
+		if err != nil {
+			glog.Errorf("oidc authenticator: async token verifier for issuer: %q: %v", iss, err)
+			return false, nil
+		}
+		t.m.Lock()
+		defer t.m.Unlock()
+		t.v = v
+		close(sync)
+		return true, nil
+
+	}
+	go func() {
+		if done, _ := initFn(); !done {
+			go wait.PollUntil(time.Second*10, initFn, ctx.Done())
+		}
+	}()
+
+	// Let tests wait until the verifier is initialized.
+	if synchronizeVerifierForTest {
+		<-sync
+	}
+	return t
+}
+
+// verifier returns the underlying ID token verifier, or nil if one is not yet initialized.
+func (a *asyncIDTokenVerifier) verifier() *oidc.IDTokenVerifier {
+	a.m.Lock()
+	defer a.m.Unlock()
+	return a.v
 }
 
 type Authenticator struct {
@@ -120,6 +215,8 @@ type Authenticator struct {
 	verifier atomic.Value
 
 	cancel context.CancelFunc
+
+	claimsProcessor *claimResolver
 }
 
 func (a *Authenticator) setVerifier(v *oidc.IDTokenVerifier) {
@@ -217,16 +314,6 @@ func newAuthenticator(opts Options, initVerifier func(ctx context.Context, a *Au
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = oidc.ClientContext(ctx, client)
 
-	authenticator := &Authenticator{
-		issuerURL:      opts.IssuerURL,
-		usernameClaim:  opts.UsernameClaim,
-		usernamePrefix: opts.UsernamePrefix,
-		groupsClaim:    opts.GroupsClaim,
-		groupsPrefix:   opts.GroupsPrefix,
-		requiredClaims: opts.RequiredClaims,
-		cancel:         cancel,
-	}
-
 	now := opts.now
 	if now == nil {
 		now = time.Now
@@ -238,43 +325,272 @@ func newAuthenticator(opts Options, initVerifier func(ctx context.Context, a *Au
 		Now:                  now,
 	}
 
+	authenticator := &Authenticator{
+		issuerURL:       opts.IssuerURL,
+		usernameClaim:   opts.UsernameClaim,
+		usernamePrefix:  opts.UsernamePrefix,
+		groupsClaim:     opts.GroupsClaim,
+		groupsPrefix:    opts.GroupsPrefix,
+		requiredClaims:  opts.RequiredClaims,
+		cancel:          cancel,
+		claimsProcessor: newClaimResolver(ctx, opts.IssuersPerClaim, tr, verifierConfig),
+	}
+
 	initVerifier(ctx, authenticator, verifierConfig)
 	return authenticator, nil
 }
 
-func hasCorrectIssuer(iss, tokenData string) bool {
-	parts := strings.Split(tokenData, ".")
+// untrustedIssuer extracts an untrusted "iss" claim from the given JWT token,
+// or returns an error if the token can not be parsed.  Since the JWT is not
+// verified, the returned issuer should not be trusted.
+func untrustedIssuer(token string) (string, error) {
+	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return false
+		return "", fmt.Errorf("malformed token %q", token)
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return false
+		return "", fmt.Errorf("error decoding token %q", token)
 	}
 	claims := struct {
 		// WARNING: this JWT is not verified. Do not trust these claims.
 		Issuer string `json:"iss"`
 	}{}
 	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("while unmarshaling token: %q: %v", err)
+	}
+	return claims.Issuer, nil
+}
+
+func hasCorrectIssuer(iss, tokenData string) bool {
+	uiss, err := untrustedIssuer(tokenData)
+	if err != nil {
+		glog.Errorf("while checking issuer: %v", err)
 		return false
 	}
-	if claims.Issuer != iss {
+	if uiss != iss {
+		glog.V(11).Infof("Issuer mismatch: want=%q, got=%q", iss, uiss)
 		return false
 	}
 	return true
 }
 
+// endpoint represents an OIDC distributed claims endpoint.
+type endpoint struct {
+	// URL to use to request the distributed claim.  This URL is expected to be
+	// prefixed by one of the known issuer URLs.
+	URL string `json:"endpoint,omitempty"`
+	// AccessToken is the bearer token to use for access.  If empty, it is
+	// not used.  Access token is optional per the OIDC distributed claims
+	// specification.
+	// See: http://openid.net/specs/openid-connect-core-1_0.html#DistributedExample
+	AccessToken string `json:"access_token,omitempty"`
+	// JWT is the container for aggregated claims.  Not supported at the moment.
+	// See: http://openid.net/specs/openid-connect-core-1_0.html#AggregatedExample
+	JWT string `json:"JWT,omitempty"`
+}
+
+// claimInfo contains information used to verify a single claim.
+type claimInfo struct {
+	// name is the claim name, e.g. "groups"
+	name string
+
+	// verifierPerIssuer contains, for each issuer, the appropriate verifier to use
+	// for this claim.
+	verifierPerIssuer map[string]*asyncIDTokenVerifier
+}
+
+func (i claimInfo) String() string {
+	return fmt.Sprintf("name:%q, verifierPerIssuer:%+v", i.name, i.verifierPerIssuer)
+}
+
+// claimResolver expands distributed claims by calling respective claim source
+// endpoints.
+type claimResolver struct {
+	// claimInfos is a map from a claim to verifier map.
+	claimInfos map[string]claimInfo
+
+	// A HTTP transport to use for distributed claims
+	t *http.Transport
+}
+
+// newClaimResolver creates a new resolver for distributed claims.  Each claim
+// has a number of allowed issuers, as specified by issuersPerClaim, and only
+// those issuers are honored.
+// TODO: Support separate client IDs per different issuer/claim.
+func newClaimResolver(ctx context.Context, issuersPerClaim map[string][]string, t *http.Transport, config *oidc.Config) *claimResolver {
+	cp := &claimResolver{claimInfos: map[string]claimInfo{}, t: t}
+	for c, issuers := range issuersPerClaim {
+		verifierPerIssuer := map[string]*asyncIDTokenVerifier{}
+		for _, iss := range issuers {
+			glog.V(10).Infof("adding claim info: %v", iss)
+			verifierPerIssuer[iss] = newAsyncIDTokenVerifier(ctx, config, iss)
+		}
+		ci := claimInfo{c, verifierPerIssuer}
+		cp.claimInfos[c] = ci
+		glog.V(10).Infof("adding claim info: %+v", ci)
+	}
+	return cp
+}
+
+// Verifier returns either the verifier for the specified issuer, or error.
+func (p *claimResolver) Verifier(claim, iss string) (*oidc.IDTokenVerifier, error) {
+	ci, ok := p.claimInfos[claim]
+	if !ok {
+		return nil, fmt.Errorf("no claim info for claim: %q, issuer: %q", claim, iss)
+	}
+	av := ci.verifierPerIssuer[iss]
+	if av == nil {
+		return nil, fmt.Errorf("no verifier for claim: %q, issuer: %q", claim, iss)
+	}
+	v := av.verifier()
+	if v == nil {
+		return nil, fmt.Errorf("verifier not initialized for claim: %q, issuer: %q", claim, iss)
+	}
+	glog.V(10).Infof("Got verifier for: claim: %q, iss: %q: %+v", claim, iss, v)
+	return v, nil
+}
+
+// expand extracts the distributed claims from claim names and claim sources.
+// The extracted claim value is pulled up into the supplied claims.
+//
+// Distributed claims are of the form as seen below, and are defined in the
+// OIDC Connect Core 1.0, section 5.6.2.
+// See: https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
+//
+// {
+//   ... (other normal claims)...
+//   "_claim_names": {
+//     "groups": "src1"
+//   },
+//   "_claim_sources": {
+//     "src1": {
+//       "endpoint": "https://www.example.com",
+//       "access_token": "f005ba11"
+//     },
+//   },
+// }
+func (r *claimResolver) expand(c claims) error {
+	const (
+		// The claim containing a map of endpoint references per claim.
+		// OIDC Connect Core 1.0, section 5.6.2.
+		claimNamesKey = "_claim_names"
+		// The claim containing endpoint specifications.
+		// OIDC Connect Core 1.0, section 5.6.2.
+		claimSourcesKey = "_claim_sources"
+	)
+
+	if glog.V(11) {
+		glog.Infof("initial claim set: %v", c)
+	}
+	defer func() {
+		if glog.V(10) {
+			glog.Infof("final claim set: %v", c)
+		}
+	}()
+	names, ok := c[claimNamesKey]
+	if !ok {
+		// No _claim_names, no keys to look up.
+		return nil
+	}
+
+	claimToSource := map[string]string{}
+	if err := json.Unmarshal([]byte(names), &claimToSource); err != nil {
+		return fmt.Errorf("oidc: error parsing distributed claim names: %v", err)
+	}
+
+	var rawSources json.RawMessage
+	rawSources, ok = c[claimSourcesKey]
+	if !ok {
+		// Having _claim_names claim,  but no _claim_sources is not an expected
+		// state.
+		return fmt.Errorf("oidc: no claim sources")
+	}
+
+	var sources claims
+	if err := json.Unmarshal([]byte(rawSources), &sources); err != nil {
+		// The claims sources claim is malformed, this is not an expected state.
+		return fmt.Errorf("oidc: could not parse claim sources")
+	}
+
+	// Build a map of claims to endpoint, resolving the indirection between
+	// _claim_names and _claim_sources.
+	cep := map[string]endpoint{}
+	for claim, source := range claimToSource {
+		if _, ok := c[claim]; ok {
+			// Skip distributed claim if a normal claim is already present.
+			continue
+		}
+		rawEndpoint, ok := sources[source]
+		if !ok {
+			// We expect that if a claim is named, that the corresponding source exists, too.
+			return fmt.Errorf("missing source for claim: %v", claim)
+		}
+		var e endpoint
+		if err := json.Unmarshal([]byte(rawEndpoint), &e); err != nil {
+			return fmt.Errorf("could not unmarshal claim: %v", err)
+		}
+		if e.URL == "" {
+			// Ignoring aggregate claims for now.
+			continue
+		}
+		cep[claim] = e
+	}
+	return r.resolve(cep, c)
+}
+
+// resolve requests distributed claims from all endpoints passed in,
+// and inserts the lookup results into allClaims.
+func (p *claimResolver) resolve(endpoints map[string]endpoint, allClaims claims) error {
+	for claim, endpoint := range endpoints {
+		// This could be parallelized if needed.
+		// The endpoint MUST return a JWT per
+		// http://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
+		// TODO: cache resolved claims.
+		// TODO: support aggregated claims.
+		jwt, err := getClaimJWT(p.t, endpoint.URL, endpoint.AccessToken)
+		if err != nil {
+			return fmt.Errorf("while getting distributed claim %q: %v", claim, err)
+		}
+		untrustedIss, err := untrustedIssuer(jwt)
+		if err != nil {
+			glog.Errorf("while getting issuer: %q: %v", claim, err)
+			continue
+		}
+		v, err := p.Verifier(claim, untrustedIss)
+		if err != nil {
+			glog.Errorf("verifier: %v", err)
+			continue
+		}
+		t, err := v.Verify(context.Background(), jwt)
+		if err != nil {
+			return fmt.Errorf("verify distributed claim token: %v", err)
+		}
+		var distClaims claims
+		if err := t.Claims(&distClaims); err != nil {
+			return fmt.Errorf("could not parse distributed claims for claim %v: %v", claim, err)
+		}
+		value, ok := distClaims[claim]
+		if !ok {
+			return fmt.Errorf("could not find distributed claim: %v", claim)
+		}
+		allClaims[claim] = value
+	}
+	return nil
+}
+
 func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error) {
 	if !hasCorrectIssuer(a.issuerURL, token) {
+		glog.V(10).Infof("Issuer mismatch at entry.")
 		return nil, false, nil
 	}
 
-	ctx := context.Background()
 	verifier, ok := a.idTokenVerifier()
 	if !ok {
 		return nil, false, fmt.Errorf("oidc: authenticator not initialized")
 	}
 
+	ctx := context.Background()
 	idToken, err := verifier.Verify(ctx, token)
 	if err != nil {
 		return nil, false, fmt.Errorf("oidc: verify token: %v", err)
@@ -284,6 +600,10 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 	if err := idToken.Claims(&c); err != nil {
 		return nil, false, fmt.Errorf("oidc: parse claims: %v", err)
 	}
+	if err := a.claimsProcessor.expand(c); err != nil {
+		return nil, false, fmt.Errorf("oidc: could not expand distributed claims: %v", err)
+	}
+
 	var username string
 	if err := c.unmarshalClaim(a.usernameClaim, &username); err != nil {
 		return nil, false, fmt.Errorf("oidc: parse username claims %q: %v", a.usernameClaim, err)
@@ -349,6 +669,32 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 	return info, true, nil
 }
 
+// getClaimJWT gets a distributed claim JWT from url, using the supplied access
+// token as bearer token.  If the access token is "", the authorization header
+// will not be set.
+// TODO: Allow passing in JSON hints to the IDP.
+func getClaimJWT(t *http.Transport, url, accessToken string) (string, error) {
+	client := &http.Client{Transport: t, Timeout: 30 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// TODO: Allow passing request body with configurable information.
+	req, _ := http.NewRequest("GET", url, nil)
+	if accessToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", accessToken))
+	}
+	req.WithContext(ctx)
+	response, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	responseBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not decode distributed claim response")
+	}
+	return string(responseBytes), nil
+}
+
 type stringOrArray []string
 
 func (s *stringOrArray) UnmarshalJSON(b []byte) error {
@@ -380,4 +726,12 @@ func (c claims) hasClaim(name string) bool {
 		return false
 	}
 	return true
+}
+
+func (c claims) String() string {
+	r := map[string]string{}
+	for k, v := range c {
+		r[k] = string(v)
+	}
+	return fmt.Sprintf("%+v", r)
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package oidc
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/x509"
@@ -25,12 +26,17 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
+	"github.com/golang/glog"
 	jose "gopkg.in/square/go-jose.v2"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -122,22 +128,149 @@ var (
 )
 
 type claimsTest struct {
-	name        string
-	options     Options
-	now         time.Time
-	signingKey  *jose.JSONWebKey
-	pubKeys     []*jose.JSONWebKey
-	claims      string
-	want        *user.DefaultInfo
-	wantSkip    bool
-	wantErr     bool
-	wantInitErr bool
+	name               string
+	options            Options
+	now                time.Time
+	signingKey         *jose.JSONWebKey
+	pubKeys            []*jose.JSONWebKey
+	claims             string
+	want               *user.DefaultInfo
+	wantSkip           bool
+	wantErr            bool
+	wantInitErr        bool
+	claimToResponseMap map[string]string
+	openIDConfig       string
+	asyncInit          bool
+}
+
+// Replace formats the contents of v into the provided template.
+func replace(tmpl string, v interface{}) string {
+	t := template.Must(template.New("test").Parse(tmpl))
+	buf := bytes.NewBuffer(nil)
+	t.Execute(buf, &v)
+	ret := buf.String()
+	glog.V(10).Infof("Replaced: %v into: %v", tmpl, ret)
+	return ret
+}
+
+// newClaimServer returns a new test HTTPS server, which is rigged to return
+// OIDC responses to requests that resolve distributed claims. signer is the
+// signer used for the served JWT tokens.  claimToResponseMap is a map of
+// responses that the server will return for each claim it is given.
+func newClaimServer(t *testing.T, keys jose.JSONWebKeySet, signer jose.Signer, claimToResponseMap map[string]string, openIDConfig *string) *httptest.Server {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		glog.V(11).Infof("request: %+v", *r)
+		switch r.URL.Path {
+		case "/.testing/keys":
+			w.Header().Set("Content-Type", "application/json")
+			keyBytes, err := json.Marshal(keys)
+			if err != nil {
+				t.Fatalf("unexpected error while marshaling keys: %v", err)
+			}
+			glog.V(11).Infof("%v: returning: %+v", r.URL, string(keyBytes))
+			w.Write(keyBytes)
+
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			glog.V(11).Infof("%v: returning: %+v", r.URL, *openIDConfig)
+			w.Write([]byte(*openIDConfig))
+		default:
+			if claimToResponseMap == nil {
+				t.Fatalf("no claims specified in response")
+			}
+			claim := r.URL.Path[1:] // "/groups" -> "groups"
+			expectedAuth := fmt.Sprintf("Bearer %v_token", claim)
+			auth := r.Header.Get("Authorization")
+			if auth != expectedAuth {
+				t.Fatalf("bearer token expected: %q, was %q", expectedAuth, auth)
+			}
+			jws, err := signer.Sign([]byte(claimToResponseMap[claim]))
+			if err != nil {
+				t.Fatalf("while signing response token: %v", err)
+			}
+			token, err := jws.CompactSerialize()
+			if err != nil {
+				t.Fatalf("while serializing response token: %v", err)
+			}
+			w.Write([]byte(token))
+		}
+	}))
+	glog.V(10).Infof("Serving OIDC at: %v", ts.URL)
+	return ts
+}
+
+// writeTempCert writes out the supplied certificate into a temporary file in
+// PEM-encoded format.  Returns the name of the temporary file used.  The caller
+// is responsible for cleaning the file up.
+func writeTempCert(t *testing.T, cert []byte) string {
+	tempFile, err := ioutil.TempFile("", "ca.crt")
+	if err != nil {
+		t.Fatalf("could not open temp file: %v", err)
+	}
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	}
+	if err := pem.Encode(tempFile, block); err != nil {
+		t.Fatalf("could not write to temp file %v: %v", tempFile.Name(), err)
+	}
+	tempFile.Close()
+	return tempFile.Name()
+}
+
+func toKeySet(keys []*jose.JSONWebKey) jose.JSONWebKeySet {
+	ret := jose.JSONWebKeySet{}
+	for _, k := range keys {
+		ret.Keys = append(ret.Keys, *k)
+	}
+	return ret
 }
 
 func (c *claimsTest) run(t *testing.T) {
+	synchronizeVerifierForTest = !c.asyncInit
+	var (
+		signer jose.Signer
+		err    error
+	)
+	if c.signingKey != nil {
+		// Initialize the signer only in the tests that make use of it.  We can
+		// not defer this initialization because the test server uses it too.
+		signer, err = jose.NewSigner(jose.SigningKey{
+			Algorithm: jose.SignatureAlgorithm(c.signingKey.Algorithm),
+			Key:       c.signingKey,
+		}, nil)
+		if err != nil {
+			t.Fatalf("initialize signer: %v", err)
+		}
+	}
+	// The HTTPS server used for requesting distributed groups claims.
+	ts := newClaimServer(t, toKeySet(c.pubKeys), signer, c.claimToResponseMap, &c.openIDConfig)
+	defer ts.Close()
+
+	// Make the certificate of the helper server available to the authenticator
+	// by writing its root CA certificate into a temporary file.
+	tempFileName := writeTempCert(t, ts.TLS.Certificates[0].Certificate[0])
+	defer os.Remove(tempFileName)
+	c.options.CAFile = tempFileName
+
+	// Allow claims to refer to the serving URL of the test server.  For this,
+	// substitute all references to {{.URL}} in appropriate places.
+	v := struct{ URL string }{URL: ts.URL}
+	c.claims = replace(c.claims, &v)
+	c.openIDConfig = replace(c.openIDConfig, &v)
+	c.options.IssuerURL = replace(c.options.IssuerURL, &v)
+	for claim, issuers := range c.options.IssuersPerClaim {
+		for j, issuer := range issuers {
+			c.options.IssuersPerClaim[claim][j] = replace(issuer, &v)
+		}
+	}
+	for claim, response := range c.claimToResponseMap {
+		c.claimToResponseMap[claim] = replace(response, &v)
+	}
+
+	// Initialize the authenticator.
 	a, err := newAuthenticator(c.options, func(ctx context.Context, a *Authenticator, config *oidc.Config) {
-		// Set the verifier to use the public key set instead of reading
-		// from a remote.
+		// Set the verifier to use the public key set instead of reading from a remote.
 		a.setVerifier(oidc.NewVerifier(
 			c.options.IssuerURL,
 			&staticKeySet{keys: c.pubKeys},
@@ -155,13 +288,6 @@ func (c *claimsTest) run(t *testing.T) {
 	}
 
 	// Sign and serialize the claims in a JWT.
-	signer, err := jose.NewSigner(jose.SigningKey{
-		Algorithm: jose.SignatureAlgorithm(c.signingKey.Algorithm),
-		Key:       c.signingKey,
-	}, nil)
-	if err != nil {
-		t.Fatalf("initialize signer: %v", err)
-	}
 	jws, err := signer.Sign([]byte(c.claims))
 	if err != nil {
 		t.Fatalf("sign claims: %v", err)
@@ -200,6 +326,7 @@ func (c *claimsTest) run(t *testing.T) {
 }
 
 func TestToken(t *testing.T) {
+	synchronizeVerifierForTest = true
 	tests := []claimsTest{
 		{
 			name: "token",
@@ -357,6 +484,155 @@ func TestToken(t *testing.T) {
 			},
 		},
 		{
+			name: "groups-distributed",
+			options: Options{
+				IssuerURL:     "{{.URL}}",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+				IssuersPerClaim: map[string][]string{
+					"groups": []string{"{{.URL}}"},
+				},
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"username": "jane",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": ["team1", "team2"],
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
+			want: &user.DefaultInfo{
+				Name:   "jane",
+				Groups: []string{"team1", "team2"},
+			},
+		},
+		{
+			name: "groups-distributed-mismatched-issuer",
+			// Keep trying to initialize the issuer even if it will never
+			// succeed.
+			asyncInit: true,
+			options: Options{
+				IssuerURL:     "{{.URL}}",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+				IssuersPerClaim: map[string][]string{
+					"groups": []string{"https://other.example.com"},
+				},
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"username": "jane",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": ["team1", "team2"],
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
+			want: &user.DefaultInfo{
+				Name: "jane",
+				// Due to a mismatched issuer, groups have not been resolved.
+				Groups: nil,
+			},
+		},
+		{
+			// Specs are unclear about this behavior.  We adopt a behavior where
+			// normal claim wins over a distributed claim by the same name.
+			name: "groups-distributed-normal-claim-wins",
+			options: Options{
+				IssuerURL:     "{{.URL}}",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"username": "jane",
+				"groups": "team1",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": ["team2"],
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
+			want: &user.DefaultInfo{
+				Name: "jane",
+				// "team1" is from the normal "groups" claim.
+				Groups: []string{"team1"},
+			},
+		},
+		{
 			// Groups should be able to be a single string, not just a slice.
 			name: "group-string-claim",
 			options: Options{
@@ -377,6 +653,145 @@ func TestToken(t *testing.T) {
 				"groups": "team1",
 				"exp": %d
 			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name:   "jane",
+				Groups: []string{"team1"},
+			},
+		},
+		{
+			// Groups should be able to be a single string, not just a slice.
+			name: "group-string-claim-distributed",
+			options: Options{
+				IssuerURL:     "{{.URL}}",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+				IssuersPerClaim: map[string][]string{
+					"groups": []string{"{{.URL}}"},
+				},
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"username": "jane",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": "team1",
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
+			want: &user.DefaultInfo{
+				Name:   "jane",
+				Groups: []string{"team1"},
+			},
+		},
+		{
+			name: "group-string-claim-aggregated-not-supported",
+			options: Options{
+				IssuerURL:     "https://auth.example.com",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": "my-client",
+				"username": "jane",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"JWT": "some.jwt.token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name: "jane",
+			},
+		},
+		{
+			name: "various-claims-distributed",
+			options: Options{
+				IssuerURL:     "{{.URL}}",
+				ClientID:      "my-client",
+				UsernameClaim: "username",
+				GroupsClaim:   "groups",
+				now:           func() time.Time { return now },
+				IssuersPerClaim: map[string][]string{
+					"groups":   []string{"{{.URL}}"},
+					"username": []string{"{{.URL}}"},
+				},
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"_claim_names": {
+						"username": "src1",
+						"groups": "src2"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/username",
+								"access_token": "username_token"
+						},
+						"src2": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"username": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"username": "jane",
+					"exp": %d
+			     }`, valid.Unix()),
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": "team1",
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
 			want: &user.DefaultInfo{
 				Name:   "jane",
 				Groups: []string{"team1"},
@@ -656,6 +1071,56 @@ func TestToken(t *testing.T) {
 				"groups": ["team1", "team2"],
 				"exp": %d
 			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name:   "oidc:jane",
+				Groups: []string{"groups:team1", "groups:team2"},
+			},
+		},
+		{
+			name: "groups-prefix-distributed",
+			options: Options{
+				IssuerURL:      "{{.URL}}",
+				ClientID:       "my-client",
+				UsernameClaim:  "username",
+				UsernamePrefix: "oidc:",
+				GroupsClaim:    "groups",
+				GroupsPrefix:   "groups:",
+				now:            func() time.Time { return now },
+				IssuersPerClaim: map[string][]string{
+					"groups": []string{"{{.URL}}"},
+				},
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "{{.URL}}",
+				"aud": "my-client",
+				"username": "jane",
+				"_claim_names": {
+						"groups": "src1"
+				},
+				"_claim_sources": {
+						"src1": {
+								"endpoint": "{{.URL}}/groups",
+								"access_token": "groups_token"
+						}
+				},
+				"exp": %d
+			}`, valid.Unix()),
+			claimToResponseMap: map[string]string{
+				"groups": fmt.Sprintf(`{
+					"iss": "{{.URL}}",
+				    "aud": "my-client",
+					"groups": ["team1", "team2"],
+					"exp": %d
+			     }`, valid.Unix()),
+			},
+			openIDConfig: `{
+					"issuer": "{{.URL}}",
+					"jwks_uri": "{{.URL}}/.testing/keys"
+			}`,
 			want: &user.DefaultInfo{
 				Name:   "oidc:jane",
 				Groups: []string{"groups:team1", "groups:team2"},


### PR DESCRIPTION
A distributed claim allows the OIDC provider to delegate a claim to a
separate URL.  Distributed claims are of the form as seen below, and are
defined in the OIDC Connect Core 1.0, section 5.6.2.

See: https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims

Example claim:

```
{
  ... (other normal claims)...
  "_claim_names": {
    "groups": "src1"
  },
  "_claim_sources": {
    "src1": {
      "endpoint": "https://www.example.com",
      "access_token": "f005ba11"
    },
  },
}
```

Example response to a followup request to https://www.example.com is a
JWT-encoded claim token:

```
{
  "iss": "https://www.example.com",
  "aud": "my-client",
  "groups": ["team1", "team2"],
  "exp": 9876543210
}
```

Apart from the indirection, the distributed claim behaves exactly
the same as a standard claim.  For Kubernetes, this means that the
token must be verified using the same approach as for the original OIDC
token.  This requires the presence of "iss", "aud" and "exp" claims in
addition to "groups".

All existing OIDC options (e.g. groups prefix) apply.

Any claim can be made distributed, even though the "groups" claim is
the primary use case.

Allows groups to be a single string due to
https://github.com/kubernetes/kubernetes/issues/33290, even though
OIDC defines "groups" claim to be an array of strings. So, this will
be parsed correctly:

```
{
  "iss": "https://www.example.com",
  "aud": "my-client",
  "groups": "team1",
  "exp": 9876543210
}
```

Expects that distributed claims endpoints return JWT, per OIDC specs.

In case both a standard and a distributed claim with the same name
exist, standard claim wins.  The specs seem undecided about the correct
approach here.

Distributed claims are resolved serially.  This could be parallelized
for performance if needed.

Aggregated claims are silently skipped.  Support could be added if
needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
