### PR TITLE
Fix bug with controllerrevision equality check

### DIFF
--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
@@ -126,14 +127,18 @@ func EqualRevision(lhs *apps.ControllerRevision, rhs *apps.ControllerRevision) b
 	}
 	if hs, found := lhs.Labels[ControllerRevisionHashLabel]; found {
 		hash, err := strconv.ParseUint(hs, 10, 32)
-		if err == nil {
+		if err != nil {
+			glog.Errorf("Error parsing hash %s as uint32 for controller revision %s: %v", hs, lhs.Name, err)
+		} else {
 			lhsHash = new(uint32)
 			*lhsHash = uint32(hash)
 		}
 	}
 	if hs, found := rhs.Labels[ControllerRevisionHashLabel]; found {
 		hash, err := strconv.ParseUint(hs, 10, 32)
-		if err == nil {
+		if err != nil {
+			glog.Errorf("Error parsing hash %s as uint32 for controller revision %s: %v", hs, rhs.Name, err)
+		} else {
 			rhsHash = new(uint32)
 			*rhsHash = uint32(hash)
 		}

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -125,14 +125,14 @@ func EqualRevision(lhs *apps.ControllerRevision, rhs *apps.ControllerRevision) b
 		return lhs == rhs
 	}
 	if hs, found := lhs.Labels[ControllerRevisionHashLabel]; found {
-		hash, err := strconv.ParseInt(hs, 10, 32)
+		hash, err := strconv.ParseUint(hs, 10, 32)
 		if err == nil {
 			lhsHash = new(uint32)
 			*lhsHash = uint32(hash)
 		}
 	}
 	if hs, found := rhs.Labels[ControllerRevisionHashLabel]; found {
-		hash, err := strconv.ParseInt(hs, 10, 32)
+		hash, err := strconv.ParseUint(hs, 10, 32)
 		if err == nil {
 			rhsHash = new(uint32)
 			*rhsHash = uint32(hash)


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/61998
Cause was reading a label value as an int32 that was written as a uint32.

**Release note**:
```release-note
1. Fixed bug with controllerrevision equality check that could cause nondeterministic statefulset target controllerrevisions (caused statefulsets to continually roll pods)
```
