### PR TITLE
Deprecate in-tree OpenStack cloud provider

### DIFF
--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -33,8 +33,11 @@ type Factory func(config io.Reader) (Interface, error)
 
 // All registered cloud providers.
 var (
-	providersMutex sync.Mutex
-	providers      = make(map[string]Factory)
+	providersMutex           sync.Mutex
+	providers                = make(map[string]Factory)
+	deprecatedCloudProviders = []string{
+		"openstack",
+	}
 )
 
 const externalCloudProvider = "external"
@@ -93,6 +96,14 @@ func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	if IsExternal(name) {
 		glog.Info("External cloud provider specified")
 		return nil, nil
+	}
+
+	for _, provider := range deprecatedCloudProviders {
+		if provider == name {
+			glog.Warningf("WARNING: %s built-in cloud provider is now deprecated. "+
+				"Please use 'external' cloud provider for %s", name, name)
+			break
+		}
 	}
 
 	if configFilePath != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Warn operators and users to switch to the external cloud provider
for openstack.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OpenStack built-in cloud provider is now deprecated. Please use the external cloud provider for OpenStack.
```
