### PR TITLE
kubectl: fix Flatten() when used without Latest()

### DIFF
--- a/pkg/kubectl/genericclioptions/resource/builder.go
+++ b/pkg/kubectl/genericclioptions/resource/builder.go
@@ -1022,12 +1022,12 @@ func (b *Builder) visitByPaths() *Result {
 		visitors = VisitorList(b.paths)
 	}
 
+	if b.flatten {
+		visitors = NewFlattenListVisitor(visitors, b.objectTyper, b.mapper)
+	}
+
 	// only items from disk can be refetched
 	if b.latest {
-		// must flatten lists prior to fetching
-		if b.flatten {
-			visitors = NewFlattenListVisitor(visitors, b.objectTyper, b.mapper)
-		}
 		// must set namespace prior to fetching
 		if b.defaultNamespace {
 			visitors = NewDecoratedVisitor(visitors, SetNamespace(b.namespace))


### PR DESCRIPTION
**What this PR does / why we need it**:

If `Flatten()` is used on resource builder the list is not flattened unless the `Latest()` is used in the chain.
We should support `Flatten()` without Latest() as well. For example:

```
$ oc apply -l foo=bar -f /tmp/list.yaml
```
 will fail with:
```
F0517 13:45:07.831195   31795 helpers.go:119] error: object does not implement the Object interfaces
```

**Release note**:
```release-note
NONE
```