### PR TITLE
Skip NodeAffinity validation test.

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -368,8 +368,18 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 
 	It("validates that a pod with an invalid NodeAffinity is rejected", func() {
 		By("Trying to launch a pod with an invalid Affinity data.")
+		validationChangedVersion := utilversion.MustParseSemantic("v1.10.2")
+		validationChanged, err := framework.ServerVersionGTE(validationChangedVersion, f.ClientSet.Discovery())
+		if err != nil {
+			framework.Failf("Unable to check server version: %v", err)
+		}
+		if validationChanged {
+			// See https://github.com/kubernetes/kubernetes/issues/63815
+			framework.Skipf("NodeAffinity validation changed in 1.10.2")
+		}
+
 		podName := "without-label"
-		_, err := cs.CoreV1().Pods(ns).Create(initPausePod(f, pausePodConfig{
+		_, err = cs.CoreV1().Pods(ns).Create(initPausePod(f, pausePodConfig{
 			Name: podName,
 			Affinity: &v1.Affinity{
 				NodeAffinity: &v1.NodeAffinity{


### PR DESCRIPTION
**What this PR does / why we need it**:
NodeAffinity validation logic changed in 1.10.2, and the tests were
updated to reflect it. E2E upgrade tests use 1.9 tests against a 1.10
server, though, so this specific test fails.

Fix it by calling framework.Skipf when the server version is >=1.10.2.
This test was deleted in 1.10.2.
See https://github.com/kubernetes/kubernetes/issues/63815

Fixes #63815

**Special notes for your reviewer**:
I was not sure if the ginkgo "By" statement should come before or after the version check. (for the purposes of making test output more readable.)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
