### PR TITLE
fix typo in apiextentions apiserver

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -51,7 +51,7 @@ func NewCustomResourceDefinitionsServerOptions(out, errOut io.Writer) *CustomRes
 		StdErr: errOut,
 	}
 
-	// the shared informer is not needed for kube-aggregator. Disable the kubeconfig flag and the client creation.
+	// the shared informer is not needed for apiextentions apiserver. Disable the kubeconfig flag and the client creation.
 	o.RecommendedOptions.CoreAPI = nil
 
 	return o


### PR DESCRIPTION
the comment should be apiextentions apiserver

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
