### PR TITLE
Auto-calculate allowed-not-ready-nodes in test framework

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -374,4 +374,8 @@ func AfterReadingAllFlags(t *TestContextType) {
 			t.Host = defaultHost
 		}
 	}
+	// Allow 1% of nodes to be unready (statistically) - relevant for large clusters.
+	if t.AllowedNotReadyNodes == 0 {
+		t.AllowedNotReadyNodes = t.CloudConfig.NumNodes / 100
+	}
 }


### PR DESCRIPTION
Actually we (sig-scalability) are pretty much the only users of this flag.
This reduces the overhead of having to provide its value based on num-nodes each time we run our tests.

/cc @wojtek-t 

```release-note
NONE
```