### PR TITLE
Fix SkippedPaths

### DIFF
--- a/build/root/.kazelcfg.json
+++ b/build/root/.kazelcfg.json
@@ -2,6 +2,7 @@
 	"GoPrefix": "k8s.io/kubernetes",
 	"SkippedPaths": [
 		"^_.*",
+		"/_",
 		"^third_party/etcd.*"
 	],
 	"AddSourcesRules": true,


### PR DESCRIPTION
Bazel walks through the Kubernetes repo to add vendor targets for OpenAPI generation. `SkippedPaths` is used to skip the paths such as `_examples`. However, it doesn't work as desired, because it matches for `_` at the beginning of the path, so paths like `vendor\..\_example` are picked up by the generator. This PR fixes this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes failing bazel tests in #55472

```release-note
NONE
```

/cc @sttts 