### PR TITLE
Automated cherry pick of #63720: log error for os.NewComputeV2

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -43,6 +43,7 @@ func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 
 	compute, err := os.NewComputeV2()
 	if err != nil {
+		glog.Errorf("unable to access compute v2 API : %v", err)
 		return nil, false
 	}
 


### PR DESCRIPTION
Cherry pick of #63720 on release-1.10.

#63720: log error for os.NewComputeV2