### PR TITLE
[CustomResourceSubresources] fix status subresource

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/BUILD
@@ -87,3 +87,10 @@ go_test(
         "//vendor/k8s.io/client-go/discovery:go_default_library",
     ],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["status_strategy_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library"],
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/status_strategy_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresource
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestPrepareForUpdate(t *testing.T) {
+	strategy := statusStrategy{}
+	tcs := []struct {
+		old      *unstructured.Unstructured
+		obj      *unstructured.Unstructured
+		expected *unstructured.Unstructured
+	}{
+		{
+			// changes to spec are ignored
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "new",
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+		},
+		{
+			// changes to other places are also ignored
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"new": "new",
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+		},
+		{
+			// delete status
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "old",
+					"status": "old",
+				},
+			},
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": "old",
+				},
+			},
+		},
+		{
+			// update status
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "old",
+					"status": "old",
+				},
+			},
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": "new",
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "old",
+					"status": "new",
+				},
+			},
+		},
+		{
+			// update status and other parts
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "old",
+					"status": "old",
+				},
+			},
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "new",
+					"new":    "new",
+					"status": "new",
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec":   "old",
+					"status": "new",
+				},
+			},
+		},
+	}
+	for index, tc := range tcs {
+		strategy.PrepareForUpdate(context.TODO(), tc.obj, tc.old)
+		if !reflect.DeepEqual(tc.obj, tc.expected) {
+			t.Errorf("test %d failed: expected: %v, got %v", index, tc.expected, tc.obj)
+		}
+	}
+}


### PR DESCRIPTION
This change make the codes consistent with the document.
Fixes: https://github.com/kubernetes/kubernetes/issues/63359

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @nikhita 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When updating /status subresource of a custom resource, only the value at the `.status` subpath for the update is considered.
```
