### PR TITLE
use new dynamic client

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -34,7 +33,7 @@ import (
 // ClientBackedDryRunGetter implements the DryRunGetter interface for use in NewDryRunClient() and proxies all GET and LIST requests to the backing API server reachable via rest.Config
 type ClientBackedDryRunGetter struct {
 	client        clientset.Interface
-	dynClientPool dynamic.ClientPool
+	dynamicClient dynamic.DynamicInterface
 }
 
 // InitDryRunGetter should implement the DryRunGetter interface
@@ -46,10 +45,14 @@ func NewClientBackedDryRunGetter(config *rest.Config) (*ClientBackedDryRunGetter
 	if err != nil {
 		return nil, err
 	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
 
 	return &ClientBackedDryRunGetter{
 		client:        client,
-		dynClientPool: dynamic.NewDynamicClientPool(config),
+		dynamicClient: dynamicClient,
 	}, nil
 }
 
@@ -68,22 +71,13 @@ func NewClientBackedDryRunGetterFromKubeconfig(file string) (*ClientBackedDryRun
 
 // HandleGetAction handles GET actions to the dryrun clientset this interface supports
 func (clg *ClientBackedDryRunGetter) HandleGetAction(action core.GetAction) (bool, runtime.Object, error) {
-	rc, err := clg.actionToResourceClient(action)
+	unstructuredObj, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).Get(action.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return true, nil, err
 	}
-
-	unversionedObj, err := rc.Get(action.GetName(), metav1.GetOptions{})
+	newObj, err := decodeUnstructuredIntoAPIObject(action, unstructuredObj)
 	if err != nil {
-		return true, nil, err
-	}
-	// If the unversioned object does not have .apiVersion; the inner object is probably nil
-	if len(unversionedObj.GetAPIVersion()) == 0 {
-		return true, nil, apierrors.NewNotFound(action.GetResource().GroupResource(), action.GetName())
-	}
-	newObj, err := decodeUnversionedIntoAPIObject(action, unversionedObj)
-	if err != nil {
-		fmt.Printf("error after decode: %v %v\n", unversionedObj, err)
+		fmt.Printf("error after decode: %v %v\n", unstructuredObj, err)
 		return true, nil, err
 	}
 	return true, newObj, err
@@ -91,27 +85,18 @@ func (clg *ClientBackedDryRunGetter) HandleGetAction(action core.GetAction) (boo
 
 // HandleListAction handles LIST actions to the dryrun clientset this interface supports
 func (clg *ClientBackedDryRunGetter) HandleListAction(action core.ListAction) (bool, runtime.Object, error) {
-	rc, err := clg.actionToResourceClient(action)
-	if err != nil {
-		return true, nil, err
-	}
-
 	listOpts := metav1.ListOptions{
 		LabelSelector: action.GetListRestrictions().Labels.String(),
 		FieldSelector: action.GetListRestrictions().Fields.String(),
 	}
 
-	unversionedList, err := rc.List(listOpts)
+	unstructuredList, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).List(listOpts)
 	if err != nil {
 		return true, nil, err
 	}
-	// If the runtime.Object here is nil, we should return successfully with no result
-	if unversionedList == nil {
-		return true, unversionedList, nil
-	}
-	newObj, err := decodeUnversionedIntoAPIObject(action, unversionedList)
+	newObj, err := decodeUnstructuredIntoAPIObject(action, unstructuredList)
 	if err != nil {
-		fmt.Printf("error after decode: %v %v\n", unversionedList, err)
+		fmt.Printf("error after decode: %v %v\n", unstructuredList, err)
 		return true, nil, err
 	}
 	return true, newObj, err
@@ -122,28 +107,10 @@ func (clg *ClientBackedDryRunGetter) Client() clientset.Interface {
 	return clg.client
 }
 
-// actionToResourceClient returns the ResourceInterface for the given action
-// First; the function gets the right API group interface from the resource type. The API group struct behind the interface
-// returned may be cached in the dynamic client pool. Then, an APIResource object is constructed so that it can be passed to
-// dynamic.Interface's Resource() function, which will give us the final ResourceInterface to query
-func (clg *ClientBackedDryRunGetter) actionToResourceClient(action core.Action) (dynamic.ResourceInterface, error) {
-	dynIface, err := clg.dynClientPool.ClientForGroupVersionResource(action.GetResource())
-	if err != nil {
-		return nil, err
-	}
-
-	apiResource := &metav1.APIResource{
-		Name:       action.GetResource().Resource,
-		Namespaced: action.GetNamespace() != "",
-	}
-
-	return dynIface.Resource(apiResource, action.GetNamespace()), nil
-}
-
 // decodeUnversionedIntoAPIObject converts the *unversioned.Unversioned object returned from the dynamic client
 // to bytes; and then decodes it back _to an external api version (k8s.io/api vs k8s.io/kubernetes/pkg/api*)_ using the normal API machinery
-func decodeUnversionedIntoAPIObject(action core.Action, unversionedObj runtime.Object) (runtime.Object, error) {
-	objBytes, err := json.Marshal(unversionedObj)
+func decodeUnstructuredIntoAPIObject(action core.Action, unstructuredObj runtime.Unstructured) (runtime.Object, error) {
+	objBytes, err := json.Marshal(unstructuredObj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates kubeadm to use the new dynamic client that simplifies call patterns.

@kubernetes/sig-cluster-lifecycle-pr-reviews 

```release-note
NONE
```