### PR TITLE
scope AWS LoadBalancer security group ICMP rules to spec.loadBalancerSourceRanges

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3513,7 +3513,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 				IpProtocol: aws.String("icmp"),
 				FromPort:   aws.Int64(3),
 				ToPort:     aws.Int64(4),
-				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+				IpRanges:   ec2SourceRanges,
 			}
 
 			permissions.Insert(permission)


### PR DESCRIPTION
/sig aws
**What this PR does / why we need it**:
Make the client CIDR ranges for MTU consistent with what [the documentation appears to describe](https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer), where the ranges should be equal to `spec.loadBalancerSourceRanges` if supplied.

**Which issue(s) this PR fixes**:
Fixes #63564

**Release note**:
```release-note
scope AWS LoadBalancer security group ICMP rules to spec.loadBalancerSourceRanges
```
