### PR TITLE
Adds support for arm64 to microbot example of the kubernetes-worker charm.

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions/microbot
+++ b/cluster/juju/layers/kubernetes-worker/actions/microbot
@@ -21,7 +21,7 @@ from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import unit_public_ip
 from charms.templating.jinja2 import render
-from subprocess import call
+from subprocess import call, check_output
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
@@ -29,6 +29,9 @@ context = {}
 context['replicas'] = action_get('replicas')
 context['delete'] = action_get('delete')
 context['public_address'] = unit_public_ip()
+
+arch = check_output(['dpkg', '--print-architecture']).rstrip()
+context['arch'] = arch.decode('utf-8')
 
 if not context['replicas']:
     context['replicas'] = 3

--- a/cluster/juju/layers/kubernetes-worker/templates/microbot-example.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/microbot-example.yaml
@@ -18,7 +18,7 @@ spec:
         app: microbot
     spec:
       containers:
-      - image: dontrebootme/microbot:v1
+      - image: cdkbot/microbot-{{ arch }}:latest
         imagePullPolicy: ""
         name: microbot
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**: Adds support for arm64 to microbot example of the kubernetes-worker charm.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
