### PR TITLE
E2e path utils

### DIFF
--- a/test/e2e_node/builder/BUILD
+++ b/test/e2e_node/builder/BUILD
@@ -9,7 +9,10 @@ go_library(
     name = "go_default_library",
     srcs = ["build.go"],
     importpath = "k8s.io/kubernetes/test/e2e_node/builder",
-    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+    deps = [
+        "//test/utils:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
 )
 
 filegroup(

--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -22,10 +22,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/test/utils"
 )
 
 var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet binaries.")
@@ -39,7 +39,7 @@ var buildTargets = []string{
 
 func BuildGo() error {
 	glog.Infof("Building k8s binaries...")
-	k8sRoot, err := GetK8sRootDir()
+	k8sRoot, err := utils.GetK8sRootDir()
 	if err != nil {
 		return fmt.Errorf("failed to locate kubernetes root directory %v.", err)
 	}
@@ -75,7 +75,7 @@ func getK8sBin(bin string) (string, error) {
 		return filepath.Join(path, bin), nil
 	}
 
-	buildOutputDir, err := GetK8sBuildOutputDir()
+	buildOutputDir, err := utils.GetK8sBuildOutputDir()
 	if err != nil {
 		return "", err
 	}
@@ -84,53 +84,7 @@ func getK8sBin(bin string) (string, error) {
 	}
 
 	// Give up with error
-	return "", fmt.Errorf("Unable to locate %s.  Can be defined using --k8s-path.", bin)
-}
-
-// GetK8sRootDir returns the root directory for kubernetes, if present in the gopath.
-func GetK8sRootDir() (string, error) {
-	dir, err := RootDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("%s/", "k8s.io/kubernetes")), nil
-}
-
-// GetCAdvisorRootDir returns the root directory for cAdvisor, if present in the gopath.
-func GetCAdvisorRootDir() (string, error) {
-	dir, err := RootDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("%s/", "github.com/google/cadvisor")), nil
-}
-
-// TODO: Dedup / merge this with comparable utilities in e2e/util.go
-// RootDir returns the path to the directory containing the k8s.io directory
-func RootDir() (string, error) {
-	// Get the directory of the current executable
-	_, testExec, _, _ := runtime.Caller(0)
-	path := filepath.Dir(testExec)
-
-	// Look for the kubernetes source root directory
-	if strings.Contains(path, "k8s.io/kubernetes") {
-		splitPath := strings.Split(path, "k8s.io/kubernetes")
-		return splitPath[0], nil
-	}
-
-	return "", fmt.Errorf("Could not find kubernetes source root directory.")
-}
-
-func GetK8sBuildOutputDir() (string, error) {
-	k8sRoot, err := GetK8sRootDir()
-	if err != nil {
-		return "", err
-	}
-	buildOutputDir := filepath.Join(k8sRoot, "_output/local/go/bin")
-	if _, err := os.Stat(buildOutputDir); err != nil {
-		return "", err
-	}
-	return buildOutputDir, nil
+	return "", fmt.Errorf("unable to locate %s, Can be defined using --k8s-path", bin)
 }
 
 func GetKubeletServerBin() string {

--- a/test/e2e_node/remote/BUILD
+++ b/test/e2e_node/remote/BUILD
@@ -19,6 +19,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e_node/remote",
     deps = [
         "//test/e2e_node/builder:go_default_library",
+        "//test/utils:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
     ],

--- a/test/e2e_node/remote/cadvisor_e2e.go
+++ b/test/e2e_node/remote/cadvisor_e2e.go
@@ -23,8 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
-	"k8s.io/kubernetes/test/e2e_node/builder"
+	"k8s.io/kubernetes/test/utils"
 )
 
 // CAdvisorE2ERemote contains the specific functions in the cadvisor e2e test suite.
