### PR TITLE
kubeadm - fix upgrades with static pod etcd

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
-	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
@@ -277,9 +276,8 @@ func PerformStaticPodUpgrade(client clientset.Interface, waiter apiclient.Waiter
 		return err
 	}
 
-	// These are uninitialized because passing in the clients allow for mocking the client during testing
-	var oldEtcdClient, newEtdClient etcdutil.Client
-	return upgrade.StaticPodControlPlane(waiter, pathManager, internalcfg, etcdUpgrade, oldEtcdClient, newEtdClient)
+	// The arguments oldEtcdClient and newEtdClient, are uninitialized because passing in the clients allow for mocking the client during testing
+	return upgrade.StaticPodControlPlane(waiter, pathManager, internalcfg, etcdUpgrade, nil, nil)
 }
 
 // DryRunStaticPodUpgrade fakes an upgrade of the control plane

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -133,14 +133,10 @@ func (c Client) GetVersion() (string, error) {
 		return "", err
 	}
 	for _, v := range versions {
-		if clusterVersion == "" {
-			// This is the first version we've seen
-			clusterVersion = v
-		} else if v != clusterVersion {
+		if clusterVersion != "" && clusterVersion != v {
 			return "", fmt.Errorf("etcd cluster contains endpoints with mismatched versions: %v", versions)
-		} else {
-			clusterVersion = v
 		}
+		clusterVersion = v
 	}
 	if clusterVersion == "" {
 		return "", fmt.Errorf("could not determine cluster etcd version")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a regression introduced by https://github.com/kubernetes/kubernetes/pull/63495 which broke kubeadm upgrades for installations using a static pod etcd.

**Release note**:
```release-note
NONE
```
