### PR TITLE
[WIP] [Do not review!] Revert "Remove ExtraArgs kubeadm preflight check"

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -49,6 +49,9 @@ go_library(
     }),
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/preflight",
     deps = [
+        "//cmd/kube-apiserver/app/options:go_default_library",
+        "//cmd/kube-controller-manager/app/options:go_default_library",
+        "//cmd/kube-scheduler/app:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
@@ -63,6 +66,7 @@ go_library(
         "//vendor/github.com/PuerkitoBio/purell:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -38,11 +38,15 @@ import (
 	"github.com/PuerkitoBio/purell"
 	"github.com/blang/semver"
 	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 
 	"net/url"
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
+	apiservoptions "k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	cmoptions "k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+	schedulerapp "k8s.io/kubernetes/cmd/kube-scheduler/app"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmdefaults "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -506,6 +510,56 @@ func (subnet HTTPProxyCIDRCheck) Check() (warnings, errors []error) {
 	return nil, nil
 }
 
+// ExtraArgsCheck checks if arguments are valid.
+type ExtraArgsCheck struct {
+	APIServerExtraArgs         map[string]string
+	ControllerManagerExtraArgs map[string]string
+	SchedulerExtraArgs         map[string]string
+}
+
+// Name will return ExtraArgs as name for ExtraArgsCheck
+func (ExtraArgsCheck) Name() string {
+	return "ExtraArgs"
+}
+
+// Check validates additional arguments of the control plane components.
+func (eac ExtraArgsCheck) Check() (warnings, errors []error) {
+	glog.V(1).Infoln("validating additional arguments of the control plane components")
+	argsCheck := func(name string, args map[string]string, f *pflag.FlagSet) []error {
+		errs := []error{}
+		for k, v := range args {
+			if err := f.Set(k, v); err != nil {
+				errs = append(errs, fmt.Errorf("%s: failed to parse extra argument --%s=%s", name, k, v))
+			}
+		}
+		return errs
+	}
+
+	warnings = []error{}
+	if len(eac.APIServerExtraArgs) > 0 {
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		s := apiservoptions.NewServerRunOptions()
+		s.AddFlags(flags)
+		warnings = append(warnings, argsCheck("kube-apiserver", eac.APIServerExtraArgs, flags)...)
+	}
+	if len(eac.ControllerManagerExtraArgs) > 0 {
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		s := cmoptions.NewKubeControllerManagerOptions()
+		s.AddFlags(flags, []string{}, []string{})
+		warnings = append(warnings, argsCheck("kube-controller-manager", eac.ControllerManagerExtraArgs, flags)...)
+	}
+	if len(eac.SchedulerExtraArgs) > 0 {
+		opts, err := schedulerapp.NewOptions()
+		if err != nil {
+			warnings = append(warnings, err)
+		}
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		opts.AddFlags(flags)
+		warnings = append(warnings, argsCheck("kube-scheduler", eac.SchedulerExtraArgs, flags)...)
+	}
+	return warnings, nil
+}
+
 // SystemVerificationCheck defines struct used for for running the system verification node check in test/e2e_node/system
 type SystemVerificationCheck struct {
 	CRISocket string
@@ -859,6 +913,11 @@ func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.MasterConfi
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.KubeControllerManager, manifestsDir)},
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.KubeScheduler, manifestsDir)},
 		FileAvailableCheck{Path: kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestsDir)},
+		ExtraArgsCheck{
+			APIServerExtraArgs:         cfg.APIServerExtraArgs,
+			ControllerManagerExtraArgs: cfg.ControllerManagerExtraArgs,
+			SchedulerExtraArgs:         cfg.SchedulerExtraArgs,
+		},
 		HTTPProxyCheck{Proto: "https", Host: cfg.API.AdvertiseAddress},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.ServiceSubnet},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.PodSubnet},

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -288,6 +288,17 @@ func TestRunChecks(t *testing.T) {
 		{[]Checker{FileContentCheck{Path: "/", Content: []byte("does not exist")}}, false, ""},
 		{[]Checker{InPathCheck{executable: "foobarbaz", exec: exec.New()}}, true, "\t[WARNING FileExisting-foobarbaz]: foobarbaz not found in system path\n"},
 		{[]Checker{InPathCheck{executable: "foobarbaz", mandatory: true, exec: exec.New()}}, false, ""},
+		{[]Checker{ExtraArgsCheck{
+			APIServerExtraArgs:         map[string]string{"secure-port": "1234"},
+			ControllerManagerExtraArgs: map[string]string{"use-service-account-credentials": "true"},
+			SchedulerExtraArgs:         map[string]string{"leader-elect": "true"},
+		}}, true, ""},
+		{[]Checker{ExtraArgsCheck{
+			APIServerExtraArgs: map[string]string{"secure-port": "foo"},
+		}}, true, "\t[WARNING ExtraArgs]: kube-apiserver: failed to parse extra argument --secure-port=foo\n"},
+		{[]Checker{ExtraArgsCheck{
+			APIServerExtraArgs: map[string]string{"invalid-argument": "foo"},
+		}}, true, "\t[WARNING ExtraArgs]: kube-apiserver: failed to parse extra argument --invalid-argument=foo\n"},
 		{[]Checker{InPathCheck{executable: "foobar", mandatory: false, exec: exec.New(), suggestion: "install foobar"}}, true, "\t[WARNING FileExisting-foobar]: foobar not found in system path\nSuggestion: install foobar\n"},
 	}
 	for _, rt := range tokenTest {


### PR DESCRIPTION
This reverts commit 9f21f5dd1e3b9a42f5983c2d756c18f3a1f53b7a.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
