### PR TITLE
scheduler: further cleanup of equivalence cache

### DIFF
--- a/pkg/scheduler/core/equivalence_cache.go
+++ b/pkg/scheduler/core/equivalence_cache.go
@@ -31,22 +31,30 @@ import (
 	"github.com/golang/glog"
 )
 
-// EquivalenceCache holds:
-// 1. a map of AlgorithmCache with node name as key
-// 2. function to get equivalence pod
+// EquivalenceCache saves and reuses the output of predicate functions. Use
+// RunPredicate to get or update the cached results. An appropriate Invalidate*
+// function should be called when some predicate results are no longer valid.
+//
+// Internally, results are keyed by node name, predicate name, and "equivalence
+// class". (Equivalence class is defined in the `EquivalenceClassInfo` type.)
+// Saved results will be reused until an appropriate invalidation function is
+// called.
 type EquivalenceCache struct {
-	mu             sync.RWMutex
-	algorithmCache map[string]AlgorithmCache
+	mu    sync.RWMutex
+	cache nodeMap
 }
 
-// The AlgorithmCache stores PredicateMap with predicate name as key, PredicateMap as value.
-type AlgorithmCache map[string]PredicateMap
+// nodeMap stores PredicateCaches with node name as the key.
+type nodeMap map[string]predicateMap
 
-// PredicateMap stores HostPrediacte with equivalence hash as key
-type PredicateMap map[uint64]HostPredicate
+// predicateMap stores resultMaps with predicate name as the key.
+type predicateMap map[string]resultMap
 
