### PR TITLE
Deflake discovery timeout test

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -136,7 +136,10 @@ func TestGetServerGroupsWithTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// first we need to write headers, otherwise http client will complain about
 		// exceeding timeout awaiting headers, only after we can block the call
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Connection", "keep-alive")
+		if wf, ok := w.(http.Flusher); ok {
+			wf.Flush()
+		}
 		<-done
 	}))
 	defer server.Close()
@@ -145,7 +148,11 @@ func TestGetServerGroupsWithTimeout(t *testing.T) {
 	defaultTimeout = 2 * time.Second
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	_, err := client.ServerGroups()
-	if err == nil || !strings.Contains(err.Error(), "deadline") {
+	// the error we're getting here is wrapped in errors.errorString which makes
+	// it impossible to unwrap and check it's attributes, so instead we're checking
+	// the textual output which is presenting http.httpError with timeout set to true
+	if !strings.Contains(err.Error(), "timeout:true") &&
+		!strings.Contains(err.Error(), "context.deadlineExceededError") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	done <- true


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the server may delay sending out the response (buffering), thus we need to flush the headers always. Additionally, I've changed the error output check looking for timeout:true string, because the error is of errors.errorString type.

/assign @sttts 

**Release note**:
```release-note
NONE
```
