### PR TITLE
 remove rootscopedkinds from groupmeta

### DIFF
--- a/pkg/apis/admission/install/BUILD
+++ b/pkg/apis/admission/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/admission/install/install.go
+++ b/pkg/apis/admission/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/admission"
 	"k8s.io/kubernetes/pkg/apis/admission/v1beta1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  admission.GroupName,
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("AdmissionReview"),
 			AddInternalObjectsToScheme: admission.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/admissionregistration/install/BUILD
+++ b/pkg/apis/admissionregistration/install/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/admissionregistration/install/install.go
+++ b/pkg/apis/admissionregistration/install/install.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1"
@@ -36,7 +35,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  admissionregistration.GroupName,
-			RootScopedKinds:            sets.NewString("InitializerConfiguration", "ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"),
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: admissionregistration.AddToScheme,
 		},

--- a/pkg/apis/authentication/install/BUILD
+++ b/pkg/apis/authentication/install/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/authentication/install/install.go
+++ b/pkg/apis/authentication/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/authentication"
 	"k8s.io/kubernetes/pkg/apis/authentication/v1"
@@ -39,7 +38,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  authentication.GroupName,
 			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("TokenReview"),
 			AddInternalObjectsToScheme: authentication.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/authorization/install/BUILD
+++ b/pkg/apis/authorization/install/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/authorization/install/install.go
+++ b/pkg/apis/authorization/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/apis/authorization/v1"
@@ -39,7 +38,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  authorization.GroupName,
 			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("SubjectAccessReview", "SelfSubjectAccessReview", "SelfSubjectRulesReview"),
 			AddInternalObjectsToScheme: authorization.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/certificates/install/BUILD
+++ b/pkg/apis/certificates/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/certificates/install/install.go
+++ b/pkg/apis/certificates/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  certificates.GroupName,
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("CertificateSigningRequest"),
 			AddInternalObjectsToScheme: certificates.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/core/install/BUILD
+++ b/pkg/apis/core/install/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/core/install/install.go
+++ b/pkg/apis/core/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/v1"
@@ -39,12 +38,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 			GroupName:                  core.GroupName,
 			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: core.AddToScheme,
