### PR TITLE
kubeadm: Use the API machinery for marshalling

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/util:go_default_library",
@@ -28,7 +29,6 @@ go_library(
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/version:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -24,15 +24,15 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	clientset "k8s.io/client-go/kubernetes"
+	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -100,7 +100,7 @@ func printConfiguration(cfg *kubeadmapiv1alpha1.MasterConfiguration, w io.Writer
 		return
 	}
 
-	cfgYaml, err := yaml.Marshal(*cfg)
+	cfgYaml, err := kubeadmutil.MarshalToYamlForCodecs(cfg, kubeadmapiv1alpha1.SchemeGroupVersion, kubeadmscheme.Codecs)
 	if err == nil {
 		fmt.Fprintln(w, "[upgrade/config] Configuration used:")
 

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -42,6 +42,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  advertiseAddress: ""
 	  bindPort: 0
 	  controlPlaneEndpoint: ""
+	apiVersion: kubeadm.k8s.io/v1alpha1
 	auditPolicy:
 	  logDir: ""
 	  path: ""
@@ -55,6 +56,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  image: ""
 	  keyFile: ""
 	imageRepository: ""
+	kind: MasterConfiguration
 	kubeProxy: {}
 	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1
@@ -80,6 +82,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  advertiseAddress: ""
 	  bindPort: 0
 	  controlPlaneEndpoint: ""
+	apiVersion: kubeadm.k8s.io/v1alpha1
 	auditPolicy:
 	  logDir: ""
 	  path: ""
@@ -93,6 +96,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  image: ""
 	  keyFile: ""
 	imageRepository: ""
+	kind: MasterConfiguration
 	kubeProxy: {}
 	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1
@@ -123,6 +127,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  advertiseAddress: ""
 	  bindPort: 0
 	  controlPlaneEndpoint: ""
+	apiVersion: kubeadm.k8s.io/v1alpha1
 	auditPolicy:
 	  logDir: ""
 	  path: ""
@@ -141,6 +146,7 @@ func TestPrintConfiguration(t *testing.T) {
 	    etcdVersion: v0.1.0
 	    operatorVersion: v0.1.0
 	imageRepository: ""
+	kind: MasterConfiguration
 	kubeProxy: {}
 	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Similar to https://github.com/kubernetes/kubernetes/pull/63723, we should not use a generic `yaml` 
package for marshalling, but use the API machinery we have already in place. This now correctly includes `apiVersion` and `kind` when printing the configuration in the upgrade procedure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes/community/pull/2131

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @liztio 