### PR TITLE
Don't panic if admission options is nil

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -87,6 +87,10 @@ func NewAdmissionOptions() *AdmissionOptions {
 
 // AddFlags adds flags related to admission for a specific APIServer to the specified FlagSet
 func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
+	if a == nil {
+		return
+	}
+
 	fs.StringSliceVar(&a.EnablePlugins, "enable-admission-plugins", a.EnablePlugins, ""+
 		"admission plugins that should be enabled in addition to default enabled ones. "+
 		"Comma-delimited list of admission plugins: "+strings.Join(a.Plugins.Registered(), ", ")+". "+


### PR DESCRIPTION
Since [1.10 release](https://github.com/kubernetes/apiserver/blob/release-1.10/pkg/server/options/recommended.go#L43) admission options are enabled by default . This was not the case in 1.9 release. Admission plugins seem unnecessary for a webhook server. This change is needed so that disabling admission options don't cause panic.

```release-note
NONE
```

@deads2k @sttts 

ref: https://github.com/openshift/generic-admission-server/pull/14
