### PR TITLE
Update scheduler table tests to use subtest

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -236,7 +236,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 	}
 
 	tests := []struct {
-		description  string
+		name         string
 		pendingPod   *v1.Pod
 		addedPod     *v1.Pod
 		existingPods []*v1.Pod
@@ -244,7 +244,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 		services     []*v1.Service
 	}{
 		{
-			description: "no anti-affinity or service affinity exist",
+			name: "no anti-affinity or service affinity exist",
 			pendingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
 			},
@@ -267,7 +267,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			},
 		},
 		{
-			description: "metadata anti-affinity terms are updated correctly after adding and removing a pod",
+			name: "metadata anti-affinity terms are updated correctly after adding and removing a pod",
 			pendingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
 			},
@@ -300,7 +300,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			},
 		},
 		{
-			description: "metadata service-affinity data are updated correctly after adding and removing a pod",
+			name: "metadata service-affinity data are updated correctly after adding and removing a pod",
 			pendingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
 			},
@@ -324,7 +324,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			},
 		},
 		{
-			description: "metadata anti-affinity terms and service affinity data are updated correctly after adding and removing a pod",
+			name: "metadata anti-affinity terms and service affinity data are updated correctly after adding and removing a pod",
 			pendingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
 			},
@@ -358,7 +358,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			},
 		},
 		{
-			description: "metadata matching pod affinity and anti-affinity are updated correctly after adding and removing a pod",
+			name: "metadata matching pod affinity and anti-affinity are updated correctly after adding and removing a pod",
 			pendingPod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
 			},
@@ -395,44 +395,46 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		allPodLister := schedulertesting.FakePodLister(append(test.existingPods, test.addedPod))
-		// getMeta creates predicate meta data given the list of pods.
-		getMeta := func(lister schedulertesting.FakePodLister) (*predicateMetadata, map[string]*schedulercache.NodeInfo) {
-			nodeInfoMap := schedulercache.CreateNodeNameToInfoMap(lister, test.nodes)
-			// nodeList is a list of non-pointer nodes to feed to FakeNodeListInfo.
-			nodeList := []v1.Node{}
-			for _, n := range test.nodes {
-				nodeList = append(nodeList, *n)
+		t.Run(test.name, func(t *testing.T) {
+			allPodLister := schedulertesting.FakePodLister(append(test.existingPods, test.addedPod))
+			// getMeta creates predicate meta data given the list of pods.
+			getMeta := func(lister schedulertesting.FakePodLister) (*predicateMetadata, map[string]*schedulercache.NodeInfo) {
+				nodeInfoMap := schedulercache.CreateNodeNameToInfoMap(lister, test.nodes)
+				// nodeList is a list of non-pointer nodes to feed to FakeNodeListInfo.
+				nodeList := []v1.Node{}
+				for _, n := range test.nodes {
+					nodeList = append(nodeList, *n)
+				}
+				_, precompute := NewServiceAffinityPredicate(lister, schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodeList), nil)
+				RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", precompute)
+				pmf := PredicateMetadataFactory{lister}
+				meta := pmf.GetMetadata(test.pendingPod, nodeInfoMap)
+				return meta.(*predicateMetadata), nodeInfoMap
 			}
-			_, precompute := NewServiceAffinityPredicate(lister, schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodeList), nil)
-			RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", precompute)
-			pmf := PredicateMetadataFactory{lister}
-			meta := pmf.GetMetadata(test.pendingPod, nodeInfoMap)
-			return meta.(*predicateMetadata), nodeInfoMap
-		}
 
-		// allPodsMeta is meta data produced when all pods, including test.addedPod
-		// are given to the metadata producer.
-		allPodsMeta, _ := getMeta(allPodLister)
-		// existingPodsMeta1 is meta data produced for test.existingPods (without test.addedPod).
-		existingPodsMeta1, nodeInfoMap := getMeta(schedulertesting.FakePodLister(test.existingPods))
-		// Add test.addedPod to existingPodsMeta1 and make sure meta is equal to allPodsMeta
-		nodeInfo := nodeInfoMap[test.addedPod.Spec.NodeName]
-		if err := existingPodsMeta1.AddPod(test.addedPod, nodeInfo); err != nil {
-			t.Errorf("test [%v]: error adding pod to meta: %v", test.description, err)
-		}
-		if err := predicateMetadataEquivalent(allPodsMeta, existingPodsMeta1); err != nil {
-			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
-		}
-		// Remove the added pod and from existingPodsMeta1 an make sure it is equal
-		// to meta generated for existing pods.
-		existingPodsMeta2, _ := getMeta(schedulertesting.FakePodLister(test.existingPods))
-		if err := existingPodsMeta1.RemovePod(test.addedPod); err != nil {
-			t.Errorf("test [%v]: error removing pod from meta: %v", test.description, err)
-		}
-		if err := predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2); err != nil {
-			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
-		}
+			// allPodsMeta is meta data produced when all pods, including test.addedPod
+			// are given to the metadata producer.
+			allPodsMeta, _ := getMeta(allPodLister)
+			// existingPodsMeta1 is meta data produced for test.existingPods (without test.addedPod).
+			existingPodsMeta1, nodeInfoMap := getMeta(schedulertesting.FakePodLister(test.existingPods))
+			// Add test.addedPod to existingPodsMeta1 and make sure meta is equal to allPodsMeta
+			nodeInfo := nodeInfoMap[test.addedPod.Spec.NodeName]
+			if err := existingPodsMeta1.AddPod(test.addedPod, nodeInfo); err != nil {
+				t.Errorf("error adding pod to meta: %v", err)
+			}
+			if err := predicateMetadataEquivalent(allPodsMeta, existingPodsMeta1); err != nil {
+				t.Errorf("meta data are not equivalent: %v", err)
+			}
+			// Remove the added pod and from existingPodsMeta1 an make sure it is equal
+			// to meta generated for existing pods.
+			existingPodsMeta2, _ := getMeta(schedulertesting.FakePodLister(test.existingPods))
+			if err := existingPodsMeta1.RemovePod(test.addedPod); err != nil {
+				t.Errorf("error removing pod from meta: %v", err)
+			}
+			if err := predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2); err != nil {
+				t.Errorf("meta data are not equivalent: %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -97,7 +97,7 @@ func TestPodFitsResources(t *testing.T) {
 		pod                      *v1.Pod
 		nodeInfo                 *schedulercache.NodeInfo
 		fits                     bool
-		test                     string
+		name                     string
 		reasons                  []algorithm.PredicateFailureReason
 		ignoredExtendedResources sets.String
 	}{
@@ -106,14 +106,14 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 10, Memory: 20})),
 			fits: true,
-			test: "no resources requested always fits",
+			name: "no resources requested always fits",
 		},
 		{
 			pod: newResourcePod(schedulercache.Resource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 10, Memory: 20})),
 			fits: false,
-			test: "too many resources fails",
+			name: "too many resources fails",
 			reasons: []algorithm.PredicateFailureReason{
 				NewInsufficientResourceError(v1.ResourceCPU, 1, 10, 10),
 				NewInsufficientResourceError(v1.ResourceMemory, 1, 20, 20),
@@ -124,7 +124,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 8, Memory: 19})),
 			fits:    false,
-			test:    "too many resources fails due to init container cpu",
+			name:    "too many resources fails due to init container cpu",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceCPU, 3, 8, 10)},
 		},
 		{
@@ -132,7 +132,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 8, Memory: 19})),
 			fits:    false,
-			test:    "too many resources fails due to highest init container cpu",
+			name:    "too many resources fails due to highest init container cpu",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceCPU, 3, 8, 10)},
 		},
 		{
@@ -140,7 +140,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 9, Memory: 19})),
 			fits:    false,
-			test:    "too many resources fails due to init container memory",
+			name:    "too many resources fails due to init container memory",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceMemory, 3, 19, 20)},
 		},
 		{
@@ -148,7 +148,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 9, Memory: 19})),
 			fits:    false,
-			test:    "too many resources fails due to highest init container memory",
+			name:    "too many resources fails due to highest init container memory",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceMemory, 3, 19, 20)},
 		},
 		{
@@ -156,28 +156,28 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 9, Memory: 19})),
 			fits: true,
-			test: "init container fits because it's the max, not sum, of containers and init containers",
+			name: "init container fits because it's the max, not sum, of containers and init containers",
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(schedulercache.Resource{MilliCPU: 1, Memory: 1}), schedulercache.Resource{MilliCPU: 1, Memory: 1}, schedulercache.Resource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 9, Memory: 19})),
 			fits: true,
-			test: "multiple init containers fit because it's the max, not sum, of containers and init containers",
+			name: "multiple init containers fit because it's the max, not sum, of containers and init containers",
 		},
 		{
 			pod: newResourcePod(schedulercache.Resource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 5})),
 			fits: true,
-			test: "both resources fit",
+			name: "both resources fit",
 		},
 		{
 			pod: newResourcePod(schedulercache.Resource{MilliCPU: 2, Memory: 1}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 9, Memory: 5})),
 			fits:    false,
-			test:    "one resource memory fits",
+			name:    "one resource memory fits",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceCPU, 2, 9, 10)},
 		},
 		{
@@ -185,7 +185,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 19})),
 			fits:    false,
-			test:    "one resource cpu fits",
+			name:    "one resource cpu fits",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourceMemory, 2, 19, 20)},
 		},
 		{
@@ -193,26 +193,26 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 19})),
 			fits: true,
-			test: "equal edge case",
+			name: "equal edge case",
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(schedulercache.Resource{MilliCPU: 4, Memory: 1}), schedulercache.Resource{MilliCPU: 5, Memory: 1}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 19})),
 			fits: true,
-			test: "equal edge case for init container",
+			name: "equal edge case for init container",
 		},
 		{
 			pod:      newResourcePod(schedulercache.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
 			nodeInfo: schedulercache.NewNodeInfo(newResourcePod(schedulercache.Resource{})),
 			fits:     true,
-			test:     "extended resource fits",
+			name:     "extended resource fits",
 		},
 		{
 			pod:      newResourceInitPod(newResourcePod(schedulercache.Resource{}), schedulercache.Resource{ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 1}}),
 			nodeInfo: schedulercache.NewNodeInfo(newResourcePod(schedulercache.Resource{})),
 			fits:     true,
-			test:     "extended resource fits for init container",
+			name:     "extended resource fits for init container",
 		},
 		{
 			pod: newResourcePod(
@@ -220,7 +220,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			fits:    false,
-			test:    "extended resource capacity enforced",
+			name:    "extended resource capacity enforced",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 10, 0, 5)},
 		},
 		{
@@ -229,7 +229,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 0}})),
 			fits:    false,
-			test:    "extended resource capacity enforced for init container",
+			name:    "extended resource capacity enforced for init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 10, 0, 5)},
 		},
 		{
@@ -238,7 +238,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			fits:    false,
-			test:    "extended resource allocatable enforced",
+			name:    "extended resource allocatable enforced",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 1, 5, 5)},
 		},
 		{
@@ -247,7 +247,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 5}})),
 			fits:    false,
-			test:    "extended resource allocatable enforced for init container",
+			name:    "extended resource allocatable enforced for init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 1, 5, 5)},
 		},
 		{
@@ -257,7 +257,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			fits:    false,
-			test:    "extended resource allocatable enforced for multiple containers",
+			name:    "extended resource allocatable enforced for multiple containers",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 6, 2, 5)},
 		},
 		{
@@ -267,7 +267,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			fits: true,
-			test: "extended resource allocatable admits multiple init containers",
+			name: "extended resource allocatable admits multiple init containers",
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(schedulercache.Resource{}),
@@ -276,7 +276,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{extendedResourceA: 2}})),
 			fits:    false,
-			test:    "extended resource allocatable enforced for multiple init containers",
+			name:    "extended resource allocatable enforced for multiple init containers",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceA, 6, 2, 5)},
 		},
 		{
@@ -285,7 +285,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
 			fits:    false,
-			test:    "extended resource allocatable enforced for unknown resource",
+			name:    "extended resource allocatable enforced for unknown resource",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceB, 1, 0, 0)},
 		},
 		{
@@ -294,7 +294,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
 			fits:    false,
-			test:    "extended resource allocatable enforced for unknown resource for init container",
+			name:    "extended resource allocatable enforced for unknown resource for init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(extendedResourceB, 1, 0, 0)},
 		},
 		{
@@ -303,7 +303,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
 			fits:    false,
-			test:    "kubernetes.io resource capacity enforced",
+			name:    "kubernetes.io resource capacity enforced",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(kubernetesIOResourceA, 10, 0, 0)},
 		},
 		{
@@ -312,7 +312,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
 			fits:    false,
-			test:    "kubernetes.io resource capacity enforced for init container",
+			name:    "kubernetes.io resource capacity enforced for init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(kubernetesIOResourceB, 10, 0, 0)},
 		},
 		{
@@ -321,7 +321,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			fits:    false,
-			test:    "hugepages resource capacity enforced",
+			name:    "hugepages resource capacity enforced",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(hugePageResourceA, 10, 0, 5)},
 		},
 		{
@@ -330,7 +330,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 0}})),
 			fits:    false,
-			test:    "hugepages resource capacity enforced for init container",
+			name:    "hugepages resource capacity enforced for init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(hugePageResourceA, 10, 0, 5)},
 		},
 		{
@@ -340,7 +340,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0, ScalarResources: map[v1.ResourceName]int64{hugePageResourceA: 2}})),
 			fits:    false,
-			test:    "hugepages resource allocatable enforced for multiple containers",
+			name:    "hugepages resource allocatable enforced for multiple containers",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(hugePageResourceA, 6, 2, 5)},
 		},
 		{
@@ -350,32 +350,34 @@ func TestPodFitsResources(t *testing.T) {
 				newResourcePod(schedulercache.Resource{MilliCPU: 0, Memory: 0})),
 			fits: true,
 			ignoredExtendedResources: sets.NewString(string(extendedResourceB)),
-			test: "skip checking ignored extended resource",
+			name: "skip checking ignored extended resource",
 		},
 	}
 
 	for _, test := range enoughPodsTests {
-		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
-		test.nodeInfo.SetNode(&node)
-		RegisterPredicateMetadataProducerWithExtendedResourceOptions(test.ignoredExtendedResources)
-		meta := PredicateMetadata(test.pod, nil)
-		fits, reasons, err := PodFitsResources(test.pod, meta, test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
+			test.nodeInfo.SetNode(&node)
+			RegisterPredicateMetadataProducerWithExtendedResourceOptions(test.ignoredExtendedResources)
+			meta := PredicateMetadata(test.pod, nil)
+			fits, reasons, err := PodFitsResources(test.pod, meta, test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, test.reasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, test.reasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 
 	notEnoughPodsTests := []struct {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		fits     bool
-		test     string
+		name     string
 		reasons  []algorithm.PredicateFailureReason
 	}{
 		{
@@ -383,7 +385,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 10, Memory: 20})),
 			fits:    false,
-			test:    "even without specified resources predicate fails when there's no space for additional pod",
+			name:    "even without specified resources predicate fails when there's no space for additional pod",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourcePods, 1, 1, 1)},
 		},
 		{
@@ -391,7 +393,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 5})),
 			fits:    false,
-			test:    "even if both resources fit predicate fails when there's no space for additional pod",
+			name:    "even if both resources fit predicate fails when there's no space for additional pod",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourcePods, 1, 1, 1)},
 		},
 		{
@@ -399,7 +401,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 19})),
 			fits:    false,
-			test:    "even for equal edge case predicate fails when there's no space for additional pod",
+			name:    "even for equal edge case predicate fails when there's no space for additional pod",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourcePods, 1, 1, 1)},
 		},
 		{
@@ -407,30 +409,32 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 5, Memory: 19})),
 			fits:    false,
-			test:    "even for equal edge case predicate fails when there's no space for additional pod due to init container",
+			name:    "even for equal edge case predicate fails when there's no space for additional pod due to init container",
 			reasons: []algorithm.PredicateFailureReason{NewInsufficientResourceError(v1.ResourcePods, 1, 1, 1)},
 		},
 	}
 	for _, test := range notEnoughPodsTests {
-		node := v1.Node{Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: makeAllocatableResources(10, 20, 1, 0, 0, 0)}}
-		test.nodeInfo.SetNode(&node)
-		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			node := v1.Node{Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: makeAllocatableResources(10, 20, 1, 0, 0, 0)}}
+			test.nodeInfo.SetNode(&node)
+			fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, test.reasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, test.reasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 
 	storagePodsTests := []struct {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		fits     bool
-		test     string
+		name     string
 		reasons  []algorithm.PredicateFailureReason
 	}{
 		{
@@ -438,7 +442,7 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 10, Memory: 10})),
 			fits: false,
-			test: "due to container scratch disk",
+			name: "due to container scratch disk",
 			reasons: []algorithm.PredicateFailureReason{
 				NewInsufficientResourceError(v1.ResourceCPU, 1, 10, 10),
 			},
@@ -448,14 +452,14 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 2, Memory: 10})),
 			fits: true,
-			test: "pod fit",
+			name: "pod fit",
 		},
 		{
 			pod: newResourcePod(schedulercache.Resource{EphemeralStorage: 25}),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 2, Memory: 2})),
 			fits: false,
-			test: "storage ephemeral local storage request exceeds allocatable",
+			name: "storage ephemeral local storage request exceeds allocatable",
 			reasons: []algorithm.PredicateFailureReason{
 				NewInsufficientResourceError(v1.ResourceEphemeralStorage, 25, 0, 20),
 			},
