### PR TITLE
split audit events into different files by namespace or username

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
@@ -8,9 +8,15 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["backend.go"],
+    srcs = [
+        "backend.go",
+        "logger.go",
+    ],
     importpath = "k8s.io/apiserver/plugin/pkg/audit/log",
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/hashicorp/golang-lru:go_default_library",
+        "//vendor/gopkg.in/natefinch/lumberjack.v2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
@@ -33,7 +39,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["backend_test.go"],
+    srcs = [
+        "backend_test.go",
+        "logger_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/pborman/uuid:go_default_library",

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend_test.go
@@ -98,7 +98,7 @@ func TestLogEventsLegacy(t *testing.T) {
 		},
 	} {
 		var buf bytes.Buffer
-		backend := NewBackend(&buf, FormatLegacy, auditv1beta1.SchemeGroupVersion)
+		backend := NewBackend(&eventLogger{staticLogger: &buf}, FormatLegacy, auditv1beta1.SchemeGroupVersion)
 		backend.ProcessEvents(test.event)
 		match, err := regexp.MatchString(test.expected, buf.String())
 		if err != nil {
@@ -151,7 +151,7 @@ func TestLogEventsJson(t *testing.T) {
 		},
 	} {
 		var buf bytes.Buffer
-		backend := NewBackend(&buf, FormatJson, auditv1beta1.SchemeGroupVersion)
+		backend := NewBackend(&eventLogger{staticLogger: &buf}, FormatJson, auditv1beta1.SchemeGroupVersion)
 		backend.ProcessEvents(event)
 		// decode events back and compare with the original one.
 		result := &auditinternal.Event{}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/logger.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/logger.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/golang-lru"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+)
+
+const (
+	// hold 400 file handlers at max
+	maxLoggerNum = 400
+)
+
+var AllowedSyntax []string = []string{
+	"{username}",  // user.username
+	"{namespace}", // objectRef.namespace
+}
+
+type EventLogger interface {
+	GetWriter(ev *auditinternal.Event) io.Writer
+	Close()
+}
+
+type eventLogger struct {
+	path       string
+	maxAge     int
+	maxBackups int
+	maxSize    int
+
+	// staticLogger is used when there is no {username} or {namespace} syntax at path
+	staticLogger io.Writer
+	// loggers is a least-recently-used cache, the key is the filename, the value is lumberjack logger
+	loggers *lru.Cache
+}
+
+func (el *eventLogger) GetWriter(ev *auditinternal.Event) io.Writer {
+	if el.staticLogger != nil {
+		return el.staticLogger
+	}
+
+	path := preparePath(ev, el.path)
+	out, found := el.loggers.Get(path)
+	if found {
+		return out.(*lumberjack.Logger)
+	}
+
+	glog.V(5).Info("About to emit some audit events to file:", path)
+	logger := &lumberjack.Logger{
+		Filename:   path,
+		MaxAge:     el.maxAge,
+		MaxBackups: el.maxBackups,
+		MaxSize:    el.maxSize,
+	}
+	el.loggers.Add(path, logger)
+	return logger
+}
+
+// Close closes all opening Loggers.
+func (el *eventLogger) Close() {
+	if el.loggers != nil {
+		el.loggers.Purge()
+	}
+}
+
+// preparePath replaces "{namespace}","{username}" in the path with the info from audit event.
+func preparePath(ev *auditinternal.Event, path string) string {
+	username := "none"
+	if len(ev.User.Username) > 0 {
+		username = ev.User.Username
+	}
+
+	namespace := "none"
+	if ev.ObjectRef != nil && len(ev.ObjectRef.Namespace) != 0 {
+		namespace = ev.ObjectRef.Namespace
+	}
+
+	path = strings.Replace(path, "{username}", username, -1)
+	path = strings.Replace(path, "{namespace}", namespace, -1)
+	return path
+}
+
+func NewEventLogger(path string, maxAge, maxBackups, maxSize int) (EventLogger, error) {
+	var useStaticLogger bool = true
+	for _, syntax := range AllowedSyntax {
+		if strings.Contains(path, syntax) {
+			useStaticLogger = false
+		}
+	}
+	if useStaticLogger {
+		var staticLogger io.Writer = os.Stdout
+		if path != "-" {
+			staticLogger = &lumberjack.Logger{
+				Filename:   path,
+				MaxAge:     maxAge,
+				MaxBackups: maxBackups,
+				MaxSize:    maxSize,
+			}
+		}
+		return &eventLogger{
+			staticLogger: staticLogger,
+		}, nil
+	} else {
+		loggers, err := lru.NewWithEvict(maxLoggerNum, onEvicted)
+		if err != nil {
+			return nil, err
+		}
+		return &eventLogger{
+			path:       path,
+			maxAge:     maxAge,
+			maxBackups: maxBackups,
+			maxSize:    maxSize,
+			loggers:    loggers,
+		}, nil
+	}
+}
+
+//onEvicated is lru eviction hook, it closes the Logger
+func onEvicted(key interface{}, value interface{}) {
+	glog.V(5).Info("Closing audit logger in path: ", key.(string))
+	logger := value.(*lumberjack.Logger)
+	// What will happen if another goroutine tries to write to the logger after closed?
+	// lumberjack.Logger will reopen the file, so the openned file handlers may be larger than maxLoggerNum.
+	// But it's still thread-safe in this case. This will seldom (or never) happen, because the loggers
+	// are storred in a lru cache.
+	if err := logger.Close(); err != nil {
+		glog.Errorf("Failed to close audit events logger in path: %q, %s", logger.Filename, err.Error())
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/logger_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/logger_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pborman/uuid"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
+	"k8s.io/apiserver/pkg/audit"
+)
+
+// fakeEvent creates one fake event
+func fakeEvent(namespace, username string) *auditinternal.Event {
+	return &auditinternal.Event{
+		AuditID: types.UID(uuid.NewRandom().String()),
+		Level:   auditinternal.LevelMetadata,
+		ObjectRef: &auditinternal.ObjectReference{
+			Resource:    "foo",
+			APIVersion:  "v1",
+			Subresource: "bar",
+			Namespace:   namespace,
+		},
+		User: auditinternal.UserInfo{
+			Username: username,
+			Groups: []string{
+				"system:masters",
+				"system:authenticated",
+			},
+		},
+	}
+}
+
+func TestLogEvents(t *testing.T) {
+	// create 1000 audit events
+	events := map[types.UID]*auditinternal.Event{}
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 100; j++ {
+			namespace := "" // cluster scope
+			if i > 0 {
+				namespace = "namespace-" + strconv.Itoa(i)
+			}
+			username := "user-" + strconv.Itoa(j)
+			ev := fakeEvent(namespace, username)
+			events[ev.AuditID] = ev
+		}
+	}
+
+	// log events
+	dir, err := ioutil.TempDir("", "k8s-test-audit-event-logger")
+	if err != nil {
+		t.Fatalf("Unable to create the test directory %q: %v", dir, err)
+	}
+	path := filepath.Join(dir, "{namespace}", "{username}", "audit.log")
+	logger, err := NewEventLogger(path, 0, 0, 0)
+	backend := NewBackend(logger, FormatJson, auditv1beta1.SchemeGroupVersion)
+
+	var wg sync.WaitGroup
+	ch := make(chan struct{}, 20)
+	for _, ev := range events {
+		ch <- struct{}{}
+		wg.Add(1)
+		go func(ev *auditinternal.Event) {
+			backend.ProcessEvents(ev)
+			<-ch
+			wg.Done()
+		}(ev)
+	}
+	wg.Wait()
+	backend.Shutdown()
+
+	// check events
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 100; j++ {
+			namespace := "" // cluster scope
+			nsInPath := "none"
+			if i > 0 {
+				namespace = "namespace-" + strconv.Itoa(i)
+				nsInPath = namespace
+			}
+			username := "user-" + strconv.Itoa(j)
+			filepath := strings.Replace(path, "{namespace}", nsInPath, -1)
+			filepath = strings.Replace(filepath, "{username}", username, -1)
+			bytes, err := ioutil.ReadFile(filepath)
+			if err != nil {
+				t.Errorf("failed to read audit events from file %q: %+v", filepath, err)
+				continue
+			}
+			result := &auditinternal.Event{}
+			decoder := audit.Codecs.UniversalDecoder(auditv1beta1.SchemeGroupVersion)
+			if err := runtime.DecodeInto(decoder, bytes, result); err != nil {
+				t.Errorf("failed decoding buf: %s", bytes)
+				continue
+			}
+			if result.User.Username != username {
+				t.Errorf("Unexpected username: %q in file: %s, expected username is %q", result.User.Username, filepath, username)
+			}
+			if result.ObjectRef.Namespace != namespace {
+				t.Errorf("Unexpected namespace: %q in file: %s, expected namespace is %q", result.ObjectRef.Namespace, filepath, namespace)
+			}
+			if !reflect.DeepEqual(events[result.AuditID], result) {
+				t.Errorf("The result event should be the same with the original one, \noriginal: \n%#v\n result: \n%#v", events[result.AuditID], result)
+			}
+
+		}
+	}
+
+	// clean up
+	if err := os.RemoveAll(dir); err != nil {
+		t.Errorf("Unable to clean up test directory %q: %v", dir, err)
+	}
+}


### PR DESCRIPTION
Save all audit events in the same file or directory makes audit events difficult to handle in large cluster.
For example:  https://github.com/kubernetes/kubernetes/issues/56683
This change add a syntactic sugar to split audit events into different files. 
It will save time in such causes:
1. faster locating of  audit events like `grep`
2. distributing audit events to tenants

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @sttts 
Please take a look, thanks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
when {namespace} or {username} in --audit-log-path option advanced audit events will be saved into different files according to the namespace and username of audit events.
```
