### PR TITLE
Drop unnecessary redirection of ci/latest.txt to ci-cross/latest.txt for kubeadm's kubernetes version flag

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -122,8 +122,8 @@ func splitVersion(version string) (string, string, error) {
 
 	switch {
 	case strings.HasPrefix(subs[0][2], "ci"):
-		// Special case. CI images populated only by ci-cross area
-		urlSuffix = "ci-cross"
+		// Just use whichever the user specified
+		urlSuffix = subs[0][2]
 	default:
 		urlSuffix = "release"
 	}

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -180,8 +180,10 @@ func TestSplitVersion(t *testing.T) {
 		{"release/v1.7.0", "https://dl.k8s.io/release", "v1.7.0", true},
 		{"release/latest-1.7", "https://dl.k8s.io/release", "latest-1.7", true},
 		// CI builds area, lookup actual builds at ci-cross/*.txt
+		{"ci/latest", "https://dl.k8s.io/ci", "latest", true},
 		{"ci-cross/latest", "https://dl.k8s.io/ci-cross", "latest", true},
-		{"ci/latest-1.7", "https://dl.k8s.io/ci-cross", "latest-1.7", true},
+		{"ci/latest-1.7", "https://dl.k8s.io/ci", "latest-1.7", true},
+		{"ci-cross/latest-1.7", "https://dl.k8s.io/ci-cross", "latest-1.7", true},
 		// unknown label in default (release) area: splitVersion validate only areas.
 		{"unknown-1", "https://dl.k8s.io/release", "unknown-1", true},
 		// unknown area, not valid input.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

For 1.8,1.9,1.10 branches, we need to load the latest
version from ci/latest*.txt.

For master, we need to load the version number from
ci-cross/latest.txt

try these to verify:
```
gsutil cat gs://kubernetes-release-dev/ci/latest-1.9.txt
gsutil cat gs://kubernetes-release-dev/ci-cross/latest.txt
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/61483

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubernetes version command line parameter in kubeadm has been updated to drop an unnecessary redirection from ci/latest.txt to ci-cross/latest.txt. Users should know exactly where the builds are stored on Google Cloud storage buckets from now on. For example for 1.9 and 1.10, users can specify ci/latest-1.9 and ci/latest-1.10 as the CI build jobs what build images correctly updates those. The CI jobs for master update the ci-cross/latest location, so if you are looking for latest master builds, then the correct parameter to use would be ci-cross/latest.
```
