### PR TITLE
use subtest for table units (pkg-scheduler-algorithm-priorities-util)

### DIFF
--- a/pkg/scheduler/algorithm/priorities/util/non_zero_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/non_zero_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGetNonzeroRequests(t *testing.T) {
-	tds := []struct {
+	tests := []struct {
 		name           string
 		requests       v1.ResourceList
 		expectedCPU    int64
@@ -65,9 +65,11 @@ func TestGetNonzeroRequests(t *testing.T) {
 		},
 	}
 
-	for _, td := range tds {
-		realCPU, realMemory := GetNonzeroRequests(&td.requests)
-		assert.EqualValuesf(t, td.expectedCPU, realCPU, "Failed to test: %s", td.name)
-		assert.EqualValuesf(t, td.expectedMemory, realMemory, "Failed to test: %s", td.name)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			realCPU, realMemory := GetNonzeroRequests(&test.requests)
+			assert.EqualValuesf(t, test.expectedCPU, realCPU, "Failed to test: %s", test.name)
+			assert.EqualValuesf(t, test.expectedMemory, realMemory, "Failed to test: %s", test.name)
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/util/topologies_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/topologies_test.go
@@ -59,8 +59,10 @@ func TestGetNamespacesFromPodAffinityTerm(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		realValue := GetNamespacesFromPodAffinityTerm(fakePod(), test.podAffinityTerm)
-		assert.EqualValuesf(t, test.expectedValue, realValue, "Failed to test: %s", test.name)
+		t.Run(test.name, func(t *testing.T) {
+			realValue := GetNamespacesFromPodAffinityTerm(fakePod(), test.podAffinityTerm)
+			assert.EqualValuesf(t, test.expectedValue, realValue, "Failed to test: %s", test.name)
+		})
 	}
 }
 
@@ -96,12 +98,14 @@ func TestPodMatchesTermsNamespaceAndSelector(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		fakeTestPod := fakePod()
-		fakeTestPod.Namespace = test.podNamespaces
-		fakeTestPod.Labels = test.podLabels
+		t.Run(test.name, func(t *testing.T) {
+			fakeTestPod := fakePod()
+			fakeTestPod.Namespace = test.podNamespaces
+			fakeTestPod.Labels = test.podLabels
 
-		realValue := PodMatchesTermsNamespaceAndSelector(fakeTestPod, fakeNamespaces, fakeSelector)
-		assert.EqualValuesf(t, test.expectedResult, realValue, "Faild to test: %s", test.name)
+			realValue := PodMatchesTermsNamespaceAndSelector(fakeTestPod, fakeNamespaces, fakeSelector)
+			assert.EqualValuesf(t, test.expectedResult, realValue, "Faild to test: %s", test.name)
+		})
 	}
 
 }
@@ -248,7 +252,9 @@ func TestNodesHaveSameTopologyKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := NodesHaveSameTopologyKey(test.nodeA, test.nodeB, test.topologyKey)
-		assert.Equalf(t, test.expected, got, "Failed to test: %s", test.name)
+		t.Run(test.name, func(t *testing.T) {
+			got := NodesHaveSameTopologyKey(test.nodeA, test.nodeB, test.topologyKey)
+			assert.Equalf(t, test.expected, got, "Failed to test: %s", test.name)
+		})
 	}
 }

--- a/pkg/scheduler/algorithm/priorities/util/util_test.go
+++ b/pkg/scheduler/algorithm/priorities/util/util_test.go
@@ -109,11 +109,13 @@ func TestGetControllerRef(t *testing.T) {
 	}
 
 	for _, td := range tds {
-		realOR := GetControllerRef(&td.pod)
-		if td.expectedNil {
-			assert.Nilf(t, realOR, "Failed to test: %s", td.name)
-		} else {
-			assert.Equalf(t, &td.expectedOR, realOR, "Failed to test: %s", td.name)
-		}
+		t.Run(td.name, func(t *testing.T) {
+			realOR := GetControllerRef(&td.pod)
+			if td.expectedNil {
+				assert.Nilf(t, realOR, "Failed to test: %s", td.name)
+			} else {
+				assert.Equalf(t, &td.expectedOR, realOR, "Failed to test: %s", td.name)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**: Update scheduler's unit table tests to use subtest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
breaks up PR: https://github.com/kubernetes/kubernetes/pull/63281
/ref #63267

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR will leverage subtests on the existing table tests for the scheduler units.
Some refactoring of error/status messages and functions to align with new approach.

```
