### PR TITLE
Fix cgroup names in node_container_manager_test.

### DIFF
--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func setDesiredConfiguration(initialConfig *kubeletconfig.KubeletConfiguration) {
-	initialConfig.EnforceNodeAllocatable = []string{"pods", "kube-reserved", "system-reserved"}
+	initialConfig.EnforceNodeAllocatable = []string{"pods", kubeReservedCgroup, systemReservedCgroup}
 	initialConfig.SystemReserved = map[string]string{
 		string(v1.ResourceCPU):    "100m",
 		string(v1.ResourceMemory): "100Mi",
@@ -98,8 +98,8 @@ func getAllocatableLimits(cpu, memory string, capacity v1.ResourceList) (*resour
 }
 
 const (
-	kubeReservedCgroup   = "kube_reserved"
-	systemReservedCgroup = "system_reserved"
+	kubeReservedCgroup   = "kube-reserved"
+	systemReservedCgroup = "system-reserved"
 )
 
 func createIfNotExists(cm cm.CgroupManager, cgroupConfig *cm.CgroupConfig) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix cgroup names in node_container_manager_test.

The names were made invalid for the CgroupName refactor in #62541, so update them here.

Furthermore, as the new names are now compatible with what EnforceNodeAllocatable wants, reuse the constants there as well.

Tested:
```
  $ make test-e2e-node REMOTE=true HOSTS=test-cos-beta-67-10575-27-0 FOCUS='Validate Node Allocatable' SKIP='' TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
  • [SLOW TEST:39.488 seconds]
  [k8s.io] Node Container Manager [Serial]
    Validate Node Allocatable
      set's up the node and runs the test
  Ran 1 of 261 Specs in 57.348 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 260 Skipped
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63549

**Special notes for your reviewer**:
/assign @dashpole 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
