### PR TITLE
Manual cherrypick of kube-openapi changes for release-1.9

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3084,35 +3084,35 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto/validation",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/utils/clock",

--- a/staging/src/k8s.io/api/Godeps/Godeps.json
+++ b/staging/src/k8s.io/api/Godeps/Godeps.json
@@ -220,7 +220,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1648,23 +1648,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -244,11 +244,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1676,23 +1676,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -700,11 +700,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/code-generator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/code-generator/Godeps/Godeps.json
@@ -252,11 +252,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1636,27 +1636,27 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/metrics/Godeps/Godeps.json
+++ b/staging/src/k8s.io/metrics/Godeps/Godeps.json
@@ -516,7 +516,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1624,23 +1624,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -984,11 +984,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
+			"Rev": "7ee50c0aa8059d610950c952a9ed7a5e33ab336a"
 		}
 	]
 }

--- a/vendor/k8s.io/kube-openapi/pkg/aggregator/aggregator.go
+++ b/vendor/k8s.io/kube-openapi/pkg/aggregator/aggregator.go
@@ -142,6 +142,9 @@ func (s *referenceWalker) walkOperation(op *spec.Operation) {
 }
 
 func (s *referenceWalker) Start() {
+	if s.root.Paths == nil {
+		return
+	}
 	for _, pathItem := range s.root.Paths.Paths {
 		s.walkParams(pathItem.Parameters)
 		s.walkOperation(pathItem.Delete)
@@ -215,6 +218,10 @@ func renameDefinition(s *spec.Swagger, old, new string) {
 		}
 		return ref
 	}, s)
+	// Make sure we don't assign to nil map
+	if s.Definitions == nil {
+		s.Definitions = spec.Definitions{}
+	}
 	s.Definitions[new] = s.Definitions[old]
 	delete(s.Definitions, old)
 }
@@ -239,6 +246,13 @@ func MergeSpecs(dest, source *spec.Swagger) error {
 
 func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConflicts bool) (err error) {
 	specCloned := false
+	// Paths may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).
+	if source.Paths == nil {
+		source.Paths = &spec.Paths{}
+	}
+	if dest.Paths == nil {
+		dest.Paths = &spec.Paths{}
+	}
 	if ignorePathConflicts {
 		keepPaths := []string{}
 		hasConflictingPath := false
@@ -316,6 +330,9 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 	}
 	for k, v := range source.Definitions {
 		if _, found := dest.Definitions[k]; !found {
+			if dest.Definitions == nil {
+				dest.Definitions = spec.Definitions{}
+			}
 			dest.Definitions[k] = v
 		}
 	}
@@ -323,6 +340,10 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 	for k, v := range source.Paths.Paths {
 		if _, found := dest.Paths.Paths[k]; found {
 			return fmt.Errorf("unable to merge: duplicated path %s", k)
+		}
+		// PathItem may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).
+		if dest.Paths.Paths == nil {
+			dest.Paths.Paths = map[string]spec.PathItem{}
 		}
 		dest.Paths.Paths[k] = v
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cherry-picks https://github.com/kubernetes/kube-openapi/pull/64 and https://github.com/kubernetes/kube-openapi/pull/67
Fixes bugs that make apiserver panic when aggregating valid but not well formed OpenAPI spec (with empty `Paths`/`Definitions`)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bugs that make apiserver panic when aggregating valid but not well formed OpenAPI spec
```

/cc @mbohlool 
/sig api-machinery