### PR TITLE
use subtest for table units (pkg/proxy)

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -42,79 +42,86 @@ func (proxier *FakeProxier) deleteEndpoints(endpoints *api.Endpoints) {
 
 func TestGetLocalEndpointIPs(t *testing.T) {
 	testCases := []struct {
+		name         string
 		endpointsMap EndpointsMap
 		expected     map[types.NamespacedName]sets.String
-	}{{
-		// Case[0]: nothing
-		endpointsMap: EndpointsMap{},
-		expected:     map[types.NamespacedName]sets.String{},
-	}, {
-		// Case[1]: unnamed port
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
+	}{
+		{
+			name:         "nothing",
+			endpointsMap: EndpointsMap{},
+			expected:     map[types.NamespacedName]sets.String{},
+		},
+		{
+			name: "unnamed port",
+			endpointsMap: EndpointsMap{
+				makeServicePortName("ns1", "ep1", ""): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
+				},
+			},
+			expected: map[types.NamespacedName]sets.String{},
+		},
+		{
+			name: "unnamed port local",
+			endpointsMap: EndpointsMap{
+				makeServicePortName("ns1", "ep1", ""): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true},
+				},
+			},
+			expected: map[types.NamespacedName]sets.String{
+				{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.1"),
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{},
-	}, {
-		// Case[2]: unnamed port local
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true},
+		{
+			name: "named local and non-local ports for the same IP",
+			endpointsMap: EndpointsMap{
+				makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
+					&BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true},
+				},
+				makeServicePortName("ns1", "ep1", "p12"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false},
+					&BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true},
+				},
+			},
+			expected: map[types.NamespacedName]sets.String{
+				{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.2"),
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{
-			{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.1"),
-		},
-	}, {
-		// Case[3]: named local and non-local ports for the same IP.
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
-				&BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true},
+		{
+			name: "named local and non-local ports for different IPs",
+			endpointsMap: EndpointsMap{
+				makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
+				},
+				makeServicePortName("ns2", "ep2", "p22"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true},
+					&BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true},
+				},
+				makeServicePortName("ns2", "ep2", "p23"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true},
+				},
+				makeServicePortName("ns4", "ep4", "p44"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true},
+					&BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: false},
+				},
+				makeServicePortName("ns4", "ep4", "p45"): []Endpoint{
+					&BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true},
+				},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false},
-				&BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true},
-			},
-		},
-		expected: map[types.NamespacedName]sets.String{
-			{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.2"),
-		},
-	}, {
-		// Case[4]: named local and non-local ports for different IPs.
-		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
-			},
-			makeServicePortName("ns2", "ep2", "p22"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true},
-				&BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true},
-			},
-			makeServicePortName("ns2", "ep2", "p23"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true},
-			},
-			makeServicePortName("ns4", "ep4", "p44"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true},
-				&BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: false},
-			},
-			makeServicePortName("ns4", "ep4", "p45"): []Endpoint{
-				&BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true},
+			expected: map[types.NamespacedName]sets.String{
+				{Namespace: "ns2", Name: "ep2"}: sets.NewString("2.2.2.2", "2.2.2.22", "2.2.2.3"),
+				{Namespace: "ns4", Name: "ep4"}: sets.NewString("4.4.4.4", "4.4.4.6"),
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{
-			{Namespace: "ns2", Name: "ep2"}: sets.NewString("2.2.2.2", "2.2.2.22", "2.2.2.3"),
-			{Namespace: "ns4", Name: "ep4"}: sets.NewString("4.4.4.4", "4.4.4.6"),
-		},
-	}}
+	}
 
-	for tci, tc := range testCases {
-		// outputs
-		localIPs := GetLocalEndpointIPs(tc.endpointsMap)
-
-		if !reflect.DeepEqual(localIPs, tc.expected) {
-			t.Errorf("[%d] expected %#v, got %#v", tci, tc.expected, localIPs)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			localIPs := GetLocalEndpointIPs(tc.endpointsMap)
+			if !reflect.DeepEqual(localIPs, tc.expected) {
+				t.Fatalf("expected %#v, got %#v", tc.expected, localIPs)
+			}
+		})
 	}
 }
 