@@ -465,25 +469,26 @@ func TestPodFitsResources(t *testing.T) {
 			nodeInfo: schedulercache.NewNodeInfo(
 				newResourcePod(schedulercache.Resource{MilliCPU: 2, Memory: 2})),
 			fits: true,
-			test: "pod fits",
+			name: "pod fits",
 		},
 	}
 
 	for _, test := range storagePodsTests {
-		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
-		test.nodeInfo.SetNode(&node)
-		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 32, 5, 20, 5)}}
+			test.nodeInfo.SetNode(&node)
+			fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, test.reasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, test.reasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
-
 }
 
 func TestPodFitsHost(t *testing.T) {
@@ -491,13 +496,13 @@ func TestPodFitsHost(t *testing.T) {
 		pod  *v1.Pod
 		node *v1.Node
 		fits bool
-		test string
+		name string
 	}{
 		{
 			pod:  &v1.Pod{},
 			node: &v1.Node{},
 			fits: true,
-			test: "no host specified",
+			name: "no host specified",
 		},
 		{
 			pod: &v1.Pod{
@@ -511,7 +516,7 @@ func TestPodFitsHost(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "host matches",
+			name: "host matches",
 		},
 		{
 			pod: &v1.Pod{
@@ -525,24 +530,26 @@ func TestPodFitsHost(t *testing.T) {
 				},
 			},
 			fits: false,
-			test: "host doesn't match",
+			name: "host doesn't match",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrPodNotMatchHostName}
 
 	for _, test := range tests {
-		nodeInfo := schedulercache.NewNodeInfo()
-		nodeInfo.SetNode(test.node)
-		fits, reasons, err := PodFitsHost(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: unexpected difference: expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeInfo := schedulercache.NewNodeInfo()
+			nodeInfo.SetNode(test.node)
+			fits, reasons, err := PodFitsHost(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("unexpected difference: expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -575,112 +582,114 @@ func TestPodFitsHostPorts(t *testing.T) {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		fits     bool
-		test     string
+		name     string
 	}{
 		{
 			pod:      &v1.Pod{},
 			nodeInfo: schedulercache.NewNodeInfo(),
 			fits:     true,
-			test:     "nothing running",
+			name:     "nothing running",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/9090")),
 			fits: true,
-			test: "other port",
+			name: "other port",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			fits: false,
-			test: "same udp port",
+			name: "same udp port",
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			fits: false,
-			test: "same tcp port",
+			name: "same tcp port",
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.2/8080")),
 			fits: true,
-			test: "different host ip",
+			name: "different host ip",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8080")),
 			fits: true,
-			test: "different protocol",
+			name: "different protocol",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8000", "UDP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "UDP/127.0.0.1/8080")),
 			fits: false,
-			test: "second udp port conflict",
+			name: "second udp port conflict",
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8080"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001", "UDP/127.0.0.1/8081")),
 			fits: false,
-			test: "first tcp port conflict",
+			name: "first tcp port conflict",
 		},
 		{
 			pod: newPod("m1", "TCP/0.0.0.0/8001"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			fits: false,
-			test: "first tcp port conflict due to 0.0.0.0 hostIP",
+			name: "first tcp port conflict due to 0.0.0.0 hostIP",
 		},
 		{
 			pod: newPod("m1", "TCP/10.0.10.10/8001", "TCP/0.0.0.0/8001"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/127.0.0.1/8001")),
 			fits: false,
-			test: "TCP hostPort conflict due to 0.0.0.0 hostIP",
+			name: "TCP hostPort conflict due to 0.0.0.0 hostIP",
 		},
 		{
 			pod: newPod("m1", "TCP/127.0.0.1/8001"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			fits: false,
-			test: "second tcp port conflict to 0.0.0.0 hostIP",
+			name: "second tcp port conflict to 0.0.0.0 hostIP",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001")),
 			fits: true,
-			test: "second different protocol",
+			name: "second different protocol",
 		},
 		{
 			pod: newPod("m1", "UDP/127.0.0.1/8001"),
 			nodeInfo: schedulercache.NewNodeInfo(
 				newPod("m1", "TCP/0.0.0.0/8001", "UDP/0.0.0.0/8001")),
 			fits: false,
-			test: "UDP hostPort conflict due to 0.0.0.0 hostIP",
+			name: "UDP hostPort conflict due to 0.0.0.0 hostIP",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrPodNotFitsHostPorts}
 
 	for _, test := range tests {
-		fits, reasons, err := PodFitsHostPorts(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.fits != fits {
-			t.Errorf("%s: expected %v, saw %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			fits, reasons, err := PodFitsHostPorts(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if test.fits != fits {
+				t.Errorf("expected %v, saw %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -711,7 +720,7 @@ func TestGCEDiskConflicts(t *testing.T) {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		isOk     bool
-		test     string
+		name     string
 	}{
 		{&v1.Pod{}, schedulercache.NewNodeInfo(), true, "nothing"},
 		{&v1.Pod{}, schedulercache.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state"},
@@ -721,19 +730,21 @@ func TestGCEDiskConflicts(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrDiskConflict}
 
 	for _, test := range tests {
-		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if test.isOk && !ok {
+				t.Errorf("expected ok, got none.  %v %s", test.pod, test.nodeInfo)
+			}
+			if !test.isOk && ok {
+				t.Errorf("expected no ok, got one.  %v %s", test.pod, test.nodeInfo)
+			}
+		})
 	}
 }
 
@@ -764,7 +775,7 @@ func TestAWSDiskConflicts(t *testing.T) {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		isOk     bool
-		test     string
+		name     string
 	}{
 		{&v1.Pod{}, schedulercache.NewNodeInfo(), true, "nothing"},
 		{&v1.Pod{}, schedulercache.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state"},
@@ -774,19 +785,21 @@ func TestAWSDiskConflicts(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrDiskConflict}
 
 	for _, test := range tests {
-		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if test.isOk && !ok {
+				t.Errorf("expected ok, got none.  %v %s", test.pod, test.nodeInfo)
+			}
+			if !test.isOk && ok {
+				t.Errorf("expected no ok, got one.  %v %s", test.pod, test.nodeInfo)
+			}
+		})
 	}
 }
 
@@ -823,7 +836,7 @@ func TestRBDDiskConflicts(t *testing.T) {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		isOk     bool
-		test     string
+		name     string
 	}{
 		{&v1.Pod{}, schedulercache.NewNodeInfo(), true, "nothing"},
 		{&v1.Pod{}, schedulercache.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state"},
@@ -833,19 +846,21 @@ func TestRBDDiskConflicts(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrDiskConflict}
 
 	for _, test := range tests {
-		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if test.isOk && !ok {
+				t.Errorf("expected ok, got none.  %v %s", test.pod, test.nodeInfo)
+			}
+			if !test.isOk && ok {
+				t.Errorf("expected no ok, got one.  %v %s", test.pod, test.nodeInfo)
+			}
+		})
 	}
 }
 
@@ -882,7 +897,7 @@ func TestISCSIDiskConflicts(t *testing.T) {
 		pod      *v1.Pod
 		nodeInfo *schedulercache.NodeInfo
 		isOk     bool
-		test     string
+		name     string
 	}{
 		{&v1.Pod{}, schedulercache.NewNodeInfo(), true, "nothing"},
 		{&v1.Pod{}, schedulercache.NewNodeInfo(&v1.Pod{Spec: volState}), true, "one state"},
@@ -892,19 +907,21 @@ func TestISCSIDiskConflicts(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrDiskConflict}
 
 	for _, test := range tests {
-		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if test.isOk && !ok {
+				t.Errorf("expected ok, got none.  %v %s", test.pod, test.nodeInfo)
+			}
+			if !test.isOk && ok {
+				t.Errorf("expected no ok, got one.  %v %s", test.pod, test.nodeInfo)
+			}
+		})
 	}
 }
 
@@ -915,12 +932,12 @@ func TestPodFitsSelector(t *testing.T) {
 		labels   map[string]string
 		nodeName string
 		fits     bool
-		test     string
+		name     string
 	}{
 		{
 			pod:  &v1.Pod{},
 			fits: true,
-			test: "no selector",
+			name: "no selector",
 		},
 		{
 			pod: &v1.Pod{
@@ -931,7 +948,7 @@ func TestPodFitsSelector(t *testing.T) {
 				},
 			},
 			fits: false,
-			test: "missing labels",
+			name: "missing labels",
 		},
 		{
 			pod: &v1.Pod{
@@ -945,7 +962,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "same labels",
+			name: "same labels",
 		},
 		{
 			pod: &v1.Pod{
@@ -960,7 +977,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"baz": "blah",
 			},
 			fits: true,
-			test: "node labels are superset",
+			name: "node labels are superset",
 		},
 		{
 			pod: &v1.Pod{
@@ -975,7 +992,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "node labels are subset",
+			name: "node labels are subset",
 		},
 		{
 			pod: &v1.Pod{
@@ -1003,7 +1020,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "Pod with matchExpressions using In operator that matches the existing node",
+			name: "Pod with matchExpressions using In operator that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1032,7 +1049,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"kernel-version": "0206",
 			},
 			fits: true,
-			test: "Pod with matchExpressions using Gt operator that matches the existing node",
+			name: "Pod with matchExpressions using Gt operator that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1060,7 +1077,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"mem-type": "DDR3",
 			},
 			fits: true,
-			test: "Pod with matchExpressions using NotIn operator that matches the existing node",
+			name: "Pod with matchExpressions using NotIn operator that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1087,7 +1104,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"GPU": "NVIDIA-GRID-K1",
 			},
 			fits: true,
-			test: "Pod with matchExpressions using Exists operator that matches the existing node",
+			name: "Pod with matchExpressions using Exists operator that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1115,7 +1132,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "Pod with affinity that don't match node's labels won't schedule onto the node",
+			name: "Pod with affinity that don't match node's labels won't schedule onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1133,7 +1150,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "Pod with a nil []NodeSelectorTerm in affinity, can't match the node's labels and won't schedule onto the node",
+			name: "Pod with a nil []NodeSelectorTerm in affinity, can't match the node's labels and won't schedule onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1151,7 +1168,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "Pod with an empty []NodeSelectorTerm in affinity, can't match the node's labels and won't schedule onto the node",
+			name: "Pod with an empty []NodeSelectorTerm in affinity, can't match the node's labels and won't schedule onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1173,7 +1190,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "Pod with empty MatchExpressions is not a valid value will match no objects and won't schedule onto the node",
+			name: "Pod with empty MatchExpressions is not a valid value will match no objects and won't schedule onto the node",
 		},
 		{
 			pod: &v1.Pod{},
@@ -1181,7 +1198,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "Pod with no Affinity will schedule onto a node",
+			name: "Pod with no Affinity will schedule onto a node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1197,7 +1214,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "Pod with Affinity but nil NodeSelector will schedule onto a node",
+			name: "Pod with Affinity but nil NodeSelector will schedule onto a node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1228,7 +1245,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"GPU": "NVIDIA-GRID-K1",
 			},
 			fits: true,
-			test: "Pod with multiple matchExpressions ANDed that matches the existing node",
+			name: "Pod with multiple matchExpressions ANDed that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1259,7 +1276,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"GPU": "NVIDIA-GRID-K1",
 			},
 			fits: false,
-			test: "Pod with multiple matchExpressions ANDed that doesn't match the existing node",
+			name: "Pod with multiple matchExpressions ANDed that doesn't match the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1296,7 +1313,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "Pod with multiple NodeSelectorTerms ORed in affinity, matches the node's labels and will schedule onto the node",
+			name: "Pod with multiple NodeSelectorTerms ORed in affinity, matches the node's labels and will schedule onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1326,7 +1343,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: true,
-			test: "Pod with an Affinity and a PodSpec.NodeSelector(the old thing that we are deprecating) " +
+			name: "Pod with an Affinity and a PodSpec.NodeSelector(the old thing that we are deprecating) " +
 				"both are satisfied, will schedule onto the node",
 		},
 		{
@@ -1357,7 +1374,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "barrrrrr",
 			},
 			fits: false,
-			test: "Pod with an Affinity matches node's labels but the PodSpec.NodeSelector(the old thing that we are deprecating) " +
+			name: "Pod with an Affinity matches node's labels but the PodSpec.NodeSelector(the old thing that we are deprecating) " +
 				"is not satisfied, won't schedule onto the node",
 		},
 		{
@@ -1386,7 +1403,7 @@ func TestPodFitsSelector(t *testing.T) {
 				"foo": "bar",
 			},
 			fits: false,
-			test: "Pod with an invalid value in Affinity term won't be scheduled onto the node",
+			name: "Pod with an invalid value in Affinity term won't be scheduled onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1412,7 +1429,7 @@ func TestPodFitsSelector(t *testing.T) {
 			},
 			nodeName: "node_1",
 			fits:     true,
-			test:     "Pod with matchFields using In operator that matches the existing node",
+			name:     "Pod with matchFields using In operator that matches the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1438,7 +1455,7 @@ func TestPodFitsSelector(t *testing.T) {
 			},
 			nodeName: "node_2",
 			fits:     false,
-			test:     "Pod with matchFields using In operator that does not match the existing node",
+			name:     "Pod with matchFields using In operator that does not match the existing node",
 		},
 		{
 			pod: &v1.Pod{
@@ -1474,7 +1491,7 @@ func TestPodFitsSelector(t *testing.T) {
 			nodeName: "node_2",
 			labels:   map[string]string{"foo": "bar"},
 			fits:     true,
-			test:     "Pod with two terms: matchFields does not match, but matchExpressions matches",
+			name:     "Pod with two terms: matchFields does not match, but matchExpressions matches",
 		},
 		{
 			pod: &v1.Pod{
@@ -1508,7 +1525,7 @@ func TestPodFitsSelector(t *testing.T) {
 			nodeName: "node_2",
 			labels:   map[string]string{"foo": "bar"},
 			fits:     false,
-			test:     "Pod with one term: matchFields does not match, but matchExpressions matches",
+			name:     "Pod with one term: matchFields does not match, but matchExpressions matches",
 		},
 		{
 			pod: &v1.Pod{
@@ -1542,7 +1559,7 @@ func TestPodFitsSelector(t *testing.T) {
 			nodeName: "node_1",
 			labels:   map[string]string{"foo": "bar"},
 			fits:     true,
-			test:     "Pod with one term: both matchFields and matchExpressions match",
+			name:     "Pod with one term: both matchFields and matchExpressions match",
 		},
 		{
 			pod: &v1.Pod{
@@ -1578,29 +1595,31 @@ func TestPodFitsSelector(t *testing.T) {
 			nodeName: "node_2",
 			labels:   map[string]string{"foo": "bar"},
 			fits:     false,
-			test:     "Pod with two terms: both matchFields and matchExpressions do not match",
+			name:     "Pod with two terms: both matchFields and matchExpressions do not match",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrNodeSelectorNotMatch}
 
 	for _, test := range tests {
-		node := v1.Node{ObjectMeta: metav1.ObjectMeta{
-			Name:   test.nodeName,
-			Labels: test.labels,
-		}}
-		nodeInfo := schedulercache.NewNodeInfo()
-		nodeInfo.SetNode(&node)
+		t.Run(test.name, func(t *testing.T) {
+			node := v1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name:   test.nodeName,
+				Labels: test.labels,
+			}}
+			nodeInfo := schedulercache.NewNodeInfo()
+			nodeInfo.SetNode(&node)
 
-		fits, reasons, err := PodMatchNodeSelector(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+			fits, reasons, err := PodMatchNodeSelector(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -1611,63 +1630,65 @@ func TestNodeLabelPresence(t *testing.T) {
 		labels   []string
 		presence bool
 		fits     bool
-		test     string
+		name     string
 	}{
 		{
 			labels:   []string{"baz"},
 			presence: true,
 			fits:     false,
-			test:     "label does not match, presence true",
+			name:     "label does not match, presence true",
 		},
 		{
 			labels:   []string{"baz"},
 			presence: false,
 			fits:     true,
-			test:     "label does not match, presence false",
+			name:     "label does not match, presence false",
 		},
 		{
 			labels:   []string{"foo", "baz"},
 			presence: true,
 			fits:     false,
-			test:     "one label matches, presence true",
+			name:     "one label matches, presence true",
 		},
 		{
 			labels:   []string{"foo", "baz"},
 			presence: false,
 			fits:     false,
-			test:     "one label matches, presence false",
+			name:     "one label matches, presence false",
 		},
 		{
 			labels:   []string{"foo", "bar"},
 			presence: true,
 			fits:     true,
-			test:     "all labels match, presence true",
+			name:     "all labels match, presence true",
 		},
 		{
 			labels:   []string{"foo", "bar"},
 			presence: false,
 			fits:     false,
-			test:     "all labels match, presence false",
+			name:     "all labels match, presence false",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrNodeLabelPresenceViolated}
 
 	for _, test := range tests {
-		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: label}}
-		nodeInfo := schedulercache.NewNodeInfo()
-		nodeInfo.SetNode(&node)
+		t.Run(test.name, func(t *testing.T) {
+			node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: label}}
+			nodeInfo := schedulercache.NewNodeInfo()
+			nodeInfo.SetNode(&node)
 
-		labelChecker := NodeLabelChecker{test.labels, test.presence}
-		fits, reasons, err := labelChecker.CheckNodeLabelPresence(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+			labelChecker := NodeLabelChecker{test.labels, test.presence}
+			fits, reasons, err := labelChecker.CheckNodeLabelPresence(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -1701,28 +1722,28 @@ func TestServiceAffinity(t *testing.T) {
 		node     *v1.Node
 		labels   []string
 		fits     bool
-		test     string
+		name     string
 	}{
 		{
 			pod:    new(v1.Pod),
 			node:   &node1,
 			fits:   true,
 			labels: []string{"region"},
-			test:   "nothing scheduled",
+			name:   "nothing scheduled",
 		},
 		{
 			pod:    &v1.Pod{Spec: v1.PodSpec{NodeSelector: map[string]string{"region": "r1"}}},
 			node:   &node1,
 			fits:   true,
 			labels: []string{"region"},
-			test:   "pod with region label match",
+			name:   "pod with region label match",
 		},
 		{
 			pod:    &v1.Pod{Spec: v1.PodSpec{NodeSelector: map[string]string{"region": "r2"}}},
 			node:   &node1,
 			fits:   false,
 			labels: []string{"region"},
-			test:   "pod with region label mismatch",
+			name:   "pod with region label mismatch",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector}},
@@ -1731,7 +1752,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}}},
 			fits:     true,
 			labels:   []string{"region"},
-			test:     "service pod on same node",
+			name:     "service pod on same node",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector}},
@@ -1740,7 +1761,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}}},
 			fits:     true,
 			labels:   []string{"region"},
-			test:     "service pod on different node, region match",
+			name:     "service pod on different node, region match",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector}},
@@ -1749,7 +1770,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}}},
 			fits:     false,
 			labels:   []string{"region"},
-			test:     "service pod on different node, region mismatch",
+			name:     "service pod on different node, region mismatch",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector, Namespace: "ns1"}},
@@ -1758,7 +1779,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}, ObjectMeta: metav1.ObjectMeta{Namespace: "ns2"}}},
 			fits:     true,
 			labels:   []string{"region"},
-			test:     "service in different namespace, region mismatch",
+			name:     "service in different namespace, region mismatch",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector, Namespace: "ns1"}},
@@ -1767,7 +1788,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}, ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"}}},
 			fits:     true,
 			labels:   []string{"region"},
-			test:     "pod in different namespace, region mismatch",
+			name:     "pod in different namespace, region mismatch",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector, Namespace: "ns1"}},
@@ -1776,7 +1797,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}, ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"}}},
 			fits:     false,
 			labels:   []string{"region"},
-			test:     "service and pod in same namespace, region mismatch",
+			name:     "service and pod in same namespace, region mismatch",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector}},
@@ -1785,7 +1806,7 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}}},
 			fits:     false,
 			labels:   []string{"region", "zone"},
-			test:     "service pod on different node, multiple labels, not all match",
+			name:     "service pod on different node, multiple labels, not all match",
 		},
 		{
 			pod:      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: selector}},
@@ -1794,42 +1815,44 @@ func TestServiceAffinity(t *testing.T) {
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector}}},
 			fits:     true,
 			labels:   []string{"region", "zone"},
-			test:     "service pod on different node, multiple labels, all match",
+			name:     "service pod on different node, multiple labels, all match",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrServiceAffinityViolated}
 	for _, test := range tests {
-		testIt := func(skipPrecompute bool) {
-			nodes := []v1.Node{node1, node2, node3, node4, node5}
-			nodeInfo := schedulercache.NewNodeInfo()
-			nodeInfo.SetNode(test.node)
-			nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
-			// Reimplementing the logic that the scheduler implements: Any time it makes a predicate, it registers any precomputations.
-			predicate, precompute := NewServiceAffinityPredicate(schedulertesting.FakePodLister(test.pods), schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodes), test.labels)
-			// Register a precomputation or Rewrite the precomputation to a no-op, depending on the state we want to test.
-			RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", func(pm *predicateMetadata) {
-				if !skipPrecompute {
-					precompute(pm)
+		t.Run(test.name, func(t *testing.T) {
+			testIt := func(skipPrecompute bool) {
+				nodes := []v1.Node{node1, node2, node3, node4, node5}
+				nodeInfo := schedulercache.NewNodeInfo()
+				nodeInfo.SetNode(test.node)
+				nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
+				// Reimplementing the logic that the scheduler implements: Any time it makes a predicate, it registers any precomputations.
+				predicate, precompute := NewServiceAffinityPredicate(schedulertesting.FakePodLister(test.pods), schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodes), test.labels)
+				// Register a precomputation or Rewrite the precomputation to a no-op, depending on the state we want to test.
+				RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", func(pm *predicateMetadata) {
+					if !skipPrecompute {
+						precompute(pm)
+					}
+				})
+				if pmeta, ok := (PredicateMetadata(test.pod, nodeInfoMap)).(*predicateMetadata); ok {
+					fits, reasons, err := predicate(test.pod, pmeta, nodeInfo)
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+					}
+					if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+						t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+					}
+					if fits != test.fits {
+						t.Errorf("expected: %v got %v", test.fits, fits)
+					}
+				} else {
+					t.Errorf("Error casting.")
 				}
-			})
-			if pmeta, ok := (PredicateMetadata(test.pod, nodeInfoMap)).(*predicateMetadata); ok {
-				fits, reasons, err := predicate(test.pod, pmeta, nodeInfo)
-				if err != nil {
-					t.Errorf("%s: unexpected error: %v", test.test, err)
-				}
-				if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-					t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-				}
-				if fits != test.fits {
-					t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-				}
-			} else {
-				t.Errorf("Error casting.")
 			}
-		}
 
-		testIt(false) // Confirm that the predicate works without precomputed data (resilience)
-		testIt(true)  // Confirm that the predicate works with the precomputed data (better performance)
+			testIt(false) // Confirm that the predicate works without precomputed data (resilience)
+			testIt(true)  // Confirm that the predicate works with the precomputed data (better performance)
+		})
 	}
 }
 
@@ -2053,7 +2076,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 		filterName   string
 		maxVols      int
 		fits         bool
