### PR TITLE
fix event ref determination for apigroups

### DIFF
--- a/staging/src/k8s.io/client-go/tools/reference/BUILD
+++ b/staging/src/k8s.io/client-go/tools/reference/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -28,4 +29,15 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ref_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/client-go/tools/reference/ref.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref.go
@@ -86,10 +86,14 @@ func GetReference(scheme *runtime.Scheme, obj runtime.Object) (*v1.ObjectReferen
 		}
 		// example paths: /<prefix>/<version>/*
 		parts := strings.Split(selfLinkUrl.Path, "/")
-		if len(parts) < 3 {
+		if len(parts) < 4 {
 			return nil, fmt.Errorf("unexpected self link format: '%v'; got version '%v'", selfLink, version)
 		}
-		version = parts[2]
+		if parts[1] == "api" {
+			version = parts[2]
+		} else {
+			version = parts[2] + "/" + parts[3]
+		}
 	}
 
 	// only has list metadata

--- a/staging/src/k8s.io/client-go/tools/reference/ref_test.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reference
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type TestRuntimeObj struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}
+
+func (o *TestRuntimeObj) DeepCopyObject() runtime.Object {
+	panic("die")
+}
+
+func TestGetReferenceRefVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              *TestRuntimeObj
+		expectedRefVersion string
+	}{
+		{
+			name: "api from selflink",
+			input: &TestRuntimeObj{
+				ObjectMeta: metav1.ObjectMeta{SelfLink: "/api/v1/namespaces"},
+			},
+			expectedRefVersion: "v1",
+		},
+		{
+			name: "foo.group/v3 from selflink",
+			input: &TestRuntimeObj{
+				ObjectMeta: metav1.ObjectMeta{SelfLink: "/apis/foo.group/v3/namespaces"},
+			},
+			expectedRefVersion: "foo.group/v3",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "this", Version: "is ignored"}, &TestRuntimeObj{})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ref, err := GetReference(scheme, test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.expectedRefVersion != ref.APIVersion {
+				t.Errorf("expected %q, got %q", test.expectedRefVersion, ref.APIVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The event ref determination was never updated to handle apigroups so it has been returning only a group (not a version).

@kubernetes/sig-apps-bugs 

```release-note
event object references with apiversion will now report an apiversion.
```