### PR TITLE
fix a small mistake in function getFieldMeta

### DIFF
--- a/pkg/kubectl/apply/parse/util.go
+++ b/pkg/kubectl/apply/parse/util.go
@@ -104,7 +104,7 @@ func getFieldMeta(s proto.Schema, name string) (apply.FieldMetaImpl, error) {
 		if e, found := ext["x-kubernetes-patch-strategy"]; found {
 			strategy, ok := e.(string)
 			if !ok {
-				return apply.FieldMetaImpl{}, fmt.Errorf("Expected string for x-kubernetes-patch-strategy by got %T", s)
+				return apply.FieldMetaImpl{}, fmt.Errorf("Expected string for x-kubernetes-patch-strategy by got %T", e)
 			}
 
 			// Take the first strategy if there are substrategies.


### PR DESCRIPTION
**What this PR does / why we need it**:
fix a small mistake in function getFieldMeta
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
```
if e, found := ext["x-kubernetes-patch-strategy"]; found {
	strategy, ok := e.(string)
	if !ok {
		return apply.FieldMetaImpl{}, fmt.Errorf("Expected string for x-kubernetes-patch-strategy by got %T", s)
	}
}
```
According the judgment above, I think we should print the type of e.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
