### PR TITLE
print result object from kubectl taint correctly

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4617,6 +4617,17 @@ __EOF__
 }
 __EOF__
 
+  # taint/untaint
+  # Pre-condition: node has no taints
+  kube::test::get_object_assert "nodes 127.0.0.1" "{{.spec.taints}}" '<no value>'
+  # taint can add a taint
+  kubectl taint node 127.0.0.1 dedicated=foo:PreferNoSchedule
+  kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{.effect}}{{end}}' 'PreferNoSchedule'
+  # taint can remove a taint
+  kubectl taint node 127.0.0.1 dedicated-
+  # Post-condition: node has no taints
+  kube::test::get_object_assert "nodes 127.0.0.1" "{{.spec.taints}}" '<no value>'
+
   ### kubectl cordon update with --dry-run does not mark node unschedulable
   # Pre-condition: node is schedulable
   kube::test::get_object_assert "nodes 127.0.0.1" "{{.spec.unschedulable}}" '<no value>'

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -290,6 +290,7 @@ func (o TaintOptions) RunTaint() error {
 		if err != nil {
 			return err
 		}
+		outputObj = cmdutil.AsDefaultVersionedOrOriginal(outputObj, mapping)
 
 		printer, err := o.ToPrinter(operation)
 		if err != nil {


### PR DESCRIPTION
fixes #63767 

```release-note
NONE
```