### PR TITLE
should return err when Marshal nodeCondition error

### DIFF
--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -137,14 +137,14 @@ func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.N
 	generatePatch := func(condition v1.NodeCondition) ([]byte, error) {
 		raw, err := json.Marshal(&[]v1.NodeCondition{condition})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to Marshal raw for condition %v: %v", condition, err)
 		}
 		return []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw)), nil
 	}
 	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
 	patch, err := generatePatch(condition)
 	if err != nil {
-		return nil
+		return err
 	}
 	_, err = c.CoreV1().Nodes().PatchStatus(string(node), patch)
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
should return err when Marshal nodeCondition error
duplicate of [https://github.com/kubernetes/kubernetes/pull/56545](https://github.com/kubernetes/kubernetes/pull/56545), which close accidentaly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
