### PR TITLE
Update usage of kubectl create pdb

### DIFF
--- a/pkg/kubectl/cmd/create/create_pdb.go
+++ b/pkg/kubectl/cmd/create/create_pdb.go
@@ -51,7 +51,7 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericcliopti
 	}
 
 	cmd := &cobra.Command{
-		Use: "poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run]",
+		Use: "poddisruptionbudget NAME --selector=SELECTOR --min-available=N|--max-unavailable=N [--dry-run]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"pdb"},
 		Short:                 i18n.T("Create a pod disruption budget with the specified name."),


### PR DESCRIPTION
**What this PR does / why we need it**:

- Currently `kubectl create pdb -h` displays only `--min-available` is required flag, but `--max-unavailable=N ` is also available.

~~~
$ kubectl create pdb -h
  ...
   kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run] [options]
~~~

This patch adds `--max-unavailable=N` to the help message:

AFTER:
~~~
$ kubectl create pdb -h
  ...
   kubectl create poddisruptionbudget NAME --selector=SELECTOR --min-available=N|--max-unavailable=N [--dry-run] [options]
~~~

**Release note**:
```release-note
NONE
```
