### PR TITLE
//hack:update-mirror: ensure last URL in list is mirrored too

### DIFF
--- a/build/workspace_mirror.bzl
+++ b/build/workspace_mirror.bzl
@@ -39,7 +39,11 @@ def export_urls_impl(repo_ctx):
     repo_ctx.file(repo_ctx.path("BUILD.bazel"), """
 exports_files(glob(["**"]), visibility=["//visibility:public"])
 """)
-    repo_ctx.file(repo_ctx.path("urls.txt"), content = "\n".join(repo_ctx.attr.urls))
+    repo_ctx.file(
+        repo_ctx.path("urls.txt"),
+        # Add a trailing newline, since the "while read" loop needs it
+        content = ("\n".join(repo_ctx.attr.urls) + "\n"),
+    )
 
 _export_urls = repository_rule(
     attrs = {

--- a/build/workspace_mirror.bzl
+++ b/build/workspace_mirror.bzl
@@ -15,31 +15,31 @@
 prefix = "https://storage.googleapis.com/k8s-bazel-cache/"
 
 def mirror(url):
-  """Try downloading a URL from a GCS mirror first, then from the original.
+    """Try downloading a URL from a GCS mirror first, then from the original.
 
-  Update the GCS bucket using bazel run //hack:update-mirror"""
-  return [prefix + url, url]
+    Update the GCS bucket using bazel run //hack:update-mirror"""
+    return [prefix + url, url]
 
-# This function only gives proper results when executed from WORKSPACE,
-# but the data is needed in sh_binary, which can only be in a BUILD file.
-# Thus, it is be exported by a repository_rule (which executes in WORKSPACE)
-# to be used by the sh_binary.
 def mirror_urls():
-  urls = []
-  for k, v in native.existing_rules().items():
-    us = list(v.get('urls', []))
-    if 'url' in v:
-      us.append(v['url'])
-    for u in us:
-      if u and not u.startswith(prefix):
-        urls.append(u)
-  return sorted(urls)
+    # This function only gives proper results when executed from WORKSPACE,
+    # but the data is needed in sh_binary, which can only be in a BUILD file.
+    # Thus, it is be exported by a repository_rule (which executes in WORKSPACE)
+    # to be used by the sh_binary.
+    urls = []
+    for k, v in native.existing_rules().items():
+        us = list(v.get("urls", []))
+        if "url" in v:
+            us.append(v["url"])
+        for u in us:
+            if u and not u.startswith(prefix):
+                urls.append(u)
+    return sorted(urls)
 
 def export_urls_impl(repo_ctx):
-  repo_ctx.file(repo_ctx.path("BUILD.bazel"), """
+    repo_ctx.file(repo_ctx.path("BUILD.bazel"), """
 exports_files(glob(["**"]), visibility=["//visibility:public"])
 """)
-  repo_ctx.file(repo_ctx.path("urls.txt"), content="\n".join(repo_ctx.attr.urls))
+    repo_ctx.file(repo_ctx.path("urls.txt"), content = "\n".join(repo_ctx.attr.urls))
 
 _export_urls = repository_rule(
     attrs = {
@@ -50,4 +50,4 @@ _export_urls = repository_rule(
 )
 
 def export_urls(name):
-  return _export_urls(name=name, urls=mirror_urls())
+    return _export_urls(name = name, urls = mirror_urls())

--- a/hack/update-workspace-mirror.sh
+++ b/hack/update-workspace-mirror.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 if [[ $# -ne 1 ]]; then
-    echo 'use "bazel run //build:update-mirror"'
+    echo 'use "bazel run //hack:update-mirror"'
     echo "(usage: $0 <file with list of URLs to mirror>)"
     exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**: a small bug in https://github.com/kubernetes/kubernetes/pull/62495 prevented the last URL from mirrored, since there wasn't a trailing newline.

Also, the bazel target printed out if you ran `hack/update-workspace-mirror.sh` directly was incorrect, so that's now fixed.

**Special notes for your reviewer**: buildifier is apparently now formatting bzl files, and I can't figure out how to disable that, so I reformatted this as the first commit.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @BenTheElder 
/cc @rmmh 