### PR TITLE
Expose openapi schema to handlers

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3334,35 +3334,35 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto/validation",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/utils/clock",

--- a/staging/BUILD
+++ b/staging/BUILD
@@ -92,6 +92,7 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/util/flag:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/logs:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/util/openapi:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/proxy:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/trace:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:all-srcs",

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1467,6 +1467,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/pkg/util/openapi",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -2024,23 +2028,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -180,7 +180,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1756,23 +1756,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -79,6 +79,9 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/openapi:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/registry/rest"
+	openapicommon "k8s.io/kube-openapi/pkg/common"
 )
 
 // APIGroupVersion is a helper for exposing rest.Storage objects as http.Handlers via go-restful
@@ -77,6 +78,9 @@ type APIGroupVersion struct {
 	// EnableAPIResponseCompression indicates whether API Responses should support compression
 	// if the client requests it via Accept-Encoding
 	EnableAPIResponseCompression bool
+
+	// OpenAPIConfig lets the individual handlers build a subset of the OpenAPI schema before they are installed.
+	OpenAPIConfig *openapicommon.Config
 }
 
 // InstallREST registers the REST handlers (storage, watch, proxy and redirect) into a restful Container.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -80,6 +80,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/httplog:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 )
 
 // RequestScope encapsulates common fields across all RESTful handler methods.
@@ -55,6 +56,7 @@ type RequestScope struct {
 	UnsafeConvertor runtime.ObjectConvertor
 
 	TableConvertor rest.TableConvertor
+	OpenAPISchema  openapiproto.Schema
 
 	Resource    schema.GroupVersionResource
 	Kind        schema.GroupVersionKind

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -15,6 +15,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -426,6 +426,7 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Admit:                        s.admissionControl,
 		MinRequestTimeout:            s.minRequestTimeout,
 		EnableAPIResponseCompression: s.enableAPIResponseCompression,
+		OpenAPIConfig:                s.openAPIConfig,
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	openapi "github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,9 +79,45 @@ func init() {
 	examplev1.AddToScheme(scheme)
 }
 
