### PR TITLE
Add roundtrip, defaulting, upgrading and validation unit tests for the kubeadm API types

### DIFF
--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -32,8 +32,23 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["masterconfig_test.go"],
+    srcs = [
+        "masterconfig_test.go",
+        "nodeconfig_test.go",
+    ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/scheme:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha2:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
+        "//vendor/github.com/pmezard/go-difflib/difflib:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/util/config/masterconfig_test.go
+++ b/cmd/kubeadm/app/util/config/masterconfig_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,5 +14,178 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: write unit tests for the functions in this package
 package config
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pmezard/go-difflib/difflib"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+)
+
+const (
+	master_v1alpha1YAML                = "testdata/conversion/master/v1alpha1.yaml"
+	master_v1alpha1WithoutTypeMetaYAML = "testdata/conversion/master/v1alpha1_without_TypeMeta.yaml"
+	master_v1alpha2YAML                = "testdata/conversion/master/v1alpha2.yaml"
+	master_internalYAML                = "testdata/conversion/master/internal.yaml"
+	master_incompleteYAML              = "testdata/defaulting/master/incomplete.yaml"
+	master_defaultedv1alpha1YAML       = "testdata/defaulting/master/defaulted_v1alpha1.yaml"
+	master_defaultedv1alpha2YAML       = "testdata/defaulting/master/defaulted_v1alpha2.yaml"
+	master_invalidYAML                 = "testdata/validation/invalid_mastercfg.yaml"
+	master_beforeUpgradeYAML           = "testdata/v1alpha1_upgrade/before.yaml"
+	master_afterUpgradeYAML            = "testdata/v1alpha1_upgrade/after.yaml"
+)
+
+func diff(expected, actual []byte) string {
+	// Write out the diff
+	var diffBytes bytes.Buffer
+	difflib.WriteUnifiedDiff(&diffBytes, difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(expected)),
+		B:        difflib.SplitLines(string(actual)),
+		FromFile: "expected",
+		ToFile:   "actual",
+		Context:  3,
+	})
+	return diffBytes.String()
+}
+
+func TestConfigFileAndDefaultsToInternalConfig(t *testing.T) {
+	var tests = []struct {
+		name, in, out string
+		groupVersion  schema.GroupVersion
+		expectedErr   bool
+	}{
+		// These tests are reading one file, loading it using ConfigFileAndDefaultsToInternalConfig that all of kubeadm is using for unmarshal of our API types,
+		// and then marshals the internal object to the expected groupVersion
+		{ // v1alpha1 (faulty) -> internal
+			name:         "v1alpha1WithoutTypeMetaToInternal",
+			in:           master_v1alpha1WithoutTypeMetaYAML,
+			out:          master_internalYAML,
+			groupVersion: kubeadm.SchemeGroupVersion,
+		},
+		{ // v1alpha1 -> internal
+			name:         "v1alpha1ToInternal",
+			in:           master_v1alpha1YAML,
+			out:          master_internalYAML,
+			groupVersion: kubeadm.SchemeGroupVersion,
+		},
+		{ // v1alpha1 (faulty) -> internal -> v1alpha1
+			name:         "v1alpha1WithoutTypeMetaTov1alpha1",
+			in:           master_v1alpha1WithoutTypeMetaYAML,
+			out:          master_v1alpha1YAML,
+			groupVersion: v1alpha1.SchemeGroupVersion,
+		},
+		{ // v1alpha2 -> internal
+			name:         "v1alpha2ToInternal",
+			in:           master_v1alpha2YAML,
+			out:          master_internalYAML,
+			groupVersion: kubeadm.SchemeGroupVersion,
+		},
+		{ // v1alpha1 (faulty) -> internal -> v1alpha2
+			name:         "v1alpha1WithoutTypeMetaTov1alpha2",
+			in:           master_v1alpha1WithoutTypeMetaYAML,
+			out:          master_v1alpha2YAML,
+			groupVersion: v1alpha2.SchemeGroupVersion,
+		},
+		{ // v1alpha1 -> internal -> v1alpha2
+			name:         "v1alpha1Tov1alpha2",
+			in:           master_v1alpha1YAML,
+			out:          master_v1alpha2YAML,
+			groupVersion: v1alpha2.SchemeGroupVersion,
+		},
+		// These tests are reading one file that has only a subset of the fields populated, loading it using ConfigFileAndDefaultsToInternalConfig,
+		// and then marshals the internal object to the expected groupVersion
+		{ // v1alpha1 (faulty) -> default -> validate -> internal -> v1alpha1
+			name:         "incompleteYAMLToDefaultedv1alpha1",
+			in:           master_incompleteYAML,
+			out:          master_defaultedv1alpha1YAML,
+			groupVersion: v1alpha1.SchemeGroupVersion,
+		},
+		{ // v1alpha1 (faulty) -> default -> validate -> internal -> v1alpha2
+			name:         "incompleteYAMLToDefaultedv1alpha2",
+			in:           master_incompleteYAML,
+			out:          master_defaultedv1alpha2YAML,
+			groupVersion: v1alpha2.SchemeGroupVersion,
+		},
+		{ // v1alpha1 (faulty) -> validation should fail
+			name:        "invalidYAMLShouldFail",
+			in:          master_invalidYAML,
+			expectedErr: true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+
+			internalcfg, err := ConfigFileAndDefaultsToInternalConfig(rt.in, &v1alpha2.MasterConfiguration{})
+			if err != nil {
+				if rt.expectedErr {
+					return
+				}
+				t2.Fatalf("couldn't unmarshal test data: %v", err)
+			}
+
+			actual, err := kubeadmutil.MarshalToYamlForCodecs(internalcfg, rt.groupVersion, scheme.Codecs)
+			if err != nil {
+				t2.Fatalf("couldn't marshal internal object: %v", err)
+			}
+
+			expected, err := ioutil.ReadFile(rt.out)
+			if err != nil {
+				t2.Fatalf("couldn't read test data: %v", err)
+			}
+
+			if !bytes.Equal(expected, actual) {
+				t2.Errorf("the expected and actual output differs.\n\tin: %s\n\tout: %s\n\tgroupversion: %s\n\tdiff: \n%s\n",
+					rt.in, rt.out, rt.groupVersion.String(), diff(expected, actual))
+			}
+		})
+	}
+}
+
+// TestUpgrade tests reading a faulty YAML representation of the MasterConfiguration object (as found in kubeadm clusters <= v1.9.x),
+// fixes the problems internally and verifies the marshalled output is the expected output
+func TestUpgrade(t *testing.T) {
+	before, err := ioutil.ReadFile(master_beforeUpgradeYAML)
+	if err != nil {
+		t.Fatalf("couldn't read test data: %v", err)
+	}
+
+	afterExpected, err := ioutil.ReadFile(master_afterUpgradeYAML)
+	if err != nil {
+		t.Fatalf("couldn't read test data: %v", err)
+	}
+
+	decoded, err := kubeadmutil.LoadYAML(before)
+	if err != nil {
+		t.Fatalf("couldn't unmarshal test yaml: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	v1alpha1.AddToScheme(scheme)
+	codecs := serializer.NewCodecFactory(scheme)
+
+	obj := &v1alpha1.MasterConfiguration{}
+	if err := v1alpha1.Migrate(decoded, obj, codecs); err != nil {
+		t.Fatalf("couldn't decode migrated object: %v", err)
+	}
+
+	afterActual, err := kubeadmutil.MarshalToYamlForCodecs(obj, v1alpha1.SchemeGroupVersion, codecs)
+	if err != nil {
+		t.Fatalf("couldn't marshal object: %v", err)
+	}
+
+	if !bytes.Equal(afterExpected, afterActual) {
+		t.Errorf("v1alpha1 object after unmarshal, conversion and marshal didn't match expected value.\n\tdiff: \n%s\n", diff(afterExpected, afterActual))
+	}
+}

--- a/cmd/kubeadm/app/util/config/nodeconfig_test.go
+++ b/cmd/kubeadm/app/util/config/nodeconfig_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+)
+
+const (
+	node_v1alpha1YAML          = "testdata/conversion/node/v1alpha1.yaml"
+	node_v1alpha2YAML          = "testdata/conversion/node/v1alpha2.yaml"
+	node_internalYAML          = "testdata/conversion/node/internal.yaml"
+	node_incompleteYAML        = "testdata/defaulting/node/incomplete.yaml"
+	node_defaultedv1alpha1YAML = "testdata/defaulting/node/defaulted_v1alpha1.yaml"
+	node_defaultedv1alpha2YAML = "testdata/defaulting/node/defaulted_v1alpha2.yaml"
+	node_invalidYAML           = "testdata/validation/invalid_nodecfg.yaml"
+)
+
+func TestNodeConfigFileAndDefaultsToInternalConfig(t *testing.T) {
+	var tests = []struct {
+		name, in, out string
+		groupVersion  schema.GroupVersion
+		expectedErr   bool
+	}{
+		// These tests are reading one file, loading it using NodeConfigFileAndDefaultsToInternalConfig that all of kubeadm is using for unmarshal of our API types,
+		// and then marshals the internal object to the expected groupVersion
+		{ // v1alpha1 -> internal
+			name:         "v1alpha1ToInternal",
+			in:           node_v1alpha1YAML,
+			out:          node_internalYAML,
+			groupVersion: kubeadm.SchemeGroupVersion,
+		},
+		{ // v1alpha2 -> internal
+			name:         "v1alpha2ToInternal",
+			in:           node_v1alpha2YAML,
+			out:          node_internalYAML,
+			groupVersion: kubeadm.SchemeGroupVersion,
+		},
+		{ // v1alpha1 -> internal -> v1alpha2
+			name:         "v1alpha1WithoutTypeMetaTov1alpha2",
+			in:           node_v1alpha1YAML,
+			out:          node_v1alpha2YAML,
+			groupVersion: v1alpha2.SchemeGroupVersion,
+		},
+		// These tests are reading one file that has only a subset of the fields populated, loading it using NodeConfigFileAndDefaultsToInternalConfig,
+		// and then marshals the internal object to the expected groupVersion
+		{ // v1alpha1 -> default -> validate -> internal -> v1alpha1
+			name:         "incompleteYAMLToDefaulted",
+			in:           node_incompleteYAML,
+			out:          node_defaultedv1alpha1YAML,
+			groupVersion: v1alpha1.SchemeGroupVersion,
+		},
+		{ // v1alpha1 -> default -> validate -> internal -> v1alpha2
+			name:         "incompleteYAMLToDefaulted",
+			in:           node_incompleteYAML,
+			out:          node_defaultedv1alpha2YAML,
+			groupVersion: v1alpha2.SchemeGroupVersion,
+		},
+		{ // v1alpha1 (faulty) -> validation should fail
+			name:        "invalidYAMLShouldFail",
+			in:          node_invalidYAML,
+			expectedErr: true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t2 *testing.T) {
+
+			internalcfg, err := NodeConfigFileAndDefaultsToInternalConfig(rt.in, &v1alpha2.NodeConfiguration{})
+			if err != nil {
+				if rt.expectedErr {
+					return
+				}
+				t2.Fatalf("couldn't unmarshal test data: %v", err)
+			}
+
+			actual, err := kubeadmutil.MarshalToYamlForCodecs(internalcfg, rt.groupVersion, scheme.Codecs)
+			if err != nil {
+				t2.Fatalf("couldn't marshal internal object: %v", err)
+			}
+
+			expected, err := ioutil.ReadFile(rt.out)
+			if err != nil {
+				t2.Fatalf("couldn't read test data: %v", err)
+			}
+
+			if !bytes.Equal(expected, actual) {
+				t2.Errorf("the expected and actual output differs.\n\tin: %s\n\tout: %s\n\tgroupversion: %s\n\tdiff: \n%s\n",
+					rt.in, rt.out, rt.groupVersion.String(), diff(expected, actual))
+			}
+		})
+	}
+}

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -1,0 +1,158 @@
+API:
+  AdvertiseAddress: 192.168.2.2
+  BindPort: 6443
+  ControlPlaneEndpoint: ""
+APIServerCertSANs: null
+APIServerExtraArgs: null
+APIServerExtraVolumes: null
+AuditPolicyConfiguration:
+  LogDir: /var/log/kubernetes/audit
+  LogMaxAge: 2
+  Path: ""
+AuthorizationModes:
+- Node
+- RBAC
+CIImageRepository: ""
+CRISocket: /var/run/dockershim.sock
+CertificatesDir: /etc/kubernetes/pki
+ClusterName: kubernetes
+ControllerManagerExtraArgs: null
+ControllerManagerExtraVolumes: null
+Etcd:
+  CAFile: ""
+  CertFile: ""
+  DataDir: /var/lib/etcd
+  Endpoints: null
+  ExtraArgs: null
+  Image: ""
+  KeyFile: ""
+  PeerCertSANs: null
+  ServerCertSANs: null
+FeatureGates: null
+ImagePullPolicy: ""
+ImageRepository: k8s.gcr.io
+KubeProxy:
+  Config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates:
+      ServiceNodeExclusion: true
+      SupportIPVSProxyMode: true
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+KubeletConfiguration:
+  BaseConfig:
+    address: 0.0.0.0
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - 10.96.0.10
+    clusterDomain: cluster.local
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s
+KubernetesVersion: v1.10.2
+Networking:
+  DNSDomain: cluster.local
+  PodSubnet: ""
+  ServiceSubnet: 10.96.0.0/12
+NoTaintMaster: false
+NodeName: master-1
+SchedulerExtraArgs: null
+SchedulerExtraVolumes: null
+Token: s73ybu.6tw6wnqgp5z0wb77
+TokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+TokenTTL: 24h0m0s
+TokenUsages:
+- signing
+- authentication
+UnifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1.yaml
@@ -1,0 +1,148 @@
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+apiVersion: kubeadm.k8s.io/v1alpha1
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /etc/kubernetes/pki
+cloudProvider: ""
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: k8s.gcr.io
+kind: MasterConfiguration
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates:
+      ServiceNodeExclusion: true
+      SupportIPVSProxyMode: true
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration:
+  baseConfig:
+    address: 0.0.0.0
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - 10.96.0.10
+    clusterDomain: cluster.local
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+nodeName: master-1
+privilegedPods: false
+token: s73ybu.6tw6wnqgp5z0wb77
+tokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+tokenTTL: 24h0m0s
+tokenUsages:
+- signing
+- authentication
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1_without_TypeMeta.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1_without_TypeMeta.yaml
@@ -1,0 +1,145 @@
+# This file don't have TypeMeta set. kubeadm should then unmarshal it as a apiVersion=kubeadm.k8s.io/v1alpha1 and kind=MasterConfiguration
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /etc/kubernetes/pki
+cloudProvider: ""
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: k8s.gcr.io
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates: "SupportIPVSProxyMode=true,ServiceNodeExclusion=true"
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration:
+  baseConfig:
+    address: 0.0.0.0
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - 10.96.0.10
+    clusterDomain: cluster.local
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+nodeName: master-1
+privilegedPods: false
+token: s73ybu.6tw6wnqgp5z0wb77
+tokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+tokenTTL: 24h0m0s
+tokenUsages:
+- signing
+- authentication
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
@@ -1,0 +1,146 @@
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+apiVersion: kubeadm.k8s.io/v1alpha2
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /etc/kubernetes/pki
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: k8s.gcr.io
+kind: MasterConfiguration
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates:
+      ServiceNodeExclusion: true
+      SupportIPVSProxyMode: true
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration:
+  baseConfig:
+    address: 0.0.0.0
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 2m0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 5m0s
+        cacheUnauthorizedTTL: 30s
+    cgroupDriver: cgroupfs
+    cgroupsPerQOS: true
+    clusterDNS:
+    - 10.96.0.10
+    clusterDomain: cluster.local
+    containerLogMaxFiles: 5
+    containerLogMaxSize: 10Mi
+    contentType: application/vnd.kubernetes.protobuf
+    cpuCFSQuota: true
+    cpuManagerPolicy: none
+    cpuManagerReconcilePeriod: 10s
+    enableControllerAttachDetach: true
+    enableDebuggingHandlers: true
+    enforceNodeAllocatable:
+    - pods
+    eventBurst: 10
+    eventRecordQPS: 5
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 5m0s
+    failSwapOn: true
+    fileCheckFrequency: 20s
+    hairpinMode: promiscuous-bridge
+    healthzBindAddress: 127.0.0.1
+    healthzPort: 10248
+    httpCheckFrequency: 20s
+    imageGCHighThresholdPercent: 85
+    imageGCLowThresholdPercent: 80
+    imageMinimumGCAge: 2m0s
+    iptablesDropBit: 15
+    iptablesMasqueradeBit: 14
+    kubeAPIBurst: 10
+    kubeAPIQPS: 5
+    makeIPTablesUtilChains: true
+    maxOpenFiles: 1000000
+    maxPods: 110
+    nodeStatusUpdateFrequency: 10s
+    oomScoreAdj: -999
+    podPidsLimit: -1
+    port: 10250
+    registryBurst: 10
+    registryPullQPS: 5
+    resolvConf: /etc/resolv.conf
+    runtimeRequestTimeout: 2m0s
+    serializeImagePulls: true
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 4h0m0s
+    syncFrequency: 1m0s
+    volumeStatsAggPeriod: 1m0s
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.local
+  podSubnet: ""
+  serviceSubnet: 10.96.0.0/12
+nodeName: master-1
+token: s73ybu.6tw6wnqgp5z0wb77
+tokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+tokenTTL: 24h0m0s
+tokenUsages:
+- signing
+- authentication
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/conversion/node/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/node/internal.yaml
@@ -1,0 +1,14 @@
+CACertPath: /etc/kubernetes/pki/ca.crt
+CRISocket: /var/run/dockershim.sock
+ClusterName: kubernetes
+DiscoveryFile: ""
+DiscoveryTimeout: 5m0s
+DiscoveryToken: abcdef.0123456789abcdef
+DiscoveryTokenAPIServers:
+- kube-apiserver:6443
+DiscoveryTokenCACertHashes: null
+DiscoveryTokenUnsafeSkipCAVerification: true
+FeatureGates: null
+NodeName: master-1
+TLSBootstrapToken: abcdef.0123456789abcdef
+Token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/conversion/node/v1alpha1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/node/v1alpha1.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: NodeConfiguration
+caCertPath: /etc/kubernetes/pki/ca.crt
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+discoveryFile: ""
+discoveryTimeout: 5m0s
+discoveryToken: abcdef.0123456789abcdef
+discoveryTokenAPIServers:
+- kube-apiserver:6443
+discoveryTokenUnsafeSkipCAVerification: true
+nodeName: master-1
+tlsBootstrapToken: abcdef.0123456789abcdef
+token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/conversion/node/v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/node/v1alpha2.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubeadm.k8s.io/v1alpha2
+caCertPath: /etc/kubernetes/pki/ca.crt
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+discoveryFile: ""
+discoveryTimeout: 5m0s
+discoveryToken: abcdef.0123456789abcdef
+discoveryTokenAPIServers:
+- kube-apiserver:6443
+discoveryTokenUnsafeSkipCAVerification: true
+kind: NodeConfiguration
+nodeName: master-1
+tlsBootstrapToken: abcdef.0123456789abcdef
+token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_v1alpha1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_v1alpha1.yaml
@@ -1,0 +1,78 @@
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+apiVersion: kubeadm.k8s.io/v1alpha1
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /var/lib/kubernetes/pki
+cloudProvider: ""
+clusterName: kubernetes
+criSocket: /var/run/criruntime.sock
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: my-company.com
+kind: MasterConfiguration
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration: {}
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.global
+  podSubnet: ""
+  serviceSubnet: 10.196.0.0/12
+nodeName: master-1
+privilegedPods: false
+token: s73ybu.6tw6wnqgp5z0wb77
+tokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+tokenTTL: 24h0m0s
+tokenUsages:
+- signing
+- authentication
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted_v1alpha2.yaml
@@ -1,0 +1,76 @@
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+  controlPlaneEndpoint: ""
+apiVersion: kubeadm.k8s.io/v1alpha2
+auditPolicy:
+  logDir: /var/log/kubernetes/audit
+  logMaxAge: 2
+  path: ""
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /var/lib/kubernetes/pki
+clusterName: kubernetes
+criSocket: /var/run/criruntime.sock
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: my-company.com
+kind: MasterConfiguration
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      ExcludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    nodePortAddresses: null
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpIdleTimeout: 250ms
+kubeletConfiguration: {}
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.global
+  podSubnet: ""
+  serviceSubnet: 10.196.0.0/12
+nodeName: master-1
+token: s73ybu.6tw6wnqgp5z0wb77
+tokenGroups:
+- system:bootstrappers:kubeadm:default-node-token
+tokenTTL: 24h0m0s
+tokenUsages:
+- signing
+- authentication
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/incomplete.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/incomplete.yaml
@@ -1,0 +1,13 @@
+api:
+  advertiseAddress: 192.168.2.2
+  bindPort: 6443
+certificatesDir: /var/lib/kubernetes/pki
+clusterName: kubernetes
+criSocket: /var/run/criruntime.sock
+imageRepository: my-company.com
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.global
+  serviceSubnet: 10.196.0.0/12
+nodeName: master-1
+token: s73ybu.6tw6wnqgp5z0wb77

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/node/defaulted_v1alpha1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/node/defaulted_v1alpha1.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+caCertPath: /etc/kubernetes/pki/ca.crt
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+discoveryFile: ""
+discoveryTimeout: 5m0s
+discoveryToken: abcdef.0123456789abcdef
+discoveryTokenAPIServers:
+- kube-apiserver:6443
+discoveryTokenUnsafeSkipCAVerification: true
+kind: NodeConfiguration
+nodeName: thegopher
+tlsBootstrapToken: abcdef.0123456789abcdef
+token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/node/defaulted_v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/node/defaulted_v1alpha2.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubeadm.k8s.io/v1alpha2
+caCertPath: /etc/kubernetes/pki/ca.crt
+clusterName: kubernetes
+criSocket: /var/run/dockershim.sock
+discoveryFile: ""
+discoveryTimeout: 5m0s
+discoveryToken: abcdef.0123456789abcdef
+discoveryTokenAPIServers:
+- kube-apiserver:6443
+discoveryTokenUnsafeSkipCAVerification: true
+kind: NodeConfiguration
+nodeName: thegopher
+tlsBootstrapToken: abcdef.0123456789abcdef
+token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/node/incomplete.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/node/incomplete.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: NodeConfiguration
+discoveryTokenAPIServers:
+- kube-apiserver:6443
+discoveryTokenUnsafeSkipCAVerification: true
+nodeName: thegopher
+token: abcdef.0123456789abcdef

