### PR TITLE
stop using Info.Mappings when they may not be present

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -108,6 +108,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/validation"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -319,7 +320,11 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 			indent := ""
 			if !one {
 				indent = " "
-				fmt.Fprintf(o.ErrOut, "Listing labels for %s.%s/%s:\n", info.Mapping.GroupVersionKind.Kind, info.Mapping.GroupVersionKind.Group, info.Name)
+				gvks, _, err := unstructuredscheme.NewUnstructuredObjectTyper().ObjectKinds(info.Object)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(o.ErrOut, "Listing labels for %s.%s/%s:\n", gvks[0].Kind, gvks[0].Group, info.Name)
 			}
 			for k, v := range accessor.GetLabels() {
 				fmt.Fprintf(o.Out, "%s%s=%s\n", indent, k, v)

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -234,9 +235,10 @@ func (o TaintOptions) RunTaint() error {
 			return err
 		}
 
-		obj, err := legacyscheme.Scheme.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion())
+		obj, err := legacyscheme.Scheme.ConvertToVersion(info.Object, v1.SchemeGroupVersion)
 		if err != nil {
-			return err
+			glog.V(1).Info(err)
+			return fmt.Errorf("object was not a node.v1.: %T", info.Object)
 		}
 		name, namespace := info.Name, info.Namespace
 		oldData, err := json.Marshal(obj)

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -73,9 +73,9 @@ type ResourceMapping interface {
 // Info contains temporary info to execute a REST call, or show the results
 // of an already completed REST call.
 type Info struct {
+	// Client will only be present if this builder was not local
 	Client RESTClient
-	// Mapping may be nil if the object has no available metadata, but is still parseable
-	// from disk.
+	// Mapping will only be present if this builder was not local
 	Mapping *meta.RESTMapping
 
 	// Namespace will be set if the object is namespaced and has a specified value.


### PR DESCRIPTION
On a resource builder, you cannot logically have a RESTMapping or a Client if you're running a local action.  Reliance on the `info.Client` and `info.Mapping` is a bug we need to fix.  This updates the docs and eliminates unnecessary reliance.  Other hits I found didn't have `--local` options, so we're safe or had them and and were already broken.  I think we'll be able to help them after making our creation flow obvious.

@kubernetes/sig-cli-maintainers 

```release-note
NONE
```