### PR TITLE
add test for sparse version encoding/decoding

### DIFF
--- a/pkg/kubectl/scheme/BUILD
+++ b/pkg/kubectl/scheme/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -60,4 +60,18 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sparse_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
+        "//vendor/k8s.io/api/batch/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+    ],
 )

--- a/pkg/kubectl/scheme/sparse_test.go
+++ b/pkg/kubectl/scheme/sparse_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	"testing"
+
+	"k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestCronJob(t *testing.T) {
+	src := &v1beta1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+
+	encoder := Codecs.LegacyCodec(v1.SchemeGroupVersion, v1beta1.SchemeGroupVersion)
+	cronjobBytes, err := runtime.Encode(encoder, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(cronjobBytes))
+	t.Log(Registry.RegisteredGroupVersions())
+
+	decoder := Codecs.UniversalDecoder(Registry.RegisteredGroupVersions()...)
+
+	uncastDst, err := runtime.Decode(decoder, cronjobBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// clear typemeta
+	uncastDst.(*v1beta1.CronJob).TypeMeta = metav1.TypeMeta{}
+
+	if !equality.Semantic.DeepEqual(src, uncastDst) {
+		t.Fatal(diff.ObjectDiff(src, uncastDst))
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/BUILD
@@ -8,12 +8,16 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["codec_test.go"],
+    srcs = [
+        "codec_test.go",
+        "sparse_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/sparse_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/sparse_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serializer
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+type FakeV1Obj struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func (*FakeV1Obj) DeepCopyObject() runtime.Object {
+	panic("not supported")
+}
+
+type FakeV2DifferentObj struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func (*FakeV2DifferentObj) DeepCopyObject() runtime.Object {
+	panic("not supported")
+}
+func TestSparse(t *testing.T) {
+	v1 := schema.GroupVersion{Group: "mygroup", Version: "v1"}
+	v2 := schema.GroupVersion{Group: "mygroup", Version: "v2"}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(v1, &FakeV1Obj{})
+	scheme.AddKnownTypes(v2, &FakeV2DifferentObj{})
+	codecs := NewCodecFactory(scheme)
+
+	srcObj1 := &FakeV1Obj{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	srcObj2 := &FakeV2DifferentObj{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+
+	encoder := codecs.LegacyCodec(v2, v1)
+	decoder := codecs.UniversalDecoder(v2, v1)
+
+	srcObj1Bytes, err := runtime.Encode(encoder, srcObj1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(srcObj1Bytes))
+	srcObj2Bytes, err := runtime.Encode(encoder, srcObj2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(srcObj2Bytes))
+
+	uncastDstObj1, err := runtime.Decode(decoder, srcObj1Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	uncastDstObj2, err := runtime.Decode(decoder, srcObj2Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// clear typemeta
+	uncastDstObj1.(*FakeV1Obj).TypeMeta = metav1.TypeMeta{}
+	uncastDstObj2.(*FakeV2DifferentObj).TypeMeta = metav1.TypeMeta{}
+
+	if !equality.Semantic.DeepEqual(srcObj1, uncastDstObj1) {
+		t.Fatal(diff.ObjectDiff(srcObj1, uncastDstObj1))
+	}
+	if !equality.Semantic.DeepEqual(srcObj2, uncastDstObj2) {
+		t.Fatal(diff.ObjectDiff(srcObj2, uncastDstObj2))
+	}
+}


### PR DESCRIPTION
This adds tests that make sure the sparse version encoding and encoding work as callers will expect, with the correct version being picked from the list.  I wrote two tests, one a theoretical test not dependent on any API and another practical test using cronjobs which are currently sparse in the registry.

@liggitt turns out that because we find exact matches, sparse versions ought to work out fine.
@smarterclayton I hate that the versioner matches on type.  I'll update that separately I think.


```release-note
NONE
```