### PR TITLE
Retry certificate approval on conflict errors

### DIFF
--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -216,15 +217,24 @@ func (options *CertificateOptions) modifyCertificateCondition(builder *resource.
 		if err != nil {
 			return err
 		}
-		csr := info.Object.(*certificates.CertificateSigningRequest)
-		csr, hasCondition := modify(csr)
-		if !hasCondition || force {
-			csr, err = clientSet.Certificates().
-				CertificateSigningRequests().
-				UpdateApproval(csr)
-			if err != nil {
-				return err
+		for i := 0; ; i++ {
+			csr := info.Object.(*certificates.CertificateSigningRequest)
+			csr, hasCondition := modify(csr)
+			if !hasCondition || force {
+				csr, err = clientSet.Certificates().
+					CertificateSigningRequests().
+					UpdateApproval(csr)
+				if errors.IsConflict(err) && i < 10 {
+					if err := info.Get(); err != nil {
+						return err
+					}
+					continue
+				}
+				if err != nil {
+					return err
+				}
 			}
+			break
 		}
 		found++
 


### PR DESCRIPTION
We already check preconditions. We were seeing a non-trivial number of conflicts when using the command from automation.

Fixes openshift/origin#19430

@mikedanese @mfojtik