### PR TITLE
Let the kubernetes service reconciler timeout on shutdown

### DIFF
--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -150,7 +150,22 @@ func (c *Controller) Stop() {
 		c.runner.Stop()
 	}
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https", c.ExtraEndpointPorts)
-	c.EndpointReconciler.StopReconciling("kubernetes", c.PublicIP, endpointPorts)
+	finishedReconciling := make(chan struct{})
+	go func() {
+		defer close(finishedReconciling)
+		glog.Infof("Shutting down kubernetes service endpoint reconciler")
+		if err := c.EndpointReconciler.StopReconciling("kubernetes", c.PublicIP, endpointPorts); err != nil {
+			glog.Error(err)
+		}
+	}()
+
+	select {
+	case <-finishedReconciling:
+		// done
+	case <-time.After(2 * c.EndpointInterval):
+		// don't block server shutdown forever if we can't reach etcd to remove ourselves
+		glog.Warning("StopReconciling() timed out")
+	}
 }
 
 // RunKubernetesNamespaces periodically makes sure that all internal namespaces exist


### PR DESCRIPTION
Cherry-pick of shutdown fix from https://github.com/kubernetes/kubernetes/pull/63383 to 1.9 branch

Fixes the apiserver shutdown to not hang forever if the kubernetes service reconciler cannot persist to etcd

```release-note
NONE
```

/sig api-machinery

cc: @liggitt 
