### PR TITLE
Add support for arm64 to the registry action of the kuberntes-worker juju charm.

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -25,13 +25,16 @@ from base64 import b64encode
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charms.templating.jinja2 import render
-from subprocess import call
+from subprocess import call, check_output
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 deletion = action_get('delete')
 
 context = {}
+
+arch = check_output(['dpkg', '--print-architecture']).rstrip()
+context['arch'] = arch.decode('utf-8')
 
 # These config options must be defined in the case of a creation
 param_error = False

--- a/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: registry
-        image: registry:2
+        image: cdkbot/registry-{{ arch }}:2.6
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**: Add support for arm64 to the registry action of the kuberntes-worker juju charm.

**Release note**:
```release-note
NONE
```
