### PR TITLE
[prometheus addon] Add filter out timeseries without image in prometheus integration cpu tests

### DIFF
--- a/test/e2e/instrumentation/monitoring/prometheus.go
+++ b/test/e2e/instrumentation/monitoring/prometheus.go
@@ -91,7 +91,7 @@ var _ = instrumentation.SIGDescribe("[Feature:PrometheusMonitoring] Prometheus",
 })
 
 func prometheusCPUQuery(namespace, podNamePrefix string, rate time.Duration) string {
-	return fmt.Sprintf(`sum(irate(container_cpu_usage_seconds_total{namespace="%v",pod_name=~"%v.*"}[%vm]))`,
+	return fmt.Sprintf(`sum(irate(container_cpu_usage_seconds_total{namespace="%v",pod_name=~"%v.*",image!=""}[%vm]))`,
 		namespace, podNamePrefix, int64(rate.Minutes()))
 }
 


### PR DESCRIPTION
This PR fixes prometheus integration tests https://k8s-testgrid.appspot.com/sig-instrumentation#gce-prometheus

New pod timeseries was introduced (https://github.com/kubernetes/kubernetes/pull/63406/files) that has same labels for namespace and
pod_name resulting in doubling value in old query. New metric is not
based on containers so filtering on image solves that problem.


```release-note
NONE
```
/cc @brancz