### PR TITLE
tests: Removed hardcoded images from yaml files

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -17,7 +17,9 @@ limitations under the License.
 package common
 
 import (
+	"bytes"
 	"fmt"
+	"text/template"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -62,6 +64,51 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
 	imageutils.GetE2EImage(imageutils.Net),
 )
+
+type testImagesStruct struct {
+	BusyBoxImage      string
+	GBFrontendImage   string
+	GBRedisSlaveImage string
+	KittenImage       string
+	LivenessImage     string
+	MounttestImage    string
+	NautilusImage     string
+	NginxImage        string
+	NginxNewImage     string
+	PauseImage        string
+	RedisImage        string
+}
+
+var testImages testImagesStruct
+
+func init() {
+	testImages = testImagesStruct{
+		imageutils.GetE2EImage(imageutils.BusyBox),
+		imageutils.GetE2EImage(imageutils.GBFrontend),
+		imageutils.GetE2EImage(imageutils.GBRedisSlave),
+		imageutils.GetE2EImage(imageutils.Kitten),
+		imageutils.GetE2EImage(imageutils.Liveness),
+		imageutils.GetE2EImage(imageutils.Mounttest),
+		imageutils.GetE2EImage(imageutils.Nautilus),
+		imageutils.GetE2EImage(imageutils.Nginx),
+		imageutils.GetE2EImage(imageutils.NginxNew),
+		imageutils.GetE2EImage(imageutils.Pause),
+		imageutils.GetE2EImage(imageutils.Redis),
+	}
+}
+
+func SubstituteImageName(content string) string {
+	contentWithImageName := new(bytes.Buffer)
+	tmpl, err := template.New("imagemanifest").Parse(content)
+	if err != nil {
+		framework.Failf("Failed Parse the template: %v", err)
+	}
+	err = tmpl.Execute(contentWithImageName, testImages)
+	if err != nil {
+		framework.Failf("Failed executing template: %v", err)
+	}
+	return contentWithImageName.String()
+}
 
 func svcByName(name string, port int) *v1.Service {
 	return &v1.Service{

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	commonutils "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 
@@ -62,8 +63,8 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Liveness", func() {
 		It("liveness pods should be automatically restarted", func() {
 			test := "test/fixtures/doc-yaml/user-guide/liveness"
-			execYaml := readFile(test, "exec-liveness.yaml")
-			httpYaml := readFile(test, "http-liveness.yaml")
+			execYaml := readFile(test, "exec-liveness.yaml.in")
+			httpYaml := readFile(test, "http-liveness.yaml.in")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			framework.RunKubectlOrDieInput(execYaml, "create", "-f", "-", nsFlag)
@@ -111,7 +112,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 		It("should create a pod that reads a secret", func() {
 			test := "test/fixtures/doc-yaml/user-guide/secrets"
 			secretYaml := readFile(test, "secret.yaml")
-			podYaml := readFile(test, "secret-pod.yaml")
+			podYaml := readFile(test, "secret-pod.yaml.in")
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podName := "secret-test-pod"
@@ -131,7 +132,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Downward API", func() {
 		It("should create a pod that prints his name and namespace", func() {
 			test := "test/fixtures/doc-yaml/user-guide/downward-api"
-			podYaml := readFile(test, "dapi-pod.yaml")
+			podYaml := readFile(test, "dapi-pod.yaml.in")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podName := "dapi-test-pod"
 
@@ -151,5 +152,5 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 func readFile(test, file string) string {
 	from := filepath.Join(test, file)
-	return string(testfiles.ReadOrDie(from, Fail))
+	return commonutils.SubstituteImageName(string(testfiles.ReadOrDie(from, Fail)))
 }

--- a/test/e2e/kubectl/BUILD
+++ b/test/e2e/kubectl/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/scheduling:go_default_library",

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -37,7 +37,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/elazarl/goproxy"
@@ -57,6 +56,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/controller"
+	commonutils "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/scheduling"
@@ -98,25 +98,6 @@ var (
 	busyboxImage  = imageutils.GetE2EImage(imageutils.BusyBox)
 )
 
-var testImages = struct {
-	GBFrontendImage   string
-	PauseImage        string
-	NginxImage        string
-	NginxNewImage     string
-	RedisImage        string
-	GBRedisSlaveImage string
-	NautilusImage     string
-	KittenImage       string
-}{
-	imageutils.GetE2EImage(imageutils.GBFrontend),
-	imageutils.GetE2EImage(imageutils.Pause),
-	imageutils.GetE2EImage(imageutils.Nginx),
-	imageutils.GetE2EImage(imageutils.NginxNew),
-	imageutils.GetE2EImage(imageutils.Redis),
-	imageutils.GetE2EImage(imageutils.GBRedisSlave),
-	imageutils.GetE2EImage(imageutils.Nautilus),
-	imageutils.GetE2EImage(imageutils.Kitten),
-}
 var (
 	proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
 
@@ -136,19 +117,6 @@ func cleanupKubectlInputs(fileContents string, ns string, selectors ...string) {
 	// dependencies from this test.
 	framework.RunKubectlOrDieInput(fileContents, "delete", "--grace-period=0", "--force", "-f", "-", nsArg)
 	framework.AssertCleanup(ns, selectors...)
-}
-
-func substituteImageName(content string) string {
-	contentWithImageName := new(bytes.Buffer)
-	tmpl, err := template.New("imagemanifest").Parse(content)
-	if err != nil {
-		framework.Failf("Failed Parse the template: %v", err)
-	}
-	err = tmpl.Execute(contentWithImageName, testImages)
-	if err != nil {
-		framework.Failf("Failed executing template: %v", err)
-	}
-	return contentWithImageName.String()
 }
 
 func readTestFileOrDie(file string) []byte {
@@ -294,8 +262,8 @@ var _ = SIGDescribe("Kubectl client", func() {
 		var nautilus, kitten string
 		BeforeEach(func() {
 			updateDemoRoot := "test/fixtures/doc-yaml/user-guide/update-demo"
-			nautilus = substituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"), Fail)))
-			kitten = substituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "kitten-rc.yaml.in"), Fail)))
+			nautilus = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"), Fail)))
+			kitten = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "kitten-rc.yaml.in"), Fail)))
 		})
 		/*
 			Release : v1.9
@@ -359,7 +327,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				"redis-master-deployment.yaml.in",
 				"redis-slave-deployment.yaml.in",
 			} {
-				contents := substituteImageName(string(testfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile), Fail)))
+				contents := commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile), Fail)))
 				run(contents)
 			}
 		}
@@ -388,7 +356,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 		var podYaml string
 		BeforeEach(func() {
 			By(fmt.Sprintf("creating the pod from %v", podYaml))
-			podYaml = substituteImageName(string(readTestFileOrDie("pod-with-readiness-probe.yaml.in")))
+			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pod-with-readiness-probe.yaml.in")))
 			framework.RunKubectlOrDieInput(podYaml, "create", "-f", "-", fmt.Sprintf("--namespace=%v", ns))
 			Expect(framework.CheckPodsRunningReady(c, ns, []string{simplePodName}, framework.PodStartTimeout)).To(BeTrue())
 		})
@@ -748,7 +716,7 @@ metadata:
 
 	framework.KubeDescribe("Kubectl apply", func() {
 		It("should apply a new configuration to an existing RC", func() {
-			controllerJson := substituteImageName(string(readTestFileOrDie(redisControllerFilename)))
+			controllerJson := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			By("creating Redis RC")
@@ -784,9 +752,9 @@ metadata:
 		})
 
 		It("apply set/view last-applied", func() {
-			deployment1Yaml := substituteImageName(string(readTestFileOrDie(nginxDeployment1Filename)))
-			deployment2Yaml := substituteImageName(string(readTestFileOrDie(nginxDeployment2Filename)))
-			deployment3Yaml := substituteImageName(string(readTestFileOrDie(nginxDeployment3Filename)))
+			deployment1Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(nginxDeployment1Filename)))
+			deployment2Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(nginxDeployment2Filename)))
+			deployment3Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(nginxDeployment3Filename)))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			By("deployment replicas number is 2")
@@ -864,7 +832,7 @@ metadata:
 			kv, err := framework.KubectlVersion()
 			Expect(err).NotTo(HaveOccurred())
 			framework.SkipUnlessServerVersionGTE(kv, c.Discovery())
-			controllerJson := substituteImageName(string(readTestFileOrDie(redisControllerFilename)))
+			controllerJson := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 			serviceJson := readTestFileOrDie(redisServiceFilename)
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
@@ -969,7 +937,7 @@ metadata:
 			Description: Create a Pod running redis master listening to port 6379. Using kubectl expose the redis master  replication controllers at port 1234. Validate that the replication controller is listening on port 1234 and the target port is set to 6379, port that redis master is listening. Using kubectl expose the redis master as a service at port 2345. The service MUST be listening on port 2345 and the target port is set to 6379, port that redis master is listening.
 		*/
 		framework.ConformanceIt("should create services for rc ", func() {
-			controllerJson := substituteImageName(string(readTestFileOrDie(redisControllerFilename)))
+			controllerJson := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			redisPort := 6379
@@ -1051,7 +1019,7 @@ metadata:
 		var nsFlag string
 		BeforeEach(func() {
 			By("creating the pod")
-			podYaml = substituteImageName(string(readTestFileOrDie("pause-pod.yaml.in")))
+			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pause-pod.yaml.in")))
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
 			framework.RunKubectlOrDieInput(podYaml, "create", "-f", "-", nsFlag)
 			Expect(framework.CheckPodsRunningReady(c, ns, []string{pausePodName}, framework.PodStartTimeout)).To(BeTrue())
@@ -1093,7 +1061,7 @@ metadata:
 		BeforeEach(func() {
 			By("creating the pod")
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
-			podYaml = substituteImageName(string(readTestFileOrDie("busybox-pod.yaml")))
+			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-pod.yaml")))
 			framework.RunKubectlOrDieInput(podYaml, "create", "-f", "-", nsFlag)
 			Expect(framework.CheckPodsRunningReady(c, ns, []string{busyboxPodName}, framework.PodStartTimeout)).To(BeTrue())
 		})
@@ -1133,7 +1101,7 @@ metadata:
 		containerName := "redis-master"
 		BeforeEach(func() {
 			By("creating an rc")
-			rc = substituteImageName(string(readTestFileOrDie(redisControllerFilename)))
+			rc = commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
 			framework.RunKubectlOrDieInput(rc, "create", "-f", "-", nsFlag)
 		})
@@ -1209,7 +1177,7 @@ metadata:
 			Description: Start running a redis master and a replication controller. When the pod is running, using ‘kubectl patch’ command add annotations. The annotation MUST be added to running pods and SHOULD be able to read added annotations from each of the Pods running under the replication controller.
 		*/
 		framework.ConformanceIt("should add annotations for pods in rc ", func() {
-			controllerJson := substituteImageName(string(readTestFileOrDie(redisControllerFilename)))
+			controllerJson := commonutils.SubstituteImageName(string(readTestFileOrDie(redisControllerFilename)))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			By("creating Redis RC")
 			framework.RunKubectlOrDieInput(controllerJson, "create", "-f", "-", nsFlag)

--- a/test/fixtures/doc-yaml/user-guide/downward-api/dapi-pod.yaml.in
+++ b/test/fixtures/doc-yaml/user-guide/downward-api/dapi-pod.yaml.in
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: busybox
+      image: {{.BusyBoxImage}}
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: MY_POD_NAME

--- a/test/fixtures/doc-yaml/user-guide/liveness/exec-liveness.yaml.in
+++ b/test/fixtures/doc-yaml/user-guide/liveness/exec-liveness.yaml.in
@@ -10,7 +10,7 @@ spec:
     - /bin/sh
     - -c
     - echo ok > /tmp/health; sleep 10; rm -rf /tmp/health; sleep 600
-    image: busybox
+    image: {{.BusyBoxImage}}
     livenessProbe:
       exec:
         command:

--- a/test/fixtures/doc-yaml/user-guide/liveness/http-liveness.yaml.in
+++ b/test/fixtures/doc-yaml/user-guide/liveness/http-liveness.yaml.in
@@ -8,7 +8,7 @@ spec:
   containers:
   - args:
     - /server
-    image: gcr.io/kubernetes-e2e-test-images/liveness:1.0
+    image: {{.LivenessImage}}
     livenessProbe:
       httpGet:
         path: /healthz

--- a/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml.in
+++ b/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml.in
@@ -5,8 +5,8 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: gcr.io/kubernetes-e2e-test-images/mounttest:1.0
-      command: [ "/mt", "--file_content=/etc/secret-volume/data-1" ]
+      image: {{.MounttestImage}}
+      command: [ "/mounttest", "--file_content=/etc/secret-volume/data-1" ]
       volumeMounts:
           # name must match the volume name below
           - name: secret-volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Some tests use .yaml files to deploy pods, which have hardcoded
images. Those images cannot be used for Windows containers.

The image names can be injected by the tests themselves, based on
the configured registries.

Related to issue #60487

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```

