### PR TITLE
Correctly apply request transforms with flattened resource builder

### DIFF
--- a/pkg/kubectl/genericclioptions/resource/interfaces.go
+++ b/pkg/kubectl/genericclioptions/resource/interfaces.go
@@ -47,6 +47,9 @@ type RequestTransform func(*rest.Request)
 // NewClientWithOptions wraps the provided RESTClient and invokes each transform on each
 // newly created request.
 func NewClientWithOptions(c RESTClient, transforms ...RequestTransform) RESTClient {
+	if len(transforms) == 0 {
+		return c
+	}
 	return &clientOptions{c: c, transforms: transforms}
 }
 


### PR DESCRIPTION
This change moves the NewClientWithOptions call into Builder.getClient.  Since getClient is the only way for Builder and its visitors to create a RESTClient, we can reasonably guarantee that the request transforms will be honored.  Previously, it was possible for a call to NewFlattenListVisitor to return resource Info objects whose Client field did not honor the request transforms.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/kind bug
@kubernetes/sig-cli-maintainers
/assign @smarterclayton @deads2k
Builds on #63318

```release-note
NONE
```