### PR TITLE
uses a more resilient way to get branch name from version

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
-	"k8s.io/kubernetes/pkg/util/version"
+	versionutil "k8s.io/kubernetes/pkg/util/version"
 )
 
 // Upgrade defines an upgrade possibility to upgrade from a current version to a new one
@@ -279,22 +279,23 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 }
 
 func getBranchFromVersion(version string) string {
-	return strings.TrimPrefix(version, "v")[:4]
+	v := versionutil.MustParseGeneric(version)
+	return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
 }
 
-func patchVersionBranchExists(clusterVersion, stableVersion *version.Version) bool {
+func patchVersionBranchExists(clusterVersion, stableVersion *versionutil.Version) bool {
 	return stableVersion.AtLeast(clusterVersion)
 }
 
-func patchUpgradePossible(clusterVersion, patchVersion *version.Version) bool {
+func patchUpgradePossible(clusterVersion, patchVersion *versionutil.Version) bool {
 	return clusterVersion.LessThan(patchVersion)
 }
 
-func rcUpgradePossible(clusterVersion, previousBranchLatestVersion *version.Version) bool {
+func rcUpgradePossible(clusterVersion, previousBranchLatestVersion *versionutil.Version) bool {
 	return strings.HasPrefix(previousBranchLatestVersion.PreRelease(), "rc") && clusterVersion.LessThan(previousBranchLatestVersion)
 }
 
-func minorUpgradePossibleWithPatchRelease(stableVersion, patchVersion *version.Version) bool {
+func minorUpgradePossibleWithPatchRelease(stableVersion, patchVersion *versionutil.Version) bool {
 	return patchVersion.LessThan(stableVersion)
 }
 

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -826,3 +826,56 @@ func TestKubeletUpgrade(t *testing.T) {
 		}
 	}
 }
+
+func TestGetBranchFromVersion(t *testing.T) {
+	testCases := []struct {
+		version         string
+		expectedVersion string
+	}{
+		{
+			version:         "v1.9.5",
+			expectedVersion: "1.9",
+		},
+		{
+			version:         "v1.9.0-alpha.2",
+			expectedVersion: "1.9",
+		},
+		{
+			version:         "v1.9.0-beta.0",
+			expectedVersion: "1.9",
+		},
+		{
+			version:         "v1.9.0-rc.1",
+			expectedVersion: "1.9",
+		},
+		{
+			version:         "v1.12.5",
+			expectedVersion: "1.12",
+		},
+		{
+			version:         "v1.11.0-alpha.0",
+			expectedVersion: "1.11",
+		},
+
+		{
+			version:         "v1.11.0-beta.1",
+			expectedVersion: "1.11",
+		},
+		{
+			version:         "v1.11.0-rc.0",
+			expectedVersion: "1.11",
+		},
+		{
+			version:         "1.12.5",
+			expectedVersion: "1.12",
+		},
+	}
+
+	for _, tc := range testCases {
+		v := getBranchFromVersion(tc.version)
+		if v != tc.expectedVersion {
+			t.Errorf("expected version %s, got %s", tc.expectedVersion, v)
+		}
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently `getBranchFromVersion` uses a hard coded way to extract branch name from the version string. This is error prone, especially when bumping the minimum supported k8s version from v1.9 to v1.10.

This follow-up PR tries to use a more resilient way to handle this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #63920

**Special notes for your reviewer**:
/cc luxas timothysc 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
