### PR TITLE
Report parsing error in json serializer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/json-iterator/go:go_default_library",
+        "//vendor/github.com/modern-go/reflect2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/recognizer:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -68,43 +69,60 @@ type Serializer struct {
 var _ runtime.Serializer = &Serializer{}
 var _ recognizer.RecognizingDecoder = &Serializer{}
 
-func init() {
-	// Force jsoniter to decode number to interface{} via ints, if possible.
-	decodeNumberAsInt64IfPossible := func(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		switch iter.WhatIsNext() {
-		case jsoniter.NumberValue:
-			var number json.Number
-			iter.ReadVal(&number)
-			i64, err := strconv.ParseInt(string(number), 10, 64)
-			if err == nil {
-				*(*interface{})(ptr) = i64
-				return
-			}
-			f64, err := strconv.ParseFloat(string(number), 64)
-			if err == nil {
-				*(*interface{})(ptr) = f64
-				return
-			}
-			// Not much we can do here.
-		default:
-			*(*interface{})(ptr) = iter.Read()
-		}
+type customNumberExtension struct {
+	jsoniter.DummyExtension
+}
+
+func (cne *customNumberExtension) CreateDecoder(typ reflect2.Type) jsoniter.ValDecoder {
+	if typ.String() == "interface {}" {
+		return customNumberDecoder{}
 	}
-	jsoniter.RegisterTypeDecoderFunc("interface {}", decodeNumberAsInt64IfPossible)
+	return nil
+}
+
+type customNumberDecoder struct {
+}
+
+func (customNumberDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		var number jsoniter.Number
+		iter.ReadVal(&number)
+		i64, err := strconv.ParseInt(string(number), 10, 64)
+		if err == nil {
+			*(*interface{})(ptr) = i64
+			return
+		}
+		f64, err := strconv.ParseFloat(string(number), 64)
+		if err == nil {
+			*(*interface{})(ptr) = f64
+			return
+		}
+		iter.ReportError("DecodeNumber", err.Error())
+	default:
+		*(*interface{})(ptr) = iter.Read()
+	}
 }
 
 // CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
 // case-sensitive when unmarshalling, and otherwise compatible with
 // the encoding/json standard library.
 func CaseSensitiveJsonIterator() jsoniter.API {
-	return jsoniter.Config{
+	config := jsoniter.Config{
 		EscapeHTML:             true,
 		SortMapKeys:            true,
 		ValidateJsonRawMessage: true,
 		CaseSensitive:          true,
 	}.Froze()
+	// Force jsoniter to decode number to interface{} via int64/float64, if possible.
+	config.RegisterExtension(&customNumberExtension{})
+	return config
 }
 
+// Private copy of jsoniter to try to shield against possible mutations
+// from outside. Still does not protect from package level jsoniter.Register*() functions - someone calling them
+// in some other library will mess with every usage of the jsoniter library in the whole program.
+// See https://github.com/json-iterator/go/issues/265
 var caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
 
 // gvkWithDefaults returns group kind and version defaulting from provided default


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes missing error reporting in json parsing using the json-iterator library. Also introduces a private copy of the library config to partially shield from external mutations. https://github.com/json-iterator/go/issues/265. 

**Special notes for your reviewer**:
Found while working on refactoring in https://github.com/kubernetes/kubernetes/pull/63284.

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery
/cc wojtek-t liggitt