### PR TITLE
Add --ignore-already-exists to create

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -863,6 +863,10 @@ __EOF__
   kubectl create -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml "${kube_flags[@]}"
   # Post-condition: redis-master and valid-pod PODs exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'redis-master:valid-pod:'
+  # Command succeeds when run again with --ignore-already-exists
+  kubectl create --ignore-already-exists -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml "${kube_flags[@]}"
+  # Command fails when run again without --ignore-already-exists
+  ! kubectl create --ignore-already-exists -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml "${kube_flags[@]}"
 
   ### Delete two PODs from 1 yaml file
   # Pre-condition: redis-master and valid-pod PODs exist
@@ -2401,6 +2405,10 @@ run_secrets_test() {
   kubectl create namespace test-secrets
   # Post-condition: namespace 'test-secrets' is created.
   kube::test::get_object_assert 'namespaces/test-secrets' "{{$id_field}}" 'test-secrets'
+  # Command succeeds when --ignore-already-exists is passed
+  kubectl create namespace test-secrets --ignore-already-exists
+  # Command fails when --ignore-already-exists is not passed
+  ! kubectl create namespace test-secrets --ignore-already-exists
 
   ### Create a generic secret in a specific namespace
   # Pre-condition: no SECRET exists

--- a/pkg/kubectl/cmd/create/BUILD
+++ b/pkg/kubectl/cmd/create/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//vendor/k8s.io/api/batch/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 
 	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,10 +48,11 @@ type CreateOptions struct {
 
 	DryRun bool
 
-	FilenameOptions  resource.FilenameOptions
-	Selector         string
-	EditBeforeCreate bool
-	Raw              string
+	FilenameOptions     resource.FilenameOptions
+	Selector            string
+	EditBeforeCreate    bool
+	Raw                 string
+	IgnoreAlreadyExists bool
 
 	Recorder genericclioptions.Recorder
 	PrintObj func(obj kruntime.Object) error
@@ -119,6 +121,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 		"Only relevant if --edit=true. Defaults to the line ending native to your platform.")
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
+	cmd.Flags().BoolVar(&o.IgnoreAlreadyExists, "ignore-already-exists", o.IgnoreAlreadyExists, "Treat \"already exists\" as a successful create.")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.")
 
@@ -233,6 +236,10 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
+	if o.IgnoreAlreadyExists {
+		r.IgnoreErrors(errors.IsAlreadyExists)
+	}
+
 	count := 0
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -339,6 +346,8 @@ type CreateSubcommandOptions struct {
 	DryRun           bool
 	CreateAnnotation bool
 
+	IgnoreAlreadyExists bool
+
 	PrintObj func(obj kruntime.Object) error
 
 	genericclioptions.IOStreams
@@ -349,6 +358,11 @@ func NewCreateSubcommandOptions(ioStreams genericclioptions.IOStreams) *CreateSu
 		PrintFlags: NewPrintFlags("created"),
 		IOStreams:  ioStreams,
 	}
+}
+
+func (o *CreateSubcommandOptions) AddFlags(cmd *cobra.Command) {
+	o.PrintFlags.AddFlags(cmd)
+	cmd.Flags().BoolVar(&o.IgnoreAlreadyExists, "ignore-already-exists", o.IgnoreAlreadyExists, "Treat \"already exists\" as a successful create.")
 }
 
 func (o *CreateSubcommandOptions) Complete(cmd *cobra.Command, args []string, generator kubectl.StructuredGenerator) error {
@@ -419,7 +433,9 @@ func RunCreateSubcommand(f cmdutil.Factory, options *CreateSubcommandOptions) er
 
 		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
 		if err != nil {
-			return err
+			if !options.IgnoreAlreadyExists || !errors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 
 		// ensure we pass a versioned object to the printer

--- a/pkg/kubectl/cmd/create/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create/create_clusterrolebinding.go
@@ -57,7 +57,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_configmap.go
+++ b/pkg/kubectl/cmd/create/create_configmap.go
@@ -79,7 +79,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_deployment.go
+++ b/pkg/kubectl/cmd/create/create_deployment.go
@@ -60,7 +60,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStr
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_namespace.go
+++ b/pkg/kubectl/cmd/create/create_namespace.go
@@ -58,7 +58,7 @@ func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_pdb.go
+++ b/pkg/kubectl/cmd/create/create_pdb.go
@@ -63,7 +63,7 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericcliopti
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_priorityclass.go
+++ b/pkg/kubectl/cmd/create/create_priorityclass.go
@@ -61,7 +61,7 @@ func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericclioptions.IO
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_quota.go
+++ b/pkg/kubectl/cmd/create/create_quota.go
@@ -61,7 +61,7 @@ func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create/create_rolebinding.go
@@ -57,7 +57,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_secret.go
+++ b/pkg/kubectl/cmd/create/create_secret.go
@@ -94,7 +94,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IO
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -179,7 +179,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericcliopt
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -270,7 +270,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_service.go
+++ b/pkg/kubectl/cmd/create/create_service.go
@@ -82,7 +82,7 @@ func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -154,7 +154,7 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -223,7 +223,7 @@ func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericcliopti
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
@@ -294,7 +294,7 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericcliopti
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/create/create_serviceaccount.go
+++ b/pkg/kubectl/cmd/create/create_serviceaccount.go
@@ -58,7 +58,7 @@ func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.I
 		},
 	}
 
-	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+	options.CreateSubcommandOptions.AddFlags(cmd)
 
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)


### PR DESCRIPTION
We support `--ignore-*` flags on commands to make scripting easier.
`--ignore-already-exists` instructs the create command to not error out
when a resource already exists, but instead to continue, consistent with
other commands like `kubectl delete`.

Only `create` subcommands that share the common pattern are changed, all
others need to be made compatible.

```release-note
`kubectl create` and its subcommands now support the `--ignore-already-exists` flag which will return success if the resource to be created already existed.
```