-		test         string
+		name         string
 	}{
 		// filterName:EBSVolumeFilterType
 		{
@@ -2062,7 +2085,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "fits when node capacity >= new pod's EBS volumes",
+			name:         "fits when node capacity >= new pod's EBS volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2070,7 +2093,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "doesn't fit when node capacity < new pod's EBS volumes",
+			name:         "doesn't fit when node capacity < new pod's EBS volumes",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2078,7 +2101,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores non-EBS volumes",
+			name:         "new pod's count ignores non-EBS volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2086,7 +2109,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "existing pods' counts ignore non-EBS volumes",
+			name:         "existing pods' counts ignore non-EBS volumes",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2094,7 +2117,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count considers PVCs backed by EBS volumes",
+			name:         "new pod's count considers PVCs backed by EBS volumes",
 		},
 		{
 			newPod:       splitPVCPod(EBSVolumeFilterType),
@@ -2102,7 +2125,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores PVCs not backed by EBS volumes",
+			name:         "new pod's count ignores PVCs not backed by EBS volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2110,7 +2133,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         false,
-			test:         "existing pods' counts considers PVCs backed by EBS volumes",
+			name:         "existing pods' counts considers PVCs backed by EBS volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2118,7 +2141,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "already-mounted EBS volumes are always ok to allow",
+			name:         "already-mounted EBS volumes are always ok to allow",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2126,7 +2149,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "the same EBS volumes are not counted multiple times",
+			name:         "the same EBS volumes are not counted multiple times",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2134,7 +2157,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2142,7 +2165,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2150,7 +2173,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         false,
-			test:         "pod with missing two PVCs is counted towards the PV limit twice",
+			name:         "pod with missing two PVCs is counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2158,7 +2181,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2166,7 +2189,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       deletedPVPod2,
@@ -2174,7 +2197,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two pods missing the same PV are counted towards the PV limit only once",
+			name:         "two pods missing the same PV are counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherDeletedPVPod,
@@ -2182,7 +2205,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "two pods missing different PVs are counted towards the PV limit twice",
+			name:         "two pods missing different PVs are counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2190,7 +2213,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(EBSVolumeFilterType),
@@ -2198,7 +2221,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       unboundPVCPod2,
@@ -2206,7 +2229,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
+			name:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherUnboundPVCPod,
@@ -2214,7 +2237,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   EBSVolumeFilterType,
 			maxVols:      2,
 			fits:         false,
-			test:         "two different unbound PVCs are counted towards the PV limit as two volumes",
+			name:         "two different unbound PVCs are counted towards the PV limit as two volumes",
 		},
 		// filterName:GCEPDVolumeFilterType
 		{
@@ -2223,7 +2246,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "fits when node capacity >= new pod's GCE volumes",
+			name:         "fits when node capacity >= new pod's GCE volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2231,7 +2254,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "fit when node capacity < new pod's GCE volumes",
+			name:         "fit when node capacity < new pod's GCE volumes",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2239,7 +2262,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores non-GCE volumes",
+			name:         "new pod's count ignores non-GCE volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2247,7 +2270,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "existing pods' counts ignore non-GCE volumes",
+			name:         "existing pods' counts ignore non-GCE volumes",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2255,7 +2278,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count considers PVCs backed by GCE volumes",
+			name:         "new pod's count considers PVCs backed by GCE volumes",
 		},
 		{
 			newPod:       splitPVCPod(GCEPDVolumeFilterType),
@@ -2263,7 +2286,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores PVCs not backed by GCE volumes",
+			name:         "new pod's count ignores PVCs not backed by GCE volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2271,7 +2294,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "existing pods' counts considers PVCs backed by GCE volumes",
+			name:         "existing pods' counts considers PVCs backed by GCE volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2279,7 +2302,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "already-mounted EBS volumes are always ok to allow",
+			name:         "already-mounted EBS volumes are always ok to allow",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2287,7 +2310,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "the same GCE volumes are not counted multiple times",
+			name:         "the same GCE volumes are not counted multiple times",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2295,7 +2318,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2303,7 +2326,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2311,7 +2334,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing two PVCs is counted towards the PV limit twice",
+			name:         "pod with missing two PVCs is counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2319,7 +2342,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2327,7 +2350,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       deletedPVPod2,
@@ -2335,7 +2358,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two pods missing the same PV are counted towards the PV limit only once",
+			name:         "two pods missing the same PV are counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherDeletedPVPod,
@@ -2343,7 +2366,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two pods missing different PVs are counted towards the PV limit twice",
+			name:         "two pods missing different PVs are counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2351,7 +2374,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(GCEPDVolumeFilterType),
@@ -2359,7 +2382,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       unboundPVCPod2,
@@ -2367,7 +2390,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
+			name:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherUnboundPVCPod,
@@ -2375,7 +2398,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   GCEPDVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two different unbound PVCs are counted towards the PV limit as two volumes",
+			name:         "two different unbound PVCs are counted towards the PV limit as two volumes",
 		},
 		// filterName:AzureDiskVolumeFilterType
 		{
@@ -2384,7 +2407,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "fits when node capacity >= new pod's AzureDisk volumes",
+			name:         "fits when node capacity >= new pod's AzureDisk volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2392,7 +2415,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "fit when node capacity < new pod's AzureDisk volumes",
+			name:         "fit when node capacity < new pod's AzureDisk volumes",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2400,7 +2423,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores non-AzureDisk volumes",
+			name:         "new pod's count ignores non-AzureDisk volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2408,7 +2431,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "existing pods' counts ignore non-AzureDisk volumes",
+			name:         "existing pods' counts ignore non-AzureDisk volumes",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2416,7 +2439,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count considers PVCs backed by AzureDisk volumes",
+			name:         "new pod's count considers PVCs backed by AzureDisk volumes",
 		},
 		{
 			newPod:       splitPVCPod(AzureDiskVolumeFilterType),
@@ -2424,7 +2447,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "new pod's count ignores PVCs not backed by AzureDisk volumes",
+			name:         "new pod's count ignores PVCs not backed by AzureDisk volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2432,7 +2455,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "existing pods' counts considers PVCs backed by AzureDisk volumes",
+			name:         "existing pods' counts considers PVCs backed by AzureDisk volumes",
 		},
 		{
 			newPod:       twoVolPod,
@@ -2440,7 +2463,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      4,
 			fits:         true,
-			test:         "already-mounted AzureDisk volumes are always ok to allow",
+			name:         "already-mounted AzureDisk volumes are always ok to allow",
 		},
 		{
 			newPod:       splitVolsPod,
@@ -2448,7 +2471,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "the same AzureDisk volumes are not counted multiple times",
+			name:         "the same AzureDisk volumes are not counted multiple times",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2456,7 +2479,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2464,7 +2487,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PVC is counted towards the PV limit",
+			name:         "pod with missing PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2472,7 +2495,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing two PVCs is counted towards the PV limit twice",
+			name:         "pod with missing two PVCs is counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2480,7 +2503,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2488,7 +2511,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with missing PV is counted towards the PV limit",
+			name:         "pod with missing PV is counted towards the PV limit",
 		},
 		{
 			newPod:       deletedPVPod2,
@@ -2496,7 +2519,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two pods missing the same PV are counted towards the PV limit only once",
+			name:         "two pods missing the same PV are counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherDeletedPVPod,
@@ -2504,7 +2527,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two pods missing different PVs are counted towards the PV limit twice",
+			name:         "two pods missing different PVs are counted towards the PV limit twice",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2512,7 +2535,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       onePVCPod(AzureDiskVolumeFilterType),
@@ -2520,7 +2543,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      3,
 			fits:         true,
-			test:         "pod with unbound PVC is counted towards the PV limit",
+			name:         "pod with unbound PVC is counted towards the PV limit",
 		},
 		{
 			newPod:       unboundPVCPod2,
@@ -2528,7 +2551,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
+			name:         "the same unbound PVC in multiple pods is counted towards the PV limit only once",
 		},
 		{
 			newPod:       anotherUnboundPVCPod,
@@ -2536,7 +2559,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 			filterName:   AzureDiskVolumeFilterType,
 			maxVols:      2,
 			fits:         true,
-			test:         "two different unbound PVCs are counted towards the PV limit as two volumes",
+			name:         "two different unbound PVCs are counted towards the PV limit as two volumes",
 		},
 	}
 
@@ -2591,18 +2614,20 @@ func TestVolumeCountConflicts(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrMaxVolumeCountExceeded}
 
 	for _, test := range tests {
-		os.Setenv(KubeMaxPDVols, strconv.Itoa(test.maxVols))
-		pred := NewMaxPDVolumeCountPredicate(test.filterName, pvInfo(test.filterName), pvcInfo(test.filterName))
-		fits, reasons, err := pred(test.newPod, PredicateMetadata(test.newPod, nil), schedulercache.NewNodeInfo(test.existingPods...))
-		if err != nil {
-			t.Errorf("[%s]%s: unexpected error: %v", test.filterName, test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("[%s]%s: unexpected failure reasons: %v, want: %v", test.filterName, test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("[%s]%s: expected %v, got %v", test.filterName, test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv(KubeMaxPDVols, strconv.Itoa(test.maxVols))
+			pred := NewMaxPDVolumeCountPredicate(test.filterName, pvInfo(test.filterName), pvcInfo(test.filterName))
+			fits, reasons, err := pred(test.newPod, PredicateMetadata(test.newPod, nil), schedulercache.NewNodeInfo(test.existingPods...))
+			if err != nil {
+				t.Errorf("[%s]: unexpected error: %v", test.filterName, err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("[%s]: unexpected failure reasons: %v, want: %v", test.filterName, reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("[%s]: expected %v, got %v", test.filterName, test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -2628,7 +2653,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 		nodeInfo *schedulercache.NodeInfo
 		node     *v1.Node
 		fits     bool
-		test     string
+		name     string
 		wErr     error
 		reasons  []algorithm.PredicateFailureReason
 	}{
@@ -2642,7 +2667,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 			},
 			fits: true,
 			wErr: nil,
-			test: "no resources/port/host requested always fits",
+			name: "no resources/port/host requested always fits",
 		},
 		{
 			pod: newResourcePod(schedulercache.Resource{MilliCPU: 8, Memory: 10}),
@@ -2658,7 +2683,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 				NewInsufficientResourceError(v1.ResourceCPU, 8, 5, 10),
 				NewInsufficientResourceError(v1.ResourceMemory, 10, 19, 20),
 			},
-			test: "not enough cpu and memory resource",
+			name: "not enough cpu and memory resource",
 		},
 		{
 			pod: &v1.Pod{
@@ -2674,7 +2699,7 @@ func TestRunGeneralPredicates(t *testing.T) {
 			fits:    false,
 			wErr:    nil,
 			reasons: []algorithm.PredicateFailureReason{ErrPodNotMatchHostName},
-			test:    "host not match",
+			name:    "host not match",
 		},
 		{
 			pod:      newPodWithPort(123),
@@ -2686,21 +2711,23 @@ func TestRunGeneralPredicates(t *testing.T) {
 			fits:    false,
 			wErr:    nil,
 			reasons: []algorithm.PredicateFailureReason{ErrPodNotFitsHostPorts},
-			test:    "hostport conflict",
+			name:    "hostport conflict",
 		},
 	}
 	for _, test := range resourceTests {
-		test.nodeInfo.SetNode(test.node)
-		fits, reasons, err := GeneralPredicates(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			test.nodeInfo.SetNode(test.node)
+			fits, reasons, err := GeneralPredicates(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, test.reasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, test.reasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -2718,14 +2745,14 @@ func TestInterPodAffinity(t *testing.T) {
 		pods                 []*v1.Pod
 		node                 *v1.Node
 		fits                 bool
-		test                 string
+		name                 string
 		expectFailureReasons []algorithm.PredicateFailureReason
 	}{
 		{
 			pod:  new(v1.Pod),
 			node: &node1,
 			fits: true,
-			test: "A pod that has no required pod affinity scheduling rules can schedule onto a node with no existing pods",
+			name: "A pod that has no required pod affinity scheduling rules can schedule onto a node with no existing pods",
 		},
 		{
 			pod: &v1.Pod{
@@ -2756,7 +2783,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node: &node1,
 			fits: true,
-			test: "satisfies with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using In operator that matches the existing pod",
+			name: "satisfies with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using In operator that matches the existing pod",
 		},
 		{
 			pod: &v1.Pod{
@@ -2787,7 +2814,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node: &node1,
 			fits: true,
-			test: "satisfies the pod with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using not in operator in labelSelector that matches the existing pod",
+			name: "satisfies the pod with requiredDuringSchedulingIgnoredDuringExecution in PodAffinity using not in operator in labelSelector that matches the existing pod",
 		},
 		{
 			pod: &v1.Pod{
@@ -2818,7 +2845,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods:                 []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel, Namespace: "ns"}}},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "Does not satisfy the PodAffinity with labelSelector because of diff Namespace",
+			name:                 "Does not satisfy the PodAffinity with labelSelector because of diff Namespace",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrPodAffinityRulesNotMatch},
 		},
 		{
@@ -2849,7 +2876,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods:                 []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "Doesn't satisfy the PodAffinity because of unmatching labelSelector with the existing pod",
+			name:                 "Doesn't satisfy the PodAffinity because of unmatching labelSelector with the existing pod",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrPodAffinityRulesNotMatch},
 		},
 		{
@@ -2898,7 +2925,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node: &node1,
 			fits: true,
-			test: "satisfies the PodAffinity with different label Operators in multiple RequiredDuringSchedulingIgnoredDuringExecution ",
+			name: "satisfies the PodAffinity with different label Operators in multiple RequiredDuringSchedulingIgnoredDuringExecution ",
 		},
 		{
 			pod: &v1.Pod{
@@ -2946,7 +2973,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods:                 []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "The labelSelector requirements(items of matchExpressions) are ANDed, the pod cannot schedule onto the node because one of the matchExpression item don't match.",
+			name:                 "The labelSelector requirements(items of matchExpressions) are ANDed, the pod cannot schedule onto the node because one of the matchExpression item don't match.",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrPodAffinityRulesNotMatch},
 		},
 		{
@@ -2994,7 +3021,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node: &node1,
 			fits: true,
-			test: "satisfies the PodAffinity and PodAntiAffinity with the existing pod",
+			name: "satisfies the PodAffinity and PodAntiAffinity with the existing pod",
 		},
 		{
 			pod: &v1.Pod{
@@ -3066,7 +3093,7 @@ func TestInterPodAffinity(t *testing.T) {
 			},
 			node: &node1,
 			fits: true,
-			test: "satisfies the PodAffinity and PodAntiAffinity and PodAntiAffinity symmetry with the existing pod",
+			name: "satisfies the PodAffinity and PodAntiAffinity and PodAntiAffinity symmetry with the existing pod",
 		},
 		{
 			pod: &v1.Pod{
@@ -3113,7 +3140,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods:                 []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "satisfies the PodAffinity but doesn't satisfies the PodAntiAffinity with the existing pod",
+			name:                 "satisfies the PodAffinity but doesn't satisfies the PodAntiAffinity with the existing pod",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrPodAntiAffinityRulesNotMatch},
 		},
 		{
@@ -3186,7 +3213,7 @@ func TestInterPodAffinity(t *testing.T) {
 			},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "satisfies the PodAffinity and PodAntiAffinity but doesn't satisfies PodAntiAffinity symmetry with the existing pod",
+			name:                 "satisfies the PodAffinity and PodAntiAffinity but doesn't satisfies PodAntiAffinity symmetry with the existing pod",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrExistingPodsAntiAffinityRulesNotMatch},
 		},
 		{
@@ -3218,7 +3245,7 @@ func TestInterPodAffinity(t *testing.T) {
 			pods:                 []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine2"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel}}},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "pod matches its own Label in PodAffinity and that matches the existing pod Labels",
+			name:                 "pod matches its own Label in PodAffinity and that matches the existing pod Labels",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrPodAffinityRulesNotMatch},
 		},
 		{
@@ -3254,7 +3281,7 @@ func TestInterPodAffinity(t *testing.T) {
 			},
 			node:                 &node1,
 			fits:                 false,
-			test:                 "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. doesn't satisfy PodAntiAffinity symmetry with the existing pod",
+			name:                 "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. doesn't satisfy PodAntiAffinity symmetry with the existing pod",
 			expectFailureReasons: []algorithm.PredicateFailureReason{ErrPodAffinityNotMatch, ErrExistingPodsAntiAffinityRulesNotMatch},
 		},
 		{
@@ -3290,33 +3317,35 @@ func TestInterPodAffinity(t *testing.T) {
 			},
 			node: &node1,
 			fits: true,
-			test: "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. satisfy PodAntiAffinity symmetry with the existing pod",
+			name: "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. satisfy PodAntiAffinity symmetry with the existing pod",
 		},
 	}
 
 	for _, test := range tests {
-		node := test.node
-		var podsOnNode []*v1.Pod
-		for _, pod := range test.pods {
-			if pod.Spec.NodeName == node.Name {
-				podsOnNode = append(podsOnNode, pod)
+		t.Run(test.name, func(t *testing.T) {
+			node := test.node
+			var podsOnNode []*v1.Pod
+			for _, pod := range test.pods {
+				if pod.Spec.NodeName == node.Name {
+					podsOnNode = append(podsOnNode, pod)
+				}
 			}
-		}
 
-		fit := PodAffinityChecker{
-			info:      FakeNodeInfo(*node),
-			podLister: schedulertesting.FakePodLister(test.pods),
-		}
-		nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
-		nodeInfo.SetNode(test.node)
-		nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
-		fits, reasons, _ := fit.InterPodAffinityMatches(test.pod, PredicateMetadata(test.pod, nodeInfoMap), nodeInfo)
-		if !fits && !reflect.DeepEqual(reasons, test.expectFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.expectFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.test, test.fits, fits)
-		}
+			fit := PodAffinityChecker{
+				info:      FakeNodeInfo(*node),
+				podLister: schedulertesting.FakePodLister(test.pods),
+			}
+			nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
+			nodeInfo.SetNode(test.node)
+			nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
+			fits, reasons, _ := fit.InterPodAffinityMatches(test.pod, PredicateMetadata(test.pod, nodeInfoMap), nodeInfo)
+			if !fits && !reflect.DeepEqual(reasons, test.expectFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, test.expectFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -3344,7 +3373,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 		nodes                             []v1.Node
 		nodesExpectAffinityFailureReasons [][]algorithm.PredicateFailureReason
 		fits                              map[string]bool
-		test                              string
+		name                              string
 		nometa                            bool
 	}{
 		{
@@ -3384,7 +3413,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"machine3": false,
 			},
 			nodesExpectAffinityFailureReasons: [][]algorithm.PredicateFailureReason{nil, nil, {ErrPodAffinityNotMatch, ErrPodAffinityRulesNotMatch}},
-			test: "A pod can be scheduled onto all the nodes that have the same topology key & label value with one of them has an existing pod that match the affinity rules",
+			name: "A pod can be scheduled onto all the nodes that have the same topology key & label value with one of them has an existing pod that match the affinity rules",
 		},
 		{
 			pod: &v1.Pod{
@@ -3437,7 +3466,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeA": false,
 				"nodeB": true,
 			},
-			test: "NodeA and nodeB have same topologyKey and label value. NodeA does not satisfy node affinity rule, but has an existing pod that match the inter pod affinity rule. The pod can be scheduled onto nodeB.",
+			name: "NodeA and nodeB have same topologyKey and label value. NodeA does not satisfy node affinity rule, but has an existing pod that match the inter pod affinity rule. The pod can be scheduled onto nodeB.",
 		},
 		{
 			pod: &v1.Pod{
@@ -3490,7 +3519,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeA": true,
 				"nodeB": true,
 			},
-			test: "The affinity rule is to schedule all of the pods of this collection to the same zone. The first pod of the collection " +
+			name: "The affinity rule is to schedule all of the pods of this collection to the same zone. The first pod of the collection " +
 				"should not be blocked from being scheduled onto any node, even there's no existing pod that match the rule anywhere.",
 		},
 		{
@@ -3528,7 +3557,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeA": false,
 				"nodeB": false,
 			},
-			test: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB.",
+			name: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB.",
 		},
 		{
 			pod: &v1.Pod{
@@ -3577,7 +3606,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeA": false,
 				"nodeB": true,
 			},
-			test: "This test ensures that anti-affinity matches a pod when all terms of the anti-affinity rule matches a pod.",
+			name: "This test ensures that anti-affinity matches a pod when all terms of the anti-affinity rule matches a pod.",
 		},
 		{
 			pod: &v1.Pod{
@@ -3616,7 +3645,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeB": false,
 				"nodeC": true,
 			},
-			test: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB but can be scheduled onto nodeC",
+			name: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB but can be scheduled onto nodeC",
 		},
 		{
 			pod: &v1.Pod{
@@ -3686,7 +3715,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeC": false,
 				"nodeD": true,
 			},
-			test:   "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. NodeC has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA, nodeB and nodeC but can be schedulerd onto nodeD",
+			name:   "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. NodeC has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA, nodeB and nodeC but can be schedulerd onto nodeD",
 			nometa: true,
 		},
 		{
@@ -3764,61 +3793,87 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				"nodeB": false,
 				"nodeC": true,
 			},
-			test: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA, nodeB, but can be scheduled onto nodeC (NodeC has an existing pod that match the inter pod affinity rule but in different namespace)",
+			name: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that match the inter pod affinity rule. The pod can not be scheduled onto nodeA, nodeB, but can be scheduled onto nodeC (NodeC has an existing pod that match the inter pod affinity rule but in different namespace)",
 		},
 	}
 
 	selectorExpectedFailureReasons := []algorithm.PredicateFailureReason{ErrNodeSelectorNotMatch}
 
 	for indexTest, test := range tests {
-		nodeListInfo := FakeNodeListInfo(test.nodes)
-		nodeInfoMap := make(map[string]*schedulercache.NodeInfo)
-		for i, node := range test.nodes {
-			var podsOnNode []*v1.Pod
-			for _, pod := range test.pods {
-				if pod.Spec.NodeName == node.Name {
-					podsOnNode = append(podsOnNode, pod)
-				}
-			}
+		t.Run(test.name, func(t *testing.T) {
+			testInterPodAffinityWithMultipleNodes(
+				selectorExpectedFailureReasons,
+				indexTest,
+				test.pod,
+				test.pods,
+				test.nodes,
+				test.nodesExpectAffinityFailureReasons,
+				test.fits,
+				test.nometa,
+				t,
+			)
+		})
+	}
+}
 
-			nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
-			nodeInfo.SetNode(&test.nodes[i])
-			nodeInfoMap[node.Name] = nodeInfo
+func testInterPodAffinityWithMultipleNodes(
+	selectorExpectedFailureReasons []algorithm.PredicateFailureReason,
+	indexTest int,
+	pod *v1.Pod,
+	pods []*v1.Pod,
+	nodes []v1.Node,
+	nodesExpectAffinityFailureReasons [][]algorithm.PredicateFailureReason,
+	testFits map[string]bool,
+	nometa bool,
+	t *testing.T,
+) {
+	nodeListInfo := FakeNodeListInfo(nodes)
+	nodeInfoMap := make(map[string]*schedulercache.NodeInfo)
+	for i, node := range nodes {
+		var podsOnNode []*v1.Pod
+		for _, pod := range pods {
+			if pod.Spec.NodeName == node.Name {
+				podsOnNode = append(podsOnNode, pod)
+			}
 		}
 
-		for indexNode, node := range test.nodes {
-			testFit := PodAffinityChecker{
-				info:      nodeListInfo,
-				podLister: schedulertesting.FakePodLister(test.pods),
-			}
+		nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
+		nodeInfo.SetNode(&nodes[i])
+		nodeInfoMap[node.Name] = nodeInfo
+	}
 
-			var meta algorithm.PredicateMetadata
-			if !test.nometa {
-				meta = PredicateMetadata(test.pod, nodeInfoMap)
-			}
+	for indexNode, node := range nodes {
+		testFit := PodAffinityChecker{
+			info:      nodeListInfo,
+			podLister: schedulertesting.FakePodLister(pods),
+		}
 
-			fits, reasons, _ := testFit.InterPodAffinityMatches(test.pod, meta, nodeInfoMap[node.Name])
-			if !fits && !reflect.DeepEqual(reasons, test.nodesExpectAffinityFailureReasons[indexNode]) {
-				t.Errorf("index: %d test: %s unexpected failure reasons: %v expect: %v", indexTest, test.test, reasons, test.nodesExpectAffinityFailureReasons[indexNode])
-			}
-			affinity := test.pod.Spec.Affinity
-			if affinity != nil && affinity.NodeAffinity != nil {
-				nodeInfo := schedulercache.NewNodeInfo()
-				nodeInfo.SetNode(&node)
-				nodeInfoMap := map[string]*schedulercache.NodeInfo{node.Name: nodeInfo}
-				fits2, reasons, err := PodMatchNodeSelector(test.pod, PredicateMetadata(test.pod, nodeInfoMap), nodeInfo)
-				if err != nil {
-					t.Errorf("%s: unexpected error: %v", test.test, err)
-				}
-				if !fits2 && !reflect.DeepEqual(reasons, selectorExpectedFailureReasons) {
-					t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, selectorExpectedFailureReasons)
-				}
-				fits = fits && fits2
-			}
+		var meta algorithm.PredicateMetadata
+		if !nometa {
+			meta = PredicateMetadata(pod, nodeInfoMap)
+		}
 
-			if fits != test.fits[node.Name] {
-				t.Errorf("%s: expected %v for %s got %v", test.test, test.fits[node.Name], node.Name, fits)
+		fits, reasons, _ := testFit.InterPodAffinityMatches(pod, meta, nodeInfoMap[node.Name])
+		if !fits && !reflect.DeepEqual(reasons, nodesExpectAffinityFailureReasons[indexNode]) {
+			t.Errorf("index: %d unexpected failure reasons: %v expect: %v", indexTest, reasons, nodesExpectAffinityFailureReasons[indexNode])
+		}
+		affinity := pod.Spec.Affinity
+		if affinity != nil && affinity.NodeAffinity != nil {
+			nodeInfo := schedulercache.NewNodeInfo()
+			nodeInfo.SetNode(&node)
+			nodeInfoMap := map[string]*schedulercache.NodeInfo{node.Name: nodeInfo}
+			fits2, reasons, err := PodMatchNodeSelector(pod, PredicateMetadata(pod, nodeInfoMap), nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
+			if !fits2 && !reflect.DeepEqual(reasons, selectorExpectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, selectorExpectedFailureReasons)
+			}
+			fits = fits && fits2
+		}
+
+		if fits != testFits[node.Name] {
+			t.Errorf("expected %v for %s got %v", testFits[node.Name], node.Name, fits)
 		}
 	}
 }
@@ -3828,7 +3883,7 @@ func TestPodToleratesTaints(t *testing.T) {
 		pod  *v1.Pod
 		node v1.Node
 		fits bool
-		test string
+		name string
 	}{
 		{
 			pod: &v1.Pod{
@@ -3842,7 +3897,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: false,
-			test: "a pod having no tolerations can't be scheduled onto a node with nonempty taints",
+			name: "a pod having no tolerations can't be scheduled onto a node with nonempty taints",
 		},
 		{
 			pod: &v1.Pod{
@@ -3860,7 +3915,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "a pod which can be scheduled on a dedicated node assigned to user1 with effect NoSchedule",
+			name: "a pod which can be scheduled on a dedicated node assigned to user1 with effect NoSchedule",
 		},
 		{
 			pod: &v1.Pod{
@@ -3878,7 +3933,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: false,
-			test: "a pod which can't be scheduled on a dedicated node assigned to user2 with effect NoSchedule",
+			name: "a pod which can't be scheduled on a dedicated node assigned to user2 with effect NoSchedule",
 		},
 		{
 			pod: &v1.Pod{
@@ -3896,7 +3951,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "a pod can be scheduled onto the node, with a toleration uses operator Exists that tolerates the taints on the node",
+			name: "a pod can be scheduled onto the node, with a toleration uses operator Exists that tolerates the taints on the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -3920,7 +3975,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "a pod has multiple tolerations, node has multiple taints, all the taints are tolerated, pod can be scheduled onto the node",
+			name: "a pod has multiple tolerations, node has multiple taints, all the taints are tolerated, pod can be scheduled onto the node",
 		},
 		{
 			pod: &v1.Pod{
@@ -3940,7 +3995,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: false,
-			test: "a pod has a toleration that keys and values match the taint on the node, but (non-empty) effect doesn't match, " +
+			name: "a pod has a toleration that keys and values match the taint on the node, but (non-empty) effect doesn't match, " +
 				"can't be scheduled onto the node",
 		},
 		{
@@ -3961,7 +4016,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "The pod has a toleration that keys and values match the taint on the node, the effect of toleration is empty, " +
+			name: "The pod has a toleration that keys and values match the taint on the node, the effect of toleration is empty, " +
 				"and the effect of taint is NoSchedule. Pod can be scheduled onto the node",
 		},
 		{
@@ -3982,7 +4037,7 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "The pod has a toleration that key and value don't match the taint on the node, " +
+			name: "The pod has a toleration that key and value don't match the taint on the node, " +
 				"but the effect of taint on node is PreferNochedule. Pod can be scheduled onto the node",
 		},
 		{
@@ -4002,25 +4057,27 @@ func TestPodToleratesTaints(t *testing.T) {
 				},
 			},
 			fits: true,
-			test: "The pod has no toleration, " +
+			name: "The pod has no toleration, " +
 				"but the effect of taint on node is PreferNochedule. Pod can be scheduled onto the node",
 		},
 	}
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrTaintsTolerationsNotMatch}
 
 	for _, test := range podTolerateTaintsTests {
-		nodeInfo := schedulercache.NewNodeInfo()
-		nodeInfo.SetNode(&test.node)
-		fits, reasons, err := PodToleratesNodeTaints(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s, unexpected error: %v", test.test, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s, unexpected failure reason: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s, expected: %v got %v", test.test, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeInfo := schedulercache.NewNodeInfo()
+			nodeInfo.SetNode(&test.node)
+			fits, reasons, err := PodToleratesNodeTaints(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reason: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected: %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -4121,16 +4178,18 @@ func TestPodSchedulesOnNodeWithMemoryPressureCondition(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrNodeUnderMemoryPressure}
 
 	for _, test := range tests {
-		fits, reasons, err := CheckNodeMemoryPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.name, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.name, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			fits, reasons, err := CheckNodeMemoryPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
@@ -4193,88 +4252,80 @@ func TestPodSchedulesOnNodeWithDiskPressureCondition(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrNodeUnderDiskPressure}
 
 	for _, test := range tests {
-		fits, reasons, err := CheckNodeDiskPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.name, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.name, test.fits, fits)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			fits, reasons, err := CheckNodeDiskPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.fits {
+				t.Errorf("expected %v got %v", test.fits, fits)
+			}
+		})
 	}
 }
 
 func TestNodeConditionPredicate(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		node        *v1.Node
 		schedulable bool
 	}{
-		// node1 considered
-		{
+		"node1 considered": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}}}},
 			schedulable: true,
 		},
-		// node2 ignored - node not Ready
-		{
+		"node2 ignored - node not Ready": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}}}},
 			schedulable: false,
 		},
-		// node3 ignored - node out of disk
-		{
+		"node3 ignored - node out of disk": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeOutOfDisk, Status: v1.ConditionTrue}}}},
 			schedulable: false,
 		},
-
-		// node4 considered
-		{
+		"node4 considered": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node4"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeOutOfDisk, Status: v1.ConditionFalse}}}},
 			schedulable: true,
 		},
-		// node5 ignored - node out of disk
-		{
+		"node5 ignored - node out of disk": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node5"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}, {Type: v1.NodeOutOfDisk, Status: v1.ConditionTrue}}}},
 			schedulable: false,
 		},
-		// node6 considered
-		{
+		"node6 considered": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node6"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}, {Type: v1.NodeOutOfDisk, Status: v1.ConditionFalse}}}},
 			schedulable: true,
 		},
-		// node7 ignored - node out of disk, node not Ready
-		{
+		"node7 ignored - node out of disk, node not Ready": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node7"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}, {Type: v1.NodeOutOfDisk, Status: v1.ConditionTrue}}}},
 			schedulable: false,
 		},
-		// node8 ignored - node not Ready
-		{
+		"node8 ignored - node not Ready": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node8"}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}, {Type: v1.NodeOutOfDisk, Status: v1.ConditionFalse}}}},
 			schedulable: false,
 		},
-		// node9 ignored - node unschedulable
-		{
+		"node9 ignored - node unschedulable": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node9"}, Spec: v1.NodeSpec{Unschedulable: true}},
 			schedulable: false,
 		},
-		// node10 considered
-		{
+		"node10 considered": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node10"}, Spec: v1.NodeSpec{Unschedulable: false}},
 			schedulable: true,
 		},
-		// node11 considered
-		{
+		"node11 considered": {
 			node:        &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node11"}},
 			schedulable: true,
 		},
 	}
 
-	for _, test := range tests {
-		nodeInfo := makeEmptyNodeInfo(test.node)
-		if fit, reasons, err := CheckNodeConditionPredicate(nil, nil, nodeInfo); fit != test.schedulable {
-			t.Errorf("%s: expected: %t, got %t; %+v, %v",
-				test.node.Name, test.schedulable, fit, reasons, err)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			nodeInfo := makeEmptyNodeInfo(test.node)
+			if fit, reasons, err := CheckNodeConditionPredicate(nil, nil, nodeInfo); fit != test.schedulable {
+				t.Errorf("%s: expected: %t, got %t; %+v, %v",
+					test.node.Name, test.schedulable, fit, reasons, err)
+			}
+		})
 	}
 }
 
