### PR TITLE
e2e/storage: parameterize container images

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -110,6 +110,8 @@ type TestContextType struct {
 	FeatureGates map[string]bool
 	// Node e2e specific test context
 	NodeTestContextType
+	// Storage e2e specific test context
+	StorageTestContextType
 	// Monitoring solution that is used in current cluster.
 	ClusterMonitoringMode string
 	// Separate Prometheus monitoring deployed in cluster
@@ -155,6 +157,14 @@ type NodeTestContextType struct {
 	// the node e2e test. If empty, the default one (system.DefaultSpec) is
 	// used. The system specs are in test/e2e_node/system/specs/.
 	SystemSpecName string
+}
+
+// StorageConfig contains the shared settings for storage 2e2 tests.
+type StorageTestContextType struct {
+	// CSIImageVersion overrides the builtin stable version numbers if set.
+	CSIImageVersion string
+	// CSIImageRegistry defines the image registry hosting the CSI container images.
+	CSIImageRegistry string
 }
 
 type CloudConfig struct {
@@ -290,6 +300,11 @@ func RegisterNodeFlags() {
 	flag.StringVar(&TestContext.SystemSpecName, "system-spec-name", "", "The name of the system spec (e.g., gke) that's used in the node e2e test. The system specs are in test/e2e_node/system/specs/. This is used by the test framework to determine which tests to run for validating the system requirements.")
 }
 
+func RegisterStorageFlags() {
+	flag.StringVar(&TestContext.CSIImageVersion, "csiImageVersion", "", "overrides the default tag used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
+	flag.StringVar(&TestContext.CSIImageRegistry, "csiImageRegistry", "quay.io/k8scsi", "overrides the default repository used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
+}
+
 // ViperizeFlags sets up all flag and config processing. Future configuration info should be added to viper, not to flags.
 func ViperizeFlags() {
 
@@ -298,6 +313,7 @@ func ViperizeFlags() {
 	// since go test 'flag's are sort of incompatible w/ flag, glog, etc.
 	RegisterCommonFlags()
 	RegisterClusterFlags()
+	RegisterStorageFlags()
 	flag.Parse()
 
 	// Part 2: Set Viper provided flags.

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -20,7 +20,6 @@ limitations under the License.
 package storage
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -44,19 +43,12 @@ var csiImageVersions = map[string]string{
 	"csi-provisioner":  "v0.2.1",
 	"driver-registrar": "v0.2.0",
 }
-var csiImageVersion string
-var csiImageRegistry string
-
-func init() {
-	flag.StringVar(&csiImageVersion, "csiImageVersion", "", "overrides the default tag used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
-	flag.StringVar(&csiImageRegistry, "csiImageRegistry", "quay.io/k8scsi", "overrides the default repository used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
-}
 
 func csiContainerImage(image string) string {
 	var fullName string
-	fullName += csiImageRegistry + "/" + image + ":"
-	if csiImageVersion != "" {
-		fullName += csiImageVersion
+	fullName += framework.TestContext.CSIImageRegistry + "/" + image + ":"
+	if framework.TestContext.CSIImageVersion != "" {
+		fullName += framework.TestContext.CSIImageVersion
 	} else {
 		fullName += csiImageVersions[image]
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The CSI integration test for hostpath was hard-coded to use the latest
stable release of the sidecar and hostpath container images. This
makes sense for regression testing of changes made in Kubernetes
itself, but the same test is also useful for testing the "canary"
images on quay.io before tagging them as a new release or for testing
locally produced images. Both is now possible via command line
parameters.

**Which issue(s) this PR fixes**:
Related-to: kubernetes-csi/docs#23

**Special notes for your reviewer**:

The commit message has usage instructions.

```release-note
NONE
```

/sig storage