### PR TITLE
add Wrapper function in staging/src/k8s.io/apimachinery/…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/waitgroup/waitgroup.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/waitgroup/waitgroup.go
@@ -55,3 +55,20 @@ func (wg *SafeWaitGroup) Wait() {
 	wg.mu.Unlock()
 	wg.wg.Wait()
 }
+
+// Wrapper is a struct that as a waiter for all linetr-tasks.And it
+// encapsulates sync.WaitGroup that can be call as a interface.
+type Wrapper struct {
+	sync.WaitGroup
+}
+
+// Wrap implements a interface that run the function cd as a goroutine.And it
+// encapsulates Add(1) and Done() operation.You can just think go cd() but not
+// worry about synchronization and security issues.
+func (w *Wrapper) Wrap(cb func()) {
+	w.Add(1)
+	go func() {
+		defer w.Done()
+		cb()
+	}()
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/waitgroup/waitgroup_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/waitgroup/waitgroup_test.go
@@ -49,6 +49,21 @@ func TestWaitGroup(t *testing.T) {
 	}
 }
 
+func TestWaitGroup_WaitGroupWrapper(t *testing.T) {
+	wg := &Wrapper{}
+	n := 16
+	exited := make(chan bool, n)
+	for i := 0; i != n; i++ {
+		wg.Wrap(func() {
+			exited <- true
+		})
+	}
+	wg.Wait()
+	for i := 0; i != n; i++ {
+		<-exited // Will block if barrier fails to unlock someone.
+	}
+}
+
 func TestWaitGroupAddFail(t *testing.T) {
 	wg := &SafeWaitGroup{}
 	wg.Add(1)


### PR DESCRIPTION
…pkg/util/waitgroup

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Wrap implements a interface that run the function cd as a goroutine.And it encapsulates Add(1) and Done() operation. You can just think go cd() but not worry about synchronization and security issues.

And I will replace the operation using waitgroup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
