### PR TITLE
Sort API Services by Kube-Version order

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -86370,7 +86370,7 @@
       "type": "string"
      },
      "versionPriority": {
-      "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) Since it's inside of a group, the number can be small, probably in the 10s.",
+      "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA \u003e beta \u003e alpha, and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
       "type": "integer",
       "format": "int32"
      }
@@ -86515,7 +86515,7 @@
       "type": "string"
      },
      "versionPriority": {
-      "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) Since it's inside of a group, the number can be small, probably in the 10s.",
+      "description": "VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA \u003e beta \u003e alpha, and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
       "type": "integer",
       "format": "int32"
      }

--- a/staging/src/k8s.io/apimachinery/pkg/version/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/version/BUILD
@@ -3,12 +3,14 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "helpers.go",
         "types.go",
     ],
     importpath = "k8s.io/apimachinery/pkg/version",
@@ -25,4 +27,10 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/version/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/helpers.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type versionType int
+
+const (
+	// Bigger the version type number, higher priority it is
+	versionTypeAlpha versionType = iota
+	versionTypeBeta
+	versionTypeGA
+)
+
+var kubeVersionRegex = regexp.MustCompile("^v([\\d]+)(?:(alpha|beta)([\\d]+))?$")
+
+func parseKubeVersion(v string) (majorVersion int, vType versionType, minorVersion int, ok bool) {
+	var err error
+	submatches := kubeVersionRegex.FindStringSubmatch(v)
+	if len(submatches) != 4 {
+		return 0, 0, 0, false
+	}
+	switch submatches[2] {
+	case "alpha":
+		vType = versionTypeAlpha
+	case "beta":
+		vType = versionTypeBeta
+	case "":
+		vType = versionTypeGA
+	default:
+		return 0, 0, 0, false
+	}
+	if majorVersion, err = strconv.Atoi(submatches[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if vType != versionTypeGA {
+		if minorVersion, err = strconv.Atoi(submatches[3]); err != nil {
+			return 0, 0, 0, false
+		}
+	}
+	return majorVersion, vType, minorVersion, true
+}
+
+// CompareKubeAwareVersionStrings compares two kube-like version strings.
+// Kube-like version strings are starting with a v, followed by a major version, optional "alpha" or "beta" strings
+// followed by a minor version (e.g. v1, v2beta1). Versions will be sorted based on GA/alpha/beta first and then major
+// and minor versions. e.g. v2, v1, v1beta2, v1beta1, v1alpha1.
+func CompareKubeAwareVersionStrings(v1, v2 string) int {
+	if v1 == v2 {
+		return 0
+	}
+	v1major, v1type, v1minor, ok1 := parseKubeVersion(v1)
+	v2major, v2type, v2minor, ok2 := parseKubeVersion(v2)
+	switch {
+	case !ok1 && !ok2:
+		return strings.Compare(v2, v1)
+	case !ok1 && ok2:
+		return -1
+	case ok1 && !ok2:
+		return 1
+	}
+	if v1type != v2type {
+		return int(v1type) - int(v2type)
+	}
+	if v1major != v2major {
+		return v1major - v2major
+	}
+	return v1minor - v2minor
+}

--- a/staging/src/k8s.io/apimachinery/pkg/version/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/helpers_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+)
+
+func TestCompareKubeAwareVersionStrings(t *testing.T) {
+	tests := []*struct {
+		v1, v2          string
+		expectedGreater bool
+	}{
+		{"v1", "v2", false},
+		{"v2", "v1", true},
+		{"v10", "v2", true},
+		{"v1", "v2alpha1", true},
+		{"v1", "v2beta1", true},
+		{"v1alpha2", "v1alpha1", true},
+		{"v1beta1", "v2alpha3", true},
+		{"v1alpha10", "v1alpha2", true},
+		{"v1beta10", "v1beta2", true},
+		{"foo", "v1beta2", false},
+		{"bar", "foo", true},
+		{"version1", "version2", true}, // Non kube-like versions are sorted alphabetically
+		{"version1", "version10", true}, // Non kube-like versions are sorted alphabetically
+	}
+
+	for _, tc := range tests {
+		if e, a := tc.expectedGreater, CompareKubeAwareVersionStrings(tc.v1, tc.v2) > 0; e != a {
+			if e {
+				t.Errorf("expected %s to be greater than %s", tc.v1, tc.v2)
+			} else {
+				t.Errorf("expected %s to be less than than %s", tc.v1, tc.v2)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/version/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/helpers_test.go
@@ -36,7 +36,7 @@ func TestCompareKubeAwareVersionStrings(t *testing.T) {
 		{"v1beta10", "v1beta2", true},
 		{"foo", "v1beta2", false},
 		{"bar", "foo", true},
-		{"version1", "version2", true}, // Non kube-like versions are sorted alphabetically
+		{"version1", "version2", true},  // Non kube-like versions are sorted alphabetically
 		{"version1", "version10", true}, // Non kube-like versions are sorted alphabetically
 	}
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -19,6 +20,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
     ],
 )
 
@@ -39,4 +41,10 @@ filegroup(
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/validation:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 func SortedByGroupAndVersion(servers []*APIService) [][]*APIService {
@@ -76,7 +77,7 @@ func (s ByVersionPriority) Less(i, j int) bool {
 	if s[i].Spec.VersionPriority != s[j].Spec.VersionPriority {
 		return s[i].Spec.VersionPriority > s[j].Spec.VersionPriority
 	}
-	return s[i].Name < s[j].Name
+	return version.CompareKubeAwareVersionStrings(s[i].Spec.Version, s[j].Spec.Version) > 0
 }
 
 // APIServiceNameToGroupVersion returns the GroupVersion for a given apiServiceName.  The name

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiregistration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortedAPIServicesByVersion(t *testing.T) {
+	tests := []*struct {
+		name     string
+		versions []string
+		expected []string
+	}{
+		{
+			name:     "case1",
+			versions: []string{"v1", "v2"},
+			expected: []string{"v2", "v1"},
+		},
+		{
+			name:     "case2",
+			versions: []string{"v2", "v10"},
+			expected: []string{"v10", "v2"},
+		},
+		{
+			name:     "case3",
+			versions: []string{"v2", "v2beta1", "v10beta2", "v10beta1", "v10alpha1", "v1"},
+			expected: []string{"v2", "v1", "v10beta2", "v10beta1", "v2beta1", "v10alpha1"},
+		},
+		{
+			name:     "case4",
+			versions: []string{"v1", "v2", "test", "foo10", "final", "foo2", "foo1"},
+			expected: []string{"v2", "v1", "final", "foo1", "foo10", "foo2", "test"},
+		},
+		{
+			name:     "case5_from_documentation",
+			versions: []string{"v12alpha1", "v10", "v11beta2", "v10beta3", "v3beta1", "v2", "v11alpha2", "foo1", "v1", "foo10"},
+			expected: []string{"v10", "v2", "v1", "v11beta2", "v10beta3", "v3beta1", "v12alpha1", "v11alpha2", "foo1", "foo10"},
+		},
+	}
+
+	for _, tc := range tests {
+		apiServices := []*APIService{}
+		for _, v := range tc.versions {
+			apiServices = append(apiServices, &APIService{Spec: APIServiceSpec{Version: v, VersionPriority: 100}})
+		}
+		sortedServices := SortedByGroupAndVersion(apiServices)
+		actual := []string{}
+		for _, s := range sortedServices[0] {
+			actual = append(actual, s.Spec.Version)
+		}
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("expected %s, actual %s", tc.expected, actual)
+		}
+	}
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
@@ -66,8 +66,13 @@ type APIServiceSpec struct {
 
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
 	// The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-	// The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
 	// Since it's inside of a group, the number can be small, probably in the 10s.
+	// In case of equal version priorities, the version string will be used to compute the order inside a group.
+	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+	// by GA > beta > alpha, and then by comparing major version, then minor version. An example sorted list of
+	// versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	VersionPriority int32
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/generated.proto
@@ -102,8 +102,13 @@ message APIServiceSpec {
 
   // VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
   // The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-  // The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
   // Since it's inside of a group, the number can be small, probably in the 10s.
+  // In case of equal version priorities, the version string will be used to compute the order inside a group.
+  // If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+  // lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+  // then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+  // by GA > beta > alpha, and then by comparing major version, then minor version. An example sorted list of
+  // versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
   optional int32 versionPriority = 8;
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go
@@ -66,8 +66,13 @@ type APIServiceSpec struct {
 
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
 	// The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-	// The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
 	// Since it's inside of a group, the number can be small, probably in the 10s.
+	// In case of equal version priorities, the version string will be used to compute the order inside a group.
+	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+	// by GA > beta > alpha, and then by comparing major version, then minor version. An example sorted list of
+	// versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	VersionPriority int32 `json:"versionPriority" protobuf:"varint,8,opt,name=versionPriority"`
 
 	// leaving this here so everyone remembers why proto index 6 is skipped

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/generated.proto
@@ -102,8 +102,13 @@ message APIServiceSpec {
 
   // VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
   // The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-  // The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
   // Since it's inside of a group, the number can be small, probably in the 10s.
+  // In case of equal version priorities, the version string will be used to compute the order inside a group.
+  // If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+  // lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+  // then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+  // by GA > beta > alpha, and then by comparing major version, then minor version. An example sorted list of
+  // versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
   optional int32 versionPriority = 8;
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -66,8 +66,13 @@ type APIServiceSpec struct {
 
 	// VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero.
 	// The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10).
-	// The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo)
 	// Since it's inside of a group, the number can be small, probably in the 10s.
+	// In case of equal version priorities, the version string will be used to compute the order inside a group.
+	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+	// by GA > beta > alpha, and then by comparing major version, then minor version. An example sorted list of
+	// versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 	VersionPriority int32 `json:"versionPriority" protobuf:"varint,8,opt,name=versionPriority"`
 
 	// leaving this here so everyone remembers why proto index 6 is skipped

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
@@ -220,17 +220,17 @@ func TestAPIs(t *testing.T) {
 						Name: "bar",
 						Versions: []metav1.GroupVersionForDiscovery{
 							{
-								GroupVersion: "bar/v1",
-								Version:      "v1",
-							},
-							{
 								GroupVersion: "bar/v2",
 								Version:      "v2",
 							},
+							{
+								GroupVersion: "bar/v1",
+								Version:      "v1",
+							},
 						},
 						PreferredVersion: metav1.GroupVersionForDiscovery{
-							GroupVersion: "bar/v1",
-							Version:      "v1",
+							GroupVersion: "bar/v2",
+							Version:      "v2",
 						},
 					},
 				},


### PR DESCRIPTION
Sort API services based on kube-version format. If the version does not have kube-version format.

kube-version format: `v[MajorVersion]((alpha|beta)[minorVersion])?`
e.g. v1alpha1, v4, v21beta12

Sort base on:
Version type first: GA>Beta>Alpha
Major version then Minor version (if exists).

```release-note
APIServices with kube-like versions (e.g. v1, v2beta1, etc.) will be sorted appropriately within each group. 
```