### PR TITLE
kubeadm etcd liveness probe changes.

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -68,7 +68,7 @@ func GetEtcdPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.Pod {
 			staticpodutil.NewVolumeMount(certsVolumeName, cfg.CertificatesDir+"/etcd", false),
 		},
 		LivenessProbe: staticpodutil.EtcdProbe(
-			cfg, kubeadmconstants.Etcd, 2379, cfg.CertificatesDir,
+			cfg, kubeadmconstants.Etcd, cfg.CertificatesDir,
 			kubeadmconstants.EtcdCACertName, kubeadmconstants.EtcdHealthcheckClientCertName, kubeadmconstants.EtcdHealthcheckClientKeyName,
 		),
 	}, etcdMounts)

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"strings"
 
 	"k8s.io/api/core/v1"
 
@@ -44,8 +43,8 @@ const (
 	// kubeSchedulerAddressArg represents the address argument of the kube-scheduler configuration.
 	kubeSchedulerAddressArg = "address"
 
-	// etcdListenClientURLsArg represents the listen-client-urls argument of the etcd configuration.
-	etcdListenClientURLsArg = "listen-client-urls"
+	// etcdAdvertiseClientURLsArg represents the advertise-client-urls argument of the etcd configuration.
+	etcdAdvertiseClientURLsArg = "advertise-client-urls"
 )
 
 // ComponentPod returns a Pod object from the container and volume specifications
@@ -98,10 +97,10 @@ func ComponentProbe(cfg *kubeadmapi.MasterConfiguration, componentName string, p
 }
 
 // EtcdProbe is a helper function for building a shell-based, etcdctl v1.Probe object to healthcheck etcd
