### PR TITLE
use subtest for table units (pkg/master)

### DIFF
--- a/pkg/master/client_ca_hook_test.go
+++ b/pkg/master/client_ca_hook_test.go
@@ -189,18 +189,18 @@ func TestWriteClientCAs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		client := fake.NewSimpleClientset(test.preexistingObjs...)
-		test.hook.tryToWriteClientCAs(client.Core())
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(test.preexistingObjs...)
+			test.hook.tryToWriteClientCAs(client.Core())
 
-		actualConfigMaps, updated := getFinalConfiMaps(client)
-		if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {
-			t.Errorf("%s: %v", test.name, diff.ObjectReflectDiff(test.expectedConfigMaps, actualConfigMaps))
-			continue
-		}
-		if test.expectUpdate != updated {
-			t.Errorf("%s: expected %v, got %v", test.name, test.expectUpdate, updated)
-			continue
-		}
+			actualConfigMaps, updated := getFinalConfiMaps(client)
+			if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {
+				t.Fatalf("%s: %v", test.name, diff.ObjectReflectDiff(test.expectedConfigMaps, actualConfigMaps))
+			}
+			if test.expectUpdate != updated {
+				t.Fatalf("%s: expected %v, got %v", test.name, test.expectUpdate, updated)
+			}
+		})
 	}
 }
 

--- a/pkg/master/controller/crdregistration/crdregistration_controller_test.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller_test.go
@@ -78,25 +78,27 @@ func TestHandleVersionUpdate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		registration := &fakeAPIServiceRegistration{}
-		crdCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		crdLister := crdlisters.NewCustomResourceDefinitionLister(crdCache)
-		c := crdRegistrationController{
-			crdLister:              crdLister,
-			apiServiceRegistration: registration,
-		}
-		for i := range test.startingCRDs {
-			crdCache.Add(test.startingCRDs[i])
-		}
+		t.Run(test.name, func(t *testing.T) {
+			registration := &fakeAPIServiceRegistration{}
+			crdCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			crdLister := crdlisters.NewCustomResourceDefinitionLister(crdCache)
+			c := crdRegistrationController{
+				crdLister:              crdLister,
+				apiServiceRegistration: registration,
+			}
+			for i := range test.startingCRDs {
+				crdCache.Add(test.startingCRDs[i])
+			}
 
-		c.handleVersionUpdate(test.version)
+			c.handleVersionUpdate(test.version)
 
-		if !reflect.DeepEqual(test.expectedAdded, registration.added) {
-			t.Errorf("%s expected %v, got %v", test.name, test.expectedAdded, registration.added)
-		}
-		if !reflect.DeepEqual(test.expectedRemoved, registration.removed) {
-			t.Errorf("%s expected %v, got %v", test.name, test.expectedRemoved, registration.removed)
-		}
+			if !reflect.DeepEqual(test.expectedAdded, registration.added) {
+				t.Errorf("%s expected %v, got %v", test.name, test.expectedAdded, registration.added)
+			}
+			if !reflect.DeepEqual(test.expectedRemoved, registration.removed) {
+				t.Errorf("%s expected %v, got %v", test.name, test.expectedRemoved, registration.removed)
+			}
+		})
 	}
 
 }

--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -509,29 +509,31 @@ func TestLeaseEndpointReconciler(t *testing.T) {
 		},
 	}
 	for _, test := range nonReconcileTests {
-		fakeLeases := newFakeLeases()
-		fakeLeases.SetKeys(test.endpointKeys)
-		registry := &registrytest.EndpointRegistry{
-			Endpoints: test.endpoints,
-		}
-		r := NewLeaseEndpointReconciler(registry, fakeLeases)
-		err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
-		if err != nil {
-			t.Errorf("case %q: unexpected error: %v", test.testName, err)
-		}
-		if test.expectUpdate != nil {
-			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
-				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+		t.Run(test.testName, func(t *testing.T) {
+			fakeLeases := newFakeLeases()
+			fakeLeases.SetKeys(test.endpointKeys)
+			registry := &registrytest.EndpointRegistry{
+				Endpoints: test.endpoints,
 			}
-		}
-		if test.expectUpdate == nil && len(registry.Updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
-		}
-		if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
-			t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
-		}
+			r := NewLeaseEndpointReconciler(registry, fakeLeases)
+			err := r.ReconcileEndpoints(test.serviceName, net.ParseIP(test.ip), test.endpointPorts, false)
+			if err != nil {
+				t.Errorf("case %q: unexpected error: %v", test.testName, err)
+			}
+			if test.expectUpdate != nil {
+				if len(registry.Updates) != 1 {
+					t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
+				} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+				}
+			}
+			if test.expectUpdate == nil && len(registry.Updates) > 0 {
+				t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
+			}
+			if updatedKeys := fakeLeases.GetUpdatedKeys(); len(updatedKeys) != 1 || updatedKeys[0] != test.ip {
+				t.Errorf("case %q: expected the master's IP to be refreshed, but the following IPs were refreshed instead: %v", test.testName, updatedKeys)
+			}
+		})
 	}
 }
 
