### PR TITLE
Respect KUBE_BUILD_PLATFORMS in build container

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -596,6 +596,7 @@ function kube::build::run_build_command_ex() {
 
   docker_run_opts+=(
     --env "KUBE_FASTBUILD=${KUBE_FASTBUILD:-false}"
+    --env "KUBE_BUILD_PLATFORMS=${KUBE_BUILD_PLATFORMS:-}"
     --env "KUBE_BUILDER_OS=${OSTYPE:-notdetected}"
     --env "KUBE_VERBOSE=${KUBE_VERBOSE}"
     --env "GOFLAGS=${GOFLAGS:-}"


### PR DESCRIPTION

**What this PR does / why we need it**:

Environment variable `KUBE_BUILD_PLATFORMS` is used for custom arch builds with local golang. 
Build in docker container should respect this var too, would make cross-platform builds easier.

Example:
`KUBE_BUILD_PLATFORMS=darwin/amd64 build/run.sh make kubectl`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
