### PR TITLE
forbid wrong quantity unit for memory resource

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -31,6 +31,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1079,6 +1080,16 @@ func parseResourceList(m map[string]string) (v1.ResourceList, error) {
 			}
 			if q.Sign() == -1 {
 				return nil, fmt.Errorf("resource quantity for %q cannot be negative: %v", k, v)
+			}
+
+			if v1.ResourceName(k) == v1.ResourceMemory {
+				valueStr := q.String()
+				lastChar := valueStr[len(valueStr)-1:]
+				if lastChar != "i" {
+					if strings.ToUpper(lastChar) != lastChar {
+						return nil, fmt.Errorf("invalid resource quantity unit for %q: %v", k, v)
+					}
+				}
 			}
 			rl[v1.ResourceName(k)] = q
 		default:

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -40,6 +40,18 @@ func TestValueOfAllocatableResources(t *testing.T) {
 			name:           "invalid quantity unit",
 		},
 		{
+			kubeReserved:   map[string]string{"cpu": "200m", "memory": "15G"},
+			systemReserved: map[string]string{"cpu": "200m", "memory": "15m"},
+			errorExpected:  true,
+			name:           "invalid quantity unit (m) for memory",
+		},
+		{
+			kubeReserved:   map[string]string{"cpu": "200m", "memory": "15G"},
+			systemReserved: map[string]string{"cpu": "200m", "memory": "15k"},
+			errorExpected:  true,
+			name:           "invalid quantity unit (k) for memory",
+		},
+		{
 			kubeReserved:   map[string]string{"cpu": "200m", "memory": "15G", "ephemeral-storage": "10Gi"},
 			systemReserved: map[string]string{"cpu": "200m", "memory": "15Ki"},
 			errorExpected:  false,

--- a/pkg/apis/core/v1/validation/validation.go
+++ b/pkg/apis/core/v1/validation/validation.go
@@ -90,6 +90,20 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}
+
+	// The quantity unit can only be one of E, P, T, G, M, K.
+	// Or use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
+	// e.g. "100m" is not allowed for memory, which will be parsed as milli.
+	if resource == string(v1.ResourceMemory) {
+		valueStr := value.String()
+		lastChar := valueStr[len(valueStr)-1:]
+		if lastChar != "i" {
+			if strings.ToUpper(lastChar) != lastChar {
+				allErrs = append(allErrs, field.Invalid(fldPath, value, "invalid quantity unit"))
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4687,6 +4687,20 @@ func ValidateResourceQuantityValue(resource string, value resource.Quantity, fld
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}
+
+	// The quantity unit can only be one of E, P, T, G, M, K.
+	// Or use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
+	// e.g. "100m" is not allowed for memory, which will be parsed as milli.
+	if resource == string(core.ResourceMemory) {
+		valueStr := value.String()
+		lastChar := valueStr[len(valueStr)-1:]
+		if lastChar != "i" {
+			if strings.ToUpper(lastChar) != lastChar {
+				allErrs = append(allErrs, field.Invalid(fldPath, value, "invalid quantity unit"))
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -5347,6 +5347,28 @@ func TestValidateContainers(t *testing.T) {
 				TerminationMessagePolicy: "File",
 			},
 		},
+		"Resource Memory Quantity Unit (m) invalid": {
+			{
+				Name:  "abc-123",
+				Image: "image",
+				Resources: core.ResourceRequirements{
+					Limits: getResourceLimits("0", "100m"),
+				},
+				ImagePullPolicy:          "IfNotPresent",
+				TerminationMessagePolicy: "File",
+			},
+		},
+		"Resource Memory Quantity Unit (k) invalid": {
+			{
+				Name:  "abc-123",
+				Image: "image",
+				Resources: core.ResourceRequirements{
+					Limits: getResourceLimits("0", "100k"),
+				},
+				ImagePullPolicy:          "IfNotPresent",
+				TerminationMessagePolicy: "File",
+			},
+		},
 		"Request limit simple invalid": {
 			{
 				Name:  "abc-123",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

For memory resource, `100m` will be parsed as "100 milli", instead of "100 M". That's the root cause for #54567.

And just as [the doc](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory) said, 
>  You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.

For memory, the quantity unit should be checked as well, not only the quantity value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54567, #64011

**Special notes for your reviewer**:
/cc liggitt smarterclayton
/cc kubernetes/sig-api-machinery-api-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
forbid wrong resource quantity unit
```
