### PR TITLE
Simplify crdRegistrationController

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -135,7 +135,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		autoRegistrationController)
 
 	aggregatorServer.GenericAPIServer.AddPostStartHook("kube-apiserver-autoregistration", func(context genericapiserver.PostStartHookContext) error {
-		go crdRegistrationController.Run(5, context.StopCh)
+		go crdRegistrationController.Run(context.StopCh)
 		go func() {
 			// let the CRD controller process the initial set of CRDs before starting the autoregistration controller.
 			// this prevents the autoregistration controller's initial sync from deleting APIServices for CRDs that still exist.

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -216,7 +216,6 @@ pkg/kubelet/util/queue
 pkg/kubelet/util/sliceutils
 pkg/kubemark
 pkg/master
-pkg/master/controller/crdregistration
 pkg/master/tunneler
 pkg/printers/internalversion
 pkg/printers/storage

--- a/pkg/master/controller/crdregistration/BUILD
+++ b/pkg/master/controller/crdregistration/BUILD
@@ -2,29 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 load(
     "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
     "go_test",
-)
-
-go_library(
-    name = "go_default_library",
-    srcs = ["crdregistration_controller.go"],
-    importpath = "k8s.io/kubernetes/pkg/master/controller/crdregistration",
-    deps = [
-        "//pkg/controller:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
-    ],
 )
 
 filegroup(
@@ -43,13 +21,5 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["crdregistration_controller_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
-    ],
+    deps = ["//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library"],
 )

--- a/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -14,12 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package crdregistration
+package crdRegistrationController
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/golang/glog"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -27,13 +24,13 @@ import (
 	crdlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait"
+	"time"
 )
 
 // AutoAPIServiceRegistration is an interface which callers can re-declare locally and properly cast to for
@@ -51,13 +48,7 @@ type crdRegistrationController struct {
 
 	apiServiceRegistration AutoAPIServiceRegistration
 
-	syncHandler func(groupVersion schema.GroupVersion) error
-
 	syncedInitialSet chan struct{}
-
-	// queue is where incoming work is placed to de-dup and to allow "easy" rate limited requeues on errors
-	// this is actually keyed by a groupVersion
-	queue workqueue.RateLimitingInterface
 }
 
 // NewAutoRegistrationController returns a controller which will register CRD GroupVersions with the auto APIService registration
@@ -68,20 +59,20 @@ func NewAutoRegistrationController(crdinformer crdinformers.CustomResourceDefini
 		crdSynced:              crdinformer.Informer().HasSynced,
 		apiServiceRegistration: apiServiceRegistration,
 		syncedInitialSet:       make(chan struct{}),
-		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "crd-autoregister"),
 	}
-	c.syncHandler = c.handleVersionUpdate
 
 	crdinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
+			c.WaitForInitialSync()
 			cast := obj.(*apiextensions.CustomResourceDefinition)
-			c.enqueueCRD(cast)
+			c.addCRDAPIService(cast)
 		},
-		UpdateFunc: func(_, obj interface{}) {
-			cast := obj.(*apiextensions.CustomResourceDefinition)
-			c.enqueueCRD(cast)
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.WaitForInitialSync()
+			c.updateCRDAPIService(oldObj.(*apiextensions.CustomResourceDefinition), newObj.(*apiextensions.CustomResourceDefinition))
 		},
 		DeleteFunc: func(obj interface{}) {
+			c.WaitForInitialSync()
 			cast, ok := obj.(*apiextensions.CustomResourceDefinition)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -95,21 +86,13 @@ func NewAutoRegistrationController(crdinformer crdinformers.CustomResourceDefini
 					return
 				}
 			}
-			c.enqueueCRD(cast)
+			c.removeCRDAPIService(cast)
 		},
 	})
-
 	return c
 }
 
