### PR TITLE
sample-apiserver admission wait for informer sync before serving

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
@@ -53,6 +53,10 @@ func (d *DisallowFlunder) Admit(a admission.Attributes) error {
 		return nil
 	}
 
+	if !d.WaitForReady() {
+		return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+	}
+
 	metaAccessor, err := meta.Accessor(a.GetObject())
 	if err != nil {
 		return err
@@ -82,6 +86,7 @@ func (d *DisallowFlunder) Admit(a admission.Attributes) error {
 // The lister knows how to lists Fischers.
 func (d *DisallowFlunder) SetInternalWardleInformerFactory(f informers.SharedInformerFactory) {
 	d.lister = f.Wardle().InternalVersion().Fischers().Lister()
+	d.SetReadyFunc(f.Wardle().InternalVersion().Fischers().Informer().HasSynced)
 }
 
 // ValidaValidateInitializationte checks whether the plugin was correctly initialized.

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -137,6 +137,7 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 
 	server.GenericAPIServer.AddPostStartHook("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
 		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+		o.SharedInformerFactory.Start(context.StopCh)
 		return nil
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

sample-apiserver admission wait for informer sync before serving

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
