### PR TITLE
kubeadm - fix upgrades with external etcd

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -124,13 +124,13 @@ func RunPlan(flags *planFlags) error {
 	}
 
 	// Tell the user which upgrades are available
-	printAvailableUpgrades(availUpgrades, os.Stdout, upgradeVars.cfg.FeatureGates)
+	printAvailableUpgrades(availUpgrades, os.Stdout, upgradeVars.cfg.FeatureGates, isExternalEtcd)
 	return nil
 }
 
 // printAvailableUpgrades prints a UX-friendly overview of what versions are available to upgrade to
 // TODO look into columnize or some other formatter when time permits instead of using the tabwriter
-func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGates map[string]bool) {
+func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGates map[string]bool, isExternalEtcd bool) {
 
 	// Return quickly if no upgrades can be made
 	if len(upgrades) == 0 {
@@ -142,6 +142,16 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 
 	// Loop through the upgrade possibilities and output text to the command line
 	for _, upgrade := range upgrades {
+
+		if isExternalEtcd && upgrade.CanUpgradeEtcd() {
+			fmt.Fprintln(w, "External components that should be upgraded manually before you upgrade the control plane with 'kubeadm upgrade apply':")
+			fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
+			fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+
+			// We should flush the writer here at this stage; as the columns will now be of the right size, adjusted to the above content
+			tabw.Flush()
+			fmt.Fprintln(w, "")
+		}
 
 		if upgrade.CanUpgradeKubelets() {
 			fmt.Fprintln(w, "Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':")
@@ -177,7 +187,9 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 		} else {
 			fmt.Fprintf(tabw, "Kube DNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
 		}
-		fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+		if !isExternalEtcd {
+			fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+		}
 
 		// The tabwriter should be flushed at this stage as we have now put in all the required content for this time. This is required for the tabs' size to be correct.
 		tabw.Flush()

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -62,16 +62,27 @@ func TestSortedSliceFromStringIntMap(t *testing.T) {
 func TestPrintAvailableUpgrades(t *testing.T) {
 	featureGates := make(map[string]bool)
 	var tests = []struct {
+		name          string
 		upgrades      []upgrade.Upgrade
 		buf           *bytes.Buffer
 		expectedBytes []byte
+		externalEtcd  bool
 	}{
 		{
+			name:     "Up to date",
 			upgrades: []upgrade.Upgrade{},
 			expectedBytes: []byte(`Awesome, you're up-to-date! Enjoy!
 `),
 		},
 		{
+			name:         "Up to date external etcd",
+			externalEtcd: true,
+			upgrades:     []upgrade.Upgrade{},
+			expectedBytes: []byte(`Awesome, you're up-to-date! Enjoy!
+`),
+		},
+		{
+			name: "Patch version available",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "version in the v1.8 series",
@@ -117,6 +128,7 @@ _____________________________________________________________________
 `),
 		},
 		{
+			name: "minor version available",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "stable version",
@@ -160,6 +172,7 @@ _____________________________________________________________________
 `),
 		},
 		{
+			name: "patch and minor version available",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "version in the v1.8 series",
@@ -243,6 +256,7 @@ _____________________________________________________________________
 `),
 		},
 		{
+			name: "experimental version available",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "experimental version",
@@ -288,6 +302,7 @@ _____________________________________________________________________
 `),
 		},
 		{
+			name: "release candidate available",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "release candidate version",
@@ -333,6 +348,7 @@ _____________________________________________________________________
 `),
 		},
 		{
+			name: "multiple kubelet versions",
 			upgrades: []upgrade.Upgrade{
 				{
 					Description: "version in the v1.9 series",
@@ -379,17 +395,69 @@ _____________________________________________________________________
 
 `),
 		},
+		{
+			name: "external etcd upgrade available",
+			upgrades: []upgrade.Upgrade{
+				{
+					Description: "version in the v1.9 series",
+					Before: upgrade.ClusterState{
+						KubeVersion: "v1.9.2",
+						KubeletVersions: map[string]uint16{
+							"v1.9.2": 1,
+						},
+						KubeadmVersion: "v1.9.2",
+						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
+					},
+					After: upgrade.ClusterState{
+						KubeVersion:    "v1.9.3",
+						KubeadmVersion: "v1.9.3",
+						DNSVersion:     "1.14.8",
+						EtcdVersion:    "3.1.12",
+					},
+				},
+			},
+			externalEtcd: true,
+			expectedBytes: []byte(`External components that should be upgraded manually before you upgrade the control plane with 'kubeadm upgrade apply':
+COMPONENT   CURRENT   AVAILABLE
+Etcd        3.0.17    3.1.12
+
+Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
+COMPONENT   CURRENT      AVAILABLE
+Kubelet     1 x v1.9.2   v1.9.3
+
+Upgrade to the latest version in the v1.9 series:
+
+COMPONENT            CURRENT   AVAILABLE
+API Server           v1.9.2    v1.9.3
+Controller Manager   v1.9.2    v1.9.3
+Scheduler            v1.9.2    v1.9.3
+Kube Proxy           v1.9.2    v1.9.3
+Kube DNS             1.14.5    1.14.8
+
+You can now apply the upgrade by executing the following command:
+
+	kubeadm upgrade apply v1.9.3
+
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.3.
+
+_____________________________________________________________________
+
+`),
+		},
 	}
 	for _, rt := range tests {
-		rt.buf = bytes.NewBufferString("")
-		printAvailableUpgrades(rt.upgrades, rt.buf, featureGates)
-		actualBytes := rt.buf.Bytes()
-		if !bytes.Equal(actualBytes, rt.expectedBytes) {
-			t.Errorf(
-				"failed PrintAvailableUpgrades:\n\texpected: %q\n\t  actual: %q",
-				string(rt.expectedBytes),
-				string(actualBytes),
-			)
-		}
+		t.Run(rt.name, func(t *testing.T) {
+			rt.buf = bytes.NewBufferString("")
+			printAvailableUpgrades(rt.upgrades, rt.buf, featureGates, rt.externalEtcd)
+			actualBytes := rt.buf.Bytes()
+			if !bytes.Equal(actualBytes, rt.expectedBytes) {
+				t.Errorf(
+					"failed PrintAvailableUpgrades:\n\texpected: %q\n\t  actual: %q",
+					string(rt.expectedBytes),
+					string(actualBytes),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -74,7 +74,7 @@ type ClusterState struct {
 
 // GetAvailableUpgrades fetches all versions from the specified VersionGetter and computes which
 // kinds of upgrades can be performed
-func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, etcdClient etcdutil.Client, featureGates map[string]bool) ([]Upgrade, error) {
+func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, etcdClient etcdutil.ClusterInterrogator, featureGates map[string]bool) ([]Upgrade, error) {
 	fmt.Println("[upgrade] Fetching available versions to upgrade to")
 
 	// Collect the upgrades kubeadm can do in this list

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package upgrade
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	versionutil "k8s.io/kubernetes/pkg/util/version"
 )
 
@@ -62,28 +64,81 @@ func (f *fakeVersionGetter) KubeletVersions() (map[string]uint16, error) {
 	}, nil
 }
 
-type fakeEtcdCluster struct{ TLS bool }
+type fakeEtcdClient struct{ TLS bool }
 
-func (f fakeEtcdCluster) HasTLS() bool { return f.TLS }
+func (f fakeEtcdClient) HasTLS() bool { return f.TLS }
 
-func (f fakeEtcdCluster) GetStatus() (*clientv3.StatusResponse, error) {
-	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.12"
-	return client, nil
+func (f fakeEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
+	//	clusterStatus, err := f.GetClusterStatus()
+	//	return clusterStatus[0], err
+	return &clientv3.StatusResponse{
+		Version: "3.1.12",
+	}, nil
 }
 
-func (f fakeEtcdCluster) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
+func (f fakeEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+	var responses []*clientv3.StatusResponse
+	responses = append(responses, &clientv3.StatusResponse{
+		Version: "3.1.12",
+	})
+	return responses, nil
+}
+
+func (f fakeEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
+	return f.GetStatus()
+}
+
+type mismatchEtcdClient struct{}
+
+func (f mismatchEtcdClient) HasTLS() bool { return true }
+
+func (f mismatchEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
+	clusterStatus, err := f.GetClusterStatus()
+	return clusterStatus[0], err
+}
+
+func (f mismatchEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+	return []*clientv3.StatusResponse{
+		&clientv3.StatusResponse{
+			Version: "3.1.12",
+		},
+		&clientv3.StatusResponse{
+			Version: "3.2.0",
+		},
+	}, nil
+}
+
+func (f mismatchEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
+	return f.GetStatus()
+}
+
+type degradedEtcdClient struct{}
+
+func (f degradedEtcdClient) HasTLS() bool { return true }
+
+func (f degradedEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
+	return nil, fmt.Errorf("Degraded etcd cluster")
+}
+
+func (f degradedEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+	var res []*clientv3.StatusResponse
+	return res, fmt.Errorf("Degraded etcd cluster")
+}
+
+func (f degradedEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
 	return f.GetStatus()
 }
 
 func TestGetAvailableUpgrades(t *testing.T) {
 	featureGates := make(map[string]bool)
+	etcdClient := fakeEtcdClient{}
 	tests := []struct {
 		name                        string
 		vg                          VersionGetter
 		expectedUpgrades            []Upgrade
 		allowExperimental, allowRCs bool
 		errExpected                 bool
+		etcdClient                  etcdutil.ClusterInterrogator
 	}{
 		{
 			name: "no action needed, already up-to-date",
@@ -98,6 +153,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			expectedUpgrades:  []Upgrade{},
 			allowExperimental: false,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "simple patch version upgrade",
@@ -131,6 +187,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: false,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "no version provided to offline version getter does not change behavior",
@@ -164,6 +221,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: false,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "minor version upgrade only",
@@ -197,6 +255,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: false,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "both minor version upgrade and patch version upgrade available",
@@ -248,6 +307,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: false,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "allow experimental upgrades, but no upgrade available",
@@ -263,6 +323,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			expectedUpgrades:  []Upgrade{},
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "upgrade to an unstable version should be supported",
@@ -297,6 +358,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "upgrade from an unstable version to an unstable version should be supported",
@@ -331,6 +393,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "v1.X.0-alpha.0 should be ignored",
@@ -366,6 +429,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "upgrade to an RC version should be supported",
@@ -401,6 +465,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowRCs:    true,
 			errExpected: false,
+			etcdClient:  etcdClient,
 		},
 		{
 			name: "it is possible (but very uncommon) that the latest version from the previous branch is an rc and the current latest version is alpha.0. In that case, show the RC",
@@ -436,6 +501,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
 		},
 		{
 			name: "upgrade to an RC version should be supported. There may also be an even newer unstable version.",
@@ -490,6 +556,37 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			allowRCs:          true,
 			allowExperimental: true,
 			errExpected:       false,
+			etcdClient:        etcdClient,
+		},
+		{
+			name: "Upgrades with external etcd with mismatched versions should not be allowed.",
+			vg: &fakeVersionGetter{
+				clusterVersion:     "v1.9.3",
+				kubeletVersion:     "v1.9.3",
+				kubeadmVersion:     "v1.9.3",
+				stablePatchVersion: "v1.9.3",
+				stableVersion:      "v1.9.3",
+			},
+			allowRCs:          false,
+			allowExperimental: false,
+			etcdClient:        mismatchEtcdClient{},
+			expectedUpgrades:  []Upgrade{},
+			errExpected:       true,
+		},
+		{
+			name: "Upgrades with external etcd with a degraded status should not be allowed.",
+			vg: &fakeVersionGetter{
+				clusterVersion:     "v1.9.3",
+				kubeletVersion:     "v1.9.3",
+				kubeadmVersion:     "v1.9.3",
+				stablePatchVersion: "v1.9.3",
+				stableVersion:      "v1.9.3",
+			},
+			allowRCs:          false,
+			allowExperimental: false,
+			etcdClient:        degradedEtcdClient{},
+			expectedUpgrades:  []Upgrade{},
+			errExpected:       true,
 		},
 		{
 			name: "offline version getter",
@@ -498,6 +595,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 				kubeletVersion: "v1.10.0",
 				kubeadmVersion: "v1.10.1",
 			}, "v1.11.1"),
+			etcdClient: etcdClient,
 			expectedUpgrades: []Upgrade{
 				{
 					Description: "version in the v1.1 series",
@@ -523,10 +621,9 @@ func TestGetAvailableUpgrades(t *testing.T) {
 
 	// Instantiating a fake etcd cluster for being able to get etcd version for a corresponding
 	// kubernetes release.
-	testCluster := fakeEtcdCluster{}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			actualUpgrades, actualErr := GetAvailableUpgrades(rt.vg, rt.allowExperimental, rt.allowRCs, testCluster, featureGates)
+			actualUpgrades, actualErr := GetAvailableUpgrades(rt.vg, rt.allowExperimental, rt.allowRCs, rt.etcdClient, featureGates)
 			if !reflect.DeepEqual(actualUpgrades, rt.expectedUpgrades) {
 				t.Errorf("failed TestGetAvailableUpgrades\n\texpected upgrades: %v\n\tgot: %v", rt.expectedUpgrades, actualUpgrades)
 			}

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	controlplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
@@ -215,20 +215,27 @@ func (c fakeTLSEtcdClient) HasTLS() bool {
 	return c.TLS
 }
 
-func (c fakeTLSEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	clusterStatus, err := c.GetClusterStatus()
-	return clusterStatus[0], err
+func (c fakeTLSEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
+
+func (c fakeTLSEtcdClient) WaitForClusterAvailable(delay time.Duration, retries int, retryInterval time.Duration) (bool, error) {
+	return true, nil
 }
 
-func (c fakeTLSEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
-	client := &clientv3.StatusResponse{
-		Version: "3.1.12",
-	}
-	return []*clientv3.StatusResponse{client}, nil
+func (c fakeTLSEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
+	return map[string]*clientv3.StatusResponse{
+		"foo": {
+			Version: "3.1.12",
+		}}, nil
 }
 
-func (c fakeTLSEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return c.GetStatus()
+func (c fakeTLSEtcdClient) GetClusterVersions() (map[string]string, error) {
+	return map[string]string{
+		"foo": "3.1.12",
+	}, nil
+}
+
+func (c fakeTLSEtcdClient) GetVersion() (string, error) {
+	return "3.1.12", nil
 }
 
 type fakePodManifestEtcdClient struct{ ManifestDir, CertificatesDir string }
@@ -238,12 +245,13 @@ func (c fakePodManifestEtcdClient) HasTLS() bool {
 	return hasTLS
 }
 
-func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	clusterStatus, err := c.GetClusterStatus()
-	return clusterStatus[0], err
+func (c fakePodManifestEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
+
+func (c fakePodManifestEtcdClient) WaitForClusterAvailable(delay time.Duration, retries int, retryInterval time.Duration) (bool, error) {
+	return true, nil
 }
 
-func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+func (c fakePodManifestEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
 	// Make sure the certificates generated from the upgrade are readable from disk
 	tlsInfo := transport.TLSInfo{
 		CertFile:      filepath.Join(c.CertificatesDir, constants.EtcdCACertName),
@@ -255,13 +263,19 @@ func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusRespons
 		return nil, err
 	}
 
-	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.12"
-	return []*clientv3.StatusResponse{client}, nil
+	return map[string]*clientv3.StatusResponse{
+		"foo": {Version: "3.1.12"},
+	}, nil
 }
 
-func (c fakePodManifestEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return c.GetStatus()
+func (c fakePodManifestEtcdClient) GetClusterVersions() (map[string]string, error) {
+	return map[string]string{
+		"foo": "3.1.12",
+	}, nil
+}
+
+func (c fakePodManifestEtcdClient) GetVersion() (string, error) {
+	return "3.1.12", nil
 }
 
 func TestStaticPodControlPlane(t *testing.T) {
@@ -496,7 +510,7 @@ func getAPIServerHash(dir string) (string, error) {
 }
 
 func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.MasterConfiguration, error) {
-	externalcfg := &kubeadmapiext.MasterConfiguration{}
+	externalcfg := &kubeadmapiv1alpha1.MasterConfiguration{}
 	internalcfg := &kubeadmapi.MasterConfiguration{}
 	if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), []byte(fmt.Sprintf(testConfiguration, certsDir, etcdDataDir, version)), externalcfg); err != nil {
 		return nil, fmt.Errorf("unable to decode config: %v", err)

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	controlplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
@@ -216,9 +216,15 @@ func (c fakeTLSEtcdClient) HasTLS() bool {
 }
 
 func (c fakeTLSEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.12"
-	return client, nil
+	clusterStatus, err := c.GetClusterStatus()
+	return clusterStatus[0], err
+}
+
+func (c fakeTLSEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+	client := &clientv3.StatusResponse{
+		Version: "3.1.12",
+	}
+	return []*clientv3.StatusResponse{client}, nil
 }
 
 func (c fakeTLSEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
@@ -233,6 +239,11 @@ func (c fakePodManifestEtcdClient) HasTLS() bool {
 }
 
 func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
+	clusterStatus, err := c.GetClusterStatus()
+	return clusterStatus[0], err
+}
+
+func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
 	// Make sure the certificates generated from the upgrade are readable from disk
 	tlsInfo := transport.TLSInfo{
 		CertFile:      filepath.Join(c.CertificatesDir, constants.EtcdCACertName),
@@ -246,7 +257,7 @@ func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error)
 
 	client := &clientv3.StatusResponse{}
 	client.Version = "3.1.12"
-	return client, nil
+	return []*clientv3.StatusResponse{client}, nil
 }
 
 func (c fakePodManifestEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
@@ -485,7 +496,7 @@ func getAPIServerHash(dir string) (string, error) {
 }
 
 func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.MasterConfiguration, error) {
-	externalcfg := &kubeadmapiv1alpha1.MasterConfiguration{}
+	externalcfg := &kubeadmapiext.MasterConfiguration{}
 	internalcfg := &kubeadmapi.MasterConfiguration{}
 	if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), []byte(fmt.Sprintf(testConfiguration, certsDir, etcdDataDir, version)), externalcfg); err != nil {
 		return nil, fmt.Errorf("unable to decode config: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allow for upgrade plan and upgrade apply to work with external etcd
  - https://github.com/kubernetes/kubeadm/issues/727
  - https://github.com/kubernetes/kubernetes/pull/62141

- Update upgrade plan output when configured for external etcd
  - Move etcd to a separate section and show available upgrades

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/727

**Release note**:
```release-note
kubeadm upgrade now supports external etcd setups again
```

I created a gist documenting the manual testing I've been doing for this PR here: https://gist.github.com/detiber/e18d907c41901fbb5e12ffa1af5750f8