### PR TITLE
apiextensions: allow "required" at root with status subresource

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/BUILD
@@ -27,8 +27,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -19,9 +19,13 @@ package validation
 import (
 	"testing"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apiextensions-apiserver/pkg/features"
 )
 
 type validationMatch struct {
@@ -515,5 +519,72 @@ func TestValidateCustomResourceDefinitionUpdate(t *testing.T) {
 				t.Errorf("%s: unexpected error: %v", tc.name, errs[i])
 			}
 		}
+	}
+}
+
+func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
+	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CustomResourceSubresources, true)()
+
+	tests := []struct {
+		name          string
+		input         apiextensions.CustomResourceValidation
+		statusEnabled bool
+		wantError     bool
+	}{
+		{
+			name:      "empty",
+			input:     apiextensions.CustomResourceValidation{},
+			wantError: false,
+		},
+		{
+			name:          "empty with status",
+			input:         apiextensions.CustomResourceValidation{},
+			statusEnabled: true,
+			wantError:     false,
+		},
+		{
+			name: "root type without status",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+				},
+			},
+			statusEnabled: false,
+			wantError:     false,
+		},
+		{
+			name: "root type with status",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+				},
+			},
+			statusEnabled: true,
+			wantError:     true,
+		},
+		{
+			name: "properties and required with status",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"spec":   {},
+						"status": {},
+					},
+					Required: []string{"spec", "status"},
+				},
+			},
+			statusEnabled: true,
+			wantError:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateCustomResourceDefinitionValidation(&tt.input, tt.statusEnabled, field.NewPath("spec", "validation"))
+			if !tt.wantError && len(got) > 0 {
+				t.Errorf("Expected no error, but got: %v", got)
+			} else if tt.wantError && len(got) == 0 {
+				t.Error("Expected error, but got none")
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -355,9 +355,12 @@ func TestValidationSchema(t *testing.T) {
 
 	// fields other than properties in root schema are not allowed
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition.Spec.Subresources = &apiextensionsv1beta1.CustomResourceSubresources{
+		Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+	}
 	err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err == nil {
-		t.Fatalf("unexpected non-error: if subresources for custom resources are enabled, only properties can be used at the root of the schema")
+		t.Fatalf(`unexpected non-error, expected: must only have "properties" or "required" at the root if the status subresource is enabled`)
 	}
 
 	// make sure we are not restricting fields to properties even in subschemas
@@ -372,6 +375,7 @@ func TestValidationSchema(t *testing.T) {
 				},
 			},
 		},
+		Required: []string{"spec"},
 	}
 	err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
@@ -245,6 +245,7 @@ func checkForWatchCachePrimed(crd *apiextensionsv1beta1.CustomResourceDefinition
 			"gamma":   "bar",
 			"delta":   "hello",
 			"epsilon": "foobar",
+			"spec":    map[string]interface{}{},
 		},
 	}
 	if _, err := resourceClient.Create(instance); err != nil {


### PR DESCRIPTION
In the subresources alpha we intentionally disallowed anything than `properties` at the root of the validation schema in order to allow us to project it to the .status subtree. By doing this we also disallowed `required` at the root which is necessary to enforce e.g. a spec to be set. This PR fixes this.

Moreover, it fixes that the restriction is only enforced when the status subresource is actually enabled. Before this PR we were enforcing the restriction as soon as the feature gate was enabled, leading to a backwards incompatible change.

```release-note
Allow "required" and "description" to be used at the CRD OpenAPI validation schema root when the /status subresource is enabled.
```

There was an issue reporting the bug. But cannot find it.