### PR TITLE
remove unused PrintFlags.Scheme

### DIFF
--- a/pkg/printers/flags.go
+++ b/pkg/printers/flags.go
@@ -76,8 +76,6 @@ type PrintFlags struct {
 	NamePrintFlags     *NamePrintFlags
 
 	OutputFormat *string
-
-	Scheme runtime.ObjectConvertor
 }
 
 func (f *PrintFlags) Complete(successTemplate string) error {
@@ -125,8 +123,6 @@ func NewPrintFlags(operation string, scheme runtime.ObjectConvertor) *PrintFlags
 
 	return &PrintFlags{
 		OutputFormat: &outputFormat,
-
-		Scheme: scheme,
 
 		JSONYamlPrintFlags: NewJSONYamlPrintFlags(scheme),
 		NamePrintFlags:     NewNamePrintFlags(operation, scheme),


### PR DESCRIPTION
PrintFlags.Scheme is unused, remove it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
