### PR TITLE
Make kubelet `ReadLogs` backward compatible.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -736,10 +736,7 @@ func (m *kubeGenericRuntimeManager) GetContainerLogs(pod *v1.Pod, containerID ku
 		glog.V(4).Infof("failed to get container status for %v: %v", containerID.String(), err)
 		return fmt.Errorf("Unable to retrieve container logs for %v", containerID.String())
 	}
-	labeledInfo := getContainerInfoFromLabels(status.Labels)
-	annotatedInfo := getContainerInfoFromAnnotations(status.Annotations)
-	path := buildFullContainerLogsPath(pod.UID, labeledInfo.ContainerName, annotatedInfo.RestartCount)
-	return m.ReadLogs(path, containerID.ID, logOptions, stdout, stderr)
+	return m.ReadLogs(status.GetLogPath(), containerID.ID, logOptions, stdout, stderr)
 }
 
 // GetExec gets the endpoint the runtime will serve the exec request from.


### PR DESCRIPTION
`containerLogPathLabelKey` label was added in dockershim since 1.5. https://github.com/kubernetes/kubernetes/commit/121a91eb12a186640c634266e5d190c3ecd7f527

ContainerStatus.LogPath was added since Kubernetes 1.7. https://github.com/kubernetes/kubernetes/commit/c3b52267ca615e1efca70e47f24a39bfcab321cc

I believe it is safe to reply on this field without backward compatibility issue. And `crictl` is using it as well https://github.com/kubernetes-incubator/cri-tools/blob/master/cmd/crictl/logs.go#L88.

With this change, in the future, kubelet `ReadLogs` will be backward compatible as long as the log format is backward compatible.

@feiskyer @yujuhong @kubernetes/sig-node-pr-reviews 

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make kubelet ReadLogs backward compatible.
```
