### PR TITLE
when etcd is not installed, add log info to tell users 'hack/install-etcd.sh' to install etcd

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -24,6 +24,7 @@ kube::etcd::validate() {
   # validate if in path
   command -v etcd >/dev/null || {
     kube::log::usage "etcd must be in your PATH"
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
     exit 1
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
when etcd is not installed, I think we should add log info to tell users 'hack/install-etcd.sh' to install etcd
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
