### PR TITLE
 kubelet: force filterContainerID to empty string when removeAll is true 

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -903,7 +903,11 @@ func (kl *Kubelet) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bo
 		return false
 	}
 	if len(runtimeStatus.ContainerStatuses) > 0 {
-		glog.V(3).Infof("Pod %q is terminated, but some containers have not been cleaned up: %+v", format.Pod(pod), runtimeStatus.ContainerStatuses)
+		var statusStr string
+		for _, status := range runtimeStatus.ContainerStatuses {
+			statusStr += fmt.Sprintf("%+v ", *status)
+		}
+		glog.V(3).Infof("Pod %q is terminated, but some containers have not been cleaned up: %s", format.Pod(pod), statusStr)
 		return false
 	}
 	if kl.podVolumesExist(pod.UID) && !kl.keepTerminatedPodVolumes {

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -99,6 +99,7 @@ func (p *podContainerDeletor) deleteContainersInPod(filterContainerID string, po
 	containersToKeep := p.containersToKeep
 	if removeAll {
 		containersToKeep = 0
+		filterContainerID = ""
 	}
 
 	for _, candidate := range getContainersToDeleteInPod(filterContainerID, podStatus, containersToKeep) {


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/57865

alternative to https://github.com/kubernetes/kubernetes/pull/62170

There is a bug in the container deletor where if `removeAll` is `true` in `deleteContainersInPod()` the `filterContainerID` is still used to filter results in `getContainersToDeleteInPod()`.  If the filter container is not found, no containers are returned for deletion.

https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/pod_container_deletor.go#L74-L77

This is the case for the delayed deletion a pod in `CrashLoopBackoff` as the death of the infra container in response to the `DELETE` is detected by PLEG and triggers an attempt to clean up all containers but uses the infra container id as a filter with `removeAll` set to `true`.  The infra container is immediately deleted and thus can not be found when `getContainersToDeleteInPod()` tries to find it.  Thus the dead app container from the previous restart attempt still exists.

`canBeDeleted()` in the status manager will return `false` until all the pod containers are deleted, delaying the deletion of the pod on the API server.

The removal of the containers is eventually forced by the API server `REMOVE` after the grace period.