### PR TITLE
Deprecate rest.Config.Dial and transport.Config.Dial

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -109,7 +110,12 @@ type Config struct {
 	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
 	Timeout time.Duration
 
+	// DialContext specifies the dial function for creating unencrypted TCP connections.
+	DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
 	// Dial specifies the dial function for creating unencrypted TCP connections.
+	// Deprecated: Use DialContext instead, which allows cancel the dialing.
+	// If both are set, DialContext takes priority.
 	Dial func(network, addr string) (net.Conn, error)
 
 	// Version forces a specific version to be used (if registered)
@@ -415,6 +421,7 @@ func AnonymousClientConfig(config *Config) *Config {
 		Burst:         config.Burst,
 		Timeout:       config.Timeout,
 		Dial:          config.Dial,
+		DialContext:   config.DialContext,
 	}
 }
 
@@ -453,5 +460,6 @@ func CopyConfig(config *Config) *Config {
 		RateLimiter:   config.RateLimiter,
 		Timeout:       config.Timeout,
 		Dial:          config.Dial,
+		DialContext:   config.DialContext,
 	}
 }

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -110,6 +110,7 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
-		Dial: c.Dial,
+		Dial:        c.Dial,
+		DialContext: c.DialContext,
 	}, nil
 }

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transport
 
 import (
+	"context"
 	"net"
 	"net/http"
 )
@@ -52,7 +53,12 @@ type Config struct {
 	// RoundTripper.
 	WrapTransport func(rt http.RoundTripper) http.RoundTripper
 
+	// DialContext specifies the dial function for creating unencrypted TCP connections.
+	DialContext func(ctx context.Context, network, address string) (net.Conn, error)
+
 	// Dial specifies the dial function for creating unencrypted TCP connections.
+	// Deprecated: Use DialContext instead, which allows cancel the dialing.
+	// If both are set, DialContext takes priority.
 	Dial func(network, addr string) (net.Conn, error)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

1. 1st commit: Deprecate reset.Config.Dial && transport.Config.Dial, and introduce DialContext to allow setting dial timeout.

1. 2nd commit: replace Dial in admission webhook.

partially fix #63455 

**Special notes for your reviewer**:

following #63454 ,will replace Dial with DialContext step by step.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate reset.Config.Dial && transport.Config.Dial, and will be removed in the future, please use the DialContext instead.
```
