### PR TITLE
Move uncordon to after the node is ready

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -342,16 +342,6 @@ function do-single-node-upgrade() {
     sleep 1
   done
 
-  # Uncordon the node.
-  echo "== Uncordon ${instance}. == " >&2
-  local uncordon_rc
-  "${KUBE_ROOT}/cluster/kubectl.sh" uncordon "${instance}" \
-    && uncordon_rc=$? || uncordon_rc=$?
-  if [[ "${uncordon_rc}" != 0 ]]; then
-    echo "== FAILED to uncordon ${instance} =="
-    return ${uncordon_rc}
-  fi
-  
   # Wait for the node to have Ready=True.
   echo "== Waiting for ${instance} to become ready. ==" >&2
   while true; do
@@ -364,6 +354,16 @@ function do-single-node-upgrade() {
     fi
     sleep 1
   done
+
+  # Uncordon the node.
+  echo "== Uncordon ${instance}. == " >&2
+  local uncordon_rc
+  "${KUBE_ROOT}/cluster/kubectl.sh" uncordon "${instance}" \
+    && uncordon_rc=$? || uncordon_rc=$?
+  if [[ "${uncordon_rc}" != 0 ]]; then
+    echo "== FAILED to uncordon ${instance} =="
+    return ${uncordon_rc}
+  fi
 }
 
 # Prereqs:


### PR DESCRIPTION
**What this PR does / why we need it**:
It is possible that the node API object doesn't exist in a brief
window between recreation and registering. By moving the uncordon
until after the node is ready, we can be sure the API object exists.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63506 #63499

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
