### PR TITLE
compute configmap/secret key correctly cross-platform

### DIFF
--- a/pkg/kubectl/util/util.go
+++ b/pkg/kubectl/util/util.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -60,7 +61,7 @@ func ParseFileSource(source string) (keyName, filePath string, err error) {
 	numSeparators := strings.Count(source, "=")
 	switch {
 	case numSeparators == 0:
-		return path.Base(source), source, nil
+		return path.Base(filepath.ToSlash(source)), source, nil
 	case numSeparators == 1 && strings.HasPrefix(source, "="):
 		return "", "", fmt.Errorf("key name for file path %v missing.", strings.TrimPrefix(source, "="))
 	case numSeparators == 1 && strings.HasSuffix(source, "="):


### PR DESCRIPTION
fixes #61710

```release-note
`kubectl create [secret | configmap] --from-file` now works on Windows with fully-qualified paths
```