### PR TITLE
Bump down to cos-stable-65 in config-test

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -76,7 +76,7 @@ ALLOWED_NOTREADY_NODES="${ALLOWED_NOTREADY_NODES:-$((NUM_NODES / 100))}"
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=${CVM_VERSION:-container-vm-v20170627}
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-beta-66-10452-28-0}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-stable-65-10323-64-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}


### PR DESCRIPTION
Until https://github.com/kubernetes/kubernetes/issues/62456 is fixed (and we have a good patched version of cos-66), we probably should not be using the current version for testing which we anyway know we wouldn't be using for prod due to the bug.

/cc @yujuhong @filbranden @wojtek-t 
Wdyt?

```release-note
NONE
```