### PR TITLE
Remove redundant validation for create role's name arg

### DIFF
--- a/pkg/kubectl/cmd/create/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create/create_clusterrole.go
@@ -111,6 +111,10 @@ func (c *CreateClusterRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Comman
 }
 
 func (c *CreateClusterRoleOptions) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("name must be specified")
+	}
+
 	if len(c.AggregationRule) > 0 {
 		if len(c.NonResourceURLs) > 0 || len(c.Verbs) > 0 || len(c.Resources) > 0 || len(c.ResourceNames) > 0 {
 			return fmt.Errorf("aggregation rule must be specified without nonResourceURLs, verbs, resources or resourceNames")

--- a/pkg/kubectl/cmd/create/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create/create_clusterrole.go
@@ -111,10 +111,6 @@ func (c *CreateClusterRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Comman
 }
 
 func (c *CreateClusterRoleOptions) Validate() error {
-	if c.Name == "" {
-		return fmt.Errorf("name must be specified")
-	}
-
 	if len(c.AggregationRule) > 0 {
 		if len(c.NonResourceURLs) > 0 || len(c.Verbs) > 0 || len(c.Resources) > 0 || len(c.ResourceNames) > 0 {
 			return fmt.Errorf("aggregation rule must be specified without nonResourceURLs, verbs, resources or resourceNames")

--- a/pkg/kubectl/cmd/create/create_role.go
+++ b/pkg/kubectl/cmd/create/create_role.go
@@ -241,10 +241,6 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 }
 
 func (o *CreateRoleOptions) Validate() error {
-	if o.Name == "" {
-		return fmt.Errorf("name must be specified")
-	}
-
 	// validate verbs.
 	if len(o.Verbs) == 0 {
 		return fmt.Errorf("at least one verb must be specified")


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove redundant validation for name arg of `kubectl create {cluster}role`
- Since `NameFromCommandArgs()` already checked the number of args, `o.Name == ""` in `Validate()` is not necessary.

**Special notes for your reviewer**:

- It was suggested on another PR - https://github.com/kubernetes/kubernetes/pull/63591#discussion_r187065959

**Release note**:
```release-note
NONE
```
