### PR TITLE
Implemented truncating audit backend

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/buffered:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/audit/truncate:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	auditbuffered "k8s.io/apiserver/plugin/pkg/audit/buffered"
+	audittruncate "k8s.io/apiserver/plugin/pkg/audit/truncate"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
@@ -61,6 +62,9 @@ func TestAddFlags(t *testing.T) {
 		"--audit-log-batch-throttle-enable=true",
 		"--audit-log-batch-throttle-qps=49.5",
 		"--audit-log-batch-throttle-burst=50",
+		"--audit-log-truncate-enabled=true",
+		"--audit-log-truncate-max-batch-size=45",
+		"--audit-log-truncate-max-event-size=44",
 		"--audit-policy-file=/policy",
 		"--audit-webhook-config-file=/webhook-config",
 		"--audit-webhook-mode=blocking",
@@ -70,6 +74,9 @@ func TestAddFlags(t *testing.T) {
 		"--audit-webhook-batch-throttle-enable=false",
 		"--audit-webhook-batch-throttle-qps=43.5",
 		"--audit-webhook-batch-throttle-burst=44",
+		"--audit-webhook-truncate-enabled=true",
+		"--audit-webhook-truncate-max-batch-size=43",
+		"--audit-webhook-truncate-max-event-size=42",
 		"--audit-webhook-initial-backoff=2s",
 		"--authentication-token-webhook-cache-ttl=3m",
 		"--authentication-token-webhook-config-file=/token-webhook-config",
@@ -199,6 +206,13 @@ func TestAddFlags(t *testing.T) {
 						ThrottleBurst:  50,
 					},
 				},
+				TruncateOptions: apiserveroptions.AuditTruncateOptions{
+					Enabled: true,
+					TruncateConfig: audittruncate.Config{
+						MaxBatchSize: 45,
+						MaxEventSize: 44,
+					},
+				},
 			},
 			WebhookOptions: apiserveroptions.AuditWebhookOptions{
 				ConfigFile: "/webhook-config",
@@ -211,6 +225,13 @@ func TestAddFlags(t *testing.T) {
 						ThrottleEnable: false,
 						ThrottleQPS:    43.5,
 						ThrottleBurst:  44,
+					},
+				},
+				TruncateOptions: apiserveroptions.AuditTruncateOptions{
+					Enabled: true,
+					TruncateConfig: audittruncate.Config{
+						MaxBatchSize: 43,
+						MaxEventSize: 42,
 					},
 				},
 				InitialBackoff: 2 * time.Second,

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1479,6 +1479,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/truncate",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -57,6 +57,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/buffered:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/log:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/audit/truncate:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/webhook:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
@@ -78,6 +78,15 @@ func TestAuditValidOptions(t *testing.T) {
 			return o
 		},
 		expected: "union[buffered<log>,webhook]",
+	}, {
+		name: "default webhook with truncating",
+		options: func() *AuditOptions {
+			o := NewAuditOptions()
+			o.WebhookOptions.ConfigFile = webhookConfig
+			o.WebhookOptions.TruncateOptions.Enabled = true
+			return o
+		},
+		expected: "truncate<buffered<webhook>>",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -146,6 +155,25 @@ func TestAuditInvalidOptions(t *testing.T) {
 			o.WebhookOptions.ConfigFile = "/audit"
 			o.WebhookOptions.BatchOptions.Mode = "batch"
 			o.WebhookOptions.BatchOptions.BatchConfig.ThrottleQPS = -1
+			return o
+		},
+	}, {
+		name: "invalid webhook truncate max event size",
+		options: func() *AuditOptions {
+			o := NewAuditOptions()
+			o.WebhookOptions.ConfigFile = "/audit"
+			o.WebhookOptions.TruncateOptions.Enabled = true
+			o.WebhookOptions.TruncateOptions.TruncateConfig.MaxEventSize = -1
+			return o
+		},
+	}, {
+		name: "invalid webhook truncate max batch size",
+		options: func() *AuditOptions {
+			o := NewAuditOptions()
+			o.WebhookOptions.ConfigFile = "/audit"
+			o.WebhookOptions.TruncateOptions.Enabled = true
+			o.WebhookOptions.TruncateOptions.TruncateConfig.MaxEventSize = 2
+			o.WebhookOptions.TruncateOptions.TruncateConfig.MaxBatchSize = 1
 			return o
 		},
 	}}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/BUILD
