### PR TITLE
Fix openapi spec: posting a rollback returns a deploymentstatus

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -29279,19 +29279,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus"
        }
       },
       "401": {
@@ -47633,19 +47633,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStatus"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStatus"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStatus"
        }
       },
       "401": {

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -1957,7 +1957,7 @@
     "description": "API at /apis/apps/v1beta1",
     "operations": [
      {
-      "type": "v1beta1.DeploymentRollback",
+      "type": "v1beta1.DeploymentStatus",
       "method": "POST",
       "summary": "create rollback of a Deployment",
       "nickname": "createNamespacedDeploymentRollback",
@@ -1999,17 +1999,17 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        },
        {
         "code": 201,
         "message": "Created",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        },
        {
         "code": 202,
         "message": "Accepted",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        }
       ],
       "produces": [

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -2127,7 +2127,7 @@
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
-      "type": "v1beta1.DeploymentRollback",
+      "type": "v1beta1.DeploymentStatus",
       "method": "POST",
       "summary": "create rollback of a Deployment",
       "nickname": "createNamespacedDeploymentRollback",
@@ -2169,17 +2169,17 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        },
        {
         "code": 201,
         "message": "Created",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        },
        {
         "code": 202,
         "message": "Accepted",
-        "responseModel": "v1beta1.DeploymentRollback"
+        "responseModel": "v1beta1.DeploymentStatus"
        }
       ],
       "produces": [

--- a/docs/api-reference/apps/v1beta1/operations.html
+++ b/docs/api-reference/apps/v1beta1/operations.html
@@ -2950,17 +2950,17 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">202</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Accepted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">201</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Created</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/docs/api-reference/extensions/v1beta1/operations.html
+++ b/docs/api-reference/extensions/v1beta1/operations.html
@@ -3508,17 +3508,17 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">202</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Accepted</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">201</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Created</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</a></p></td>
 </tr>
 </tbody>
 </table>

--- a/pkg/registry/apps/deployment/storage/BUILD
+++ b/pkg/registry/apps/deployment/storage/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
         "//pkg/registry/apps/deployment:go_default_library",
+        "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 
+	externalappsv1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -136,6 +137,20 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 type RollbackREST struct {
 	store *genericregistry.Store
 }
+
+// ProducesMIMETypes returns a list of the MIME types the specified HTTP verb (GET, POST, DELETE,
+// PATCH) can respond with.
+func (r *RollbackREST) ProducesMIMETypes(verb string) []string {
+	return nil
+}
+
+// ProducesObject returns an object the specified HTTP verb respond with. It will overwrite storage object if
+// it is not nil. Only the type of the return object matters, the value will be ignored.
+func (r *RollbackREST) ProducesObject(verb string) interface{} {
+	return externalappsv1beta1.DeploymentStatus{}
+}
+
+var _ = rest.StorageMetadata(&RollbackREST{})
 
 // New creates a rollback
 func (r *RollbackREST) New() runtime.Object {

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -47,6 +47,17 @@ func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorag
 	return apiGroupInfo, true
 }
 
+type RollbackREST struct {
+	*deploymentstore.RollbackREST
+}
+
+// override RollbackREST.ProducesObject
+func (r *RollbackREST) ProducesObject(verb string) interface{} {
+	return extensionsapiv1beta1.DeploymentStatus{}
+}
+
+var _ = rest.StorageMetadata(&RollbackREST{})
+
 func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
 	storage := map[string]rest.Storage{}
 
@@ -65,7 +76,7 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	deploymentStorage := deploymentstore.NewStorage(restOptionsGetter)
 	storage["deployments"] = deploymentStorage.Deployment.WithCategories(nil)
 	storage["deployments/status"] = deploymentStorage.Status
-	storage["deployments/rollback"] = deploymentStorage.Rollback
+	storage["deployments/rollback"] = &RollbackREST{deploymentStorage.Rollback}
 	storage["deployments/scale"] = deploymentStorage.Scale
 	// ingresses
 	ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix openapi spec and documentation. Posting a rollback doesnt return a rollback object, it instead returns a deployment status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref #56591 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig api-machinery
/sig apps