### PR TITLE
clean duplicate test function

### DIFF
--- a/pkg/serviceaccount/BUILD
+++ b/pkg/serviceaccount/BUILD
@@ -36,7 +36,6 @@ go_test(
         "//pkg/controller/serviceaccount:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	certutil "k8s.io/client-go/util/cert"
@@ -301,25 +300,6 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 		if !reflect.DeepEqual(user.GetGroups(), tc.ExpectedGroups) {
 			t.Errorf("%s: Expected groups=%v, got %v", k, tc.ExpectedGroups, user.GetGroups())
 			continue
-		}
-	}
-}
-
-func TestMakeSplitUsername(t *testing.T) {
-	username := apiserverserviceaccount.MakeUsername("ns", "name")
-	ns, name, err := apiserverserviceaccount.SplitUsername(username)
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-	if ns != "ns" || name != "name" {
-		t.Errorf("Expected ns/name, got %s/%s", ns, name)
-	}
-
-	invalid := []string{"test", "system:serviceaccount", "system:serviceaccount:", "system:serviceaccount:ns", "system:serviceaccount:ns:name:extra"}
-	for _, n := range invalid {
-		_, _, err := apiserverserviceaccount.SplitUsername("test")
-		if err == nil {
-			t.Errorf("Expected error for %s", n)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
As the patch shows, the function it tests has been moved to 
https://github.com/kubernetes/kubernetes/blob/b87a392b1a7ece8335ad3ade410e5070e29f216e/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util.go#L43
 The make/split function has been tested on file https://github.com/kubernetes/kubernetes/blob/b87a392b1a7ece8335ad3ade410e5070e29f216e/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount/util_test.go#L21

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