@@ -4406,21 +4457,22 @@ func TestVolumeZonePredicate(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrVolumeZoneConflict}
 
 	for _, test := range tests {
-		fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
-		node := &schedulercache.NodeInfo{}
-		node.SetNode(test.Node)
+		t.Run(test.Name, func(t *testing.T) {
+			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
+			node := &schedulercache.NodeInfo{}
+			node.SetNode(test.Node)
 
-		fits, reasons, err := fit(test.Pod, nil, node)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.Name, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
-		}
-		if fits != test.Fits {
-			t.Errorf("%s: expected %v got %v", test.Name, test.Fits, fits)
-		}
-
+			fits, reasons, err := fit(test.Pod, nil, node)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.Fits {
+				t.Errorf("expected %v got %v", test.Fits, fits)
+			}
+		})
 	}
 }
 
@@ -4499,21 +4551,22 @@ func TestVolumeZonePredicateMultiZone(t *testing.T) {
 	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrVolumeZoneConflict}
 
 	for _, test := range tests {
-		fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
-		node := &schedulercache.NodeInfo{}
-		node.SetNode(test.Node)
+		t.Run(test.Name, func(t *testing.T) {
+			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
+			node := &schedulercache.NodeInfo{}
+			node.SetNode(test.Node)
 
-		fits, reasons, err := fit(test.Pod, nil, node)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.Name, err)
-		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
-		}
-		if fits != test.Fits {
-			t.Errorf("%s: expected %v got %v", test.Name, test.Fits, fits)
-		}
-
+			fits, reasons, err := fit(test.Pod, nil, node)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+				t.Errorf("unexpected failure reasons: %v, want: %v", reasons, expectedFailureReasons)
+			}
+			if fits != test.Fits {
+				t.Errorf("expected %v got %v", test.Fits, fits)
+			}
+		})
 	}
 }
 
@@ -4619,20 +4672,22 @@ func TestVolumeZonePredicateWithVolumeBinding(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fit := NewVolumeZonePredicate(pvInfo, pvcInfo, classInfo)
-		node := &schedulercache.NodeInfo{}
-		node.SetNode(test.Node)
+		t.Run(test.Name, func(t *testing.T) {
+			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, classInfo)
+			node := &schedulercache.NodeInfo{}
+			node.SetNode(test.Node)
 
-		fits, _, err := fit(test.Pod, nil, node)
-		if !test.ExpectFailure && err != nil {
-			t.Errorf("%s: unexpected error: %v", test.Name, err)
-		}
-		if test.ExpectFailure && err == nil {
-			t.Errorf("%s: expected error, got success", test.Name)
-		}
-		if fits != test.Fits {
-			t.Errorf("%s: expected %v got %v", test.Name, test.Fits, fits)
-		}
+			fits, _, err := fit(test.Pod, nil, node)
+			if !test.ExpectFailure && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if test.ExpectFailure && err == nil {
+				t.Errorf("expected error, got success")
+			}
+			if fits != test.Fits {
+				t.Errorf("expected %v got %v", test.Fits, fits)
+			}
+		})
 	}
 
 	err = utilfeature.DefaultFeatureGate.Set("VolumeScheduling=false")
@@ -4648,31 +4703,33 @@ func TestGetMaxVols(t *testing.T) {
 	tests := []struct {
 		rawMaxVols string
 		expected   int
-		test       string
+		name       string
 	}{
 		{
 			rawMaxVols: "invalid",
 			expected:   defaultValue,
-			test:       "Unable to parse maximum PD volumes value, using default value",
+			name:       "Unable to parse maximum PD volumes value, using default value",
 		},
 		{
 			rawMaxVols: "-2",
 			expected:   defaultValue,
-			test:       "Maximum PD volumes must be a positive value, using default value",
+			name:       "Maximum PD volumes must be a positive value, using default value",
 		},
 		{
 			rawMaxVols: "40",
 			expected:   40,
-			test:       "Parse maximum PD volumes value from env",
+			name:       "Parse maximum PD volumes value from env",
 		},
 	}
 
 	for _, test := range tests {
-		os.Setenv(KubeMaxPDVols, test.rawMaxVols)
-		result := getMaxVols(defaultValue)
-		if result != test.expected {
-			t.Errorf("%s: expected %v got %v", test.test, test.expected, result)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv(KubeMaxPDVols, test.rawMaxVols)
+			result := getMaxVols(defaultValue)
+			if result != test.expected {
+				t.Errorf("expected %v got %v", test.expected, result)
+			}
+		})
 	}
 
 	os.Unsetenv(KubeMaxPDVols)

