### PR TITLE
use subtest for table units (pkg/scheduler/util)

### DIFF
--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -203,7 +203,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 				hp.Remove(param.ip, param.protocol, param.port)
 			}
 			if hp.Len() != test.length {
-				t.Errorf("failed: expect length %d; got %d", test.length, hp.Len())
+				t.Errorf("expect length %d; got %d", test.length, hp.Len())
 				t.Error(hp)
 			}
 		})
@@ -306,7 +306,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 				hp.Add(param.ip, param.protocol, param.port)
 			}
 			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
-				t.Errorf("failed, expected %t; got %t", test.expect, !test.expect)
+				t.Errorf("expected %t; got %t", test.expect, !test.expect)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**: Update scheduler's unit table tests to use subtest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
breaks up PR: https://github.com/kubernetes/kubernetes/pull/63281
/ref #63267

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR will leverage subtests on the existing table tests for the scheduler units.
Some refactoring of error/status messages and functions to align with new approach.

```
