### PR TITLE
 slim printer interface down to printing

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -53,10 +53,10 @@ import (
 
 // GetOptions contains the input to the get command.
 type GetOptions struct {
-	PrintFlags           *PrintFlags
-	ToPrinter            func(*meta.RESTMapping, bool) (printers.ResourcePrinterFunc, error)
-	IsGeneric            bool
-	PrintWithOpenAPICols bool
+	PrintFlags             *PrintFlags
+	ToPrinter              func(*meta.RESTMapping, bool) (printers.ResourcePrinterFunc, error)
+	IsHumanReadablePrinter bool
+	PrintWithOpenAPICols   bool
 
 	CmdParent string
 
@@ -219,13 +219,10 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		o.ServerPrint = false
 	}
 
-	// obtain printer here in order to determine if we are
-	// printing humanreadable or generic output.
-	printer, err := o.PrintFlags.ToPrinter()
-	if err != nil {
-		return err
+	// human readable printers have special conversion rules, so we determine if we're using one.
+	if len(*o.PrintFlags.OutputFormat) == 0 || *o.PrintFlags.OutputFormat == "wide" {
+		o.IsHumanReadablePrinter = true
 	}
-	o.IsGeneric = printer.IsGeneric()
 
 	o.IncludeUninitialized = cmdutil.ShouldIncludeUninitialized(cmd, false)
 	o.PrintWithOpenAPICols = cmdutil.GetFlagBool(cmd, useOpenAPIPrintColumnFlagLabel)
@@ -321,7 +318,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		Latest().
 		Flatten().
 		TransformRequests(func(req *rest.Request) {
-			if o.ServerPrint && !o.IsGeneric && !o.Sort {
+			if o.ServerPrint && o.IsHumanReadablePrinter && !o.Sort {
 				group := metav1beta1.GroupName
 				version := metav1beta1.SchemeGroupVersion.Version
 
@@ -338,7 +335,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		return err
 	}
 
-	if o.IsGeneric {
+	if !o.IsHumanReadablePrinter {
 		return o.printGeneric(r)
 	}
 
@@ -547,7 +544,7 @@ func (o *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []string)
 			objsToPrint = append(objsToPrint, obj)
 		}
 		for _, objToPrint := range objsToPrint {
-			if !o.IsGeneric {
+			if o.IsHumanReadablePrinter {
 				// printing always takes the internal version, but the watch event uses externals
 				internalGV := mapping.GroupVersionKind.GroupKind().WithVersion(runtime.APIVersionInternal).GroupVersion()
 				objToPrint = attemptToConvertToInternal(objToPrint, legacyscheme.Scheme, internalGV)

--- a/pkg/kubectl/sorter.go
+++ b/pkg/kubectl/sorter.go
@@ -44,10 +44,6 @@ type SortingPrinter struct {
 	Decoder   runtime.Decoder
 }
 
-func (s *SortingPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	if !meta.IsListType(obj) {
 		return s.Delegate.PrintObj(obj, out)
@@ -57,15 +53,6 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 		return err
 	}
 	return s.Delegate.PrintObj(obj, out)
-}
-
-// TODO: implement HandledResources()
-func (s *SortingPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (s *SortingPrinter) IsGeneric() bool {
-	return s.Delegate.IsGeneric()
 }
 
 func (s *SortingPrinter) sortObj(obj runtime.Object) error {

--- a/pkg/printers/customcolumn.go
+++ b/pkg/printers/customcolumn.go
@@ -150,10 +150,6 @@ type CustomColumnsPrinter struct {
 	lastType reflect.Type
 }
 
-func (s *CustomColumnsPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	if w, found := out.(*tabwriter.Writer); !found {
 		w = GetNewTabWriter(out)
@@ -235,12 +231,4 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 	}
 	fmt.Fprintln(out, strings.Join(columns, "\t"))
 	return nil
-}
-
-func (s *CustomColumnsPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (s *CustomColumnsPrinter) IsGeneric() bool {
-	return true
 }

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -257,14 +257,6 @@ func (h *HumanReadablePrinter) HandledResources() []string {
 	return keys
 }
 
-func (h *HumanReadablePrinter) AfterPrint(output io.Writer, res string) error {
-	return nil
-}
-
-func (h *HumanReadablePrinter) IsGeneric() bool {
-	return false
-}
-
 func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "Unknown object: %s", string(data))
 	return err

--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -28,12 +28,6 @@ import (
 type ResourcePrinter interface {
 	// Print receives a runtime object, formats it and prints it to a writer.
 	PrintObj(runtime.Object, io.Writer) error
-	HandledResources() []string
-	//Can be used to print out warning/clarifications if needed
-	//after all objects were printed
-	AfterPrint(io.Writer, string) error
-	// Identify if it is a generic printer
-	IsGeneric() bool
 }
 
 // ResourcePrinterFunc is a function that can print objects
@@ -42,19 +36,6 @@ type ResourcePrinterFunc func(runtime.Object, io.Writer) error
 // PrintObj implements ResourcePrinter
 func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 	return fn(obj, w)
-}
-
-// TODO: implement HandledResources()
-func (fn ResourcePrinterFunc) HandledResources() []string {
-	return []string{}
-}
-
-func (fn ResourcePrinterFunc) AfterPrint(io.Writer, string) error {
-	return nil
-}
-
-func (fn ResourcePrinterFunc) IsGeneric() bool {
-	return true
 }
 
 type PrintOptions struct {

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -268,7 +268,7 @@ func TestPrinter(t *testing.T) {
 		if err != nil {
 			t.Errorf("in %s, unexpected error: %#v", test.Name, err)
 		}
-		if printer.IsGeneric() && len(test.OutputVersions) > 0 {
+		if len(test.OutputVersions) > 0 {
 			printer = printers.NewVersionedPrinter(printer, legacyscheme.Scheme, legacyscheme.Scheme, test.OutputVersions...)
 		}
 		if err := printer.PrintObj(test.Input, buf); err != nil {

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -31,10 +31,6 @@ import (
 type JSONPrinter struct {
 }
 
-func (p *JSONPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 // PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
 func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	switch obj := obj.(type) {
@@ -58,25 +54,12 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	return err
 }
 
-// TODO: implement HandledResources()
-func (p *JSONPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *JSONPrinter) IsGeneric() bool {
-	return true
-}
-
 // YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
 // The input object is assumed to be in the internal version of an API and is converted
 // to the given version first.
 type YAMLPrinter struct {
 	version   string
 	converter runtime.ObjectConvertor
-}
-
-func (p *YAMLPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
 }
 
 // PrintObj prints the data as YAML.
@@ -97,13 +80,4 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	}
 	_, err = fmt.Fprint(w, string(output))
 	return err
-}
-
-// TODO: implement HandledResources()
-func (p *YAMLPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *YAMLPrinter) IsGeneric() bool {
-	return true
 }

--- a/pkg/printers/jsonpath.go
+++ b/pkg/printers/jsonpath.go
@@ -110,10 +110,6 @@ func NewJSONPathPrinter(tmpl string) (*JSONPathPrinter, error) {
 	return &JSONPathPrinter{tmpl, j}, nil
 }
 
-func (j *JSONPathPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 // PrintObj formats the obj with the JSONPath Template.
 func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	var queryObj interface{} = obj
@@ -149,13 +145,4 @@ func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return fmt.Errorf("error executing jsonpath %q: %v\n", j.rawTemplate, err)
 	}
 	return nil
-}
-
-// TODO: implement HandledResources()
-func (p *JSONPathPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *JSONPathPrinter) IsGeneric() bool {
-	return true
 }

--- a/pkg/printers/name.go
+++ b/pkg/printers/name.go
@@ -42,10 +42,6 @@ type NamePrinter struct {
 	Typer    runtime.ObjectTyper
 }
 
-func (p *NamePrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 // PrintObj is an implementation of ResourcePrinter.PrintObj which decodes the object
 // and print "resource/name" pair. If the object is a List, print all items in it.
 func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
@@ -122,13 +118,4 @@ func printObj(w io.Writer, name string, operation string, shortOutput bool, grou
 
 	fmt.Fprintf(w, "%s.%s/%s%s\n", strings.ToLower(groupKind.Kind), groupKind.Group, name, operation)
 	return nil
-}
-
-// TODO: implement HandledResources()
-func (p *NamePrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *NamePrinter) IsGeneric() bool {
-	return true
 }

--- a/pkg/printers/template.go
+++ b/pkg/printers/template.go
@@ -57,10 +57,6 @@ func (p *GoTemplatePrinter) AllowMissingKeys(allow bool) {
 	}
 }
 
-func (p *GoTemplatePrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 // PrintObj formats the obj with the Go Template.
 func (p *GoTemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	var data []byte
@@ -85,15 +81,6 @@ func (p *GoTemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return fmt.Errorf("error executing template %q: %v", p.rawTemplate, err)
 	}
 	return nil
-}
-
-// TODO: implement HandledResources()
-func (p *GoTemplatePrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *GoTemplatePrinter) IsGeneric() bool {
-	return true
 }
 
 // safeExecute tries to execute the template, but catches panics and returns an error

--- a/pkg/printers/versioned.go
+++ b/pkg/printers/versioned.go
@@ -45,20 +45,10 @@ func NewVersionedPrinter(printer ResourcePrinter, converter runtime.ObjectConver
 	}
 }
 
-func (p *VersionedPrinter) AfterPrint(w io.Writer, res string) error {
-	return nil
-}
-
 // PrintObj implements ResourcePrinter
 func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	// if we're unstructured, no conversion necessary
 	if _, ok := obj.(*unstructured.Unstructured); ok {
-		return p.printer.PrintObj(obj, w)
-	}
-	// if we aren't a generic printer, we don't convert.  This means the printer must be aware of what it is getting.
-	// The default printers fall into this category.
-	// TODO eventually, all printers must be generic
-	if !p.IsGeneric() {
 		return p.printer.PrintObj(obj, w)
 	}
 
@@ -92,13 +82,4 @@ func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		return err
 	}
 	return p.printer.PrintObj(converted, w)
-}
-
-// TODO: implement HandledResources()
-func (p *VersionedPrinter) HandledResources() []string {
-	return []string{}
-}
-
-func (p *VersionedPrinter) IsGeneric() bool {
-	return p.printer.IsGeneric()
 }


### PR DESCRIPTION
The printer interface only needs to know how to print.  This reduces it's interface to scope it to printing.

@kubernetes/sig-cli-maintainers 
@soltysh @juanvallejo  you've been active in the area

/assign @juanvallejo 

```release-note
NONE
```