### PR TITLE
Fix pkg_rpm rules for bazel 0.13+

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -39,7 +39,7 @@ http_archive(
 
 load("@bazel_skylib//:lib.bzl", "versions")
 
-versions.check(minimum_bazel_version = "0.10.0")
+versions.check(minimum_bazel_version = "0.13.0")
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_download_sdk")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")
@@ -83,4 +83,5 @@ docker_pull(
 )
 
 load("//build:workspace_mirror.bzl", "export_urls")
+
 export_urls("workspace_urls")

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -2,6 +2,18 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_tools//tools/build_defs/pkg:rpm.bzl", "pkg_rpm")
 
+filegroup(
+    name = "rpms",
+    srcs = [
+        ":kubeadm",
+        ":kubectl",
+        ":kubelet",
+        ":kubernetes-cni",
+    ],
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
 pkg_rpm(
     name = "kubectl",
     architecture = "x86_64",

--- a/build/rpms/kubeadm.spec
+++ b/build/rpms/kubeadm.spec
@@ -17,9 +17,9 @@ install -m 755 -d %{buildroot}%{_bindir}
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/kubelet.service.d/
 install -m 755 -d %{buildroot}%{_sysconfdir}/sysconfig/
-install -p -m 755 -t %{buildroot}%{_bindir} kubeadm
-install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/kubelet.service.d/ 10-kubeadm.conf
-install -p -m 755 -T kubelet.env %{buildroot}%{_sysconfdir}/sysconfig/kubelet
+install -p -m 755 -t %{buildroot}%{_bindir} {kubeadm}
+install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/kubelet.service.d/ {10-kubeadm.conf}
+install -p -m 755 -T {kubelet.env} %{buildroot}%{_sysconfdir}/sysconfig/kubelet
 
 %files
 %{_bindir}/kubeadm

--- a/build/rpms/kubectl.spec
+++ b/build/rpms/kubectl.spec
@@ -12,7 +12,7 @@ Command-line utility for interacting with a Kubernetes cluster.
 %install
 
 install -m 755 -d %{buildroot}%{_bindir}
-install -p -m 755 -t %{buildroot}%{_bindir} kubectl
+install -p -m 755 -t %{buildroot}%{_bindir} {kubectl}
 
 %files
 %{_bindir}/kubectl

--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -22,8 +22,8 @@ The node agent of Kubernetes, the container cluster manager.
 install -m 755 -d %{buildroot}%{_bindir}
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
 install -m 755 -d %{buildroot}%{_sysconfdir}/kubernetes/manifests/
-install -p -m 755 -t %{buildroot}%{_bindir} kubelet
-install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ kubelet.service
+install -p -m 755 -t %{buildroot}%{_bindir} {kubelet}
+install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ {kubelet.service}
 
 %files
 %{_bindir}/kubelet

--- a/build/rpms/kubernetes-cni.spec
+++ b/build/rpms/kubernetes-cni.spec
@@ -11,7 +11,7 @@ Binaries required to provision container networking.
 
 %prep
 mkdir -p ./bin
-tar -C ./bin -xz -f cni-plugins-amd64-v0.6.0.tgz
+tar -C ./bin -xz -f {cni-plugins-amd64-v0.6.0.tgz}
 
 %install
 


### PR DESCRIPTION
**What this PR does / why we need it**: next step in addressing https://github.com/kubernetes/kubernetes/issues/63108; we can use the substitutions supported by bazel 0.13+ to get the `pkg_rpm` rules to work properly again.

I've also added a filegroup to allow building all of the RPMs easily with `bazel build //build/rpms`. Note that since these are manual, `bazel build //...` will still skip building them. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder 
cc @sigma 