### PR TITLE
don't block e2e namespace cleanup checks on metrics.k8s.io API group

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1221,6 +1221,8 @@ func isDynamicDiscoveryError(err error) bool {
 			// garbage_collector
 		case "wardle.k8s.io":
 			// aggregator
+		case "metrics.k8s.io":
+			// aggregated metrics server add-on, no persisted resources
 		default:
 			Logf("discovery error for unexpected group: %#v", gv)
 			return false


### PR DESCRIPTION
e2e tests discovery persisted resource types and ensure they were cleaned up by namespace deletion

the metrics.k8s.io API group doesn't have any persisted resources, so if there is a discovery error involving that group, we can ignore it for purposes of e2e cleanup checks

```release-note
NONE
```