### PR TITLE
NFS support for default storage

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -14,6 +14,7 @@ includes:
   - 'interface:kube-control'
   - 'interface:aws'
   - 'interface:gcp'
+  - 'interface:mount'
 config:
   deletes:
     - install_from_upstream

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -7,6 +7,7 @@ maintainers:
   - Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
   - Charles Butler <Chuck@dasroot.net>
   - Matthew Bruzek <mbruzek@ubuntu.com>
+  - Mike Wilson <mike.wilson@canonical.com>
 description: |
   Kubernetes is an open-source platform for deploying, scaling, and operations
   of application containers across a cluster of hosts. Kubernetes is portable
@@ -32,6 +33,8 @@ requires:
     interface: aws
   gcp:
     interface: gcp
+  nfs:
+    interface: mount
 provides:
   cni:
     interface: kubernetes-cni

--- a/cluster/juju/layers/kubernetes-worker/templates/nfs-provisioner.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/nfs-provisioner.yaml
@@ -1,0 +1,39 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: fuseim.pri/ifs
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nfs-client-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nfs-client-provisioner
+    spec:
+      containers:
+        - name: nfs-client-provisioner
+          image: quay.io/external_storage/nfs-client-provisioner:latest
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            - name: PROVISIONER_NAME
+              value: fuseim.pri/ifs
+            - name: NFS_SERVER
+              value: {{ hostname }}
+            - name: NFS_PATH
+              value: {{ mountpoint }}
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: {{ hostname }}
+            path: {{ mountpoint }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds NFS support for kubernetes-worker charm allowing default storage for NFS charms.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for NFS relations on kubernetes-worker charm.
```