+func buildTestOpenAPIDefinition() kubeopenapi.OpenAPIDefinition {
+	return kubeopenapi.OpenAPIDefinition{
+		Schema: openapi.Schema{
+			SchemaProps: openapi.SchemaProps{
+				Description: "Description",
+				Properties:  map[string]openapi.Schema{},
+			},
+			VendorExtensible: openapi.VendorExtensible{
+				Extensions: openapi.Extensions{
+					"x-kubernetes-group-version-kind": []map[string]string{
+						{
+							"group":   "",
+							"version": "v1",
+							"kind":    "Getter",
+						},
+						{
+							"group":   "batch",
+							"version": "v1",
+							"kind":    "Getter",
+						},
+						{
+							"group":   "extensions",
+							"version": "v1",
+							"kind":    "Getter",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func testGetOpenAPIDefinitions(_ kubeopenapi.ReferenceCallback) map[string]kubeopenapi.OpenAPIDefinition {
 	return map[string]kubeopenapi.OpenAPIDefinition{
-		"k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList": {},
+		"k8s.io/apimachinery/pkg/apis/meta/v1.Status":          {},
+		"k8s.io/apimachinery/pkg/apis/meta/v1.APIVersions":     {},
+		"k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList":    {},
+		"k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup":        buildTestOpenAPIDefinition(),
+		"k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList": {},
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/BUILD
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["proto.go"],
+    importpath = "k8s.io/apiserver/pkg/util/openapi",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["proto_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/proto.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/proto.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-openapi/spec"
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
+	"github.com/googleapis/gnostic/compiler"
+	yaml "gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+const (
+	// groupVersionKindExtensionKey is the key used to lookup the
+	// GroupVersionKind value for an object definition from the
+	// definition's "extensions" map.
+	groupVersionKindExtensionKey = "x-kubernetes-group-version-kind"
+)
+
+// ToProtoSchema builds the proto formatted schema from an OpenAPI spec
+func ToProtoSchema(openAPIDefinitions *spec.Definitions, gvk schema.GroupVersionKind) (proto.Schema, error) {
+	openAPISpec := newMinimalValidOpenAPISpec()
+	openAPISpec.Definitions = *openAPIDefinitions
+
+	specBytes, err := json.MarshalIndent(openAPISpec, " ", " ")
+	if err != nil {
+		return nil, err
+	}
+
+	var info yaml.MapSlice
+	err = yaml.Unmarshal(specBytes, &info)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := openapi_v2.NewDocument(info, compiler.NewContext("$root", nil))
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := proto.NewOpenAPIData(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, modelName := range models.ListModels() {
+		model := models.LookupModel(modelName)
+		if model == nil {
+			return nil, fmt.Errorf("the ListModels function returned a model that can't be looked-up")
+		}
+		gvkList := parseGroupVersionKind(model)
+		for _, modelGVK := range gvkList {
+			if modelGVK == gvk {
+				return model, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no model found with a %v tag matching %v", groupVersionKindExtensionKey, gvk)
+}
+
+// newMinimalValidOpenAPISpec creates a minimal openapi spec with only the required fields filled in
+func newMinimalValidOpenAPISpec() *spec.Swagger {
+	return &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Swagger: "2.0",
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title:   "Kubernetes",
+					Version: "0.0.0",
+				},
+			},
+		},
+	}
+}
+
+// parseGroupVersionKind gets and parses GroupVersionKind from the extension. Returns empty if it doesn't have one.
+func parseGroupVersionKind(s proto.Schema) []schema.GroupVersionKind {
+	extensions := s.GetExtensions()
+
+	gvkListResult := []schema.GroupVersionKind{}
+
+	// Get the extensions
+	gvkExtension, ok := extensions[groupVersionKindExtensionKey]
+	if !ok {
+		return []schema.GroupVersionKind{}
+	}
+
+	// gvk extension must be a list of at least 1 element.
+	gvkList, ok := gvkExtension.([]interface{})
+	if !ok {
+		return []schema.GroupVersionKind{}
+	}
+
+	for _, gvk := range gvkList {
+		// gvk extension list must be a map with group, version, and
+		// kind fields
+		gvkMap, ok := gvk.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+		group, ok := gvkMap["group"].(string)
+		if !ok {
+			continue
+		}
+		version, ok := gvkMap["version"].(string)
+		if !ok {
+			continue
+		}
+		kind, ok := gvkMap["kind"].(string)
+		if !ok {
+			continue
+		}
+
+		gvkListResult = append(gvkListResult, schema.GroupVersionKind{
+			Group:   group,
+			Version: version,
+			Kind:    kind,
+		})
+	}
+
+	return gvkListResult
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/proto_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/proto_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-openapi/spec"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+// TestOpenAPIDefinitionsToProtoSchema tests the openapi parser
+func TestOpenAPIDefinitionsToProtoSchema(t *testing.T) {
+	openAPIDefinitions := &spec.Definitions{
+		"io.k8s.api.testgroup.v1.Foo": spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Description of Foos",
+				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-group-version-kind": []map[string]string{
+						{
+							"group":   "testgroup.k8s.io",
+							"version": "v1",
+							"kind":    "Foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "testgroup.k8s.io",
+		Version: "v1",
+		Kind:    "Foo",
+	}
+	expectedSchema := &proto.Arbitrary{
+		BaseSchema: proto.BaseSchema{
+			Description: "Description of Foos",
+			Extensions: map[string]interface{}{
+				"x-kubernetes-group-version-kind": []interface{}{
+					map[interface{}]interface{}{
+						"group":   "testgroup.k8s.io",
+						"version": "v1",
+						"kind":    "Foo",
+					},
+				},
+			},
+			Path: proto.NewPath("io.k8s.api.testgroup.v1.Foo"),
+		},
+	}
+	actualSchema, err := ToProtoSchema(openAPIDefinitions, gvk)
+	if err != nil {
+		t.Fatalf("expected ToProtoSchema not to return an error")
+	}
+	if !reflect.DeepEqual(expectedSchema, actualSchema) {
+		t.Fatalf("expected schema:\n%v\nbut got:\n%v", expectedSchema, actualSchema)
+	}
+}

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -588,7 +588,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/staging/src/k8s.io/code-generator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/code-generator/Godeps/Godeps.json
@@ -260,11 +260,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/generators",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1139,6 +1139,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/pkg/util/openapi",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/proxy",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -1672,27 +1676,27 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1111,6 +1111,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/pkg/util/openapi",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -1636,23 +1640,23 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/handler",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -1068,7 +1068,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/util/proto",
-			"Rev": "61db125d227fc9d4e373819a059516f32f7f23c7"
+			"Rev": "86e28c192d2743f0232b9bc5f0a531568ef9f2a5"
 		}
 	]
 }

--- a/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
@@ -432,7 +432,7 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
 	extensions, errors := parseExtensions(t.CommentLines)
 	// Initially, we will only log struct extension errors.
 	if len(errors) > 0 {
-		for e := range errors {
+		for _, e := range errors {
 			glog.V(2).Infof("[%s]: %s\n", t.String(), e)
 		}
 	}
@@ -442,17 +442,16 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
 }
 
 func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *types.Type) error {
-	extensions, errors := parseExtensions(m.CommentLines)
+	extensions, parseErrors := parseExtensions(m.CommentLines)
+	validationErrors := validateMemberExtensions(extensions, m)
+	errors := append(parseErrors, validationErrors...)
 	// Initially, we will only log member extension errors.
 	if len(errors) > 0 {
 		errorPrefix := fmt.Sprintf("[%s] %s:", parent.String(), m.String())
-		for e := range errors {
+		for _, e := range errors {
 			glog.V(2).Infof("%s %s\n", errorPrefix, e)
 		}
 	}
-	// TODO(seans3): Validate member extensions here.
-	// Example: listType extension is only on a Slice.
-	// Example: cross-extension validation - listMapKey only makes sense with listType=map
 	g.emitExtensions(extensions)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Build an openapi spec for each api resource handler. This spec will be able to be consumed by server-side apply and server-side openapi validation.
The reason for putting it into master is so we can work on implementing server side validation against the openapi spec as well as server side apply, and it will make merging the server side apply feature branch a smaller, less risky PR

/sig api-machinery
/kind feature
cc @liggitt @lavalamp @seans3 @mbohlool @apelisse 

**Release note**:
```release-note
NONE
```