### PR TITLE
kubectl support certificate and key data

### DIFF
--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -182,6 +182,8 @@ func (o *createAuthInfoOptions) modifyAuthInfo(existingAuthInfo clientcmdapi.Aut
 				modifiedAuthInfo.ClientCertificateData = nil
 			}
 		}
+	} else if o.clientCertificateData.Provided() {
+		modifiedAuthInfo.ClientCertificateData = []byte(o.clientCertificateData.Value())
 	}
 	if o.clientKey.Provided() {
 		keyPath := o.clientKey.Value()
@@ -195,11 +197,7 @@ func (o *createAuthInfoOptions) modifyAuthInfo(existingAuthInfo clientcmdapi.Aut
 				modifiedAuthInfo.ClientKeyData = nil
 			}
 		}
-	}
-	if o.clientCertificateData.Provided() {
-		modifiedAuthInfo.ClientCertificateData = []byte(o.clientCertificateData.Value())
-	}
-	if o.clientKeyData.Provided() {
+	} else if o.clientKeyData.Provided() {
 		modifiedAuthInfo.ClientKeyData = []byte(o.clientKeyData.Value())
 	}
 	if o.token.Provided() {

--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -183,7 +184,8 @@ func (o *createAuthInfoOptions) modifyAuthInfo(existingAuthInfo clientcmdapi.Aut
 			}
 		}
 	} else if o.clientCertificateData.Provided() {
-		modifiedAuthInfo.ClientCertificateData = []byte(o.clientCertificateData.Value())
+		clientCertificateDataBytes, _ := base64.StdEncoding.DecodeString(o.clientCertificateData.Value())
+		modifiedAuthInfo.ClientCertificateData = clientCertificateDataBytes
 	}
 	if o.clientKey.Provided() {
 		keyPath := o.clientKey.Value()
@@ -198,7 +200,8 @@ func (o *createAuthInfoOptions) modifyAuthInfo(existingAuthInfo clientcmdapi.Aut
 			}
 		}
 	} else if o.clientKeyData.Provided() {
-		modifiedAuthInfo.ClientKeyData = []byte(o.clientKeyData.Value())
+		clientKeyDataBytes, _ := base64.StdEncoding.DecodeString(o.clientKeyData.Value())
+		modifiedAuthInfo.ClientKeyData = clientKeyDataBytes
 	}
 	if o.token.Provided() {
 		modifiedAuthInfo.Token = o.token.Value()

--- a/pkg/kubectl/genericclioptions/config_flags.go
+++ b/pkg/kubectl/genericclioptions/config_flags.go
@@ -41,7 +41,9 @@ const (
 	flagAPIServer        = "server"
 	flagInsecure         = "insecure-skip-tls-verify"
 	flagCertFile         = "client-certificate"
+	flagCertData         = "client-certificate-data"
 	flagKeyFile          = "client-key"
+	flagKeyData          = "client-key-data"
 	flagCAFile           = "certificate-authority"
 	flagBearerToken      = "token"
 	flagImpersonate      = "as"
@@ -84,7 +86,9 @@ type ConfigFlags struct {
 	APIServer        *string
 	Insecure         *bool
 	CertFile         *string
+	CertData         *string
 	KeyFile          *string
+	KeyData          *string
 	CAFile           *string
 	BearerToken      *string
 	Impersonate      *string
@@ -231,8 +235,14 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 	if f.CertFile != nil {
 		flags.StringVar(f.CertFile, flagCertFile, *f.CertFile, "Path to a client certificate file for TLS")
 	}
+	if f.CertData != nil {
+		flags.StringVar(f.CertFile, flagCertData, *f.CertData, "Client certificate data for TLS")
+	}
 	if f.KeyFile != nil {
 		flags.StringVar(f.KeyFile, flagKeyFile, *f.KeyFile, "Path to a client key file for TLS")
+	}
+	if f.KeyData != nil {
+		flags.StringVar(f.KeyData, flagKeyData, *f.KeyData, "Client key data for TLS")
 	}
 	if f.BearerToken != nil {
 		flags.StringVar(f.BearerToken, flagBearerToken, *f.BearerToken, "Bearer token for authentication to the API server")

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -148,6 +148,8 @@ const (
 	FlagInsecure         = "insecure-skip-tls-verify"
 	FlagCertFile         = "client-certificate"
 	FlagKeyFile          = "client-key"
+	FlagCertData         = "client-certificate-data"
+	FlagKeyData          = "client-key-data"
 	FlagCAFile           = "certificate-authority"
 	FlagEmbedCerts       = "embed-certs"
 	FlagBearerToken      = "token"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kubectl config set-credentials` supports using certificate and key data instead of only file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63435 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubectl config set-credentials` supports using certificate and key data instead of only file.
```