@@ -23,7 +23,9 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered:all-srcs",
+        "//staging/src/k8s.io/apiserver/plugin/pkg/audit/fake:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/log:all-srcs",
+        "//staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "fake.go",
+    ],
+    importpath = "k8s.io/apiserver/plugin/pkg/audit/fake",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/doc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake provides a fake audit.Backend interface implementation for testing.
+package fake // import "k8s.io/apiserver/plugin/pkg/audit/fake"

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/fake.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/fake.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+)
+
+var _ audit.Backend = &Backend{}
+
+// Backend is a fake audit backend for testing purposes.
+type Backend struct {
+	OnRequest func(events []*auditinternal.Event)
+}
+
+// Run does nothing.
+func (b *Backend) Run(stopCh <-chan struct{}) error {
+	return nil
+}
+
+// Shutdown does nothing.
+func (b *Backend) Shutdown() {
+	return
+}
+
+// ProcessEvents calls a callback on a batch, if present.
+func (b *Backend) ProcessEvents(ev ...*auditinternal.Event) {
+	if b.OnRequest != nil {
+		b.OnRequest(ev)
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/BUILD
@@ -3,29 +3,31 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "buffered.go",
         "doc.go",
+        "truncate.go",
     ],
-    importpath = "k8s.io/apiserver/plugin/pkg/audit/buffered",
+    importpath = "k8s.io/apiserver/plugin/pkg/audit/truncate",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
-        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["buffered_test.go"],
+    srcs = ["truncate_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/stretchr/testify/require:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/fake:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/audit/webhook:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/doc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package truncate provides an implementation for the audit.Backend interface
+// that truncates audit events and sends them to the delegate audit.Backend.
+package truncate // import "k8s.io/apiserver/plugin/pkg/audit/truncate"

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package truncate
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+)
+
+const (
+	// PluginName is the name reported in error metrics.
+	PluginName = "truncate"
+
+	// annotationKey defines the name of the annotation used to indicate truncation.
+	annotationKey = "audit.k8s.io/truncated"
+	// annotationValue defines the value of the annotation used to indicate truncation.
+	annotationValue = "true"
+)
+
+// Config represents truncating backend configuration.
+type Config struct {
+	// MaxEventSize defines max allowed size of the event. If the event is larger,
+	// truncating will be performed.
+	MaxEventSize int64
+
+	// MaxBatchSize defined max allowed size of the batch of events, passed to the backend.
+	// If the total size of the batch is larger than this number, batch will be split. Actual
+	// size of the serialized request might be slightly higher, on the order of hundreds of bytes.
+	MaxBatchSize int64
+}
+
+type backend struct {
+	// The delegate backend that actually exports events.
+	delegateBackend audit.Backend
+
+	// Configuration used for truncation.
+	c Config
+
+	// Encoder used to calculate audit event sizes.
+	e runtime.Encoder
+}
+
+var _ audit.Backend = &backend{}
+
+// NewBackend returns a new truncating backend, using configuration passed in the parameters.
+func NewBackend(delegateBackend audit.Backend, config Config, groupVersion schema.GroupVersion) audit.Backend {
+	return &backend{
+		delegateBackend: delegateBackend,
+		c:               config,
+		e:               audit.Codecs.LegacyCodec(groupVersion),
+	}
+}
+
+func (b *backend) ProcessEvents(events ...*auditinternal.Event) {
+	var errors []error
+	var impacted []*auditinternal.Event
+	var batch []*auditinternal.Event
+	var batchSize int64
+	for _, event := range events {
+		size, err := b.calcSize(event)
+		// If event was correctly serialized, but the size is more than allowed
+		// and it makes sense to do trimming, i.e. there's a request and/or
+		// response present, try to strip away request and response.
+		if err == nil && size > b.c.MaxEventSize && event.Level.GreaterOrEqual(auditinternal.LevelRequest) {
+			event = truncate(event)
+			size, err = b.calcSize(event)
+		}
+		if err != nil {
+			errors = append(errors, err)
+			impacted = append(impacted, event)
+			continue
+		}
+		if size > b.c.MaxEventSize {
+			errors = append(errors, fmt.Errorf("event is too large even after truncating"))
+			impacted = append(impacted, event)
+			continue
+		}
+
+		if len(batch) > 0 && batchSize+size > b.c.MaxBatchSize {
+			b.delegateBackend.ProcessEvents(batch...)
+			batch = []*auditinternal.Event{}
+			batchSize = 0
+		}
+
+		batchSize += size
+		batch = append(batch, event)
+	}
+
+	if len(batch) > 0 {
+		b.delegateBackend.ProcessEvents(batch...)
+	}
+
+	if len(impacted) > 0 {
+		audit.HandlePluginError(PluginName, utilerrors.NewAggregate(errors), impacted...)
+	}
+}
+
+// truncate removed request and response objects from the audit events,
+// to try and keep at least metadata.
+func truncate(e *auditinternal.Event) *auditinternal.Event {
+	// Make a shallow copy to avoid copying response/request objects.
+	newEvent := &auditinternal.Event{}
+	*newEvent = *e
+
+	newEvent.RequestObject = nil
+	newEvent.ResponseObject = nil
+	audit.LogAnnotation(newEvent, annotationKey, annotationValue)
+	return newEvent
+}
+
+func (b *backend) Run(stopCh <-chan struct{}) error {
+	// Nothing to do here
+	return nil
+}
+
+func (b *backend) Shutdown() {
+	// Nothing to do here
+}
+
+func (b *backend) calcSize(e *auditinternal.Event) (int64, error) {
+	s := &sizer{}
+	if err := b.e.Encode(e, s); err != nil {
+		return 0, err
+	}
+	return s.Size, nil
+}
+
+func (b *backend) String() string {
+	return fmt.Sprintf("%s<%s>", PluginName, b.delegateBackend)
+}
+
+type sizer struct {
+	Size int64
+}
+
+func (s *sizer) Write(p []byte) (n int, err error) {
+	s.Size += int64(len(p))
+	return len(p), nil
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package truncate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
+	"k8s.io/apiserver/plugin/pkg/audit/fake"
+	// Importing just for the schema definitions.
+	_ "k8s.io/apiserver/plugin/pkg/audit/webhook"
+)
+
+var (
+	defaultConfig = Config{
+		MaxBatchSize: 4 * 1024 * 1024,
+		MaxEventSize: 100 * 1024,
+	}
+)
+
+func TestTruncatingEvents(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		event         *auditinternal.Event
+		wantDropped   bool
+		wantTruncated bool
+	}{
+		{
+			desc:  "Empty event should not be truncated",
+			event: &auditinternal.Event{},
+		},
+		{
+			desc: "Event with too large body should be truncated",
+			event: &auditinternal.Event{
+				Level: auditinternal.LevelRequest,
+				RequestObject: &runtime.Unknown{
+					Raw: []byte("\"" + strings.Repeat("A", int(defaultConfig.MaxEventSize)) + "\""),
+				},
+			},
+			wantTruncated: true,
+		},
+		{
+			desc: "Event with too large metadata should be dropped",
+			event: &auditinternal.Event{
+				Annotations: map[string]string{
+					"key": strings.Repeat("A", int(defaultConfig.MaxEventSize)),
+				},
+			},
+			wantDropped: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var event *auditinternal.Event
+
+			fb := &fake.Backend{
+				OnRequest: func(events []*auditinternal.Event) {
+					require.Equal(t, 1, len(events), "Expected single event in batch")
+					event = events[0]
+				},
+			}
+			b := NewBackend(fb, defaultConfig, auditv1beta1.SchemeGroupVersion)
+			b.ProcessEvents(tc.event)
+
+			require.Equal(t, !tc.wantDropped, event != nil, "Incorrect event presence")
+			if tc.wantTruncated {
+				require.Equal(t, annotationValue, event.Annotations[annotationKey], "Annotation should be present")
+				require.Nil(t, event.RequestObject, "After truncation request should be nil")
+				require.Nil(t, event.ResponseObject, "After truncation response should be nil")
+			}
+		})
+	}
+}
+
+func TestSplittingBatches(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		config         Config
+		events         []*auditinternal.Event
+		wantBatchCount int
+	}{
+		{
+			desc:           "Events fitting in one batch should not be split",
+			config:         defaultConfig,
+			events:         []*auditinternal.Event{{}},
+			wantBatchCount: 1,
+		},
+		{
+			desc: "Events not fitting in one batch should be split",
+			config: Config{
+				MaxEventSize: defaultConfig.MaxEventSize,
+				MaxBatchSize: 1,
+			},
+			events: []*auditinternal.Event{
+				{Annotations: map[string]string{"key": strings.Repeat("A", int(50))}},
+				{Annotations: map[string]string{"key": strings.Repeat("A", int(50))}},
+			},
+			wantBatchCount: 2,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var gotBatchCount int
+			fb := &fake.Backend{
+				OnRequest: func(events []*auditinternal.Event) {
+					gotBatchCount++
+				},
+			}
+			b := NewBackend(fb, tc.config, auditv1beta1.SchemeGroupVersion)
+			b.ProcessEvents(tc.events...)
+
+			require.Equal(t, tc.wantBatchCount, gotBatchCount)
+		})
+	}
+}

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1151,6 +1151,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/truncate",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1119,6 +1119,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/truncate",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/audit/webhook",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},


### PR DESCRIPTION
Fixes #60432

Introduces an optional truncating backend, disabled by default, that estimates the size of audit events and truncates events/split batches based on the configuration.

```release-note
Introduce truncating audit backend that can be enabled by passing --audit-log-truncate-enabled or --audit-webhook-truncate-enabled flag to the apiserver to limit the size of individual audit events and batches of events.
```

I had to manually remove dependency of original PR #61711, from #60056, that's why automated cherry-pick was not used.
