### PR TITLE
update restmapping to indicate fully qualified resource

### DIFF
--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -48,7 +48,7 @@ func (gc *GarbageCollector) apiResource(apiVersion, kind string) (*metav1.APIRes
 	}
 	glog.V(5).Infof("map kind %s, version %s to resource %s", kind, apiVersion, mapping.Resource)
 	resource := metav1.APIResource{
-		Name:       mapping.Resource,
+		Name:       mapping.Resource.Resource,
 		Namespaced: mapping.Scope == meta.RESTScopeNamespace,
 		Kind:       kind,
 	}

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -620,7 +620,7 @@ func (a *HorizontalController) shouldScale(hpa *autoscalingv2.HorizontalPodAutos
 func (a *HorizontalController) scaleForResourceMappings(namespace, name string, mappings []*apimeta.RESTMapping) (*autoscalingv1.Scale, schema.GroupResource, error) {
 	var firstErr error
 	for i, mapping := range mappings {
-		targetGR := mapping.GroupVersionKind.GroupVersion().WithResource(mapping.Resource).GroupResource()
+		targetGR := mapping.Resource.GroupResource()
 		scale, err := a.scaleNamespacer.Scales(namespace).Get(targetGR, name)
 		if err == nil {
 			return scale, targetGR, nil

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -523,7 +523,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 					t.Logf("unable to get mapping for %s: %v", gk.String(), err)
 					continue
 				}
-				groupResource := schema.GroupResource{Group: mapping.GroupVersionKind.Group, Resource: mapping.Resource}
+				groupResource := mapping.Resource.GroupResource()
 
 				if getForAction.GetResource().Resource == groupResource.String() {
 					matchedTarget = &tc.metricsTarget[i]

--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
@@ -161,7 +161,7 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 				if err != nil {
 					return true, nil, fmt.Errorf("unable to get mapping for %s: %v", gk.String(), err)
 				}
-				groupResource := schema.GroupResource{Group: mapping.GroupVersionKind.Group, Resource: mapping.Resource}
+				groupResource := mapping.Resource.GroupResource()
 
 				assert.Equal(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
 				assert.Equal(t, tc.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -230,7 +230,7 @@ func (tc *replicaCalcTestCase) prepareTestClient(t *testing.T) (*fake.Clientset,
 		if err != nil {
 			return true, nil, fmt.Errorf("unable to get mapping for %s: %v", gk.String(), err)
 		}
-		groupResource := schema.GroupResource{Group: mapping.GroupVersionKind.Group, Resource: mapping.Resource}
+		groupResource := mapping.Resource.GroupResource()
 
 		assert.Equal(t, groupResource.String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
 		assert.Equal(t, tc.metric.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -42,6 +42,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -302,7 +303,7 @@ func (o *DrainOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		if err != nil {
 			return err
 		}
-		if info.Mapping.Resource != "nodes" {
+		if info.Mapping.Resource.GroupResource() != (schema.GroupResource{Group: "", Resource: "nodes"}) {
 			return fmt.Errorf("error: expected resource of type node, got %q", info.Mapping.Resource)
 		}
 

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -109,7 +109,7 @@ func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []str
 			return err
 		}
 
-		header := fmt.Sprintf("%s %q", mapping.Resource, info.Name)
+		header := fmt.Sprintf("%s %q", mapping.Resource.Resource, info.Name)
 		if revision > 0 {
 			header = fmt.Sprintf("%s with revision #%d", header, revision)
 		}

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -146,7 +146,11 @@ func (o PauseConfig) RunPause() error {
 	for _, patch := range set.CalculatePatches(o.Infos, cmdutil.InternalVersionJSONEncoder(), o.Pauser) {
 		info := patch.Info
 		if patch.Err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error: %s %q %v", info.Mapping.Resource, info.Name, patch.Err))
+			resourceString := info.Mapping.Resource.Resource
+			if len(info.Mapping.Resource.Group) > 0 {
+				resourceString = resourceString + "." + info.Mapping.Resource.Group
+			}
+			allErrs = append(allErrs, fmt.Errorf("error: %s %q %v", resourceString, info.Name, patch.Err))
 			continue
 		}
 

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -151,7 +151,11 @@ func (o ResumeConfig) RunResume() error {
 		info := patch.Info
 
 		if patch.Err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error: %s %q %v", info.Mapping.Resource, info.Name, patch.Err))
+			resourceString := info.Mapping.Resource.Resource
+			if len(info.Mapping.Resource.Group) > 0 {
+				resourceString = resourceString + "." + info.Mapping.Resource.Group
+			}
+			allErrs = append(allErrs, fmt.Errorf("error: %s %q %v", resourceString, info.Name, patch.Err))
 			continue
 		}
 

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -461,7 +461,7 @@ func (o *RunOptions) removeCreatedObjects(f cmdutil.Factory, createdObjects []*R
 			Internal(legacyscheme.Scheme).
 			ContinueOnError().
 			NamespaceParam(namespace).DefaultNamespace().
-			ResourceNames(obj.Mapping.Resource, name).
+			ResourceNames(obj.Mapping.Resource.Resource+"."+obj.Mapping.Resource.Group, name).
 			Flatten().
 			Do()
 		// Note: we pass in "true" for the "quiet" parameter because

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -738,11 +738,16 @@ type editResults struct {
 }
 
 func (r *editResults) addError(err error, info *resource.Info) string {
+	resourceString := info.Mapping.Resource.Resource
+	if len(info.Mapping.Resource.Group) > 0 {
+		resourceString = resourceString + "." + info.Mapping.Resource.Group
+	}
+
 	switch {
 	case apierrors.IsInvalid(err):
 		r.edit = append(r.edit, info)
 		reason := editReason{
-			head: fmt.Sprintf("%s %q was not valid", info.Mapping.Resource, info.Name),
+			head: fmt.Sprintf("%s %q was not valid", resourceString, info.Name),
 		}
 		if err, ok := err.(apierrors.APIStatus); ok {
 			if details := err.Status().Details; details != nil {
@@ -752,13 +757,13 @@ func (r *editResults) addError(err error, info *resource.Info) string {
 			}
 		}
 		r.header.reasons = append(r.header.reasons, reason)
-		return fmt.Sprintf("error: %s %q is invalid", info.Mapping.Resource, info.Name)
+		return fmt.Sprintf("error: %s %q is invalid", resourceString, info.Name)
 	case apierrors.IsNotFound(err):
 		r.notfound++
-		return fmt.Sprintf("error: %s %q could not be found on the server", info.Mapping.Resource, info.Name)
+		return fmt.Sprintf("error: %s %q could not be found on the server", resourceString, info.Name)
 	default:
 		r.retryable++
-		return fmt.Sprintf("error: %s %q could not be patched: %v", info.Mapping.Resource, info.Name, err)
+		return fmt.Sprintf("error: %s %q could not be patched: %v", resourceString, info.Name, err)
 	}
 }
 

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -576,31 +576,6 @@ func ParsePairs(pairArgs []string, pairType string, supportRemove bool) (newPair
 	return
 }
 
-// MustPrintWithKinds determines if printer is dealing
-// with multiple resource kinds, in which case it will
-// return true, indicating resource kind will be
-// included as part of printer output
-func MustPrintWithKinds(objs []runtime.Object, infos []*resource.Info, sorter *kubectl.RuntimeSort) bool {
-	var lastMap *meta.RESTMapping
-
-	for ix := range objs {
-		var mapping *meta.RESTMapping
-		if sorter != nil {
-			mapping = infos[sorter.OriginalPosition(ix)].Mapping
-		} else {
-			mapping = infos[ix].Mapping
-		}
-
-		// display "kind" only if we have mixed resources
-		if lastMap != nil && mapping.Resource != lastMap.Resource {
-			return true
-		}
-		lastMap = mapping
-	}
-
-	return false
-}
-
 // IsSiblingCommandExists receives a pointer to a cobra command and a target string.
 // Returns true if the target string is found in the list of sibling commands.
 func IsSiblingCommandExists(cmd *cobra.Command, targetCmdName string) bool {

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -697,7 +697,7 @@ func (b *Builder) resourceMappings() ([]*meta.RESTMapping, error) {
 
 func (b *Builder) resourceTupleMappings() (map[string]*meta.RESTMapping, error) {
 	mappings := make(map[string]*meta.RESTMapping)
-	canonical := make(map[string]struct{})
+	canonical := make(map[schema.GroupVersionResource]struct{})
 	for _, r := range b.resourceTuples {
 		if _, ok := mappings[r.Resource]; ok {
 			continue
@@ -707,7 +707,6 @@ func (b *Builder) resourceTupleMappings() (map[string]*meta.RESTMapping, error) 
 			return nil, err
 		}
 
-		mappings[mapping.Resource] = mapping
 		mappings[r.Resource] = mapping
 		canonical[mapping.Resource] = struct{}{}
 	}
@@ -829,7 +828,7 @@ func (b *Builder) visitByResource() *Result {
 	}
 	clients := make(map[string]RESTClient)
 	for _, mapping := range mappings {
-		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource)
+		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource.Resource)
 		if _, ok := clients[s]; ok {
 			continue
 		}
@@ -848,7 +847,7 @@ func (b *Builder) visitByResource() *Result {
 		if !ok {
 			return result.withError(fmt.Errorf("resource %q is not recognized: %v", tuple.Resource, mappings))
 		}
-		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource)
+		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource.Resource)
 		client, ok := clients[s]
 		if !ok {
 			return result.withError(fmt.Errorf("could not find a client for resource %q", tuple.Resource))

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -594,7 +594,7 @@ func TestResourceByName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mapping.Resource != "pods" {
+	if mapping.Resource != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }
@@ -726,7 +726,7 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mapping.GroupVersionKind.Kind != "Pod" || mapping.Resource != "pods" {
+	if mapping.GroupVersionKind.Kind != "Pod" || mapping.Resource != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }
@@ -753,7 +753,7 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mapping.Resource != "pods" {
+	if mapping.Resource != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }
@@ -1124,7 +1124,7 @@ func TestListObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if mapping.Resource != "pods" {
+	if mapping.Resource != (schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}) {
 		t.Errorf("unexpected resource mapping: %#v", mapping)
 	}
 }

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -43,7 +43,7 @@ type Helper struct {
 // NewHelper creates a Helper from a ResourceMapping
 func NewHelper(client RESTClient, mapping *meta.RESTMapping) *Helper {
 	return &Helper{
-		Resource:        mapping.Resource,
+		Resource:        mapping.Resource.Resource,
 		RESTClient:      client,
 		NamespaceScoped: mapping.Scope.Name() == meta.RESTScopeNameNamespace,
 	}

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
@@ -196,7 +197,7 @@ func (r *Result) ResourceMapping() (*meta.RESTMapping, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
-	mappings := map[string]*meta.RESTMapping{}
+	mappings := map[schema.GroupVersionResource]*meta.RESTMapping{}
 	for i := range r.sources {
 		m, ok := r.sources[i].(ResourceMapping)
 		if !ok {

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -158,7 +158,7 @@ func (i *Info) Refresh(obj runtime.Object, ignoreError bool) error {
 func (i *Info) String() string {
 	basicInfo := fmt.Sprintf("Name: %q, Namespace: %q\nObject: %+q", i.Name, i.Namespace, i.Object)
 	if i.Mapping != nil {
-		mappingInfo := fmt.Sprintf("Resource: %q, GroupVersionKind: %q", i.Mapping.Resource,
+		mappingInfo := fmt.Sprintf("Resource: %q, GroupVersionKind: %q", i.Mapping.Resource.String(),
 			i.Mapping.GroupVersionKind.String())
 		return fmt.Sprint(mappingInfo, "\n", basicInfo)
 	}

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -204,7 +204,7 @@ type genericDescriber struct {
 
 func (g *genericDescriber) Describe(namespace, name string, describerSettings printers.DescriberSettings) (output string, err error) {
 	apiResource := &metav1.APIResource{
-		Name:       g.mapping.Resource,
+		Name:       g.mapping.Resource.Resource,
 		Namespaced: g.mapping.Scope.Name() == meta.RESTScopeNameNamespace,
 		Kind:       g.mapping.GroupVersionKind.Kind,
 	}

--- a/plugin/pkg/admission/gc/gc_admission.go
+++ b/plugin/pkg/admission/gc/gc_admission.go
@@ -186,9 +186,9 @@ func (a *gcPermissionsEnforcement) ownerRefToDeleteAttributeRecords(ref metav1.O
 			Verb: "update",
 			// ownerReference can only refer to an object in the same namespace, so attributes.GetNamespace() equals to the owner's namespace
 			Namespace:       attributes.GetNamespace(),
-			APIGroup:        groupVersion.Group,
-			APIVersion:      groupVersion.Version,
-			Resource:        mapping.Resource,
+			APIGroup:        mapping.Resource.Group,
+			APIVersion:      mapping.Resource.Version,
+			Resource:        mapping.Resource.Resource,
 			Subresource:     "finalizers",
 			Name:            ref.Name,
 			ResourceRequest: true,

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -91,9 +91,10 @@ type RESTScope interface {
 // RESTMapping contains the information needed to deal with objects of a specific
 // resource and kind in a RESTful manner.
 type RESTMapping struct {
-	// Resource is a string representing the name of this resource as a REST client would see it
-	Resource string
+	// Resource is the GroupVersionResource (location) for this endpoint
+	Resource schema.GroupVersionResource
 
+	// GroupVersionKind is the GroupVersionKind (data format) to submit to this endpoint
 	GroupVersionKind schema.GroupVersionKind
 
 	// Scope contains the information needed to deal with REST Resources that are in a resource hierarchy

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -505,7 +505,7 @@ func (m *DefaultRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string
 		}
 
 		mappings = append(mappings, &RESTMapping{
-			Resource:         res.Resource,
+			Resource:         res,
 			GroupVersionKind: gvk,
 			Scope:            scope,
 		})

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
@@ -104,11 +104,8 @@ func (c *customMetricsClient) qualResourceForKind(groupKind schema.GroupKind) (s
 		return "", fmt.Errorf("unable to map kind %s to resource: %v", groupKind.String(), err)
 	}
 
-	groupResource := schema.GroupResource{
-		Group:    mapping.GroupVersionKind.Group,
-		Resource: mapping.Resource,
-	}
-	return groupResource.String(), nil
+	gr := mapping.Resource.GroupResource()
+	return gr.String(), nil
 }
 
 type rootScopedMetrics struct {

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -177,7 +177,7 @@ func TestServerSidePrint(t *testing.T) {
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 			req = req.Namespace(ns.Name)
 		}
-		body, err := req.Resource(mapping.Resource).SetHeader("Accept", tableParam).Do().Raw()
+		body, err := req.Resource(mapping.Resource.Resource).SetHeader("Accept", tableParam).Do().Raw()
 		if err != nil {
 			t.Errorf("unexpected error getting %s: %v", gvk, err)
 			continue

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -588,10 +588,9 @@ func TestEtcdStoragePath(t *testing.T) {
 			continue
 		}
 
-		gvResource := gvk.GroupVersion().WithResource(mapping.Resource)
-		etcdSeen[gvResource] = empty{}
+		etcdSeen[mapping.Resource] = empty{}
 
-		testData, hasTest := etcdStorageData[gvResource]
+		testData, hasTest := etcdStorageData[mapping.Resource]
 
 		if !hasTest {
 			t.Errorf("no test data for %s from %s.  Please add a test for your new type to etcdStorageData.", kind, pkgPath)
@@ -659,7 +658,7 @@ func TestEtcdStoragePath(t *testing.T) {
 			}
 
 			addGVKToEtcdBucket(cohabitatingResources, actualGVK, getEtcdBucket(testData.expectedEtcdPath))
-			pathSeen[testData.expectedEtcdPath] = append(pathSeen[testData.expectedEtcdPath], gvResource)
+			pathSeen[testData.expectedEtcdPath] = append(pathSeen[testData.expectedEtcdPath], mapping.Resource)
 		}()
 	}
 
@@ -955,7 +954,7 @@ func (c *allClient) create(stub, ns string, mapping *meta.RESTMapping, all *[]cl
 		return err
 	}
 	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
-	output, err := req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource).Body(strings.NewReader(stub)).Do().Get()
+	output, err := req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource.Resource).Body(strings.NewReader(stub)).Do().Get()
 	if err != nil {
 		return err
 	}
@@ -977,7 +976,7 @@ func (c *allClient) destroy(obj runtime.Object, mapping *meta.RESTMapping) error
 	if err != nil {
 		return err
 	}
-	return req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource).Name(name).Do().Error()
+	return req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource.Resource).Name(name).Do().Error()
 }
 
 func (c *allClient) cleanup(all *[]cleanupData) error {


### PR DESCRIPTION
The resource of a restmapping is logically fully qualified and we have that value when we construct it.  Update the return value so that callers don't have to synthentically create one.

@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```