### PR TITLE
kubeadm: Use the release-1.11 branch by default

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -39,7 +39,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.10"
+	DefaultKubernetesVersion = "stable-1.11"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultAuthorizationModes defines default authorization modes

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -38,7 +38,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.10"
+	DefaultKubernetesVersion = "stable-1.11"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultCertificatesDir defines default certificate directory

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -54,11 +54,6 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 		configContents          []byte
 	}{
 		{
-			name:               "empty config contents",
-			expectedImageCount: defaultNumberOfImages,
-			configContents:     []byte{},
-		},
-		{
 			name:               "set k8s version",
 			expectedImageCount: defaultNumberOfImages,
 			expectedImageSubstrings: []string{
@@ -79,6 +74,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			configContents: []byte(dedent.Dedent(`
 				apiVersion: kubeadm.k8s.io/v1alpha2
 				kind: MasterConfiguration
+				kubernetesVersion: 1.11.0
 				featureGates:
 				    CoreDNS: True
 			`)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#820

**Special notes for your reviewer**:
/cc luxas 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/kubernetes-release-managers
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: Use the release-1.11 branch by default
```
