### PR TITLE
Restore pre-1.10 openstack instance naming behavior

### DIFF
--- a/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/pkg/cloudprovider/providers/openstack/metadata.go
@@ -70,7 +70,7 @@ type DeviceMetadata struct {
 // See http://docs.openstack.org/user-guide/cli_config_drive.html
 type Metadata struct {
 	UUID             string           `json:"uuid"`
-	Hostname         string           `json:"hostname"`
+	Name             string           `json:"name"`
 	AvailabilityZone string           `json:"availability_zone"`
 	Devices          []DeviceMetadata `json:"devices,omitempty"`
 	// .. and other fields we don't care about.  Expand as necessary.

--- a/pkg/cloudprovider/providers/openstack/metadata_test.go
+++ b/pkg/cloudprovider/providers/openstack/metadata_test.go
@@ -23,7 +23,7 @@ import (
 
 var FakeMetadata = Metadata{
 	UUID:             "83679162-1378-4288-a2d4-70e13ec132aa",
-	Hostname:         "test",
+	Name:             "test",
 	AvailabilityZone: "nova",
 }
 
@@ -81,8 +81,8 @@ func TestParseMetadata(t *testing.T) {
 		t.Fatalf("Should succeed when provided with valid data: %s", err)
 	}
 
-	if md.Hostname != "test.novalocal" {
-		t.Errorf("incorrect hostname: %s", md.Hostname)
+	if md.Name != "test" {
+		t.Errorf("incorrect name: %s", md.Name)
 	}
 
 	if md.UUID != "83679162-1378-4288-a2d4-70e13ec132aa" {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -121,7 +121,6 @@ type RouterOpts struct {
 type MetadataOpts struct {
 	SearchOrder    string     `gcfg:"search-order"`
 	RequestTimeout MyDuration `gcfg:"request-timeout"`
-	DHCPDomain     string     `gcfg:"dhcp-domain"`
 }
 
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
@@ -234,7 +233,6 @@ func configFromEnv() (cfg Config, ok bool) {
 			cfg.Global.TrustID != "")
 
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
-	cfg.Metadata.DHCPDomain = "novalocal"
 	cfg.BlockStorage.BSVersion = "auto"
 
 	return
@@ -252,7 +250,6 @@ func readConfig(config io.Reader) (Config, error) {
 	cfg.BlockStorage.TrustDevicePath = false
 	cfg.BlockStorage.IgnoreVolumeAZ = false
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)
-	cfg.Metadata.DHCPDomain = "novalocal"
 
 	err := gcfg.ReadInto(&cfg, config)
 	return cfg, err

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -62,10 +62,6 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
-	domain := "." + i.opts.DHCPDomain
-	if i.opts.DHCPDomain != "" && strings.HasSuffix(md.Hostname, domain) {
-		return types.NodeName(strings.TrimSuffix(md.Hostname, domain)), nil
-	}
 	return types.NodeName(strings.Split(md.Hostname, ".")[0]), nil
 }
 

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -61,7 +61,7 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
-	return types.NodeName(md.Hostname), nil
+	return types.NodeName(md.Name), nil
 }
 
 // AddSSHKeyToAllInstances is not implemented for OpenStack

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
@@ -62,7 +61,7 @@ func (i *Instances) CurrentNodeName(ctx context.Context, hostname string) (types
 	if err != nil {
 		return "", err
 	}
-	return types.NodeName(strings.Split(md.Hostname, ".")[0]), nil
+	return types.NodeName(md.Hostname), nil
 }
 
 // AddSSHKeyToAllInstances is not implemented for OpenStack


### PR DESCRIPTION
As noted in https://github.com/kubernetes/kubernetes/pull/61890#issuecomment-377282182 and https://github.com/kubernetes/kubernetes/issues/62295#issuecomment-389374492, the 1.10 changes to the openstack cloud provider node name computation (in #58502, #61000, and #61890) broke existing deployments that provisioned instances with credentials matching their instance names. It also did not account for version skewed kubelets, which can run 1.8 and 1.9 versions against a 1.10 master, and still register based on instance name.

This PR reverts the incompatible changes to restore pre-1.10 behavior.

Further improvements to handle instances with names that cannot be used as node names are tracked in https://github.com/kubernetes/kubernetes/issues/62295

/assign @dims
/sig openstack
/kind bug

```release-note
Restores the pre-1.10 behavior of the openstack cloud provider which uses the instance name as the Kubernetes Node name. This requires instances be named with RFC-1123 compatible names.
```