### PR TITLE
Add kind and version to Kubeadm MasterConfiguration configmaps

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/BUILD
@@ -37,6 +37,7 @@ filegroup(
         ":package-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/fuzzer:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/install:all-srcs",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/validation:all-srcs",
     ],

--- a/cmd/kubeadm/app/apis/kubeadm/scheme/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["scheme.go"],
+    importpath = "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+)
+
+// Scheme is the runtime.Scheme to which all kubeadm api types are registered.
+var Scheme = runtime.NewScheme()
+
+// Codecs provides access to encoding and decoding for the scheme.
+var Codecs = serializer.NewCodecFactory(Scheme)
+
+func init() {
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	AddToScheme(Scheme)
+}
+
+// AddToScheme builds the Kubeadm scheme using all known versions of the kubeadm api.
+func AddToScheme(scheme *runtime.Scheme) {
+	v1alpha1.AddToScheme(scheme)
+}

--- a/cmd/kubeadm/app/phases/uploadconfig/BUILD
+++ b/cmd/kubeadm/app/phases/uploadconfig/BUILD
@@ -12,11 +12,12 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -17,15 +17,16 @@ limitations under the License.
 package uploadconfig
 
 import (
-	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
@@ -42,7 +43,7 @@ func UploadConfiguration(cfg *kubeadmapi.MasterConfiguration, client clientset.I
 	// Removes sensitive info from the data that will be stored in the config map
 	externalcfg.Token = ""
 
-	cfgYaml, err := yaml.Marshal(*externalcfg)
+	cfgYaml, err := util.MarshalToYamlForCodecs(externalcfg, kubeadmapiext.SchemeGroupVersion, scheme.Codecs)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -113,6 +113,14 @@ func TestUploadConfiguration(t *testing.T) {
 				if decodedCfg.Token != "" {
 					t.Errorf("Decoded value contains token (sensitive info), decoded = %#v, expected = empty", decodedCfg.Token)
 				}
+
+				if decodedExtCfg.Kind != "MasterConfiguration" {
+					t.Errorf("Expected kind MasterConfiguration, got %v", decodedExtCfg.Kind)
+				}
+
+				if decodedExtCfg.APIVersion != "kubeadm.k8s.io/v1alpha1" {
+					t.Errorf("Expected apiVersion kubeadm.k8s.io/v1alpha1, got %v", decodedExtCfg.APIVersion)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now Kubeadm serializes its configuration objects with just `yaml.Marshal`. By switching to `runtime.Encode`, we guarantee that version information will be added.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
First part of KEP0008

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