-// HostPredicate is the cached predicate result
-type HostPredicate struct {
+// resultMap stores PredicateResult with pod equivalence hash as the key.
+type resultMap map[uint64]predicateResult
+
+// predicateResult stores the output of a FitPredicate.
+type predicateResult struct {
 	Fit         bool
 	FailReasons []algorithm.PredicateFailureReason
 }
@@ -55,12 +63,12 @@ type HostPredicate struct {
 // result from previous scheduling.
 func NewEquivalenceCache() *EquivalenceCache {
 	return &EquivalenceCache{
-		algorithmCache: make(map[string]AlgorithmCache),
+		cache: make(nodeMap),
 	}
 }
 
-// RunPredicate will return a cached predicate result. In case of a cache miss, the predicate will
-// be run and its results cached for the next call.
+// RunPredicate returns a cached predicate result. In case of a cache miss, the predicate will be
+// run and its results cached for the next call.
 //
 // NOTE: RunPredicate will not update the equivalence cache if the given NodeInfo is stale.
 func (ec *EquivalenceCache) RunPredicate(
@@ -69,7 +77,7 @@ func (ec *EquivalenceCache) RunPredicate(
 	pod *v1.Pod,
 	meta algorithm.PredicateMetadata,
 	nodeInfo *schedulercache.NodeInfo,
-	equivClassInfo *equivalenceClassInfo,
+	equivClassInfo *EquivalenceClassInfo,
 	cache schedulercache.Cache,
 ) (bool, []algorithm.PredicateFailureReason, error) {
 	if nodeInfo == nil || nodeInfo.Node() == nil {
@@ -111,20 +119,20 @@ func (ec *EquivalenceCache) updateResult(
 		return
 	}
 	nodeName := nodeInfo.Node().GetName()
-	if _, exist := ec.algorithmCache[nodeName]; !exist {
-		ec.algorithmCache[nodeName] = AlgorithmCache{}
+	if _, exist := ec.cache[nodeName]; !exist {
+		ec.cache[nodeName] = make(predicateMap)
 	}
-	predicateItem := HostPredicate{
+	predicateItem := predicateResult{
 		Fit:         fit,
 		FailReasons: reasons,
 	}
 	// if cached predicate map already exists, just update the predicate by key
-	if predicateMap, ok := ec.algorithmCache[nodeName][predicateKey]; ok {
+	if predicates, ok := ec.cache[nodeName][predicateKey]; ok {
 		// maps in golang are references, no need to add them back
-		predicateMap[equivalenceHash] = predicateItem
+		predicates[equivalenceHash] = predicateItem
 	} else {
-		ec.algorithmCache[nodeName][predicateKey] =
-			PredicateMap{
+		ec.cache[nodeName][predicateKey] =
+			resultMap{
 				equivalenceHash: predicateItem,
 			}
 	}
@@ -143,11 +151,11 @@ func (ec *EquivalenceCache) lookupResult(
 	defer ec.mu.RUnlock()
 	glog.V(5).Infof("Begin to calculate predicate: %v for pod: %s on node: %s based on equivalence cache",
 		predicateKey, podName, nodeName)
-	if hostPredicate, exist := ec.algorithmCache[nodeName][predicateKey][equivalenceHash]; exist {
-		if hostPredicate.Fit {
+	if result, exist := ec.cache[nodeName][predicateKey][equivalenceHash]; exist {
+		if result.Fit {
 			return true, []algorithm.PredicateFailureReason{}, false
 		}
-		return false, hostPredicate.FailReasons, false
+		return false, result.FailReasons, false
 	}
 	// is invalid
 	return false, []algorithm.PredicateFailureReason{}, true
@@ -161,40 +169,43 @@ func (ec *EquivalenceCache) InvalidateCachedPredicateItem(nodeName string, predi
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
 	for predicateKey := range predicateKeys {
-		delete(ec.algorithmCache[nodeName], predicateKey)
+		delete(ec.cache[nodeName], predicateKey)
 	}
 	glog.V(5).Infof("Done invalidating cached predicates: %v on node: %s", predicateKeys, nodeName)
 }
 
-// InvalidateCachedPredicateItemOfAllNodes marks all items of given predicateKeys, of all pods, on all node as invalid
+// InvalidateCachedPredicateItemOfAllNodes marks all items of given
+// predicateKeys, of all pods, on all node as invalid
 func (ec *EquivalenceCache) InvalidateCachedPredicateItemOfAllNodes(predicateKeys sets.String) {
 	if len(predicateKeys) == 0 {
 		return
 	}
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
-	// algorithmCache uses nodeName as key, so we just iterate it and invalid given predicates
-	for _, algorithmCache := range ec.algorithmCache {
+	// ec.cache uses nodeName as key, so we just iterate it and invalid given predicates
+	for _, predicates := range ec.cache {
 		for predicateKey := range predicateKeys {
-			delete(algorithmCache, predicateKey)
+			delete(predicates, predicateKey)
 		}
 	}
 	glog.V(5).Infof("Done invalidating cached predicates: %v on all node", predicateKeys)
 }
 
-// InvalidateAllCachedPredicateItemOfNode marks all cached items on given node as invalid
+// InvalidateAllCachedPredicateItemOfNode marks all cached items on given node
+// as invalid
 func (ec *EquivalenceCache) InvalidateAllCachedPredicateItemOfNode(nodeName string) {
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
-	delete(ec.algorithmCache, nodeName)
+	delete(ec.cache, nodeName)
 	glog.V(5).Infof("Done invalidating all cached predicates on node: %s", nodeName)
 }
 
-// InvalidateCachedPredicateItemForPodAdd is a wrapper of InvalidateCachedPredicateItem for pod add case
+// InvalidateCachedPredicateItemForPodAdd is a wrapper of
+// InvalidateCachedPredicateItem for pod add case
 func (ec *EquivalenceCache) InvalidateCachedPredicateItemForPodAdd(pod *v1.Pod, nodeName string) {
 	// MatchInterPodAffinity: we assume scheduler can make sure newly bound pod
-	// will not break the existing inter pod affinity. So we does not need to invalidate
-	// MatchInterPodAffinity when pod added.
+	// will not break the existing inter pod affinity. So we does not need to
+	// invalidate MatchInterPodAffinity when pod added.
 	//
 	// But when a pod is deleted, existing inter pod affinity may become invalid.
 	// (e.g. this pod was preferred by some else, or vice versa)
@@ -227,22 +238,23 @@ func (ec *EquivalenceCache) InvalidateCachedPredicateItemForPodAdd(pod *v1.Pod, 
 	ec.InvalidateCachedPredicateItem(nodeName, invalidPredicates)
 }
 
-// equivalenceClassInfo holds equivalence hash which is used for checking equivalence cache.
-// We will pass this to podFitsOnNode to ensure equivalence hash is only calculated per schedule.
-type equivalenceClassInfo struct {
+// EquivalenceClassInfo holds equivalence hash which is used for checking
+// equivalence cache. We will pass this to podFitsOnNode to ensure equivalence
+// hash is only calculated per schedule.
+type EquivalenceClassInfo struct {
 	// Equivalence hash.
 	hash uint64
 }
 
-// getEquivalenceClassInfo returns a hash of the given pod.
-// The hashing function returns the same value for any two pods that are
-// equivalent from the perspective of scheduling.
-func (ec *EquivalenceCache) getEquivalenceClassInfo(pod *v1.Pod) *equivalenceClassInfo {
-	equivalencePod := getEquivalenceHash(pod)
+// GetEquivalenceClassInfo returns a hash of the given pod. The hashing function
+// returns the same value for any two pods that are equivalent from the
+// perspective of scheduling.
+func (ec *EquivalenceCache) GetEquivalenceClassInfo(pod *v1.Pod) *EquivalenceClassInfo {
+	equivalencePod := getEquivalencePod(pod)
 	if equivalencePod != nil {
 		hash := fnv.New32a()
 		hashutil.DeepHashObject(hash, equivalencePod)
-		return &equivalenceClassInfo{
+		return &EquivalenceClassInfo{
 			hash: uint64(hash.Sum32()),
 		}
 	}
@@ -254,9 +266,9 @@ func (ec *EquivalenceCache) getEquivalenceClassInfo(pod *v1.Pod) *equivalenceCla
 // include any Pod field which is used by a FitPredicate.
 //
 // NOTE: For equivalence hash to be formally correct, lists and maps in the
-// equivalencePod should be normalized. (e.g. by sorting them) However, the
-// vast majority of equivalent pod classes are expected to be created from a
-// single pod template, so they will all have the same ordering.
+// equivalencePod should be normalized. (e.g. by sorting them) However, the vast
+// majority of equivalent pod classes are expected to be created from a single
+// pod template, so they will all have the same ordering.
 type equivalencePod struct {
 	Namespace      *string
 	Labels         map[string]string
@@ -269,8 +281,9 @@ type equivalencePod struct {
 	Volumes        []v1.Volume // See note about ordering
 }
 
-// getEquivalenceHash returns the equivalencePod for a Pod.
-func getEquivalenceHash(pod *v1.Pod) *equivalencePod {
+// getEquivalencePod returns a normalized representation of a pod so that two
+// "equivalent" pods will hash to the same value.
+func getEquivalencePod(pod *v1.Pod) *equivalencePod {
 	ep := &equivalencePod{
 		Namespace:      &pod.Namespace,
 		Labels:         pod.Labels,

--- a/pkg/scheduler/core/equivalence_cache_test.go
+++ b/pkg/scheduler/core/equivalence_cache_test.go
@@ -493,7 +493,7 @@ func TestLookupResult(t *testing.T) {
 		if test.expectedPredicateKeyMiss {
 			predicateKeys := sets.NewString()
 			predicateKeys.Insert(test.predicateKey)
-			ecache.InvalidateCachedPredicateItem(test.nodeName, predicateKeys)
+			ecache.InvalidatePredicatesOnNode(test.nodeName, predicateKeys)
 		}
 		// calculate predicate with equivalence cache
 		result, ok := ecache.lookupResult(test.podName,
@@ -709,7 +709,7 @@ func TestInvalidateCachedPredicateItemOfAllNodes(t *testing.T) {
 	}
 
 	// invalidate cached predicate for all nodes
-	ecache.InvalidateCachedPredicateItemOfAllNodes(sets.NewString(testPredicate))
+	ecache.InvalidatePredicates(sets.NewString(testPredicate))
 
 	// there should be no cached predicate any more
 	for _, test := range tests {
@@ -782,7 +782,7 @@ func TestInvalidateAllCachedPredicateItemOfNode(t *testing.T) {
 
 	for _, test := range tests {
 		// invalidate cached predicate for all nodes
-		ecache.InvalidateAllCachedPredicateItemOfNode(test.nodeName)
+		ecache.InvalidateAllPredicatesOnNode(test.nodeName)
 		if _, exist := ecache.cache[test.nodeName]; exist {
 			t.Errorf("Failed: cached item for node: %v should be invalidated", test.nodeName)
 			break
@@ -857,7 +857,7 @@ func TestEquivalenceCacheInvalidationRace(t *testing.T) {
 		if err := cache.AddPod(pod); err != nil {
 			t.Errorf("Could not add pod to cache: %v", err)
 		}
-		eCache.InvalidateAllCachedPredicateItemOfNode("machine1")
+		eCache.InvalidateAllPredicatesOnNode("machine1")
 		mockCache.cacheInvalidated <- struct{}{}
 	}()
 

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -342,10 +342,10 @@ func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v
 		// We can use the same metadata producer for all nodes.
 		meta := g.predicateMetaProducer(pod, g.cachedNodeInfoMap)
 
-		var equivCacheInfo *equivalenceClassInfo
+		var equivCacheInfo *EquivalenceClassInfo
 		if g.equivalenceCache != nil {
 			// getEquivalenceClassInfo will return immediately if no equivalence pod found
-			equivCacheInfo = g.equivalenceCache.getEquivalenceClassInfo(pod)
+			equivCacheInfo = g.equivalenceCache.GetEquivalenceClassInfo(pod)
 		}
 
 		checkNode := func(i int) {
@@ -462,7 +462,7 @@ func podFitsOnNode(
 	ecache *EquivalenceCache,
 	queue SchedulingQueue,
 	alwaysCheckAllPredicates bool,
-	equivCacheInfo *equivalenceClassInfo,
+	equivCacheInfo *EquivalenceClassInfo,
 ) (bool, []algorithm.PredicateFailureReason, error) {
 	var (
 		eCacheAvailable  bool

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -284,7 +284,7 @@ func (sched *Scheduler) assumeAndBindVolumes(assumed *v1.Pod, host string) error
 			if bindingRequired {
 				if sched.config.Ecache != nil {
 					invalidPredicates := sets.NewString(predicates.CheckVolumeBindingPred)
-					sched.config.Ecache.InvalidateCachedPredicateItemOfAllNodes(invalidPredicates)
+					sched.config.Ecache.InvalidatePredicates(invalidPredicates)
 				}
 
 				// bindVolumesWorker() will update the Pod object to put it back in the scheduler queue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This improves comments and simplifies some names/logic in equivalence_cache.go, as well as changing the order of some items in the file.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind cleanup