### PR TITLE
use IOStreams for cli commands

### DIFF
--- a/pkg/kubectl/cmd/alpha.go
+++ b/pkg/kubectl/cmd/alpha.go
@@ -17,17 +17,16 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
 // NewCmdAlpha creates a command that acts as an alternate root command for features in alpha
-func NewCmdAlpha(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+func NewCmdAlpha(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alpha",
 		Short: i18n.T("Commands for features in alpha"),
@@ -37,7 +36,7 @@ func NewCmdAlpha(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Com
 	// Alpha commands should be added here. As features graduate from alpha they should move
 	// from here to the CommandGroups defined by NewKubeletCommand() in cmd.go.
 	//cmd.AddCommand(NewCmdDebug(f, in, out, err))
-	cmd.AddCommand(NewCmdDiff(f, out, err))
+	cmd.AddCommand(NewCmdDiff(f, streams))
 
 	// NewKubeletCommand() will hide the alpha command if it has no subcommands. Overriding
 	// the help function ensures a reasonable message if someone types the hidden command anyway.

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -197,7 +197,7 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
-	o.DeleteOptions = o.DeleteFlags.ToOptions(o.Out, o.ErrOut)
+	o.DeleteOptions = o.DeleteFlags.ToOptions(o.IOStreams)
 	return nil
 }
 

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +37,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
@@ -249,9 +249,6 @@ func TestAttach(t *testing.T) {
 			}
 			tf.Namespace = "test"
 			tf.ClientConfigVal = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs, GroupVersion: &schema.GroupVersion{Version: test.version}}}
-			bufOut := bytes.NewBuffer([]byte{})
-			bufErr := bytes.NewBuffer([]byte{})
-			bufIn := bytes.NewBuffer([]byte{})
 			remoteAttach := &fakeRemoteAttach{}
 			if test.remoteAttachErr {
 				remoteAttach.err = fmt.Errorf("attach error")
@@ -259,9 +256,7 @@ func TestAttach(t *testing.T) {
 			params := &AttachOptions{
 				StreamOptions: StreamOptions{
 					ContainerName: test.container,
-					In:            bufIn,
-					Out:           bufOut,
-					Err:           bufErr,
+					IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
 				},
 				Attach:        remoteAttach,
 				GetPodTimeout: 1000,
@@ -342,16 +337,12 @@ func TestAttachWarnings(t *testing.T) {
 			}
 			tf.Namespace = "test"
 			tf.ClientConfigVal = &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: legacyscheme.Codecs, GroupVersion: &schema.GroupVersion{Version: test.version}}}
-			bufOut := bytes.NewBuffer([]byte{})
-			bufErr := bytes.NewBuffer([]byte{})
-			bufIn := bytes.NewBuffer([]byte{})
+			streams, _, _, bufErr := genericclioptions.NewTestIOStreams()
 			ex := &fakeRemoteAttach{}
 			params := &AttachOptions{
 				StreamOptions: StreamOptions{
 					ContainerName: test.container,
-					In:            bufIn,
-					Out:           bufOut,
-					Err:           bufErr,
+					IOStreams:     streams,
 					Stdin:         test.stdin,
 					TTY:           test.tty,
 				},

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -275,7 +275,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 				NewCmdExplain("kubectl", f, ioStreams),
 				get.NewCmdGet("kubectl", f, ioStreams),
 				NewCmdEdit(f, ioStreams),
-				NewCmdDelete(f, out, err),
+				NewCmdDelete(f, ioStreams),
 			},
 		},
 		{
@@ -292,7 +292,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			Commands: []*cobra.Command{
 				NewCmdCertificate(f, ioStreams),
 				NewCmdClusterInfo(f, ioStreams),
-				NewCmdTop(f, out, err),
+				NewCmdTop(f, ioStreams),
 				NewCmdCordon(f, ioStreams),
 				NewCmdUncordon(f, ioStreams),
 				NewCmdDrain(f, ioStreams),
@@ -303,11 +303,11 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			Message: "Troubleshooting and Debugging Commands:",
 			Commands: []*cobra.Command{
 				NewCmdDescribe("kubectl", f, ioStreams),
-				NewCmdLogs(f, out, err),
-				NewCmdAttach(f, in, out, err),
-				NewCmdExec(f, in, out, err),
-				NewCmdPortForward(f, out, err),
-				NewCmdProxy(f, out),
+				NewCmdLogs(f, ioStreams),
+				NewCmdAttach(f, ioStreams),
+				NewCmdExec(f, ioStreams),
+				NewCmdPortForward(f, ioStreams),
+				NewCmdProxy(f, ioStreams),
 				NewCmdCp(f, ioStreams),
 				auth.NewCmdAuth(f, ioStreams),
 			},
@@ -317,7 +317,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			Commands: []*cobra.Command{
 				NewCmdApply("kubectl", f, ioStreams),
 				NewCmdPatch(f, ioStreams),
-				NewCmdReplace(f, out, err),
+				NewCmdReplace(f, ioStreams),
 				NewCmdConvert(f, ioStreams),
 			},
 		},
@@ -326,7 +326,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 			Commands: []*cobra.Command{
 				NewCmdLabel(f, ioStreams),
 				NewCmdAnnotate("kubectl", f, ioStreams),
-				NewCmdCompletion(out, ""),
+				NewCmdCompletion(ioStreams.Out, ""),
 			},
 		},
 	}
