### PR TITLE
use subtest for table units (pkg/scheduler/algorithmprovider/defuaults)

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package defaults
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -43,11 +44,13 @@ func TestCopyAndReplace(t *testing.T) {
 			expected:    sets.String{"A": sets.Empty{}, "B": sets.Empty{}},
 		},
 	}
-	for _, testCase := range testCases {
-		result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
-		if !result.Equal(testCase.expected) {
-			t.Errorf("expected %v got %v", testCase.expected, result)
-		}
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v/replace %v with %v", i, testCase.replaceWhat, testCase.replaceWith), func(t *testing.T) {
+			result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
+			if !result.Equal(testCase.expected) {
+				t.Errorf("expected %v got %v", testCase.expected, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**: Update scheduler's unit table tests to use subtest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
breaks up PR: https://github.com/kubernetes/kubernetes/pull/63281
/ref #63267

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR will leverage subtests on the existing table tests for the scheduler units.
Some refactoring of error/status messages and functions to align with new approach.

```
