### PR TITLE
remove redundant runtime.GOMAXPROCS

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"runtime"
 
 	"github.com/golang/glog"
 
@@ -31,10 +30,6 @@ import (
 func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	cmd := server.NewCommandStartCustomResourceDefinitionsServer(os.Stdout, os.Stderr, stopCh)

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"runtime"
 
 	"github.com/golang/glog"
 
@@ -38,10 +37,6 @@ import (
 func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"runtime"
 
 	"github.com/golang/glog"
 
@@ -31,10 +30,6 @@ import (
 func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	options := server.NewWardleServerOptions(os.Stdout, os.Stderr)


### PR DESCRIPTION
Since golang 1.5, `By default, Go programs run with GOMAXPROCS set to the number of cores available;`
If env `GOMAXPROCS `, it uses default `runtime.NumCPU()`. So set again is redundant.

cc @deads2k 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
