### PR TITLE
remove decoder from name printing

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -40,7 +40,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/client-go/util/jsonpath:go_default_library",
     ],

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -390,10 +390,25 @@ func TestNamePrinter(t *testing.T) {
 				},
 				Items: []runtime.RawExtension{
 					{
-						Raw: []byte(`{"kind": "Pod", "apiVersion": "v1", "metadata": { "name": "foo"}}`),
+						Object: &v1.Pod{
+							TypeMeta: metav1.TypeMeta{
+								Kind: "Pod",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "foo",
+							},
+						},
 					},
 					{
-						Raw: []byte(`{"kind": "Pod", "apiVersion": "v1", "metadata": { "name": "bar"}}`),
+						Object: &unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name": "bar",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -574,8 +589,7 @@ func TestPrinters(t *testing.T) {
 		"template2": templatePrinter2,
 		"jsonpath":  jsonpathPrinter,
 		"name": &printers.NamePrinter{
-			Typer:    legacyscheme.Scheme,
-			Decoders: []runtime.Decoder{legacyscheme.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme},
+			Typer: legacyscheme.Scheme,
 		},
 	}
 	objects := map[string]runtime.Object{

--- a/pkg/printers/name.go
+++ b/pkg/printers/name.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // NamePrinter is an implementation of ResourcePrinter which outputs "resource/name" pair of an object.
@@ -39,8 +38,7 @@ type NamePrinter struct {
 	// finalized "successful" message.
 	Operation string
 
-	Decoders []runtime.Decoder
-	Typer    runtime.ObjectTyper
+	Typer runtime.ObjectTyper
 }
 
 // PrintObj is an implementation of ResourcePrinter.PrintObj which decodes the object
@@ -57,9 +55,6 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		items, err := meta.ExtractList(obj)
 		if err != nil {
 			return err
-		}
-		if errs := runtime.DecodeList(items, p.Decoders...); len(errs) > 0 {
-			return utilerrors.NewAggregate(errs)
 		}
 		for _, obj := range items {
 			if err := p.PrintObj(obj, w); err != nil {

--- a/pkg/printers/name_flags.go
+++ b/pkg/printers/name_flags.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -50,11 +49,9 @@ func (f *NamePrintFlags) Complete(successTemplate string) error {
 // Returns false if the specified outputFormat does not match a supported format.
 // Supported format types can be found in pkg/printers/printers.go
 func (f *NamePrintFlags) ToPrinter(outputFormat string) (ResourcePrinter, error) {
-	decoders := []runtime.Decoder{scheme.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme}
 	namePrinter := &NamePrinter{
 		Operation: f.Operation,
 		Typer:     scheme.Scheme,
-		Decoders:  decoders,
 	}
 
 	outputFormat = strings.ToLower(outputFormat)


### PR DESCRIPTION
The extra decoding step inside of name printing isn't useful.  It's only current utility is when the content inside of the list is a runtime.Unknown.  However, when you're making use of this printer in a CLI, you've read the content in via a builder or a scheme directly.  You would logically set this decoder based on that same scheme.  If you were unable to decode using the scheme before, you'll simple be unable to do it again here.

Near as I can tell, this would only be useful if objects weren't decoded before printing.  There is a unit test that ensures this remains.  I'd like to see if any practical tests (cmd, e2e) rely on it.

@smarterclayton @liggitt not many people would have written it to begin with.  One of you?

@kubernetes/sig-cli-maintainers 

```release-note
NONE
```