### PR TITLE
[kubeadm] Support `HostPathType` of ExtraVolumes in the kubeadm configuration file.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -300,6 +300,8 @@ type HostPathMount struct {
 	MountPath string
 	// Writable controls write access to the volume
 	Writable bool
+	// PathType is the type of the HostPath.
+	PathType string
 }
 
 // KubeProxy contains elements describing the proxy configuration.

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -301,7 +301,7 @@ type HostPathMount struct {
 	// Writable controls write access to the volume
 	Writable bool
 	// PathType is the type of the HostPath.
-	PathType string
+	PathType v1.HostPathType
 }
 
 // KubeProxy contains elements describing the proxy configuration.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -278,6 +278,8 @@ type HostPathMount struct {
 	MountPath string `json:"mountPath"`
 	// Writable controls write access to the volume
 	Writable bool `json:"writable,omitempty"`
+	// PathType is the type of the HostPath.
+	PathType v1.HostPathType `json:"pathType,omitempty"`
 }
 
 // KubeProxy contains elements describing the proxy configuration.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -23,8 +23,8 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	core_v1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -156,6 +156,7 @@ func autoConvert_v1alpha1_HostPathMount_To_kubeadm_HostPathMount(in *HostPathMou
 	out.HostPath = in.HostPath
 	out.MountPath = in.MountPath
 	out.Writable = in.Writable
+	out.PathType = v1.HostPathType(in.PathType)
 	return nil
 }
 
@@ -169,6 +170,7 @@ func autoConvert_kubeadm_HostPathMount_To_v1alpha1_HostPathMount(in *kubeadm.Hos
 	out.HostPath = in.HostPath
 	out.MountPath = in.MountPath
 	out.Writable = in.Writable
+	out.PathType = v1.HostPathType(in.PathType)
 	return nil
 }
 
@@ -240,7 +242,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.NoTaintMaster = in.NoTaintMaster
 	out.PrivilegedPods = in.PrivilegedPods
 	out.Token = in.Token
