### PR TITLE
[WIP]: Use json-iter for JSON parsing

### DIFF
--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -83,6 +83,7 @@ go_test(
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
@@ -94,7 +95,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
@@ -106,5 +106,6 @@ go_test(
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/json-iterator/go:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )

--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -37,9 +37,9 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -581,10 +581,9 @@ func BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary(b *testi
 	}
 
 	b.ResetTimer()
-	iter := json.CaseSensitiveJsonIterator()
 	for i := 0; i < b.N; i++ {
 		obj := v1.Pod{}
-		if err := iter.Unmarshal(encoded[i%width], &obj); err != nil {
+		if err := utiljson.Unmarshal(encoded[i%width], &obj); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/api/testing/unstructured_test.go
+++ b/pkg/api/testing/unstructured_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package testing
 
 import (
+	encodingjson "encoding/json"
+	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
 
 	"github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
 
+	"k8s.io/api/certificates/v1beta1"
 	"k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -73,48 +77,57 @@ func doRoundTrip(t *testing.T, internalVersion schema.GroupVersion, externalVers
 
 	data, err := json.Marshal(item)
 	if err != nil {
-		t.Errorf("Error when marshaling object: %v", err)
-		return
+		t.Fatalf("Error when marshaling object: %v", err)
 	}
 	unstr := make(map[string]interface{})
 	err = json.Unmarshal(data, &unstr)
 	if err != nil {
-		t.Errorf("Error when unmarshaling to unstructured: %v", err)
-		return
+		t.Fatalf("Error when unmarshaling to unstructured: %v", err)
 	}
 
 	data, err = json.Marshal(unstr)
 	if err != nil {
-		t.Errorf("Error when marshaling unstructured: %v", err)
-		return
+		t.Fatalf("Error when marshaling unstructured: %v", err)
 	}
 	unmarshalledObj := reflect.New(reflect.TypeOf(item).Elem()).Interface()
-	err = json.Unmarshal(data, &unmarshalledObj)
+	err = json.Unmarshal(data, unmarshalledObj)
 	if err != nil {
-		t.Errorf("Error when unmarshaling to object: %v", err)
-		return
+		t.Fatalf("Error when unmarshaling to object: %v", err)
 	}
 	if !apiequality.Semantic.DeepEqual(item, unmarshalledObj) {
-		t.Errorf("Object changed during JSON operations, diff: %v", diff.ObjectReflectDiff(item, unmarshalledObj))
-		return
+		t.Fatalf("Object changed during JSON operations, diff: %v", diff.ObjectReflectDiff(item, unmarshalledObj))
 	}
 
 	newUnstr, err := runtime.NewTestUnstructuredConverter(apiequality.Semantic).ToUnstructured(item)
 	if err != nil {
-		t.Errorf("ToUnstructured failed: %v", err)
-		return
+		t.Fatalf("ToUnstructured failed: %v", err)
 	}
 
 	newObj := reflect.New(reflect.TypeOf(item).Elem()).Interface().(runtime.Object)
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(newUnstr, newObj)
 	if err != nil {
-		t.Errorf("FromUnstructured failed: %v", err)
-		return
+		t.Fatalf("FromUnstructured failed: %v", err)
 	}
 
 	if !apiequality.Semantic.DeepEqual(item, newObj) {
-		t.Errorf("Object changed, diff: %v", diff.ObjectReflectDiff(item, newObj))
+		t.Fatalf("Object changed, diff: %v", diff.ObjectReflectDiff(item, newObj))
 	}
+}
+
+func TestSlice(t *testing.T) {
+	var x v1beta1.CertificateSigningRequestSpec
+	data, err := encodingjson.Marshal(&x)
+	require.NoError(t, err)
+
+	var m1 map[string]interface{}
+	err = encodingjson.Unmarshal(data, &m1)
+	require.NoError(t, err)
+
+	var m2 map[string]interface{}
+	err = json.Unmarshal(data, &m2)
+	require.NoError(t, err)
+
+	t.Fatalf("%s", diff.ObjectGoPrintDiff(m1, m2))
 }
 
 func TestRoundTrip(t *testing.T) {
@@ -123,13 +136,11 @@ func TestRoundTrip(t *testing.T) {
 			if nonRoundTrippableTypes.Has(kind) {
 				continue
 			}
-			t.Logf("Testing: %v in %v", kind, groupKey)
-			for i := 0; i < 50; i++ {
-				doRoundTrip(t, schema.GroupVersion{Group: groupKey, Version: runtime.APIVersionInternal}, *group.GroupVersion(), kind)
-				if t.Failed() {
-					break
+			t.Run(fmt.Sprintf("%v/%v", groupKey, kind), func(t *testing.T) {
+				for i := 0; i < 50; i++ {
+					doRoundTrip(t, schema.GroupVersion{Group: groupKey, Version: runtime.APIVersionInternal}, *group.GroupVersion(), kind)
 				}
-			}
+			})
 		}
 	}
 }

--- a/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
@@ -211,7 +211,15 @@ spec:
   }
 }
 `))
-		Expect(err.Error()).To(Equal("invalid character ':' after array element"))
+		Expect(err.Error()).To(Equal(`ReadArrayCB: expect ] in the end, but found :, error found in #10 byte of ...|   "name": "shared-d|..., bigger context ...|
+  },
+  "spec": {
+    "volumes": [
+        "name": "shared-disk"
+    ],
+    "containers": [
+      {
+|...`))
 	})
 
 	It("fails because some string lists have empty strings", func() {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -99,6 +99,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 	"k8s.io/apimachinery/pkg/types"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
@@ -830,8 +831,6 @@ func (v *unstructuredSchemaCoercer) apply(u *unstructured.Unstructured) error {
 	return nil
 }
 
-var encodingjson = json.CaseSensitiveJsonIterator()
-
 func getObjectMeta(u *unstructured.Unstructured, dropMalformedFields bool) (*metav1.ObjectMeta, bool, error) {
 	metadata, found := u.UnstructuredContent()["metadata"]
 	if !found {
@@ -840,11 +839,11 @@ func getObjectMeta(u *unstructured.Unstructured, dropMalformedFields bool) (*met
 
 	// round-trip through JSON first, hoping that unmarshaling just works
 	objectMeta := &metav1.ObjectMeta{}
-	metadataBytes, err := encodingjson.Marshal(metadata)
+	metadataBytes, err := utiljson.Marshal(metadata)
 	if err != nil {
 		return nil, false, err
 	}
-	if err = encodingjson.Unmarshal(metadataBytes, objectMeta); err == nil {
+	if err = utiljson.Unmarshal(metadataBytes, objectMeta); err == nil {
 		// if successful, return
 		return objectMeta, true, nil
 	}
@@ -865,11 +864,11 @@ func getObjectMeta(u *unstructured.Unstructured, dropMalformedFields bool) (*met
 	testObjectMeta := &metav1.ObjectMeta{}
 	for k, v := range metadataMap {
 		// serialize a single field
-		if singleFieldBytes, err := encodingjson.Marshal(map[string]interface{}{k: v}); err == nil {
+		if singleFieldBytes, err := utiljson.Marshal(map[string]interface{}{k: v}); err == nil {
 			// do a test unmarshal
-			if encodingjson.Unmarshal(singleFieldBytes, testObjectMeta) == nil {
+			if utiljson.Unmarshal(singleFieldBytes, testObjectMeta) == nil {
 				// if that succeeds, unmarshal for real
-				encodingjson.Unmarshal(singleFieldBytes, accumulatedObjectMeta)
+				utiljson.Unmarshal(singleFieldBytes, accumulatedObjectMeta)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -189,12 +190,12 @@ func TestMalformedObjectMetaFields(t *testing.T) {
 				}
 
 				// See if it can unmarshal to object meta
-				spuriousJSON, err := encodingjson.Marshal(spuriousMetaMap)
+				spuriousJSON, err := utiljson.Marshal(spuriousMetaMap)
 				if err != nil {
 					t.Fatalf("error on %v=%#v: %v", pth, v, err)
 				}
 				expectedObjectMeta := &metav1.ObjectMeta{}
-				if err := encodingjson.Unmarshal(spuriousJSON, expectedObjectMeta); err != nil {
+				if err := utiljson.Unmarshal(spuriousJSON, expectedObjectMeta); err != nil {
 					// if standard json unmarshal would fail decoding this field, drop the field entirely
 					truncatedMetaMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(fuzzedObjectMeta.DeepCopy())
 					if err != nil {
@@ -208,12 +209,12 @@ func TestMalformedObjectMetaFields(t *testing.T) {
 						DeleteJsonPath(truncatedMetaMap, pth[:1], 0)
 					}
 
-					truncatedJSON, err := encodingjson.Marshal(truncatedMetaMap)
+					truncatedJSON, err := utiljson.Marshal(truncatedMetaMap)
 					if err != nil {
 						t.Fatalf("error on %v=%#v: %v", pth, v, err)
 					}
 					expectedObjectMeta = &metav1.ObjectMeta{}
-					if err := encodingjson.Unmarshal(truncatedJSON, expectedObjectMeta); err != nil {
+					if err := utiljson.Unmarshal(truncatedJSON, expectedObjectMeta); err != nil {
 						t.Fatalf("error on %v=%#v: %v", pth, v, err)
 					}
 				}
@@ -261,7 +262,7 @@ func TestGetObjectMetaNils(t *testing.T) {
 	}
 
 	// double check this what the kube JSON decode is doing
-	bs, _ := encodingjson.Marshal(u.UnstructuredContent())
+	bs, _ := utiljson.Marshal(u.UnstructuredContent())
 	kubeObj, _, err := clientgoscheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion).Decode(bs, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -24,7 +24,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 )
 
 type GroupVersionHolder struct {
@@ -47,8 +47,7 @@ func TestGroupVersionUnmarshalJSON(t *testing.T) {
 			t.Errorf("JSON codec failed to unmarshal input '%s': expected %+v, got %+v", c.input, c.expect, result.GV)
 		}
 		// test the json-iterator codec
-		iter := json.CaseSensitiveJsonIterator()
-		if err := iter.Unmarshal(c.input, &result); err != nil {
+		if err := utiljson.Unmarshal(c.input, &result); err != nil {
 			t.Errorf("json-iterator codec failed to unmarshal input '%v': %v", c.input, err)
 		}
 		if !reflect.DeepEqual(result.GV, c.expect) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	gojson "encoding/json"
+	encodingjson "encoding/json"
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 )
 
 func TestVerbsMarshalJSON(t *testing.T) {
@@ -35,7 +35,7 @@ func TestVerbsMarshalJSON(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		result, err := gojson.Marshal(&c.input)
+		result, err := encodingjson.Marshal(&c.input)
 		if err != nil {
 			t.Errorf("[%d] Failed to marshal input: '%v': %v", i, c.input, err)
 		}
@@ -56,10 +56,9 @@ func TestVerbsJsonIterUnmarshalJSON(t *testing.T) {
 		{`{"verbs":["delete"]}`, APIResource{Verbs: Verbs([]string{"delete"})}},
 	}
 
-	iter := json.CaseSensitiveJsonIterator()
 	for i, c := range cases {
 		var result APIResource
-		if err := iter.Unmarshal([]byte(c.input), &result); err != nil {
+		if err := utiljson.Unmarshal([]byte(c.input), &result); err != nil {
 			t.Errorf("[%d] Failed to unmarshal input '%v': %v", i, c.input, err)
 		}
 		if !reflect.DeepEqual(result, c.result) {
@@ -80,7 +79,7 @@ func TestMarshalJSONWithOmit(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		result, err := gojson.Marshal(&c.input)
+		result, err := encodingjson.Marshal(&c.input)
 		if err != nil {
 			t.Errorf("[%d] Failed to marshal input: '%v': %v", i, c.input, err)
 		}
@@ -103,7 +102,7 @@ func TestVerbsUnmarshalJSON(t *testing.T) {
 
 	for i, c := range cases {
 		var result APIResource
-		if err := gojson.Unmarshal([]byte(c.input), &result); err != nil {
+		if err := encodingjson.Unmarshal([]byte(c.input), &result); err != nil {
 			t.Errorf("[%d] Failed to unmarshal input '%v': %v", i, c.input, err)
 		}
 		if !reflect.DeepEqual(result, c.result) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
@@ -61,13 +61,14 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion/queryparams:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/naming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/json-iterator/go:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -141,7 +141,7 @@ func doRoundTrip(t *testing.T, item interface{}) {
 		return
 	}
 	if !reflect.DeepEqual(item, unmarshalledObj) {
-		t.Errorf("Object changed during JSON operations, diff: %v", diff.ObjectReflectDiff(item, unmarshalledObj))
+		t.Errorf("Object changed during JSON operations, diff: %v", diff.ObjectGoPrintDiff(item, unmarshalledObj))
 		return
 	}
 
@@ -274,7 +274,7 @@ func TestRoundTrip(t *testing.T) {
 		{
 			// Test slice of interface{} with different values.
 			obj: &D{
-				A: []interface{}{3.0, "3.0", nil},
+				A: []interface{}{3.1, int64(4), "3.0", nil},
 			},
 		},
 	}
@@ -311,7 +311,7 @@ func doUnrecognized(t *testing.T, jsonData string, item interface{}, expectedErr
 	}
 
 	if expectedErr == nil && !reflect.DeepEqual(unmarshalledObj, newObj) {
-		t.Errorf("Object changed, diff: %v", diff.ObjectReflectDiff(unmarshalledObj, newObj))
+		t.Errorf("Object changed, diff: %v", diff.ObjectGoPrintDiff(unmarshalledObj, newObj))
 	}
 }
 
@@ -322,11 +322,11 @@ func TestUnrecognized(t *testing.T) {
 		err  error
 	}{
 		{
-			data: "{\"da\":[3.0,\"3.0\",null]}",
+			data: "{\"da\":[3.1,\"3.0\",null]}",
 			obj:  &D{},
 		},
 		{
-			data: "{\"ea\":[3.0,\"3.0\",null]}",
+			data: "{\"ea\":[3.1,\"3.0\",null]}",
 			obj:  &E{},
 		},
 		{

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
@@ -33,10 +33,9 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/recognizer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/framer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
-        "//vendor/github.com/json-iterator/go:go_default_library",
-        "//vendor/github.com/modern-go/reflect2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -17,19 +17,15 @@ limitations under the License.
 package json
 
 import (
-	"encoding/json"
 	"io"
-	"strconv"
-	"unsafe"
 
 	"github.com/ghodss/yaml"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/modern-go/reflect2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
 	"k8s.io/apimachinery/pkg/util/framer"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -68,62 +64,6 @@ type Serializer struct {
 // Serializer implements Serializer
 var _ runtime.Serializer = &Serializer{}
 var _ recognizer.RecognizingDecoder = &Serializer{}
-
-type customNumberExtension struct {
-	jsoniter.DummyExtension
-}
-
-func (cne *customNumberExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
-	if typ.String() == "interface {}" {
-		return customNumberDecoder{}
-	}
-	return nil
-}
-
-type customNumberDecoder struct {
-}
-
-func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	switch iter.WhatIsNext() {
-	case jsoniter.NumberValue:
-		var number jsoniter.Number
-		iter.ReadVal(&number)
-		i64, err := strconv.ParseInt(string(number), 10, 64)
-		if err == nil {
-			*(*interface{})(ptr) = i64
-			return
-		}
-		f64, err := strconv.ParseFloat(string(number), 64)
-		if err == nil {
-			*(*interface{})(ptr) = f64
-			return
-		}
-		iter.ReportError("DecodeNumber", err.Error())
-	default:
-		*(*interface{})(ptr) = iter.Read()
-	}
-}
-
-// CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
-// case-sensitive when unmarshalling, and otherwise compatible with
-// the encoding/json standard library.
-func CaseSensitiveJsonIterator() jsoniter.API {
-	config := jsoniter.Config{
-		EscapeHTML:             true,
-		SortMapKeys:            true,
-		ValidateJsonRawMessage: true,
-		CaseSensitive:          true,
-	}.Froze()
-	// Force jsoniter to decode number to interface{} via int64/float64, if possible.
-	config.RegisterExtension(&customNumberExtension{})
-	return config
-}
-
-// Private copy of jsoniter to try to shield against possible mutations
-// from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
-// in some other library will mess with every usage of the jsoniter library in the whole program.
-// See https://github.com/json-iterator/go/issues/265
-var caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
 
 // gvkWithDefaults returns group kind and version defaulting from provided default
 func gvkWithDefaults(actual, defaultGVK schema.GroupVersionKind) schema.GroupVersionKind {
@@ -189,7 +129,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		types, _, err := s.typer.ObjectKinds(into)
 		switch {
 		case runtime.IsNotRegisteredError(err), isUnstructured:
-			if err := caseSensitiveJsonIterator.Unmarshal(data, into); err != nil {
+			if err := utiljson.Unmarshal(data, into); err != nil {
 				return nil, actual, err
 			}
 			return into, actual, nil
@@ -213,7 +153,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		return nil, actual, err
 	}
 
-	if err := caseSensitiveJsonIterator.Unmarshal(data, obj); err != nil {
+	if err := utiljson.Unmarshal(data, obj); err != nil {
 		return nil, actual, err
 	}
 	return obj, actual, nil
@@ -222,7 +162,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 // Encode serializes the provided object to the given writer.
 func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	if s.yaml {
-		json, err := caseSensitiveJsonIterator.Marshal(obj)
+		json, err := utiljson.Marshal(obj)
 		if err != nil {
 			return err
 		}
@@ -235,14 +175,14 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	}
 
 	if s.pretty {
-		data, err := caseSensitiveJsonIterator.MarshalIndent(obj, "", "  ")
+		data, err := utiljson.MarshalIndent(obj, "", "  ")
 		if err != nil {
 			return err
 		}
 		_, err = w.Write(data)
 		return err
 	}
-	encoder := json.NewEncoder(w)
+	encoder := utiljson.NewEncoder(w)
 	return encoder.Encode(obj)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/BUILD
@@ -11,6 +11,10 @@ go_library(
     srcs = ["json.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/json",
     importpath = "k8s.io/apimachinery/pkg/util/json",
+    deps = [
+        "//vendor/github.com/json-iterator/go:go_default_library",
+        "//vendor/github.com/modern-go/reflect2:go_default_library",
+    ],
 )
 
 go_test(

--- a/staging/src/k8s.io/apimachinery/pkg/util/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/json.go
@@ -17,103 +17,92 @@ limitations under the License.
 package json
 
 import (
-	"bytes"
-	"encoding/json"
 	"io"
+	"strconv"
+	"unsafe"
+
+	"github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
 )
 
-// NewEncoder delegates to json.NewEncoder
-// It is only here so this package can be a drop-in for common encoding/json uses
-func NewEncoder(w io.Writer) *json.Encoder {
-	return json.NewEncoder(w)
+var (
+	// Private copy of jsoniter to try to shield against possible mutations
+	// from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
+	// in some other library will mess with every usage of the jsoniter library in the whole program.
+	// See https://github.com/json-iterator/go/issues/265
+	caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
+)
+
+type customNumberExtension struct {
+	jsoniter.DummyExtension
 }
 
-// Marshal delegates to json.Marshal
-// It is only here so this package can be a drop-in for common encoding/json uses
-func Marshal(v interface{}) ([]byte, error) {
-	return json.Marshal(v)
+func (cne *customNumberExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
+	if typ.String() == "interface {}" {
+		return customNumberDecoder{}
+	}
+	return nil
 }
 
-// Unmarshal unmarshals the given data
-// If v is a *map[string]interface{}, numbers are converted to int64 or float64
-func Unmarshal(data []byte, v interface{}) error {
-	switch v := v.(type) {
-	case *map[string]interface{}:
-		// Build a decoder from the given data
-		decoder := json.NewDecoder(bytes.NewBuffer(data))
-		// Preserve numbers, rather than casting to float64 automatically
-		decoder.UseNumber()
-		// Run the decode
-		if err := decoder.Decode(v); err != nil {
-			return err
-		}
-		// If the decode succeeds, post-process the map to convert json.Number objects to int64 or float64
-		return convertMapNumbers(*v)
+type customNumberDecoder struct {
+}
 
-	case *[]interface{}:
-		// Build a decoder from the given data
-		decoder := json.NewDecoder(bytes.NewBuffer(data))
-		// Preserve numbers, rather than casting to float64 automatically
-		decoder.UseNumber()
-		// Run the decode
-		if err := decoder.Decode(v); err != nil {
-			return err
+func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		var number jsoniter.Number
+		iter.ReadVal(&number)
+		i64, err := strconv.ParseInt(string(number), 10, 64)
+		if err == nil {
+			*(*interface{})(ptr) = i64
+			return
 		}
-		// If the decode succeeds, post-process the map to convert json.Number objects to int64 or float64
-		return convertSliceNumbers(*v)
-
+		f64, err := strconv.ParseFloat(string(number), 64)
+		if err == nil {
+			*(*interface{})(ptr) = f64
+			return
+		}
+		iter.ReportError("DecodeNumber", err.Error())
 	default:
-		return json.Unmarshal(data, v)
+		*(*interface{})(ptr) = iter.Read()
 	}
 }
 
-// convertMapNumbers traverses the map, converting any json.Number values to int64 or float64.
-// values which are map[string]interface{} or []interface{} are recursively visited
-func convertMapNumbers(m map[string]interface{}) error {
-	var err error
-	for k, v := range m {
-		switch v := v.(type) {
-		case json.Number:
-			m[k], err = convertNumber(v)
-		case map[string]interface{}:
-			err = convertMapNumbers(v)
-		case []interface{}:
-			err = convertSliceNumbers(v)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+// CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// case-sensitive when unmarshalling, and otherwise compatible with
+// the encoding/json standard library.
+func CaseSensitiveJsonIterator() jsoniter.API {
+	config := jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+	}.Froze()
+	// Force jsoniter to decode number to interface{} via int64/float64, if possible.
+	config.RegisterExtension(&customNumberExtension{})
+	return config
 }
 
-// convertSliceNumbers traverses the slice, converting any json.Number values to int64 or float64.
-// values which are map[string]interface{} or []interface{} are recursively visited
-func convertSliceNumbers(s []interface{}) error {
-	var err error
-	for i, v := range s {
-		switch v := v.(type) {
-		case json.Number:
-			s[i], err = convertNumber(v)
-		case map[string]interface{}:
-			err = convertMapNumbers(v)
-		case []interface{}:
-			err = convertSliceNumbers(v)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+// NewEncoder mirrors json.NewEncoder().
+// It is here so this package can be a drop-in for common encoding/json uses.
+func NewEncoder(w io.Writer) *jsoniter.Encoder {
+	return caseSensitiveJsonIterator.NewEncoder(w)
 }
 
-// convertNumber converts a json.Number to an int64 or float64, or returns an error
-func convertNumber(n json.Number) (interface{}, error) {
-	// Attempt to convert to an int64 first
-	if i, err := n.Int64(); err == nil {
-		return i, nil
-	}
-	// Return a float64 (default json.Decode() behavior)
-	// An overflow will return an error
-	return n.Float64()
+// Marshal mirrors json.Marshal().
+// It is here so this package can be a drop-in for common encoding/json uses.
+func Marshal(v interface{}) ([]byte, error) {
+	return caseSensitiveJsonIterator.Marshal(v)
+}
+
+// MarshalIndent mirrors json.MarshalIndent().
+// It is here so this package can be a drop-in for common encoding/json uses.
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return caseSensitiveJsonIterator.MarshalIndent(v, prefix, indent)
+}
+
+// Unmarshal mirrors json.Unmarshal().
+// Numbers are converted to int64 or float64.
+func Unmarshal(data []byte, v interface{}) error {
+	return caseSensitiveJsonIterator.Unmarshal(data, v)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/json.go
@@ -30,7 +30,7 @@ var (
 	// from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
 	// in some other library will mess with every usage of the jsoniter library in the whole program.
 	// See https://github.com/json-iterator/go/issues/265
-	caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
+	caseSensitiveJSONIterator = CaseSensitiveJSONIterator()
 )
 
 type customNumberExtension struct {
@@ -68,10 +68,10 @@ func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	}
 }
 
-// CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// CaseSensitiveJSONIterator returns a jsoniterator API that's configured to be
 // case-sensitive when unmarshalling, and otherwise compatible with
 // the encoding/json standard library.
-func CaseSensitiveJsonIterator() jsoniter.API {
+func CaseSensitiveJSONIterator() jsoniter.API {
 	config := jsoniter.Config{
 		EscapeHTML:             true,
 		SortMapKeys:            true,
@@ -86,23 +86,23 @@ func CaseSensitiveJsonIterator() jsoniter.API {
 // NewEncoder mirrors json.NewEncoder().
 // It is here so this package can be a drop-in for common encoding/json uses.
 func NewEncoder(w io.Writer) *jsoniter.Encoder {
-	return caseSensitiveJsonIterator.NewEncoder(w)
+	return caseSensitiveJSONIterator.NewEncoder(w)
 }
 
 // Marshal mirrors json.Marshal().
 // It is here so this package can be a drop-in for common encoding/json uses.
 func Marshal(v interface{}) ([]byte, error) {
-	return caseSensitiveJsonIterator.Marshal(v)
+	return caseSensitiveJSONIterator.Marshal(v)
 }
 
 // MarshalIndent mirrors json.MarshalIndent().
 // It is here so this package can be a drop-in for common encoding/json uses.
 func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
-	return caseSensitiveJsonIterator.MarshalIndent(v, prefix, indent)
+	return caseSensitiveJSONIterator.MarshalIndent(v, prefix, indent)
 }
 
 // Unmarshal mirrors json.Unmarshal().
 // Numbers are converted to int64 or float64.
 func Unmarshal(data []byte, v interface{}) error {
-	return caseSensitiveJsonIterator.Unmarshal(data, v)
+	return caseSensitiveJSONIterator.Unmarshal(data, v)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -111,7 +111,7 @@ func TestPatchInvalid(t *testing.T) {
 		TestPatchSubType: TestPatchSubType{StringField: "my-value"},
 	}
 	patch := `barbaz`
-	expectedError := "invalid character 'b' looking for beginning of value"
+	expectedError := "ReadMapCB: expect { or n, but found b, error found in #1 byte of ...|barbaz|..., bigger context ...|barbaz|..."
 
 	actual := &testPatchType{}
 	err := strategicPatchObject(defaulter, original, []byte(patch), actual, &testPatchType{})


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Changes `k8s.io/apimachinery/pkg/util/json` to use `github.com/json-iterator/go` instead of  `encoding/json`;
2. Changes all `encoding/json` usages and all direct `github.com/json-iterator/go` usages to `k8s.io/apimachinery/pkg/util/json`

This is to ensure json marshaling and unmarshaling is consistent and always uses the same library which is better performance-wise.

**Special notes for your reviewer**:
Inconsistency discovered while working on https://github.com/kubernetes/kubernetes/pull/62981.

**Release note**:
```release-note
NONE
```
/kind enhancement
/sig api-machinery