### PR TITLE
use subtest for table units (pkg/printers)

### DIFF
--- a/pkg/printers/humanreadable_test.go
+++ b/pkg/printers/humanreadable_test.go
@@ -48,7 +48,8 @@ func testPrintNamespace(obj *api.Namespace, options PrintOptions) ([]metav1beta1
 func TestPrintRowsForHandlerEntry(t *testing.T) {
 	printFunc := reflect.ValueOf(testPrintNamespace)
 
-	testCase := map[string]struct {
+	testCase := []struct {
+		name          string
 		h             *handlerEntry
 		opt           PrintOptions
 		obj           runtime.Object
@@ -56,7 +57,8 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 		expectOut     string
 		expectErr     string
 	}{
-		"no tablecolumndefinition and includeheader flase": {
+		{
+			name: "no tablecolumndefinition and includeheader flase",
 			h: &handlerEntry{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
 				printRows:         true,
@@ -69,7 +71,8 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			includeHeader: false,
 			expectOut:     "test\t\t<unknow>\n",
 		},
-		"no tablecolumndefinition and includeheader true": {
+		{
+			name: "no tablecolumndefinition and includeheader true",
 			h: &handlerEntry{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
 				printRows:         true,
@@ -82,7 +85,8 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			includeHeader: true,
 			expectOut:     "\ntest\t\t<unknow>\n",
 		},
-		"have tablecolumndefinition and includeheader true": {
+		{
+			name: "have tablecolumndefinition and includeheader true",
 			h: &handlerEntry{
 				columnDefinitions: testNamespaceColumnDefinitions,
 				printRows:         true,
@@ -95,7 +99,8 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			includeHeader: true,
 			expectOut:     "NAME\tSTATUS\tAGE\ntest\t\t<unknow>\n",
 		},
-		"print namespace and withnamespace true, should not print header": {
+		{
+			name: "print namespace and withnamespace true, should not print header",
 			h: &handlerEntry{
 				columnDefinitions: testNamespaceColumnDefinitions,
 				printRows:         true,
@@ -112,16 +117,18 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 			expectErr:     "namespace is not namespaced",
 		},
 	}
-	for name, test := range testCase {
-		buffer := &bytes.Buffer{}
-		err := printRowsForHandlerEntry(buffer, test.h, test.obj, test.opt, test.includeHeader)
-		if err != nil {
-			if err.Error() != test.expectErr {
-				t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", name, test.expectErr, err)
+	for _, test := range testCase {
+		t.Run(test.name, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			err := printRowsForHandlerEntry(buffer, test.h, test.obj, test.opt, test.includeHeader)
+			if err != nil {
+				if err.Error() != test.expectErr {
+					t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", test.name, test.expectErr, err)
+				}
 			}
-		}
-		if test.expectOut != buffer.String() {
-			t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", name, test.expectOut, buffer.String())
-		}
+			if test.expectOut != buffer.String() {
+				t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", test.name, test.expectOut, buffer.String())
+			}
+		})
 	}
 }

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -282,10 +282,12 @@ func getResourceList(cpu, memory string) api.ResourceList {
 
 func TestDescribeService(t *testing.T) {
 	testCases := []struct {
+		name    string
 		service *api.Service
 		expect  []string
 	}{
 		{
+			name: "test1",
 			service: &api.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -323,6 +325,7 @@ func TestDescribeService(t *testing.T) {
 			},
 		},
 		{
+			name: "test2",
 			service: &api.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -361,18 +364,20 @@ func TestDescribeService(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		fake := fake.NewSimpleClientset(testCase.service)
-		c := &describeClient{T: t, Namespace: "foo", Interface: fake}
-		d := ServiceDescriber{c}
-		out, err := d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		for _, expected := range testCase.expect {
-			if !strings.Contains(out, expected) {
-				t.Errorf("expected to find %q in output: %q", expected, out)
+		t.Run(testCase.name, func(t *testing.T) {
+			fake := fake.NewSimpleClientset(testCase.service)
+			c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+			d := ServiceDescriber{c}
+			out, err := d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
-		}
+			for _, expected := range testCase.expect {
+				if !strings.Contains(out, expected) {
+					t.Errorf("expected to find %q in output: %q", expected, out)
+				}
+			}
+		})
 	}
 }
 
@@ -452,12 +457,14 @@ func VerifyDatesInOrder(
 func TestDescribeContainers(t *testing.T) {
 	trueVal := true
 	testCases := []struct {
+		name             string
 		container        api.Container
 		status           api.ContainerStatus
 		expectedElements []string
 	}{
 		// Running state.
 		{
+			name:      "test1",
 			container: api.Container{Name: "test", Image: "image"},
 			status: api.ContainerStatus{
 				Name: "test",
@@ -473,6 +480,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Waiting state.
 		{
+			name:      "test2",
 			container: api.Container{Name: "test", Image: "image"},
 			status: api.ContainerStatus{
 				Name: "test",
@@ -488,6 +496,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Terminated state.
 		{
+			name:      "test3",
 			container: api.Container{Name: "test", Image: "image"},
 			status: api.ContainerStatus{
 				Name: "test",
@@ -506,6 +515,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Last Terminated
 		{
+			name:      "test4",
 			container: api.Container{Name: "test", Image: "image"},
 			status: api.ContainerStatus{
 				Name: "test",
@@ -529,6 +539,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// No state defaults to waiting.
 		{
+			name:      "test5",
 			container: api.Container{Name: "test", Image: "image"},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -539,6 +550,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Env
 		{
+			name:      "test6",
 			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}, EnvFrom: []api.EnvFromSource{{ConfigMapRef: &api.ConfigMapEnvSource{LocalObjectReference: api.LocalObjectReference{Name: "a123"}}}}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -548,6 +560,7 @@ func TestDescribeContainers(t *testing.T) {
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "envname", "xyz", "a123\tConfigMap\tOptional: false"},
 		},
 		{
+			name:      "test7",
 			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}, EnvFrom: []api.EnvFromSource{{Prefix: "p_", ConfigMapRef: &api.ConfigMapEnvSource{LocalObjectReference: api.LocalObjectReference{Name: "a123"}}}}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -557,6 +570,7 @@ func TestDescribeContainers(t *testing.T) {
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "envname", "xyz", "a123\tConfigMap with prefix 'p_'\tOptional: false"},
 		},
 		{
+			name:      "test8",
 			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}, EnvFrom: []api.EnvFromSource{{ConfigMapRef: &api.ConfigMapEnvSource{Optional: &trueVal, LocalObjectReference: api.LocalObjectReference{Name: "a123"}}}}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -566,6 +580,7 @@ func TestDescribeContainers(t *testing.T) {
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "envname", "xyz", "a123\tConfigMap\tOptional: true"},
 		},
 		{
+			name:      "test9",
 			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}, EnvFrom: []api.EnvFromSource{{SecretRef: &api.SecretEnvSource{LocalObjectReference: api.LocalObjectReference{Name: "a123"}, Optional: &trueVal}}}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -575,6 +590,7 @@ func TestDescribeContainers(t *testing.T) {
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "envname", "xyz", "a123\tSecret\tOptional: true"},
 		},
 		{
+			name:      "test10",
 			container: api.Container{Name: "test", Image: "image", Env: []api.EnvVar{{Name: "envname", Value: "xyz"}}, EnvFrom: []api.EnvFromSource{{Prefix: "p_", SecretRef: &api.SecretEnvSource{LocalObjectReference: api.LocalObjectReference{Name: "a123"}}}}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -585,6 +601,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Command
 		{
+			name:      "test11",
 			container: api.Container{Name: "test", Image: "image", Command: []string{"sleep", "1000"}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -595,6 +612,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Args
 		{
+			name:      "test12",
 			container: api.Container{Name: "test", Image: "image", Args: []string{"time", "1000"}},
 			status: api.ContainerStatus{
 				Name:         "test",
@@ -605,6 +623,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Using limits.
 		{
+			name: "test13",
 			container: api.Container{
 				Name:  "test",
 				Image: "image",
@@ -625,6 +644,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// Using requests.
 		{
+			name: "test14",
 			container: api.Container{
 				Name:  "test",
 				Image: "image",
@@ -640,6 +660,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// volumeMounts read/write
 		{
+			name: "test15",
 			container: api.Container{
 				Name:  "test",
 				Image: "image",
@@ -654,6 +675,7 @@ func TestDescribeContainers(t *testing.T) {
 		},
 		// volumeMounts readonly
 		{
+			name: "test16",
 			container: api.Container{
 				Name:  "test",
 				Image: "image",
@@ -670,6 +692,7 @@ func TestDescribeContainers(t *testing.T) {
 
 		// volumeDevices
 		{
+			name: "test17",
 			container: api.Container{
 				Name:  "test",
 				Image: "image",
@@ -685,23 +708,25 @@ func TestDescribeContainers(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		out := new(bytes.Buffer)
-		pod := api.Pod{
-			Spec: api.PodSpec{
-				Containers: []api.Container{testCase.container},
-			},
-			Status: api.PodStatus{
-				ContainerStatuses: []api.ContainerStatus{testCase.status},
-			},
-		}
-		writer := NewPrefixWriter(out)
-		describeContainers("Containers", pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(&pod), writer, "")
-		output := out.String()
-		for _, expected := range testCase.expectedElements {
-			if !strings.Contains(output, expected) {
-				t.Errorf("Test case %d: expected to find %q in output: %q", i, expected, output)
+		t.Run(testCase.name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			pod := api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{testCase.container},
+				},
+				Status: api.PodStatus{
+					ContainerStatuses: []api.ContainerStatus{testCase.status},
+				},
 			}
-		}
+			writer := NewPrefixWriter(out)
+			describeContainers("Containers", pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(&pod), writer, "")
+			output := out.String()
+			for _, expected := range testCase.expectedElements {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Test case %d: expected to find %q in output: %q", i, expected, output)
+				}
+			}
+		})
 	}
 }
 
@@ -787,10 +812,12 @@ func TestDefaultDescribers(t *testing.T) {
 
 func TestGetPodsTotalRequests(t *testing.T) {
 	testCases := []struct {
+		name         string
 		pods         *api.PodList
 		expectedReqs map[api.ResourceName]resource.Quantity
 	}{
 		{
+			name: "test1",
 			pods: &api.PodList{
 				Items: []api.Pod{
 					{
@@ -852,10 +879,12 @@ func TestGetPodsTotalRequests(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		reqs, _ := getPodsTotalRequestsAndLimits(testCase.pods)
-		if !apiequality.Semantic.DeepEqual(reqs, testCase.expectedReqs) {
-			t.Errorf("Expected %v, got %v", testCase.expectedReqs, reqs)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			reqs, _ := getPodsTotalRequestsAndLimits(testCase.pods)
+			if !apiequality.Semantic.DeepEqual(reqs, testCase.expectedReqs) {
+				t.Errorf("Expected %v, got %v", testCase.expectedReqs, reqs)
+			}
+		})
 	}
 }
 
@@ -863,12 +892,14 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 	block := api.PersistentVolumeBlock
 	file := api.PersistentVolumeFilesystem
 	testCases := []struct {
+		name               string
 		plugin             string
 		pv                 *api.PersistentVolume
 		expectedElements   []string
 		unexpectedElements []string
 	}{
 		{
+			name:   "test0",
 			plugin: "hostpath",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -881,6 +912,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test1",
 			plugin: "gce",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -894,6 +926,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			expectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test2",
 			plugin: "ebs",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -906,6 +939,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test3",
 			plugin: "nfs",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -918,6 +952,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test4",
 			plugin: "iscsi",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -931,6 +966,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			expectedElements: []string{"VolumeMode", "Block"},
 		},
 		{
+			name:   "test5",
 			plugin: "gluster",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -943,6 +979,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test6",
 			plugin: "rbd",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -955,6 +992,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test7",
 			plugin: "quobyte",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -967,6 +1005,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test8",
 			plugin: "cinder",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -979,6 +1018,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
 		{
+			name:   "test9",
 			plugin: "fc",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -992,6 +1032,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			expectedElements: []string{"VolumeMode", "Block"},
 		},
 		{
+			name:   "test10",
 			plugin: "local",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -1005,6 +1046,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"Required Terms", "Term "},
 		},
 		{
+			name:   "test11",
 			plugin: "local",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -1019,6 +1061,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"Required Terms", "Term "},
 		},
 		{
+			name:   "test12",
 			plugin: "local",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -1035,6 +1078,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			unexpectedElements: []string{"Term "},
 		},
 		{
+			name:   "test13",
 			plugin: "local",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -1059,6 +1103,7 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			expectedElements: []string{"Node Affinity", "Required Terms", "Term 0", "Term 1"},
 		},
 		{
+			name:   "test14",
 			plugin: "local",
 			pv: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
@@ -1094,25 +1139,27 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		fake := fake.NewSimpleClientset(test.pv)
-		c := PersistentVolumeDescriber{fake}
-		str, err := c.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
-		if err != nil {
-			t.Errorf("Unexpected error for test %s: %v", test.plugin, err)
-		}
-		if str == "" {
-			t.Errorf("Unexpected empty string for test %s.  Expected PV Describer output", test.plugin)
-		}
-		for _, expected := range test.expectedElements {
-			if !strings.Contains(str, expected) {
-				t.Errorf("expected to find %q in output: %q", expected, str)
+		t.Run(test.name, func(t *testing.T) {
+			fake := fake.NewSimpleClientset(test.pv)
+			c := PersistentVolumeDescriber{fake}
+			str, err := c.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("Unexpected error for test %s: %v", test.plugin, err)
 			}
-		}
-		for _, unexpected := range test.unexpectedElements {
-			if strings.Contains(str, unexpected) {
-				t.Errorf("unexpected to find %q in output: %q", unexpected, str)
+			if str == "" {
+				t.Errorf("Unexpected empty string for test %s.  Expected PV Describer output", test.plugin)
 			}
-		}
+			for _, expected := range test.expectedElements {
+				if !strings.Contains(str, expected) {
+					t.Errorf("expected to find %q in output: %q", expected, str)
+				}
+			}
+			for _, unexpected := range test.unexpectedElements {
+				if strings.Contains(str, unexpected) {
+					t.Errorf("unexpected to find %q in output: %q", unexpected, str)
+				}
+			}
+		})
 	}
 }
 
@@ -1271,25 +1318,27 @@ func TestPersistentVolumeClaimDescriber(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		fake := fake.NewSimpleClientset(test.pvc)
-		c := PersistentVolumeClaimDescriber{fake}
-		str, err := c.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
-		if err != nil {
-			t.Errorf("Unexpected error for test %s: %v", test.name, err)
-		}
-		if str == "" {
-			t.Errorf("Unexpected empty string for test %s.  Expected PVC Describer output", test.name)
-		}
-		for _, expected := range test.expectedElements {
-			if !strings.Contains(str, expected) {
-				t.Errorf("expected to find %q in output: %q", expected, str)
+		t.Run(test.name, func(t *testing.T) {
+			fake := fake.NewSimpleClientset(test.pvc)
+			c := PersistentVolumeClaimDescriber{fake}
+			str, err := c.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("Unexpected error for test %s: %v", test.name, err)
 			}
-		}
-		for _, unexpected := range test.unexpectedElements {
-			if strings.Contains(str, unexpected) {
-				t.Errorf("unexpected to find %q in output: %q", unexpected, str)
+			if str == "" {
+				t.Errorf("Unexpected empty string for test %s.  Expected PVC Describer output", test.name)
 			}
-		}
+			for _, expected := range test.expectedElements {
+				if !strings.Contains(str, expected) {
+					t.Errorf("expected to find %q in output: %q", expected, str)
+				}
+			}
+			for _, unexpected := range test.unexpectedElements {
+				if strings.Contains(str, unexpected) {
+					t.Errorf("unexpected to find %q in output: %q", unexpected, str)
+				}
+			}
+		})
 	}
 }
 
@@ -1879,20 +1928,22 @@ func TestDescribeHorizontalPodAutoscaler(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.hpa.ObjectMeta = metav1.ObjectMeta{
-			Name:      "bar",
-			Namespace: "foo",
-		}
-		fake := fake.NewSimpleClientset(&test.hpa)
-		desc := HorizontalPodAutoscalerDescriber{fake}
-		str, err := desc.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
-		if err != nil {
-			t.Errorf("Unexpected error for test %s: %v", test.name, err)
-		}
-		if str == "" {
-			t.Errorf("Unexpected empty string for test %s.  Expected HPA Describer output", test.name)
-		}
-		t.Logf("Description for %q:\n%s", test.name, str)
+		t.Run(test.name, func(t *testing.T) {
+			test.hpa.ObjectMeta = metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			}
+			fake := fake.NewSimpleClientset(&test.hpa)
+			desc := HorizontalPodAutoscalerDescriber{fake}
+			str, err := desc.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("Unexpected error for test %s: %v", test.name, err)
+			}
+			if str == "" {
+				t.Errorf("Unexpected empty string for test %s.  Expected HPA Describer output", test.name)
+			}
+			t.Logf("Description for %q:\n%s", test.name, str)
+		})
 	}
 }
 
@@ -2022,27 +2073,29 @@ func TestDescribeEvents(t *testing.T) {
 	}
 
 	for name, d := range m {
-		out, err := d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
-		if err != nil {
-			t.Errorf("unexpected error for %q: %v", name, err)
-		}
-		if !strings.Contains(out, "bar") {
-			t.Errorf("unexpected out for %q: %s", name, out)
-		}
-		if !strings.Contains(out, "Events:") {
-			t.Errorf("events not found for %q when ShowEvents=true: %s", name, out)
-		}
+		t.Run(name, func(t *testing.T) {
+			out, err := d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: true})
+			if err != nil {
+				t.Errorf("unexpected error for %q: %v", name, err)
+			}
+			if !strings.Contains(out, "bar") {
+				t.Errorf("unexpected out for %q: %s", name, out)
+			}
+			if !strings.Contains(out, "Events:") {
+				t.Errorf("events not found for %q when ShowEvents=true: %s", name, out)
+			}
 
-		out, err = d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: false})
-		if err != nil {
-			t.Errorf("unexpected error for %q: %s", name, err)
-		}
-		if !strings.Contains(out, "bar") {
-			t.Errorf("unexpected out for %q: %s", name, out)
-		}
-		if strings.Contains(out, "Events:") {
-			t.Errorf("events found for %q when ShowEvents=false: %s", name, out)
-		}
+			out, err = d.Describe("foo", "bar", printers.DescriberSettings{ShowEvents: false})
+			if err != nil {
+				t.Errorf("unexpected error for %q: %s", name, err)
+			}
+			if !strings.Contains(out, "bar") {
+				t.Errorf("unexpected out for %q: %s", name, out)
+			}
+			if strings.Contains(out, "Events:") {
+				t.Errorf("events found for %q when ShowEvents=false: %s", name, out)
+			}
+		})
 	}
 }
 
@@ -2070,13 +2123,15 @@ func TestPrintLabelsMultiline(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
-		out := new(bytes.Buffer)
-		writer := NewPrefixWriter(out)
-		printAnnotationsMultiline(writer, "Annotations", testCase.annotations)
-		output := out.String()
-		if output != testCase.expectPrint {
-			t.Errorf("Test case %d: expected to find %q in output: %q", i, testCase.expectPrint, output)
-		}
+		t.Run(testCase.expectPrint, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			writer := NewPrefixWriter(out)
+			printAnnotationsMultiline(writer, "Annotations", testCase.annotations)
+			output := out.String()
+			if output != testCase.expectPrint {
+				t.Errorf("Test case %d: expected to find %q in output: %q", i, testCase.expectPrint, output)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Many table-driven tests in pkg/kubectl are not using this feature.

/kind cleanup

Further reading: [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
