### PR TITLE
adding support for VM name with extra Separator String

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_vmss_cache.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss_cache.go
@@ -47,13 +47,19 @@ func (ss *scaleSet) makeVmssVMName(scaleSetName, instanceID string) string {
 }
 
 func extractVmssVMName(name string) (string, string, error) {
-	ret := strings.Split(name, vmssNameSeparator)
-	if len(ret) != 2 {
+	split := strings.SplitAfter(name, vmssNameSeparator)
+	if len(split) < 2 {
 		glog.Errorf("Failed to extract vmssVMName %q", name)
 		return "", "", ErrorNotVmssInstance
 	}
 
-	return ret[0], ret[1], nil
+	ssName := strings.Join(split[0:len(split)-1], "")
+	// removing the trailing `vmssNameSeparator` since we used SplitAfter
+	ssName = ssName[:len(ssName)-1]
+
+	instanceId := split[len(split)-1]
+
+	return ssName, instanceId, nil
 }
 
 func (ss *scaleSet) newVmssCache() (*timedCache, error) {

--- a/pkg/cloudprovider/providers/azure/azure_vmss_cache_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss_cache_test.go
@@ -46,6 +46,12 @@ func TestExtractVmssVMName(t *testing.T) {
 			expectedScaleSet:   "vm",
 			expectedInstanceID: "1234",
 		},
+		{
+			description:        "correct vmss VM name with Extra Separator should return correct scaleSet and instanceID",
+			vmName:             "vm_test_1234",
+			expectedScaleSet:   "vm_test",
+			expectedInstanceID: "1234",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows the Azure VM name to have within their name the `_` character

**Special notes for your reviewer**:
This is the error I got before testing
```
May 07 21:55:14 kn-infra000000.<domainname> kubelet[39465]: I0507 21:55:14.462125   39465 azure_vmss.go:108] getVmssVM gets scaleSetName ("kn-infra_ss") and instanceID ("0") for node "kn-infra000000"
May 07 21:55:14 kn-infra000000.<domainname> kubelet[39465]: E0507 21:55:14.462147   39465 azure_vmss_cache.go:52] Failed to extract vmssVMName "kn-infra_ss_0"
May 07 21:55:14 kn-infra000000.<domainname> kubelet[39465]: F0507 21:55:14.462160   39465 kubelet.go:1349] Kubelet failed to get node info: failed to get external ID from cloud provider: not a vmss instance
```

**Release note**:
```release-note
Azure VMSS: support VM names to contain the `_` character
```
