### PR TITLE
Add Makefile target to push fat manifest for multi-arch images

### DIFF
--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include  ../../hack/make-rules/Makefile.manifest
+
 REGISTRY ?= gcr.io/kubernetes-e2e-test-images
 GOARM=7
 QEMUVERSION=v2.9.1
@@ -34,7 +36,7 @@ all: all-container
 all-container:
 	./image-util.sh build $(WHAT)
 
-all-push: all-container
+all-push: all-container manifest-tool
 	./image-util.sh push $(WHAT)
 
 .PHONY: all all-push all-container

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -99,6 +99,10 @@ push() {
     TAG=$(<${IMAGE}/VERSION)
     docker push ${REGISTRY}/${IMAGE}-${arch}:${TAG}
   done
+
+  # Make archs list into OS/architecture pair. Eg: 'amd64 ppc64le' to 'linux/amd64,linux/ppc64le'
+  archs=$(echo $archs | sed -e 's/[^ ]* */linux\/&/g' -e 's/ /,/g')
+  manifest-tool push from-args --platforms ${archs} --template ${REGISTRY}/${IMAGE}-ARCH:${TAG} --target ${REGISTRY}/${IMAGE}:${TAG}
 }
 
 # This function is for building the go code


### PR DESCRIPTION
Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds support to push fat manifest for multi-arch images. We need this
so that we can seamlessly pull and run the test images on multiple platforms. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
