### PR TITLE
Remove interrupt handler registration from pkg/kubelet

### DIFF
--- a/pkg/kubelet/dockershim/remote/BUILD
+++ b/pkg/kubelet/dockershim/remote/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
         "//pkg/kubelet/dockershim:go_default_library",
         "//pkg/kubelet/util:go_default_library",
-        "//pkg/util/interrupt:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
     ],

--- a/pkg/kubelet/dockershim/remote/docker_server.go
+++ b/pkg/kubelet/dockershim/remote/docker_server.go
@@ -25,7 +25,6 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim"
 	"k8s.io/kubernetes/pkg/kubelet/util"
-	"k8s.io/kubernetes/pkg/util/interrupt"
 )
 
 // DockerServer is the grpc server of dockershim.
@@ -64,9 +63,7 @@ func (s *DockerServer) Start() error {
 	runtimeapi.RegisterRuntimeServiceServer(s.server, s.service)
 	runtimeapi.RegisterImageServiceServer(s.server, s.service)
 	go func() {
-		// Use interrupt handler to make sure the server to be stopped properly.
-		h := interrupt.New(nil, s.Stop)
-		err := h.Run(func() error { return s.server.Serve(l) })
+		err := s.server.Serve(l)
 		if err != nil {
 			glog.Errorf("Failed to serve connections: %v", err)
 		}


### PR DESCRIPTION
The goal of this change is to remove the registration of signal
handling from package code.

If you register a signal handler in `main()` to aid in a controlled
exit then the handler registered here in `pkg/kubelet` often wins and
exits immediately; this means all other signal handler registrations
are racy if you use invoke `DockerServer.Start()`.

I experienced the net effect of this when registering a signal handler
in main() and the handler in this pkg often runs first. The final
action registered with the signal handler machinery in this pkg is
`nil` and that means the process will always exit with status code 1.
This is unhelpful when you would like your binary to exit with
0 (i.e., success).

By removing this signal registration handler, the server will no
longer clean up as it used to. Right now I don't know what the full
ramification of this change really is. I would point out, however,
that previously the 'other end' of this connection could disappear at
any time (i.e., all established connections would immediately drop)
and there was no clean up code for that particular event.

I did look at weaving a stopCh through to this function but that
effort began to explode.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


