### PR TITLE
[e2e ingress-gce] Implement Skip() and skip SSL check if needed

### DIFF
--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -29,6 +29,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -45,6 +46,7 @@ type IngressUpgradeTest struct {
 	httpClient    *http.Client
 	ip            string
 	ipName        string
+	skipSSLCheck  bool
 }
 
 // GCPResourceStore keeps track of the GCP resources spun up by an ingress.
@@ -145,6 +147,26 @@ func (t *IngressUpgradeTest) Teardown(f *framework.Framework) {
 	framework.ExpectNoError(t.gceController.CleanupGCEIngressController())
 }
 
+// Skip checks if the test or part of the test should be skipped.
+func (t *IngressUpgradeTest) Skip(upgCtx UpgradeContext) bool {
+	sslNameChangeVersion, err := version.ParseGeneric("v1.10.0")
+	framework.ExpectNoError(err)
+	var hasVersionBelow, hasVersionAboveOrEqual bool
+	for _, v := range upgCtx.Versions {
+		if v.Version.LessThan(sslNameChangeVersion) {
+			hasVersionBelow = true
+			continue
+		}
+		hasVersionAboveOrEqual = true
+	}
+	// Skip SSL certificates check if k8s version changes between 1.10-
+	// and 1.10+ because the naming scheme has changed.
+	if hasVersionBelow && hasVersionAboveOrEqual {
+		t.skipSSLCheck = true
+	}
+	return false
+}
+
 func (t *IngressUpgradeTest) verify(f *framework.Framework, done <-chan struct{}, testDuringDisruption bool) {
 	if testDuringDisruption {
 		By("continuously hitting the Ingress IP")
@@ -183,6 +205,11 @@ func (t *IngressUpgradeTest) verify(f *framework.Framework, done <-chan struct{}
 	}
 	for _, ig := range postUpgradeResourceStore.IgList {
 		ig.Size = 0
+	}
+	// Stub out compute.SslCertificates in case we know it will change during an upgrade/downgrade.
+	if t.skipSSLCheck {
+		t.resourceStore.SslList = nil
+		postUpgradeResourceStore.SslList = nil
 	}
 
 	framework.ExpectNoError(compareGCPResourceStores(t.resourceStore, postUpgradeResourceStore, func(v1 reflect.Value, v2 reflect.Value) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix failing ingress-upgrade test in [gke-staging-1-9-1-10-upgrade-cluster](https://k8s-testgrid.appspot.com/google-gke-staging#gke-staging-1-9-1-10-upgrade-cluster).

Example failure run: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-1-9-1-10-upgrade-cluster/40.

Similar to https://github.com/kubernetes/kubernetes/pull/62291, but making test aware of k8s versions. Hope this makes sense.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @rramkumar1 @krousey 
@liyinan926 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
