### PR TITLE
Avoid unnecessary calls to the cloud provider

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -282,6 +282,11 @@ func (s *ServiceController) createLoadBalancerIfNeeded(key string, service *v1.S
 	var err error
 
 	if !wantsLoadBalancer(service) {
+		if v1helper.LoadBalancerStatusEqual(previousState, &v1.LoadBalancerStatus{}) {
+			return nil
+		}
+
+		glog.V(3).Infof("Getting load balancer for service %s", key)
 		_, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service)
 		if err != nil {
 			return fmt.Errorf("error getting LB for service %s: %v", key, err)


### PR DESCRIPTION
If the service controller is processing a service that does not have type LoadBalancer and does not have any external load balancer recorded in its status, do not ask the cloud provider to check for an associated load balancer.

**What this PR does / why we need it**:

We are seeing excessive `DescribeLoadBalancers` calls on some clusters.  This PR is intended to mitigate excessive API calls by avoiding unnecessary calls to the `DescribeLoadBalancers` API.

For example, these are the numbers from one of our production clusters, showing that calls to `DescribeLoadBalancers` dominate API usage:

| user           | API                   | calls |
| ---------------|---------------------- | ----- |
| cloud_provider | DescribeLoadBalancers | 23675 |
| ops_volume     | CreateTags            | 22653 |
| "              | DeleteSnapshot        | 21060 |
| "              | CreateSnapshot        | 12426 |
| "              | DescribeVolumes       | 11832 |
| cloud_provider | DescribeVolumes       |  1940 |
| "              | DescribeInstances     |  1546 |
| "              | AttachVolume          |   553 |
| "              | DetachVolume          |   514 |
| ops_monitoring | DescribeLoadBalancers |   373 |
| cloud_provider | DeleteVolume          |   310 |
| inventory      | DescribeInstances     |   270 |
| cloud_provider | DescribeSubnets       |   193 |
| "              | CreateVolume          |   192 |
| "              | CreateTags            |   185 |
| ops_volume     | DescribeInstances     |   156 |
| "              | DescribeSnapshots     |    83 |
| ops_config     | CreateTags            |    81 |
| "              | DescribeTags          |    81 |
| ops_monitoring | DescribeInstances     |     6 |
| s3_docker      | ListBuckets           |     2 |


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #30700.

**Special notes for your reviewer**:

Based on #34271.

**Release note**:

```release-note
The service controller no longer checks for external load balancers associated with services that do not have type LoadBalancer and do not have any external load balancer recorded in their statuses.
```