### PR TITLE
Minor GC pressure optimization: use bindingInfo{} values in slices

### DIFF
--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache.go
@@ -28,13 +28,13 @@ import (
 type PodBindingCache interface {
 	// UpdateBindings will update the cache with the given bindings for the
 	// pod and node.
-	UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo)
+	UpdateBindings(pod *v1.Pod, node string, bindings []bindingInfo)
 
 	// DeleteBindings will remove all cached bindings for the given pod.
 	DeleteBindings(pod *v1.Pod)
 
 	// GetBindings will return the cached bindings for the given pod and node.
-	GetBindings(pod *v1.Pod, node string) []*bindingInfo
+	GetBindings(pod *v1.Pod, node string) []bindingInfo
 }
 
 type podBindingCache struct {
@@ -47,7 +47,7 @@ type podBindingCache struct {
 
 // Key = nodeName
 // Value = array of bindingInfo
-type nodeBindings map[string][]*bindingInfo
+type nodeBindings map[string][]bindingInfo
 
 func NewPodBindingCache() PodBindingCache {
 	return &podBindingCache{bindings: map[string]nodeBindings{}}
@@ -61,7 +61,7 @@ func (c *podBindingCache) DeleteBindings(pod *v1.Pod) {
 	delete(c.bindings, podName)
 }
 
-func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []*bindingInfo) {
+func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []bindingInfo) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -74,7 +74,7 @@ func (c *podBindingCache) UpdateBindings(pod *v1.Pod, node string, bindings []*b
 	nodeBinding[node] = bindings
 }
 
-func (c *podBindingCache) GetBindings(pod *v1.Pod, node string) []*bindingInfo {
+func (c *podBindingCache) GetBindings(pod *v1.Pod, node string) []bindingInfo {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_cache_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_cache_test.go
@@ -26,11 +26,11 @@ import (
 
 func TestUpdateGetBindings(t *testing.T) {
 	scenarios := map[string]struct {
-		updateBindings []*bindingInfo
+		updateBindings []bindingInfo
 		updatePod      string
 		updateNode     string
 
-		getBindings []*bindingInfo
+		getBindings []bindingInfo
 		getPod      string
 		getNode     string
 	}{
@@ -41,17 +41,17 @@ func TestUpdateGetBindings(t *testing.T) {
 		"no-node": {
 			updatePod:      "pod1",
 			updateNode:     "node1",
-			updateBindings: []*bindingInfo{},
+			updateBindings: []bindingInfo{},
 			getPod:         "pod1",
 			getNode:        "node2",
 		},
 		"binding-exists": {
 			updatePod:      "pod1",
 			updateNode:     "node1",
-			updateBindings: []*bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}},
+			updateBindings: []bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}},
 			getPod:         "pod1",
 			getNode:        "node1",
-			getBindings:    []*bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}},
+			getBindings:    []bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}},
 		},
 	}
 
@@ -78,7 +78,7 @@ func TestUpdateGetBindings(t *testing.T) {
 }
 
 func TestDeleteBindings(t *testing.T) {
-	initialBindings := []*bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}}
+	initialBindings := []bindingInfo{{pvc: &v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc1"}}}}
 	cache := NewPodBindingCache()
 
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns"}}


### PR DESCRIPTION
Not storing pointer types reduces number of allocations and slices of value types are
not scanned by GC.
 
/sig scheduling


```release-note
NONE
```
