### PR TITLE
fix kubectl get can't print namespace correctly

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -325,8 +325,8 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 				group := metav1beta1.GroupName
 				version := metav1beta1.SchemeGroupVersion.Version
 
-				tableParam := fmt.Sprintf("application/json;as=Table;v=%s;g=%s, application/json", version, group)
-				req.SetHeader("Accept", tableParam)
+				tableParam := fmt.Sprintf("application/json;as=Table;v=%s;g=%s", version, group)
+				req.SetHeader("Accept", "application/json", tableParam)
 			}
 		}).
 		Do()


### PR DESCRIPTION
**What this PR does / why we need it**:
fix kubectl get can't namespace correctly
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
[63277](https://github.com/kubernetes/kubernetes/issues/63277)
**Special notes for your reviewer**:
```
kubectl get po --all-namespaces
NAMESPACE   NAME                        READY     STATUS    RESTARTS   AGE
            kube-dns-659bc9899c-ngxrj   2/3       Running   0          20s
```
use kubectl get --all-namespaces can't print namespace correctly
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
