### PR TITLE
Use exec if token invalid

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -166,7 +166,10 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// If a user has already set credentials, use that. This makes commands like
 	// "kubectl get --token (token) pods" work.
 	if req.Header.Get("Authorization") != "" {
-		return r.base.RoundTrip(req)
+		resp, err := r.base.RoundTrip(req)
+		if resp.StatusCode != http.StatusUnauthorized {
+			return resp, err
+		}
 	}
 
 	token, err := r.a.token()

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -301,6 +301,7 @@ func TestGetToken(t *testing.T) {
 
 func TestRoundTripper(t *testing.T) {
 	wantToken := ""
+	tokenFromUser := ""
 
 	n := time.Now()
 	now := func() time.Time { return n }
@@ -353,6 +354,12 @@ func TestRoundTripper(t *testing.T) {
 		request := &http.Request{
 			Method: "GET",
 			URL:    u,
+		}
+
+		if tokenFromUser != "" {
+			request.Header = http.Header{
+				"Authorization": []string{fmt.Sprintf("bearer %s", tokenFromUser)},
+			}
 		}
 
 		resp, err := client.Do(request)
@@ -416,5 +423,39 @@ func TestRoundTripper(t *testing.T) {
 	}`)
 	wantToken = "token4"
 	// Old token is expired, should refresh automatically without hitting a 401.
+	get(t, http.StatusOK)
+
+	//test tokenFromUser scenario, configure execAuth to return invalid token
+	setOutput(`{
+		"kind": "ExecCredential",
+		"apiVersion": "client.authentication.k8s.io/v1alpha1",
+		"status": {
+			"token": "some-invalid-token"
+		}
+	}`)
+
+	// tokenFromUser is valid, so we should get OK response
+	tokenFromUser = "token1"
+	wantToken = "token1"
+	get(t, http.StatusOK)
+
+	//tokenFromUser is invalid/expired, and execAuth also returns invalid token
+	tokenFromUser = "invalid-token"
+	wantToken = "valid-token"
+	get(t, http.StatusUnauthorized)
+
+	//tokenFromUser is invalid/expired, BUT execAuth returns valid token
+	setOutput(`{
+		"kind": "ExecCredential",
+		"apiVersion": "client.authentication.k8s.io/v1alpha1",
+		"status": {
+			"token": "some-valid-token"
+		}
+	}`)
+	tokenFromUser = "invalid-token"
+	wantToken = "some-valid-token"
+	// some-invalid-token is still cached, hits unauthorized but causes token to rotate.
+	get(t, http.StatusUnauthorized)
+	// Follow up request uses the rotated token (some-valid-token).
 	get(t, http.StatusOK)
 }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -348,7 +349,13 @@ func TestRoundTripper(t *testing.T) {
 
 	get := func(t *testing.T, statusCode int) {
 		t.Helper()
-		resp, err := client.Get(server.URL)
+		u, _ := url.Parse(server.URL)
+		request := &http.Request{
+			Method: "GET",
+			URL:    u,
+		}
+
+		resp, err := client.Do(request)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enhances how execAuth is triggered in client-go. If the user provides a token with --token or a token is available in current context of kubeconfig file, it tries to use that first. If we still get Unauthorized error, we trigger execAuth and use that token.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61857

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fallback on execAuth if its configured and token provided using --token or kubeconfig file has expired. Note that this does not persist the new token in kubeconfig file.
```
