### PR TITLE
[e2e ingress-gce] Change ingress-upgrade test to not check for number of instances

### DIFF
--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -177,6 +177,14 @@ func (t *IngressUpgradeTest) verify(f *framework.Framework, done <-chan struct{}
 	postUpgradeResourceStore := &GCPResourceStore{}
 	t.populateGCPResourceStore(postUpgradeResourceStore)
 
+	// Stub out the number of instances as that is out of Ingress controller's control.
+	for _, ig := range t.resourceStore.IgList {
+		ig.Size = 0
+	}
+	for _, ig := range postUpgradeResourceStore.IgList {
+		ig.Size = 0
+	}
+
 	framework.ExpectNoError(compareGCPResourceStores(t.resourceStore, postUpgradeResourceStore, func(v1 reflect.Value, v2 reflect.Value) error {
 		i1 := v1.Interface()
 		i2 := v2.Interface()


### PR DESCRIPTION
**What this PR does / why we need it**:
From #62710 and #63500, ingress-upgrade test is failing on asserting resources are intact after cluster upgrade because some instances appear to be absent from the instance group.

This PR stubs out the number of instances during verification as that is out of ingress controller's control.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @rramkumar1 
cc @bowei 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
