### PR TITLE
stop anonymously including types in resource struct so we can track usage

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -610,13 +610,13 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(resourceOrKindArg)
 	gvk := schema.GroupVersionKind{}
 	if fullySpecifiedGVR != nil {
-		gvk, _ = b.mapper.KindFor(*fullySpecifiedGVR)
+		gvk, _ = b.mapper.RESTMapper.KindFor(*fullySpecifiedGVR)
 	}
 	if gvk.Empty() {
-		gvk, _ = b.mapper.KindFor(groupResource.WithVersion(""))
+		gvk, _ = b.mapper.RESTMapper.KindFor(groupResource.WithVersion(""))
 	}
 	if !gvk.Empty() {
-		return b.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		return b.mapper.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	}
 
 	fullySpecifiedGVK, groupKind := schema.ParseKindArg(resourceOrKindArg)
@@ -626,12 +626,12 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 	}
 
 	if !fullySpecifiedGVK.Empty() {
-		if mapping, err := b.mapper.RESTMapping(fullySpecifiedGVK.GroupKind(), fullySpecifiedGVK.Version); err == nil {
+		if mapping, err := b.mapper.RESTMapper.RESTMapping(fullySpecifiedGVK.GroupKind(), fullySpecifiedGVK.Version); err == nil {
 			return mapping, nil
 		}
 	}
 
-	mapping, err := b.mapper.RESTMapping(groupKind, gvk.Version)
+	mapping, err := b.mapper.RESTMapper.RESTMapping(groupKind, gvk.Version)
 	if err != nil {
 		// if we error out here, it is because we could not match a resource or a kind
 		// for the given argument. To maintain consistency with previous behavior,
@@ -752,7 +752,7 @@ func (b *Builder) visitBySelector() *Result {
 
 	visitors := []Visitor{}
 	for _, mapping := range mappings {
-		client, err := b.mapper.ClientForMapping(mapping)
+		client, err := b.mapper.ClientMapper.ClientForMapping(mapping)
 		if err != nil {
 			result.err = err
 			return result
@@ -802,7 +802,7 @@ func (b *Builder) visitByResource() *Result {
 		if _, ok := clients[s]; ok {
 			continue
 		}
-		client, err := b.mapper.ClientForMapping(mapping)
+		client, err := b.mapper.ClientMapper.ClientForMapping(mapping)
 		if err != nil {
 			result.err = err
 			return result
@@ -881,7 +881,7 @@ func (b *Builder) visitByName() *Result {
 	}
 	mapping := mappings[0]
 
-	client, err := b.mapper.ClientForMapping(mapping)
+	client, err := b.mapper.ClientMapper.ClientForMapping(mapping)
 	if err != nil {
 		result.err = err
 		return result

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -28,41 +28,29 @@ import (
 // Mapper is a convenience struct for holding references to the interfaces
 // needed to create Info for arbitrary objects.
 type Mapper struct {
-	runtime.ObjectTyper
+	ObjectTyper     runtime.ObjectTyper
 	ObjectConverter runtime.ObjectConvertor
 
-	meta.RESTMapper
-	ClientMapper
-	runtime.Decoder
-}
-
-// AcceptUnrecognizedObjects will return a mapper that will tolerate objects
-// that are not recognized by the RESTMapper, returning mappings that can
-// perform minimal transformation. Allows working in disconnected mode, or with
-// objects that the server does not recognize. Returned resource.Info objects
-// may have empty resource fields and nil clients.
-func (m *Mapper) AcceptUnrecognizedObjects() *Mapper {
-	copied := *m
-	copied.RESTMapper = NewRelaxedRESTMapper(m.RESTMapper)
-	copied.ClientMapper = NewRelaxedClientMapper(m.ClientMapper)
-	return &copied
+	RESTMapper   meta.RESTMapper
+	ClientMapper ClientMapper
+	Decoder      runtime.Decoder
 }
 
 // InfoForData creates an Info object for the given data. An error is returned
 // if any of the decoding or client lookup steps fail. Name and namespace will be
 // set into Info if the mapping's MetadataAccessor can retrieve them.
 func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
-	obj, gvk, err := m.Decode(data, nil, nil)
+	obj, gvk, err := m.Decoder.Decode(data, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode %q: %v", source, err)
 	}
 
-	mapping, err := m.RESTMapping(gvk.GroupKind(), gvk.Version)
+	mapping, err := m.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %q: %v", source, err)
 	}
 
-	client, err := m.ClientForMapping(mapping)
+	client, err := m.ClientMapper.ClientForMapping(mapping)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 	}
@@ -89,7 +77,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 // if the object cannot be introspected. Name and namespace will be set into Info
 // if the mapping's MetadataAccessor can retrieve them.
 func (m *Mapper) InfoForObject(obj runtime.Object, preferredGVKs []schema.GroupVersionKind) (*Info, error) {
-	groupVersionKinds, _, err := m.ObjectKinds(obj)
+	groupVersionKinds, _, err := m.ObjectTyper.ObjectKinds(obj)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get type info from the object %q: %v", reflect.TypeOf(obj), err)
 	}
@@ -99,12 +87,12 @@ func (m *Mapper) InfoForObject(obj runtime.Object, preferredGVKs []schema.GroupV
 		groupVersionKind = preferredObjectKind(groupVersionKinds, preferredGVKs)
 	}
 
-	mapping, err := m.RESTMapping(groupVersionKind.GroupKind(), groupVersionKind.Version)
+	mapping, err := m.RESTMapper.RESTMapping(groupVersionKind.GroupKind(), groupVersionKind.Version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %v: %v", groupVersionKind, err)
 	}
 
-	client, err := m.ClientForMapping(mapping)
+	client, err := m.ClientMapper.ClientForMapping(mapping)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
 	}
@@ -168,70 +156,4 @@ type DisabledClientForMapping struct {
 
 func (f DisabledClientForMapping) ClientForMapping(mapping *meta.RESTMapping) (RESTClient, error) {
 	return nil, nil
-}
-
-// NewRelaxedClientMapper will return a nil mapping if the object is not a recognized resource.
-func NewRelaxedClientMapper(mapper ClientMapper) ClientMapper {
-	return relaxedClientMapper{mapper}
-}
-
-type relaxedClientMapper struct {
-	ClientMapper
-}
-
-func (f relaxedClientMapper) ClientForMapping(mapping *meta.RESTMapping) (RESTClient, error) {
-	if len(mapping.Resource) == 0 {
-		return nil, nil
-	}
-	return f.ClientMapper.ClientForMapping(mapping)
-}
-
-// NewRelaxedRESTMapper returns a RESTMapper that will tolerate mappings that don't exist in provided
-// RESTMapper, returning a mapping that is a best effort against the current server. This allows objects
-// that the server does not recognize to still be loaded.
-func NewRelaxedRESTMapper(mapper meta.RESTMapper) meta.RESTMapper {
-	return relaxedMapper{mapper}
-}
-
-type relaxedMapper struct {
-	meta.RESTMapper
-}
-
-func (m relaxedMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	mapping, err := m.RESTMapper.RESTMapping(gk, versions...)
-	if err != nil && meta.IsNoMatchError(err) && len(versions) > 0 {
-		return &meta.RESTMapping{
-			GroupVersionKind: gk.WithVersion(versions[0]),
-			Scope:            meta.RESTScopeRoot,
-		}, nil
-	}
-	return mapping, err
-}
-func (m relaxedMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
-	mappings, err := m.RESTMapper.RESTMappings(gk, versions...)
-	if err != nil && meta.IsNoMatchError(err) && len(versions) > 0 {
-		return []*meta.RESTMapping{
-			{
-				GroupVersionKind: gk.WithVersion(versions[0]),
-				Scope:            meta.RESTScopeRoot,
-			},
-		}, nil
-	}
-	return mappings, err
-}
-
-type identityConvertor struct{}
-
-var _ runtime.ObjectConvertor = identityConvertor{}
-
-func (c identityConvertor) Convert(in interface{}, out interface{}, context interface{}) error {
-	return fmt.Errorf("unable to convert objects across pointers")
-}
-
-func (c identityConvertor) ConvertToVersion(in runtime.Object, gv runtime.GroupVersioner) (out runtime.Object, err error) {
-	return in, nil
-}
-
-func (c identityConvertor) ConvertFieldLabel(version string, kind string, label string, value string) (string, string, error) {
-	return "", "", fmt.Errorf("unable to convert field labels")
 }


### PR DESCRIPTION
Just stops anonymous inclusion in a struct so we can track down who uses what and why.

/assign @soltysh 

```release-note
NONE
```