### PR TITLE
update advanced audit documents

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -100,7 +100,7 @@ type Event struct {
 	// +optional
 	SourceIPs []string
 	// Object reference this request is targeted at.
-	// Does not apply for List-type requests, or non-resource requests.
+	// Does not apply for non-resource requests.
 	// +optional
 	ObjectRef *ObjectReference
 	// The response status, populated even when the ResponseObject is not a Status type.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/generated.proto
@@ -67,7 +67,7 @@ message Event {
   repeated string sourceIPs = 10;
 
   // Object reference this request is targeted at.
-  // Does not apply for List-type requests, or non-resource requests.
+  // Does not apply for non-resource requests.
   // +optional
   optional ObjectReference objectRef = 11;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
@@ -106,7 +106,7 @@ type Event struct {
 	// +optional
 	SourceIPs []string `json:"sourceIPs,omitempty" protobuf:"bytes,10,rep,name=sourceIPs"`
 	// Object reference this request is targeted at.
-	// Does not apply for List-type requests, or non-resource requests.
+	// Does not apply for non-resource requests.
 	// +optional
 	ObjectRef *ObjectReference `json:"objectRef,omitempty" protobuf:"bytes,11,opt,name=objectRef"`
 	// The response status, populated even when the ResponseObject is not a Status type.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
@@ -71,7 +71,7 @@ message Event {
   repeated string sourceIPs = 10;
 
   // Object reference this request is targeted at.
-  // Does not apply for List-type requests, or non-resource requests.
+  // Does not apply for non-resource requests.
   // +optional
   optional ObjectReference objectRef = 11;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
@@ -102,7 +102,7 @@ type Event struct {
 	// +optional
 	SourceIPs []string `json:"sourceIPs,omitempty" protobuf:"bytes,10,rep,name=sourceIPs"`
 	// Object reference this request is targeted at.
-	// Does not apply for List-type requests, or non-resource requests.
+	// Does not apply for non-resource requests.
 	// +optional
 	ObjectRef *ObjectReference `json:"objectRef,omitempty" protobuf:"bytes,11,opt,name=objectRef"`
 	// The response status, populated even when the ResponseObject is not a Status type.


### PR DESCRIPTION
The list type does work.
When running `kubectl get pods` to list pods, we get this:
```json
    "objectRef": {
        "apiVersion": "v1",
        "namespace": "default",
        "resource": "pods"
    },
    "verb": "list",
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
