### PR TITLE
Enable kubectl proxy to set tcp keepalive

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -93,6 +93,7 @@ func NewCmdProxy(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	cmd.Flags().StringP("address", "", "127.0.0.1", "The IP address on which to serve on.")
 	cmd.Flags().Bool("disable-filter", false, "If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.")
 	cmd.Flags().StringP("unix-socket", "u", "", "Unix socket on which to run the proxy.")
+	cmd.Flags().Duration("keepalive", 0, "keepalive specifies the keep-alive period for an active network connection. Set to 0 to disable keepalive.")
 	return cmd
 }
 
@@ -141,7 +142,9 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		filter = nil
 	}
 
-	server, err := proxy.NewServer(staticDir, apiProxyPrefix, staticPrefix, filter, clientConfig)
+	keepalive := cmdutil.GetFlagDuration(cmd, "keepalive")
+
+	server, err := proxy.NewServer(staticDir, apiProxyPrefix, staticPrefix, filter, clientConfig, keepalive)
 
 	// Separate listening from serving so we can report the bound port
 	// when it is chosen by os (eg: port == 0)

--- a/pkg/kubectl/proxy/proxy_server_test.go
+++ b/pkg/kubectl/proxy/proxy_server_test.go
@@ -452,7 +452,7 @@ func TestPathHandling(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := NewServer("", tt.prefix, "/not/used/for/this/test", nil, cc)
+			p, err := NewServer("", tt.prefix, "/not/used/for/this/test", nil, cc, 0)
 			if err != nil {
 				t.Fatalf("%#v: %v", tt, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows setting keepalive period for kubectl proxy.

Fixes #63727

**Special notes for your reviewer**:

/assign @brendandburns

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce a new flag `--keepalive` for kubectl proxy to allow setting keep-alive period for long-running request.
```
