### PR TITLE
Uncordon the node after upgrade

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -342,15 +342,21 @@ function do-single-node-upgrade() {
     sleep 1
   done
 
-  # Wait for the node to not have SchedulingDisabled=True and also to have
-  # Ready=True.
+  # Uncordon the node.
+  echo "== Uncordon ${instance}. == " >&2
+  local uncordon_rc
+  "${KUBE_ROOT}/cluster/kubectl.sh" uncordon "${instance}" \
+    && uncordon_rc=$? || uncordon_rc=$?
+  if [[ "${uncordon_rc}" != 0 ]]; then
+    echo "== FAILED to uncordon ${instance} =="
+    return ${uncordon_rc}
+  fi
+  
+  # Wait for the node to have Ready=True.
   echo "== Waiting for ${instance} to become ready. ==" >&2
   while true; do
-    local cordoned=$("${KUBE_ROOT}/cluster/kubectl.sh" get node "${instance}" --output='jsonpath={.status.conditions[?(@.type == "SchedulingDisabled")].status}')
     local ready=$("${KUBE_ROOT}/cluster/kubectl.sh" get node "${instance}" --output='jsonpath={.status.conditions[?(@.type == "Ready")].status}')
-    if [[ "${cordoned}" == 'True' ]]; then
-      echo "Node ${instance} is still not ready: SchedulingDisabled=${ready}"
-    elif [[ "${ready}" != 'True' ]]; then
+    if [[ "${ready}" != 'True' ]]; then
       echo "Node ${instance} is still not ready: Ready=${ready}"
     else
       echo "Node ${instance} Ready=${ready}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous logic was relying on the node to recreate the node API object
and, as a side-effect, uncordon itself. A change went in that no
longer ensures the node recreates itself, so the bug in this logic was exposed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63506

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @dchen1107 @AishSundar 