--- a/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/after.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/after.yaml
@@ -1,6 +1,11 @@
 api:
   advertiseAddress: 172.31.93.180
   bindPort: 6443
+  controlPlaneEndpoint: ""
+apiVersion: kubeadm.k8s.io/v1alpha1
+auditPolicy:
+  logDir: ""
+  path: ""
 authorizationModes:
 - Node
 - RBAC
@@ -14,6 +19,7 @@ etcd:
   image: ""
   keyFile: ""
 imageRepository: gcr.io/google_containers
+kind: MasterConfiguration
 kubeProxy:
   config:
     bindAddress: 0.0.0.0
@@ -32,7 +38,9 @@ kubeProxy:
       tcpCloseWaitTimeout: 1h0m0s
       tcpEstablishedTimeout: 24h0m0s
     enableProfiling: false
-    featureGates: ""
+    featureGates:
+      ServiceNodeExclusion: true
+      SupportIPVSProxyMode: true
     healthzBindAddress: 0.0.0.0:10256
     hostnameOverride: ""
     iptables:
@@ -41,15 +49,17 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
+      ExcludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s
     metricsBindAddress: 127.0.0.1:10249
     mode: ""
+    nodePortAddresses: null
     oomScoreAdj: -999
     portRange: ""
     resourceContainer: /kube-proxy
