### PR TITLE
change deprecated Kubelet --allow-privileged flag default to true

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -196,7 +196,7 @@ type KubeletFlags struct {
 	// enable gathering custom metrics.
 	EnableCustomMetrics bool
 	// allowPrivileged enables containers to request privileged mode.
-	// Defaults to false.
+	// Defaults to true.
 	AllowPrivileged bool
 	// hostNetworkSources is a comma-separated list of sources from which the
 	// Kubelet allows pods to use of host network. Defaults to "*". Valid
@@ -244,6 +244,8 @@ func NewKubeletFlags() *KubeletFlags {
 		HostIPCSources:      []string{kubetypes.AllSource},
 		// TODO(#56523): default CAdvisorPort to 0 (disabled) and deprecate it
 		CAdvisorPort: 4194,
+		// TODO(#58010:v1.13.0): Remove --allow-privileged, it is deprecated
+		AllowPrivileged: true,
 	}
 }
 
@@ -416,8 +418,8 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	// TODO(#54161:v1.11.0): Remove --enable-custom-metrics flag, it is deprecated.
 	fs.BoolVar(&f.EnableCustomMetrics, "enable-custom-metrics", f.EnableCustomMetrics, "Support for gathering custom metrics.")
 	fs.MarkDeprecated("enable-custom-metrics", "will be removed in a future version")
-	// TODO(#58010:v1.12.0): Remove --allow-privileged, it is deprecated
-	fs.BoolVar(&f.AllowPrivileged, "allow-privileged", f.AllowPrivileged, "If true, allow containers to request privileged mode.")
+	// TODO(#58010:v1.13.0): Remove --allow-privileged, it is deprecated
+	fs.BoolVar(&f.AllowPrivileged, "allow-privileged", f.AllowPrivileged, "If true, allow containers to request privileged mode. Default: true")
 	fs.MarkDeprecated("allow-privileged", "will be removed in a future version")
 	// TODO(#58010:v1.12.0): Remove --host-network-sources, it is deprecated
 	fs.StringSliceVar(&f.HostNetworkSources, "host-network-sources", f.HostNetworkSources, "Comma-separated list of sources from which the Kubelet allows pods to use of host network.")


### PR DESCRIPTION
This enables a smooth transition to PSP. Today, users would have to
manually set --allow-privileged to true before transitioning to PSP,
which isn't a smooth deprecation path for the flag (we want people
to *stop* setting it). This PR makes the default behavior isomorphic
with what will happen after the flag is removed.

Defaulting --allow-privileged to true should be safe, because it simply
allows a superset of Pods to run (all workloads continue to work).

WRT https://github.com/kubernetes/kubernetes/issues/58010#issuecomment-383264473
the --allow-privileged flag is effectively useless for security, so this
shouldn't be a concern from that perspective.

I also bumped the deprecation timeline in the comment to 1.13.0, so that
we give people the full period of time to stop setting
--allow-privileged, now that the behavior makes it possible to do so.

```release-note
The Kubelet's deprecated --allow-privileged flag now defaults to true. This enables users to stop setting --allow-privileged in order to transition to PodSecurityPolicy. Previously, users had to continue setting --allow-privileged, because the default was false.
```