@@ -37,7 +36,7 @@ func InitCAdvisorE2ERemote() TestSuite {
 
 // SetupTestPackage implements TestSuite.SetupTestPackage
 func (n *CAdvisorE2ERemote) SetupTestPackage(tardir, systemSpecName string) error {
-	cadvisorRootDir, err := builder.GetCAdvisorRootDir()
+	cadvisorRootDir, err := utils.GetCAdvisorRootDir()
 	if err != nil {
 		return err
 	}

--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/test/e2e_node/builder"
+	"k8s.io/kubernetes/test/utils"
 )
 
 // ConformanceRemote contains the specific functions in the node conformance test suite.
@@ -39,7 +40,7 @@ func InitConformanceRemote() TestSuite {
 
 // getConformanceDirectory gets node conformance test build directory.
 func getConformanceDirectory() (string, error) {
-	k8sRoot, err := builder.GetK8sRootDir()
+	k8sRoot, err := utils.GetK8sRootDir()
 	if err != nil {
 		return "", err
 	}
@@ -106,7 +107,7 @@ func (c *ConformanceRemote) SetupTestPackage(tardir, systemSpecName string) erro
 	}
 
 	// Make sure we can find the newly built binaries
-	buildOutputDir, err := builder.GetK8sBuildOutputDir()
+	buildOutputDir, err := utils.GetK8sBuildOutputDir()
 	if err != nil {
 		return fmt.Errorf("failed to locate kubernetes build output directory %v", err)
 	}

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/test/e2e_node/builder"
+	"k8s.io/kubernetes/test/utils"
 )
 
 const (
@@ -49,12 +50,12 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir, systemSpecName string) error {
 	}
 
 	// Make sure we can find the newly built binaries
-	buildOutputDir, err := builder.GetK8sBuildOutputDir()
+	buildOutputDir, err := utils.GetK8sBuildOutputDir()
 	if err != nil {
 		return fmt.Errorf("failed to locate kubernetes build output directory: %v", err)
 	}
 
-	rootDir, err := builder.GetK8sRootDir()
+	rootDir, err := utils.GetK8sRootDir()
 	if err != nil {
 		return fmt.Errorf("failed to locate kubernetes root directory: %v", err)
 	}

--- a/test/e2e_node/runner/local/BUILD
+++ b/test/e2e_node/runner/local/BUILD
@@ -17,6 +17,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e_node/runner/local",
     deps = [
         "//test/e2e_node/builder:go_default_library",
+        "//test/utils:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )

--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/test/e2e_node/builder"
+	"k8s.io/kubernetes/test/utils"
 
 	"github.com/golang/glog"
 )
@@ -49,7 +50,7 @@ func main() {
 	}
 
 	// Run node e2e test
-	outputDir, err := builder.GetK8sBuildOutputDir()
+	outputDir, err := utils.GetK8sBuildOutputDir()
 	if err != nil {
 		glog.Fatalf("Failed to get build output directory: %v", err)
 	}
@@ -59,7 +60,7 @@ func main() {
 
 	args := []string{*ginkgoFlags, test, "--", *testFlags}
 	if *systemSpecName != "" {
-		rootDir, err := builder.GetK8sRootDir()
+		rootDir, err := utils.GetK8sRootDir()
 		if err != nil {
 			glog.Fatalf("Failed to get k8s root directory: %v", err)
 		}

--- a/test/utils/BUILD
+++ b/test/utils/BUILD
@@ -13,6 +13,7 @@ go_library(
         "delete_resources.go",
         "density_utils.go",
         "deployment.go",
+        "paths.go",
         "pod_store.go",
         "replicaset.go",
         "runners.go",

--- a/test/utils/paths.go
+++ b/test/utils/paths.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// GetK8sRootDir returns the root directory for kubernetes, if present in the gopath.
+func GetK8sRootDir() (string, error) {
+	dir, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s/", "k8s.io/kubernetes")), nil
+}
+
+// GetCAdvisorRootDir returns the root directory for cAdvisor, if present in the gopath.
+func GetCAdvisorRootDir() (string, error) {
+	dir, err := RootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s/", "github.com/google/cadvisor")), nil
+}
+
+// RootDir gets the on-disk kubernetes source directory, returning an error is none is found
+func RootDir() (string, error) {
+	// Get the directory of the current executable
+	_, testExec, _, _ := runtime.Caller(0)
+	path := filepath.Dir(testExec)
+
+	// Look for the kubernetes source root directory
+	if strings.Contains(path, "k8s.io/kubernetes") {
+		splitPath := strings.Split(path, "k8s.io/kubernetes")
+		return splitPath[0], nil
+	}
+
+	return "", errors.New("could not find kubernetes source root directory")
+}
+
+// GetK8sBuildOutputDir returns the build output directory for k8s
+func GetK8sBuildOutputDir() (string, error) {
+	k8sRoot, err := GetK8sRootDir()
+	if err != nil {
+		return "", err
+	}
+	buildOutputDir := filepath.Join(k8sRoot, "_output/local/go/bin")
+	if _, err := os.Stat(buildOutputDir); err != nil {
+		return "", err
+	}
+	return buildOutputDir, nil
+}


### PR DESCRIPTION

**What this PR does / why we need it**:

A bunch of useful methods for getting k8s paths and stuff are secreted away in `e2e_node`. This PR pulls them out so they can be used in other E2E method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:



**Special notes for your reviewer**:
This is motivated by the upcoming kubeadm-specific E2E tests. Those tests will be added in a follow-up to this PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
