### PR TITLE
[prometheus addon] Fix missing storage class in alertmanager PVC

### DIFF
--- a/cluster/addons/prometheus/alertmanager-pvc.yaml
+++ b/cluster/addons/prometheus/alertmanager-pvc.yaml
@@ -7,6 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists
 spec:
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Fixes ci-kubernetes-e2e-gce-prometheus test suite
https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-prometheus
This PR adds missing storage class to PVC, gce does not have default storage class, so k8s was not able to create PVC.
```release-note
NONE
```
