### PR TITLE
Sort arguments before joining them, for reproducible return string

### DIFF
--- a/cmd/kubeadm/app/util/arguments.go
+++ b/cmd/kubeadm/app/util/arguments.go
@@ -18,17 +18,32 @@ package util
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
-// BuildArgumentListFromMap takes two string-string maps, one with the base arguments and one with optional override arguments
+// BuildArgumentListFromMap takes two string-string maps, one with the base arguments and one
+// with optional override arguments. In the return list override arguments will precede base
+// arguments
 func BuildArgumentListFromMap(baseArguments map[string]string, overrideArguments map[string]string) []string {
 	var command []string
-	for k, v := range overrideArguments {
+	var keys []string
+	for k := range overrideArguments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := overrideArguments[k]
 		// values of "" are allowed as well
 		command = append(command, fmt.Sprintf("--%s=%s", k, v))
 	}
-	for k, v := range baseArguments {
+	keys = []string{}
+	for k := range baseArguments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := baseArguments[k]
 		if _, overrideExists := overrideArguments[k]; !overrideExists {
 			command = append(command, fmt.Sprintf("--%s=%s", k, v))
 		}

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -39,8 +39,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
+				"--insecure-bind-address=127.0.0.1",
 			},
 		},
 		{ // add an argument that is not in base
@@ -53,8 +53,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
+				"--insecure-bind-address=127.0.0.1",
 			},
 		},
 		{ // allow empty strings in base
@@ -68,8 +68,8 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
 				"--allow-privileged=true",
+				"--insecure-bind-address=127.0.0.1",
 				"--something-that-allows-empty-string=",
 			},
 		},
@@ -85,17 +85,15 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--insecure-bind-address=127.0.0.1",
-				"--allow-privileged=true",
 				"--something-that-allows-empty-string=",
+				"--allow-privileged=true",
+				"--insecure-bind-address=127.0.0.1",
 			},
 		},
 	}
 
 	for _, rt := range tests {
 		actual := BuildArgumentListFromMap(rt.base, rt.overrides)
-		sort.Strings(actual)
-		sort.Strings(rt.expected)
 		if !reflect.DeepEqual(actual, rt.expected) {
 			t.Errorf("failed BuildArgumentListFromMap:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes kubeadm static pod manifest generation consistent. Right now when `kubeadm init` is called repeatedly, the generated pod manifest files under /etc/kubernetes/manifest/ are changing. Its really hard to test how a configuration change effects the manifest files.

The current implementation is ranging over a map[string]string which will be happening in a random order, generating different pod manifests even without changing any configuration.

The suggested solution makes pom manifest generation idempotent. It opens up integration test possibilities, like testing whole yaml result of `kubeadm alpha phase controlplane`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/sig cluster-lifecycle
/assign @luxas