### PR TITLE
Report unknown JSON fields, to catch errors early.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -76,6 +76,9 @@ func (d *YAMLToJSONDecoder) Decode(into interface{}) error {
 	}
 	return err
 }
+// Set strict parsing to report unknown or duplicate fields, noop for YAML
+func (d *YAMLToJSONDecoder) DisallowUnknownFields() {
+}
 
 // YAMLDecoder reads chunks of objects and returns ErrShortBuffer if
 // the data is not sufficient.
@@ -171,6 +174,7 @@ func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err 
 // decoder is a convenience interface for Decode.
 type decoder interface {
 	Decode(into interface{}) error
+	DisallowUnknownFields()
 }
 
 // YAMLOrJSONDecoder attempts to decode a stream of JSON documents or
@@ -224,6 +228,7 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 			glog.V(4).Infof("decoding stream as YAML")
 			d.decoder = NewYAMLToJSONDecoder(buffer)
 		}
+		d.decoder.DisallowUnknownFields()
 	}
 	err := d.decoder.Decode(into)
 	if jsonDecoder, ok := d.decoder.(*json.Decoder); ok {
@@ -249,6 +254,10 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 		}
 	}
 	return err
+}
+// Do not allow unknown fields
+func (d *YAMLOrJSONDecoder) DisallowUnknownFields() {
+	d.decoder.DisallowUnknownFields()
 }
 
 type Reader interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We'd like to catch errors in CRI early, for example when unknown JSON fields are used. An example of consuming this change is in `cri-tools` repo: https://github.com/kubernetes-incubator/cri-tools/pull/284.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
