### PR TITLE
Remove ExtraArgs kubeadm preflight check

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -49,9 +49,6 @@ go_library(
     }),
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/preflight",
     deps = [
-        "//cmd/kube-apiserver/app/options:go_default_library",
-        "//cmd/kube-controller-manager/app/options:go_default_library",
-        "//cmd/kube-scheduler/app:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
@@ -65,7 +62,6 @@ go_library(
         "//vendor/github.com/PuerkitoBio/purell:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -288,17 +288,6 @@ func TestRunChecks(t *testing.T) {
 		{[]Checker{FileContentCheck{Path: "/", Content: []byte("does not exist")}}, false, ""},
 		{[]Checker{InPathCheck{executable: "foobarbaz", exec: exec.New()}}, true, "\t[WARNING FileExisting-foobarbaz]: foobarbaz not found in system path\n"},
 		{[]Checker{InPathCheck{executable: "foobarbaz", mandatory: true, exec: exec.New()}}, false, ""},
-		{[]Checker{ExtraArgsCheck{
-			APIServerExtraArgs:         map[string]string{"secure-port": "1234"},
-			ControllerManagerExtraArgs: map[string]string{"use-service-account-credentials": "true"},
-			SchedulerExtraArgs:         map[string]string{"leader-elect": "true"},
-		}}, true, ""},
-		{[]Checker{ExtraArgsCheck{
-			APIServerExtraArgs: map[string]string{"secure-port": "foo"},
-		}}, true, "\t[WARNING ExtraArgs]: kube-apiserver: failed to parse extra argument --secure-port=foo\n"},
-		{[]Checker{ExtraArgsCheck{
-			APIServerExtraArgs: map[string]string{"invalid-argument": "foo"},
-		}}, true, "\t[WARNING ExtraArgs]: kube-apiserver: failed to parse extra argument --invalid-argument=foo\n"},
 		{[]Checker{InPathCheck{executable: "foobar", mandatory: false, exec: exec.New(), suggestion: "install foobar"}}, true, "\t[WARNING FileExisting-foobar]: foobar not found in system path\nSuggestion: install foobar\n"},
 	}
 	for _, rt := range tokenTest {


### PR DESCRIPTION
This check pulled in a number of dependencies that bloated the dep graph.

The feature itself was not worth an extra 500 dependencies so we decided
to remove the feature.

Closes kubernetes/kubeadm#497

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This PR removes a check that was pulling in a lot of external dependencies. We decided the check was not worth the extra dependencies.

**Special notes for your reviewer**:
We might want to keep the first part of the check and only delete the second part, but it was easier to delete the whole thing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes a preflight check for kubeadm that validated custom kube-apiserver, kube-controller-manager and kube-scheduler arguments.
```
