### PR TITLE
kubectl uses its own pkg/kubectl/util/logs

### DIFF
--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -20,9 +20,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/kubectl/cmd:go_default_library",
+        "//pkg/kubectl/util/logs:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
     ],
 )

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/pflag"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
+	"k8s.io/kubernetes/pkg/kubectl/util/logs"
 
 	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/pkg/kubectl/util/logs/logs.go
+++ b/pkg/kubectl/util/logs/logs.go
@@ -46,7 +46,7 @@ func (writer GlogWriter) Write(data []byte) (n int, err error) {
 func InitLogs() {
 	log.SetOutput(GlogWriter{})
 	log.SetFlags(0)
-	// The default glog flush interval is 30 seconds, which is frighteningly long.
+	// The default glog flush interval is 5 seconds.
 	go wait.Until(glog.Flush, *logFlushFreq, wait.NeverStop)
 }
 


### PR DESCRIPTION
kubectl uses its own logs instead of  `staging/src/k8s.io/apiserver/pkg/util/logs`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
