### PR TITLE
Use assertions for unit tests of taint_toleration under pkg/scheduler/algorithm/priorities

### DIFF
--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/schedulercache:go_default_library",
         "//pkg/scheduler/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
+++ b/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package priorities
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -229,13 +230,8 @@ func TestTaintAndToleration(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
 		ttp := priorityFunction(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil)
 		list, err := ttp(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("%s, unexpected error: %v", test.test, err)
-		}
-
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s,\nexpected:\n\t%+v,\ngot:\n\t%+v", test.test, test.expectedList, list)
-		}
+		assert.NoErrorf(t, err, "%s, unexpected error: %v", test.test, err)
+		assert.EqualValuesf(t, test.expectedList, list, "%s,\nexpected:\n\t%+v,\ngot:\n\t%+v", test.test, test.expectedList, list)
 	}
 
 }


### PR DESCRIPTION
use assertions for unit tests of pkg/scheduler/algorith/priorities/taint_toleration

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**What this PR does / why we need it**:
Replaces the checks done in unit tests with assertions, for the source file: `pkg/scheduler/algorith/priorities/taint_toleration_test.go`

Please refer to #43788 for a discussion/list of reasons for using assertions in the unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of work on #43788

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
