### PR TITLE
Fix test "should fail due to non-existent path" under gce-slow

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -386,7 +386,6 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 				reason:  "FailedMount",
 				pattern: make([]string, 2)}
 			ep.pattern = append(ep.pattern, "MountVolume.SetUp failed")
-			ep.pattern = append(ep.pattern, "does not exist")
 
 			testVol := &localTestVolume{
 				node:            config.node0,


### PR DESCRIPTION
**What this PR does / why we need it**:

PR #62903 changed error string GetMountRefs() returned, which broke test `should fail due to non-existent path`.
Remove error string check to fix test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```
go run hack/e2e.go -- \
    --provider=local \ 
    --test \
    --test_args="--ginkgo.focus=PersistentVolumes-local.*should\sfail\sdue\sto\snon-existent\spath --clean-start=true"
```

passed now.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