-	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
+	out.TokenTTL = (*meta_v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.TokenUsages = *(*[]string)(unsafe.Pointer(&in.TokenUsages))
 	out.TokenGroups = *(*[]string)(unsafe.Pointer(&in.TokenGroups))
 	out.CRISocket = in.CRISocket
@@ -253,7 +255,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.APIServerCertSANs = *(*[]string)(unsafe.Pointer(&in.APIServerCertSANs))
 	out.CertificatesDir = in.CertificatesDir
 	out.ImageRepository = in.ImageRepository
-	out.ImagePullPolicy = core_v1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullPolicy = v1.PullPolicy(in.ImagePullPolicy)
 	out.UnifiedControlPlaneImage = in.UnifiedControlPlaneImage
 	if err := Convert_v1alpha1_AuditPolicyConfiguration_To_kubeadm_AuditPolicyConfiguration(&in.AuditPolicyConfiguration, &out.AuditPolicyConfiguration, s); err != nil {
 		return err
@@ -291,7 +293,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.NoTaintMaster = in.NoTaintMaster
 	out.PrivilegedPods = in.PrivilegedPods
 	out.Token = in.Token
-	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
+	out.TokenTTL = (*meta_v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.TokenUsages = *(*[]string)(unsafe.Pointer(&in.TokenUsages))
 	out.TokenGroups = *(*[]string)(unsafe.Pointer(&in.TokenGroups))
 	out.CRISocket = in.CRISocket
@@ -303,7 +305,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.SchedulerExtraVolumes = *(*[]HostPathMount)(unsafe.Pointer(&in.SchedulerExtraVolumes))
 	out.APIServerCertSANs = *(*[]string)(unsafe.Pointer(&in.APIServerCertSANs))
 	out.CertificatesDir = in.CertificatesDir
-	out.ImagePullPolicy = core_v1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullPolicy = v1.PullPolicy(in.ImagePullPolicy)
 	out.ImageRepository = in.ImageRepository
 	// INFO: in.CIImageRepository opted out of conversion generation
 	out.UnifiedControlPlaneImage = in.UnifiedControlPlaneImage
@@ -349,7 +351,7 @@ func autoConvert_v1alpha1_NodeConfiguration_To_kubeadm_NodeConfiguration(in *Nod
 	out.DiscoveryFile = in.DiscoveryFile
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
-	out.DiscoveryTimeout = (*v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
+	out.DiscoveryTimeout = (*meta_v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
 	out.NodeName = in.NodeName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token
@@ -371,7 +373,7 @@ func autoConvert_kubeadm_NodeConfiguration_To_v1alpha1_NodeConfiguration(in *kub
 	out.DiscoveryFile = in.DiscoveryFile
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
-	out.DiscoveryTimeout = (*v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
+	out.DiscoveryTimeout = (*meta_v1.Duration)(unsafe.Pointer(in.DiscoveryTimeout))
 	out.NodeName = in.NodeName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -107,9 +107,9 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 
 	// Merge user defined mounts and ensure unique volume and volume mount
 	// names
-	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeAPIServer, cfg.APIServerExtraVolumes, &hostPathDirectoryOrCreate)
-	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeControllerManager, cfg.ControllerManagerExtraVolumes, &hostPathDirectoryOrCreate)
-	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeScheduler, cfg.SchedulerExtraVolumes, &hostPathDirectoryOrCreate)
+	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeAPIServer, cfg.APIServerExtraVolumes)
+	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeControllerManager, cfg.ControllerManagerExtraVolumes)
+	mounts.AddExtraHostPathMounts(kubeadmconstants.KubeScheduler, cfg.SchedulerExtraVolumes)
 
 	return mounts
 }
@@ -155,10 +155,11 @@ func (c *controlPlaneHostPathMounts) AddHostPathMounts(component string, vols []
 
 // AddExtraHostPathMounts adds host path mounts and overwrites the default
 // paths in the case that a user specifies the same volume/volume mount name.
-func (c *controlPlaneHostPathMounts) AddExtraHostPathMounts(component string, extraVols []kubeadmapi.HostPathMount, hostPathType *v1.HostPathType) {
+func (c *controlPlaneHostPathMounts) AddExtraHostPathMounts(component string, extraVols []kubeadmapi.HostPathMount) {
 	for _, extraVol := range extraVols {
 		fmt.Printf("[controlplane] Adding extra host path mount %q to %q\n", extraVol.Name, component)
-		c.NewHostPathMount(component, extraVol.Name, extraVol.HostPath, extraVol.MountPath, !extraVol.Writable, hostPathType)
+		hostPathType := v1.HostPathType(extraVol.PathType)
+		c.NewHostPathMount(component, extraVol.Name, extraVol.HostPath, extraVol.MountPath, !extraVol.Writable, &hostPathType)
 	}
 }
 

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -158,7 +158,7 @@ func (c *controlPlaneHostPathMounts) AddHostPathMounts(component string, vols []
 func (c *controlPlaneHostPathMounts) AddExtraHostPathMounts(component string, extraVols []kubeadmapi.HostPathMount) {
 	for _, extraVol := range extraVols {
 		fmt.Printf("[controlplane] Adding extra host path mount %q to %q\n", extraVol.Name, component)
-		hostPathType := v1.HostPathType(extraVol.PathType)
+		hostPathType := extraVol.PathType
 		c.NewHostPathMount(component, extraVol.Name, extraVol.HostPath, extraVol.MountPath, !extraVol.Writable, &hostPathType)
 	}
 }

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -615,19 +615,35 @@ func TestAddExtraHostPathMounts(t *testing.T) {
 	mounts.AddHostPathMounts("component", vols, volMounts)
 	hostPathMounts := []kubeadmapi.HostPathMount{
 		{
-			Name:      "foo",
-			HostPath:  "/tmp/qux",
-			MountPath: "/tmp/qux",
+			Name:      "foo-0",
+			HostPath:  "/tmp/qux-0",
+			MountPath: "/tmp/qux-0",
 			Writable:  false,
+			PathType:  v1.HostPathFile,
 		},
 		{
-			Name:      "bar",
-			HostPath:  "/tmp/asd",
-			MountPath: "/tmp/asd",
+			Name:      "bar-0",
+			HostPath:  "/tmp/asd-0",
+			MountPath: "/tmp/asd-0",
 			Writable:  true,
+			PathType:  v1.HostPathDirectory,
+		},
+		{
+			Name:      "foo-1",
+			HostPath:  "/tmp/qux-1",
+			MountPath: "/tmp/qux-1",
+			Writable:  false,
+			PathType:  v1.HostPathFileOrCreate,
+		},
+		{
+			Name:      "bar-1",
+			HostPath:  "/tmp/asd-1",
+			MountPath: "/tmp/asd-1",
+			Writable:  true,
+			PathType:  v1.HostPathDirectoryOrCreate,
 		},
 	}
-	mounts.AddExtraHostPathMounts("component", hostPathMounts, &hostPathDirectoryOrCreate)
+	mounts.AddExtraHostPathMounts("component", hostPathMounts)
 	for _, hostMount := range hostPathMounts {
 		volumeName := hostMount.Name
 		if _, ok := mounts.volumes["component"][volumeName]; !ok {
@@ -642,6 +658,9 @@ func TestAddExtraHostPathMounts(t *testing.T) {
 		}
 		if _, ok := mounts.volumeMounts["component"][volumeName]; !ok {
 			t.Errorf("Expected to find volume mount %q", volumeName)
+		}
+		if *vol.HostPath.Type != v1.HostPathType(hostMount.PathType) {
+			t.Errorf("Expected to host path type %q", hostMount.PathType)
 		}
 		volMount, _ := mounts.volumeMounts["component"][volumeName]
 		if volMount.Name != volumeName {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Now we use `DirectoryOrCreate ` as a default `HostPathType` in the kubeadm configuration file, when we create user's extra volumes(like `apiServerExtraVolumes`). So, user can't use other `HostPathType`. In order to let users use other types of `HostPath`(like `File`), I think we should support `HostPathType` of ExtraVolumes in the kubeadm configuration file. 

**Which issue(s) this PR fixes**

ref [kubernetes/kubeadm#788](https://github.com/kubernetes/kubeadm/issues/788)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
