### PR TITLE
Bump QPS on namespace controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -297,8 +297,8 @@ func startNamespaceController(ctx ControllerContext) (bool, error) {
 	// the ratelimiter negatively affects its speed.  Deleting 100 total items in a namespace (that's only a few of each resource
 	// including events), takes ~10 seconds by default.
 	nsKubeconfig := ctx.ClientBuilder.ConfigOrDie("namespace-controller")
-	nsKubeconfig.QPS *= 10
-	nsKubeconfig.Burst *= 10
+	nsKubeconfig.QPS *= 20
+	nsKubeconfig.Burst *= 100
 	namespaceKubeClient := clientset.NewForConfigOrDie(nsKubeconfig)
 
 	discoverResourcesFn := namespaceKubeClient.Discovery().ServerPreferredNamespacedResources

--- a/test/e2e_node/services/namespace_controller.go
+++ b/test/e2e_node/services/namespace_controller.go
@@ -49,8 +49,12 @@ func NewNamespaceController(host string) *NamespaceController {
 
 // Start starts the namespace controller.
 func (n *NamespaceController) Start() error {
-	// Use the default QPS
 	config := restclient.AddUserAgent(&restclient.Config{Host: n.host}, ncName)
+
+	// the namespace cleanup controller is very chatty.  It makes lots of discovery calls and then it makes lots of delete calls.
+	config.QPS = 50
+	config.Burst = 200
+
 	client, err := clientset.NewForConfig(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/62913 switched from using a client pool, where each groupVersionResource got its own rest client, to a single client.

This increases the QPS to account for increased requests using a single rest client rate limiter.

Fixes #63240

```release-note
NONE
```