### PR TITLE
Make from flag a required flag for kubectl create job

### DIFF
--- a/pkg/kubectl/cmd/create/create_job.go
+++ b/pkg/kubectl/cmd/create/create_job.go
@@ -98,6 +98,9 @@ func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 }
 
 func (o *CreateJobOptions) Validate() (err error) {
+	if o.Name == "" {
+		return fmt.Errorf("name must be specified")
+	}
 	if len(strings.Split(o.From, "/")) != 2 {
 		return fmt.Errorf("--from must be specified as RESOURCE/JOBNAME")
 	}

--- a/pkg/kubectl/cmd/create/create_job_test.go
+++ b/pkg/kubectl/cmd/create/create_job_test.go
@@ -135,3 +135,34 @@ func TestCreateJobFromCronJob(t *testing.T) {
 		t.Errorf("expected '%s', got '%s'", testImageName, submittedJob.Spec.Template.Spec.Containers[0].Image)
 	}
 }
+
+func TestJobValidate(t *testing.T) {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+
+	tf.Namespace = "test"
+
+	tests := map[string]struct {
+		jobOptions *CreateJobOptions
+		expectErr  bool
+	}{
+		"test-from-without-slash": {
+			jobOptions: &CreateJobOptions{From: "cronjob"},
+			expectErr:  true,
+		},
+		"test-from-extra-slash": {
+			jobOptions: &CreateJobOptions{From: "cronjob/a-cronjob/extra"},
+			expectErr:  true,
+		},
+	}
+	for name, test := range tests {
+		var err error
+		err = test.jobOptions.Validate()
+		if test.expectErr && err == nil {
+			t.Errorf("%s: expect error happens but validate passes.", name)
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("%s: unexpected error: %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Currently `kubectl create job somejob` is supposed to require `--from` flag.
- When running `create job` without `--from`, the error does not display correct message.

~~~
$ kubectl create job somejob
error: resource(s) were provided, but no name, label selector, or --all flag specified
~~~

- Also, even when running with `--from=cronjob`, the error does not display correct message.

~~~
$ kubectl create job somejob --from=somecron
error: resource(s) were provided, but no name, label selector, or --all flag specified
~~~

**Special notes for your reviewer**:

This patch contains:

- Add `Validate()` func.
- Use `NameFromCommandArgs()` util.
- Introduce validation of `--from` and  `RESOURCE/NAME` style
- Change help message `[--from=CRONJOB] ` to `--from=CRONJOB`

**Release note**:
```release-note
NONE
```
