### PR TITLE
Promote aggregator e2e test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -1,3 +1,4 @@
+test/e2e/apimachinery/aggregator.go: "Should be able to support the 1.10 Sample API Server using the current Aggregator"
 test/e2e/apimachinery/custom_resource_definition.go: "creating/deleting custom resource definition objects works"
 test/e2e/apimachinery/garbage_collector.go: "should delete pods created by rc when not orphaning"
 test/e2e/apimachinery/garbage_collector.go: "should orphan pods created by rc if delete options say so"

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -72,11 +72,12 @@ var _ = SIGDescribe("Aggregator", func() {
 		aggrclient = f.AggregatorClient
 	})
 
-	It("Should be able to support the 1.10 Sample API Server using the current Aggregator", func() {
-		// Make sure the relevant provider supports Aggregator
-		framework.SkipUnlessServerVersionGTE(serverAggregatorVersion, f.ClientSet.Discovery())
-		framework.SkipUnlessProviderIs("gce", "gke")
-
+	/*
+		    Testname: aggregator-supports-the-sample-apiserver
+		    Description: Ensure that the sample-apiserver code from 1.10 and compiled against 1.10
+			will work on the current Aggregator/API-Server.
+	*/
+	framework.ConformanceIt("Should be able to support the 1.10 Sample API Server using the current Aggregator", func() {
 		// Testing a 1.10 version of the sample-apiserver
 		TestSampleAPIServer(f, imageutils.GetE2EImage(imageutils.APIServer))
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
The aggregation API has been GA [since 1.9](https://github.com/kubernetes/kubernetes/pull/58393), and it is currently the only way to extend the kubernetes API that is GA. It needs to be conformance tested so kubernetes users can rely on its behavior.

The test is not flaky according to [testgrid](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gci-gce&width=5&include-filter-by-regex=api-machinery&include-filter-by-regex=Aggregator)

**Release note**:
```release-note
New conformance tests added for API Aggregation.
```

/sig api-machinery
/sig architecture
/area conformance