### PR TITLE
igore numberic temporary files when watching manifest files

### DIFF
--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -445,3 +445,43 @@ func changeFileName(dir, from, to string, t *testing.T) {
 		t.Errorf("Fail to change file name: %s", err)
 	}
 }
+
+func TestNumbericTempFile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		fileName string
+		isTemp   bool
+	}{
+		{
+			name:     "4913 as the file name",
+			fileName: "4913",
+			isTemp:   true,
+		},
+		{
+			name:     "5036 as the file name",
+			fileName: "5036",
+			isTemp:   true,
+		},
+		{
+			name:     "5159 as the file name",
+			fileName: "5159",
+			isTemp:   true,
+		},
+		{
+			name:     "4913d as the file name",
+			fileName: "4913d",
+		},
+		{
+			name:     "4914 as the file name",
+			fileName: "4914",
+		},
+	}
+
+	for _, tc := range testCases {
+		isTemp := isNumbericTempFile(tc.fileName)
+		if isTemp != tc.isTemp {
+			t.Errorf("[%s] expetected %v, got %v", tc.name, tc.isTemp, isTemp)
+		}
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When using vim to create a new file in manifest folder, a temporary file, with an arbitrary number (like 4913) as its name, will be created to check if a directory is writable and see the resulting ACL.

These temporary files will be deleted later, which should by ignored when watching the manifest folder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55928, #59009, #48219

**Special notes for your reviewer**:
/cc resouer dims luxas yujuhong xiangpengzhao
/cc kubernetes/sig-node-bugs

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
igore numberic temporary files when watching manifest files
```
