### PR TITLE
Add conversion to properly parse query parameter propagationPolicy

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
@@ -75,6 +75,8 @@ func AddConversionFuncs(scheme *runtime.Scheme) error {
 		Convert_unversioned_LabelSelector_to_map,
 
 		Convert_Slice_string_To_Slice_int32,
+
+		Convert_Slice_string_To_v1_DeletionPropagation,
 	)
 }
 
@@ -301,6 +303,16 @@ func Convert_Slice_string_To_Slice_int32(in *[]string, out *[]int32, s conversio
 			}
 			*out = append(*out, int32(x))
 		}
+	}
+	return nil
+}
+
+// Convert_Slice_string_To_v1_DeletionPropagation allows converting a URL query parameter propagationPolicy
+func Convert_Slice_string_To_v1_DeletionPropagation(input *[]string, out *DeletionPropagation, s conversion.Scope) error {
+	if len(*input) > 0 {
+		*out = DeletionPropagation((*input)[0])
+	} else {
+		*out = ""
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion_test.go
@@ -47,3 +47,38 @@ func TestMapToLabelSelectorRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertSliceStringToDeletionPropagation(t *testing.T) {
+	tcs := []struct {
+		Input  []string
+		Output v1.DeletionPropagation
+	}{
+		{
+			Input:  nil,
+			Output: "",
+		},
+		{
+			Input:  []string{},
+			Output: "",
+		},
+		{
+			Input:  []string{"foo"},
+			Output: "foo",
+		},
+		{
+			Input:  []string{"bar", "foo"},
+			Output: "bar",
+		},
+	}
+
+	for _, tc := range tcs {
+		var dp v1.DeletionPropagation
+		if err := v1.Convert_Slice_string_To_v1_DeletionPropagation(&tc.Input, &dp, nil); err != nil {
+			t.Errorf("Convert_Slice_string_To_v1_DeletionPropagation(%#v): %v", tc.Input, err)
+			continue
+		}
+		if !apiequality.Semantic.DeepEqual(dp, tc.Output) {
+			t.Errorf("slice string to DeletionPropagation conversion failed: got %v; want %v", dp, tc.Output)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This delete request query parameter has been broken for a year. I'm not sure if we want to deprecate the non-standard DeleteOptions body on delete request eventually. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #43329

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
API server properly parses propagationPolicy as a query parameter sent with a delete request
```

/sig api-machinery