### PR TITLE
Reuse cAdvisor's du and find methods for empty-dir volumes

### DIFF
--- a/pkg/volume/metrics_du.go
+++ b/pkg/volume/metrics_du.go
@@ -80,7 +80,7 @@ func (md *metricsDu) runFind(metrics *Metrics) error {
 	if err != nil {
 		return err
 	}
-	metrics.InodesUsed = resource.NewQuantity(inodesUsed, resource.BinarySI)
+	metrics.InodesUsed = inodesUsed
 	return nil
 }
 

--- a/pkg/volume/util/fs/BUILD
+++ b/pkg/volume/util/fs/BUILD
@@ -45,6 +45,7 @@ go_library(
             "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/github.com/google/cadvisor/fs:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],
@@ -55,6 +56,7 @@ go_library(
             "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/github.com/google/cadvisor/fs:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         ],

--- a/pkg/volume/util/fs/fs.go
+++ b/pkg/volume/util/fs/fs.go
@@ -19,15 +19,15 @@ limitations under the License.
 package fs
 
 import (
-	"bytes"
-	"fmt"
-	"os/exec"
-	"strings"
+	"time"
 
+	"github.com/google/cadvisor/fs"
 	"golang.org/x/sys/unix"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+const timeout = time.Minute
 
 // FSInfo linux returns (available bytes, byte capacity, byte usage, total inodes, inodes free, inode usage, error)
 // for the filesystem that path resides upon.
@@ -55,43 +55,19 @@ func FsInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 }
 
 func Du(path string) (*resource.Quantity, error) {
-	// Uses the same niceness level as cadvisor.fs does when running du
-	// Uses -B 1 to always scale to a blocksize of 1 byte
-	out, err := exec.Command("nice", "-n", "19", "du", "-s", "-B", "1", path).CombinedOutput()
+	used, err := fs.GetDirDiskUsage(path, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed command 'du' ($ nice -n 19 du -s -B 1) on path %s with error %v", path, err)
+		return nil, err
 	}
-	used, err := resource.ParseQuantity(strings.Fields(string(out))[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse 'du' output %s due to error %v", out, err)
-	}
-	used.Format = resource.BinarySI
-	return &used, nil
+	return resource.NewQuantity(int64(used), resource.BinarySI), nil
 }
 
 // Find uses the equivalent of the command `find <path> -dev -printf '.' | wc -c` to count files and directories.
 // While this is not an exact measure of inodes used, it is a very good approximation.
-func Find(path string) (int64, error) {
-	if path == "" {
-		return 0, fmt.Errorf("invalid directory")
+func Find(path string) (*resource.Quantity, error) {
+	used, err := fs.GetDirInodeUsage(path, timeout)
+	if err != nil {
+		return nil, err
 	}
-	var counter byteCounter
-	var stderr bytes.Buffer
-	findCmd := exec.Command("find", path, "-xdev", "-printf", ".")
-	findCmd.Stdout, findCmd.Stderr = &counter, &stderr
-	if err := findCmd.Start(); err != nil {
-		return 0, fmt.Errorf("failed to exec cmd %v - %v; stderr: %v", findCmd.Args, err, stderr.String())
-	}
-	if err := findCmd.Wait(); err != nil {
-		return 0, fmt.Errorf("cmd %v failed. stderr: %s; err: %v", findCmd.Args, stderr.String(), err)
-	}
-	return counter.bytesWritten, nil
-}
-
-// Simple io.Writer implementation that counts how many bytes were written.
-type byteCounter struct{ bytesWritten int64 }
-
-func (b *byteCounter) Write(p []byte) (int, error) {
-	b.bytesWritten += int64(len(p))
-	return len(p), nil
+	return resource.NewQuantity(int64(used), resource.BinarySI), nil
 }

--- a/pkg/volume/util/fs/fs_unsupported.go
+++ b/pkg/volume/util/fs/fs_unsupported.go
@@ -33,6 +33,6 @@ func Du(path string) (*resource.Quantity, error) {
 	return nil, fmt.Errorf("Du not supported for this build.")
 }
 
-func Find(path string) (int64, error) {
-	return 0, fmt.Errorf("Find not supported for this build.")
+func Find(path string) (*resource.Quantity, error) {
+	return nil, fmt.Errorf("Find not supported for this build.")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We often find issues with `du` or `find`.  This requires changes in multiple places since we need to change both cAdvisor and the volume metrics collection. This changes the empty-dir volume metrics collection to use the cadvisor functions instead of their own.

This makes no changes other than adding a 1 minute timeout to these calls.

**Release note**:
```release-note
NONE
```
/kind cleanup