### PR TITLE
Add option to run follow + label

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -199,9 +199,6 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 	o.LogsForObject = f.LogsForObject
 
 	if len(selector) != 0 {
-		if logOptions.Follow {
-			return cmdutil.UsageErrorf(cmd, "only one of follow (-f) or selector (-l) is allowed")
-		}
 		if logOptions.TailLines == nil && tail != -1 {
 			logOptions.TailLines = &selectorTail
 		}

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -198,11 +198,6 @@ func TestLogComplete(t *testing.T) {
 			flags:    map[string]string{"tail": "1"},
 			expected: "'logs (POD | TYPE/NAME) [CONTAINER_NAME]'.\nPOD or TYPE/NAME is a required argument for the logs command",
 		},
-		{
-			name:     "follow and selecter conflict",
-			flags:    map[string]string{"selector": "foo", "follow": "true"},
-			expected: "only one of follow (-f) or selector (-l) is allowed",
-		},
 	}
 	for _, test := range tests {
 		cmd := NewCmdLogs(f, genericclioptions.NewTestIOStreamsDiscard())


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove check for follow + selector when running kubectl logs -l <selector> -f

**Which issue(s) this PR fixes**
Fixes #52218

