### PR TITLE
Updated out-of-cluster configuration example for client-go

### DIFF
--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/README.md
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/README.md
@@ -23,6 +23,7 @@ Running this application will use the kubeconfig file and then authenticate to t
 cluster, and print the number of nodes in the cluster every 10 seconds:
 
     $ ./app
+    Used filesystem-hosted kubeconfig for configuration
     There are 3 pods in the cluster
     There are 3 pods in the cluster
     There are 3 pods in the cluster
@@ -33,3 +34,18 @@ Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit this application.
 > **Note:** You can use the `-kubeconfig` option to use a different config file. By default
 this program picks up the default file used by kubectl (when `KUBECONFIG`
 environment variable is not set).
+
+> **Note:** This example also can show how you can authenticate using the contents
+of a kubeconfig file stored in an environmental variable.  A similar approach could be used to
+generate configurations stored in external services (databases, etcd.)
+>
+> To try it out do the following:
+
+    $ export KUBECONFIG_CONTENTS=$(cat ~/.kube/config|base64)
+    $ ./app
+    Used environmental variable for rest configuration
+    There are 3 pods in the cluster
+    There are 3 pods in the cluster
+    There are 3 pods in the cluster
+    ...
+

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2016 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,19 +27,19 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"encoding/base64"
+	"k8s.io/client-go/rest"
 )
 
 func main() {
-	var kubeconfig *string
-	if home := homeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-	flag.Parse()
+	var config *rest.Config
+	var err error
 
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if os.Getenv("KUBECONFIG_CONTENTS") == "" {
+		config, err = loadConfigFromFile()
+	} else {
+		config, err = loadConfigFromEnvironment()
+	}
 	if err != nil {
 		panic(err.Error())
 	}
@@ -78,6 +75,39 @@ func main() {
 
 		time.Sleep(10 * time.Second)
 	}
+}
+
+// This function will try to create a rest configuration by reading in a kubeconfig file stored on a filesystem
+func loadConfigFromFile() (*rest.Config, error) {
+	var kubeconfig *string
+	if home := homeDir(); home != "" {
+		// Offer to try to grab <home>/.kube/config by default since there is a known home directory
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		// No known home directory, so we will state that this is a required parameter
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	fmt.Printf("Used filesystem-hosted kubeconfig for configuration")
+	// load kubeconfig from this path and use the current context in kubeconfig
+	return clientcmd.BuildConfigFromFlags("", *kubeconfig)
+}
+
+// This function will try to create a rest configuration by reading in an environmental variable
+// Shows off how clientcmd.RESTConfigFromKubeConfig(...) can be used to connect to external kubernetes clusters
+// through kubeconfigs delivered from an external service / not a file located on a filesystem
+func loadConfigFromEnvironment() (*rest.Config, error) {
+	// KUBECONFIG_CONTENTS is an environmental variable that is the contents of a kubeconfig file, base64 encoded
+	// Setting data to the unencoded contents (should be a byte array that contains yaml)
+	data, err := base64.StdEncoding.DecodeString(os.Getenv("KUBECONFIG_CONTENTS"))
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Used environmental variable for rest configuration\n")
+
+	// Using the contents of the kubeconfig file, generate a rest config
+	return clientcmd.RESTConfigFromKubeConfig(data)
 }
 
 func homeDir() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This updates the out-of-cluster example in client-go to show how `clientcmd.RESTConfigFromKubeConfig(...)` can be used to create a `*rest.Config` from something other than a file on the filesystem.  This method was recently added and there may be people who do not know about it nor know how to use it.  It is intended to improve user experience.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes kubernetes/client-go#404


**Special notes for your reviewer**:

I added some logic to the out of cluster configuration example to switch if a `KUBECONFIG_CONTENTS` environmental variable is set.  The example uses an environmental variable to store base64-encoded kubeconfig contents, but does try to document how this could be done if the contents are delivered through another mechanism without base64 encoding wrapping the contents.

To make it clear to the user, an additional line of output was generated to indicate if a configuration was generated through reading in a file or through this environmental variable mechanism.

README.md was updated with an example of how to create the environmental variable and the potential output of running the application in this mode.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated out-of-cluster-client-configuration example to include the generated of a `*rest.Client` through the use of `clientcmd.RESTConfigFromKubeConfig(...)`  Uses an environmental variable in the example, but has documentation on how it could be used through a different means of conveyance.
```
