### PR TITLE
Automated cherry pick of #63049: renable nodeipam in kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -326,9 +326,9 @@ func NewControllerInitializers(loopMode ControllerLoopMode) map[string]InitFunc 
 	controllers["ttl"] = startTTLController
 	controllers["bootstrapsigner"] = startBootstrapSignerController
 	controllers["tokencleaner"] = startTokenCleanerController
+	controllers["nodeipam"] = startNodeIpamController
 	if loopMode == IncludeCloudLoops {
 		controllers["service"] = startServiceController
-		controllers["nodeipam"] = startNodeIpamController
 		controllers["route"] = startRouteController
 		// TODO: volume controller into the IncludeCloudLoops only set.
 		// TODO: Separate cluster in cloud check from node lifecycle controller.

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -82,20 +82,23 @@ func startServiceController(ctx ControllerContext) (bool, error) {
 func startNodeIpamController(ctx ControllerContext) (bool, error) {
 	var clusterCIDR *net.IPNet = nil
 	var serviceCIDR *net.IPNet = nil
-	if ctx.ComponentConfig.AllocateNodeCIDRs {
-		var err error
-		if len(strings.TrimSpace(ctx.ComponentConfig.ClusterCIDR)) != 0 {
-			_, clusterCIDR, err = net.ParseCIDR(ctx.ComponentConfig.ClusterCIDR)
-			if err != nil {
-				glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", ctx.ComponentConfig.ClusterCIDR, err)
-			}
-		}
 
-		if len(strings.TrimSpace(ctx.ComponentConfig.ServiceCIDR)) != 0 {
-			_, serviceCIDR, err = net.ParseCIDR(ctx.ComponentConfig.ServiceCIDR)
-			if err != nil {
-				glog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.ComponentConfig.ServiceCIDR, err)
-			}
+	if !ctx.ComponentConfig.AllocateNodeCIDRs {
+		return false, nil
+	}
+
+	var err error
+	if len(strings.TrimSpace(ctx.ComponentConfig.ClusterCIDR)) != 0 {
+		_, clusterCIDR, err = net.ParseCIDR(ctx.ComponentConfig.ClusterCIDR)
+		if err != nil {
+			glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", ctx.ComponentConfig.ClusterCIDR, err)
+		}
+	}
+
+	if len(strings.TrimSpace(ctx.ComponentConfig.ServiceCIDR)) != 0 {
+		_, serviceCIDR, err = net.ParseCIDR(ctx.ComponentConfig.ServiceCIDR)
+		if err != nil {
+			glog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.ComponentConfig.ServiceCIDR, err)
 		}
 	}
 
@@ -106,7 +109,6 @@ func startNodeIpamController(ctx ControllerContext) (bool, error) {
 		clusterCIDR,
 		serviceCIDR,
 		int(ctx.ComponentConfig.NodeCIDRMaskSize),
-		ctx.ComponentConfig.AllocateNodeCIDRs,
 		ipam.CIDRAllocatorType(ctx.ComponentConfig.CIDRAllocatorType),
 	)
 	if err != nil {

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -58,8 +58,7 @@ const (
 
 // Controller is the controller that manages node ipam state.
 type Controller struct {
-	allocateNodeCIDRs bool
-	allocatorType     ipam.CIDRAllocatorType
+	allocatorType ipam.CIDRAllocatorType
 
 	cloud       cloudprovider.Interface
 	clusterCIDR *net.IPNet
@@ -88,7 +87,6 @@ func NewNodeIpamController(
 	clusterCIDR *net.IPNet,
 	serviceCIDR *net.IPNet,
 	nodeCIDRMaskSize int,
-	allocateNodeCIDRs bool,
 	allocatorType ipam.CIDRAllocatorType) (*Controller, error) {
 
 	if kubeClient == nil {
@@ -108,54 +106,49 @@ func NewNodeIpamController(
 		metrics.RegisterMetricAndTrackRateLimiterUsage("node_ipam_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
 	}
 
-	if allocateNodeCIDRs {
-		if clusterCIDR == nil {
-			glog.Fatal("Controller: Must specify clusterCIDR if allocateNodeCIDRs == true.")
-		}
-		mask := clusterCIDR.Mask
-		if maskSize, _ := mask.Size(); maskSize > nodeCIDRMaskSize {
-			glog.Fatal("Controller: Invalid clusterCIDR, mask size of clusterCIDR must be less than nodeCIDRMaskSize.")
-		}
+	if clusterCIDR == nil {
+		glog.Fatal("Controller: Must specify --cluster-cidr if --allocate-node-cidrs is set")
+	}
+	mask := clusterCIDR.Mask
+	if maskSize, _ := mask.Size(); maskSize > nodeCIDRMaskSize {
+		glog.Fatal("Controller: Invalid --cluster-cidr, mask size of cluster CIDR must be less than --node-cidr-mask-size")
 	}
 
 	ic := &Controller{
-		cloud:             cloud,
-		kubeClient:        kubeClient,
-		lookupIP:          net.LookupIP,
-		clusterCIDR:       clusterCIDR,
-		serviceCIDR:       serviceCIDR,
-		allocateNodeCIDRs: allocateNodeCIDRs,
-		allocatorType:     allocatorType,
+		cloud:         cloud,
+		kubeClient:    kubeClient,
+		lookupIP:      net.LookupIP,
+		clusterCIDR:   clusterCIDR,
+		serviceCIDR:   serviceCIDR,
+		allocatorType: allocatorType,
 	}
 
 	// TODO: Abstract this check into a generic controller manager should run method.
-	if ic.allocateNodeCIDRs {
-		if ic.allocatorType == ipam.IPAMFromClusterAllocatorType || ic.allocatorType == ipam.IPAMFromCloudAllocatorType {
-			cfg := &ipam.Config{
-				Resync:       ipamResyncInterval,
-				MaxBackoff:   ipamMaxBackoff,
-				InitialRetry: ipamInitialBackoff,
-			}
-			switch ic.allocatorType {
-			case ipam.IPAMFromClusterAllocatorType:
-				cfg.Mode = nodesync.SyncFromCluster
-			case ipam.IPAMFromCloudAllocatorType:
-				cfg.Mode = nodesync.SyncFromCloud
-			}
-			ipamc, err := ipam.NewController(cfg, kubeClient, cloud, clusterCIDR, serviceCIDR, nodeCIDRMaskSize)
-			if err != nil {
-				glog.Fatalf("Error creating ipam controller: %v", err)
-			}
-			if err := ipamc.Start(nodeInformer); err != nil {
-				glog.Fatalf("Error trying to Init(): %v", err)
-			}
-		} else {
-			var err error
-			ic.cidrAllocator, err = ipam.New(
-				kubeClient, cloud, nodeInformer, ic.allocatorType, ic.clusterCIDR, ic.serviceCIDR, nodeCIDRMaskSize)
-			if err != nil {
-				return nil, err
-			}
+	if ic.allocatorType == ipam.IPAMFromClusterAllocatorType || ic.allocatorType == ipam.IPAMFromCloudAllocatorType {
+		cfg := &ipam.Config{
+			Resync:       ipamResyncInterval,
+			MaxBackoff:   ipamMaxBackoff,
+			InitialRetry: ipamInitialBackoff,
+		}
+		switch ic.allocatorType {
+		case ipam.IPAMFromClusterAllocatorType:
+			cfg.Mode = nodesync.SyncFromCluster
+		case ipam.IPAMFromCloudAllocatorType:
+			cfg.Mode = nodesync.SyncFromCloud
+		}
+		ipamc, err := ipam.NewController(cfg, kubeClient, cloud, clusterCIDR, serviceCIDR, nodeCIDRMaskSize)
+		if err != nil {
+			glog.Fatalf("Error creating ipam controller: %v", err)
+		}
+		if err := ipamc.Start(nodeInformer); err != nil {
+			glog.Fatalf("Error trying to Init(): %v", err)
+		}
+	} else {
+		var err error
+		ic.cidrAllocator, err = ipam.New(
+			kubeClient, cloud, nodeInformer, ic.allocatorType, ic.clusterCIDR, ic.serviceCIDR, nodeCIDRMaskSize)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -176,11 +169,8 @@ func (nc *Controller) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	// TODO: Abstract this check into a generic controller manager should run method.
-	if nc.allocateNodeCIDRs {
-		if nc.allocatorType != ipam.IPAMFromClusterAllocatorType && nc.allocatorType != ipam.IPAMFromCloudAllocatorType {
-			go nc.cidrAllocator.Run(stopCh)
-		}
+	if nc.allocatorType != ipam.IPAMFromClusterAllocatorType && nc.allocatorType != ipam.IPAMFromCloudAllocatorType {
+		go nc.cidrAllocator.Run(stopCh)
 	}
 
 	<-stopCh


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-enables nodeipam controller for external clouds. Also does a small refactor so that we don't need to pass in `allocateNodeCidr` into the controller. 

Cherry pick of https://github.com/kubernetes/kubernetes/pull/63049 which fixes a critical bug in v1.10 that blocks external clouds from running nodeipam controller. 

**Release note**:
```release-note
Re-enable nodeipam controller for external clouds. 
```
