### PR TITLE
use subtest for table units (pkg/scheduler/schedulercache)

### DIFF
--- a/pkg/scheduler/schedulercache/node_info_test.go
+++ b/pkg/scheduler/schedulercache/node_info_test.go
@@ -32,12 +32,15 @@ func TestNewResource(t *testing.T) {
 	tests := []struct {
 		resourceList v1.ResourceList
 		expected     *Resource
+		name         string
 	}{
 		{
+			name:         "empty resource set",
 			resourceList: map[v1.ResourceName]resource.Quantity{},
 			expected:     &Resource{},
 		},
 		{
+			name: "has resources set",
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:                      *resource.NewScaledQuantity(4, -3),
 				v1.ResourceMemory:                   *resource.NewQuantity(2000, resource.BinarySI),
@@ -57,10 +60,12 @@ func TestNewResource(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := NewResource(test.resourceList)
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			r := NewResource(test.resourceList)
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
@@ -68,8 +73,10 @@ func TestResourceList(t *testing.T) {
 	tests := []struct {
 		resource *Resource
 		expected v1.ResourceList
+		name     string
 	}{
 		{
+			name:     "empty resource list",
 			resource: &Resource{},
 			expected: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
@@ -79,6 +86,7 @@ func TestResourceList(t *testing.T) {
 			},
 		},
 		{
+			name: "has resource list set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -98,10 +106,12 @@ func TestResourceList(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		rl := test.resource.ResourceList()
-		if !reflect.DeepEqual(test.expected, rl) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, rl)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			rl := test.resource.ResourceList()
+			if !reflect.DeepEqual(test.expected, rl) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, rl)
+			}
+		})
 	}
 }
 
@@ -109,12 +119,15 @@ func TestResourceClone(t *testing.T) {
 	tests := []struct {
 		resource *Resource
 		expected *Resource
+		name     string
 	}{
 		{
+			name:     "no resource to clone",
 			resource: &Resource{},
 			expected: &Resource{},
 		},
 		{
+			name: "has resource to clone",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -133,12 +146,14 @@ func TestResourceClone(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := test.resource.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.resource.MilliCPU += 1000
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			r := test.resource.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.resource.MilliCPU += 1000
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
@@ -148,8 +163,10 @@ func TestResourceAddScalar(t *testing.T) {
 		scalarName     v1.ResourceName
 		scalarQuantity int64
 		expected       *Resource
+		name           string
 	}{
 		{
+			name:           "add scalar value to empty set",
 			resource:       &Resource{},
 			scalarName:     "scalar1",
 			scalarQuantity: 100,
@@ -158,6 +175,7 @@ func TestResourceAddScalar(t *testing.T) {
 			},
 		},
 		{
+			name: "add scalar value to existing set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -178,10 +196,12 @@ func TestResourceAddScalar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.resource.AddScalar(test.scalarName, test.scalarQuantity)
-		if !reflect.DeepEqual(test.expected, test.resource) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
+			if !reflect.DeepEqual(test.expected, test.resource) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			}
+		})
 	}
 }
 
@@ -530,13 +550,15 @@ func TestNodeInfoClone(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		ni := test.nodeInfo.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.nodeInfo.generation += 10
-		if !reflect.DeepEqual(test.expected, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			ni := test.nodeInfo.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.nodeInfo.generation += 10
+			if !reflect.DeepEqual(test.expected, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, ni)
+			}
+		})
 	}
 }
 
@@ -896,30 +918,30 @@ func TestNodeInfoRemovePod(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		ni := fakeNodeInfo(pods...)
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v/%v", i, test.pod.ObjectMeta.Name), func(t *testing.T) {
+			ni := fakeNodeInfo(pods...)
 
-		gen := ni.generation
-		err := ni.RemovePod(test.pod)
-		if err != nil {
-			if test.errExpected {
-				expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.node.Name)
-				if expectedErrorMsg == err {
-					t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+			gen := ni.generation
+			err := ni.RemovePod(test.pod)
+			if err != nil {
+				if test.errExpected {
+					expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.node.Name)
+					if expectedErrorMsg == err {
+						t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+					}
 				}
 			} else {
-				t.Errorf("expected no error, got: %v", err)
+				if ni.generation <= gen {
+					t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+				}
 			}
-		} else {
-			if ni.generation <= gen {
-				t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
-			}
-		}
 
-		test.expectedNodeInfo.generation = ni.generation
-		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
-		}
+			test.expectedNodeInfo.generation = ni.generation
+			if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**: Update scheduler's unit table tests to use subtest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
breaks up PR: https://github.com/kubernetes/kubernetes/pull/63281
/ref #63267

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR will leverage subtests on the existing table tests for the scheduler units.
Some refactoring of error/status messages and functions to align with new approach.

```
