### PR TITLE
Automated cherry pick of #62621: Show deprecated kube-apiserver flags

### DIFF
--- a/pkg/kubeapiserver/options/admission.go
+++ b/pkg/kubeapiserver/options/admission.go
@@ -73,6 +73,7 @@ func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
 		"The order of plugins in which they are passed to this flag does not matter. "+
 		"Comma-delimited list of: "+strings.Join(a.GenericAdmission.Plugins.Registered(), ", ")+".")
 	fs.MarkDeprecated("admission-control", "Use --enable-admission-plugins or --disable-admission-plugins instead. Will be removed in a future version.")
+	fs.Lookup("admission-control").Hidden = false
 
 	a.GenericAdmission.AddFlags(fs)
 }

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -99,6 +99,7 @@ func (s *InsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IPVar(&s.BindAddress, "insecure-bind-address", s.BindAddress, ""+
 		"The IP address on which to serve the --insecure-port (set to 0.0.0.0 for all IPv4 interfaces and :: for all IPv6 interfaces).")
 	fs.MarkDeprecated("insecure-bind-address", "This flag will be removed in a future version.")
+	fs.Lookup("insecure-bind-address").Hidden = false
 
 	fs.IntVar(&s.BindPort, "insecure-port", s.BindPort, ""+
 		"The port on which to serve unsecured, unauthenticated access. It is assumed "+
@@ -106,6 +107,7 @@ func (s *InsecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"the cluster and that port 443 on the cluster's public address is proxied to this "+
 		"port. This is performed by nginx in the default setup. Set to zero to disable.")
 	fs.MarkDeprecated("insecure-port", "This flag will be removed in a future version.")
+	fs.Lookup("insecure-port").Hidden = false
 }
 
 // TODO: remove it until kops stop using `--address`


### PR DESCRIPTION
Cherry pick of #62621 on release-1.10.

#62621: Show deprecated kube-apiserver flags

```release-note
Show help for deprecated kube-apiserver flags
```