### PR TITLE
remove v190 from kubeadm in v1.11 cycle

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -46,16 +46,14 @@ const (
 	Auditing = "Auditing"
 )
 
-var v190 = version.MustParseSemantic("v1.9.0-alpha.1")
-
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
 	SelfHosting:         {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 	StoreCertsInSecrets: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 	// We don't want to advertise this feature gate exists in v1.9 to avoid confusion as it is not yet working
-	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190, HiddenInHelpText: true},
-	CoreDNS:              {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.GA}, MinimumVersion: v190},
-	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
+	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, HiddenInHelpText: true},
+	CoreDNS:              {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.GA}},
+	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 	Auditing:             {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 }
 

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -121,7 +121,7 @@ func TestNewFeatureGate(t *testing.T) {
 func TestValidateVersion(t *testing.T) {
 	var someFeatures = FeatureList{
 		"feature1": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
-		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
+		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}},
 	}
 
 	var tests = []struct {
@@ -133,15 +133,9 @@ func TestValidateVersion(t *testing.T) {
 			requestedFeatures: map[string]bool{"feature1": true},
 			expectedError:     false,
 		},
-		{ //min version but correct value given
+		{ //no min version
 			requestedFeatures: map[string]bool{"feature2": true},
-			requestedVersion:  "v1.9.0",
 			expectedError:     false,
-		},
-		{ //min version and incorrect value given
-			requestedFeatures: map[string]bool{"feature2": true},
-			requestedVersion:  "v1.8.2",
-			expectedError:     true,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In v1.11, the minimum supported k8s version is bumped to v1.9. So there is no need to set `MinimumVersion` explicitly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref kubernetes/kubeadm#815

**Special notes for your reviewer**:
/cc luxas 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove v190 from kubeadm in v1.11 cycle, since the minimum supported version has been bumped to v1.9
```
