### PR TITLE
kubeadm: Fix how kubeadm handles `.AuthorizationModes` and `.APIServerExtraArgs`

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/BUILD
+++ b/cmd/kubeadm/app/phases/controlplane/BUILD
@@ -19,9 +19,11 @@ go_test(
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/phases/certs:go_default_library",
         "//cmd/kubeadm/test:go_default_library",
+        "//pkg/kubeapiserver/authorizer/modes:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1alpha2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -217,11 +216,30 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 			defaultArguments["audit-log-maxage"] = fmt.Sprintf("%d", *cfg.AuditPolicyConfiguration.LogMaxAge)
 		}
 	}
-
+	if cfg.APIServerExtraArgs == nil {
+		cfg.APIServerExtraArgs = map[string]string{}
+	}
+	cfg.APIServerExtraArgs["authorization-mode"] = getAuthzModes(cfg.APIServerExtraArgs["authorization-mode"])
 	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.APIServerExtraArgs)...)
-	command = append(command, getAuthzParameters(cfg.AuthorizationModes)...)
 
 	return command
+}
+
+// getAuthzModes gets the authorization-related parameters to the api server
+// Node,RBAC should be fixed in this order at the beginning
+// AlwaysAllow and AlwaysDeny is ignored as they are only for testing
+func getAuthzModes(authzModeExtraArgs string) string {
+	modes := []string{
+		authzmodes.ModeNode,
+		authzmodes.ModeRBAC,
+	}
+	if strings.Contains(authzModeExtraArgs, authzmodes.ModeABAC) {
+		modes = append(modes, authzmodes.ModeABAC)
+	}
+	if strings.Contains(authzModeExtraArgs, authzmodes.ModeWebhook) {
+		modes = append(modes, authzmodes.ModeWebhook)
+	}
+	return strings.Join(modes, ",")
 }
 
 // calcNodeCidrSize determines the size of the subnets used on each node, based
@@ -334,26 +352,4 @@ func getProxyEnvVars() []v1.EnvVar {
 		}
 	}
 	return envs
-}
-
-// getAuthzParameters gets the authorization-related parameters to the api server
-// At this point, we can assume the list of authorization modes is valid (due to that it has been validated in the API machinery code already)
-// If the list is empty; it's defaulted (mostly for unit testing)
-func getAuthzParameters(modes []string) []string {
-	command := []string{}
-	strset := sets.NewString(modes...)
-
-	if len(modes) == 0 {
-		return []string{fmt.Sprintf("--authorization-mode=%s", kubeadmapiv1alpha2.DefaultAuthorizationModes)}
-	}
-
-	if strset.Has(authzmodes.ModeABAC) {
-		command = append(command, "--authorization-policy-file="+kubeadmconstants.AuthorizationPolicyPath)
-	}
-	if strset.Has(authzmodes.ModeWebhook) {
-		command = append(command, "--authorization-webhook-config-file="+kubeadmconstants.AuthorizationWebhookConfigPath)
-	}
-
-	command = append(command, "--authorization-mode="+strings.Join(modes, ","))
-	return command
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If _authorization-mode_ is configured as `--apiserver-extra-args` for kubeadm, than 
_authorization-mode_ argument gets duplicated in the static pod manifest file.

```
$ kubeadm alpha phase controlplane apiserver --apiserver-extra-args authorization-mode=AlwaysAllow
$ grep authorization-mode /etc/kubernetes/manifests/kube-apiserver.yaml
     - --authorization-mode=AlwaysAllow
    - --authorization-mode=Node,RBAC
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/sig cluster-lifecycle
/assign @fabriziopandini