### PR TITLE
push ToRESTMapper down a layer

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -269,7 +269,8 @@ func NewTestFactory() *TestFactory {
 	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, fallbackReader)
 
 	configFlags := cmdutil.NewTestConfigFlags().
-		WithClientConfig(clientConfig)
+		WithClientConfig(clientConfig).
+		WithRESTMapper(testRESTMapper())
 
 	return &TestFactory{
 		Factory:           cmdutil.NewFactory(configFlags),
@@ -428,7 +429,7 @@ func (f *TestFactory) ClientSetForVersion(requiredVersion *schema.GroupVersion) 
 	return f.ClientSet()
 }
 
-func (f *TestFactory) RESTMapper() (meta.RESTMapper, error) {
+func testRESTMapper() meta.RESTMapper {
 	groupResources := testDynamicResources()
 	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
 	// for backwards compatibility with existing tests, allow rest mappings from the scheme to show up
@@ -440,10 +441,9 @@ func (f *TestFactory) RESTMapper() (meta.RESTMapper, error) {
 		},
 	}
 
-	// TODO: should probably be the external scheme
 	fakeDs := &fakeCachedDiscoveryClient{}
 	expander := restmapper.NewShortcutExpander(mapper, fakeDs)
-	return expander, nil
+	return expander
 }
 
 func (f *TestFactory) LogsForObject(object, options runtime.Object, timeout time.Duration) (*restclient.Request, error) {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -98,6 +98,9 @@ type ClientAccessFactory interface {
 	// KubernetesClientSet gives you back an external clientset
 	KubernetesClientSet() (*kubernetes.Clientset, error)
 
+	// Returns interfaces for dealing with arbitrary runtime.Objects.
+	RESTMapper() (meta.RESTMapper, error)
+
 	// Returns a RESTClient for accessing Kubernetes resources or an error.
 	RESTClient() (*restclient.RESTClient, error)
 	// Returns a client.Config for accessing the Kubernetes server.
@@ -165,8 +168,6 @@ type ClientAccessFactory interface {
 // ObjectMappingFactory holds the second level of factory methods. These functions depend upon ClientAccessFactory methods.
 // Generally they provide object typing and functions that build requests based on the negotiated clients.
 type ObjectMappingFactory interface {
-	// Returns interfaces for dealing with arbitrary runtime.Objects.
-	RESTMapper() (meta.RESTMapper, error)
 	// Returns interface for expanding categories like `all`.
 	CategoryExpander() categories.CategoryExpander
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -45,7 +45,7 @@ func NewBuilderFactory(clientAccessFactory ClientAccessFactory, objectMappingFac
 
 // NewBuilder returns a new resource builder for structured api objects.
 func (f *ring2Factory) NewBuilder() *resource.Builder {
-	mapper, mapperErr := f.objectMappingFactory.RESTMapper()
+	mapper, mapperErr := f.clientAccessFactory.RESTMapper()
 
 	categoryExpander := f.objectMappingFactory.CategoryExpander()
 	return resource.NewBuilder(
@@ -84,7 +84,7 @@ func (f *ring2Factory) ScaleClient() (scaleclient.ScalesGetter, error) {
 		return nil, err
 	}
 	resolver := scaleclient.NewDiscoveryScaleKindResolver(discoClient)
-	mapper, err := f.objectMappingFactory.RESTMapper()
+	mapper, err := f.clientAccessFactory.RESTMapper()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -64,6 +64,7 @@ import (
 type RESTClientGetter interface {
 	ToRESTConfig() (*restclient.Config, error)
 	ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
+	ToRESTMapper() (meta.RESTMapper, error)
 	ToRawKubeConfigLoader() clientcmd.ClientConfig
 }
 
@@ -141,6 +142,11 @@ func (f *ring0Factory) ClientConfig() (*restclient.Config, error) {
 	setKubernetesDefaults(clientConfig)
 	return clientConfig, nil
 }
+
+func (f *ring0Factory) RESTMapper() (meta.RESTMapper, error) {
+	return f.clientGetter.ToRESTMapper()
+}
+
 func (f *ring0Factory) BareClientConfig() (*restclient.Config, error) {
 	return f.clientGetter.ToRESTConfig()
 }

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -74,20 +73,6 @@ func NewObjectMappingFactory(clientAccessFactory ClientAccessFactory) ObjectMapp
 		clientAccessFactory: clientAccessFactory,
 	}
 	return f
-}
-
-// RESTMapper returns a mapper.
-func (f *ring1Factory) RESTMapper() (meta.RESTMapper, error) {
-	discoveryClient, err := f.clientAccessFactory.DiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-
-	// allow conversion between typed and unstructured objects
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-	// TODO: should this also indicate it recognizes typed objects?
-	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
-	return expander, nil
 }
 
 func (f *ring1Factory) CategoryExpander() categories.CategoryExpander {


### PR DESCRIPTION
The RESTMapper is needed to drive some use-cases for a dynamic client and takes a little bit of wiring (nested restmappers).  This pull pushes that into information derived from the kubeconfig flags to allow easy re-use.

@kubernetes/sig-cli-maintainers 
/assign @juanvallejo 
/assign @soltysh 

assigned to original creators.


```release-note
NONE
```