-			RootScopedKinds: sets.NewString(
-				"Node",
-				"Namespace",
-				"PersistentVolume",
-				"ComponentStatus",
-			),
 		},
 		announced.VersionToSchemeFunc{
 			v1.SchemeGroupVersion.Version: v1.AddToScheme,

--- a/pkg/apis/extensions/install/BUILD
+++ b/pkg/apis/extensions/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  extensions.GroupName,
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("PodSecurityPolicy"),
 			AddInternalObjectsToScheme: extensions.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/imagepolicy/install/BUILD
+++ b/pkg/apis/imagepolicy/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/imagepolicy/install/install.go
+++ b/pkg/apis/imagepolicy/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/imagepolicy"
 	"k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  imagepolicy.GroupName,
 			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("ImageReview"),
 			AddInternalObjectsToScheme: imagepolicy.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/policy/install/BUILD
+++ b/pkg/apis/policy/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/policy/install/install.go
+++ b/pkg/apis/policy/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/apis/policy/v1beta1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  policy.GroupName,
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("PodSecurityPolicy"),
 			AddInternalObjectsToScheme: policy.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/rbac/install/BUILD
+++ b/pkg/apis/rbac/install/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/rbac/install/install.go
+++ b/pkg/apis/rbac/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -43,7 +42,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 			// 1.10 (once all stored objects are at v1):
 			// * remove v1alpha1 (announced deprecated in 1.8)
 			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("ClusterRole", "ClusterRoleBinding"),
 			AddInternalObjectsToScheme: rbac.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/scheduling/install/BUILD
+++ b/pkg/apis/scheduling/install/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/scheduling/install/install.go
+++ b/pkg/apis/scheduling/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1"
@@ -38,7 +37,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  scheduling.GroupName,
 			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("PriorityClass"),
 			AddInternalObjectsToScheme: scheduling.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/apis/storage/install/BUILD
+++ b/pkg/apis/storage/install/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/apis/storage/install/install.go
+++ b/pkg/apis/storage/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/apis/storage/v1"
@@ -38,12 +37,8 @@ func init() {
 func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:              storage.GroupName,
-			VersionPreferenceOrder: []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds: sets.NewString(
-				"StorageClass",
-				"VolumeAttachment",
-			),
+			GroupName:                  storage.GroupName,
+			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: storage.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/pkg/kubectl/scheme/BUILD
+++ b/pkg/kubectl/scheme/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
 )

--- a/pkg/kubectl/scheme/install.go
+++ b/pkg/kubectl/scheme/install.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
@@ -65,12 +64,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              corev1.GroupName,
 			VersionPreferenceOrder: []string{corev1.SchemeGroupVersion.Version},
-			RootScopedKinds: sets.NewString(
-				"Node",
-				"Namespace",
-				"PersistentVolume",
-				"ComponentStatus",
-			),
 		},
 		announced.VersionToSchemeFunc{
 			corev1.SchemeGroupVersion.Version: corev1.AddToScheme,
@@ -84,7 +77,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              admissionv1alpha1.GroupName,
 			VersionPreferenceOrder: []string{admissionv1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("AdmissionReview"),
 		},
 		announced.VersionToSchemeFunc{
 			admissionv1alpha1.SchemeGroupVersion.Version: admissionv1alpha1.AddToScheme,
@@ -97,7 +89,6 @@ func init() {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              admissionregistrationv1alpha1.GroupName,
-			RootScopedKinds:        sets.NewString("InitializerConfiguration", "ValidatingWebhookConfiguration", "MutatingWebhookConfiguration"),
 			VersionPreferenceOrder: []string{admissionregistrationv1alpha1.SchemeGroupVersion.Version},
 		},
 		announced.VersionToSchemeFunc{
@@ -127,7 +118,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              authenticationv1beta1.GroupName,
 			VersionPreferenceOrder: []string{authenticationv1.SchemeGroupVersion.Version, authenticationv1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("TokenReview"),
 		},
 		announced.VersionToSchemeFunc{
 			authenticationv1beta1.SchemeGroupVersion.Version: authenticationv1beta1.AddToScheme,
@@ -142,7 +132,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              authorizationv1.GroupName,
 			VersionPreferenceOrder: []string{authorizationv1.SchemeGroupVersion.Version, authorizationv1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("SubjectAccessReview", "SelfSubjectAccessReview", "SelfSubjectRulesReview"),
 		},
 		announced.VersionToSchemeFunc{
 			authorizationv1beta1.SchemeGroupVersion.Version: authorizationv1beta1.AddToScheme,
@@ -186,7 +175,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              certificatesv1beta1.GroupName,
 			VersionPreferenceOrder: []string{certificatesv1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("CertificateSigningRequest"),
 		},
 		announced.VersionToSchemeFunc{
 			certificatesv1beta1.SchemeGroupVersion.Version: certificatesv1beta1.AddToScheme,
@@ -200,7 +188,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              extensionsv1beta1.GroupName,
 			VersionPreferenceOrder: []string{extensionsv1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("PodSecurityPolicy"),
 		},
 		announced.VersionToSchemeFunc{
 			extensionsv1beta1.SchemeGroupVersion.Version: extensionsv1beta1.AddToScheme,
@@ -214,7 +201,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              imagepolicyv1alpha1.GroupName,
 			VersionPreferenceOrder: []string{imagepolicyv1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("ImageReview"),
 		},
 		announced.VersionToSchemeFunc{
 			imagepolicyv1alpha1.SchemeGroupVersion.Version: imagepolicyv1alpha1.AddToScheme,
@@ -254,7 +240,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              rbacv1.GroupName,
 			VersionPreferenceOrder: []string{rbacv1.SchemeGroupVersion.Version, rbacv1beta1.SchemeGroupVersion.Version, rbacv1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("ClusterRole", "ClusterRoleBinding"),
 		},
 		announced.VersionToSchemeFunc{
 			rbacv1.SchemeGroupVersion.Version:       rbacv1.AddToScheme,
@@ -270,7 +255,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              schedulingv1alpha1.GroupName,
 			VersionPreferenceOrder: []string{schedulingv1alpha1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("PriorityClass"),
 		},
 		announced.VersionToSchemeFunc{
 			schedulingv1alpha1.SchemeGroupVersion.Version: schedulingv1alpha1.AddToScheme,
@@ -297,7 +281,6 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              storagev1.GroupName,
 			VersionPreferenceOrder: []string{storagev1.SchemeGroupVersion.Version, storagev1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:        sets.NewString("StorageClass"),
 		},
 		announced.VersionToSchemeFunc{
 			storagev1.SchemeGroupVersion.Version:      storagev1.AddToScheme,

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -223,10 +223,6 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	}
 }
 
-func (*ScaleREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -151,10 +151,6 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	}
 }
 
-func (*ScaleREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -140,10 +140,6 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	}
 }
 
-func (*ScaleREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}

--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -37,6 +37,10 @@ func NewREST(tokenAuthenticator authenticator.Request) *REST {
 	return &REST{tokenAuthenticator: tokenAuthenticator}
 }
 
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
+
 func (r *REST) New() runtime.Object {
 	return &authentication.TokenReview{}
 }

--- a/pkg/registry/authorization/localsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/localsubjectaccessreview/rest.go
@@ -38,6 +38,10 @@ func NewREST(authorizer authorizer.Authorizer) *REST {
 	return &REST{authorizer}
 }
 
+func (r *REST) NamespaceScoped() bool {
+	return true
+}
+
 func (r *REST) New() runtime.Object {
 	return &authorizationapi.LocalSubjectAccessReview{}
 }

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -38,6 +38,10 @@ func NewREST(authorizer authorizer.Authorizer) *REST {
 	return &REST{authorizer}
 }
 
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
+
 func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectAccessReview{}
 }

--- a/pkg/registry/authorization/selfsubjectrulesreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectrulesreview/rest.go
@@ -38,6 +38,11 @@ func NewREST(ruleResolver authorizer.RuleResolver) *REST {
 	return &REST{ruleResolver}
 }
 
+// NamespaceScoped fulfill rest.Scoper
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
+
 // New creates a new selfsubjectrulesreview object.
 func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectRulesReview{}

--- a/pkg/registry/authorization/subjectaccessreview/rest.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest.go
@@ -37,6 +37,10 @@ func NewREST(authorizer authorizer.Authorizer) *REST {
 	return &REST{authorizer}
 }
 
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
+
 func (r *REST) New() runtime.Object {
 	return &authorizationapi.SubjectAccessReview{}
 }

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -40,6 +40,10 @@ func NewStorage(serverRetriever func() map[string]*Server) *REST {
 	}
 }
 
+func (*REST) NamespaceScoped() bool {
+	return false
+}
+
 func (rs *REST) New() runtime.Object {
 	return &api.ComponentStatus{}
 }

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -84,6 +84,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}
 }
 
+func (r *REST) NamespaceScoped() bool {
+	return r.store.NamespaceScoped()
+}
+
 func (r *REST) New() runtime.Object {
 	return r.store.New()
 }

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -72,11 +72,6 @@ func (r *EvictionREST) GroupVersionKind(containingGV schema.GroupVersion) schema
 	return schema.GroupVersionKind{Group: "policy", Version: "v1beta1", Kind: "Eviction"}
 }
 
-// ClusterScoped fulfills GroupVersionKindProvider
-func (*EvictionREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new eviction resource
 func (r *EvictionREST) New() runtime.Object {
 	return &policy.Eviction{}

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -127,6 +127,11 @@ type BindingREST struct {
 	store *genericregistry.Store
 }
 
+// NamespaceScoped fulfill rest.Scoper
+func (r *BindingREST) NamespaceScoped() bool {
+	return r.store.NamespaceScoped()
+}
+
 // New creates a new binding resource
 func (r *BindingREST) New() runtime.Object {
 	return &api.Binding{}

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -140,10 +140,6 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	}
 }
 
-func (*ScaleREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -70,6 +70,7 @@ type ServiceNodePort struct {
 }
 
 type ServiceStorage interface {
+	rest.Scoper
 	rest.Getter
 	rest.Lister
 	rest.CreaterUpdater
@@ -121,6 +122,10 @@ func (rs *REST) ShortNames() []string {
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (rs *REST) Categories() []string {
 	return []string{"all"}
+}
+
+func (rs *REST) NamespaceScoped() bool {
+	return rs.services.NamespaceScoped()
 }
 
 func (rs *REST) New() runtime.Object {

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -65,6 +65,10 @@ type serviceStorage struct {
 	Err                error
 }
 
+func (s *serviceStorage) NamespaceScoped() bool {
+	return true
+}
+
 func (s *serviceStorage) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	s.GottenID = name
 	return s.Service, s.Err

--- a/pkg/registry/core/serviceaccount/storage/token.go
+++ b/pkg/registry/core/serviceaccount/storage/token.go
@@ -121,10 +121,6 @@ func (r *TokenREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	}
 }
 
-func (*TokenREST) ClusterScoped() bool {
-	return false
-}
-
 type getter interface {
 	Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error)
 }

--- a/pkg/registry/extensions/controller/storage/storage.go
+++ b/pkg/registry/extensions/controller/storage/storage.go
@@ -124,6 +124,10 @@ func scaleFromRC(rc *api.ReplicationController) *autoscaling.Scale {
 // Dummy implementation
 type RcREST struct{}
 
+func (r *RcREST) NamespaceScoped() bool {
+	return true
+}
+
 func (r *RcREST) New() runtime.Object {
 	return &extensions.ReplicationControllerDummy{}
 }

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -42,6 +42,10 @@ func NewStorage(s rest.StandardStorage, ruleResolver rbacregistryvalidation.Auth
 	return &Storage{s, ruleResolver}
 }
 
+func (r *Storage) NamespaceScoped() bool {
+	return false
+}
+
 var fullAuthority = []rbac.PolicyRule{
 	rbac.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
 	rbac.NewRule("*").URLs("*").RuleOrDie(),

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -45,6 +45,10 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+func (r *Storage) NamespaceScoped() bool {
+	return false
+}
+
 func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, includeUninitialized bool) (runtime.Object, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -41,6 +41,10 @@ func NewStorage(s rest.StandardStorage, ruleResolver rbacregistryvalidation.Auth
 	return &Storage{s, ruleResolver}
 }
 
+func (r *Storage) NamespaceScoped() bool {
+	return true
+}
+
 func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, includeUninitialized bool) (runtime.Object, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -45,6 +45,10 @@ func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleRe
 	return &Storage{s, authorizer, ruleResolver}
 }
 
+func (r *Storage) NamespaceScoped() bool {
+	return true
+}
+
 func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, includeUninitialized bool) (runtime.Object, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Install registers the API group and adds types to a scheme
@@ -30,7 +29,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apiextensions.GroupName,
-			RootScopedKinds:            sets.NewString("CustomResourceDefinition"),
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: apiextensions.AddToScheme,
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -145,10 +145,6 @@ func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.Gr
 	return autoscalingv1.SchemeGroupVersion.WithKind("Scale")
 }
 
-func (*ScaleREST) ClusterScoped() bool {
-	return false
-}
-
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscalingv1.Scale{}

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
@@ -46,8 +46,6 @@ type GroupMetaFactoryArgs struct {
 	// example: 'servicecatalog.k8s.io'
 	GroupName              string
 	VersionPreferenceOrder []string
-	// RootScopedKinds are resources that are not namespaced.
-	RootScopedKinds sets.String // nil is allowed
 
 	// May be nil if there are no internal objects.
 	AddInternalObjectsToScheme SchemeFunc
@@ -149,8 +147,7 @@ func (gmf *GroupMetaFactory) Register(m *registered.APIRegistrationManager, sche
 	}
 
 	groupMeta := &apimachinery.GroupMeta{
-		GroupVersions:   externalVersions,
-		RootScopedKinds: gmf.GroupArgs.RootScopedKinds,
+		GroupVersions: externalVersions,
 	}
 
 	if err := m.RegisterGroup(*groupMeta); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/apiserver:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 )
@@ -30,7 +29,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apiserver.GroupName,
-			RootScopedKinds:            sets.NewString("AdmissionConfiguration"),
 			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: apiserver.AddToScheme,
 		},

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/install/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/install/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/install/install.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 	"k8s.io/apiserver/pkg/apis/audit/v1beta1"
@@ -32,10 +31,8 @@ import (
 func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
-			GroupName:              audit.GroupName,
-			VersionPreferenceOrder: []string{v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
-			// Any Kind that is not namespaced must be cluster scoped.
-			RootScopedKinds:            sets.NewString("Event", "Policy"),
+			GroupName:                  audit.GroupName,
+			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: audit.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -347,6 +347,10 @@ type SimpleRESTStorage struct {
 	injectedFunction func(obj runtime.Object) (returnObj runtime.Object, err error)
 }
 
+func (storage *SimpleRESTStorage) NamespaceScoped() bool {
+	return true
+}
+
 func (storage *SimpleRESTStorage) Export(ctx context.Context, name string, opts metav1.ExportOptions) (runtime.Object, error) {
 	obj, err := storage.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
@@ -615,6 +619,10 @@ type GetWithOptionsRootRESTStorage struct {
 	takesPath       string
 }
 
+func (r *GetWithOptionsRootRESTStorage) NamespaceScoped() bool {
+	return false
+}
+
 func (r *GetWithOptionsRootRESTStorage) Get(ctx context.Context, name string, options runtime.Object) (runtime.Object, error) {
 	if _, ok := options.(*genericapitesting.SimpleGetOptions); !ok {
 		return nil, fmt.Errorf("Unexpected options object: %#v", options)
@@ -800,6 +808,10 @@ func TestNotFound(t *testing.T) {
 }
 
 type UnimplementedRESTStorage struct{}
+
+func (UnimplementedRESTStorage) NamespaceScoped() bool {
+	return true
+}
 
 func (UnimplementedRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
@@ -3772,10 +3784,6 @@ func (storage *SimpleXGSubresourceRESTStorage) Get(ctx context.Context, id strin
 
 func (storage *SimpleXGSubresourceRESTStorage) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	return storage.itemGVK
-}
-
-func (*SimpleXGSubresourceRESTStorage) ClusterScoped() bool {
-	return false
 }
 
 func TestXGSubresource(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -132,18 +132,18 @@ func (a *APIInstaller) newWebService() *restful.WebService {
 }
 
 // getResourceKind returns the external group version kind registered for the given storage
-// object and whether or not the kind is cluster scoped. If the storage object is a subresource and has an override supplied for it, it returns
+// object. If the storage object is a subresource and has an override supplied for it, it returns
 // the group version kind supplied in the override.
-func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schema.GroupVersionKind, bool, error) {
+func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schema.GroupVersionKind, error) {
 	// Let the storage tell us exactly what GVK it has
 	if gvkProvider, ok := storage.(rest.GroupVersionKindProvider); ok {
-		return gvkProvider.GroupVersionKind(a.group.GroupVersion), gvkProvider.ClusterScoped(), nil
+		return gvkProvider.GroupVersionKind(a.group.GroupVersion), nil
 	}
 
 	object := storage.New()
 	fqKinds, _, err := a.group.Typer.ObjectKinds(object)
 	if err != nil {
-		return schema.GroupVersionKind{}, false, err
+		return schema.GroupVersionKind{}, err
 	}
 
 	// a given go type can have multiple potential fully qualified kinds.  Find the one that corresponds with the group
@@ -156,11 +156,11 @@ func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schem
 		}
 	}
 	if fqKindToRegister.Empty() {
-		return schema.GroupVersionKind{}, false, fmt.Errorf("unable to locate fully qualified kind for %v: found %v when registering for %v", reflect.TypeOf(object), fqKinds, a.group.GroupVersion)
+		return schema.GroupVersionKind{}, fmt.Errorf("unable to locate fully qualified kind for %v: found %v when registering for %v", reflect.TypeOf(object), fqKinds, a.group.GroupVersion)
 	}
 
 	// group is guaranteed to match based on the check above
-	return fqKindToRegister, a.group.RootScopedKinds.Has(fqKindToRegister.Kind), nil
+	return fqKindToRegister, nil
 }
 
 func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storage, ws *restful.WebService) (*metav1.APIResource, error) {
@@ -176,7 +176,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		return nil, err
 	}
 
-	fqKindToRegister, clusterScoped, err := a.getResourceKind(path, storage)
+	fqKindToRegister, err := a.getResourceKind(path, storage)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,28 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	}
 	defaultVersionedObject := indirectArbitraryPointer(versionedPtr)
 	kind := fqKindToRegister.Kind
-	hasSubresource := len(subresource) > 0
+	isSubresource := len(subresource) > 0
+
+	// If there is a subresource, namespace scoping is defined by the parent resource
+	namespaceScoped := true
+	if isSubresource {
+		parentStorage, ok := a.group.Storage[resource]
+		if !ok {
+			return nil, fmt.Errorf("missing parent storage: %q", resource)
+		}
+		scoper, ok := parentStorage.(rest.Scoper)
+		if !ok {
+			return nil, fmt.Errorf("%q must implement scoper", resource)
+		}
+		namespaceScoped = scoper.NamespaceScoped()
+
+	} else {
+		scoper, ok := storage.(rest.Scoper)
+		if !ok {
+			return nil, fmt.Errorf("%q must implement scoper", resource)
+		}
+		namespaceScoped = scoper.NamespaceScoped()
+	}
 
 	// what verbs are supported by the storage, used to know what verbs we support per path
 	creater, isCreater := storage.(rest.Creater)
@@ -330,7 +351,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	var apiResource metav1.APIResource
 	// Get the list of actions for the given scope.
 	switch {
-	case clusterScoped:
+	case !namespaceScoped:
 		// Handle non-namespace scoped resources like nodes.
 		resourcePath := resource
 		resourceParams := params
@@ -338,7 +359,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		nameParams := append(params, nameParam)
 		proxyParams := append(nameParams, pathParam)
 		suffix := ""
-		if hasSubresource {
+		if isSubresource {
 			suffix = "/" + subresource
 			itemPath = itemPath + suffix
 			resourcePath = itemPath
@@ -387,7 +408,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		nameParams := append(namespaceParams, nameParam)
 		proxyParams := append(nameParams, pathParam)
 		itemPathSuffix := ""
-		if hasSubresource {
+		if isSubresource {
 			itemPathSuffix = "/" + subresource
 			itemPath = itemPath + itemPathSuffix
 			resourcePath = itemPath
@@ -423,7 +444,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// list or post across namespace.
 		// For ex: LIST all pods in all namespaces by sending a LIST request at /api/apiVersion/pods.
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
-		if !hasSubresource {
+		if !isSubresource {
 			actions = appendIf(actions, action{"LIST", resource, params, namer, true}, isLister)
 			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true}, allowWatchList)
 		}
@@ -509,12 +530,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		routes := []*restful.RouteBuilder{}
 
 		// If there is a subresource, kind should be the parent's kind.
-		if hasSubresource {
+		if isSubresource {
 			parentStorage, ok := a.group.Storage[resource]
 			if !ok {
 				return nil, fmt.Errorf("missing parent storage: %q", resource)
 			}
-			fqParentKind, _, err := a.getResourceKind(resource, parentStorage)
+
+			fqParentKind, err := a.getResourceKind(resource, parentStorage)
 			if err != nil {
 				return nil, err
 			}
@@ -527,7 +549,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		case "GET": // Get a resource.
 			var handler restful.RouteFunction
 			if isGetterWithOptions {
-				handler = restfulGetResourceWithOptions(getterWithOptions, reqScope, hasSubresource)
+				handler = restfulGetResourceWithOptions(getterWithOptions, reqScope, isSubresource)
 			} else {
 				handler = restfulGetResource(getter, exporter, reqScope)
 			}
@@ -543,7 +565,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				handler = genericfilters.RestfulWithCompression(handler)
 			}
 			doc := "read the specified " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "read " + subresource + " of the specified " + kind
 			}
 			route := ws.GET(action.Path).To(handler).
@@ -567,7 +589,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			routes = append(routes, route)
 		case "LIST": // List all resources of a kind.
 			doc := "list objects of kind " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "list " + subresource + " of objects of kind " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulListResource(lister, watcher, reqScope, false, a.minRequestTimeout))
@@ -587,13 +609,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			switch {
 			case isLister && isWatcher:
 				doc := "list or watch objects of kind " + kind
-				if hasSubresource {
+				if isSubresource {
 					doc = "list or watch " + subresource + " of objects of kind " + kind
 				}
 				route.Doc(doc)
 			case isWatcher:
 				doc := "watch objects of kind " + kind
-				if hasSubresource {
+				if isSubresource {
 					doc = "watch " + subresource + "of objects of kind " + kind
 				}
 				route.Doc(doc)
@@ -602,7 +624,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			routes = append(routes, route)
 		case "PUT": // Update a resource.
 			doc := "replace the specified " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "replace " + subresource + " of the specified " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulUpdateResource(updater, reqScope, admit))
@@ -621,7 +643,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			routes = append(routes, route)
 		case "PATCH": // Partially update a resource
 			doc := "partially update the specified " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "partially update " + subresource + " of the specified " + kind
 			}
 			supportedTypes := []string{
@@ -651,7 +673,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			handler = metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, handler)
 			article := getArticleForNoun(kind, " ")
 			doc := "create" + article + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "create " + subresource + " of" + article + kind
 			}
 			route := ws.POST(action.Path).To(handler).
@@ -671,7 +693,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		case "DELETE": // Delete a resource.
 			article := getArticleForNoun(kind, " ")
 			doc := "delete" + article + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "delete " + subresource + " of" + article + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulDeleteResource(gracefulDeleter, isGracefulDeleter, reqScope, admit))
@@ -692,7 +714,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			routes = append(routes, route)
 		case "DELETECOLLECTION":
 			doc := "delete collection of " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "delete collection of " + subresource + " of a " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulDeleteCollection(collectionDeleter, isCollectionDeleter, reqScope, admit))
@@ -711,7 +733,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// TODO: deprecated
 		case "WATCH": // Watch a resource.
 			doc := "watch changes to an object of kind " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "watch changes to " + subresource + " of an object of kind " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
@@ -730,7 +752,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// TODO: deprecated
 		case "WATCHLIST": // Watch all resources of a kind.
 			doc := "watch individual changes to a list of " + kind
-			if hasSubresource {
+			if isSubresource {
 				doc = "watch individual changes to a list of " + subresource + " of " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
@@ -753,10 +775,10 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 					connectProducedObject = "string"
 				}
 				doc := "connect " + method + " requests to " + kind
-				if hasSubresource {
+				if isSubresource {
 					doc = "connect " + method + " requests to " + subresource + " of " + kind
 				}
-				handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulConnectResource(connecter, reqScope, admit, path, hasSubresource))
+				handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulConnectResource(connecter, reqScope, admit, path, isSubresource))
 				route := ws.Method(method).Path(action.Path).
 					To(handler).
 					Doc(doc).

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -242,6 +242,18 @@ func (e *Store) NewList() runtime.Object {
 	return e.NewListFunc()
 }
 
+// NamespaceScoped indicates whether the resource is namespaced
+func (e *Store) NamespaceScoped() bool {
+	if e.CreateStrategy != nil {
+		return e.CreateStrategy.NamespaceScoped()
+	}
+	if e.UpdateStrategy != nil {
+		return e.UpdateStrategy.NamespaceScoped()
+	}
+
+	panic("programmer error: no CRUD for resource, you're crazy, override NamespaceScoped too")
+}
+
 // GetCreateStrategy implements GenericStore.
 func (e *Store) GetCreateStrategy() rest.RESTCreateStrategy {
 	return e.CreateStrategy

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -58,6 +58,13 @@ type Storage interface {
 	New() runtime.Object
 }
 
+// Scoper indicates what scope the resource is at. It must be specified.
+// It is usually provided automatically based on your strategy.
+type Scoper interface {
+	// NamespaceScoped returns true if the storage is namespaced
+	NamespaceScoped() bool
+}
+
 // KindProvider specifies a different kind for its API than for its internal storage.  This is necessary for external
 // objects that are not compiled into the api server.  For such objects, there is no in-memory representation for
 // the object, so they must be represented as generic objects (e.g. runtime.Unknown), but when we present the object as part of
@@ -83,7 +90,6 @@ type CategoriesProvider interface {
 // TODO KindProvider (only used by federation) should be removed and replaced with this, but that presents greater risk late in 1.8.
 type GroupVersionKindProvider interface {
 	GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind
-	ClusterScoped() bool
 }
 
 // Lister is an object that can retrieve resources that match the provided field and label criteria.

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -25,7 +25,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/discovery:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/filters:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -424,7 +424,6 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Defaulter:       apiGroupInfo.Scheme,
 		Typer:           apiGroupInfo.Scheme,
 		Linker:          runtime.SelfLinker(meta.NewAccessor()),
-		RootScopedKinds: apiGroupInfo.GroupMeta.RootScopedKinds,
 
 		Admit:                        s.admissionControl,
 		MinRequestTimeout:            s.minRequestTimeout,

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
@@ -416,32 +415,12 @@ func (authz *mockAuthorizer) Authorize(a authorizer.Attributes) (authorized auth
 	return authorizer.DecisionAllow, "", nil
 }
 
-type mockAuthenticator struct {
-	lastURI string
-}
-
-func (authn *mockAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	authn.lastURI = req.RequestURI
-	return &user.DefaultInfo{
-		Name: "foo",
-	}, true, nil
-}
-
-func decodeResponse(resp *http.Response, obj interface{}) error {
-	defer resp.Body.Close()
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, obj); err != nil {
-		return err
-	}
-	return nil
-}
-
 type testGetterStorage struct {
 	Version string
+}
+
+func (p *testGetterStorage) NamespaceScoped() bool {
+	return true
 }
 
 func (p *testGetterStorage) New() runtime.Object {
@@ -459,6 +438,10 @@ func (p *testGetterStorage) Get(ctx context.Context, name string, options *metav
 
 type testNoVerbsStorage struct {
 	Version string
+}
+
+func (p *testNoVerbsStorage) NamespaceScoped() bool {
+	return true
 }
 
 func (p *testNoVerbsStorage) New() runtime.Object {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -31,7 +30,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apiregistration.GroupName,
-			RootScopedKinds:            sets.NewString("APIService"),
 			VersionPreferenceOrder:     []string{v1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: apiregistration.AddToScheme,
 		},

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/install/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/install/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/metrics/pkg/apis/metrics:go_default_library",
         "//vendor/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
     ],

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/metrics/pkg/apis/metrics"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
@@ -33,7 +32,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  metrics.GroupName,
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
-			RootScopedKinds:            sets.NewString("NodeMetrics"),
 			AddInternalObjectsToScheme: metrics.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/install/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/install/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/install/install.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/install/install.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/sample-apiserver/pkg/apis/wardle"
 	"k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
@@ -31,7 +30,6 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  wardle.GroupName,
-			RootScopedKinds:            sets.NewString("Fischer", "FischerList"),
 			VersionPreferenceOrder:     []string{v1alpha1.SchemeGroupVersion.Version, v1beta1.SchemeGroupVersion.Version},
 			AddInternalObjectsToScheme: wardle.AddToScheme,
 		},


### PR DESCRIPTION
builds on https://github.com/kubernetes/kubernetes/pull/63206

Since, a RESTMapping can only be determined based on a connection to a server, the only thing that needs to know the namespaced-ness of a resource is the code doing the registration.  Everything else is derived from that source of truth.  This removes the other dangling references and collapses down onto the existing namespaced-ness methods in the strategies backing the stores.

@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```