### PR TITLE
kubeadm - do not generate etcd ca/certs for external etcd

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -39,14 +39,21 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
 		CreateCACertAndKeyFiles,
 		CreateAPIServerCertAndKeyFiles,
 		CreateAPIServerKubeletClientCertAndKeyFiles,
+		CreateServiceAccountKeyAndPublicKeyFiles,
+		CreateFrontProxyCACertAndKeyFiles,
+		CreateFrontProxyClientCertAndKeyFiles,
+	}
+	etcdCertActions := []func(cfg *kubeadmapi.MasterConfiguration) error{
 		CreateEtcdCACertAndKeyFiles,
 		CreateEtcdServerCertAndKeyFiles,
 		CreateEtcdPeerCertAndKeyFiles,
 		CreateEtcdHealthcheckClientCertAndKeyFiles,
 		CreateAPIServerEtcdClientCertAndKeyFiles,
-		CreateServiceAccountKeyAndPublicKeyFiles,
-		CreateFrontProxyCACertAndKeyFiles,
-		CreateFrontProxyClientCertAndKeyFiles,
+	}
+
+	// Currently this is the only way we have to identify static pod etcd vs external etcd
+	if len(cfg.Etcd.Endpoints) == 0 {
+		certActions = append(certActions, etcdCertActions...)
 	}
 
 	for _, action := range certActions {

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -603,6 +603,7 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 		setupFunc     func(cfg *kubeadmapi.MasterConfiguration) error
 		createFunc    func(cfg *kubeadmapi.MasterConfiguration) error
 		expectedFiles []string
+		externalEtcd  bool
 	}{
 		{
 			createFunc: CreatePKIAssets,
@@ -615,6 +616,18 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 				kubeadmconstants.EtcdPeerCertName, kubeadmconstants.EtcdPeerKeyName,
 				kubeadmconstants.EtcdHealthcheckClientCertName, kubeadmconstants.EtcdHealthcheckClientKeyName,
 				kubeadmconstants.APIServerEtcdClientCertName, kubeadmconstants.APIServerEtcdClientKeyName,
+				kubeadmconstants.ServiceAccountPrivateKeyName, kubeadmconstants.ServiceAccountPublicKeyName,
+				kubeadmconstants.FrontProxyCACertName, kubeadmconstants.FrontProxyCAKeyName,
+				kubeadmconstants.FrontProxyClientCertName, kubeadmconstants.FrontProxyClientKeyName,
+			},
+		},
+		{
+			createFunc:   CreatePKIAssets,
+			externalEtcd: true,
+			expectedFiles: []string{
+				kubeadmconstants.CACertName, kubeadmconstants.CAKeyName,
+				kubeadmconstants.APIServerCertName, kubeadmconstants.APIServerKeyName,
+				kubeadmconstants.APIServerKubeletClientCertName, kubeadmconstants.APIServerKubeletClientKeyName,
 				kubeadmconstants.ServiceAccountPrivateKeyName, kubeadmconstants.ServiceAccountPublicKeyName,
 				kubeadmconstants.FrontProxyCACertName, kubeadmconstants.FrontProxyCAKeyName,
 				kubeadmconstants.FrontProxyClientCertName, kubeadmconstants.FrontProxyClientKeyName,
@@ -683,6 +696,10 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 			Networking:      kubeadmapi.Networking{ServiceSubnet: "10.96.0.0/12", DNSDomain: "cluster.local"},
 			NodeName:        "valid-hostname",
 			CertificatesDir: tmpdir,
+		}
+
+		if test.externalEtcd {
+			cfg.Etcd.Endpoints = []string{"192.168.1.1:2379"}
 		}
 
 		// executes setup func (if necessary)


### PR DESCRIPTION

**What this PR does / why we need it**:

Currently we generate an etcd CA and certificates even if we are specifying an external etcd cluster when running `kubeadm init`, this PR changes this behavior to skip generating the etcd CA and certificates if configured for an external etcd cluster.

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes/kubeadm/issues/807

**Release note**:
```release-note
kubeadm will no longer generate an unused etcd CA and certificates when configured to use an external etcd cluster.
```
