### PR TITLE
e2e: add a tooling argument to differentiate tooling

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -49,7 +49,12 @@ type TestContextType struct {
 	RepoRoot                string
 	DockershimCheckpointDir string
 
-	Provider       string
+	// Provider identifies the infrastructure provider (gce, gke, aws)
+	Provider string
+
+	// Tooling is the tooling in use (e.g. kops, gke).  Provider is the cloud provider and might not uniquely identify the tooling.
+	Tooling string
+
 	CloudConfig    CloudConfig
 	KubectlPath    string
 	OutputDir      string
@@ -233,6 +238,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.CertDir, "cert-dir", "", "Path to the directory containing the certs. Default is empty, which doesn't use certs.")
 	flag.StringVar(&TestContext.RepoRoot, "repo-root", "../../", "Root directory of kubernetes repository, for finding test files.")
 	flag.StringVar(&TestContext.Provider, "provider", "", "The name of the Kubernetes provider (gce, gke, local, etc.)")
+	flag.StringVar(&TestContext.Tooling, "tooling", "", "The tooling in use (kops, gke, etc.)")
 	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 	flag.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")


### PR DESCRIPTION
We expect lots of tools to be able to install on provider=gce - the cluster
API, kops, kube-up etc.

We introduce a new optional flag to e2e ('tooling') to enable switching on
the tooling, not just the cloud.

This will prove useful for upgrade tests, for example, where the mechanism
will likely vary by tooling, but is currently tightly bound to the provider
(i.e. cloud)

```release-note
NONE
```