### PR TITLE
Reuse existing CA cert path for kubelet certs

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1592,8 +1592,8 @@ function start-kube-apiserver {
   if [[ "${ENABLE_APISERVER_LOGS_HANDLER:-}" == "false" ]]; then
     params+=" --enable-logs-handler=false"
   fi
-  if [[ -n "${APISERVER_KUBELET_CA:-}" ]]; then
-    params+=" --kubelet-certificate-authority=${APISERVER_KUBELET_CA}"
+  if [[ "${APISERVER_SET_KUBELET_CA:-false}" == "true" ]]; then
+    params+=" --kubelet-certificate-authority=${CA_CERT_BUNDLE_PATH}"
   fi
 
   local admission_controller_config_mount=""


### PR DESCRIPTION
**What this PR does / why we need it**: configure-helper.sh already knows the path to CA cert, re-use that to avoid typos.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
