### PR TITLE
Revert "authz: nodes should not be able to delete themselves"

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -105,7 +105,7 @@ func NodeRules() []rbac.PolicyRule {
 		// Use the NodeRestriction admission plugin to limit a node to creating/updating its own API object.
 		rbac.NewRule("create", "get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 		rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
-		rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		rbac.NewRule("update", "patch", "delete").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
 		// TODO: restrict to the bound node as creator in the NodeRestrictions admission plugin
 		rbac.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1067,6 +1067,7 @@ items:
     resources:
     - nodes
     verbs:
+    - delete
     - patch
     - update
   - apiGroups:

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -419,8 +419,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, createNode2MirrorPodEviction(node2Client))
 	expectAllowed(t, createNode2(node2Client))
 	expectAllowed(t, updateNode2Status(node2Client))
-	// cleanup node
-	expectAllowed(t, deleteNode2(superuserClient))
+	expectAllowed(t, deleteNode2(node2Client))
 
 	// create a pod as an admin to add object references
 	expectAllowed(t, createNode2NormalPod(superuserClient))
@@ -510,10 +509,8 @@ func TestNodeAuthorizer(t *testing.T) {
 	expectAllowed(t, unsetNode2ConfigSource(superuserClient))
 	// node2 can no longer get the configmap after it is unassigned as its config source
 	expectForbidden(t, getConfigMapConfigSource(node2Client))
-	// node should not be able to delete itself
-	expectForbidden(t, deleteNode2(node2Client))
 	// clean up node2
-	expectAllowed(t, deleteNode2(superuserClient))
+	expectAllowed(t, deleteNode2(node2Client))
 
 	//TODO(mikedanese): integration test node restriction of TokenRequest
 }


### PR DESCRIPTION
This reverts commit 35de82094ac81713dd34c3f03d0e95d604731f61.

1.10 era kubelets still make use of this permission. we'll have to wait until 1.13 to remove it

xref https://github.com/kubernetes/kubernetes/issues/63505

```release-note
NONE
```