### PR TITLE
Fix Deployment e2e on master upgrade (62703)

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -274,10 +274,6 @@ func testRollingUpdateDeployment(f *framework.Framework) {
 	_, allOldRSs, err := deploymentutil.GetOldReplicaSets(deployment, c.ExtensionsV1beta1())
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(allOldRSs)).Should(Equal(1))
-	// The old RS should contain pod-template-hash in its selector, label, and template label
-	Expect(len(allOldRSs[0].Labels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
-	Expect(len(allOldRSs[0].Spec.Selector.MatchLabels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
-	Expect(len(allOldRSs[0].Spec.Template.Labels[extensions.DefaultDeploymentUniqueLabelKey])).Should(BeNumerically(">", 0))
 }
 
 func testRecreateDeployment(f *framework.Framework) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Selector and label mutation for RSs created by Deploys has been deprecated, but the e2e in this version still checks for it. We need to remove these checks in order for master upgrade validation to pass.

Fixes #62703

```release-note
NONE
```
