### PR TITLE
simplify findServicePort in proxy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/BUILD
@@ -26,7 +26,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],
 )


### PR DESCRIPTION
/kind cleanup

Simplify `findServicePort` and some related code.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