-    udpTimeoutMilliseconds: 250ms
+    udpIdleTimeout: 0s
 kubeletConfiguration: {}
 kubernetesVersion: v1.9.6
 networking:
@@ -57,6 +67,7 @@ networking:
   podSubnet: 192.168.0.0/16
   serviceSubnet: 10.96.0.0/12
 nodeName: ip-172-31-93-180.ec2.internal
+privilegedPods: false
 token: 8d69af.cd3e1c58f6228dfc
 tokenTTL: 24h0m0s
 unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/before.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/before.yaml
@@ -1,0 +1,64 @@
+# This MasterConfiguration object is wrong in two ways: it hasn't TypeMeta set, and .kubeProxy.config.featureGates is a string as it was in v1.9
+# In v1.10 however, it changed in an inbackwards-compatible way to a map[string]string, so we have to workaround that to unmarshal this object
+api:
+  advertiseAddress: 172.31.93.180
+  bindPort: 6443
+authorizationModes:
+- Node
+- RBAC
+certificatesDir: /etc/kubernetes/pki
+cloudProvider: aws
+etcd:
+  caFile: ""
+  certFile: ""
+  dataDir: /var/lib/etcd
+  endpoints: null
+  image: ""
+  keyFile: ""
+imageRepository: gcr.io/google_containers
+kubeProxy:
+  config:
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
+      qps: 5
+    clusterCIDR: 192.168.0.0/16
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: null
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    featureGates: "SupportIPVSProxyMode=true,ServiceNodeExclusion=true"
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    metricsBindAddress: 127.0.0.1:10249
+    mode: ""
+    oomScoreAdj: -999
+    portRange: ""
+    resourceContainer: /kube-proxy
+    udpTimeoutMilliseconds: 250ms
+kubeletConfiguration: {}
+kubernetesVersion: v1.9.6
+networking:
+  dnsDomain: cluster.local
+  podSubnet: 192.168.0.0/16
+  serviceSubnet: 10.96.0.0/12
+nodeName: ip-172-31-93-180.ec2.internal
+token: 8d69af.cd3e1c58f6228dfc
+tokenTTL: 24h0m0s
+unifiedControlPlaneImage: ""

