### PR TITLE
tests: Fixes examples/ based tests

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Redis", func() {
 		It("should create and stop redis servers", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/redis", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/storage/redis", file)
 			}
 			bootstrapYaml := mkpath("redis-master.yaml")
 			sentinelServiceYaml := mkpath("redis-sentinel-service.yaml")
@@ -162,7 +162,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Spark", func() {
 		It("should start spark master, driver and workers", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/spark", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/spark", file)
 			}
 
 			// TODO: Add Zepplin and Web UI to this example.
@@ -226,10 +226,10 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Cassandra", func() {
 		It("should create and scale cassandra", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/cassandra", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/statefulset/cassandra", file)
 			}
-			serviceYaml := mkpath("cassandra-service.yaml")
-			controllerYaml := mkpath("cassandra-controller.yaml")
+			serviceYaml := mkpath("service.yaml")
+			controllerYaml := mkpath("controller.yaml")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			By("Starting the cassandra service")
@@ -265,15 +265,15 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("CassandraStatefulSet", func() {
 		It("should create statefulset", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/cassandra", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/statefulset/cassandra", file)
 			}
-			serviceYaml := mkpath("cassandra-service.yaml")
+			serviceYaml := filepath.Join(framework.TestContext.OutputDir, mkpath("service.yaml"))
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			// have to change dns prefix because of the dynamic namespace
-			input := generated.ReadOrDie(mkpath("cassandra-statefulset.yaml"))
+			input := generated.ReadOrDie(mkpath("statefulset.yaml"))
 
-			output := strings.Replace(string(input), "cassandra-0.cassandra.default.svc.cluster.local", "cassandra-0.cassandra."+ns+".svc.cluster.local", -1)
+			output := strings.Replace(string(input), "$(POD_NAMESPACE)", ns, -1)
 
 			statefulsetYaml := "/tmp/cassandra-statefulset.yaml"
 
@@ -336,14 +336,14 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 	framework.KubeDescribe("Storm", func() {
 		It("should create and stop Zookeeper, Nimbus and Storm worker servers", func() {
-			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storm", file)
+			mkpath := func(app, file string) string {
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests", app, file)
 			}
-			zookeeperServiceJson := mkpath("zookeeper-service.json")
-			zookeeperPodJson := mkpath("zookeeper.json")
-			nimbusServiceJson := mkpath("storm-nimbus-service.json")
-			nimbusPodJson := mkpath("storm-nimbus.json")
-			workerControllerJson := mkpath("storm-worker-controller.json")
+			zookeeperServiceJson := mkpath("zookeeper", "zookeeper-service.json")
+			zookeeperPodJson := mkpath("zookeeper", "zookeeper.json")
+			nimbusServiceJson := mkpath("storm", "storm-nimbus-service.json")
+			nimbusPodJson := mkpath("storm", "storm-nimbus.json")
+			workerControllerJson := mkpath("storm", "storm-worker-controller.json")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			zookeeperPod := "zookeeper"
 			nimbusPod := "nimbus"
@@ -496,7 +496,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("RethinkDB", func() {
 		It("should create and stop rethinkdb servers", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/rethinkdb", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/storage/rethinkdb", file)
 			}
 			driverServiceYaml := mkpath("driver-service.yaml")
 			rethinkDbControllerYaml := mkpath("rc.yaml")
@@ -541,7 +541,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	framework.KubeDescribe("Hazelcast", func() {
 		It("should create and scale hazelcast", func() {
 			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/hazelcast", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/storage/hazelcast", file)
 			}
 			serviceYaml := mkpath("hazelcast-service.yaml")
 			deploymentYaml := mkpath("hazelcast-deployment.yaml")
@@ -564,7 +564,8 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("scaling hazelcast")
-			framework.ScaleRC(f.ClientSet, f.ScalesGetter, ns, "hazelcast", 2, true)
+			err = framework.ScaleDeployment(f.ClientSet, f.ScalesGetter, ns, "hazelcast", 2, true)
+			Expect(err).NotTo(HaveOccurred())
 			forEachPod("name", "hazelcast", func(pod v1.Pod) {
 				_, err := framework.LookForStringInLog(ns, pod.Name, "hazelcast", "Members [2]", serverStartTimeout)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 
 	It("should create pod that uses dns", func() {
 		mkpath := func(file string) string {
-			return filepath.Join(framework.TestContext.RepoRoot, "examples/cluster-dns", file)
+			return filepath.Join(framework.TestContext.RepoRoot, "test/e2e/testing-manifests/cluster-dns", file)
 		}
 
 		// contrary to the example, this test does not use contexts, for simplicity

--- a/test/e2e/testing-manifests/cluster-dns/dns-backend-rc.yaml
+++ b/test/e2e/testing-manifests/cluster-dns/dns-backend-rc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: dns-backend
+  labels:
+    name: dns-backend
+spec:
+  replicas: 1
+  selector:
+    name: dns-backend
+  template:
+    metadata:
+      labels:
+        name: dns-backend
+    spec:
+      containers:
+        - name: dns-backend
+          image: k8s.gcr.io/example-dns-backend:v1
+          ports:
+            - name: backend-port
+              containerPort: 8000

--- a/test/e2e/testing-manifests/cluster-dns/dns-backend-service.yaml
+++ b/test/e2e/testing-manifests/cluster-dns/dns-backend-service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dns-backend
+spec:
+  ports:
+    - port: 8000
+  selector:
+    name: dns-backend

--- a/test/e2e/testing-manifests/cluster-dns/dns-frontend-pod.yaml
+++ b/test/e2e/testing-manifests/cluster-dns/dns-frontend-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dns-frontend
+  labels:
+    name: dns-frontend
+spec:
+  containers:
+    - name: dns-frontend
+      image: k8s.gcr.io/example-dns-frontend:v1
+      command:
+        - python
+        - client.py
+        - http://dns-backend.development.svc.cluster.local:8000
+      imagePullPolicy: Always
+  restartPolicy: Never

--- a/test/e2e/testing-manifests/spark/spark-master-controller.yaml
+++ b/test/e2e/testing-manifests/spark/spark-master-controller.yaml
@@ -1,0 +1,23 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: spark-master-controller
+spec:
+  replicas: 1
+  selector:
+    component: spark-master
+  template:
+    metadata:
+      labels:
+        component: spark-master
+    spec:
+      containers:
+        - name: spark-master
+          image: k8s.gcr.io/spark:1.5.2_v1
+          command: ["/start-master"]
+          ports:
+            - containerPort: 7077
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 100m

--- a/test/e2e/testing-manifests/spark/spark-master-service.yaml
+++ b/test/e2e/testing-manifests/spark/spark-master-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: spark-master
+spec:
+  ports:
+    - port: 7077
+      targetPort: 7077
+      name: spark
+    - port: 8080
+      targetPort: 8080
+      name: http
+  selector:
+    component: spark-master

--- a/test/e2e/testing-manifests/spark/spark-worker-controller.yaml
+++ b/test/e2e/testing-manifests/spark/spark-worker-controller.yaml
@@ -1,0 +1,23 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: spark-worker-controller
+spec:
+  replicas: 2
+  selector:
+    component: spark-worker
+  template:
+    metadata:
+      labels:
+        component: spark-worker
+    spec:
+      containers:
+        - name: spark-worker
+          image: k8s.gcr.io/spark:1.5.2_v1
+          command: ["/start-worker"]
+          ports:
+            - containerPort: 8081
+          resources:
+            requests:
+              cpu: 100m
+

--- a/test/e2e/testing-manifests/storage/hazelcast/hazelcast-deployment.yaml
+++ b/test/e2e/testing-manifests/storage/hazelcast/hazelcast-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hazelcast
+  labels:
+    name: hazelcast
+spec:
+  template:
+    metadata:
+      labels:
+        name: hazelcast
+    spec:
+      containers:
+      - name: hazelcast
+        image: quay.io/pires/hazelcast-kubernetes:3.8_1
+        imagePullPolicy: Always
+        env:
+        - name: "DNS_DOMAIN"
+          value: "cluster.local"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - name: hazelcast
+          containerPort: 5701

--- a/test/e2e/testing-manifests/storage/hazelcast/hazelcast-service.yaml
+++ b/test/e2e/testing-manifests/storage/hazelcast/hazelcast-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: hazelcast
+  name: hazelcast
+spec:
+  ports:
+    - port: 5701
+  selector:
+    name: hazelcast

--- a/test/e2e/testing-manifests/storage/redis/redis-controller.yaml
+++ b/test/e2e/testing-manifests/storage/redis/redis-controller.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    name: redis
+  template:
+    metadata:
+      labels:
+        name: redis
+    spec:
+      containers:
+      - name: redis
+        image: k8s.gcr.io/redis:v1
+        ports:
+        - containerPort: 6379
+        resources:
+          limits:
+            cpu: "0.1"
+        volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+      volumes:
+        - name: data
+          emptyDir: {}
+

--- a/test/e2e/testing-manifests/storage/redis/redis-master.yaml
+++ b/test/e2e/testing-manifests/storage/redis/redis-master.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: redis
+    redis-sentinel: "true"
+    role: master
+  name: redis-master
+spec:
+  containers:
+    - name: master
+      image: k8s.gcr.io/redis:v1
+      env:
+        - name: MASTER
+          value: "true"
+      ports:
+        - containerPort: 6379
+      resources:
+        limits:
+          cpu: "0.1"
+      volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+    - name: sentinel
+      image: kubernetes/redis:v1
+      env:
+        - name: SENTINEL
+          value: "true"
+      ports:
+        - containerPort: 26379
+  volumes:
+    - name: data
+      emptyDir: {}

--- a/test/e2e/testing-manifests/storage/redis/redis-sentinel-controller.yaml
+++ b/test/e2e/testing-manifests/storage/redis/redis-sentinel-controller.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis-sentinel
+spec:
+  replicas: 1
+  selector:
+    redis-sentinel: "true"
+  template:
+    metadata:
+      labels:
+        name: redis-sentinel
+        redis-sentinel: "true"
+        role: sentinel
+    spec:
+      containers:
+      - name: sentinel
+        image: k8s.gcr.io/redis:v1
+        env:
+          - name: SENTINEL
+            value: "true"
+        ports:
+          - containerPort: 26379

--- a/test/e2e/testing-manifests/storage/redis/redis-sentinel-service.yaml
+++ b/test/e2e/testing-manifests/storage/redis/redis-sentinel-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: sentinel
+    role: service
+  name: redis-sentinel
+spec:
+  ports:
+    - port: 26379
+      targetPort: 26379
+  selector:
+    redis-sentinel: "true"

--- a/test/e2e/testing-manifests/storage/rethinkdb/admin-pod.yaml
+++ b/test/e2e/testing-manifests/storage/rethinkdb/admin-pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    db: rethinkdb
+    role: admin
+  name: rethinkdb-admin
+spec:
+  containers:
+  - image: k8s.gcr.io/rethinkdb:1.16.0_1
+    name: rethinkdb
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    ports:
+    - containerPort: 8080
+      name: admin-port
+    - containerPort: 28015
+      name: driver-port
+    - containerPort: 29015
+      name: cluster-port
+    volumeMounts:
+    - mountPath: /data/rethinkdb_data
+      name: rethinkdb-storage
+  volumes:
+  - name: rethinkdb-storage
+    emptyDir: {}

--- a/test/e2e/testing-manifests/storage/rethinkdb/admin-service.yaml
+++ b/test/e2e/testing-manifests/storage/rethinkdb/admin-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    db: rethinkdb
+  name: rethinkdb-admin
+spec:
+  ports:
+   - port: 8080
+     targetPort: 8080
+  type: LoadBalancer
+  selector:
+    db: rethinkdb
+    role: admin

--- a/test/e2e/testing-manifests/storage/rethinkdb/driver-service.yaml
+++ b/test/e2e/testing-manifests/storage/rethinkdb/driver-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    db: rethinkdb
+  name: rethinkdb-driver
+spec:
+  ports:
+    - port: 28015
+      targetPort: 28015
+  selector:
+    db: rethinkdb

--- a/test/e2e/testing-manifests/storage/rethinkdb/rc.yaml
+++ b/test/e2e/testing-manifests/storage/rethinkdb/rc.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    db: rethinkdb
+  name: rethinkdb-rc
+spec:
+  replicas: 1
+  selector:
+    db: rethinkdb
+    role: replicas
+  template:
+    metadata:
+      labels:
+        db: rethinkdb
+        role: replicas
+    spec:
+      containers:
+      - image: k8s.gcr.io/rethinkdb:1.16.0_1
+        name: rethinkdb
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 8080
+          name: admin-port
+        - containerPort: 28015
+          name: driver-port
+        - containerPort: 29015
+          name: cluster-port
+        volumeMounts:
+        - mountPath: /data/rethinkdb_data
+          name: rethinkdb-storage
+      volumes:
+      - name: rethinkdb-storage
+        emptyDir: {}

--- a/test/e2e/testing-manifests/storm/storm-nimbus-service.json
+++ b/test/e2e/testing-manifests/storm/storm-nimbus-service.json
@@ -1,0 +1,20 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nimbus",
+    "labels": {
+      "name": "nimbus"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 6627
+      }
+    ],
+    "selector": {
+      "name": "nimbus"
+    }
+  }
+}

--- a/test/e2e/testing-manifests/storm/storm-nimbus.json
+++ b/test/e2e/testing-manifests/storm/storm-nimbus.json
@@ -1,0 +1,28 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nimbus",
+    "labels": {
+      "name": "nimbus"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nimbus",
+        "image": "mattf/storm-nimbus",
+        "ports": [
+          {
+            "containerPort": 6627
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "100m"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/e2e/testing-manifests/storm/storm-worker-controller.json
+++ b/test/e2e/testing-manifests/storm/storm-worker-controller.json
@@ -1,0 +1,55 @@
+{
+  "kind": "ReplicationController",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "storm-worker-controller",
+    "labels": {
+      "name": "storm-worker"
+    }
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "name": "storm-worker"
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "name": "storm-worker",
+          "uses": "nimbus"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "storm-worker",
+            "image": "mattf/storm-worker",
+            "ports": [
+              {
+                "hostPort": 6700,
+                "containerPort": 6700
+              },
+              {
+                "hostPort": 6701,
+                "containerPort": 6701
+              },
+              {
+                "hostPort": 6702,
+                "containerPort": 6702
+              },
+              {
+                "hostPort": 6703,
+                "containerPort": 6703
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "200m"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/e2e/testing-manifests/zookeeper/zookeeper-service.json
+++ b/test/e2e/testing-manifests/zookeeper/zookeeper-service.json
@@ -1,0 +1,20 @@
+{
+  "kind": "Service",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "zookeeper",
+    "labels": {
+      "name": "zookeeper"
+    }
+  },
+  "spec": {
+    "ports": [
+      {
+        "port": 2181
+      }
+    ],
+    "selector": {
+      "name": "zookeeper"
+    }
+  }
+}

--- a/test/e2e/testing-manifests/zookeeper/zookeeper.json
+++ b/test/e2e/testing-manifests/zookeeper/zookeeper.json
@@ -1,0 +1,28 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "zookeeper",
+    "labels": {
+      "name": "zookeeper"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "zookeeper",
+        "image": "mattf/zookeeper",
+        "ports": [
+          {
+            "containerPort": 2181
+          }
+        ],
+        "resources": {
+          "limits": {
+            "cpu": "100m"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
A previous commit (f0b5e2d7c5c4bb77a2b14a8dc4ba85ec63dc1b12) removed
all of the examples, which were used by some tests. This patch readds
some of them to test/e2e/testing-manifests.

**What this PR does / why we need it**:

This patch adds the required files required by some tests (mostly examples.go tests).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63855

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
