### PR TITLE
use subtest for table units (pkg/kubeapiserver)

### DIFF
--- a/pkg/kubeapiserver/authorizer/modes/modes_test.go
+++ b/pkg/kubeapiserver/authorizer/modes/modes_test.go
@@ -32,14 +32,16 @@ func TestIsValidAuthorizationMode(t *testing.T) {
 		{"AlwaysAllow", true},  // supported
 		{"AlwaysDeny", true},   // supported
 	}
-	for _, rt := range tests {
-		actual := IsValidAuthorizationMode(rt.authzMode)
-		if actual != rt.expected {
-			t.Errorf(
-				"failed ValidAuthorizationMode:\n\texpected: %t\n\t  actual: %t",
-				rt.expected,
-				actual,
-			)
-		}
+	for _, tt := range tests {
+		t.Run("mode is "+tt.authzMode, func(t *testing.T) {
+			actual := IsValidAuthorizationMode(tt.authzMode)
+			if actual != tt.expected {
+				t.Errorf(
+					"failed ValidAuthorizationMode:\n\texpected: %t\n\t  actual: %t",
+					tt.expected,
+					actual,
+				)
+			}
+		})
 	}
 }

--- a/pkg/kubeapiserver/options/storage_versions_test.go
+++ b/pkg/kubeapiserver/options/storage_versions_test.go
@@ -25,12 +25,14 @@ import (
 
 func TestGenerateStorageVersionMap(t *testing.T) {
 	testCases := []struct {
+		name            string
 		legacyVersion   string
 		storageVersions string
 		defaultVersions string
 		expectedMap     map[string]schema.GroupVersion
 	}{
 		{
+			name:            "test-storageVersions-v1,extensions/v1beta1",
 			legacyVersion:   "v1",
 			storageVersions: "v1,extensions/v1beta1",
 			expectedMap: map[string]schema.GroupVersion{
@@ -39,6 +41,7 @@ func TestGenerateStorageVersionMap(t *testing.T) {
 			},
 		},
 		{
+			name:            "test-storageVersions-extensions/v1beta1,v1",
 			legacyVersion:   "",
 			storageVersions: "extensions/v1beta1,v1",
 			expectedMap: map[string]schema.GroupVersion{
@@ -47,6 +50,7 @@ func TestGenerateStorageVersionMap(t *testing.T) {
 			},
 		},
 		{
+			name:            "test-storageVersions-autoscaling=extensions/v1beta1,v1",
 			legacyVersion:   "",
 			storageVersions: "autoscaling=extensions/v1beta1,v1",
 			defaultVersions: "extensions/v1beta1,v1,autoscaling/v1",
@@ -57,22 +61,25 @@ func TestGenerateStorageVersionMap(t *testing.T) {
 			},
 		},
 		{
+			name:            "test-storageVersions-no value",
 			legacyVersion:   "",
 			storageVersions: "",
 			expectedMap:     map[string]schema.GroupVersion{},
 		},
 	}
-	for i, test := range testCases {
-		s := &StorageSerializationOptions{
-			StorageVersions:        test.storageVersions,
-			DefaultStorageVersions: test.defaultVersions,
-		}
-		output, err := s.StorageGroupsToEncodingVersion()
-		if err != nil {
-			t.Errorf("%v: unexpected error: %v", i, err)
-		}
-		if !reflect.DeepEqual(test.expectedMap, output) {
-			t.Errorf("%v: unexpected error. expect: %v, got: %v", i, test.expectedMap, output)
-		}
+	for i, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StorageSerializationOptions{
+				StorageVersions:        tt.storageVersions,
+				DefaultStorageVersions: tt.defaultVersions,
+			}
+			output, err := s.StorageGroupsToEncodingVersion()
+			if err != nil {
+				t.Errorf("%v: unexpected error: %v", i, err)
+			}
+			if !reflect.DeepEqual(tt.expectedMap, output) {
+				t.Errorf("%v: unexpected error. expect: %v, got: %v", i, tt.expectedMap, output)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Many table-driven tests in pkg/kubectl are not using this feature.

/kind cleanup
/area apiserver

Further reading: [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
