### PR TITLE
if a version doesn't match, picking one that's close is not the secon…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
@@ -193,7 +193,7 @@ func (gv GroupVersion) String() string {
 }
 
 // KindForGroupVersionKinds identifies the preferred GroupVersionKind out of a list. It returns ok false
-// if none of the options match the group. It prefers a match to group and version over just group.
+// if none of the options match the group. It only matches on both group and version.
 // TODO: Move GroupVersion to a package under pkg/runtime, since it's used by scheme.
 // TODO: Introduce an adapter type between GroupVersion and runtime.GroupVersioner, and use LegacyCodec(GroupVersion)
 //   in fewer places.
@@ -201,11 +201,6 @@ func (gv GroupVersion) KindForGroupVersionKinds(kinds []GroupVersionKind) (targe
 	for _, gvk := range kinds {
 		if gvk.Group == gv.Group && gvk.Version == gv.Version {
 			return gvk, true
-		}
-	}
-	for _, gvk := range kinds {
-		if gvk.Group == gv.Group {
-			return gv.WithKind(gvk.Kind), true
 		}
 	}
 	return GroupVersionKind{}, false

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version_test.go
@@ -109,8 +109,8 @@ func TestKindForGroupVersionKinds(t *testing.T) {
 		},
 		{
 			input:  []GroupVersionKind{{Group: "batch", Version: "v3alpha1", Kind: "CronJob"}},
-			target: GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
-			ok:     true,
+			target: GroupVersionKind{},
+			ok:     false,
 		},
 		{
 			input:  []GroupVersionKind{{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"}},
@@ -124,14 +124,16 @@ func TestKindForGroupVersionKinds(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
-		target, ok := gvks.KindForGroupVersionKinds(c.input)
-		if c.target != target {
-			t.Errorf("%d: unexpected target: %v, expected %v", i, target, c.target)
-		}
-		if c.ok != ok {
-			t.Errorf("%d: unexpected ok: %v, expected %v", i, ok, c.ok)
-		}
+	for _, c := range cases {
+		t.Run("value", func(t *testing.T) {
+			target, ok := gvks.KindForGroupVersionKinds(c.input)
+			if c.target != target {
+				t.Errorf("unexpected target: %v, expected %v", target, c.target)
+			}
+			if c.ok != ok {
+				t.Errorf("unexpected ok: %v, expected %v", ok, c.ok)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
…d best option

If no version matches, it's best to indicate that.

@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```
