### PR TITLE
kube-proxy and kube-scheduler should not depend on pkg/kubectl

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -201,21 +201,11 @@ package_group(
 )
 
 package_group(
-    name = "pkg_kubectl_cmd_util_CONSUMERS_BAD",
-    includes = [
-        ":KUBEADM_BAD",
-    ],
-    packages = [
-        "//cmd/kube-proxy/app",
-    ],
-)
-
-package_group(
     name = "pkg_kubectl_cmd_util_CONSUMERS",
     includes = [
         ":COMMON_generators",
         ":COMMON_testing",
-        ":pkg_kubectl_cmd_util_CONSUMERS_BAD",
+        ":KUBEADM_BAD",
     ],
     packages = [
         "//cmd/kubectl",

--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -64,7 +64,6 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
-        "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubelet/qos:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/proxy:go_default_library",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -51,7 +51,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/proxy"
@@ -353,9 +352,13 @@ with the apiserver API to configure the proxy.`,
 				glog.Fatalf("failed OS init: %v", err)
 			}
 
-			cmdutil.CheckErr(opts.Complete())
-			cmdutil.CheckErr(opts.Validate(args))
-			cmdutil.CheckErr(opts.Run())
+			if err := opts.Complete(); err != nil {
+				glog.Fatalf("failed complete: %v", err)
+			}
+			if err := opts.Validate(args); err != nil {
+				glog.Fatalf("failed validate: %v", err)
+			}
+			glog.Fatal(opts.Run())
 		},
 	}
 


### PR DESCRIPTION
remove dependent on pkg/kubectl/cmd/util in kube-proxy and kube-scheduler

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
