### PR TITLE
cherry-pick of #63495: kubeadm - fix upgrades with external etcd

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
-	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/util/version"
 )
@@ -269,9 +268,8 @@ func PerformStaticPodUpgrade(client clientset.Interface, waiter apiclient.Waiter
 		return err
 	}
 
-	// These are uninitialized because passing in the clients allow for mocking the client during testing
-	var oldEtcdClient, newEtdClient etcdutil.Client
-	return upgrade.StaticPodControlPlane(waiter, pathManager, internalcfg, etcdUpgrade, oldEtcdClient, newEtdClient)
+	// The arguments, oldEtcdClient and newEtdClient, are uninitialized because passing in the clients allow for mocking the client during testing
+	return upgrade.StaticPodControlPlane(waiter, pathManager, internalcfg, etcdUpgrade, nil, nil)
 }
 
 // DryRunStaticPodUpgrade fakes an upgrade of the control plane

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -97,13 +97,13 @@ func RunPlan(parentFlags *cmdUpgradeFlags) error {
 	}
 
 	// Tell the user which upgrades are available
-	printAvailableUpgrades(availUpgrades, os.Stdout, upgradeVars.cfg.FeatureGates)
+	printAvailableUpgrades(availUpgrades, os.Stdout, upgradeVars.cfg.FeatureGates, isExternalEtcd)
 	return nil
 }
 
 // printAvailableUpgrades prints a UX-friendly overview of what versions are available to upgrade to
 // TODO look into columnize or some other formatter when time permits instead of using the tabwriter
