### PR TITLE
use assertions for unit tests of resource_limits under pkg/scheduler

### DIFF
--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/schedulercache:go_default_library",
         "//pkg/scheduler/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/pkg/scheduler/algorithm/priorities/resource_limits_test.go
+++ b/pkg/scheduler/algorithm/priorities/resource_limits_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package priorities
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -140,12 +141,8 @@ func TestResourceLimistPriority(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
 		list, err := priorityFunction(ResourceLimitsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		assert.NoErrorf(t, err, "unexpected error: %v", err)
+		assert.EqualValuesf(t, test.expectedList, list, "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 
 }


### PR DESCRIPTION
use assertions for unit tests of pkg/scheduler/algorith/priorities/resource_limits

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**What this PR does / why we need it**:
Replaces the checks done in unit tests with assertions, for the source file: `pkg/scheduler/algorith/priorities/resource_limits_test.go`

Please refer to #43788 for a discussion/list of reasons for using assertions in the unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of work on #43788

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
