### PR TITLE
fix curl header

### DIFF
--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -331,7 +331,7 @@ func (r *requestInfo) toCurl() string {
 	headers := ""
 	for key, values := range r.RequestHeaders {
 		for _, value := range values {
-			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: '%s'", key, value))
+			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: %s", key, value))
 		}
 	}
 


### PR DESCRIPTION
partially reverts kubernetes/kubernetes#60925

such command cause a 406 status code from api-server
```
curl   -H "Accept: 'application/json;as=Table;v=v1beta1;g=meta.k8s.io, application/json'"
```

this works fine:
```
curl  -H "Accept: application/json;as=Table;v=v1beta1;g=meta.k8s.io, application/json"
```


**Release note**:
```
NONE
```