@@ -335,7 +335,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	filters := []string{"options"}
 
 	// Hide the "alpha" subcommand if there are no alpha commands in this build.
-	alpha := NewCmdAlpha(f, in, out, err)
+	alpha := NewCmdAlpha(f, ioStreams)
 	if !alpha.HasSubCommands() {
 		filters = append(filters, alpha.Name())
 	}
@@ -356,11 +356,11 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 
 	cmds.AddCommand(alpha)
 	cmds.AddCommand(cmdconfig.NewCmdConfig(f, clientcmd.NewDefaultPathOptions(), ioStreams))
-	cmds.AddCommand(NewCmdPlugin(f, in, out, err))
+	cmds.AddCommand(NewCmdPlugin(f, ioStreams))
 	cmds.AddCommand(NewCmdVersion(f, ioStreams))
 	cmds.AddCommand(NewCmdApiVersions(f, ioStreams))
 	cmds.AddCommand(NewCmdApiResources(f, ioStreams))
-	cmds.AddCommand(NewCmdOptions(out))
+	cmds.AddCommand(NewCmdOptions(ioStreams.Out))
 
 	return cmds
 }

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"archive/tar"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -34,6 +33,8 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+
+	"bytes"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -194,8 +195,10 @@ func (o *CopyOptions) Run(args []string) error {
 func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
-			Out: bytes.NewBuffer([]byte{}),
-			Err: bytes.NewBuffer([]byte{}),
+			IOStreams: genericclioptions.IOStreams{
+				Out:    bytes.NewBuffer([]byte{}),
+				ErrOut: bytes.NewBuffer([]byte{}),
+			},
 
 			Namespace: dest.PodNamespace,
 			PodName:   dest.PodName,
@@ -240,9 +243,11 @@ func (o *CopyOptions) copyToPod(src, dest fileSpec) error {
 
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
-			In:    reader,
-			Out:   o.Out,
-			Err:   o.ErrOut,
+			IOStreams: genericclioptions.IOStreams{
+				In:     reader,
+				Out:    o.Out,
+				ErrOut: o.ErrOut,
+			},
 			Stdin: true,
 
 			Namespace: dest.PodNamespace,
@@ -263,9 +268,11 @@ func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
 	reader, outStream := io.Pipe()
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
-			In:  nil,
-			Out: outStream,
-			Err: o.Out,
+			IOStreams: genericclioptions.IOStreams{
+				In:     nil,
+				Out:    outStream,
+				ErrOut: o.Out,
+			},
 
 			Namespace: src.PodNamespace,
 			PodName:   src.PodName,

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
@@ -109,11 +109,10 @@ type DeleteOptions struct {
 	Mapper meta.RESTMapper
 	Result *resource.Result
 
-	Out    io.Writer
-	ErrOut io.Writer
+	genericclioptions.IOStreams
 }
 
-func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	deleteFlags := NewDeleteCommandFlags("containing the resource to delete.")
 
 	cmd := &cobra.Command{
@@ -123,14 +122,14 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		Long:    delete_long,
 		Example: delete_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			options := deleteFlags.ToOptions(out, errOut)
-			if err := options.Complete(f, out, errOut, args, cmd); err != nil {
+			o := deleteFlags.ToOptions(streams)
+			if err := o.Complete(f, args, cmd); err != nil {
 				cmdutil.CheckErr(err)
 			}
-			if err := options.Validate(cmd); err != nil {
+			if err := o.Validate(cmd); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageErrorf(cmd, err.Error()))
 			}
-			if err := options.RunDelete(); err != nil {
+			if err := o.RunDelete(); err != nil {
 				cmdutil.CheckErr(err)
 			}
 		},
@@ -143,7 +142,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []string, cmd *cobra.Command) error {
+func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Command) error {
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -174,10 +173,6 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 	if err != nil {
 		return err
 	}
-
-	// Set up writer
-	o.Out = out
-	o.ErrOut = errOut
 
 	return nil
 }

--- a/pkg/kubectl/cmd/delete_flags.go
+++ b/pkg/kubectl/cmd/delete_flags.go
@@ -17,12 +17,12 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
@@ -72,10 +72,9 @@ type DeleteFlags struct {
 	Output         *string
 }
 
-func (f *DeleteFlags) ToOptions(out, errOut io.Writer) *DeleteOptions {
+func (f *DeleteFlags) ToOptions(streams genericclioptions.IOStreams) *DeleteOptions {
 	options := &DeleteOptions{
-		Out:    out,
-		ErrOut: errOut,
+		IOStreams: streams,
 	}
 
 	// add filename options

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/utils/exec"
@@ -101,12 +102,11 @@ func parseDiffArguments(args []string) (string, string, error) {
 	return from, to, nil
 }
 
-func NewCmdDiff(f cmdutil.Factory, stdout, stderr io.Writer) *cobra.Command {
+func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	var options DiffOptions
 	diff := DiffProgram{
-		Exec:   exec.New(),
-		Stdout: stdout,
-		Stderr: stderr,
+		Exec:      exec.New(),
+		IOStreams: streams,
 	}
 	cmd := &cobra.Command{
 		Use: "diff -f FILENAME",
@@ -132,9 +132,8 @@ func NewCmdDiff(f cmdutil.Factory, stdout, stderr io.Writer) *cobra.Command {
 // KUBERNETES_EXTERNAL_DIFF environment variable will be used a diff
 // program. By default, `diff(1)` will be used.
 type DiffProgram struct {
-	Exec   exec.Interface
-	Stdout io.Writer
-	Stderr io.Writer
+	Exec exec.Interface
+	genericclioptions.IOStreams
 }
 
 func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
@@ -147,8 +146,8 @@ func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
 	}
 
 	cmd := d.Exec.Command(diff, args...)
-	cmd.SetStdout(d.Stdout)
-	cmd.SetStderr(d.Stderr)
+	cmd.SetStdout(d.Out)
+	cmd.SetStderr(d.ErrOut)
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/diff_test.go
+++ b/pkg/kubectl/cmd/diff_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/utils/exec"
 )
 
@@ -137,11 +138,10 @@ func TestArguments(t *testing.T) {
 
 func TestDiffProgram(t *testing.T) {
 	os.Setenv("KUBERNETES_EXTERNAL_DIFF", "echo")
-	stdout := bytes.Buffer{}
+	streams, _, stdout, _ := genericclioptions.NewTestIOStreams()
 	diff := DiffProgram{
-		Stdout: &stdout,
-		Stderr: &bytes.Buffer{},
-		Exec:   exec.New(),
+		IOStreams: streams,
+		Exec:      exec.New(),
 	}
 	err := diff.Run("one", "two")
 	if err != nil {

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -32,6 +32,7 @@ import (
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 	"k8s.io/kubernetes/pkg/util/interrupt"
@@ -62,12 +63,10 @@ const (
 	execUsageStr = "expected 'exec POD_NAME COMMAND [ARG1] [ARG2] ... [ARGN]'.\nPOD_NAME and COMMAND are required arguments for the exec command"
 )
 
-func NewCmdExec(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
+func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{
-			In:  cmdIn,
-			Out: cmdOut,
-			Err: cmdErr,
+			IOStreams: streams,
 		},
 
 		Executor: &DefaultRemoteExecutor{},
@@ -125,9 +124,8 @@ type StreamOptions struct {
 	Quiet bool
 	// InterruptParent, if set, is used to handle interrupts while attached
 	InterruptParent *interrupt.Handler
-	In              io.Reader
-	Out             io.Writer
-	Err             io.Writer
+
+	genericclioptions.IOStreams
 
 	// for testing
 	overrideStreams func() (io.ReadCloser, io.Writer, io.Writer)
@@ -155,7 +153,7 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 		return cmdutil.UsageErrorf(cmd, execUsageStr)
 	}
 	if len(p.PodName) != 0 {
-		printDeprecationWarning(p.Err, "exec POD_NAME", "-p POD_NAME")
+		printDeprecationWarning(p.ErrOut, "exec POD_NAME", "-p POD_NAME")
 		if len(argsIn) < 1 {
 			return cmdutil.UsageErrorf(cmd, execUsageStr)
 		}
@@ -205,7 +203,7 @@ func (p *ExecOptions) Validate() error {
 	if len(p.Command) == 0 {
 		return fmt.Errorf("you must specify at least one command for the container")
 	}
-	if p.Out == nil || p.Err == nil {
+	if p.Out == nil || p.ErrOut == nil {
 		return fmt.Errorf("both output and error output must be provided")
 	}
 	if p.Executor == nil || p.PodClient == nil || p.Config == nil {
@@ -240,8 +238,8 @@ func (o *StreamOptions) setupTTY() term.TTY {
 	if !o.isTerminalIn(t) {
 		o.TTY = false
 
-		if o.Err != nil {
-			fmt.Fprintln(o.Err, "Unable to use a TTY - input is not a terminal or the right kind of file")
+		if o.ErrOut != nil {
+			fmt.Fprintln(o.ErrOut, "Unable to use a TTY - input is not a terminal or the right kind of file")
 		}
 
 		return t
@@ -284,7 +282,7 @@ func (p *ExecOptions) Run() error {
 			if len(p.SuggestedCmdUsage) > 0 {
 				usageString = fmt.Sprintf("%s\n%s", usageString, p.SuggestedCmdUsage)
 			}
-			fmt.Fprintf(p.Err, "%s\n", usageString)
+			fmt.Fprintf(p.ErrOut, "%s\n", usageString)
 		}
 		containerName = pod.Spec.Containers[0].Name
 	}
@@ -299,7 +297,7 @@ func (p *ExecOptions) Run() error {
 
 		// unset p.Err if it was previously set because both stdout and stderr go over p.Out when tty is
 		// true
-		p.Err = nil
+		p.ErrOut = nil
 	}
 
 	fn := func() error {
@@ -320,11 +318,11 @@ func (p *ExecOptions) Run() error {
 			Command:   p.Command,
 			Stdin:     p.Stdin,
 			Stdout:    p.Out != nil,
-			Stderr:    p.Err != nil,
+			Stderr:    p.ErrOut != nil,
 			TTY:       t.Raw,
 		}, legacyscheme.ParameterCodec)
 
-		return p.Executor.Execute("POST", req.URL(), p.Config, p.In, p.Out, p.Err, t.Raw, sizeQueue)
+		return p.Executor.Execute("POST", req.URL(), p.Config, p.In, p.Out, p.ErrOut, t.Raw, sizeQueue)
 	}
 
 	if err := t.Safe(fn); err != nil {

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 )
@@ -145,7 +146,7 @@ func TestPodAndContainer(t *testing.T) {
 
 			cmd := &cobra.Command{}
 			options := test.p
-			options.Err = bytes.NewBuffer([]byte{})
+			options.ErrOut = bytes.NewBuffer([]byte{})
 			err := options.Complete(tf, cmd, test.args, test.argsLenAtDash)
 			if test.expectError && err == nil {
 				t.Errorf("%s: unexpected non-error", test.name)
@@ -213,9 +214,6 @@ func TestExec(t *testing.T) {
 			}
 			tf.Namespace = "test"
 			tf.ClientConfigVal = defaultClientConfig()
-			bufOut := bytes.NewBuffer([]byte{})
-			bufErr := bytes.NewBuffer([]byte{})
-			bufIn := bytes.NewBuffer([]byte{})
 			ex := &fakeRemoteExecutor{}
 			if test.execErr {
 				ex.execErr = fmt.Errorf("exec error")
@@ -224,9 +222,7 @@ func TestExec(t *testing.T) {
 				StreamOptions: StreamOptions{
 					PodName:       "foo",
 					ContainerName: "bar",
-					In:            bufIn,
-					Out:           bufOut,
-					Err:           bufErr,
+					IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
 				},
 				Executor: ex,
 			}
@@ -277,16 +273,14 @@ func execPod() *api.Pod {
 }
 
 func TestSetupTTY(t *testing.T) {
-	stderr := &bytes.Buffer{}
+	streams, _, _, stderr := genericclioptions.NewTestIOStreams()
 
 	// test 1 - don't attach stdin
 	o := &StreamOptions{
 		// InterruptParent: ,
-		Stdin: false,
-		In:    &bytes.Buffer{},
-		Out:   &bytes.Buffer{},
-		Err:   stderr,
-		TTY:   true,
+		Stdin:     false,
+		IOStreams: streams,
+		TTY:       true,
 	}
 
 	tty := o.setupTTY()
@@ -334,7 +328,7 @@ func TestSetupTTY(t *testing.T) {
 	// test 3 - request a TTY, but stdin is not a terminal
 	o.Stdin = true
 	o.In = &bytes.Buffer{}
-	o.Err = stderr
+	o.ErrOut = stderr
 	o.TTY = true
 
 	tty = o.setupTTY()

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
@@ -74,9 +74,9 @@ func TestLog(t *testing.T) {
 			}
 			tf.Namespace = "test"
 			tf.ClientConfigVal = defaultClientConfig()
-			buf := bytes.NewBuffer([]byte{})
+			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-			cmd := NewCmdLogs(tf, buf, buf)
+			cmd := NewCmdLogs(tf, streams)
 			cmd.Flags().Set("namespace", "test")
 			cmd.Run(cmd, []string{"foo"})
 
@@ -144,17 +144,17 @@ func TestValidateLogFlags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := bytes.NewBuffer([]byte{})
-		cmd := NewCmdLogs(f, buf, buf)
+		streams := genericclioptions.NewTestIOStreamsDiscard()
+		cmd := NewCmdLogs(f, streams)
 		out := ""
 		for flag, value := range test.flags {
 			cmd.Flags().Set(flag, value)
 		}
 		// checkErr breaks tests in case of errors, plus we just
 		// need to check errors returned by the command validation
-		o := &LogsOptions{}
+		o := NewLogsOptions(streams)
 		cmd.Run = func(cmd *cobra.Command, args []string) {
-			o.Complete(f, os.Stdout, cmd, args)
+			o.Complete(f, cmd, args)
 			out = o.Validate().Error()
 		}
 		cmd.Run(cmd, test.args)
@@ -205,8 +205,7 @@ func TestLogComplete(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := bytes.NewBuffer([]byte{})
-		cmd := NewCmdLogs(f, buf, buf)
+		cmd := NewCmdLogs(f, genericclioptions.NewTestIOStreamsDiscard())
 		var err error
 		out := ""
 		for flag, value := range test.flags {
@@ -214,8 +213,8 @@ func TestLogComplete(t *testing.T) {
 		}
 		// checkErr breaks tests in case of errors, plus we just
 		// need to check errors returned by the command validation
-		o := &LogsOptions{}
-		err = o.Complete(f, os.Stdout, cmd, test.args)
+		o := NewLogsOptions(genericclioptions.NewTestIOStreamsDiscard())
+		err = o.Complete(f, cmd, test.args)
 		out = err.Error()
 		if !strings.Contains(out, test.expected) {
 			t.Errorf("%s: expected to find:\n\t%s\nfound:\n\t%s\n", test.name, test.expected, out)

--- a/pkg/kubectl/cmd/plugin_test.go
+++ b/pkg/kubectl/cmd/plugin_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/plugins"
 )
 
@@ -81,9 +81,7 @@ func TestPluginCmd(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			inBuf := bytes.NewBuffer([]byte{})
-			outBuf := bytes.NewBuffer([]byte{})
-			errBuf := bytes.NewBuffer([]byte{})
+			streams, _, outBuf, errBuf := genericclioptions.NewTestIOStreams()
 
 			cmdutil.BehaviorOnFatal(func(str string, code int) {
 				errBuf.Write([]byte(str))
@@ -96,7 +94,7 @@ func TestPluginCmd(t *testing.T) {
 			f := cmdtesting.NewTestFactory()
 			defer f.Cleanup()
 
-			cmd := NewCmdForPlugin(f, test.plugin, runner, inBuf, outBuf, errBuf)
+			cmd := NewCmdForPlugin(f, test.plugin, runner, streams)
 			if cmd == nil {
 				if !test.expectedNilCmd {
 					t.Fatalf("%s: command was unexpectedly not registered", test.name)

--- a/pkg/kubectl/cmd/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"testing"
 
@@ -32,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
@@ -102,7 +102,7 @@ func testPortForward(t *testing.T, flags map[string]string, args []string) {
 			}
 
 			opts := &PortForwardOptions{}
-			cmd := NewCmdPortForward(tf, os.Stdout, os.Stderr)
+			cmd := NewCmdPortForward(tf, genericclioptions.NewTestIOStreamsDiscard())
 			cmd.Run = func(cmd *cobra.Command, args []string) {
 				if err = opts.Complete(tf, cmd, args); err != nil {
 					return

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/proxy"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
@@ -69,7 +70,7 @@ var (
 		kubectl proxy --api-prefix=/k8s-api`))
 )
 
-func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdProxy(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]",
 		DisableFlagsInUseLine: true,
@@ -77,7 +78,7 @@ func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    proxyLong,
 		Example: proxyExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunProxy(f, out, cmd)
+			err := RunProxy(f, streams.Out, cmd)
 			cmdutil.CheckErr(err)
 		},
 	}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -86,11 +85,10 @@ type ReplaceOptions struct {
 
 	Recorder genericclioptions.Recorder
 
-	Out    io.Writer
-	ErrOut io.Writer
+	genericclioptions.IOStreams
 }
 
-func NewReplaceOptions(out, errOut io.Writer) *ReplaceOptions {
+func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
 	outputFormat := ""
 
 	return &ReplaceOptions{
@@ -102,13 +100,12 @@ func NewReplaceOptions(out, errOut io.Writer) *ReplaceOptions {
 		},
 		DeleteFlags: NewDeleteFlags("to use to replace the resource."),
 
-		Out:    out,
-		ErrOut: errOut,
+		IOStreams: streams,
 	}
 }
 
-func NewCmdReplace(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
-	o := NewReplaceOptions(out, errOut)
+func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewReplaceOptions(streams)
 
 	cmd := &cobra.Command{
 		Use: "replace -f FILENAME",
@@ -154,7 +151,7 @@ func (o *ReplaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	deleteOpts := o.DeleteFlags.ToOptions(o.Out, o.ErrOut)
+	deleteOpts := o.DeleteFlags.ToOptions(o.IOStreams)
 
 	//Replace will create a resource if it doesn't exist already, so ignore not found error
 	deleteOpts.IgnoreNotFound = true

--- a/pkg/kubectl/cmd/replace_test.go
+++ b/pkg/kubectl/cmd/replace_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
 	"net/http"
 	"strings"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
@@ -63,9 +63,9 @@ func TestReplaceObject(t *testing.T) {
 		}),
 	}
 	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdReplace(tf, buf, buf)
+	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
@@ -134,9 +134,9 @@ func TestReplaceMultipleObject(t *testing.T) {
 		}),
 	}
 	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdReplace(tf, buf, buf)
+	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Flags().Set("filename", "../../../test/e2e/testing-manifests/guestbook/frontend-service.yaml")
 	cmd.Flags().Set("output", "name")
@@ -192,9 +192,9 @@ func TestReplaceDirectory(t *testing.T) {
 		}),
 	}
 	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdReplace(tf, buf, buf)
+	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../test/e2e/testing-manifests/guestbook/legacy")
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("output", "name")
@@ -239,9 +239,9 @@ func TestForceReplaceObjectNotFound(t *testing.T) {
 		}),
 	}
 	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdReplace(tf, buf, buf)
+	cmd := NewCmdReplace(tf, streams)
 	cmd.Flags().Set("filename", "../../../test/e2e/testing-manifests/guestbook/legacy/redis-master-controller.yaml")
 	cmd.Flags().Set("force", "true")
 	cmd.Flags().Set("cascade", "false")

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -233,7 +233,7 @@ func (o *RunOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	deleteOpts := o.DeleteFlags.ToOptions(o.Out, o.ErrOut)
+	deleteOpts := o.DeleteFlags.ToOptions(o.IOStreams)
 	deleteOpts.IgnoreNotFound = true
 	deleteOpts.WaitForDeletion = false
 	deleteOpts.GracePeriod = -1
@@ -374,12 +374,10 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 
 		opts := &AttachOptions{
 			StreamOptions: StreamOptions{
-				In:    o.In,
-				Out:   o.Out,
-				Err:   o.ErrOut,
-				Stdin: o.Interactive,
-				TTY:   o.TTY,
-				Quiet: o.Quiet,
+				IOStreams: o.IOStreams,
+				Stdin:     o.Interactive,
+				TTY:       o.TTY,
+				Quiet:     o.Quiet,
 			},
 			GetPodTimeout: timeout,
 			CommandName:   cmd.Parent().CommandPath() + " attach",
@@ -528,7 +526,7 @@ func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, nam
 	opts.Namespace = ns
 
 	// TODO: opts.Run sets opts.Err to nil, we need to find a better way
-	stderr := opts.Err
+	stderr := opts.ErrOut
 	if err := opts.Run(); err != nil {
 		fmt.Fprintf(stderr, "Error attaching, falling back to logs: %v\n", err)
 		return logOpts(f, pod, opts)

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -208,7 +208,7 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 			deleteFlags := NewDeleteFlags("to use to replace the resource.")
 			opts := &RunOptions{
 				PrintFlags:    printFlags,
-				DeleteOptions: deleteFlags.ToOptions(os.Stdout, os.Stderr),
+				DeleteOptions: deleteFlags.ToOptions(genericclioptions.NewTestIOStreamsDiscard()),
 
 				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
 
@@ -377,7 +377,7 @@ func TestGenerateService(t *testing.T) {
 			deleteFlags := NewDeleteFlags("to use to replace the resource.")
 			opts := &RunOptions{
 				PrintFlags:    printFlags,
-				DeleteOptions: deleteFlags.ToOptions(os.Stdout, os.Stderr),
+				DeleteOptions: deleteFlags.ToOptions(genericclioptions.NewTestIOStreamsDiscard()),
 
 				IOStreams: ioStreams,
 

--- a/pkg/kubectl/cmd/top.go
+++ b/pkg/kubectl/cmd/top.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
@@ -26,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 var (
@@ -40,17 +39,17 @@ var (
 		This command requires Heapster to be correctly configured and working on the server. `))
 )
 
-func NewCmdTop(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "top",
 		Short: i18n.T("Display Resource (CPU/Memory/Storage) usage."),
 		Long:  topLong,
-		Run:   cmdutil.DefaultSubCommandRun(errOut),
+		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
 	// create subcommands
-	cmd.AddCommand(NewCmdTopNode(f, nil, out))
-	cmd.AddCommand(NewCmdTopPod(f, nil, out))
+	cmd.AddCommand(NewCmdTopNode(f, nil, streams))
+	cmd.AddCommand(NewCmdTopPod(f, nil, streams))
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"errors"
-	"io"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -29,6 +28,7 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/metricsutil"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
@@ -46,6 +46,8 @@ type TopNodeOptions struct {
 	Printer         *metricsutil.TopCmdPrinter
 	DiscoveryClient discovery.DiscoveryInterface
 	MetricsClient   metricsclientset.Interface
+
+	genericclioptions.IOStreams
 }
 
 type HeapsterTopOptions struct {
@@ -89,9 +91,11 @@ var (
 		  kubectl top node NODE_NAME`))
 )
 
-func NewCmdTopNode(f cmdutil.Factory, options *TopNodeOptions, out io.Writer) *cobra.Command {
-	if options == nil {
-		options = &TopNodeOptions{}
+func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptions.IOStreams) *cobra.Command {
+	if o == nil {
+		o = &TopNodeOptions{
+			IOStreams: streams,
+		}
 	}
 
 	cmd := &cobra.Command{
@@ -101,24 +105,24 @@ func NewCmdTopNode(f cmdutil.Factory, options *TopNodeOptions, out io.Writer) *c
 		Long:    topNodeLong,
 		Example: topNodeExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.Complete(f, cmd, args, out); err != nil {
+			if err := o.Complete(f, cmd, args); err != nil {
 				cmdutil.CheckErr(err)
 			}
-			if err := options.Validate(); err != nil {
+			if err := o.Validate(); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageErrorf(cmd, "%v", err))
 			}
-			if err := options.RunTopNode(); err != nil {
+			if err := o.RunTopNode(); err != nil {
 				cmdutil.CheckErr(err)
 			}
 		},
 		Aliases: []string{"nodes", "no"},
 	}
-	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
-	options.HeapsterOptions.Bind(cmd.Flags())
+	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	o.HeapsterOptions.Bind(cmd.Flags())
 	return cmd
 }
 
-func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		o.ResourceName = args[0]
 	} else if len(args) > 1 {
@@ -144,7 +148,7 @@ func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	o.NodeClient = clientset.CoreV1()
 	o.Client = metricsutil.NewHeapsterMetricsClient(clientset.CoreV1(), o.HeapsterOptions.Namespace, o.HeapsterOptions.Scheme, o.HeapsterOptions.Service, o.HeapsterOptions.Port)
 
-	o.Printer = metricsutil.NewTopCmdPrinter(out)
+	o.Printer = metricsutil.NewTopCmdPrinter(o.Out)
 	return nil
 }
 

--- a/pkg/kubectl/cmd/top_node_test.go
+++ b/pkg/kubectl/cmd/top_node_test.go
@@ -32,6 +32,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -79,9 +80,9 @@ func TestTopNodeAllMetrics(t *testing.T) {
 	}
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Run(cmd, []string{})
 
 	// Check the presence of node names in the output.
@@ -132,7 +133,7 @@ func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
 	}
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
 	opts := &TopNodeOptions{
 		HeapsterOptions: HeapsterTopOptions{
@@ -140,8 +141,9 @@ func TestTopNodeAllMetricsCustomDefaults(t *testing.T) {
 			Scheme:    "https",
 			Service:   "custom-heapster-service",
 		},
+		IOStreams: streams,
 	}
-	cmd := NewCmdTopNode(tf, opts, buf)
+	cmd := NewCmdTopNode(tf, opts, streams)
 	cmd.Run(cmd, []string{})
 
 	// Check the presence of node names in the output.
@@ -195,9 +197,9 @@ func TestTopNodeWithNameMetrics(t *testing.T) {
 	}
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Run(cmd, []string{expectedMetrics.Name})
 
 	// Check the presence of node names in the output.
@@ -262,9 +264,9 @@ func TestTopNodeWithLabelSelectorMetrics(t *testing.T) {
 	}
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Flags().Set("selector", label)
 	cmd.Run(cmd, []string{})
 
@@ -315,14 +317,16 @@ func TestTopNodeAllMetricsFromMetricsServer(t *testing.T) {
 	})
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 
 	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
 	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{}
-	if err := cmdOptions.Complete(tf, cmd, []string{}, buf); err != nil {
+	cmdOptions := &TopNodeOptions{
+		IOStreams: streams,
+	}
+	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
 		t.Fatal(err)
 	}
 	cmdOptions.MetricsClient = fakemetricsClientset
@@ -381,14 +385,16 @@ func TestTopNodeWithNameMetricsFromMetricsServer(t *testing.T) {
 	})
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 
 	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
 	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{}
-	if err := cmdOptions.Complete(tf, cmd, []string{expectedMetrics.Name}, buf); err != nil {
+	cmdOptions := &TopNodeOptions{
+		IOStreams: streams,
+	}
+	if err := cmdOptions.Complete(tf, cmd, []string{expectedMetrics.Name}); err != nil {
 		t.Fatal(err)
 	}
 	cmdOptions.MetricsClient = fakemetricsClientset
@@ -458,15 +464,17 @@ func TestTopNodeWithLabelSelectorMetricsFromMetricsServer(t *testing.T) {
 	})
 	tf.Namespace = "test"
 	tf.ClientConfigVal = defaultClientConfig()
-	buf := bytes.NewBuffer([]byte{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, buf)
+	cmd := NewCmdTopNode(tf, nil, streams)
 	cmd.Flags().Set("selector", label)
 
 	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
 	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{}
-	if err := cmdOptions.Complete(tf, cmd, []string{}, buf); err != nil {
+	cmdOptions := &TopNodeOptions{
+		IOStreams: streams,
+	}
+	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
 		t.Fatal(err)
 	}
 	cmdOptions.MetricsClient = fakemetricsClientset

--- a/pkg/kubectl/cmd/top_test.go
+++ b/pkg/kubectl/cmd/top_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
@@ -46,9 +47,7 @@ func TestTopSubcommandsExist(t *testing.T) {
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
-	buf := bytes.NewBuffer([]byte{})
-
-	cmd := NewCmdTop(f, buf, buf)
+	cmd := NewCmdTop(f, genericclioptions.NewTestIOStreamsDiscard())
 	if !cmd.HasSubCommands() {
 		t.Error("top command should have subcommands")
 	}

--- a/pkg/kubectl/plugins/BUILD
+++ b/pkg/kubectl/plugins/BUILD
@@ -16,6 +16,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/plugins",
     deps = [
+        "//pkg/kubectl/genericclioptions:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
@@ -45,5 +46,8 @@ go_test(
         "runner_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//pkg/kubectl/genericclioptions:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
 )

--- a/pkg/kubectl/plugins/runner.go
+++ b/pkg/kubectl/plugins/runner.go
@@ -17,12 +17,12 @@ limitations under the License.
 package plugins
 
 import (
-	"io"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 // PluginRunner is capable of running a plugin in a given running context.
@@ -34,9 +34,7 @@ type PluginRunner interface {
 // in, out, and err streams, arguments and environment passed to it, and the
 // working directory.
 type RunningContext struct {
-	In          io.Reader
-	Out         io.Writer
-	ErrOut      io.Writer
+	genericclioptions.IOStreams
 	Args        []string
 	EnvProvider EnvProvider
 	WorkingDir  string

--- a/pkg/kubectl/plugins/runner_test.go
+++ b/pkg/kubectl/plugins/runner_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package plugins
 
 import (
-	"bytes"
 	"os"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 func TestExecRunner(t *testing.T) {
@@ -50,7 +51,7 @@ func TestExecRunner(t *testing.T) {
 	defer os.Unsetenv("KUBECTL_PLUGINS_TEST")
 
 	for _, test := range tests {
-		outBuf := bytes.NewBuffer([]byte{})
+		streams, _, outBuf, _ := genericclioptions.NewTestIOStreams()
 
 		plugin := &Plugin{
 			Description: Description{
@@ -61,7 +62,7 @@ func TestExecRunner(t *testing.T) {
 		}
 
 		ctx := RunningContext{
-			Out:         outBuf,
+			IOStreams:   streams,
 			WorkingDir:  ".",
 			EnvProvider: &EmptyEnvProvider{},
 		}


### PR DESCRIPTION
Scrubs the last commands to use IOStreams for consistency and testability.

@kubernetes/sig-cli-maintainers 
/assign @juanvallejo 

```release-note
NONE
```