-func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGates map[string]bool) {
+func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGates map[string]bool, isExternalEtcd bool) {
 
 	// Return quickly if no upgrades can be made
 	if len(upgrades) == 0 {
@@ -115,6 +115,16 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 
 	// Loop through the upgrade possibilities and output text to the command line
 	for _, upgrade := range upgrades {
+
+		if isExternalEtcd && upgrade.CanUpgradeEtcd() {
+			fmt.Fprintln(w, "External components that should be upgraded manually before you upgrade the control plane with 'kubeadm upgrade apply':")
+			fmt.Fprintln(tabw, "COMPONENT\tCURRENT\tAVAILABLE")
+			fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+
+			// We should flush the writer here at this stage; as the columns will now be of the right size, adjusted to the above content
+			tabw.Flush()
+			fmt.Fprintln(w, "")
+		}
 
 		if upgrade.CanUpgradeKubelets() {
 			fmt.Fprintln(w, "Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':")
@@ -150,7 +160,9 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, featureGate
 		} else {
 			fmt.Fprintf(tabw, "Kube DNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
 		}
-		fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+		if !isExternalEtcd {
+			fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
+		}
 
 		// The tabwriter should be flushed at this stage as we have now put in all the required content for this time. This is required for the tabs' size to be correct.
 		tabw.Flush()

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -62,14 +62,31 @@ func RunPlan(parentFlags *cmdUpgradeFlags) error {
 		return err
 	}
 
-	// Define Local Etcd cluster to be able to retrieve information
-	etcdClient, err := etcdutil.NewStaticPodClient(
-		[]string{"localhost:2379"},
-		constants.GetStaticPodDirectory(),
-		upgradeVars.cfg.CertificatesDir,
-	)
-	if err != nil {
-		return err
+	var etcdClient etcdutil.ClusterInterrogator
+
+	// Currently this is the only method we have for distinguishing
+	// external etcd vs static pod etcd
+	isExternalEtcd := len(upgradeVars.cfg.Etcd.Endpoints) > 0
+	if isExternalEtcd {
+		client, err := etcdutil.New(
+			upgradeVars.cfg.Etcd.Endpoints,
+			upgradeVars.cfg.Etcd.CAFile,
+			upgradeVars.cfg.Etcd.CertFile,
+			upgradeVars.cfg.Etcd.KeyFile)
+		if err != nil {
+			return err
+		}
+		etcdClient = client
+	} else {
+		client, err := etcdutil.NewFromStaticPod(
+			[]string{"localhost:2379"},
+			constants.GetStaticPodDirectory(),
+			upgradeVars.cfg.CertificatesDir,
+		)
+		if err != nil {
+			return err
+		}
+		etcdClient = client
 	}
 
 	// Compute which upgrade possibilities there are

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -74,7 +74,7 @@ type ClusterState struct {
 
 // GetAvailableUpgrades fetches all versions from the specified VersionGetter and computes which
 // kinds of upgrades can be performed
-func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, etcdClient etcdutil.Client, featureGates map[string]bool) ([]Upgrade, error) {
+func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool, etcdClient etcdutil.ClusterInterrogator, featureGates map[string]bool) ([]Upgrade, error) {
 	fmt.Println("[upgrade] Fetching available versions to upgrade to")
 
 	// Collect the upgrades kubeadm can do in this list

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -64,69 +64,42 @@ func (f *fakeVersionGetter) KubeletVersions() (map[string]uint16, error) {
 	}, nil
 }
 
-type fakeEtcdClient struct{ TLS bool }
+type fakeEtcdClient struct {
+	TLS                bool
+	mismatchedVersions bool
+}
 
 func (f fakeEtcdClient) HasTLS() bool { return f.TLS }
 
-func (f fakeEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	//	clusterStatus, err := f.GetClusterStatus()
-	//	return clusterStatus[0], err
-	return &clientv3.StatusResponse{
-		Version: "3.1.12",
+func (f fakeEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
+
+func (f fakeEtcdClient) WaitForClusterAvailable(delay time.Duration, retries int, retryInterval time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (f fakeEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
+	return make(map[string]*clientv3.StatusResponse), nil
+}
+
+func (f fakeEtcdClient) GetVersion() (string, error) {
+	versions, _ := f.GetClusterVersions()
+	if f.mismatchedVersions {
+		return "", fmt.Errorf("etcd cluster contains endpoints with mismatched versions: %v", versions)
+	}
+	return "3.1.12", nil
+}
+
+func (f fakeEtcdClient) GetClusterVersions() (map[string]string, error) {
+	if f.mismatchedVersions {
+		return map[string]string{
+			"foo": "3.1.12",
+			"bar": "3.2.0",
+		}, nil
+	}
+	return map[string]string{
+		"foo": "3.1.12",
+		"bar": "3.1.12",
 	}, nil
-}
-
-func (f fakeEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
-	var responses []*clientv3.StatusResponse
-	responses = append(responses, &clientv3.StatusResponse{
-		Version: "3.1.12",
-	})
-	return responses, nil
-}
-
-func (f fakeEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return f.GetStatus()
-}
-
-type mismatchEtcdClient struct{}
-
-func (f mismatchEtcdClient) HasTLS() bool { return true }
-
-func (f mismatchEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	clusterStatus, err := f.GetClusterStatus()
-	return clusterStatus[0], err
-}
-
-func (f mismatchEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
-	return []*clientv3.StatusResponse{
-		&clientv3.StatusResponse{
-			Version: "3.1.12",
-		},
-		&clientv3.StatusResponse{
-			Version: "3.2.0",
-		},
-	}, nil
-}
-
-func (f mismatchEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return f.GetStatus()
-}
-
-type degradedEtcdClient struct{}
-
-func (f degradedEtcdClient) HasTLS() bool { return true }
-
-func (f degradedEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	return nil, fmt.Errorf("Degraded etcd cluster")
-}
-
-func (f degradedEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
-	var res []*clientv3.StatusResponse
-	return res, fmt.Errorf("Degraded etcd cluster")
-}
-
-func (f degradedEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return f.GetStatus()
 }
 
 func TestGetAvailableUpgrades(t *testing.T) {
@@ -522,21 +495,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 			},
 			allowRCs:          false,
 			allowExperimental: false,
-			etcdClient:        mismatchEtcdClient{},
-			expectedUpgrades:  []Upgrade{},
-			errExpected:       true,
-		},
-		{
-			vg: &fakeVersionGetter{
-				clusterVersion:     "v1.9.3",
-				kubeletVersion:     "v1.9.3",
-				kubeadmVersion:     "v1.9.3",
-				stablePatchVersion: "v1.9.3",
-				stableVersion:      "v1.9.3",
-			},
-			allowRCs:          false,
-			allowExperimental: false,
-			etcdClient:        degradedEtcdClient{},
+			etcdClient:        fakeEtcdClient{mismatchedVersions: true},
 			expectedUpgrades:  []Upgrade{},
 			errExpected:       true,
 		},

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	kubeadmapiv1alpha1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	controlplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
@@ -215,20 +215,27 @@ func (c fakeTLSEtcdClient) HasTLS() bool {
 	return c.TLS
 }
 
-func (c fakeTLSEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	clusterStatus, err := c.GetClusterStatus()
-	return clusterStatus[0], err
+func (c fakeTLSEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
+
+func (c fakeTLSEtcdClient) WaitForClusterAvailable(delay time.Duration, retries int, retryInterval time.Duration) (bool, error) {
+	return true, nil
 }
 
-func (c fakeTLSEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
-	client := &clientv3.StatusResponse{
-		Version: "3.1.12",
-	}
-	return []*clientv3.StatusResponse{client}, nil
+func (c fakeTLSEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
+	return map[string]*clientv3.StatusResponse{
+		"foo": {
+			Version: "3.1.12",
+		}}, nil
 }
 
-func (c fakeTLSEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return c.GetStatus()
+func (c fakeTLSEtcdClient) GetClusterVersions() (map[string]string, error) {
+	return map[string]string{
+		"foo": "3.1.12",
+	}, nil
+}
+
+func (c fakeTLSEtcdClient) GetVersion() (string, error) {
+	return "3.1.12", nil
 }
 
 type fakePodManifestEtcdClient struct{ ManifestDir, CertificatesDir string }
@@ -238,12 +245,13 @@ func (c fakePodManifestEtcdClient) HasTLS() bool {
 	return hasTLS
 }
 
-func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	clusterStatus, err := c.GetClusterStatus()
-	return clusterStatus[0], err
+func (c fakePodManifestEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
+
+func (c fakePodManifestEtcdClient) WaitForClusterAvailable(delay time.Duration, retries int, retryInterval time.Duration) (bool, error) {
+	return true, nil
 }
 
-func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+func (c fakePodManifestEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
 	// Make sure the certificates generated from the upgrade are readable from disk
 	tlsInfo := transport.TLSInfo{
 		CertFile:      filepath.Join(c.CertificatesDir, constants.EtcdCACertName),
@@ -255,13 +263,19 @@ func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusRespons
 		return nil, err
 	}
 
-	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.12"
-	return []*clientv3.StatusResponse{client}, nil
+	return map[string]*clientv3.StatusResponse{
+		"foo": {Version: "3.1.12"},
+	}, nil
 }
 
-func (c fakePodManifestEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
-	return c.GetStatus()
+func (c fakePodManifestEtcdClient) GetClusterVersions() (map[string]string, error) {
+	return map[string]string{
+		"foo": "3.1.12",
+	}, nil
+}
+
+func (c fakePodManifestEtcdClient) GetVersion() (string, error) {
+	return "3.1.12", nil
 }
 
 func TestStaticPodControlPlane(t *testing.T) {
@@ -496,7 +510,7 @@ func getAPIServerHash(dir string) (string, error) {
 }
 
 func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.MasterConfiguration, error) {
-	externalcfg := &kubeadmapiext.MasterConfiguration{}
+	externalcfg := &kubeadmapiv1alpha1.MasterConfiguration{}
 	internalcfg := &kubeadmapi.MasterConfiguration{}
 	if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), []byte(fmt.Sprintf(testConfiguration, certsDir, etcdDataDir, version)), externalcfg); err != nil {
 		return nil, fmt.Errorf("unable to decode config: %v", err)

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -216,9 +216,15 @@ func (c fakeTLSEtcdClient) HasTLS() bool {
 }
 
 func (c fakeTLSEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
-	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.12"
-	return client, nil
+	clusterStatus, err := c.GetClusterStatus()
+	return clusterStatus[0], err
+}
+
+func (c fakeTLSEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
+	client := &clientv3.StatusResponse{
+		Version: "3.1.12",
+	}
+	return []*clientv3.StatusResponse{client}, nil
 }
 
 func (c fakeTLSEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {
@@ -233,6 +239,11 @@ func (c fakePodManifestEtcdClient) HasTLS() bool {
 }
 
 func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error) {
+	clusterStatus, err := c.GetClusterStatus()
+	return clusterStatus[0], err
+}
+
+func (c fakePodManifestEtcdClient) GetClusterStatus() ([]*clientv3.StatusResponse, error) {
 	// Make sure the certificates generated from the upgrade are readable from disk
 	tlsInfo := transport.TLSInfo{
 		CertFile:      filepath.Join(c.CertificatesDir, constants.EtcdCACertName),
@@ -246,7 +257,7 @@ func (c fakePodManifestEtcdClient) GetStatus() (*clientv3.StatusResponse, error)
 
 	client := &clientv3.StatusResponse{}
 	client.Version = "3.1.12"
-	return client, nil
+	return []*clientv3.StatusResponse{client}, nil
 }
 
 func (c fakePodManifestEtcdClient) WaitForStatus(delay time.Duration, retries int, retryInterval time.Duration) (*clientv3.StatusResponse, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports fixes for kubeadm upgrades with external etcd

**Release note**:
```release-note
kubeadm - fix upgrades with external etcd
```