-func EtcdProbe(cfg *kubeadmapi.MasterConfiguration, componentName string, port int, certsDir string, CACertName string, CertName string, KeyName string) *v1.Probe {
+func EtcdProbe(cfg *kubeadmapi.MasterConfiguration, componentName string, certsDir string, CACertName string, CertName string, KeyName string) *v1.Probe {
 	tlsFlags := fmt.Sprintf("--cacert=%[1]s/%[2]s --cert=%[1]s/%[3]s --key=%[1]s/%[4]s", certsDir, CACertName, CertName, KeyName)
 	// etcd pod is alive if a linearizable get succeeds.
-	cmd := fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=%s:%d %s get foo", GetProbeAddress(cfg, componentName), port, tlsFlags)
+	cmd := fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=%s %s get foo", GetEtcdProbeURL(cfg, componentName), tlsFlags)
 
 	return &v1.Probe{
 		Handler: v1.Handler{
@@ -215,6 +214,32 @@ func ReadStaticPodFromDisk(manifestPath string) (*v1.Pod, error) {
 	return pod, nil
 }
 
+// GetEtcdProbeURL will return a validated --advertise-client-url URL or https://127.0.0.1:2379
+// to use for etcd liveness probes. in static pod manifests.
+func GetEtcdProbeURL(cfg *kubeadmapi.MasterConfiguration, componentName string) string {
+	if cfg.Etcd.ExtraArgs != nil {
+		if arg, exists := cfg.Etcd.ExtraArgs[etcdAdvertiseClientURLsArg]; exists {
+			// basic etcd url validation. Reference:
+			// https://github.com/coreos/etcd/blob/master/pkg/types/urls.go#L35-L47
+			u, err := url.Parse(arg)
+			_, _, splitErr := net.SplitHostPort(u.Host)
+			switch {
+			case err != nil:
+				// Ensure the Scheme is http or https
+			case u.Scheme != "https" && u.Scheme != "http":
+				// Ensure the Path is not set.
+			case u.Path != "":
+				// Ensure that Hostname looks like <ip or host>:<port>
+			case splitErr != nil:
+				// Ensure that hostport split works.
+			default:
+				return u.String()
+			}
+		}
+	}
+	return "https://127.0.0.1:2379"
+}
+
 // GetProbeAddress returns an IP address or 127.0.0.1 to use for liveness probes
 // in static pod manifests.
 func GetProbeAddress(cfg *kubeadmapi.MasterConfiguration, componentName string) string {
@@ -239,42 +264,6 @@ func GetProbeAddress(cfg *kubeadmapi.MasterConfiguration, componentName string) 
 	case componentName == kubeadmconstants.KubeScheduler:
 		if addr, exists := cfg.SchedulerExtraArgs[kubeSchedulerAddressArg]; exists {
 			return addr
-		}
-	case componentName == kubeadmconstants.Etcd:
-		if cfg.Etcd.ExtraArgs != nil {
-			if arg, exists := cfg.Etcd.ExtraArgs[etcdListenClientURLsArg]; exists {
-				// Use the first url in the listen-client-urls if multiple url's are specified.
-				if strings.ContainsAny(arg, ",") {
-					arg = strings.Split(arg, ",")[0]
-				}
-				parsedURL, err := url.Parse(arg)
-				if err != nil || parsedURL.Hostname() == "" {
-					break
-				}
-				// Return the IP if the URL contains an address instead of a name.
-				if ip := net.ParseIP(parsedURL.Hostname()); ip != nil {
-					return ip.String()
-				}
-				// Use the local resolver to try resolving the name within the URL.
-				// If the name can not be resolved, return an IPv4 loopback address.
-				// Otherwise, select the first valid IPv4 address.
-				// If the name does not resolve to an IPv4 address, select the first valid IPv6 address.
-				addrs, err := net.LookupIP(parsedURL.Hostname())
-				if err != nil {
-					break
-				}
-				var ip net.IP
-				for _, addr := range addrs {
-					if addr.To4() != nil {
-						ip = addr
-						break
-					}
-					if addr.To16() != nil && ip == nil {
-						ip = addr
-					}
-				}
-				return ip.String()
-			}
 		}
 	}
 	return "127.0.0.1"

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -196,7 +196,6 @@ func TestEtcdProbe(t *testing.T) {
 		name      string
 		cfg       *kubeadmapi.MasterConfiguration
 		component string
-		port      int
 		certsDir  string
 		cacert    string
 		cert      string
@@ -204,56 +203,53 @@ func TestEtcdProbe(t *testing.T) {
 		expected  string
 	}{
 		{
-			name: "valid etcd probe using listen-client-urls IPv4 addresses",
+			name: "valid etcd probe with listen-client-url unset",
 			cfg: &kubeadmapi.MasterConfiguration{
 				Etcd: kubeadmapi.Etcd{
 					ExtraArgs: map[string]string{
-						"listen-client-urls": "http://1.2.3.4:2379,http://4.3.2.1:2379"},
+						"advertise-client-urls": "nil"},
 				},
 			},
 			component: kubeadmconstants.Etcd,
-			port:      1,
 			certsDir:  "secretsA",
 			cacert:    "ca1",
 			cert:      "cert1",
 			key:       "key1",
-			expected:  "ETCDCTL_API=3 etcdctl --endpoints=1.2.3.4:1 --cacert=secretsA/ca1 --cert=secretsA/cert1 --key=secretsA/key1 get foo",
+			expected:  "ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cacert=secretsA/ca1 --cert=secretsA/cert1 --key=secretsA/key1 get foo",
 		},
 		{
-			name: "valid etcd probe using listen-client-urls IPv6 addresses",
+			name: "valid etcd probe will fallback to https://127.0.0.1:2379 when advertise-client-urls is invalid",
 			cfg: &kubeadmapi.MasterConfiguration{
 				Etcd: kubeadmapi.Etcd{
 					ExtraArgs: map[string]string{
-						"listen-client-urls": "http://[2001:db8::1]:2379,http://[2001:db8::2]:2379"},
+						"advertise-client-urls": "http://1.2.3.4"},
 				},
 			},
 			component: kubeadmconstants.Etcd,
-			port:      1,
-			certsDir:  "secretsB",
-			cacert:    "ca2",
-			cert:      "cert2",
-			key:       "key2",
-			expected:  "ETCDCTL_API=3 etcdctl --endpoints=2001:db8::1:1 --cacert=secretsB/ca2 --cert=secretsB/cert2 --key=secretsB/key2 get foo",
+			certsDir:  "secretsA",
+			cacert:    "ca1",
+			cert:      "cert1",
+			key:       "key1",
+			expected:  "ETCDCTL_API=3 etcdctl --endpoints=https://127.0.0.1:2379 --cacert=secretsA/ca1 --cert=secretsA/cert1 --key=secretsA/key1 get foo",
 		},
 		{
-			name: "valid IPv4 etcd probe using hostname for listen-client-urls",
+			name: "valid etcd probe using listen-client-url addresses",
 			cfg: &kubeadmapi.MasterConfiguration{
 				Etcd: kubeadmapi.Etcd{
 					ExtraArgs: map[string]string{
-						"listen-client-urls": "http://localhost:2379"},
+						"advertise-client-urls": "http://1.2.3.4:2379"},
 				},
 			},
 			component: kubeadmconstants.Etcd,
-			port:      1,
-			certsDir:  "secretsC",
-			cacert:    "ca3",
-			cert:      "cert3",
-			key:       "key3",
-			expected:  "ETCDCTL_API=3 etcdctl --endpoints=127.0.0.1:1 --cacert=secretsC/ca3 --cert=secretsC/cert3 --key=secretsC/key3 get foo",
+			certsDir:  "secretsA",
+			cacert:    "ca1",
+			cert:      "cert1",
+			key:       "key1",
+			expected:  "ETCDCTL_API=3 etcdctl --endpoints=http://1.2.3.4:2379 --cacert=secretsA/ca1 --cert=secretsA/cert1 --key=secretsA/key1 get foo",
 		},
 	}
 	for _, rt := range tests {
-		actual := EtcdProbe(rt.cfg, rt.component, rt.port, rt.certsDir, rt.cacert, rt.cert, rt.key)
+		actual := EtcdProbe(rt.cfg, rt.component, rt.certsDir, rt.cacert, rt.cert, rt.key)
 		if actual.Handler.Exec.Command[2] != rt.expected {
 			t.Errorf("%s test case failed:\n\texpected: %s\n\t  actual: %s",
 				rt.name, rt.expected,


### PR DESCRIPTION
**What this PR does / why we need it**:

- This changes the logic in kubeadm alpha phase etcd local to produce a
working url vs an ip for the liveness probe.

- Gets rid of the need for a statically defined port (2379) 

- Moved to --advertise-client-url instead of listen-client-url as the
flag can be set to 0.0.0.0  and doesn't need to match the cert.

- Adds some logic to validate that listen address is a valid etcd url.
If not returns https://127.0.0.1:2379 which should match the default
etcd local setup.

- Modified tests to fit new code and all tests pass with:
make test WHAT=./cmd/kubeadm/app/util/staticpod/ GOFLAGS="-v"


Signed-off-by: Duffie Cooley <dcooley@heptio.com>


**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
NONE
```