--- a/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
+++ b/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
@@ -216,7 +216,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 		pods         []*v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			/*
@@ -233,7 +233,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "nothing scheduled, nothing requested",
+			name:         "nothing scheduled, nothing requested",
 		},
 		{
 			/*
@@ -250,7 +250,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 7}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "nothing scheduled, resources requested, differently sized machines",
+			name:         "nothing scheduled, resources requested, differently sized machines",
 		},
 		{
 			/*
@@ -267,7 +267,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "no resources requested, pods scheduled",
+			name:         "no resources requested, pods scheduled",
 			pods: []*v1.Pod{
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -290,7 +290,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 4}, {Host: "machine2", Score: 6}},
-			test:         "no resources requested, pods scheduled with resources",
+			name:         "no resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -313,7 +313,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 6}, {Host: "machine2", Score: 9}},
-			test:         "resources requested, pods scheduled with resources",
+			name:         "resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -334,7 +334,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 6}, {Host: "machine2", Score: 6}},
-			test:         "resources requested, pods scheduled with resources, differently sized machines",
+			name:         "resources requested, pods scheduled with resources, differently sized machines",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -355,7 +355,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuOnly},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
-			test:         "requested resources exceed node capacity",
+			name:         "requested resources exceed node capacity",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -365,7 +365,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
-			test:         "zero node resources, pods scheduled with resources",
+			name:         "zero node resources, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -389,7 +389,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 			},
 			nodes:        []*v1.Node{makeNode("machine3", 3500, 40000), makeNode("machine4", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine3", Score: 8}, {Host: "machine4", Score: 9}},
-			test:         "Include volume count on a node for balanced resource allocation",
+			name:         "Include volume count on a node for balanced resource allocation",
 			pods: []*v1.Pod{
 				{Spec: cpuAndMemory3},
 				{Spec: podwithVol1},
@@ -400,20 +400,22 @@ func TestBalancedResourceAllocation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
-		if len(test.pod.Spec.Volumes) > 0 {
-			maxVolumes := 5
-			for _, info := range nodeNameToInfo {
-				info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods(), maxVolumes)
-				info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			if len(test.pod.Spec.Volumes) > 0 {
+				maxVolumes := 5
+				for _, info := range nodeNameToInfo {
+					info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods(), maxVolumes)
+					info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
+				}
 			}
-		}
-		list, err := priorityFunction(BalancedResourceAllocationMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+			list, err := priorityFunction(BalancedResourceAllocationMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -267,7 +267,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 		pods         []*v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
@@ -277,7 +277,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test:         "all machines are same priority as Affinity is nil",
+			name:         "all machines are same priority as Affinity is nil",
 		},
 		// the node(machine1) that have the label {"region": "China"} (match the topology key) and that have existing pods that match the labelSelector get high score
 		// the node(machine3) that don't have the label {"region": "whatever the value is"} (mismatch the topology key) but that have existing pods that match the labelSelector get low score
@@ -295,7 +295,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test: "Affinity: pod that matches topology key & pods in nodes will get high score comparing to others" +
+			name: "Affinity: pod that matches topology key & pods in nodes will get high score comparing to others" +
 				"which doesn't match either pods in nodes or in topology key",
 		},
 		// the node1(machine1) that have the label {"region": "China"} (match the topology key) and that have existing pods that match the labelSelector get high score
@@ -313,7 +313,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelRgIndia}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: 0}},
-			test:         "All the nodes that have the same topology key & label value with one of them has an existing pod that match the affinity rules, have the same score",
+			name:         "All the nodes that have the same topology key & label value with one of them has an existing pod that match the affinity rules, have the same score",
 		},
 		// there are 2 regions, say regionChina(machine1,machine3,machine4) and regionIndia(machine2,machine5), both regions have nodes that match the preference.
 		// But there are more nodes(actually more existing pods) in regionChina that match the preference than regionIndia.
@@ -337,7 +337,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine5", Labels: labelRgIndia}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 5}, {Host: "machine3", Score: schedulerapi.MaxPriority}, {Host: "machine4", Score: schedulerapi.MaxPriority}, {Host: "machine5", Score: 5}},
-			test:         "Affinity: nodes in one region has more matching pods comparing to other reqion, so the region which has more macthes will get high score",
+			name:         "Affinity: nodes in one region has more matching pods comparing to other reqion, so the region which has more macthes will get high score",
 		},
 		// Test with the different operators and values for pod affinity scheduling preference, including some match failures.
 		{
@@ -353,7 +353,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 2}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: 0}},
-			test:         "Affinity: different Label operators and values for pod affinity scheduling preference, including some match failures ",
+			name:         "Affinity: different Label operators and values for pod affinity scheduling preference, including some match failures ",
 		},
 		// Test the symmetry cases for affinity, the difference between affinity and symmetry is not the pod wants to run together with some existing pods,
 		// but the existing pods have the inter pod affinity preference while the pod to schedule satisfy the preference.
@@ -369,7 +369,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: 0}},
-			test:         "Affinity symmetry: considred only the preferredDuringSchedulingIgnoredDuringExecution in pod affinity symmetry",
+			name:         "Affinity symmetry: considred only the preferredDuringSchedulingIgnoredDuringExecution in pod affinity symmetry",
 		},
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
@@ -383,7 +383,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: 0}},
-			test:         "Affinity symmetry: considred RequiredDuringSchedulingIgnoredDuringExecution in pod affinity symmetry",
+			name:         "Affinity symmetry: considred RequiredDuringSchedulingIgnoredDuringExecution in pod affinity symmetry",
 		},
 
 		// The pod to schedule prefer to stay away from some existing pods at node level using the pod anti affinity.
@@ -403,7 +403,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelRgChina}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "Anti Affinity: pod that doesnot match existing pods in node will get high score ",
+			name:         "Anti Affinity: pod that doesnot match existing pods in node will get high score ",
 		},
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: "", Affinity: awayFromS1InAz}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
@@ -416,7 +416,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelRgChina}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "Anti Affinity: pod that does not matches topology key & matches the pods in nodes will get higher score comparing to others ",
+			name:         "Anti Affinity: pod that does not matches topology key & matches the pods in nodes will get higher score comparing to others ",
 		},
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: "", Affinity: awayFromS1InAz}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
@@ -430,7 +430,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelRgIndia}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "Anti Affinity: one node has more matching pods comparing to other node, so the node which has more unmacthes will get high score",
+			name:         "Anti Affinity: one node has more matching pods comparing to other node, so the node which has more unmacthes will get high score",
 		},
 		// Test the symmetry cases for anti affinity
 		{
@@ -444,7 +444,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelAzAz2}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "Anti Affinity symmetry: the existing pods in node which has anti affinity match will get high score",
+			name:         "Anti Affinity symmetry: the existing pods in node which has anti affinity match will get high score",
 		},
 		// Test both  affinity and anti-affinity
 		{
@@ -458,7 +458,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelAzAz1}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}},
-			test:         "Affinity and Anti Affinity: considered only preferredDuringSchedulingIgnoredDuringExecution in both pod affinity & anti affinity",
+			name:         "Affinity and Anti Affinity: considered only preferredDuringSchedulingIgnoredDuringExecution in both pod affinity & anti affinity",
 		},
 		// Combined cases considering both affinity and anti-affinity, the pod to schedule and existing pods have the same labels (they are in the same RC/service),
 		// the pod prefer to run together with its brother pods in the same region, but wants to stay away from them at node level,
@@ -483,7 +483,7 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine5", Labels: labelRgIndia}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 4}, {Host: "machine3", Score: schedulerapi.MaxPriority}, {Host: "machine4", Score: schedulerapi.MaxPriority}, {Host: "machine5", Score: 4}},
-			test:         "Affinity and Anti Affinity: considering both affinity and anti-affinity, the pod to schedule and existing pods have the same labels",
+			name:         "Affinity and Anti Affinity: considering both affinity and anti-affinity, the pod to schedule and existing pods have the same labels",
 		},
 		// Consider Affinity, Anti Affinity and symmetry together.
 		// for Affinity, the weights are:                8,  0,  0,  0
@@ -505,24 +505,26 @@ func TestInterPodAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine4", Labels: labelAzAz2}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: schedulerapi.MaxPriority}, {Host: "machine4", Score: 0}},
-			test:         "Affinity and Anti Affinity and symmetry: considered only preferredDuringSchedulingIgnoredDuringExecution in both pod affinity & anti affinity & symmetry",
+			name:         "Affinity and Anti Affinity and symmetry: considered only preferredDuringSchedulingIgnoredDuringExecution in both pod affinity & anti affinity & symmetry",
 		},
 	}
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
-		interPodAffinity := InterPodAffinity{
-			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
-			podLister:             schedulertesting.FakePodLister(test.pods),
-			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
-		}
-		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			interPodAffinity := InterPodAffinity{
+				info:                  FakeNodeListInfo(test.nodes),
+				nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+				podLister:             schedulertesting.FakePodLister(test.pods),
+				hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
+			}
+			list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected \n\t%#v, \ngot \n\t%#v\n", test.expectedList, list)
+			}
+		})
 	}
 }
 
@@ -563,7 +565,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 		nodes                 []*v1.Node
 		hardPodAffinityWeight int32
 		expectedList          schedulerapi.HostPriorityList
-		test                  string
+		name                  string
 	}{
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelServiceS1}},
@@ -578,7 +580,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 			},
 			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 			expectedList:          []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: 0}},
-			test:                  "Hard Pod Affinity symmetry: hard pod affinity symmetry weights 1 by default, then nodes that match the hard pod affinity symmetry rules, get a high score",
+			name:                  "Hard Pod Affinity symmetry: hard pod affinity symmetry weights 1 by default, then nodes that match the hard pod affinity symmetry rules, get a high score",
 		},
 		{
 			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelServiceS1}},
@@ -593,23 +595,25 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 			},
 			hardPodAffinityWeight: 0,
 			expectedList:          []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test:                  "Hard Pod Affinity symmetry: hard pod affinity symmetry is closed(weights 0), then nodes that match the hard pod affinity symmetry rules, get same score with those not match",
+			name:                  "Hard Pod Affinity symmetry: hard pod affinity symmetry is closed(weights 0), then nodes that match the hard pod affinity symmetry rules, get same score with those not match",
 		},
 	}
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
-		ipa := InterPodAffinity{
-			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
-			podLister:             schedulertesting.FakePodLister(test.pods),
-			hardPodAffinityWeight: test.hardPodAffinityWeight,
-		}
-		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			ipa := InterPodAffinity{
+				info:                  FakeNodeListInfo(test.nodes),
+				nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+				podLister:             schedulertesting.FakePodLister(test.pods),
+				hardPodAffinityWeight: test.hardPodAffinityWeight,
+			}
+			list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected \n\t%#v, \ngot \n\t%#v\n", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/least_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/least_requested_test.go
@@ -94,7 +94,7 @@ func TestLeastRequested(t *testing.T) {
 		pods         []*v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			/*
@@ -111,7 +111,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "nothing scheduled, nothing requested",
+			name:         "nothing scheduled, nothing requested",
 		},
 		{
 			/*
@@ -128,7 +128,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 3}, {Host: "machine2", Score: 5}},
-			test:         "nothing scheduled, resources requested, differently sized machines",
+			name:         "nothing scheduled, resources requested, differently sized machines",
 		},
 		{
 			/*
@@ -145,7 +145,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
-			test:         "no resources requested, pods scheduled",
+			name:         "no resources requested, pods scheduled",
 			pods: []*v1.Pod{
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: machine1Spec, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -168,7 +168,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 7}, {Host: "machine2", Score: 5}},
-			test:         "no resources requested, pods scheduled with resources",
+			name:         "no resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -191,7 +191,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 5}, {Host: "machine2", Score: 4}},
-			test:         "resources requested, pods scheduled with resources",
+			name:         "resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -212,7 +212,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 50000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 5}, {Host: "machine2", Score: 6}},
-			test:         "resources requested, pods scheduled with resources, differently sized machines",
+			name:         "resources requested, pods scheduled with resources, differently sized machines",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -233,7 +233,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuOnly},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 5}, {Host: "machine2", Score: 2}},
-			test:         "requested resources exceed node capacity",
+			name:         "requested resources exceed node capacity",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -243,7 +243,7 @@ func TestLeastRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 0, 0), makeNode("machine2", 0, 0)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
-			test:         "zero node resources, pods scheduled with resources",
+			name:         "zero node resources, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -252,13 +252,15 @@ func TestLeastRequested(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
-		list, err := priorityFunction(LeastRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			list, err := priorityFunction(LeastRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -117,13 +117,13 @@ func TestPriorityMetadata(t *testing.T) {
 	}
 	tests := []struct {
 		pod      *v1.Pod
-		test     string
+		name     string
 		expected interface{}
 	}{
 		{
 			pod:      nil,
 			expected: nil,
-			test:     "pod is nil , priorityMetadata is nil",
+			name:     "pod is nil , priorityMetadata is nil",
 		},
 		{
 			pod: podWithTolerationsAndAffinity,
@@ -132,7 +132,7 @@ func TestPriorityMetadata(t *testing.T) {
 				podTolerations: tolerations,
 				affinity:       podAffinity,
 			},
-			test: "Produce a priorityMetadata with default requests",
+			name: "Produce a priorityMetadata with default requests",
 		},
 		{
 			pod: podWithTolerationsAndRequests,
@@ -141,7 +141,7 @@ func TestPriorityMetadata(t *testing.T) {
 				podTolerations: tolerations,
 				affinity:       nil,
 			},
-			test: "Produce a priorityMetadata with specified requests",
+			name: "Produce a priorityMetadata with specified requests",
 		},
 		{
 			pod: podWithAffinityAndRequests,
@@ -150,7 +150,7 @@ func TestPriorityMetadata(t *testing.T) {
 				podTolerations: nil,
 				affinity:       podAffinity,
 			},
-			test: "Produce a priorityMetadata with specified requests",
+			name: "Produce a priorityMetadata with specified requests",
 		},
 	}
 	mataDataProducer := NewPriorityMetadataFactory(
@@ -159,9 +159,11 @@ func TestPriorityMetadata(t *testing.T) {
 		schedulertesting.FakeReplicaSetLister([]*extensions.ReplicaSet{}),
 		schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
 	for _, test := range tests {
-		ptData := mataDataProducer(test.pod, nil)
-		if !reflect.DeepEqual(test.expected, ptData) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expected, ptData)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ptData := mataDataProducer(test.pod, nil)
+			if !reflect.DeepEqual(test.expected, ptData) {
+				t.Errorf("expected %#v, got %#v", test.expected, ptData)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/most_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/most_requested_test.go
@@ -109,7 +109,7 @@ func TestMostRequested(t *testing.T) {
 		pods         []*v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			/*
@@ -126,7 +126,7 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}},
-			test:         "nothing scheduled, nothing requested",
+			name:         "nothing scheduled, nothing requested",
 		},
 		{
 			/*
@@ -143,7 +143,7 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 6000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 6}, {Host: "machine2", Score: 5}},
-			test:         "nothing scheduled, resources requested, differently sized machines",
+			name:         "nothing scheduled, resources requested, differently sized machines",
 		},
 		{
 			/*
@@ -160,7 +160,7 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 3}, {Host: "machine2", Score: 4}},
-			test:         "no resources requested, pods scheduled with resources",
+			name:         "no resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels2}},
 				{Spec: cpuOnly, ObjectMeta: metav1.ObjectMeta{Labels: labels1}},
@@ -183,7 +183,7 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 10000, 20000), makeNode("machine2", 10000, 20000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 4}, {Host: "machine2", Score: 5}},
-			test:         "resources requested, pods scheduled with resources",
+			name:         "resources requested, pods scheduled with resources",
 			pods: []*v1.Pod{
 				{Spec: cpuOnly},
 				{Spec: cpuAndMemory},
@@ -204,18 +204,20 @@ func TestMostRequested(t *testing.T) {
 			pod:          &v1.Pod{Spec: bigCPUAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 10000, 8000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 4}, {Host: "machine2", Score: 2}},
-			test:         "resources requested with more than the node, pods scheduled with resources",
+			name:         "resources requested with more than the node, pods scheduled with resources",
 		},
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
-		list, err := priorityFunction(MostRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			list, err := priorityFunction(MostRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/node_affinity_test.go
+++ b/pkg/scheduler/algorithm/priorities/node_affinity_test.go
@@ -105,7 +105,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 		pod          *v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			pod: &v1.Pod{
@@ -119,7 +119,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test:         "all machines are same priority as NodeAffinity is nil",
+			name:         "all machines are same priority as NodeAffinity is nil",
 		},
 		{
 			pod: &v1.Pod{
@@ -133,7 +133,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test:         "no machine macthes preferred scheduling requirements in NodeAffinity of pod so all machines' priority is zero",
+			name:         "no machine macthes preferred scheduling requirements in NodeAffinity of pod so all machines' priority is zero",
 		},
 		{
 			pod: &v1.Pod{
@@ -147,7 +147,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine3", Labels: label3}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
-			test:         "only machine1 matches the preferred scheduling requirements of pod",
+			name:         "only machine1 matches the preferred scheduling requirements of pod",
 		},
 		{
 			pod: &v1.Pod{
@@ -161,19 +161,21 @@ func TestNodeAffinityPriority(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: label2}},
 			},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 1}, {Host: "machine5", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 3}},
-			test:         "all machines matches the preferred scheduling requirements of pod but with different priorities ",
+			name:         "all machines matches the preferred scheduling requirements of pod but with different priorities ",
 		},
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
-		nap := priorityFunction(CalculateNodeAffinityPriorityMap, CalculateNodeAffinityPriorityReduce, nil)
-		list, err := nap(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected %#v, \ngot      %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+			nap := priorityFunction(CalculateNodeAffinityPriorityMap, CalculateNodeAffinityPriorityReduce, nil)
+			list, err := nap(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, \ngot      %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/node_label_test.go
+++ b/pkg/scheduler/algorithm/priorities/node_label_test.go
@@ -36,7 +36,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 		label        string
 		presence     bool
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			nodes: []*v1.Node{
@@ -47,7 +47,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
 			label:        "baz",
 			presence:     true,
-			test:         "no match found, presence true",
+			name:         "no match found, presence true",
 		},
 		{
 			nodes: []*v1.Node{
@@ -58,7 +58,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
 			label:        "baz",
 			presence:     false,
-			test:         "no match found, presence false",
+			name:         "no match found, presence false",
 		},
 		{
 			nodes: []*v1.Node{
@@ -69,7 +69,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
 			label:        "foo",
 			presence:     true,
-			test:         "one match found, presence true",
+			name:         "one match found, presence true",
 		},
 		{
 			nodes: []*v1.Node{
@@ -80,7 +80,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
 			label:        "foo",
 			presence:     false,
-			test:         "one match found, presence false",
+			name:         "one match found, presence false",
 		},
 		{
 			nodes: []*v1.Node{
@@ -91,7 +91,7 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
 			label:        "bar",
 			presence:     true,
-			test:         "two matches found, presence true",
+			name:         "two matches found, presence true",
 		},
 		{
 			nodes: []*v1.Node{
@@ -102,25 +102,27 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}},
 			label:        "bar",
 			presence:     false,
-			test:         "two matches found, presence false",
+			name:         "two matches found, presence false",
 		},
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
-		labelPrioritizer := &NodeLabelPrioritizer{
-			label:    test.label,
-			presence: test.presence,
-		}
-		list, err := priorityFunction(labelPrioritizer.CalculateNodeLabelPriorityMap, nil, nil)(nil, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		// sort the two lists to avoid failures on account of different ordering
-		sort.Sort(test.expectedList)
-		sort.Sort(list)
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+			labelPrioritizer := &NodeLabelPrioritizer{
+				label:    test.label,
+				presence: test.presence,
+			}
+			list, err := priorityFunction(labelPrioritizer.CalculateNodeLabelPriorityMap, nil, nil)(nil, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			// sort the two lists to avoid failures on account of different ordering
+			sort.Sort(test.expectedList)
+			sort.Sort(list)
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
+++ b/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
@@ -84,7 +84,7 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 		pod          *v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			pod: &v1.Pod{
@@ -97,7 +97,7 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 			},
 			nodes:        testNodes,
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
-			test:         "pod managed by ReplicationController should avoid a node, this node get lowest priority score",
+			name:         "pod managed by ReplicationController should avoid a node, this node get lowest priority score",
 		},
 		{
 			pod: &v1.Pod{
@@ -110,7 +110,7 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 			},
 			nodes:        testNodes,
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
-			test:         "ownership by random controller should be ignored",
+			name:         "ownership by random controller should be ignored",
 		},
 		{
 			pod: &v1.Pod{
@@ -123,7 +123,7 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 			},
 			nodes:        testNodes,
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
-			test:         "owner without Controller field set should be ignored",
+			name:         "owner without Controller field set should be ignored",
 		},
 		{
 			pod: &v1.Pod{
@@ -136,21 +136,23 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 			},
 			nodes:        testNodes,
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: schedulerapi.MaxPriority}},
-			test:         "pod managed by ReplicaSet should avoid a node, this node get lowest priority score",
+			name:         "pod managed by ReplicaSet should avoid a node, this node get lowest priority score",
 		},
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
-		list, err := priorityFunction(CalculateNodePreferAvoidPodsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		// sort the two lists to avoid failures on account of different ordering
-		sort.Sort(test.expectedList)
-		sort.Sort(list)
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+			list, err := priorityFunction(CalculateNodePreferAvoidPodsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			// sort the two lists to avoid failures on account of different ordering
+			sort.Sort(test.expectedList)
+			sort.Sort(list)
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/resource_limits_test.go
+++ b/pkg/scheduler/algorithm/priorities/resource_limits_test.go
@@ -103,49 +103,50 @@ func TestResourceLimistPriority(t *testing.T) {
 		pod          *v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		{
 			pod:          &v1.Pod{Spec: noResources},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 10000), makeNode("machine2", 4000, 0), makeNode("machine3", 0, 10000), makeNode("machine4", 0, 0)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: 0}, {Host: "machine4", Score: 0}},
-			test:         "pod does not specify its resource limits",
+			name:         "pod does not specify its resource limits",
 		},
 		{
 			pod:          &v1.Pod{Spec: cpuOnly},
 			nodes:        []*v1.Node{makeNode("machine1", 3000, 10000), makeNode("machine2", 2000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 1}, {Host: "machine2", Score: 0}},
-			test:         "pod only specifies  cpu limits",
+			name:         "pod only specifies  cpu limits",
 		},
 		{
 			pod:          &v1.Pod{Spec: memOnly},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 4000), makeNode("machine2", 5000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}, {Host: "machine2", Score: 1}},
-			test:         "pod only specifies  mem limits",
+			name:         "pod only specifies  mem limits",
 		},
 		{
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 4000, 4000), makeNode("machine2", 5000, 10000)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 1}, {Host: "machine2", Score: 1}},
-			test:         "pod specifies both cpu and  mem limits",
+			name:         "pod specifies both cpu and  mem limits",
 		},
 		{
 			pod:          &v1.Pod{Spec: cpuAndMemory},
 			nodes:        []*v1.Node{makeNode("machine1", 0, 0)},
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: 0}},
-			test:         "node does not advertise its allocatables",
+			name:         "node does not advertise its allocatables",
 		},
 	}
 
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
-		list, err := priorityFunction(ResourceLimitsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+			list, err := priorityFunction(ResourceLimitsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			}
+		})
 	}
-
 }

--- a/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
+++ b/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
@@ -54,11 +54,11 @@ func TestTaintAndToleration(t *testing.T) {
 		pod          *v1.Pod
 		nodes        []*v1.Node
 		expectedList schedulerapi.HostPriorityList
-		test         string
+		name         string
 	}{
 		// basic test case
 		{
-			test: "node with taints tolerated by the pod, gets a higher score than those node with intolerable taints",
+			name: "node with taints tolerated by the pod, gets a higher score than those node with intolerable taints",
 			pod: podWithTolerations([]v1.Toleration{{
 				Key:      "foo",
 				Operator: v1.TolerationOpEqual,
@@ -84,7 +84,7 @@ func TestTaintAndToleration(t *testing.T) {
 		},
 		// the count of taints that are tolerated by pod, does not matter.
 		{
-			test: "the nodes that all of their taints are tolerated by the pod, get the same score, no matter how many tolerable taints a node has",
+			name: "the nodes that all of their taints are tolerated by the pod, get the same score, no matter how many tolerable taints a node has",
 			pod: podWithTolerations([]v1.Toleration{
 				{
 					Key:      "cpu-type",
@@ -127,7 +127,7 @@ func TestTaintAndToleration(t *testing.T) {
 		},
 		// the count of taints on a node that are not tolerated by pod, matters.
 		{
-			test: "the more intolerable taints a node has, the lower score it gets.",
+			name: "the more intolerable taints a node has, the lower score it gets.",
 			pod: podWithTolerations([]v1.Toleration{{
 				Key:      "foo",
 				Operator: v1.TolerationOpEqual,
@@ -163,7 +163,7 @@ func TestTaintAndToleration(t *testing.T) {
 		},
 		// taints-tolerations priority only takes care about the taints and tolerations that have effect PreferNoSchedule
 		{
-			test: "only taints and tolerations that have effect PreferNoSchedule are checked by taints-tolerations priority function",
+			name: "only taints and tolerations that have effect PreferNoSchedule are checked by taints-tolerations priority function",
 			pod: podWithTolerations([]v1.Toleration{
 				{
 					Key:      "cpu-type",
@@ -205,7 +205,7 @@ func TestTaintAndToleration(t *testing.T) {
 			},
 		},
 		{
-			test: "Default behaviour No taints and tolerations, lands on node with no taints",
+			name: "Default behaviour No taints and tolerations, lands on node with no taints",
 			//pod without tolerations
 			pod: podWithTolerations([]v1.Toleration{}),
 			nodes: []*v1.Node{
@@ -226,16 +226,17 @@ func TestTaintAndToleration(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
-		ttp := priorityFunction(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil)
-		list, err := ttp(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("%s, unexpected error: %v", test.test, err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
+			ttp := priorityFunction(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil)
+			list, err := ttp(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s,\nexpected:\n\t%+v,\ngot:\n\t%+v", test.test, test.expectedList, list)
-		}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, list)
+			}
+		})
 	}
-
 }

--- a/pkg/scheduler/algorithm/priorities/util/non_zero_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/non_zero_test.go
@@ -66,8 +66,10 @@ func TestGetNonzeroRequests(t *testing.T) {
 	}
 
 	for _, td := range tds {
-		realCPU, realMemory := GetNonzeroRequests(&td.requests)
-		assert.EqualValuesf(t, td.expectedCPU, realCPU, "Failed to test: %s", td.name)
-		assert.EqualValuesf(t, td.expectedMemory, realMemory, "Failed to test: %s", td.name)
+		t.Run(td.name, func(t *testing.T) {
+			realCPU, realMemory := GetNonzeroRequests(&td.requests)
+			assert.EqualValuesf(t, td.expectedCPU, realCPU, "Failed to test: %s", td.name)
+			assert.EqualValuesf(t, td.expectedMemory, realMemory, "Failed to test: %s", td.name)
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/util/topologies_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/topologies_test.go
@@ -59,8 +59,10 @@ func TestGetNamespacesFromPodAffinityTerm(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		realValue := GetNamespacesFromPodAffinityTerm(fakePod(), test.podAffinityTerm)
-		assert.EqualValuesf(t, test.expectedValue, realValue, "Failed to test: %s", test.name)
+		t.Run(test.name, func(t *testing.T) {
+			realValue := GetNamespacesFromPodAffinityTerm(fakePod(), test.podAffinityTerm)
+			assert.EqualValuesf(t, test.expectedValue, realValue, "Failed to test: %s", test.name)
+		})
 	}
 }
 
@@ -96,12 +98,14 @@ func TestPodMatchesTermsNamespaceAndSelector(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fakeTestPod := fakePod()
-		fakeTestPod.Namespace = test.podNamespaces
-		fakeTestPod.Labels = test.podLabels
+		t.Run(test.name, func(t *testing.T) {
+			fakeTestPod := fakePod()
+			fakeTestPod.Namespace = test.podNamespaces
+			fakeTestPod.Labels = test.podLabels
 
-		realValue := PodMatchesTermsNamespaceAndSelector(fakeTestPod, fakeNamespaces, fakeSelector)
-		assert.EqualValuesf(t, test.expectedResult, realValue, "Faild to test: %s", test.name)
+			realValue := PodMatchesTermsNamespaceAndSelector(fakeTestPod, fakeNamespaces, fakeSelector)
+			assert.EqualValuesf(t, test.expectedResult, realValue, "Faild to test: %s", test.name)
+		})
 	}
 
 }
@@ -248,7 +252,9 @@ func TestNodesHaveSameTopologyKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := NodesHaveSameTopologyKey(test.nodeA, test.nodeB, test.topologyKey)
-		assert.Equalf(t, test.expected, got, "Failed to test: %s", test.name)
+		t.Run(test.name, func(t *testing.T) {
+			got := NodesHaveSameTopologyKey(test.nodeA, test.nodeB, test.topologyKey)
+			assert.Equalf(t, test.expected, got, "Failed to test: %s", test.name)
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/util/util_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/util_test.go
@@ -109,11 +109,13 @@ func TestGetControllerRef(t *testing.T) {
 	}
 
 	for _, td := range tds {
-		realOR := GetControllerRef(&td.pod)
-		if td.expectedNil {
-			assert.Nilf(t, realOR, "Failed to test: %s", td.name)
-		} else {
-			assert.Equalf(t, &td.expectedOR, realOR, "Failed to test: %s", td.name)
-		}
+		t.Run(td.name, func(t *testing.T) {
+			realOR := GetControllerRef(&td.pod)
+			if td.expectedNil {
+				assert.Nilf(t, realOR, "Failed to test: %s", td.name)
+			} else {
+				assert.Equalf(t, &td.expectedOR, realOR, "Failed to test: %s", td.name)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package defaults
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -43,11 +44,13 @@ func TestCopyAndReplace(t *testing.T) {
 			expected:    sets.String{"A": sets.Empty{}, "B": sets.Empty{}},
 		},
 	}
-	for _, testCase := range testCases {
-		result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
-		if !result.Equal(testCase.expected) {
-			t.Errorf("expected %v got %v", testCase.expected, result)
-		}
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v/replace %v with %v", i, testCase.replaceWhat, testCase.replaceWith), func(t *testing.T) {
+			result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
+			if !result.Equal(testCase.expected) {
+				t.Errorf("expected %v got %v", testCase.expected, result)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package algorithmprovider
 
 import (
+	"fmt"
 	"testing"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -44,44 +45,52 @@ func TestDefaultConfigExists(t *testing.T) {
 
 func TestAlgorithmProviders(t *testing.T) {
 	for _, pn := range algorithmProviderNames {
-		p, err := factory.GetAlgorithmProvider(pn)
-		if err != nil {
-			t.Errorf("error retrieving '%s' provider: %v", pn, err)
-			break
-		}
-		if len(p.PriorityFunctionKeys) == 0 {
-			t.Errorf("%s algorithm provider shouldn't have 0 priority functions", pn)
-		}
-		for _, pf := range p.PriorityFunctionKeys.List() {
-			if !factory.IsPriorityFunctionRegistered(pf) {
-				t.Errorf("priority function %s is not registered but is used in the %s algorithm provider", pf, pn)
+		t.Run(fmt.Sprintf("providername/%s", pn), func(t *testing.T) {
+			p, err := factory.GetAlgorithmProvider(pn)
+			if err != nil {
+				t.Errorf("error retrieving provider: %v", err)
+				return
 			}
-		}
-		for _, fp := range p.FitPredicateKeys.List() {
-			if !factory.IsFitPredicateRegistered(fp) {
-				t.Errorf("fit predicate %s is not registered but is used in the %s algorithm provider", fp, pn)
+			if len(p.PriorityFunctionKeys) == 0 {
+				t.Errorf("algorithm provider shouldn't have 0 priority functions")
 			}
-		}
+			for _, pf := range p.PriorityFunctionKeys.List() {
+				t.Run(fmt.Sprintf("priorityfunctionkey/%s", pf), func(t *testing.T) {
+					if !factory.IsPriorityFunctionRegistered(pf) {
+						t.Errorf("priority function is not registered but is used in the algorithm provider")
+					}
+				})
+			}
+			for _, fp := range p.FitPredicateKeys.List() {
+				t.Run(fmt.Sprintf("fitpredicatekey/%s", fp), func(t *testing.T) {
+					if !factory.IsFitPredicateRegistered(fp) {
+						t.Errorf("fit predicate is not registered but is used in the algorithm provider")
+					}
+				})
+			}
+		})
 	}
 }
 
 func TestApplyFeatureGates(t *testing.T) {
 	for _, pn := range algorithmProviderNames {
-		p, err := factory.GetAlgorithmProvider(pn)
-		if err != nil {
-			t.Errorf("Error retrieving '%s' provider: %v", pn, err)
-			break
-		}
+		t.Run(fmt.Sprintf("providername/%s", pn), func(t *testing.T) {
+			p, err := factory.GetAlgorithmProvider(pn)
+			if err != nil {
+				t.Errorf("Error retrieving '%s' provider: %v", pn, err)
+				return
+			}
 
-		if !p.FitPredicateKeys.Has("CheckNodeCondition") {
-			t.Errorf("Failed to find predicate: 'CheckNodeCondition'")
-			break
-		}
+			if !p.FitPredicateKeys.Has("CheckNodeCondition") {
+				t.Errorf("Failed to find predicate: 'CheckNodeCondition'")
+				return
+			}
 
-		if !p.FitPredicateKeys.Has("PodToleratesNodeTaints") {
-			t.Errorf("Failed to find predicate: 'PodToleratesNodeTaints'")
-			break
-		}
+			if !p.FitPredicateKeys.Has("PodToleratesNodeTaints") {
+				t.Errorf("Failed to find predicate: 'PodToleratesNodeTaints'")
+				return
+			}
+		})
 	}
 
 	// Apply features for algorithm providers.
@@ -90,20 +99,22 @@ func TestApplyFeatureGates(t *testing.T) {
 	ApplyFeatureGates()
 
 	for _, pn := range algorithmProviderNames {
-		p, err := factory.GetAlgorithmProvider(pn)
-		if err != nil {
-			t.Errorf("Error retrieving '%s' provider: %v", pn, err)
-			break
-		}
+		t.Run(fmt.Sprintf("providername/%s", pn), func(t *testing.T) {
+			p, err := factory.GetAlgorithmProvider(pn)
+			if err != nil {
+				t.Errorf("Error retrieving '%s' provider: %v", pn, err)
+				return
+			}
 
-		if !p.FitPredicateKeys.Has("PodToleratesNodeTaints") {
-			t.Errorf("Failed to find predicate: 'PodToleratesNodeTaints'")
-			break
-		}
+			if !p.FitPredicateKeys.Has("PodToleratesNodeTaints") {
+				t.Errorf("Failed to find predicate: 'PodToleratesNodeTaints'")
+				return
+			}
 
-		if p.FitPredicateKeys.Has("CheckNodeCondition") {
-			t.Errorf("Unexpected predicate: 'CheckNodeCondition'")
-			break
-		}
+			if p.FitPredicateKeys.Has("CheckNodeCondition") {
+				t.Errorf("Unexpected predicate: 'CheckNodeCondition'")
+				return
+			}
+		})
 	}
 }

--- a/pkg/scheduler/api/validation/validation_test.go
+++ b/pkg/scheduler/api/validation/validation_test.go
@@ -25,47 +25,47 @@ import (
 )
 
 func TestValidatePolicy(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		policy   api.Policy
 		expected error
 	}{
-		{
+		"no weight defined in policy": {
 			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority"}}},
 			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
 		},
-		{
+		"policy weight is not positive": {
 			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}},
 			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
 		},
-		{
+		"valid weight priority": {
 			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}},
 			expected: nil,
 		},
-		{
+		"invalide negative weight policy": {
 			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}},
 			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
 		},
-		{
+		"policy weight exceeds maximum": {
 			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: api.MaxWeight}}},
 			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
 		},
-		{
+		"valid weight in policy extender config": {
 			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: 2}}},
 			expected: nil,
 		},
-		{
+		"invalid negative weight in policy extender config": {
 			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: -2}}},
 			expected: errors.New("Priority for extender http://127.0.0.1:8081/extender should have a positive weight applied to it"),
 		},
-		{
+		"valid filterverb and url prefix": {
 			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter"}}},
 			expected: nil,
 		},
-		{
+		"valid preemtverb and urlprefix": {
 			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", PreemptVerb: "preempt"}}},
 			expected: nil,
 		},
-		{
+		"invalid multiple extenders": {
 			policy: api.Policy{
 				ExtenderConfigs: []api.ExtenderConfig{
 					{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind"},
@@ -73,7 +73,7 @@ func TestValidatePolicy(t *testing.T) {
 				}},
 			expected: errors.New("Only one extender can implement bind, found 2"),
 		},
-		{
+		"invalid duplicate extender resource name": {
 			policy: api.Policy{
 				ExtenderConfigs: []api.ExtenderConfig{
 					{URLPrefix: "http://127.0.0.1:8081/extender", ManagedResources: []api.ExtenderManagedResource{{Name: "foo.com/bar"}}},
@@ -81,7 +81,7 @@ func TestValidatePolicy(t *testing.T) {
 				}},
 			expected: errors.New("Duplicate extender managed resource name foo.com/bar"),
 		},
-		{
+		"invalid extended resource name": {
 			policy: api.Policy{
 				ExtenderConfigs: []api.ExtenderConfig{
 					{URLPrefix: "http://127.0.0.1:8081/extender", ManagedResources: []api.ExtenderManagedResource{{Name: "kubernetes.io/foo"}}},
@@ -90,10 +90,12 @@ func TestValidatePolicy(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		actual := ValidatePolicy(test.policy)
-		if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
-			t.Errorf("expected: %s, actual: %s", test.expected, actual)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := ValidatePolicy(test.policy)
+			if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
+				t.Errorf("expected: %s, actual: %s", test.expected, actual)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -496,42 +496,67 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		extenders := []algorithm.SchedulerExtender{}
-		for ii := range test.extenders {
-			extenders = append(extenders, &test.extenders[ii])
+		t.Run(test.name, func(t *testing.T) {
+			testGenericSchedulerWithExtenders(
+				test.predicates,
+				test.prioritizers,
+				test.extenders,
+				test.extenderPredicates,
+				test.extenderPrioritizers,
+				test.nodes,
+				test.expectedHost,
+				test.expectsErr,
+				t,
+			)
+		})
+	}
+}
+func testGenericSchedulerWithExtenders(
+	predicates map[string]algorithm.FitPredicate,
+	prioritizers []algorithm.PriorityConfig,
+	testExtenders []FakeExtender,
+	extenderPredicates []fitPredicate,
+	extenderPrioritizers []priorityConfig,
+	nodes []string,
+	expectedHost string,
+	expectsErr bool,
+	t *testing.T,
+) {
+	extenders := []algorithm.SchedulerExtender{}
+	for ii := range testExtenders {
+		extenders = append(extenders, &testExtenders[ii])
+	}
+	cache := schedulercache.New(time.Duration(0), wait.NeverStop)
+	for _, name := range nodes {
+		cache.AddNode(createNode(name))
+	}
+	queue := NewSchedulingQueue()
+	scheduler := NewGenericScheduler(
+		cache,
+		nil,
+		queue,
+		predicates,
+		algorithm.EmptyPredicateMetadataProducer,
+		prioritizers,
+		algorithm.EmptyPriorityMetadataProducer,
+		extenders,
+		nil,
+		schedulertesting.FakePersistentVolumeClaimLister{},
+		false,
+		false)
+	podIgnored := &v1.Pod{}
+	machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(nodes)))
+	if expectsErr {
+		if err == nil {
+			t.Errorf("Unexpected non-error, machine %s", machine)
 		}
-		cache := schedulercache.New(time.Duration(0), wait.NeverStop)
-		for _, name := range test.nodes {
-			cache.AddNode(createNode(name))
+	} else {
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+			return
 		}
-		queue := NewSchedulingQueue()
-		scheduler := NewGenericScheduler(
-			cache,
-			nil,
-			queue,
-			test.predicates,
-			algorithm.EmptyPredicateMetadataProducer,
-			test.prioritizers,
-			algorithm.EmptyPriorityMetadataProducer,
-			extenders,
-			nil,
-			schedulertesting.FakePersistentVolumeClaimLister{},
-			false,
-			false)
-		podIgnored := &v1.Pod{}
-		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
-		if test.expectsErr {
-			if err == nil {
-				t.Errorf("Unexpected non-error for %s, machine %s", test.name, machine)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				continue
-			}
-			if test.expectedHost != machine {
-				t.Errorf("Failed : %s, Expected: %s, Saw: %s", test.name, test.expectedHost, machine)
-			}
+		if expectedHost != machine {
+			t.Errorf("Failed : Expected: %s, Saw: %s", expectedHost, machine)
 		}
 	}
 }

--- a/pkg/scheduler/core/scheduling_queue_test.go
+++ b/pkg/scheduler/core/scheduling_queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package core
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -375,6 +376,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 	updatedPods[3] = pods[3].DeepCopy()
 
 	tests := []struct {
+		name                   string
 		podsToAdd              []*v1.Pod
 		expectedMapAfterAdd    map[string]*v1.Pod
 		podsToUpdate           []*v1.Pod
@@ -383,6 +385,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 		expectedMapAfterDelete map[string]*v1.Pod
 	}{
 		{
+			name:      "create, update, delete subset of pods",
 			podsToAdd: []*v1.Pod{pods[0], pods[1], pods[2], pods[3]},
 			expectedMapAfterAdd: map[string]*v1.Pod{
 				util.GetPodFullName(pods[0]): pods[0],
@@ -404,6 +407,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 			},
 		},
 		{
+			name:      "create, update, delete all",
 			podsToAdd: []*v1.Pod{pods[0], pods[3]},
 			expectedMapAfterAdd: map[string]*v1.Pod{
 				util.GetPodFullName(pods[0]): pods[0],
@@ -418,6 +422,7 @@ func TestUnschedulablePodsMap(t *testing.T) {
 			expectedMapAfterDelete: map[string]*v1.Pod{},
 		},
 		{
+			name:      "delete non-existing and existing pods",
 			podsToAdd: []*v1.Pod{pods[1], pods[2]},
 			expectedMapAfterAdd: map[string]*v1.Pod{
 				util.GetPodFullName(pods[1]): pods[1],
@@ -436,34 +441,36 @@ func TestUnschedulablePodsMap(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		upm := newUnschedulablePodsMap()
-		for _, p := range test.podsToAdd {
-			upm.addOrUpdate(p)
-		}
-		if !reflect.DeepEqual(upm.pods, test.expectedMapAfterAdd) {
-			t.Errorf("#%d: Unexpected map after adding pods. Expected: %v, got: %v",
-				i, test.expectedMapAfterAdd, upm.pods)
-		}
-
-		if len(test.podsToUpdate) > 0 {
-			for _, p := range test.podsToUpdate {
+		t.Run(fmt.Sprintf("%v/%v", i, test.name), func(t *testing.T) {
+			upm := newUnschedulablePodsMap()
+			for _, p := range test.podsToAdd {
 				upm.addOrUpdate(p)
 			}
-			if !reflect.DeepEqual(upm.pods, test.expectedMapAfterUpdate) {
-				t.Errorf("#%d: Unexpected map after updating pods. Expected: %v, got: %v",
-					i, test.expectedMapAfterUpdate, upm.pods)
+			if !reflect.DeepEqual(upm.pods, test.expectedMapAfterAdd) {
+				t.Errorf("Unexpected map after adding pods. Expected: %v, got: %v",
+					test.expectedMapAfterAdd, upm.pods)
 			}
-		}
-		for _, p := range test.podsToDelete {
-			upm.delete(p)
-		}
-		if !reflect.DeepEqual(upm.pods, test.expectedMapAfterDelete) {
-			t.Errorf("#%d: Unexpected map after deleting pods. Expected: %v, got: %v",
-				i, test.expectedMapAfterDelete, upm.pods)
-		}
-		upm.clear()
-		if len(upm.pods) != 0 {
-			t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.pods))
-		}
+
+			if len(test.podsToUpdate) > 0 {
+				for _, p := range test.podsToUpdate {
+					upm.addOrUpdate(p)
+				}
+				if !reflect.DeepEqual(upm.pods, test.expectedMapAfterUpdate) {
+					t.Errorf("Unexpected map after updating pods. Expected: %v, got: %v",
+						test.expectedMapAfterUpdate, upm.pods)
+				}
+			}
+			for _, p := range test.podsToDelete {
+				upm.delete(p)
+			}
+			if !reflect.DeepEqual(upm.pods, test.expectedMapAfterDelete) {
+				t.Errorf("Unexpected map after deleting pods. Expected: %v, got: %v",
+					test.expectedMapAfterDelete, upm.pods)
+			}
+			upm.clear()
+			if len(upm.pods) != 0 {
+				t.Errorf("Expected the map to be empty, but has %v elements.", len(upm.pods))
+			}
+		})
 	}
 }

--- a/pkg/scheduler/factory/cache_comparer_test.go
+++ b/pkg/scheduler/factory/cache_comparer_test.go
@@ -27,27 +27,25 @@ import (
 )
 
 func TestCompareNodes(t *testing.T) {
-	compare := compareStrategy{}
-
-	tests := []struct {
+	tests := map[string]struct {
 		actual    []string
 		cached    []string
 		missing   []string
 		redundant []string
 	}{
-		{
+		"redundant cached value": {
 			actual:    []string{"foo", "bar"},
 			cached:    []string{"bar", "foo", "foobar"},
 			missing:   []string{},
 			redundant: []string{"foobar"},
 		},
-		{
+		"missing cached value": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foo"},
 			missing:   []string{"foobar"},
 			redundant: []string{},
 		},
-		{
+		"proper cache set": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foobar", "foo"},
 			missing:   []string{},
@@ -55,77 +53,82 @@ func TestCompareNodes(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		nodes := []*v1.Node{}
-		for _, nodeName := range test.actual {
-			node := &v1.Node{}
-			node.Name = nodeName
-			nodes = append(nodes, node)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testCompareNodes(test.actual, test.cached, test.missing, test.redundant, t)
+		})
+	}
+}
 
-		nodeInfo := make(map[string]*schedulercache.NodeInfo)
-		for _, nodeName := range test.cached {
-			nodeInfo[nodeName] = &schedulercache.NodeInfo{}
-		}
+func testCompareNodes(actual, cached, missing, redundant []string, t *testing.T) {
+	compare := compareStrategy{}
+	nodes := []*v1.Node{}
+	for _, nodeName := range actual {
+		node := &v1.Node{}
+		node.Name = nodeName
+		nodes = append(nodes, node)
+	}
 
-		m, r := compare.CompareNodes(nodes, nodeInfo)
+	nodeInfo := make(map[string]*schedulercache.NodeInfo)
+	for _, nodeName := range cached {
+		nodeInfo[nodeName] = &schedulercache.NodeInfo{}
+	}
 
-		if !reflect.DeepEqual(m, test.missing) {
-			t.Errorf("missing expected to be %s; got %s", test.missing, m)
-		}
+	m, r := compare.CompareNodes(nodes, nodeInfo)
 
-		if !reflect.DeepEqual(r, test.redundant) {
-			t.Errorf("redundant expected to be %s; got %s", test.redundant, r)
-		}
+	if !reflect.DeepEqual(m, missing) {
+		t.Errorf("missing expected to be %s; got %s", missing, m)
+	}
+
+	if !reflect.DeepEqual(r, redundant) {
+		t.Errorf("redundant expected to be %s; got %s", redundant, r)
 	}
 }
 
 func TestComparePods(t *testing.T) {
-	compare := compareStrategy{}
-
-	tests := []struct {
+	tests := map[string]struct {
 		actual    []string
 		cached    []string
 		queued    []string
 		missing   []string
 		redundant []string
 	}{
-		{
+		"redundant cached value": {
 			actual:    []string{"foo", "bar"},
 			cached:    []string{"bar", "foo", "foobar"},
 			queued:    []string{},
 			missing:   []string{},
 			redundant: []string{"foobar"},
 		},
-		{
+		"redundant and queued values": {
 			actual:    []string{"foo", "bar"},
 			cached:    []string{"foo", "foobar"},
 			queued:    []string{"bar"},
 			missing:   []string{},
 			redundant: []string{"foobar"},
 		},
-		{
+		"missing cached value": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foo"},
 			queued:    []string{},
 			missing:   []string{"foobar"},
 			redundant: []string{},
 		},
-		{
+		"missing and queued values": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"foo"},
 			queued:    []string{"bar"},
 			missing:   []string{"foobar"},
 			redundant: []string{},
 		},
-		{
+		"correct cache set": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foobar", "foo"},
 			queued:    []string{},
 			missing:   []string{},
 			redundant: []string{},
 		},
-		{
+		"queued cache value": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"foobar", "foo"},
 			queued:    []string{"bar"},
@@ -134,65 +137,70 @@ func TestComparePods(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		pods := []*v1.Pod{}
-		for _, uid := range test.actual {
-			pod := &v1.Pod{}
-			pod.UID = types.UID(uid)
-			pods = append(pods, pod)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testComparePods(test.actual, test.cached, test.queued, test.missing, test.redundant, t)
+		})
+	}
+}
 
-		queuedPods := []*v1.Pod{}
-		for _, uid := range test.queued {
-			pod := &v1.Pod{}
-			pod.UID = types.UID(uid)
-			queuedPods = append(queuedPods, pod)
-		}
+func testComparePods(actual, cached, queued, missing, redundant []string, t *testing.T) {
+	compare := compareStrategy{}
+	pods := []*v1.Pod{}
+	for _, uid := range actual {
+		pod := &v1.Pod{}
+		pod.UID = types.UID(uid)
+		pods = append(pods, pod)
+	}
 
-		nodeInfo := make(map[string]*schedulercache.NodeInfo)
-		for _, uid := range test.cached {
-			pod := &v1.Pod{}
-			pod.UID = types.UID(uid)
-			pod.Namespace = "ns"
-			pod.Name = uid
+	queuedPods := []*v1.Pod{}
+	for _, uid := range queued {
+		pod := &v1.Pod{}
+		pod.UID = types.UID(uid)
+		queuedPods = append(queuedPods, pod)
+	}
 
-			nodeInfo[uid] = schedulercache.NewNodeInfo(pod)
-		}
+	nodeInfo := make(map[string]*schedulercache.NodeInfo)
+	for _, uid := range cached {
+		pod := &v1.Pod{}
+		pod.UID = types.UID(uid)
+		pod.Namespace = "ns"
+		pod.Name = uid
 
-		m, r := compare.ComparePods(pods, queuedPods, nodeInfo)
+		nodeInfo[uid] = schedulercache.NewNodeInfo(pod)
+	}
 
-		if !reflect.DeepEqual(m, test.missing) {
-			t.Errorf("missing expected to be %s; got %s", test.missing, m)
-		}
+	m, r := compare.ComparePods(pods, queuedPods, nodeInfo)
 
-		if !reflect.DeepEqual(r, test.redundant) {
-			t.Errorf("redundant expected to be %s; got %s", test.redundant, r)
-		}
+	if !reflect.DeepEqual(m, missing) {
+		t.Errorf("missing expected to be %s; got %s", missing, m)
+	}
+
+	if !reflect.DeepEqual(r, redundant) {
+		t.Errorf("redundant expected to be %s; got %s", redundant, r)
 	}
 }
 
 func TestComparePdbs(t *testing.T) {
-	compare := compareStrategy{}
-
-	tests := []struct {
+	tests := map[string]struct {
 		actual    []string
 		cached    []string
 		missing   []string
 		redundant []string
 	}{
-		{
+		"redundant cache value": {
 			actual:    []string{"foo", "bar"},
 			cached:    []string{"bar", "foo", "foobar"},
 			missing:   []string{},
 			redundant: []string{"foobar"},
 		},
-		{
+		"missing cache value": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foo"},
 			missing:   []string{"foobar"},
 			redundant: []string{},
 		},
-		{
+		"correct cache": {
 			actual:    []string{"foo", "bar", "foobar"},
 			cached:    []string{"bar", "foobar", "foo"},
 			missing:   []string{},
@@ -200,29 +208,36 @@ func TestComparePdbs(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		pdbs := []*policy.PodDisruptionBudget{}
-		for _, uid := range test.actual {
-			pdb := &policy.PodDisruptionBudget{}
-			pdb.UID = types.UID(uid)
-			pdbs = append(pdbs, pdb)
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testComparePdbs(test.actual, test.cached, test.missing, test.redundant, t)
+		})
+	}
+}
 
-		cache := make(map[string]*policy.PodDisruptionBudget)
-		for _, uid := range test.cached {
-			pdb := &policy.PodDisruptionBudget{}
-			pdb.UID = types.UID(uid)
-			cache[uid] = pdb
-		}
+func testComparePdbs(actual, cached, missing, redundant []string, t *testing.T) {
+	compare := compareStrategy{}
+	pdbs := []*policy.PodDisruptionBudget{}
+	for _, uid := range actual {
+		pdb := &policy.PodDisruptionBudget{}
+		pdb.UID = types.UID(uid)
+		pdbs = append(pdbs, pdb)
+	}
 
-		m, r := compare.ComparePdbs(pdbs, cache)
+	cache := make(map[string]*policy.PodDisruptionBudget)
+	for _, uid := range cached {
+		pdb := &policy.PodDisruptionBudget{}
+		pdb.UID = types.UID(uid)
+		cache[uid] = pdb
+	}
 
-		if !reflect.DeepEqual(m, test.missing) {
-			t.Errorf("missing expected to be %s; got %s", test.missing, m)
-		}
+	m, r := compare.ComparePdbs(pdbs, cache)
 
-		if !reflect.DeepEqual(r, test.redundant) {
-			t.Errorf("redundant expected to be %s; got %s", test.redundant, r)
-		}
+	if !reflect.DeepEqual(m, missing) {
+		t.Errorf("missing expected to be %s; got %s", missing, m)
+	}
+
+	if !reflect.DeepEqual(r, redundant) {
+		t.Errorf("redundant expected to be %s; got %s", redundant, r)
 	}
 }

--- a/pkg/scheduler/factory/plugins_test.go
+++ b/pkg/scheduler/factory/plugins_test.go
@@ -34,14 +34,18 @@ func TestAlgorithmNameValidation(t *testing.T) {
 		"Some,Alg:orithm",
 	}
 	for _, name := range algorithmNamesShouldValidate {
-		if !validName.MatchString(name) {
-			t.Errorf("%v should be a valid algorithm name but is not valid.", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !validName.MatchString(name) {
+				t.Errorf("should be a valid algorithm name but is not valid.")
+			}
+		})
 	}
 	for _, name := range algorithmNamesShouldNotValidate {
-		if validName.MatchString(name) {
-			t.Errorf("%v should be an invalid algorithm name but is valid.", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if validName.MatchString(name) {
+				t.Errorf("should be an invalid algorithm name but is valid.")
+			}
+		})
 	}
 }
 
@@ -68,15 +72,17 @@ func TestValidatePriorityConfigOverFlow(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		err := validateSelectedConfigs(test.configs)
-		if test.expected {
-			if err == nil {
-				t.Errorf("Expected Overflow for %s", test.description)
+		t.Run(test.description, func(t *testing.T) {
+			err := validateSelectedConfigs(test.configs)
+			if test.expected {
+				if err == nil {
+					t.Errorf("Expected Overflow")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Did not expect an overflow")
+				}
 			}
-		} else {
-			if err != nil {
-				t.Errorf("Did not expect an overflow for %s", test.description)
-			}
-		}
+		})
 	}
 }

--- a/pkg/scheduler/schedulercache/cache_test.go
+++ b/pkg/scheduler/schedulercache/cache_test.go
@@ -90,134 +90,148 @@ func TestAssumePodScheduled(t *testing.T) {
 	}
 
 	tests := []struct {
-		pods []*v1.Pod
-
+		pods      []*v1.Pod
+		name      string
 		wNodeInfo *NodeInfo
-	}{{
-		pods: []*v1.Pod{testPods[0]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU: 100,
-				Memory:   500,
+	}{
+		{
+			name: fmt.Sprintf("%v", testPods[0].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[0]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU: 100,
+					Memory:   500,
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: 100,
+					Memory:   500,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[0]},
+				usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: 100,
-				Memory:   500,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[0]},
-			usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			imageSizes:          map[string]int64{},
 		},
-	}, {
-		pods: []*v1.Pod{testPods[1], testPods[2]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU: 300,
-				Memory:   1524,
+		{
+			name: fmt.Sprintf("%v/%v", testPods[1].ObjectMeta.Name, testPods[2].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[1], testPods[2]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU: 300,
+					Memory:   1524,
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: 300,
+					Memory:   1524,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[1], testPods[2]},
+				usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: 300,
-				Memory:   1524,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[1], testPods[2]},
-			usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
-			imageSizes:          map[string]int64{},
 		},
-	}, { // test non-zero request
-		pods: []*v1.Pod{testPods[3]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU: 0,
-				Memory:   0,
+		{ // test non-zero request
+			name: fmt.Sprintf("%v", testPods[3].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[3]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU: 0,
+					Memory:   0,
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: priorityutil.DefaultMilliCPURequest,
+					Memory:   priorityutil.DefaultMemoryRequest,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[3]},
+				usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: priorityutil.DefaultMilliCPURequest,
-				Memory:   priorityutil.DefaultMemoryRequest,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[3]},
-			usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			imageSizes:          map[string]int64{},
 		},
-	}, {
-		pods: []*v1.Pod{testPods[4]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU:        100,
-				Memory:          500,
-				ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 3},
+		{
+			name: fmt.Sprintf("%v/example.com/foo:3", testPods[4].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[4]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU:        100,
+					Memory:          500,
+					ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 3},
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: 100,
+					Memory:   500,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[4]},
+				usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: 100,
-				Memory:   500,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[4]},
-			usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			imageSizes:          map[string]int64{},
 		},
-	}, {
-		pods: []*v1.Pod{testPods[4], testPods[5]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU:        300,
-				Memory:          1524,
-				ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 8},
+		{
+			name: fmt.Sprintf("%v/%v/example.com/foo:5", testPods[4].ObjectMeta.Name, testPods[5].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[4], testPods[5]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU:        300,
+					Memory:          1524,
+					ScalarResources: map[v1.ResourceName]int64{"example.com/foo": 8},
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: 300,
+					Memory:   1524,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[4], testPods[5]},
+				usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: 300,
-				Memory:   1524,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[4], testPods[5]},
-			usedPorts:           newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).add("TCP", "127.0.0.1", 8080).build(),
-			imageSizes:          map[string]int64{},
 		},
-	}, {
-		pods: []*v1.Pod{testPods[6]},
-		wNodeInfo: &NodeInfo{
-			requestedResource: &Resource{
-				MilliCPU: 100,
-				Memory:   500,
+		{
+			name: fmt.Sprintf("%v/random-invalid-extended-key:100", testPods[6].ObjectMeta.Name),
+			pods: []*v1.Pod{testPods[6]},
+			wNodeInfo: &NodeInfo{
+				requestedResource: &Resource{
+					MilliCPU: 100,
+					Memory:   500,
+				},
+				nonzeroRequest: &Resource{
+					MilliCPU: 100,
+					Memory:   500,
+				},
+				TransientInfo:       newTransientSchedulerInfo(),
+				allocatableResource: &Resource{},
+				pods:                []*v1.Pod{testPods[6]},
+				usedPorts:           newHostPortInfoBuilder().build(),
+				imageSizes:          map[string]int64{},
 			},
-			nonzeroRequest: &Resource{
-				MilliCPU: 100,
-				Memory:   500,
-			},
-			TransientInfo:       newTransientSchedulerInfo(),
-			allocatableResource: &Resource{},
-			pods:                []*v1.Pod{testPods[6]},
-			usedPorts:           newHostPortInfoBuilder().build(),
-			imageSizes:          map[string]int64{},
 		},
-	},
 	}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		for _, pod := range tt.pods {
-			if err := cache.AssumePod(pod); err != nil {
-				t.Fatalf("AssumePod failed: %v", err)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			for _, pod := range tt.pods {
+				if err := cache.AssumePod(pod); err != nil {
+					t.Fatalf("AssumePod failed: %v", err)
+				}
 			}
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
 
-		for _, pod := range tt.pods {
-			if err := cache.ForgetPod(pod); err != nil {
-				t.Fatalf("ForgetPod failed: %v", err)
+			for _, pod := range tt.pods {
+				if err := cache.ForgetPod(pod); err != nil {
+					t.Fatalf("ForgetPod failed: %v", err)
+				}
 			}
-		}
-		if cache.nodes[nodeName] != nil {
-			t.Errorf("NodeInfo should be cleaned for %s", nodeName)
-		}
+			if cache.nodes[nodeName] != nil {
+				t.Errorf("NodeInfo should be cleaned for %s", nodeName)
+			}
+		})
 	}
 }
 
@@ -248,15 +262,17 @@ func TestExpirePod(t *testing.T) {
 	tests := []struct {
 		pods        []*testExpirePodStruct
 		cleanupTime time.Time
-
-		wNodeInfo *NodeInfo
-	}{{ // assumed pod would expires
+		name        string
+		wNodeInfo   *NodeInfo
+	}{{
+		name: "assumed pod would expires",
 		pods: []*testExpirePodStruct{
 			{pod: testPods[0], assumedTime: now},
 		},
 		cleanupTime: now.Add(2 * ttl),
 		wNodeInfo:   nil,
-	}, { // first one would expire, second one would not.
+	}, {
+		name: "first one would expire, second one would not.",
 		pods: []*testExpirePodStruct{
 			{pod: testPods[0], assumedTime: now},
 			{pod: testPods[1], assumedTime: now.Add(3 * ttl / 2)},
@@ -280,17 +296,19 @@ func TestExpirePod(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
 
-		for _, pod := range tt.pods {
-			if err := assumeAndFinishBinding(cache, pod.pod, pod.assumedTime); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+			for _, pod := range tt.pods {
+				if err := assumeAndFinishBinding(cache, pod.pod, pod.assumedTime); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		// pods that have assumedTime + ttl < cleanupTime will get expired and removed
-		cache.cleanupAssumedPods(tt.cleanupTime)
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			// pods that have assumedTime + ttl < cleanupTime will get expired and removed
+			cache.cleanupAssumedPods(tt.cleanupTime)
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -310,9 +328,10 @@ func TestAddPodWillConfirm(t *testing.T) {
 	tests := []struct {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
-
-		wNodeInfo *NodeInfo
-	}{{ // two pod were assumed at same time. But first one is called Add() and gets confirmed.
+		name         string
+		wNodeInfo    *NodeInfo
+	}{{
+		name:         "two pod were assumed at same time. But first one is called Add() and gets confirmed.",
 		podsToAssume: []*v1.Pod{testPods[0], testPods[1]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		wNodeInfo: &NodeInfo{
@@ -333,21 +352,23 @@ func TestAddPodWillConfirm(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, podToAssume := range tt.podsToAssume {
+				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
+			for _, podToAdd := range tt.podsToAdd {
+				if err := cache.AddPod(podToAdd); err != nil {
+					t.Fatalf("AddPod failed: %v", err)
+				}
 			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		// check after expiration. confirmed pods shouldn't be expired.
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			// check after expiration. confirmed pods shouldn't be expired.
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -363,31 +384,35 @@ func TestSnapshot(t *testing.T) {
 	tests := []struct {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
-	}{{ // two pod were assumed at same time. But first one is called Add() and gets confirmed.
+		name         string
+	}{{
+		name:         "two pod were assumed at same time. But first one is called Add() and gets confirmed.",
 		podsToAssume: []*v1.Pod{testPods[0], testPods[1]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 	}}
 
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, podToAssume := range tt.podsToAssume {
+				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
+			for _, podToAdd := range tt.podsToAdd {
+				if err := cache.AddPod(podToAdd); err != nil {
+					t.Fatalf("AddPod failed: %v", err)
+				}
 			}
-		}
 
-		snapshot := cache.Snapshot()
-		if !reflect.DeepEqual(snapshot.Nodes, cache.nodes) {
-			t.Fatalf("expect \n%+v; got \n%+v", cache.nodes, snapshot.Nodes)
-		}
-		if !reflect.DeepEqual(snapshot.AssumedPods, cache.assumedPods) {
-			t.Fatalf("expect \n%+v; got \n%+v", cache.assumedPods, snapshot.AssumedPods)
-		}
+			snapshot := cache.Snapshot()
+			if !reflect.DeepEqual(snapshot.Nodes, cache.nodes) {
+				t.Fatalf("expect \n%+v; got \n%+v", cache.nodes, snapshot.Nodes)
+			}
+			if !reflect.DeepEqual(snapshot.AssumedPods, cache.assumedPods) {
+				t.Fatalf("expect \n%+v; got \n%+v", cache.assumedPods, snapshot.AssumedPods)
+			}
+		})
 	}
 }
 
@@ -431,27 +456,37 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
-			}
-		}
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
-			}
-		}
-		for _, podToUpdate := range tt.podsToUpdate {
-			if err := cache.UpdatePod(podToUpdate[0], podToUpdate[1]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
-			}
-		}
-		for nodeName, expected := range tt.wNodeInfo {
-			t.Log(nodeName)
-			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, expected)
-		}
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			t.Run("assumePod", func(t *testing.T) {
+				for _, podToAssume := range tt.podsToAssume {
+					if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
+			t.Run("AddPod", func(t *testing.T) {
+				for _, podToAdd := range tt.podsToAdd {
+					if err := cache.AddPod(podToAdd); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
+			t.Run("UpdatePod", func(t *testing.T) {
+				for _, podToUpdate := range tt.podsToUpdate {
+					if err := cache.UpdatePod(podToUpdate[0], podToUpdate[1]); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
+			t.Run("deepEqualWithoutGeneration", func(t *testing.T) {
+				for nodeName, expected := range tt.wNodeInfo {
+					t.Log(nodeName)
+					n := cache.nodes[nodeName]
+					deepEqualWithoutGeneration(t, i, n, expected)
+				}
+			})
+		})
 	}
 }
 
@@ -463,11 +498,12 @@ func TestAddPodAfterExpiration(t *testing.T) {
 	ttl := 10 * time.Second
 	basePod := makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
 	tests := []struct {
-		pod *v1.Pod
-
+		pod       *v1.Pod
+		name      string
 		wNodeInfo *NodeInfo
 	}{{
-		pod: basePod,
+		name: "basepod",
+		pod:  basePod,
 		wNodeInfo: &NodeInfo{
 			requestedResource: &Resource{
 				MilliCPU: 100,
@@ -487,22 +523,24 @@ func TestAddPodAfterExpiration(t *testing.T) {
 
 	now := time.Now()
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		if err := assumeAndFinishBinding(cache, tt.pod, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		// It should be expired and removed.
-		n := cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting nil node info, but get=%v", i, n)
-		}
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		// check after expiration. confirmed pods shouldn't be expired.
-		n = cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			if err := assumeAndFinishBinding(cache, tt.pod, now); err != nil {
+				t.Fatalf("assumePod failed: %v", err)
+			}
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			// It should be expired and removed.
+			n := cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting nil node info, but get=%v", i, n)
+			}
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			// check after expiration. confirmed pods shouldn't be expired.
+			n = cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -520,9 +558,10 @@ func TestUpdatePod(t *testing.T) {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
 		podsToUpdate []*v1.Pod
-
-		wNodeInfo []*NodeInfo
-	}{{ // add a pod and then update it twice
+		name         string
+		wNodeInfo    []*NodeInfo
+	}{{
+		name:         "add a pod and then update it twice",
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
 		wNodeInfo: []*NodeInfo{{
@@ -557,24 +596,30 @@ func TestUpdatePod(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
-			}
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			t.Run("AddPod", func(t *testing.T) {
+				for _, podToAdd := range tt.podsToAdd {
+					if err := cache.AddPod(podToAdd); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
 
-		for i := range tt.podsToUpdate {
-			if i == 0 {
-				continue
-			}
-			if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
-			}
-			// check after expiration. confirmed pods shouldn't be expired.
-			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
-		}
+			t.Run("UpdatePod", func(t *testing.T) {
+				for i := range tt.podsToUpdate {
+					if i == 0 {
+						continue
+					}
+					if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+					// check after expiration. confirmed pods shouldn't be expired.
+					n := cache.nodes[nodeName]
+					deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
+				}
+			})
+		})
 	}
 }
 
@@ -592,9 +637,10 @@ func TestExpireAddUpdatePod(t *testing.T) {
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
 		podsToUpdate []*v1.Pod
-
-		wNodeInfo []*NodeInfo
-	}{{ // Pod is assumed, expired, and added. Then it would be updated twice.
+		name         string
+		wNodeInfo    []*NodeInfo
+	}{{
+		name:         "Pod is assumed, expired, and added. Then it would be updated twice.",
 		podsToAssume: []*v1.Pod{testPods[0]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
@@ -631,31 +677,37 @@ func TestExpireAddUpdatePod(t *testing.T) {
 
 	now := time.Now()
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
-			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
-			}
-		}
-
-		for i := range tt.podsToUpdate {
-			if i == 0 {
-				continue
-			}
-			if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
-			}
-			// check after expiration. confirmed pods shouldn't be expired.
-			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			t.Run("assumePod", func(t *testing.T) {
+				for _, podToAssume := range tt.podsToAssume {
+					if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+				cache.cleanupAssumedPods(now.Add(2 * ttl))
+			})
+			t.Run("AddPod", func(t *testing.T) {
+				for _, podToAdd := range tt.podsToAdd {
+					if err := cache.AddPod(podToAdd); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
+			t.Run("UpdatePod", func(t *testing.T) {
+				for i := range tt.podsToUpdate {
+					if i == 0 {
+						continue
+					}
+					if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+					// check after expiration. confirmed pods shouldn't be expired.
+					n := cache.nodes[nodeName]
+					deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
+				}
+			})
+		})
 	}
 }
 
@@ -708,21 +760,23 @@ func TestEphemeralStorageResource(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
 
-		if err := cache.RemovePod(tt.pod); err != nil {
-			t.Fatalf("RemovePod failed: %v", err)
-		}
+			if err := cache.RemovePod(tt.pod); err != nil {
+				t.Fatalf("RemovePod failed: %v", err)
+			}
 
-		n = cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
-		}
+			n = cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
+			}
+		})
 	}
 }
 
@@ -755,21 +809,23 @@ func TestRemovePod(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
 
-		if err := cache.RemovePod(tt.pod); err != nil {
-			t.Fatalf("RemovePod failed: %v", err)
-		}
+			if err := cache.RemovePod(tt.pod); err != nil {
+				t.Fatalf("RemovePod failed: %v", err)
+			}
 
-		n = cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
-		}
+			n = cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
+			}
+		})
 	}
 }
 
@@ -785,45 +841,47 @@ func TestForgetPod(t *testing.T) {
 	ttl := 10 * time.Second
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, pod := range tt.pods {
-			if err := assumeAndFinishBinding(cache, pod, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, pod := range tt.pods {
+				if err := assumeAndFinishBinding(cache, pod, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
+				isAssumed, err := cache.IsAssumedPod(pod)
+				if err != nil {
+					t.Fatalf("IsAssumedPod failed: %v.", err)
+				}
+				if !isAssumed {
+					t.Fatalf("Pod is expected to be assumed.")
+				}
+				assumedPod, err := cache.GetPod(pod)
+				if err != nil {
+					t.Fatalf("GetPod failed: %v.", err)
+				}
+				if assumedPod.Namespace != pod.Namespace {
+					t.Errorf("assumedPod.Namespace != pod.Namespace (%s != %s)", assumedPod.Namespace, pod.Namespace)
+				}
+				if assumedPod.Name != pod.Name {
+					t.Errorf("assumedPod.Name != pod.Name (%s != %s)", assumedPod.Name, pod.Name)
+				}
 			}
-			isAssumed, err := cache.IsAssumedPod(pod)
-			if err != nil {
-				t.Fatalf("IsAssumedPod failed: %v.", err)
+			for _, pod := range tt.pods {
+				if err := cache.ForgetPod(pod); err != nil {
+					t.Fatalf("ForgetPod failed: %v", err)
+				}
+				isAssumed, err := cache.IsAssumedPod(pod)
+				if err != nil {
+					t.Fatalf("IsAssumedPod failed: %v.", err)
+				}
+				if isAssumed {
+					t.Fatalf("Pod is expected to be unassumed.")
+				}
 			}
-			if !isAssumed {
-				t.Fatalf("Pod is expected to be assumed.")
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			if n := cache.nodes[nodeName]; n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
 			}
-			assumedPod, err := cache.GetPod(pod)
-			if err != nil {
-				t.Fatalf("GetPod failed: %v.", err)
-			}
-			if assumedPod.Namespace != pod.Namespace {
-				t.Errorf("assumedPod.Namespace != pod.Namespace (%s != %s)", assumedPod.Namespace, pod.Namespace)
-			}
-			if assumedPod.Name != pod.Name {
-				t.Errorf("assumedPod.Name != pod.Name (%s != %s)", assumedPod.Name, pod.Name)
-			}
-		}
-		for _, pod := range tt.pods {
-			if err := cache.ForgetPod(pod); err != nil {
-				t.Fatalf("ForgetPod failed: %v", err)
-			}
-			isAssumed, err := cache.IsAssumedPod(pod)
-			if err != nil {
-				t.Fatalf("IsAssumedPod failed: %v.", err)
-			}
-			if isAssumed {
-				t.Fatalf("Pod is expected to be unassumed.")
-			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		if n := cache.nodes[nodeName]; n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n)
-		}
+		})
 	}
 }
 
@@ -992,62 +1050,67 @@ func TestNodeOperators(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		expected := buildNodeInfo(test.node, test.pods)
-		node := test.node
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("node/%v", i), func(t *testing.T) {
+			expected := buildNodeInfo(test.node, test.pods)
+			node := test.node
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache.AddNode(node)
+			for _, pod := range test.pods {
+				cache.AddPod(pod)
+			}
+			got, found := cache.nodes[node.Name]
+			t.Run("Case 1: the node was added into cache successfully.", func(t *testing.T) {
+				if !found {
+					t.Errorf("Failed to find node %v in schedulercache.", node.Name)
+				}
+			})
 
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		cache.AddNode(node)
-		for _, pod := range test.pods {
-			cache.AddPod(pod)
-		}
+			t.Run("Generations are globally unique. We check in our unit tests that they are incremented correctly.", func(t *testing.T) {
+				expected.generation = got.generation
+				if !reflect.DeepEqual(got, expected) {
+					t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)
+				}
+			})
 
-		// Case 1: the node was added into cache successfully.
-		got, found := cache.nodes[node.Name]
-		if !found {
-			t.Errorf("Failed to find node %v in schedulercache.", node.Name)
-		}
+			t.Run("Case 2: dump cached nodes successfully.", func(t *testing.T) {
+				cachedNodes := map[string]*NodeInfo{}
+				cache.UpdateNodeNameToInfoMap(cachedNodes)
+				newNode, found := cachedNodes[node.Name]
+				if !found || len(cachedNodes) != 1 {
+					t.Errorf("failed to dump cached nodes:\n got: %v \nexpected: %v", cachedNodes, cache.nodes)
+				}
+				expected.generation = newNode.generation
+				if !reflect.DeepEqual(newNode, expected) {
+					t.Errorf("Failed to clone node:\n got: %+v, \n expected: %+v", newNode, expected)
+				}
+			})
 
-		// Generations are globally unique. We check in our unit tests that they are incremented correctly.
-		expected.generation = got.generation
-		if !reflect.DeepEqual(got, expected) {
-			t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)
-		}
+			t.Run("Case 3: update node attribute successfully.", func(t *testing.T) {
+				node.Status.Allocatable[v1.ResourceMemory] = mem50m
+				expected.allocatableResource.Memory = mem50m.Value()
+				cache.UpdateNode(nil, node)
+				got, found = cache.nodes[node.Name]
+				if !found {
+					t.Errorf("Failed to find node %v in schedulercache after UpdateNode.", node.Name)
+				}
+				if got.generation <= expected.generation {
+					t.Errorf("generation is not incremented. got: %v, expected: %v", got.generation, expected.generation)
+				}
+				expected.generation = got.generation
 
-		// Case 2: dump cached nodes successfully.
-		cachedNodes := map[string]*NodeInfo{}
-		cache.UpdateNodeNameToInfoMap(cachedNodes)
-		newNode, found := cachedNodes[node.Name]
-		if !found || len(cachedNodes) != 1 {
-			t.Errorf("failed to dump cached nodes:\n got: %v \nexpected: %v", cachedNodes, cache.nodes)
-		}
-		expected.generation = newNode.generation
-		if !reflect.DeepEqual(newNode, expected) {
-			t.Errorf("Failed to clone node:\n got: %+v, \n expected: %+v", newNode, expected)
-		}
+				if !reflect.DeepEqual(got, expected) {
+					t.Errorf("Failed to update node in schedulercache:\n got: %+v \nexpected: %+v", got, expected)
+				}
+			})
 
-		// Case 3: update node attribute successfully.
-		node.Status.Allocatable[v1.ResourceMemory] = mem50m
-		expected.allocatableResource.Memory = mem50m.Value()
-		cache.UpdateNode(nil, node)
-		got, found = cache.nodes[node.Name]
-		if !found {
-			t.Errorf("Failed to find node %v in schedulercache after UpdateNode.", node.Name)
-		}
-		if got.generation <= expected.generation {
-			t.Errorf("generation is not incremented. got: %v, expected: %v", got.generation, expected.generation)
-		}
-		expected.generation = got.generation
-
-		if !reflect.DeepEqual(got, expected) {
-			t.Errorf("Failed to update node in schedulercache:\n got: %+v \nexpected: %+v", got, expected)
-		}
-
-		// Case 4: the node can not be removed if pods is not empty.
-		cache.RemoveNode(node)
-		if _, found := cache.nodes[node.Name]; !found {
-			t.Errorf("The node %v should not be removed if pods is not empty.", node.Name)
-		}
+			t.Run("Case 4: the node can not be removed if pods is not empty.", func(t *testing.T) {
+				cache.RemoveNode(node)
+				if _, found := cache.nodes[node.Name]; !found {
+					t.Errorf("The node %v should not be removed if pods is not empty.", node.Name)
+				}
+			})
+		})
 	}
 }
 
@@ -1180,7 +1243,6 @@ func makePDB(name, namespace string, uid types.UID, labels map[string]string, mi
 
 // TestPDBOperations tests that a PDB will be add/updated/deleted correctly.
 func TestPDBOperations(t *testing.T) {
-	ttl := 10 * time.Second
 	testPDBs := []*v1beta1.PodDisruptionBudget{
 		makePDB("pdb0", "ns1", "uid0", map[string]string{"tkey1": "tval1"}, 3),
 		makePDB("pdb1", "ns1", "uid1", map[string]string{"tkey1": "tval1", "tkey2": "tval2"}, 1),
@@ -1215,53 +1277,72 @@ func TestPDBOperations(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, pdbToAdd := range test.pdbsToAdd {
-			if err := cache.AddPDB(pdbToAdd); err != nil {
-				t.Fatalf("AddPDB failed: %v", err)
-			}
-		}
+	for pdbsidx, test := range tests {
+		t.Run(fmt.Sprintf("pdbs/%v", pdbsidx), func(t *testing.T) {
+			testPDBOperations(
+				test.pdbsToAdd,
+				test.pdbsToUpdate,
+				test.pdbsToDelete,
+				test.expectedPDBs,
+				t,
+			)
+		})
+	}
+}
 
-		for i := range test.pdbsToUpdate {
-			if i == 0 {
-				continue
-			}
-			if err := cache.UpdatePDB(test.pdbsToUpdate[i-1], test.pdbsToUpdate[i]); err != nil {
-				t.Fatalf("UpdatePDB failed: %v", err)
-			}
+func testPDBOperations(
+	pdbsToAdd,
+	pdbsToUpdate,
+	pdbsToDelete,
+	expectedPDBs []*v1beta1.PodDisruptionBudget,
+	t *testing.T,
+) {
+	ttl := 10 * time.Second
+	cache := newSchedulerCache(ttl, time.Second, nil)
+	for _, pdbToAdd := range pdbsToAdd {
+		if err := cache.AddPDB(pdbToAdd); err != nil {
+			t.Fatalf("AddPDB failed: %v", err)
 		}
+	}
 
-		for _, pdb := range test.pdbsToDelete {
-			if err := cache.RemovePDB(pdb); err != nil {
-				t.Fatalf("RemovePDB failed: %v", err)
-			}
+	for i := range pdbsToUpdate {
+		if i == 0 {
+			continue
 		}
+		if err := cache.UpdatePDB(pdbsToUpdate[i-1], pdbsToUpdate[i]); err != nil {
+			t.Fatalf("UpdatePDB failed: %v", err)
+		}
+	}
 
-		cachedPDBs, err := cache.ListPDBs(labels.Everything())
-		if err != nil {
-			t.Fatalf("ListPDBs failed: %v", err)
+	for _, pdb := range pdbsToDelete {
+		if err := cache.RemovePDB(pdb); err != nil {
+			t.Fatalf("RemovePDB failed: %v", err)
 		}
-		if len(cachedPDBs) != len(test.expectedPDBs) {
-			t.Errorf("Expected %d PDBs, got %d", len(test.expectedPDBs), len(cachedPDBs))
-		}
-		for _, pdb := range test.expectedPDBs {
-			found := false
-			// find it among the cached ones
-			for _, cpdb := range cachedPDBs {
-				if pdb.UID == cpdb.UID {
-					found = true
-					if !reflect.DeepEqual(pdb, cpdb) {
-						t.Errorf("%v is not equal to %v", pdb, cpdb)
-					}
-					break
+	}
+
+	cachedPDBs, err := cache.ListPDBs(labels.Everything())
+	if err != nil {
+		t.Fatalf("ListPDBs failed: %v", err)
+	}
+	if len(cachedPDBs) != len(expectedPDBs) {
+		t.Errorf("Expected %d PDBs, got %d", len(expectedPDBs), len(cachedPDBs))
+	}
+	for _, pdb := range expectedPDBs {
+		found := false
+		// find it among the cached ones
+		for _, cpdb := range cachedPDBs {
+			if pdb.UID == cpdb.UID {
+				found = true
+				if !reflect.DeepEqual(pdb, cpdb) {
+					t.Errorf("%v is not equal to %v", pdb, cpdb)
 				}
+				break
 			}
-			if !found {
-				t.Errorf("PDB with uid '%v' was not found in the cache.", pdb.UID)
-			}
-
 		}
+		if !found {
+			t.Errorf("PDB with uid '%v' was not found in the cache.", pdb.UID)
+		}
+
 	}
 }
 

--- a/pkg/scheduler/schedulercache/node_info_test.go
+++ b/pkg/scheduler/schedulercache/node_info_test.go
@@ -32,12 +32,15 @@ func TestNewResource(t *testing.T) {
 	tests := []struct {
 		resourceList v1.ResourceList
 		expected     *Resource
+		name         string
 	}{
 		{
+			name:         "empty resource set",
 			resourceList: map[v1.ResourceName]resource.Quantity{},
 			expected:     &Resource{},
 		},
 		{
+			name: "has resources set",
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:                      *resource.NewScaledQuantity(4, -3),
 				v1.ResourceMemory:                   *resource.NewQuantity(2000, resource.BinarySI),
@@ -56,11 +59,13 @@ func TestNewResource(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		r := NewResource(test.resourceList)
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.name), func(t *testing.T) {
+			r := NewResource(test.resourceList)
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
@@ -68,8 +73,10 @@ func TestResourceList(t *testing.T) {
 	tests := []struct {
 		resource *Resource
 		expected v1.ResourceList
+		name     string
 	}{
 		{
+			name:     "empty resource list",
 			resource: &Resource{},
 			expected: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
@@ -79,6 +86,7 @@ func TestResourceList(t *testing.T) {
 			},
 		},
 		{
+			name: "has resource list set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -97,11 +105,13 @@ func TestResourceList(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		rl := test.resource.ResourceList()
-		if !reflect.DeepEqual(test.expected, rl) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, rl)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.name), func(t *testing.T) {
+			rl := test.resource.ResourceList()
+			if !reflect.DeepEqual(test.expected, rl) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, rl)
+			}
+		})
 	}
 }
 
@@ -109,12 +119,15 @@ func TestResourceClone(t *testing.T) {
 	tests := []struct {
 		resource *Resource
 		expected *Resource
+		name     string
 	}{
 		{
+			name:     "no resource to clone",
 			resource: &Resource{},
 			expected: &Resource{},
 		},
 		{
+			name: "has resource to clone",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -132,13 +145,15 @@ func TestResourceClone(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		r := test.resource.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.resource.MilliCPU += 1000
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.name), func(t *testing.T) {
+			r := test.resource.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.resource.MilliCPU += 1000
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
@@ -148,8 +163,10 @@ func TestResourceAddScalar(t *testing.T) {
 		scalarName     v1.ResourceName
 		scalarQuantity int64
 		expected       *Resource
+		name           string
 	}{
 		{
+			name:           "add scalar value to empty set",
 			resource:       &Resource{},
 			scalarName:     "scalar1",
 			scalarQuantity: 100,
@@ -158,6 +175,7 @@ func TestResourceAddScalar(t *testing.T) {
 			},
 		},
 		{
+			name: "add scalar value to existing set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -177,11 +195,13 @@ func TestResourceAddScalar(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		test.resource.AddScalar(test.scalarName, test.scalarQuantity)
-		if !reflect.DeepEqual(test.expected, test.resource) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.name), func(t *testing.T) {
+			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
+			if !reflect.DeepEqual(test.expected, test.resource) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			}
+		})
 	}
 }
 
@@ -440,13 +460,15 @@ func TestNodeInfoClone(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		ni := test.nodeInfo.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.nodeInfo.generation += 10
-		if !reflect.DeepEqual(test.expected, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			ni := test.nodeInfo.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.nodeInfo.generation += 10
+			if !reflect.DeepEqual(test.expected, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, ni)
+			}
+		})
 	}
 }
 
@@ -806,30 +828,30 @@ func TestNodeInfoRemovePod(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		ni := fakeNodeInfo(pods...)
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.pod.ObjectMeta.Name), func(t *testing.T) {
+			ni := fakeNodeInfo(pods...)
 
-		gen := ni.generation
-		err := ni.RemovePod(test.pod)
-		if err != nil {
-			if test.errExpected {
-				expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.node.Name)
-				if expectedErrorMsg == err {
-					t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+			gen := ni.generation
+			err := ni.RemovePod(test.pod)
+			if err != nil {
+				if test.errExpected {
+					expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.node.Name)
+					if expectedErrorMsg == err {
+						t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+					}
 				}
 			} else {
-				t.Errorf("expected no error, got: %v", err)
+				if ni.generation <= gen {
+					t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+				}
 			}
-		} else {
-			if ni.generation <= gen {
-				t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
-			}
-		}
 
-		test.expectedNodeInfo.generation = ni.generation
-		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
-		}
+			test.expectedNodeInfo.generation = ni.generation
+			if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/testing/util_test.go
+++ b/pkg/scheduler/testing/util_test.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -26,157 +27,113 @@ import (
 )
 
 func TestResourcePathWithPrefix(t *testing.T) {
+	testGroup := Test
+	testGroup.externalGroupVersion.Group = "TestGroup"
 	testCases := []struct {
+		test      TestGroup
 		prefix    string
 		resource  string
 		namespace string
 		name      string
 		expected  string
 	}{
-		{"prefix", "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource/myresource"},
-		{"prefix", "resource", "", "myresource", "/api/" + Test.externalGroupVersion.Version + "/prefix/resource/myresource"},
-		{"prefix", "resource", "mynamespace", "", "/api/" + Test.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource"},
-		{"prefix", "resource", "", "", "/api/" + Test.externalGroupVersion.Version + "/prefix/resource"},
-		{"", "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{Test, "prefix", "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource/myresource"},
+		{Test, "prefix", "resource", "", "myresource", "/api/" + Test.externalGroupVersion.Version + "/prefix/resource/myresource"},
+		{Test, "prefix", "resource", "mynamespace", "", "/api/" + Test.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource"},
+		{Test, "prefix", "resource", "", "", "/api/" + Test.externalGroupVersion.Version + "/prefix/resource"},
+		{Test, "", "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{testGroup, "prefix", "resource", "mynamespace", "myresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource/myresource"},
+		{testGroup, "prefix", "resource", "", "myresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/prefix/resource/myresource"},
+		{testGroup, "prefix", "resource", "mynamespace", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource"},
+		{testGroup, "prefix", "resource", "", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/prefix/resource"},
+		{testGroup, "", "resource", "mynamespace", "myresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
-	for _, item := range testCases {
-		if actual := Test.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
-		}
+	for i, item := range testCases {
+		name := fmt.Sprintf("%v/%v", i, item.test.externalGroupVersion.Group)
+		t.Run(name, func(t *testing.T) {
+			if actual := item.test.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
+				t.Errorf("Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
+			}
+		})
 	}
-
-	TestGroup := Test
-	TestGroup.externalGroupVersion.Group = "TestGroup"
-
-	testGroupCases := []struct {
-		prefix    string
-		resource  string
-		namespace string
-		name      string
-		expected  string
-	}{
-		{"prefix", "resource", "mynamespace", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource/myresource"},
-		{"prefix", "resource", "", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/prefix/resource/myresource"},
-		{"prefix", "resource", "mynamespace", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/prefix/namespaces/mynamespace/resource"},
-		{"prefix", "resource", "", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/prefix/resource"},
-		{"", "resource", "mynamespace", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
-	}
-	for _, item := range testGroupCases {
-		if actual := TestGroup.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
-		}
-	}
-
 }
 
 func TestResourcePath(t *testing.T) {
+	testGroup := Test
+	testGroup.externalGroupVersion.Group = "TestGroup"
 	testCases := []struct {
+		test      TestGroup
 		resource  string
 		namespace string
 		name      string
 		expected  string
 	}{
-		{"resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
-		{"resource", "", "myresource", "/api/" + Test.externalGroupVersion.Version + "/resource/myresource"},
-		{"resource", "mynamespace", "", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource"},
-		{"resource", "", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
+		{Test, "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{Test, "resource", "", "myresource", "/api/" + Test.externalGroupVersion.Version + "/resource/myresource"},
+		{Test, "resource", "mynamespace", "", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource"},
+		{Test, "resource", "", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
+		{testGroup, "resource", "mynamespace", "myresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{testGroup, "resource", "", "myresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/resource/myresource"},
+		{testGroup, "resource", "mynamespace", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource"},
+		{testGroup, "resource", "", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/resource"},
 	}
-	for _, item := range testCases {
-		if actual := Test.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
-		}
+	for i, item := range testCases {
+		name := fmt.Sprintf("%v/%v", i, item.test.externalGroupVersion.Group)
+		t.Run(name, func(t *testing.T) {
+			if actual := item.test.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
+				t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
+			}
+		})
 	}
-
-	TestGroup := Test
-	TestGroup.externalGroupVersion.Group = "TestGroup"
-
-	testGroupCases := []struct {
-		resource  string
-		namespace string
-		name      string
-		expected  string
-	}{
-		{"resource", "mynamespace", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
-		{"resource", "", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource/myresource"},
-		{"resource", "mynamespace", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource"},
-		{"resource", "", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource"},
-	}
-	for _, item := range testGroupCases {
-		if actual := TestGroup.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
-		}
-	}
-
 }
 
 func TestSubResourcePath(t *testing.T) {
+	testGroup := Test
+	testGroup.externalGroupVersion.Group = "TestGroup"
 	testCases := []struct {
+		test      TestGroup
 		resource  string
 		namespace string
 		name      string
 		sub       string
 		expected  string
 	}{
-		{"resource", "mynamespace", "myresource", "subresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource/subresource"},
-		{"resource", "mynamespace", "myresource", "", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{Test, "resource", "mynamespace", "myresource", "subresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource/subresource"},
+		{Test, "resource", "mynamespace", "myresource", "", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
+		{testGroup, "resource", "mynamespace", "myresource", "subresource", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource/subresource"},
+		{testGroup, "resource", "mynamespace", "myresource", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
-	for _, item := range testCases {
-		if actual := Test.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
-		}
+	for i, item := range testCases {
+		name := fmt.Sprintf("%v/%v", i, item.test.externalGroupVersion.Group)
+		t.Run(name, func(t *testing.T) {
+			if actual := item.test.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {
+				t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
+			}
+		})
 	}
-
-	TestGroup := Test
-	TestGroup.externalGroupVersion.Group = "TestGroup"
-
-	testGroupCases := []struct {
-		resource  string
-		namespace string
-		name      string
-		sub       string
-		expected  string
-	}{
-		{"resource", "mynamespace", "myresource", "subresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource/subresource"},
-		{"resource", "mynamespace", "myresource", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
-	}
-	for _, item := range testGroupCases {
-		if actual := TestGroup.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
-		}
-	}
-
 }
 
 func TestSelfLink(t *testing.T) {
+	testGroup := Test
+	testGroup.externalGroupVersion.Group = "TestGroup"
 	testCases := []struct {
+		test     TestGroup
 		resource string
 		name     string
 		expected string
 	}{
-		{"resource", "name", "/api/" + Test.externalGroupVersion.Version + "/resource/name"},
-		{"resource", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
+		{Test, "resource", "name", "/api/" + Test.externalGroupVersion.Version + "/resource/name"},
+		{Test, "resource", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
+		{testGroup, "resource", "name", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/resource/name"},
+		{testGroup, "resource", "", "/apis/" + testGroup.externalGroupVersion.Group + "/" + testGroup.externalGroupVersion.Version + "/resource"},
 	}
-	for _, item := range testCases {
-		if actual := Test.SelfLink(item.resource, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
-		}
-	}
-
-	TestGroup := Test
-	TestGroup.externalGroupVersion.Group = "TestGroup"
-
-	testGroupCases := []struct {
-		resource string
-		name     string
-		expected string
-	}{
-		{"resource", "name", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource/name"},
-		{"resource", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource"},
-	}
-	for _, item := range testGroupCases {
-		if actual := TestGroup.SelfLink(item.resource, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
-		}
+	for i, item := range testCases {
+		name := fmt.Sprintf("%v/%v", i, item.test.externalGroupVersion.Group)
+		t.Run(name, func(t *testing.T) {
+			if actual := item.test.SelfLink(item.resource, item.name); actual != item.expected {
+				t.Errorf("Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -52,10 +53,11 @@ func TestGetPodPriority(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if GetPodPriority(test.pod) != test.expectedPriority {
-			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
-		}
-
+		t.Run(test.name, func(t *testing.T) {
+			if GetPodPriority(test.pod) != test.expectedPriority {
+				t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
+			}
+		})
 	}
 }
 
@@ -87,10 +89,12 @@ func TestSortableList(t *testing.T) {
 		t.Errorf("expected length of list was 10, got: %v", len(podList.Items))
 	}
 	var prevPriority = int32(10)
-	for _, p := range podList.Items {
-		if *p.(*v1.Pod).Spec.Priority >= prevPriority {
-			t.Errorf("Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
-		}
+	for i, p := range podList.Items {
+		t.Run(fmt.Sprintf("pod:%v", i), func(t *testing.T) {
+			if *p.(*v1.Pod).Spec.Priority >= prevPriority {
+				t.Errorf("Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
+			}
+		})
 	}
 }
 
@@ -189,18 +193,20 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		for _, param := range test.removed {
-			hp.Remove(param.ip, param.protocol, param.port)
-		}
-		if hp.Len() != test.length {
-			t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
-			t.Error(hp)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.desc), func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			for _, param := range test.removed {
+				hp.Remove(param.ip, param.protocol, param.port)
+			}
+			if hp.Len() != test.length {
+				t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
+				t.Error(hp)
+			}
+		})
 	}
 }
 
@@ -293,13 +299,15 @@ func TestHostPortInfo_Check(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
-			t.Errorf("%v failed, expected %t; got %t", test.desc, test.expect, !test.expect)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.desc), func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
+				t.Errorf("%v failed, expected %t; got %t", test.desc, test.expect, !test.expect)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Update scheduler's unit table tests to use subtest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63267

**Special notes for your reviewer**:
```
Integration tests and benchmark refactor will be in a separate PR to keep the footprint of change 
smaller.

Side note: there are a number of inconsistencies across the subpackages in the scheduler regarding how the tables are implemented. Implementations use maps, struct elements of several different names, etc. Perhaps another refactor issue to unify the approach would be beneficial?
I tried aligning some of the implementations in naming and approach, but likely a separate effort and discussion would be best. thoughts?

```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR will leverage subtests on the existing table tests for the scheduler units.
Some refactoring of error/status messages and functions to align with new approach.

```
