### PR TITLE
Automated cherry pick of #63504: Improve where we load builds from for kubeadm upgrade jobs

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -103,8 +103,8 @@ func splitVersion(version string) (string, string, error) {
 
 	switch {
 	case strings.HasPrefix(subs[0][2], "ci"):
-		// Special case. CI images populated only by ci-cross area
-		urlSuffix = "ci-cross"
+		// Just use whichever the user specified
+		urlSuffix = subs[0][2]
 	default:
 		urlSuffix = "release"
 	}

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -180,8 +180,10 @@ func TestSplitVersion(t *testing.T) {
 		{"release/v1.7.0", "https://dl.k8s.io/release", "v1.7.0", true},
 		{"release/latest-1.7", "https://dl.k8s.io/release", "latest-1.7", true},
 		// CI builds area, lookup actual builds at ci-cross/*.txt
+		{"ci/latest", "https://dl.k8s.io/ci", "latest", true},
 		{"ci-cross/latest", "https://dl.k8s.io/ci-cross", "latest", true},
-		{"ci/latest-1.7", "https://dl.k8s.io/ci-cross", "latest-1.7", true},
+		{"ci/latest-1.7", "https://dl.k8s.io/ci", "latest-1.7", true},
+		{"ci-cross/latest-1.7", "https://dl.k8s.io/ci-cross", "latest-1.7", true},
 		// unknown label in default (release) area: splitVersion validate only areas.
 		{"unknown-1", "https://dl.k8s.io/release", "unknown-1", true},
 		// unknown area, not valid input.


### PR DESCRIPTION
Cherry pick of #63504 on release-1.8.

#63504: Improve where we load builds from for kubeadm upgrade jobs