### PR TITLE
Bump Heapster to v1.5.3

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -36,30 +36,30 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.2
+  name: heapster-v1.5.3
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
+    version: v1.5.3
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.2
+      version: v1.5.3
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.2
+        version: v1.5.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: heapster
           livenessProbe:
             httpGet:
@@ -72,7 +72,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=gcm
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: eventer
           command:
             - /eventer
@@ -107,7 +107,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -140,7 +140,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -36,30 +36,30 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.2
+  name: heapster-v1.5.3
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
+    version: v1.5.3
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.2
+      version: v1.5.3
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.2
+        version: v1.5.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: heapster
           livenessProbe:
             httpGet:
@@ -73,7 +73,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: eventer
           command:
             - /eventer
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -141,7 +141,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -36,30 +36,30 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.2
+  name: heapster-v1.5.3
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
+    version: v1.5.3
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.2
+      version: v1.5.3
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.2
+        version: v1.5.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: heapster
           livenessProbe:
             httpGet:
@@ -72,7 +72,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: eventer
           command:
             - /eventer
@@ -107,7 +107,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -140,7 +140,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -23,30 +23,30 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.2
+  name: heapster-v1.5.3
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
+    version: v1.5.3
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.2
+      version: v1.5.3
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.2
+        version: v1.5.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: heapster
           livenessProbe:
             httpGet:
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -23,30 +23,30 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.2
+  name: heapster-v1.5.3
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.2
+    version: v1.5.3
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.2
+      version: v1.5.3
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.2
+        version: v1.5.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+        - image: k8s.gcr.io/heapster-amd64:v1.5.3
           name: heapster
           livenessProbe:
             httpGet:
@@ -87,7 +87,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.2
+            - --deployment=heapster-v1.5.3
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
This PR updates heapster version in all cluster-monitoring addons

```release-note
Fix stackdriver metrics for node memory using wrong metric type
```
/cc @kawych