### PR TITLE
Only override objects from informer when version has increased.

### DIFF
--- a/test/integration/scheduler/volume_binding_test.go
+++ b/test/integration/scheduler/volume_binding_test.go
@@ -241,8 +241,6 @@ func TestVolumeBinding(t *testing.T) {
 			validatePVPhase(t, config.client, pv.name, v1.VolumeAvailable)
 		}
 
-		// TODO: validate events on Pods and PVCs
-
 		// Force delete objects, but they still may not be immediately removed
 		deleteTestObjects(config.client, config.ns, deleteOption)
 	}
@@ -288,7 +286,9 @@ func TestVolumeBindingStress(t *testing.T) {
 
 	// Validate Pods scheduled
 	for _, pod := range pods {
-		if err := waitForPodToSchedule(config.client, pod); err != nil {
+		// Use increased timeout for stress test because there is a higher chance of
+		// PV sync error
+		if err := waitForPodToScheduleWithTimeout(config.client, pod, 60*time.Second); err != nil {
 			t.Errorf("Failed to schedule Pod %q: %v", pod.Name, err)
 		}
 	}
@@ -300,8 +300,6 @@ func TestVolumeBindingStress(t *testing.T) {
 	for _, pv := range pvs {
 		validatePVPhase(t, config.client, pv.Name, v1.VolumeBound)
 	}
-
-	// TODO: validate events on Pods and PVCs
 }
 
 func TestPVAffinityConflict(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We don't want an informer resync to override assumed volumes if the version has not increased.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63467

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
