### PR TITLE
remove service.deletecollection since the server doesn't support it

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3410,6 +3410,7 @@ type ServicePort struct {
 }
 
 // +genclient
+// +genclient:skipVerbs=deleteCollection
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -4013,6 +4014,7 @@ const (
 
 // +genclient
 // +genclient:nonNamespaced
+// +genclient:skipVerbs=deleteCollection
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Namespace provides a scope for Names.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -112,14 +112,6 @@ func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
-// DeleteCollection deletes a collection of objects.
-func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &core_v1.NamespaceList{})
-	return err
-}
-
 // Patch applies the patch and returns the patched namespace.
 func (c *FakeNamespaces) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -120,14 +120,6 @@ func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
-// DeleteCollection deletes a collection of objects.
-func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &core_v1.ServiceList{})
-	return err
-}
-
 // Patch applies the patch and returns the patched service.
 func (c *FakeServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -39,7 +39,6 @@ type NamespaceInterface interface {
 	Update(*v1.Namespace) (*v1.Namespace, error)
 	UpdateStatus(*v1.Namespace) (*v1.Namespace, error)
 	Delete(name string, options *meta_v1.DeleteOptions) error
-	DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
 	Get(name string, options meta_v1.GetOptions) (*v1.Namespace, error)
 	List(opts meta_v1.ListOptions) (*v1.NamespaceList, error)
 	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
@@ -134,16 +133,6 @@ func (c *namespaces) Delete(name string, options *meta_v1.DeleteOptions) error {
 	return c.client.Delete().
 		Resource("namespaces").
 		Name(name).
-		Body(options).
-		Do().
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *namespaces) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	return c.client.Delete().
-		Resource("namespaces").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
 		Do().
 		Error()

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -39,7 +39,6 @@ type ServiceInterface interface {
 	Update(*v1.Service) (*v1.Service, error)
 	UpdateStatus(*v1.Service) (*v1.Service, error)
 	Delete(name string, options *meta_v1.DeleteOptions) error
-	DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error
 	Get(name string, options meta_v1.GetOptions) (*v1.Service, error)
 	List(opts meta_v1.ListOptions) (*v1.ServiceList, error)
 	Watch(opts meta_v1.ListOptions) (watch.Interface, error)
@@ -143,17 +142,6 @@ func (c *services) Delete(name string, options *meta_v1.DeleteOptions) error {
 		Namespace(c.ns).
 		Resource("services").
 		Name(name).
-		Body(options).
-		Do().
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *services) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
 		Do().
 		Error()


### PR DESCRIPTION
Updates the generated service client to match the API available.

@kubernetes/sig-api-machinery-pr-reviews 
@kubernetes/api-reviewers 

```release-note
NONE
```