### PR TITLE
Add option to control SSL chain completion

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -58,6 +58,15 @@ options:
 
       The value for this config must be a JSON array of credential objects, like this:
         [{"server": "my.registry", "username": "myUser", "password": "myPass"}]
+  ingress-ssl-chain-completion:
+    type: boolean
+    default: false
+    description: |
+      Enable chain completion for TLS certificates used by the nginx ingress
+      controller.  Set this to true if you would like the ingress controller
+      to attempt auto-retrieval of intermediate certificates.  The default
+      (false) is recommended for all production kubernetes installations, and
+      any environment which does not have outbound Internet access.
   nginx-image:
     type: string
     default: "auto"

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -686,6 +686,7 @@ def create_kubeconfig(kubeconfig, server, ca, key=None, certificate=None,
 
 
 @when_any('config.changed.default-backend-image',
+          'config.changed.ingress-ssl-chain-completion',
           'config.changed.nginx-image')
 @when('kubernetes-worker.config.created')
 def launch_default_ingress_controller():
@@ -728,6 +729,7 @@ def launch_default_ingress_controller():
         return
 
     # Render the ingress daemon set controller manifest
+    context['ssl_chain_completion'] = config.get('ingress-ssl-chain-completion')
     context['ingress_image'] = config.get('nginx-image')
     if context['ingress_image'] == "" or context['ingress_image'] == "auto":
         if context['arch'] == 's390x':

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
@@ -176,3 +176,4 @@ spec:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
         - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --enable-ssl-chain-completion={{ ssl_chain_completion }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds templated support to the kubernetes-worker juju charm for the --enable-ssl-chain-completion option on the ingress proxy.  It defaults to false, to ensure that production sites are not reliant on OCSP or DNS in order to function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubernetes-worker juju charm: Added support for setting the --enable-ssl-chain-completion option on the ingress proxy.  "action required": if your installation relies on supplying incomplete certificate chains and using OCSP to fill them in, you must set "ingress-ssl-chain-completion" to "true" in your juju configuration.
```
