### PR TITLE
Increase scheduler cache generation number monotonically in order to avoid collision

### DIFF
--- a/pkg/scheduler/schedulercache/cache_test.go
+++ b/pkg/scheduler/schedulercache/cache_test.go
@@ -992,6 +992,7 @@ func TestNodeOperators(t *testing.T) {
 			t.Errorf("Failed to find node %v in schedulercache.", node.Name)
 		}
 
+		// Generations are globally unique. We check in our unit tests that they are incremented correctly.
 		expected.generation = got.generation
 		if !reflect.DeepEqual(got, expected) {
 			t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)

--- a/pkg/scheduler/schedulercache/cache_test.go
+++ b/pkg/scheduler/schedulercache/cache_test.go
@@ -992,6 +992,7 @@ func TestNodeOperators(t *testing.T) {
 			t.Errorf("Failed to find node %v in schedulercache.", node.Name)
 		}
 
+		expected.generation = got.generation
 		if !reflect.DeepEqual(got, expected) {
 			t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)
 		}
@@ -1003,6 +1004,7 @@ func TestNodeOperators(t *testing.T) {
 		if !found || len(cachedNodes) != 1 {
 			t.Errorf("failed to dump cached nodes:\n got: %v \nexpected: %v", cachedNodes, cache.nodes)
 		}
+		expected.generation = newNode.generation
 		if !reflect.DeepEqual(newNode, expected) {
 			t.Errorf("Failed to clone node:\n got: %+v, \n expected: %+v", newNode, expected)
 		}
@@ -1010,12 +1012,15 @@ func TestNodeOperators(t *testing.T) {
 		// Case 3: update node attribute successfully.
 		node.Status.Allocatable[v1.ResourceMemory] = mem50m
 		expected.allocatableResource.Memory = mem50m.Value()
-		expected.generation++
 		cache.UpdateNode(nil, node)
 		got, found = cache.nodes[node.Name]
 		if !found {
 			t.Errorf("Failed to find node %v in schedulercache after UpdateNode.", node.Name)
 		}
+		if got.generation <= expected.generation {
+			t.Errorf("generation is not incremented. got: %v, expected: %v", got.generation, expected.generation)
+		}
+		expected.generation = got.generation
 
 		if !reflect.DeepEqual(got, expected) {
 			t.Errorf("Failed to update node in schedulercache:\n got: %+v \nexpected: %+v", got, expected)

--- a/pkg/scheduler/schedulercache/node_info.go
+++ b/pkg/scheduler/schedulercache/node_info.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	emptyResource       = Resource{}
-	generation    int64 = 0
+	emptyResource = Resource{}
+	generation    int64
 )
 
 // NodeInfo is node level aggregated information.
@@ -78,9 +78,12 @@ func initializeNodeTransientInfo() nodeTransientInfo {
 	return nodeTransientInfo{AllocatableVolumesCount: 0, RequestedVolumes: 0}
 }
 
-func incrementGeneration() int64 {
-	atomic.AddInt64(&generation, 1)
-	return generation
+// nextGeneration: Let's make sure history never forgets the name...
+// Increments the generation number monotonically ensuring that generation numbers never collide.
+// Collision of the generation numbers would be particularly problematic if a node was deleted and
+// added back with the same name. See issue#63262.
+func nextGeneration() int64 {
+	return atomic.AddInt64(&generation, 1)
 }
 
 // nodeTransientInfo contains transient node information while scheduling.
@@ -221,7 +224,7 @@ func NewNodeInfo(pods ...*v1.Pod) *NodeInfo {
 		nonzeroRequest:      &Resource{},
 		allocatableResource: &Resource{},
 		TransientInfo:       newTransientSchedulerInfo(),
-		generation:          incrementGeneration(),
+		generation:          nextGeneration(),
 		usedPorts:           make(util.HostPortInfo),
 	}
 	for _, pod := range pods {
@@ -329,7 +332,7 @@ func (n *NodeInfo) AllocatableResource() Resource {
 // SetAllocatableResource sets the allocatableResource information of given node.
 func (n *NodeInfo) SetAllocatableResource(allocatableResource *Resource) {
 	n.allocatableResource = allocatableResource
-	n.generation = incrementGeneration()
+	n.generation = nextGeneration()
 }
 
 // Clone returns a copy of this node.
@@ -401,7 +404,7 @@ func (n *NodeInfo) AddPod(pod *v1.Pod) {
 	// Consume ports when pods added.
 	n.updateUsedPorts(pod, true)
 
-	n.generation = incrementGeneration()
+	n.generation = nextGeneration()
 }
 
 // RemovePod subtracts pod information from this NodeInfo.
@@ -452,7 +455,7 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 			// Release ports when remove Pods.
 			n.updateUsedPorts(pod, false)
 
-			n.generation = incrementGeneration()
+			n.generation = nextGeneration()
 
 			return nil
 		}
@@ -509,7 +512,7 @@ func (n *NodeInfo) SetNode(node *v1.Node) error {
 		}
 	}
 	n.TransientInfo = newTransientSchedulerInfo()
-	n.generation = incrementGeneration()
+	n.generation = nextGeneration()
 	return nil
 }
 
@@ -525,7 +528,7 @@ func (n *NodeInfo) RemoveNode(node *v1.Node) error {
 	n.memoryPressureCondition = v1.ConditionUnknown
 	n.diskPressureCondition = v1.ConditionUnknown
 	n.pidPressureCondition = v1.ConditionUnknown
-	n.generation = incrementGeneration()
+	n.generation = nextGeneration()
 	return nil
 }
 

--- a/pkg/scheduler/schedulercache/node_info_test.go
+++ b/pkg/scheduler/schedulercache/node_info_test.go
@@ -274,7 +274,12 @@ func TestNewNodeInfo(t *testing.T) {
 		},
 	}
 
+	gen := generation
 	ni := NewNodeInfo(pods...)
+	if ni.generation <= gen {
+		t.Errorf("generation is not incremented. previous: %v, current: %v", gen, ni.generation)
+	}
+	expected.generation = ni.generation
 	if !reflect.DeepEqual(expected, ni) {
 		t.Errorf("expected: %#v, got: %#v", expected, ni)
 	}
@@ -584,10 +589,16 @@ func TestNodeInfoAddPod(t *testing.T) {
 	}
 
 	ni := fakeNodeInfo()
+	gen := ni.generation
 	for _, pod := range pods {
 		ni.AddPod(pod)
+		if ni.generation <= gen {
+			t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+		}
+		gen = ni.generation
 	}
 
+	expected.generation = ni.generation
 	if !reflect.DeepEqual(expected, ni) {
 		t.Errorf("expected: %#v, got: %#v", expected, ni)
 	}
@@ -788,6 +799,7 @@ func TestNodeInfoRemovePod(t *testing.T) {
 	for _, test := range tests {
 		ni := fakeNodeInfo(pods...)
 
+		gen := ni.generation
 		err := ni.RemovePod(test.pod)
 		if err != nil {
 			if test.errExpected {
@@ -798,8 +810,13 @@ func TestNodeInfoRemovePod(t *testing.T) {
 			} else {
 				t.Errorf("expected no error, got: %v", err)
 			}
+		} else {
+			if ni.generation <= gen {
+				t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+			}
 		}
 
+		test.expectedNodeInfo.generation = ni.generation
 		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Increments the scheduler cache generation number monotonically to avoid collision of the generation numbers. More context in #63262.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63262.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase scheduler cache generation number monotonically in order to avoid collision and use of stale information in scheduler.
```
