### PR TITLE
[WIP]: allow recursive directory structure in configmap/secrets

### DIFF
--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -267,6 +267,28 @@ func TestMakePayload(t *testing.T) {
 			payload:  map[string]util.FileProjection{},
 			success:  true,
 		},
+		{
+			name: "part of existent key",
+			mappings: []v1.KeyToPath{
+				{
+					Key:  "foo",
+					Path: "path/to/foo",
+				},
+			},
+			configMap: &v1.ConfigMap{
+				Data: map[string]string{
+					"foo/bar": "foobar",
+					"foo/cat": "foocat",
+				},
+			},
+			mode:     0644,
+			optional: true,
+			payload: map[string]util.FileProjection{
+				"path/to/foo/bar": {Data: []byte("foobar"), Mode: 0644},
+				"path/to/foo/cat": {Data: []byte("foocat"), Mode: 0644},
+			},
+			success: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -238,6 +238,28 @@ func TestMakePayload(t *testing.T) {
 			payload:  map[string]util.FileProjection{},
 			success:  true,
 		},
+		{
+			name: "part of existent key",
+			mappings: []v1.KeyToPath{
+				{
+					Key:  "foo",
+					Path: "path/to/foo",
+				},
+			},
+			secret: &v1.Secret{
+				Data: map[string][]byte{
+					"foo/bar": []byte("foobar"),
+					"foo/cat": []byte("foocat"),
+				},
+			},
+			mode:     0644,
+			optional: true,
+			payload: map[string]util.FileProjection{
+				"path/to/foo/bar": {Data: []byte("foobar"), Mode: 0644},
+				"path/to/foo/cat": {Data: []byte("foocat"), Mode: 0644},
+			},
+			success: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -326,13 +326,16 @@ var configMapKeyRegexp = regexp.MustCompile("^" + configMapKeyFmt + "$")
 // IsConfigMapKey tests for a string that is a valid key for a ConfigMap or Secret
 func IsConfigMapKey(value string) []string {
 	var errs []string
-	if len(value) > DNS1123SubdomainMaxLength {
-		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	parts := strings.Split(value, "/")
+	for _, part := range parts {
+		if len(part) > DNS1123SubdomainMaxLength {
+			errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+		}
+		if !configMapKeyRegexp.MatchString(part) {
+			errs = append(errs, RegexError(configMapKeyErrMsg, configMapKeyFmt, "key.name", "KEY_NAME", "key-name"))
+		}
+		errs = append(errs, hasChDirPrefix(part)...)
 	}
-	if !configMapKeyRegexp.MatchString(value) {
-		errs = append(errs, RegexError(configMapKeyErrMsg, configMapKeyFmt, "key.name", "KEY_NAME", "key-name"))
-	}
-	errs = append(errs, hasChDirPrefix(value)...)
 	return errs
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -428,6 +428,8 @@ func TestIsConfigMapKey(t *testing.T) {
 		".so.is.this",
 		"THIS_IS_GOOD",
 		"so_is_this_17",
+		"go/od",
+		"go/.od",
 	}
 
 	for i := range successCases {
@@ -439,6 +441,11 @@ func TestIsConfigMapKey(t *testing.T) {
 	failureCases := []string{
 		".",
 		"..",
+		"/bad",
+		"ba//d",
+		"bad/",
+		"/",
+		"b/./ad",
 		"..bad",
 		"b*d",
 		"bad!&bad",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/62421.

This change adds support for slashes in keys of configmaps/secrets, so as a user, I can create a configmaps from directory:

```
- foo
  - bar
    cat.txt
```

With key `foo/bar/cat.txt` pointing to `<string data>`.

```release-note
support recursive directory structure in configmaps/secrets
```