### PR TITLE
apimachinery: move schema reference object into smp patcher

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -394,8 +394,6 @@ func (tc *patchTestCase) Run(t *testing.T) {
 
 			timeout: 1 * time.Second,
 
-			schemaReferenceObj: schemaReferenceObj,
-
 			restPatcher: testPatcher,
 			name:        name,
 			patchType:   patchType,


### PR DESCRIPTION
The schema reference object is only used in the strategic merge patch code path. This PR moves the creation there.

This PR is a preparation to make the patcher compatible with the UnstructuredObjectConverter without internal types. It will allow us to return an error on missing kinds at https://github.com/kubernetes/kubernetes/pull/63830#discussion_r188171025.