### PR TITLE
Fix typo in volume_stats.go

### DIFF
--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -58,17 +58,17 @@ var (
 	)
 )
 
-type volumeStatsCollecotr struct {
+type volumeStatsCollector struct {
 	statsProvider serverstats.StatsProvider
 }
 
 // NewVolumeStatsCollector creates a volume stats prometheus collector.
 func NewVolumeStatsCollector(statsProvider serverstats.StatsProvider) prometheus.Collector {
-	return &volumeStatsCollecotr{statsProvider: statsProvider}
+	return &volumeStatsCollector{statsProvider: statsProvider}
 }
 
 // Describe implements the prometheus.Collector interface.
-func (collector *volumeStatsCollecotr) Describe(ch chan<- *prometheus.Desc) {
+func (collector *volumeStatsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- volumeStatsCapacityBytesDesc
 	ch <- volumeStatsAvailableBytesDesc
 	ch <- volumeStatsUsedBytesDesc
@@ -78,7 +78,7 @@ func (collector *volumeStatsCollecotr) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect implements the prometheus.Collector interface.
-func (collector *volumeStatsCollecotr) Collect(ch chan<- prometheus.Metric) {
+func (collector *volumeStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	podStats, err := collector.statsProvider.ListPodStats()
 	if err != nil {
 		return

--- a/pkg/kubelet/metrics/collectors/volume_stats_test.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats_test.go
@@ -129,7 +129,7 @@ func TestVolumeStatsCollector(t *testing.T) {
 
 	mockStatsProvider := new(statstest.StatsProvider)
 	mockStatsProvider.On("ListPodStats").Return(podStats, nil)
-	if err := gatherAndCompare(&volumeStatsCollecotr{statsProvider: mockStatsProvider}, want, metrics); err != nil {
+	if err := gatherAndCompare(&volumeStatsCollector{statsProvider: mockStatsProvider}, want, metrics); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
While reviewing the implementation details I came across a typo in volume_stats.go
sed/volumeStatsCollecotr/volumeStatsCollector/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
