### PR TITLE
Automated cherry pick of #63297: fix commands running crictl

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -101,11 +101,11 @@ func (CRICheck) Name() string {
 func (criCheck CRICheck) Check() (warnings, errors []error) {
 	crictlPath, err := criCheck.exec.LookPath("crictl")
 	if err != nil {
-		errors = append(errors, fmt.Errorf("unable to find command crictl: %s", err))
+		errors = append(errors, fmt.Errorf("unable to find command crictl: %v", err))
 		return warnings, errors
 	}
-	if err := criCheck.exec.Command(fmt.Sprintf("%s -r %s info", crictlPath, criCheck.socket)).Run(); err != nil {
-		errors = append(errors, fmt.Errorf("unable to check if the container runtime at %q is running: %s", criCheck.socket, err))
+	if err := criCheck.exec.Command(crictlPath, "-r", criCheck.socket, "info").Run(); err != nil {
+		errors = append(errors, fmt.Errorf("unable to check if the container runtime at %q is running: %v", criCheck.socket, err))
 		return warnings, errors
 	}
 	return warnings, errors


### PR DESCRIPTION
Cherry pick of #63297 on release-1.10.

#63297: fix commands running crictl

**Release note**:
```release-note
Fix incorrect usage of Command API to run crictl in 'kubeadm reset'
```
