### PR TITLE
Implement apiserver max-requests-per-user-inflight option

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -112,6 +112,7 @@ func TestAddFlags(t *testing.T) {
 		"--proxy-client-key-file=/var/run/kubernetes/proxy.key",
 		"--request-timeout=2m",
 		"--storage-backend=etcd2",
+		"--max-requests-per-user-inflight=100",
 	}
 	f.Parse(args)
 
@@ -125,6 +126,7 @@ func TestAddFlags(t *testing.T) {
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
+			MaxRequestsPerUserInFlight:  100,
 			MaxRequestsInFlight:         400,
 			MaxMutatingRequestsInFlight: 200,
 			RequestTimeout:              time.Duration(2) * time.Minute,

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -47,6 +47,7 @@ func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.H
 	handler = genericapifilters.WithAuthentication(handler, insecureSuperuser{}, nil)
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc, c.RequestTimeout)
+	handler = genericfilters.WithMaxInFlightPerUserLimit(handler, c.MaxRequestsPerUserInFlight, c.LongRunningFunc)
 	handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.LongRunningFunc)
 	handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.HandlerChainWaitGroup)
 	handler = genericapifilters.WithRequestInfo(handler, server.NewRequestInfoResolver(c))

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -183,6 +183,88 @@ func WithMaxInFlightLimit(
 	})
 }
 
+// WithMaxInFlightPerUserLimit limits the number of in-flight requests to buffer size of the passed in channel.
+func WithMaxInFlightPerUserLimit(
+	handler http.Handler,
+	limit int,
+	longRunningRequestCheck apirequest.LongRunningRequestCheck,
+) http.Handler {
+	if limit == 0 {
+		return handler
+	}
+
+	userLimits := struct {
+		lock  sync.Mutex
+		chans map[string]chan bool
+	}{
+		chans: make(map[string]chan bool),
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+		if !ok {
+			handleError(w, r, fmt.Errorf("no RequestInfo found in context, handler chain must be wrong"))
+			return
+		}
+
+		// Skip tracking long running events.
+		if longRunningRequestCheck != nil && longRunningRequestCheck(r, requestInfo) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		var username string
+		if currUser, ok := apirequest.UserFrom(ctx); ok {
+			username = currUser.GetName()
+		}
+
+		var c chan bool
+		if limit != 0 {
+			userLimits.lock.Lock()
+			if c, ok = userLimits.chans[username]; !ok {
+				c = make(chan bool, limit)
+				userLimits.chans[username] = c
+			}
+			userLimits.lock.Unlock()
+		}
+		isMutatingRequest := !nonMutatingRequestVerbs.Has(requestInfo.Verb)
+
+		if c == nil {
+			handler.ServeHTTP(w, r)
+		} else {
+
+			select {
+			case c <- true:
+				defer func() {
+					<-c
+				}()
+				handler.ServeHTTP(w, r)
+
+			default:
+				// We need to split this data between buckets used for throttling.
+				if isMutatingRequest {
+					metrics.DroppedRequests.WithLabelValues(metrics.MutatingKind).Inc()
+				} else {
+					metrics.DroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
+				}
+				// at this point we're about to return a 429, BUT not all actors should be rate limited.  A system:master is so powerful
+				// that he should always get an answer.  It's a super-admin or a loopback connection.
+				if currUser, ok := apirequest.UserFrom(ctx); ok {
+					for _, group := range currUser.GetGroups() {
+						if group == user.SystemPrivilegedGroup {
+							handler.ServeHTTP(w, r)
+							return
+						}
+					}
+				}
+				metrics.Record(r, requestInfo, "", http.StatusTooManyRequests, 0, 0)
+				tooManyRequests(r, w)
+			}
+		}
+	})
+}
+
 func tooManyRequests(req *http.Request, w http.ResponseWriter) {
 	// Return a 429 status indicating "Too Many Requests"
 	w.Header().Set("Retry-After", retryAfter)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight_test.go
@@ -90,7 +90,7 @@ func withFakeUser(handler http.Handler) http.Handler {
 		userInfo := new(user.DefaultInfo)
 
 		if userName := r.URL.Query().Get("user"); userName != "" {
-			userInfo.Name = userName
+			userInfo.UID = userName
 		}
 
 		if len(r.Header["Groups"]) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement optional per-user simultaneously apiserver requests restriction. It allows avoid flooding apiserver with requests from buggy component.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement apiserver max-requests-per-user-inflight option
```

/sig api-machinery