### PR TITLE
kubelet: volume: do not create event on mount success

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -547,12 +547,10 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			return volumeToMount.GenerateError("MountVolume.SetUp failed", mountErr)
 		}
 
-		simpleMsg, detailedMsg := volumeToMount.GenerateMsg("MountVolume.SetUp succeeded", "")
+		_, detailedMsg := volumeToMount.GenerateMsg("MountVolume.SetUp succeeded", "")
 		verbosity := glog.Level(1)
 		if isRemount {
 			verbosity = glog.Level(4)
-		} else {
-			og.recorder.Eventf(volumeToMount.Pod, v1.EventTypeNormal, kevents.SuccessfulMountVolume, simpleMsg)
 		}
 		glog.V(verbosity).Infof(detailedMsg)
 


### PR DESCRIPTION
xref https://github.com/openshift/origin/issues/19497

There is an argument to be made that we should not emit events on volume mount successes.  Many pods have lots of volumes that generate lots of events, especially if the pods are short lived (batch, etc). This creates load on the API server and add noise in the events.

Creating events on volume mount failures is obviously a good idea.  Seems like the absence of such events or the "Started container" event implies mount success for all volumes.

/sig node
/sig storage
/release-note-none

@smarterclayton @jsafrane @saad-ali 