### PR TITLE
Typo fix in the returned message: dynamicly->dynamically

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -538,7 +538,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			By("Deleting provisioner daemonset")
 			deleteProvisionerDaemonset(config)
 		})
-		It("should discover dynamicly created local persistent volume mountpoint in discovery directory", func() {
+		It("should discover dynamically created local persistent volume mountpoint in discovery directory", func() {
 			By("Starting a provisioner daemonset")
 			createProvisionerDaemonset(config)
 


### PR DESCRIPTION
Line 541: a typo in the returned message: 
dynamicly->dynamically