### PR TITLE
Make taint behavior consistent for NoSchedule

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -81,32 +81,34 @@ var (
 	}
 
 	nodeConditionToTaintKeyStatusMap = map[v1.NodeConditionType]struct {
-		TaintKey string
-		Status   v1.ConditionStatus
+		taintKey string
+		// noScheduleStatus is the condition under which the node should be tainted as not schedulable for this
+		// NodeConditionType
+		noScheduleStatus v1.ConditionStatus
 	}{
 		v1.NodeReady: {
-			TaintKey: algorithm.TaintNodeNotReady,
-			Status:   v1.ConditionFalse,
+			taintKey:         algorithm.TaintNodeNotReady,
+			noScheduleStatus: v1.ConditionFalse,
 		},
 		v1.NodeMemoryPressure: {
-			TaintKey: algorithm.TaintNodeMemoryPressure,
-			Status:   v1.ConditionTrue,
+			taintKey:         algorithm.TaintNodeMemoryPressure,
+			noScheduleStatus: v1.ConditionTrue,
 		},
 		v1.NodeOutOfDisk: {
-			TaintKey: algorithm.TaintNodeOutOfDisk,
-			Status:   v1.ConditionTrue,
+			taintKey:         algorithm.TaintNodeOutOfDisk,
+			noScheduleStatus: v1.ConditionTrue,
 		},
 		v1.NodeDiskPressure: {
-			TaintKey: algorithm.TaintNodeDiskPressure,
-			Status:   v1.ConditionTrue,
+			taintKey:         algorithm.TaintNodeDiskPressure,
+			noScheduleStatus: v1.ConditionTrue,
 		},
 		v1.NodeNetworkUnavailable: {
-			TaintKey: algorithm.TaintNodeNetworkUnavailable,
-			Status:   v1.ConditionTrue,
+			taintKey:         algorithm.TaintNodeNetworkUnavailable,
+			noScheduleStatus: v1.ConditionTrue,
 		},
 		v1.NodePIDPressure: {
-			TaintKey: algorithm.TaintNodePIDPressure,
-			Status:   v1.ConditionTrue,
+			taintKey:         algorithm.TaintNodePIDPressure,
+			noScheduleStatus: v1.ConditionTrue,
 		},
 	}
 
@@ -453,12 +455,12 @@ func (nc *Controller) doFixDeprecatedTaintKeyPass(node *v1.Node) error {
 
 func (nc *Controller) doNoScheduleTaintingPass(node *v1.Node) error {
 	// Map node's condition to Taints.
-	taints := []v1.Taint{}
+	var taints []v1.Taint
 	for _, condition := range node.Status.Conditions {
-		if taintKeyStatus, found := nodeConditionToTaintKeyStatusMap[condition.Type]; found {
-			if condition.Status == taintKeyStatus.Status {
+		if taint, found := nodeConditionToTaintKeyStatusMap[condition.Type]; found {
+			if condition.Status == taint.noScheduleStatus {
 				taints = append(taints, v1.Taint{
-					Key:    taintKeyStatus.TaintKey,
+					Key:    taint.taintKey,
 					Effect: v1.TaintEffectNoSchedule,
 				})
 			}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2163,6 +2163,10 @@ func TestTaintsNodeByCondition(t *testing.T) {
 		Key:    algorithm.TaintNodeNetworkUnavailable,
 		Effect: v1.TaintEffectNoSchedule,
 	}
+	notReadyTaint := &v1.Taint{
+		Key:    algorithm.TaintNodeNotReady,
+		Effect: v1.TaintEffectNoSchedule,
+	}
 
 	tests := []struct {
 		Name           string
@@ -2270,6 +2274,30 @@ func TestTaintsNodeByCondition(t *testing.T) {
 				},
 			},
 			ExpectedTaints: []*v1.Taint{networkUnavailableTaint},
+		},
+		{
+			Name: "Ready is false",
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels: map[string]string{
+						kubeletapis.LabelZoneRegion:        "region1",
+						kubeletapis.LabelZoneFailureDomain: "zone1",
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			ExpectedTaints: []*v1.Taint{notReadyTaint},
 		},
 	}
 

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -229,7 +229,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 		}
 	}
 
-	// Case 4: Schedule Pod with NetworkUnavailable toleration.
+	// Case 4: Schedule Pod with NetworkUnavailable and NotReady toleration.
 	networkDaemonPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "network-daemon-pod",
@@ -245,6 +245,11 @@ func TestTaintNodeByCondition(t *testing.T) {
 			Tolerations: []v1.Toleration{
 				{
 					Key:      algorithm.TaintNodeNetworkUnavailable,
+					Operator: v1.TolerationOpExists,
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      algorithm.TaintNodeNotReady,
 					Operator: v1.TolerationOpExists,
 					Effect:   v1.TaintEffectNoSchedule,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Make taint behavior consistent.
If `TaintNodesByCondition ` is enable, taint node with `NotReady:NoSchedule`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63420

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
