### PR TITLE
Extend dns configmap tests to include CoreDNS

### DIFF
--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -56,9 +56,8 @@ type dnsTestCommon struct {
 
 func newDnsTestCommon() dnsTestCommon {
 	return dnsTestCommon{
-		f:    framework.NewDefaultFramework("dns-config-map"),
-		ns:   "kube-system",
-		name: "kube-dns",
+		f:  framework.NewDefaultFramework("dns-config-map"),
+		ns: "kube-system",
 	}
 }
 
@@ -73,6 +72,12 @@ func (t *dnsTestCommon) init() {
 
 	t.dnsPod = &pods.Items[0]
 	framework.Logf("Using DNS pod: %v", t.dnsPod.Name)
+
+	if strings.Contains(t.dnsPod.Name, "coredns") {
+		t.name = "coredns"
+	} else {
+		t.name = "kube-dns"
+	}
 }
 
 func (t *dnsTestCommon) checkDNSRecord(name string, predicate func([]string) bool, timeout time.Duration) {
@@ -103,6 +108,8 @@ func (t *dnsTestCommon) checkDNSRecordFrom(name string, predicate func([]string)
 func (t *dnsTestCommon) runDig(dnsName, target string) []string {
 	cmd := []string{"/usr/bin/dig", "+short"}
 	switch target {
+	case "coredns":
+		cmd = append(cmd, "@"+t.dnsPod.Status.PodIP)
 	case "kube-dns":
 		cmd = append(cmd, "@"+t.dnsPod.Status.PodIP, "-p", "10053")
 	case "dnsmasq":
@@ -159,6 +166,24 @@ func (t *dnsTestCommon) setConfigMap(cm *v1.ConfigMap) {
 		By(fmt.Sprintf("Updating the ConfigMap (%s:%s) to %+v", t.ns, t.name, *cm))
 		_, err := t.c.CoreV1().ConfigMaps(t.ns).Update(cm)
 		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func (t *dnsTestCommon) fetchDNSConfigMapData() map[string]string {
+	if t.name == "coredns" {
+		pcm, err := t.c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(t.name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		return pcm.Data
+	}
+	return nil
+}
+
+func (t *dnsTestCommon) restoreDNSConfigMap(configMapData map[string]string) {
+	if t.name == "coredns" {
+		t.setConfigMap(&v1.ConfigMap{Data: configMapData})
+		t.deleteCoreDNSPods()
+	} else {
+		t.c.CoreV1().ConfigMaps(t.ns).Delete(t.name, nil)
 	}
 }
 
@@ -232,6 +257,21 @@ func (t *dnsTestCommon) deleteUtilPod() {
 	if err := podClient.Delete(t.utilPod.Name, metav1.NewDeleteOptions(0)); err != nil {
 		framework.Logf("Delete of pod %v:%v failed: %v",
 			t.utilPod.Namespace, t.utilPod.Name, err)
+	}
+}
+
+// deleteCoreDNSPods manually deletes the CoreDNS pods to apply the changes to the ConfigMap.
+func (t *dnsTestCommon) deleteCoreDNSPods() {
+
+	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
+	options := metav1.ListOptions{LabelSelector: label.String()}
+
+	pods, err := t.f.ClientSet.CoreV1().Pods("kube-system").List(options)
+	podClient := t.c.CoreV1().Pods(metav1.NamespaceSystem)
+
+	for _, pod := range pods.Items {
+		err = podClient.Delete(pod.Name, metav1.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR extends the DNS configmap e2e tests to include testing the CoreDNS ConfigMap.
The tests now test the equivalent `stubdomain`, `federation` and `upstreamnameserver` configuration of kube-dns for CoreDNS, when CoreDNS is the installed DNS server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #62865

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