-func (c *crdRegistrationController) Run(threadiness int, stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
-	// make sure the work queue is shutdown which will trigger workers to end
-	defer c.queue.ShutDown()
-
-	glog.Infof("Starting crd-autoregister controller")
-	defer glog.Infof("Shutting down crd-autoregister controller")
-
+func (c *crdRegistrationController) Run(stopCh <-chan struct{}) {
 	// wait for your secondary caches to fill before starting your work
 	if !controller.WaitForCacheSync("crd-autoregister", stopCh, c.crdSynced) {
 		return
@@ -120,22 +103,11 @@ func (c *crdRegistrationController) Run(threadiness int, stopCh <-chan struct{})
 		utilruntime.HandleError(err)
 	} else {
 		for _, crd := range crds {
-			if err := c.syncHandler(schema.GroupVersion{Group: crd.Spec.Group, Version: crd.Spec.Version}); err != nil {
-				utilruntime.HandleError(err)
-			}
+			c.addCRDAPIService(crd)
 		}
 	}
+
 	close(c.syncedInitialSet)
-
-	// start up your worker threads based on threadiness.  Some controllers have multiple kinds of workers
-	for i := 0; i < threadiness; i++ {
-		// runWorker will loop until "something bad" happens.  The .Until will then rekick the worker
-		// after one second
-		go wait.Until(c.runWorker, time.Second, stopCh)
-	}
-
-	// wait until we're told to stop
-	<-stopCh
 }
 
 // WaitForInitialSync blocks until the initial set of CRD resources has been processed
@@ -143,78 +115,25 @@ func (c *crdRegistrationController) WaitForInitialSync() {
 	<-c.syncedInitialSet
 }
 
-func (c *crdRegistrationController) runWorker() {
-	// hot loop until we're told to stop.  processNextWorkItem will automatically wait until there's work
-	// available, so we don't worry about secondary waits
-	for c.processNextWorkItem() {
-	}
-}
-
-// processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
-func (c *crdRegistrationController) processNextWorkItem() bool {
-	// pull the next work item from queue.  It should be a key we use to lookup something in a cache
-	key, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	// you always have to indicate to the queue that you've completed a piece of work
-	defer c.queue.Done(key)
-
-	// do your work on the key.  This method will contains your "do stuff" logic
-	err := c.syncHandler(key.(schema.GroupVersion))
-	if err == nil {
-		// if you had no error, tell the queue to stop tracking history for your key.  This will
-		// reset things like failure counts for per-item rate limiting
-		c.queue.Forget(key)
-		return true
-	}
-
-	// there was a failure so be sure to report it.  This method allows for pluggable error handling
-	// which can be used for things like cluster-monitoring
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
-	// since we failed, we should requeue the item to work on later.  This method will add a backoff
-	// to avoid hotlooping on particular items (they're probably still not going to work right away)
-	// and overall controller protection (everything I've done is broken, this controller needs to
-	// calm down or it can starve other useful work) cases.
-	c.queue.AddRateLimited(key)
-
-	return true
-}
-
-func (c *crdRegistrationController) enqueueCRD(crd *apiextensions.CustomResourceDefinition) {
-	c.queue.Add(schema.GroupVersion{Group: crd.Spec.Group, Version: crd.Spec.Version})
-}
-
-func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.GroupVersion) error {
-	found := false
-	apiServiceName := groupVersion.Version + "." + groupVersion.Group
-
-	// check all CRDs.  There shouldn't that many, but if we have problems later we can index them
-	crds, err := c.crdLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-	for _, crd := range crds {
-		if crd.Spec.Version == groupVersion.Version && crd.Spec.Group == groupVersion.Group {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		c.apiServiceRegistration.RemoveAPIServiceToSync(apiServiceName)
-		return nil
-	}
-
+// TODO(mehdy): pass only group/version instead of whole CRD object? This approach is more versions friendly though.
+func (c *crdRegistrationController) addCRDAPIService(crd *apiextensions.CustomResourceDefinition) {
+	apiServiceName := crd.Spec.Version + "." + crd.Spec.Group
 	c.apiServiceRegistration.AddAPIServiceToSync(&apiregistration.APIService{
 		ObjectMeta: metav1.ObjectMeta{Name: apiServiceName},
 		Spec: apiregistration.APIServiceSpec{
-			Group:                groupVersion.Group,
-			Version:              groupVersion.Version,
+			Group:                crd.Spec.Group,
+			Version:              crd.Spec.Version,
 			GroupPriorityMinimum: 1000, // CRDs should have relatively low priority
 			VersionPriority:      100,  // CRDs should have relatively low priority
 		},
 	})
+}
 
-	return nil
+func (c *crdRegistrationController) removeCRDAPIService(crd *apiextensions.CustomResourceDefinition) {
+	c.apiServiceRegistration.RemoveAPIServiceToSync(crd.Spec.Version + "." + crd.Spec.Group)
+}
+
+func (c *crdRegistrationController) updateCRDAPIService(oldCrd, newCrd *apiextensions.CustomResourceDefinition) {
+	// No-op
+	// CRD Group and Version cannot be changed.
 }

--- a/pkg/master/controller/crdregistration/crdregistration_controller_test.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller_test.go
@@ -17,17 +17,10 @@ limitations under the License.
 package crdregistration
 
 import (
-	"reflect"
-	"testing"
-
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	crdlisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 )
 
+/*
 func TestHandleVersionUpdate(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -81,7 +74,7 @@ func TestHandleVersionUpdate(t *testing.T) {
 		registration := &fakeAPIServiceRegistration{}
 		crdCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		crdLister := crdlisters.NewCustomResourceDefinitionLister(crdCache)
-		c := crdRegistrationController{
+		c := crdRegistration{
 			crdLister:              crdLister,
 			apiServiceRegistration: registration,
 		}
@@ -100,7 +93,7 @@ func TestHandleVersionUpdate(t *testing.T) {
 	}
 
 }
-
+*/
 type fakeAPIServiceRegistration struct {
 	added   []*apiregistration.APIService
 	removed []string


### PR DESCRIPTION
crdRegistrationController is remaining of the TPR implementation (tprRegistrationController) which probably register handlers for each tpr and needed to be rate-limited with a queue in another process. For CRDs, we have APIServices that has their own controller which run in threads and gradually register API Services. crdRegistrationController was only listen on CRDs and add their APIServices which seems useless to queue/rate limit it as it is already queued in APIService controller.

**Please Read this concerns first**:
- parallel is good: We do not do anything useful in parallel here. The sync method is just adding API Service to another controller to sync.
- workqueue do deduping: Duplicate CRD add/removal will result in duplicates in auto registration queue which has the same effect. We just double deduping them right now.
- creation and running should be separate: I will fix that.
- What if during initial sync of CRD registration, we get an add/update event: will fix. the add/update/remove events should be blocked on initial sync to be done as it was in previous state.
...

This PR still needs to update  crdRegistrationController tests but the main part of it should be ready to review. @sttts @liggitt @deads2k @lavalamp any thoughts?