### PR TITLE
[fluentd-gcp addon] tag stackdriver events test with [Feature:Stackdr…

### DIFF
--- a/test/e2e/instrumentation/logging/stackdrvier/basic.go
+++ b/test/e2e/instrumentation/logging/stackdrvier/basic.go
@@ -138,7 +138,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 		})
 	})
 
-	ginkgo.It("should ingest events", func() {
+	ginkgo.It("should ingest events [Feature:StackdriverLogging]", func() {
 		eventCreationInterval := 10 * time.Second
 
 		withLogProviderForScope(f, eventsScope, func(p *sdLogProvider) {


### PR DESCRIPTION
[fluentd-gcp addon] tag stackdriver events test with [Feature:StackdriverLogging]


Pull request are executed in parallel which exhausts stackdriver sink limit. This PR will prevent it from executing in pull tests as a temporary solution.


```release-note
NONE
```