@@ -137,18 +144,18 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 	falseVal := false
 
 	testCases := []struct {
-		desc         string
+		name         string
 		newEndpoints *api.Endpoints
 		expected     map[ServicePortName][]*BaseEndpointInfo
 		isIPv6Mode   *bool
 	}{
 		{
-			desc:         "nothing",
+			name:         "nothing",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {}),
 			expected:     map[ServicePortName][]*BaseEndpointInfo{},
 		},
 		{
-			desc: "no changes, unnamed port",
+			name: "no changes, unnamed port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -169,7 +176,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "no changes, named port",
+			name: "no changes, named port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -190,7 +197,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "new port",
+			name: "new port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -210,12 +217,12 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc:         "remove port",
+			name:         "remove port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {}),
 			expected:     map[ServicePortName][]*BaseEndpointInfo{},
 		},
 		{
-			desc: "new IP and port",
+			name: "new IP and port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -246,7 +253,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "remove IP and port",
+			name: "remove IP and port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -267,7 +274,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "rename port",
+			name: "rename port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -288,7 +295,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "renumber port",
+			name: "renumber port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -309,7 +316,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			},
 		},
 		{
-			desc: "should omit IPv6 address in IPv4 mode",
+			name: "should omit IPv6 address in IPv4 mode",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -339,7 +346,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 			isIPv6Mode: &falseVal,
 		},
 		{
-			desc: "should omit IPv4 address in IPv6 mode",
+			name: "should omit IPv4 address in IPv6 mode",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {
 				ept.Subsets = []api.EndpointSubset{
 					{
@@ -371,25 +378,26 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		epTracker.isIPv6Mode = tc.isIPv6Mode
-		// outputs
-		newEndpoints := epTracker.endpointsToEndpointsMap(tc.newEndpoints)
+		t.Run(tc.name, func(t *testing.T) {
+			epTracker.isIPv6Mode = tc.isIPv6Mode
+			newEndpoints := epTracker.endpointsToEndpointsMap(tc.newEndpoints)
 
-		if len(newEndpoints) != len(tc.expected) {
-			t.Errorf("[%s] expected %d new, got %d: %v", tc.desc, len(tc.expected), len(newEndpoints), spew.Sdump(newEndpoints))
-		}
-		for x := range tc.expected {
-			if len(newEndpoints[x]) != len(tc.expected[x]) {
-				t.Errorf("[%s] expected %d endpoints for %v, got %d", tc.desc, len(tc.expected[x]), x, len(newEndpoints[x]))
-			} else {
-				for i := range newEndpoints[x] {
-					ep := newEndpoints[x][i].(*BaseEndpointInfo)
-					if *ep != *(tc.expected[x][i]) {
-						t.Errorf("[%s] expected new[%v][%d] to be %v, got %v", tc.desc, x, i, tc.expected[x][i], *ep)
+			if len(newEndpoints) != len(tc.expected) {
+				t.Fatalf("expected %d new, got %d: %v", len(tc.expected), len(newEndpoints), spew.Sdump(newEndpoints))
+			}
+			for x := range tc.expected {
+				if len(newEndpoints[x]) != len(tc.expected[x]) {
+					t.Fatalf("expected %d endpoints for %v, got %d", len(tc.expected[x]), x, len(newEndpoints[x]))
+				} else {
+					for i := range newEndpoints[x] {
+						ep := newEndpoints[x][i].(*BaseEndpointInfo)
+						if *ep != *(tc.expected[x][i]) {
+							t.Fatalf("expected new[%v][%d] to be %v, got %v", x, i, tc.expected[x][i], *ep)
+						}
 					}
 				}
 			}
-		}
+		})
 	}
 }
 
@@ -703,6 +711,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
+		name                      string
 		previousEndpoints         []*api.Endpoints
 		currentEndpoints          []*api.Endpoints
 		oldEndpoints              map[ServicePortName][]*BaseEndpointInfo
@@ -719,6 +728,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[1]: no change, unnamed port
+		name: "no change, unnamed port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
@@ -740,6 +750,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[2]: no change, named port, local
+		name: "no change, named port, local",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
@@ -763,6 +774,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[3]: no change, multiple subsets
+		name: "no change, multiple subsets",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
@@ -790,6 +802,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
+		name: "no change, multiple subsets, multiple ports, local",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
@@ -825,6 +838,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
+		name: "no change, multiple endpoints, subsets, IPs, and ports",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
@@ -893,6 +907,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[6]: add an Endpoints
+		name: "add an Endpoints",
 		previousEndpoints: []*api.Endpoints{
 			nil,
 		},
@@ -914,6 +929,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[7]: remove an Endpoints
+		name: "remove an Endpoints",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
 		},
@@ -934,6 +950,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[8]: add an IP and port
+		name: "add an IP and port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -964,6 +981,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[9]: remove an IP and port
+		name: "remove an IP and port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
@@ -999,6 +1017,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[10]: add a subset
+		name: "add a subset",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1027,6 +1046,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[11]: remove a subset
+		name: "remove a subset",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
@@ -1054,6 +1074,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[12]: rename a port
+		name: "rename a port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1080,6 +1101,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	}, {
 		// Case[13]: renumber a port
+		name: "renumber a port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1104,6 +1126,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
 		// Case[14]: complex add and remove
+		name: "complex add and remove",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", complexBefore1),
 			makeTestEndpoints("ns2", "ep2", complexBefore2),
@@ -1179,6 +1202,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
+		name: "change from 0 endpoint address to 1 unnamed port",
 		previousEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", emptyEndpoint),
 		},
@@ -1200,71 +1224,73 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	}
 
 	for tci, tc := range testCases {
-		fp := newFakeProxier()
-		fp.hostname = nodeName
+		t.Run(tc.name, func(t *testing.T) {
+			fp := newFakeProxier()
+			fp.hostname = nodeName
 
-		// First check that after adding all previous versions of endpoints,
-		// the fp.oldEndpoints is as we expect.
-		for i := range tc.previousEndpoints {
-			if tc.previousEndpoints[i] != nil {
-				fp.addEndpoints(tc.previousEndpoints[i])
-			}
-		}
-		UpdateEndpointsMap(fp.endpointsMap, fp.endpointsChanges)
-		compareEndpointsMaps(t, tci, fp.endpointsMap, tc.oldEndpoints)
-
-		// Now let's call appropriate handlers to get to state we want to be.
-		if len(tc.previousEndpoints) != len(tc.currentEndpoints) {
-			t.Fatalf("[%d] different lengths of previous and current endpoints", tci)
-			continue
-		}
-
-		for i := range tc.previousEndpoints {
-			prev, curr := tc.previousEndpoints[i], tc.currentEndpoints[i]
-			switch {
-			case prev == nil:
-				fp.addEndpoints(curr)
-			case curr == nil:
-				fp.deleteEndpoints(prev)
-			default:
-				fp.updateEndpoints(prev, curr)
-			}
-		}
-		result := UpdateEndpointsMap(fp.endpointsMap, fp.endpointsChanges)
-		newMap := fp.endpointsMap
-		compareEndpointsMaps(t, tci, newMap, tc.expectedResult)
-		if len(result.StaleEndpoints) != len(tc.expectedStaleEndpoints) {
-			t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedStaleEndpoints), len(result.StaleEndpoints), result.StaleEndpoints)
-		}
-		for _, x := range tc.expectedStaleEndpoints {
-			found := false
-			for _, stale := range result.StaleEndpoints {
-				if stale == x {
-					found = true
-					break
+			// First check that after adding all previous versions of endpoints,
+			// the fp.oldEndpoints is as we expect.
+			for i := range tc.previousEndpoints {
+				if tc.previousEndpoints[i] != nil {
+					fp.addEndpoints(tc.previousEndpoints[i])
 				}
 			}
-			if !found {
-				t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.StaleEndpoints)
+			UpdateEndpointsMap(fp.endpointsMap, fp.endpointsChanges)
+			compareEndpointsMaps(t, tci, fp.endpointsMap, tc.oldEndpoints)
+
+			// Now let's call appropriate handlers to get to state we want to be.
+			if len(tc.previousEndpoints) != len(tc.currentEndpoints) {
+				t.Fatalf("[%d] different lengths of previous and current endpoints", tci)
+				return
 			}
-		}
-		if len(result.StaleServiceNames) != len(tc.expectedStaleServiceNames) {
-			t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedStaleServiceNames), len(result.StaleServiceNames), result.StaleServiceNames)
-		}
-		for svcName := range tc.expectedStaleServiceNames {
-			found := false
-			for _, stale := range result.StaleServiceNames {
-				if stale == svcName {
-					found = true
+
+			for i := range tc.previousEndpoints {
+				prev, curr := tc.previousEndpoints[i], tc.currentEndpoints[i]
+				switch {
+				case prev == nil:
+					fp.addEndpoints(curr)
+				case curr == nil:
+					fp.deleteEndpoints(prev)
+				default:
+					fp.updateEndpoints(prev, curr)
 				}
 			}
-			if !found {
-				t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.StaleServiceNames)
+			result := UpdateEndpointsMap(fp.endpointsMap, fp.endpointsChanges)
+			newMap := fp.endpointsMap
+			compareEndpointsMaps(t, tci, newMap, tc.expectedResult)
+			if len(result.StaleEndpoints) != len(tc.expectedStaleEndpoints) {
+				t.Fatalf("expected %d staleEndpoints, got %d: %v", len(tc.expectedStaleEndpoints), len(result.StaleEndpoints), result.StaleEndpoints)
 			}
-		}
-		if !reflect.DeepEqual(result.HCEndpointsLocalIPSize, tc.expectedHealthchecks) {
-			t.Errorf("[%d] expected healthchecks %v, got %v", tci, tc.expectedHealthchecks, result.HCEndpointsLocalIPSize)
-		}
+			for _, x := range tc.expectedStaleEndpoints {
+				found := false
+				for _, stale := range result.StaleEndpoints {
+					if stale == x {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected staleEndpoints[%v], but didn't find it: %v", x, result.StaleEndpoints)
+				}
+			}
+			if len(result.StaleServiceNames) != len(tc.expectedStaleServiceNames) {
+				t.Fatalf("expected %d staleServiceNames, got %d: %v", len(tc.expectedStaleServiceNames), len(result.StaleServiceNames), result.StaleServiceNames)
+			}
+			for svcName := range tc.expectedStaleServiceNames {
+				found := false
+				for _, stale := range result.StaleServiceNames {
+					if stale == svcName {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("expected staleServiceNames[%v], but didn't find it: %v", svcName, result.StaleServiceNames)
+				}
+			}
+			if !reflect.DeepEqual(result.HCEndpointsLocalIPSize, tc.expectedHealthchecks) {
+				t.Fatalf("expected healthchecks %v, got %v", tc.expectedHealthchecks, result.HCEndpointsLocalIPSize)
+			}
+		})
 	}
 }
 

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -353,24 +353,26 @@ func TestServiceToServiceMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		svcTracker.isIPv6Mode = tc.isIPv6Mode
-		// outputs
-		newServices := svcTracker.serviceToServiceMap(tc.service)
+		t.Run(tc.desc, func(t *testing.T) {
+			svcTracker.isIPv6Mode = tc.isIPv6Mode
+			// outputs
+			newServices := svcTracker.serviceToServiceMap(tc.service)
 
-		if len(newServices) != len(tc.expected) {
-			t.Errorf("[%s] expected %d new, got %d: %v", tc.desc, len(tc.expected), len(newServices), spew.Sdump(newServices))
-		}
-		for svcKey, expectedInfo := range tc.expected {
-			svcInfo := newServices[svcKey].(*BaseServiceInfo)
-			if !svcInfo.ClusterIP.Equal(expectedInfo.ClusterIP) ||
-				svcInfo.Port != expectedInfo.Port ||
-				svcInfo.Protocol != expectedInfo.Protocol ||
-				svcInfo.HealthCheckNodePort != expectedInfo.HealthCheckNodePort ||
-				!sets.NewString(svcInfo.ExternalIPs...).Equal(sets.NewString(expectedInfo.ExternalIPs...)) ||
-				!sets.NewString(svcInfo.LoadBalancerSourceRanges...).Equal(sets.NewString(expectedInfo.LoadBalancerSourceRanges...)) {
-				t.Errorf("[%s] expected new[%v]to be %v, got %v", tc.desc, svcKey, expectedInfo, *svcInfo)
+			if len(newServices) != len(tc.expected) {
+				t.Fatalf("expected %d new, got %d: %v", len(tc.expected), len(newServices), spew.Sdump(newServices))
 			}
-		}
+			for svcKey, expectedInfo := range tc.expected {
+				svcInfo := newServices[svcKey].(*BaseServiceInfo)
+				if !svcInfo.ClusterIP.Equal(expectedInfo.ClusterIP) ||
+					svcInfo.Port != expectedInfo.Port ||
+					svcInfo.Protocol != expectedInfo.Protocol ||
+					svcInfo.HealthCheckNodePort != expectedInfo.HealthCheckNodePort ||
+					!sets.NewString(svcInfo.ExternalIPs...).Equal(sets.NewString(expectedInfo.ExternalIPs...)) ||
+					!sets.NewString(svcInfo.LoadBalancerSourceRanges...).Equal(sets.NewString(expectedInfo.LoadBalancerSourceRanges...)) {
+					t.Fatalf("expected new[%v]to be %v, got %v", svcKey, expectedInfo, *svcInfo)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Many table-driven tests in pkg/kubectl are not using this feature.

/kind cleanup
/area kube-proxy

Further reading: [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
