### PR TITLE
[GCE] check for new backend naming scheme

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -907,28 +908,38 @@ func (cont *GCEIngressController) isHTTPErrorCode(err error, code int) bool {
 }
 
 // BackendServiceUsingNEG returns true only if all global backend service with matching nodeports pointing to NEG as backend
-func (cont *GCEIngressController) BackendServiceUsingNEG(nodeports []string) (bool, error) {
-	return cont.backendMode(nodeports, "networkEndpointGroups")
+func (cont *GCEIngressController) BackendServiceUsingNEG(svcPorts map[string]v1.ServicePort) (bool, error) {
+	return cont.backendMode(svcPorts, "networkEndpointGroups")
 }
 
-// BackendServiceUsingIG returns true only if all global backend service with matching nodeports pointing to IG as backend
-func (cont *GCEIngressController) BackendServiceUsingIG(nodeports []string) (bool, error) {
-	return cont.backendMode(nodeports, "instanceGroups")
+// BackendServiceUsingIG returns true only if all global backend service with matching svcPorts pointing to IG as backend
+func (cont *GCEIngressController) BackendServiceUsingIG(svcPorts map[string]v1.ServicePort) (bool, error) {
+	return cont.backendMode(svcPorts, "instanceGroups")
 }
 
-func (cont *GCEIngressController) backendMode(nodeports []string, keyword string) (bool, error) {
+func (cont *GCEIngressController) backendMode(svcPorts map[string]v1.ServicePort, keyword string) (bool, error) {
 	gceCloud := cont.Cloud.Provider.(*gcecloud.GCECloud)
 	beList, err := gceCloud.ListGlobalBackendServices()
 	if err != nil {
 		return false, fmt.Errorf("failed to list backend services: %v", err)
 	}
 
+	uid := cont.UID
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+
 	matchingBackendService := 0
 	for _, bs := range beList {
 		match := false
-		for _, np := range nodeports {
-			// Warning: This assumes backend service naming convention includes nodeport in the name
-			if strings.Contains(bs.Name, np) {
+		for svcName, sp := range svcPorts {
+			// Non-NEG BackendServices are named with the Nodeport in the name.
+			// NEG BackendServices' names contain the a sha256 hash of a string.
+			negString := strings.Join([]string{uid, cont.Ns, svcName, sp.TargetPort.String()}, ";")
+			negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))[:8]
+
+			if strings.Contains(bs.Name, strconv.Itoa(int(sp.NodePort))) ||
+				strings.Contains(bs.Name, negHash) {
 				match = true
 				matchingBackendService += 1
 			}
@@ -941,7 +952,7 @@ func (cont *GCEIngressController) backendMode(nodeports []string, keyword string
 			}
 		}
 	}
-	return matchingBackendService == len(nodeports), nil
+	return matchingBackendService == len(svcPorts), nil
 }
 
 // Cleanup cleans up cloud resources.
@@ -1480,10 +1491,22 @@ func (j *IngressTestJig) GetDefaultBackendNodePort() (int32, error) {
 // by default, so retrieve its nodePort if includeDefaultBackend is true.
 func (j *IngressTestJig) GetIngressNodePorts(includeDefaultBackend bool) []string {
 	nodePorts := []string{}
+	svcPorts := j.GetServicePorts(includeDefaultBackend)
+	for _, svcPort := range svcPorts {
+		nodePorts = append(nodePorts, strconv.Itoa(int(svcPort.NodePort)))
+	}
+	return nodePorts
+}
+
+// GetIngressNodePorts returns related backend services' svcPorts.
+// Current GCE ingress controller allows traffic to the default HTTP backend
+// by default, so retrieve its nodePort if includeDefaultBackend is true.
+func (j *IngressTestJig) GetServicePorts(includeDefaultBackend bool) map[string]v1.ServicePort {
+	svcPorts := make(map[string]v1.ServicePort)
 	if includeDefaultBackend {
 		defaultSvc, err := j.Client.CoreV1().Services(metav1.NamespaceSystem).Get(defaultBackendName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		nodePorts = append(nodePorts, strconv.Itoa(int(defaultSvc.Spec.Ports[0].NodePort)))
+		svcPorts[defaultBackendName] = defaultSvc.Spec.Ports[0]
 	}
 
 	backendSvcs := []string{}
@@ -1498,9 +1521,9 @@ func (j *IngressTestJig) GetIngressNodePorts(includeDefaultBackend bool) []strin
 	for _, svcName := range backendSvcs {
 		svc, err := j.Client.CoreV1().Services(j.Ingress.Namespace).Get(svcName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		nodePorts = append(nodePorts, strconv.Itoa(int(svc.Spec.Ports[0].NodePort)))
+		svcPorts[svcName] = svc.Spec.Ports[0]
 	}
-	return nodePorts
+	return svcPorts
 }
 
 // ConstructFirewallForIngress returns the expected GCE firewall rule for the ingress resource

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -497,7 +497,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				t.Execute()
 				By(t.ExitLog)
 				jig.WaitForIngress(true)
-				usingNeg, err := gceController.BackendServiceUsingNEG(jig.GetIngressNodePorts(false))
+				usingNeg, err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(false))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(usingNeg).To(BeTrue())
 			}
@@ -508,7 +508,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			By("Create a basic HTTP ingress using NEG")
 			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
 			jig.WaitForIngress(true)
-			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetIngressNodePorts(false))
+			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(false))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(usingNEG).To(BeTrue())
 
@@ -521,7 +521,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			wait.Poll(5*time.Second, framework.LoadBalancerPollTimeout, func() (bool, error) {
-				return gceController.BackendServiceUsingIG(jig.GetIngressNodePorts(true))
+				return gceController.BackendServiceUsingIG(jig.GetServicePorts(true))
 			})
 			jig.WaitForIngress(true)
 
@@ -534,7 +534,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			wait.Poll(5*time.Second, framework.LoadBalancerPollTimeout, func() (bool, error) {
-				return gceController.BackendServiceUsingNEG(jig.GetIngressNodePorts(false))
+				return gceController.BackendServiceUsingNEG(jig.GetServicePorts(false))
 			})
 			jig.WaitForIngress(true)
 		})
@@ -561,7 +561,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			By("Create a basic HTTP ingress using NEG")
 			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
 			jig.WaitForIngress(true)
-			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetIngressNodePorts(false))
+			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(false))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(usingNEG).To(BeTrue())
 			// initial replicas number is 1
@@ -586,7 +586,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			By("Create a basic HTTP ingress using NEG")
 			jig.CreateIngress(filepath.Join(framework.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
 			jig.WaitForIngress(true)
-			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetIngressNodePorts(false))
+			usingNEG, err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(false))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(usingNEG).To(BeTrue())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks for both the old Backend naming scheme (Nodeport in the name) and the new naming scheme (same scheme used to name NEGs). We need to check for both, in order for both the tests against Ingress head (once https://github.com/kubernetes/ingress-gce/pull/239 gets merged) and tests against prior Ingress versions to pass. 

See https://github.com/kubernetes/ingress-gce/pull/239 .

**Release note**:
```release-note
NONE
```
