### PR TITLE
kubeadm: Restructure internal config usage and fix bugs

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -59,7 +59,6 @@ go_library(
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
         "//vendor/github.com/json-iterator/go:go_default_library",
         "//vendor/github.com/ugorji/go/codec:go_default_library",
-        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
@@ -89,9 +88,5 @@ go_test(
     srcs = ["upgrade_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = [
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
-    ],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library"],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade.go
@@ -18,15 +18,13 @@ package v1alpha1
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/ugorji/go/codec"
-	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,36 +98,4 @@ func proxyFeatureListToMap(m map[string]interface{}) error {
 
 	unstructured.SetNestedMap(m, gateMap, featureGatePath...)
 	return nil
-}
-
-// LoadYAML is a small wrapper around go-yaml that ensures all nested structs are map[string]interface{} instead of map[interface{}]interface{}.
-func LoadYAML(bytes []byte) (map[string]interface{}, error) {
-	var decoded map[interface{}]interface{}
-	if err := yaml.Unmarshal(bytes, &decoded); err != nil {
-		return map[string]interface{}{}, fmt.Errorf("couldn't unmarshal YAML: %v", err)
-	}
-
-	converted, ok := convert(decoded).(map[string]interface{})
-	if !ok {
-		return map[string]interface{}{}, errors.New("yaml is not a map")
-	}
-
-	return converted, nil
-}
-
-// https://stackoverflow.com/questions/40737122/convert-yaml-to-json-without-struct-golang
-func convert(i interface{}) interface{} {
-	switch x := i.(type) {
-	case map[interface{}]interface{}:
-		m2 := map[string]interface{}{}
-		for k, v := range x {
-			m2[k.(string)] = convert(v)
-		}
-		return m2
-	case []interface{}:
-		for i, v := range x {
-			x[i] = convert(v)
-		}
-	}
-	return i
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade_test.go
@@ -17,36 +17,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
-
-const test196 = "testdata/kubeadm196.yaml"
-
-func TestUpgrade(t *testing.T) {
-	testYAML, err := ioutil.ReadFile(test196)
-	if err != nil {
-		t.Fatalf("couldn't read test data: %v", err)
-	}
-
-	decoded, err := LoadYAML(testYAML)
-	if err != nil {
-		t.Fatalf("couldn't unmarshal test yaml: %v", err)
-	}
-
-	scheme := runtime.NewScheme()
-	AddToScheme(scheme)
-	codecs := serializer.NewCodecFactory(scheme)
-
-	obj := &MasterConfiguration{}
-	if err := Migrate(decoded, obj, codecs); err != nil {
-		t.Fatalf("couldn't decode migrated object: %v", err)
-	}
-}
 
 func TestProxyFeatureListToMap(t *testing.T) {
 

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
         "//cmd/kubeadm/app/util/etcd:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
@@ -46,7 +45,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/phases/upgrade:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -26,6 +26,7 @@ import (
 
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -37,7 +38,6 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
@@ -87,7 +87,7 @@ func NewCmdApply(parentFlags *cmdUpgradeFlags) *cobra.Command {
 			// If the version is specified in config file, pick up that value.
 			if flags.parent.cfgPath != "" {
 				glog.V(1).Infof("fetching configuration from file", flags.parent.cfgPath)
-				cfg, err := upgrade.FetchConfigurationFromFile(flags.parent.cfgPath)
+				cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(parentFlags.cfgPath, &kubeadmapiv1alpha1.MasterConfiguration{})
 				kubeadmutil.CheckErr(err)
 
 				if cfg.KubernetesVersion != "" {
@@ -147,26 +147,21 @@ func RunApply(flags *applyFlags) error {
 		return err
 	}
 
-	// Grab the external, versioned configuration and convert it to the internal type for usage here later
-	glog.V(1).Infof("[upgrade/apply] converting configuration for internal use")
-	internalcfg := &kubeadmapi.MasterConfiguration{}
-	legacyscheme.Scheme.Convert(upgradeVars.cfg, internalcfg, nil)
-
 	// Validate requested and validate actual version
 	glog.V(1).Infof("[upgrade/apply] validating requested and actual version")
-	if err := configutil.NormalizeKubernetesVersion(internalcfg); err != nil {
+	if err := configutil.NormalizeKubernetesVersion(upgradeVars.cfg); err != nil {
 		return err
 	}
 
 	// Use normalized version string in all following code.
-	flags.newK8sVersionStr = internalcfg.KubernetesVersion
+	flags.newK8sVersionStr = upgradeVars.cfg.KubernetesVersion
 	k8sVer, err := version.ParseSemantic(flags.newK8sVersionStr)
 	if err != nil {
 		return fmt.Errorf("unable to parse normalized version %q as a semantic version", flags.newK8sVersionStr)
 	}
 	flags.newK8sVersion = k8sVer
 
-	if err := features.ValidateVersion(features.InitFeatureGates, internalcfg.FeatureGates, internalcfg.KubernetesVersion); err != nil {
+	if err := features.ValidateVersion(features.InitFeatureGates, upgradeVars.cfg.FeatureGates, upgradeVars.cfg.KubernetesVersion); err != nil {
 		return err
 	}
 
@@ -186,18 +181,18 @@ func RunApply(flags *applyFlags) error {
 	// Use a prepuller implementation based on creating DaemonSets
 	// and block until all DaemonSets are ready; then we know for sure that all control plane images are cached locally
 	glog.V(1).Infof("[upgrade/apply] creating prepuller")
-	prepuller := upgrade.NewDaemonSetPrepuller(upgradeVars.client, upgradeVars.waiter, internalcfg)
+	prepuller := upgrade.NewDaemonSetPrepuller(upgradeVars.client, upgradeVars.waiter, upgradeVars.cfg)
 	upgrade.PrepullImagesInParallel(prepuller, flags.imagePullTimeout)
 
 	// Now; perform the upgrade procedure
 	glog.V(1).Infof("[upgrade/apply] performing upgrade")
-	if err := PerformControlPlaneUpgrade(flags, upgradeVars.client, upgradeVars.waiter, internalcfg); err != nil {
+	if err := PerformControlPlaneUpgrade(flags, upgradeVars.client, upgradeVars.waiter, upgradeVars.cfg); err != nil {
 		return fmt.Errorf("[upgrade/apply] FATAL: %v", err)
 	}
 
 	// Upgrade RBAC rules and addons.
 	glog.V(1).Infof("[upgrade/postupgrade] upgrading RBAC rules and addons")
-	if err := upgrade.PerformPostUpgradeTasks(upgradeVars.client, internalcfg, flags.newK8sVersion, flags.dryRun); err != nil {
+	if err := upgrade.PerformPostUpgradeTasks(upgradeVars.client, upgradeVars.cfg, flags.newK8sVersion, flags.dryRun); err != nil {
 		return fmt.Errorf("[upgrade/postupgrade] FATAL post-upgrade error: %v", err)
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -20,12 +20,12 @@ import (
 	"bytes"
 	"testing"
 
-	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 func TestPrintConfiguration(t *testing.T) {
 	var tests = []struct {
-		cfg           *kubeadmapiv1alpha1.MasterConfiguration
+		cfg           *kubeadmapi.MasterConfiguration
 		buf           *bytes.Buffer
 		expectedBytes []byte
 	}{
@@ -34,7 +34,7 @@ func TestPrintConfiguration(t *testing.T) {
 			expectedBytes: []byte(""),
 		},
 		{
-			cfg: &kubeadmapiv1alpha1.MasterConfiguration{
+			cfg: &kubeadmapi.MasterConfiguration{
 				KubernetesVersion: "v1.7.1",
 			},
 			expectedBytes: []byte(`[upgrade/config] Configuration used:
@@ -71,9 +71,9 @@ func TestPrintConfiguration(t *testing.T) {
 `),
 		},
 		{
-			cfg: &kubeadmapiv1alpha1.MasterConfiguration{
+			cfg: &kubeadmapi.MasterConfiguration{
 				KubernetesVersion: "v1.7.1",
-				Networking: kubeadmapiv1alpha1.Networking{
+				Networking: kubeadmapi.Networking{
 					ServiceSubnet: "10.96.0.1/12",
 				},
 			},
@@ -111,10 +111,10 @@ func TestPrintConfiguration(t *testing.T) {
 `),
 		},
 		{
-			cfg: &kubeadmapiv1alpha1.MasterConfiguration{
+			cfg: &kubeadmapi.MasterConfiguration{
 				KubernetesVersion: "v1.7.1",
-				Etcd: kubeadmapiv1alpha1.Etcd{
-					SelfHosted: &kubeadmapiv1alpha1.SelfHostedEtcd{
+				Etcd: kubeadmapi.Etcd{
+					SelfHosted: &kubeadmapi.SelfHostedEtcd{
 						CertificatesDir:    "/var/foo",
 						ClusterServiceName: "foo",
 						EtcdVersion:        "v0.1.0",

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -26,11 +26,13 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 )
 
@@ -59,7 +61,7 @@ func NewCmdPlan(parentFlags *cmdUpgradeFlags) *cobra.Command {
 			// If the version is specified in config file, pick up that value.
 			if parentFlags.cfgPath != "" {
 				glog.V(1).Infof("fetching configuration from file", parentFlags.cfgPath)
-				cfg, err := upgrade.FetchConfigurationFromFile(parentFlags.cfgPath)
+				cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(parentFlags.cfgPath, &kubeadmapiv1alpha1.MasterConfiguration{})
 				kubeadmutil.CheckErr(err)
 
 				if cfg.KubernetesVersion != "" {

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -17,9 +17,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//pkg/util/node:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/marshal.go
+++ b/cmd/kubeadm/app/util/marshal.go
@@ -17,7 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -57,4 +60,36 @@ func UnmarshalFromYamlForCodecs(buffer []byte, gv schema.GroupVersion, codecs se
 
 	decoder := codecs.DecoderToVersion(info.Serializer, gv)
 	return runtime.Decode(decoder, buffer)
+}
+
+// LoadYAML is a small wrapper around go-yaml that ensures all nested structs are map[string]interface{} instead of map[interface{}]interface{}.
+func LoadYAML(bytes []byte) (map[string]interface{}, error) {
+	var decoded map[interface{}]interface{}
+	if err := yaml.Unmarshal(bytes, &decoded); err != nil {
+		return map[string]interface{}{}, fmt.Errorf("couldn't unmarshal YAML: %v", err)
+	}
+
+	converted, ok := convert(decoded).(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}, errors.New("yaml is not a map")
+	}
+
+	return converted, nil
+}
+
+// https://stackoverflow.com/questions/40737122/convert-yaml-to-json-without-struct-golang
+func convert(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = convert(v)
+		}
+		return m2
+	case []interface{}:
+		for i, v := range x {
+			x[i] = convert(v)
+		}
+	}
+	return i
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
 - Moves the generic LoadYAML function from the versioned, external API package to a helper library so it can be consumed more easily
 - Makes the upgrading code use the internal version of the API (which always should be used anyway)
 - Moves all config-loading code to `configutil`, together with the migration code needed. This way we have everything in one centralized place, instead of duplicating that logic N times.
 - Makes `kubeadm init` use `configutil` for the reasons mentioned above.

This PR is needed in order to support multiple external API groups (like v1alpha2)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes/community/pull/2131

**Special notes for your reviewer**:
This PR depends on:
 - https://github.com/kubernetes/kubernetes/pull/63782
 - https://github.com/kubernetes/kubernetes/pull/63783

**Please review only the last (third) commit**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @liztio 