@@ -604,30 +606,32 @@ func TestLeaseStopReconciling(t *testing.T) {
 		},
 	}
 	for _, test := range stopTests {
-		fakeLeases := newFakeLeases()
-		fakeLeases.SetKeys(test.endpointKeys)
-		registry := &registrytest.EndpointRegistry{
-			Endpoints: test.endpoints,
-		}
-		r := NewLeaseEndpointReconciler(registry, fakeLeases)
-		err := r.StopReconciling(test.serviceName, net.ParseIP(test.ip), test.endpointPorts)
-		if err != nil {
-			t.Errorf("case %q: unexpected error: %v", test.testName, err)
-		}
-		if test.expectUpdate != nil {
-			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
-			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
-				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+		t.Run(test.testName, func(t *testing.T) {
+			fakeLeases := newFakeLeases()
+			fakeLeases.SetKeys(test.endpointKeys)
+			registry := &registrytest.EndpointRegistry{
+				Endpoints: test.endpoints,
 			}
-		}
-		if test.expectUpdate == nil && len(registry.Updates) > 0 {
-			t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
-		}
-		for _, key := range fakeLeases.GetUpdatedKeys() {
-			if key == test.ip {
-				t.Errorf("case %q: Found ip %s in leases but shouldn't be there", test.testName, key)
+			r := NewLeaseEndpointReconciler(registry, fakeLeases)
+			err := r.StopReconciling(test.serviceName, net.ParseIP(test.ip), test.endpointPorts)
+			if err != nil {
+				t.Errorf("case %q: unexpected error: %v", test.testName, err)
 			}
-		}
+			if test.expectUpdate != nil {
+				if len(registry.Updates) != 1 {
+					t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
+				} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
+					t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
+				}
+			}
+			if test.expectUpdate == nil && len(registry.Updates) > 0 {
+				t.Errorf("case %q: no update expected, yet saw: %v", test.testName, registry.Updates)
+			}
+			for _, key := range fakeLeases.GetUpdatedKeys() {
+				if key == test.ip {
+					t.Errorf("case %q: Found ip %s in leases but shouldn't be there", test.testName, key)
+				}
+			}
+		})
 	}
 }

--- a/pkg/master/tunneler/ssh_test.go
+++ b/pkg/master/tunneler/ssh_test.go
@@ -32,39 +32,66 @@ import (
 // TestSecondsSinceSync verifies that proper results are returned
 // when checking the time between syncs
 func TestSecondsSinceSync(t *testing.T) {
-	tunneler := &SSHTunneler{}
-	assert := assert.New(t)
+	tests := []struct {
+		name     string
+		lastSync int64
+		clock    *clock.FakeClock
+		want     int64
+	}{
+		{
+			name:     "Nano Second. No difference",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 1, 2, time.UTC)),
+			want:     int64(0),
+		},
+		{
+			name:     "Second",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 2, 1, time.UTC)),
+			want:     int64(1),
+		},
+		{
+			name:     "Minute",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 2, 1, 1, time.UTC)),
+			want:     int64(60),
+		},
+		{
+			name:     "Hour",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 1, 2, 1, 1, 1, time.UTC)),
+			want:     int64(3600),
+		},
+		{
+			name:     "Day",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 2, 1, 1, 1, 1, time.UTC)),
+			want:     int64(86400),
+		},
+		{
+			name:     "Month",
+			lastSync: time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC)),
+			want:     int64(2678400),
+		},
+		{
+			name:     "Future Month. Should be -Month",
+			lastSync: time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC).Unix(),
+			clock:    clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 1, 2, time.UTC)),
+			want:     int64(-2678400),
+		},
+	}
 
-	tunneler.lastSync = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC).Unix()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tunneler := &SSHTunneler{}
+			assert := assert.New(t)
+			tunneler.lastSync = tt.lastSync
+			tunneler.clock = tt.clock
+			assert.Equal(int64(tt.want), tunneler.SecondsSinceSync())
+		})
+	}
 
-	// Nano Second. No difference.
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 1, 2, time.UTC))
-	assert.Equal(int64(0), tunneler.SecondsSinceSync())
-
-	// Second
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 2, 1, time.UTC))
-	assert.Equal(int64(1), tunneler.SecondsSinceSync())
-
-	// Minute
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 2, 1, 1, time.UTC))
-	assert.Equal(int64(60), tunneler.SecondsSinceSync())
-
-	// Hour
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 1, 2, 1, 1, 1, time.UTC))
-	assert.Equal(int64(3600), tunneler.SecondsSinceSync())
-
-	// Day
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 2, 1, 1, 1, 1, time.UTC))
-	assert.Equal(int64(86400), tunneler.SecondsSinceSync())
-
-	// Month
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC))
-	assert.Equal(int64(2678400), tunneler.SecondsSinceSync())
-
-	// Future Month. Should be -Month.
-	tunneler.lastSync = time.Date(2015, time.February, 1, 1, 1, 1, 1, time.UTC).Unix()
-	tunneler.clock = clock.NewFakeClock(time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC))
-	assert.Equal(int64(-2678400), tunneler.SecondsSinceSync())
 }
 
 // generateTempFile creates a temporary file path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Many table-driven tests in pkg/kubectl are not using this feature.

/kind cleanup

Further reading:  [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
