### PR TITLE
Add InstallPathHandler which allows for more then one path to be associated with health checking.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -42,6 +42,38 @@ func TestInstallHandler(t *testing.T) {
 	}
 }
 
+func TestInstallPathHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	InstallPathHandler(mux, "/healthz/test")
+	InstallPathHandler(mux, "/healthz/ready")
+	req, err := http.NewRequest("GET", "http://example.com/healthz/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("expected %v, got %v", "ok", w.Body.String())
+	}
+
+	req, err = http.NewRequest("GET", "http://example.com/healthz/ready", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("expected %v, got %v", "ok", w.Body.String())
+	}
+
+}
+
 func TestMulitipleChecks(t *testing.T) {
 	tests := []struct {
 		path             string


### PR DESCRIPTION
Currently it is only possible to have one group of checks which must all pass for the handler to report success.
Allowing multiple paths for these checks allows use of the same machinery for other kinds of checks, i.e. readiness.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
