### PR TITLE
move plugin loader pieces to cmdutil

### DIFF
--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -167,6 +167,7 @@ func (p *factoryAttrsPluginEnvProvider) Env() (plugins.EnvList, error) {
 	}, nil
 }
 
+// pluginLoader provides the implementation to be used to load cli plugins.
 // pluginLoader loads plugins from a path set by the KUBECTL_PLUGINS_PATH env var.
 // If this env var is not set, it defaults to
 //   "~/.kube/plugins", plus
@@ -182,6 +183,7 @@ func pluginLoader() plugins.PluginLoader {
 	}
 }
 
+// pluginRunner provides the implementation to be used to run cli plugins.
 func pluginRunner() plugins.PluginRunner {
 	return &plugins.ExecPluginRunner{}
 }


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

These pieces do not depend on the factory, therefore, they should be removed from the factory.

cc @deads2k @soltysh 