### PR TITLE
gcp: allow non-bootstrap kubeconfig

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -914,6 +914,9 @@ contexts:
   name: service-account-context
 current-context: service-account-context
 EOF
+  elif [[ "${FETCH_BOOTSTRAP_KUBECONFIG:-false}" == "true" ]]; then
+    echo "Fetching kubelet bootstrap-kubeconfig file from metadata"
+    get-metadata-value "instance/attributes/bootstrap-kubeconfig" >/var/lib/kubelet/bootstrap-kubeconfig
   else
     echo "Fetching kubelet kubeconfig file from metadata"
     get-metadata-value "instance/attributes/kubeconfig" >/var/lib/kubelet/kubeconfig

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -892,8 +892,9 @@ function create-kubelet-kubeconfig() {
     echo "Must provide API server address to create Kubelet kubeconfig file!"
     exit 1
   fi
-  echo "Creating kubelet kubeconfig file"
-  cat <<EOF >/var/lib/kubelet/bootstrap-kubeconfig
+  if [[ "${CREATE_BOOTSTRAP_KUBECONFIG:-true}" == "true" ]]; then
+    echo "Creating kubelet bootstrap-kubeconfig file"
+    cat <<EOF >/var/lib/kubelet/bootstrap-kubeconfig
 apiVersion: v1
 kind: Config
 users:
@@ -913,6 +914,10 @@ contexts:
   name: service-account-context
 current-context: service-account-context
 EOF
+  else
+    echo "Fetching kubelet kubeconfig file from metadata"
+    get-metadata-value "instance/attributes/kubeconfig" >/var/lib/kubelet/kubeconfig
+  fi
 }
 
 # Uses KUBELET_CA_CERT (falling back to CA_CERT), KUBELET_CERT, and KUBELET_KEY
@@ -1611,7 +1616,7 @@ function start-kube-apiserver {
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
   if [[ -n "${PROJECT_ID:-}" && -n "${TOKEN_URL:-}" && -n "${TOKEN_BODY:-}" && -n "${NODE_NETWORK:-}" ]]; then
-    local -r vm_external_ip=$(curl --retry 5 --retry-delay 3 ${CURL_RETRY_CONNREFUSED} --fail --silent -H 'Metadata-Flavor: Google' "http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip")
+    local -r vm_external_ip=$(get-metadata-value "instance/network-interfaces/0/access-configs/0/external-ip")
     if [[ -n "${PROXY_SSH_USER:-}" ]]; then
       params+=" --advertise-address=${vm_external_ip}"
       params+=" --ssh-user=${PROXY_SSH_USER}"
@@ -2002,6 +2007,20 @@ function download-extra-addons {
   curl_cmd+=("${EXTRA_ADDONS_URL}")
 
   "${curl_cmd[@]}"
+}
+
+# A function that fetches a GCE metadata value and echoes it out.
+#
+# $1: URL path after /computeMetadata/v1/ (without heading slash).
+function get-metadata-value {
+    curl \
+        --retry 5 \
+        --retry-delay 3 \
+        ${CURL_RETRY_CONNREFUSED} \
+        --fail \
+        --silent \
+        -H 'Metadata-Flavor: Google' \
+        "http://metadata/computeMetadata/v1/${1}"
 }
 
 # A helper function for copying manifests and setting dir/files


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed for https://github.com/kubernetes/community/pull/2022
This change lets us generate a non-bootstrap kubeconfig with exec plugin for authn.
The plugin does TLS bootstrapping internally.

**Special notes for your reviewer**:
Defaults when no new env vars are set will behave same as before this change.
`KUBELET_AUTH_TYPE` should never be `tls-auth` in practice, but leaving it there just in case.

**Release note**:
```release-note
NONE
```
