### PR TITLE
register client-go auth plugins for e2e

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -69,6 +69,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
     ],
 )
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -43,6 +43,9 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
 	"k8s.io/kubernetes/test/e2e/manifest"
 	testutils "k8s.io/kubernetes/test/utils"
+
+	// ensure auth plugins are loaded
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (


### PR DESCRIPTION
e2e depends on use of the gcp client-go auth provider, but did not explicitly register the auth provider. it indirectly imported the plugins via a roundabout chain (see https://github.com/kubernetes/kubernetes/issues/63731#issuecomment-388529120) which broke when those imports were trimmed in https://github.com/kubernetes/kubernetes/pull/63673

if e2e requires these auth plugins, it should include them explicitly in the top-level test package

fixes #63731

```release-note
NONE
```