--- a/cmd/kubeadm/app/util/config/testdata/validation/invalid_mastercfg.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/validation/invalid_mastercfg.yaml
@@ -1,0 +1,12 @@
+api:
+  bindPort: 0
+certificatesDir: relativepath
+clusterName: kubernetes
+criSocket: relativepath
+imageRepository: my-company.com
+kubernetesVersion: v1.10.2
+networking:
+  dnsDomain: cluster.GLOBAL
+  serviceSubnet: 10.196.1000.0/100
+nodeName: MASTER
+token: s7bu.6tw6wn

--- a/cmd/kubeadm/app/util/config/testdata/validation/invalid_nodecfg.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/validation/invalid_nodecfg.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: NodeConfiguration
+caCertPath: relativepath
+criSocket: relativepath
+discoveryFile: relativepath
+discoveryTimeout: not-a-time
+discoveryTokenAPIServers:
+- INVALID_URL
+discoveryTokenUnsafeSkipCAVerification: false
+nodeName: NODE-1
+token: invalidtoken


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Follows up from https://github.com/kubernetes/kubernetes/pull/63799, as well as net-new unit testing for our serialization/deserialization package. This tests our API machinery pretty much end to end.

This is more important now given we now support two external types: https://github.com/kubernetes/kubernetes/pull/63788

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of kubernetes/community#2131
Fixes: https://github.com/kubernetes/kubeadm/issues/841

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @liztio 