### PR TITLE
[POC] openapi generation failure on meta dep

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	_ "k8s.io/apimachinery/pkg/api/meta"
 )
 
 // Scheme defines methods for serializing and deserializing API objects, a type


### PR DESCRIPTION
adding a dependency from apimachinery/pkg/runtime to apimachinery/pkg/meta produces an openapi generation failure. 

```
[deads@deads-02 kubernetes]$ make
E0517 09:53:43.235609   18198 openapi.go:350] Error when generating: items, Items []invalid type
F0517 09:53:43.235628   18198 main.go:58] Error: Failed executing generator: some packages had errors:
slice Element kind Unsupported is not supported in []invalid type
make[1]: *** [Makefile.generated_files:755: pkg/generated/openapi/zz_generated.openapi.go] Error 1
make: *** [Makefile:483: generated_files] Error 2
```

Does anyone know why?  

@kubernetes/sig-api-machinery-bugs @sttts @liggitt @mbohlool 