### PR TITLE
Enable SELinux relabeling in CSI volumes

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -116,6 +116,10 @@ func (mi *fakeMountInterface) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
 
+func (mi *fakeMountInterface) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/pkg/util/mount/exec_mount.go
+++ b/pkg/util/mount/exec_mount.go
@@ -159,3 +159,7 @@ func (m *execMounter) GetMountRefs(pathname string) ([]string, error) {
 func (m *execMounter) GetFSGroup(pathname string) (int64, error) {
 	return m.wrappedMounter.GetFSGroup(pathname)
 }
+
+func (m *execMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return m.wrappedMounter.GetSELinuxSupport(pathname)
+}

--- a/pkg/util/mount/exec_mount_test.go
+++ b/pkg/util/mount/exec_mount_test.go
@@ -172,3 +172,7 @@ func (fm *fakeMounter) GetMountRefs(pathname string) ([]string, error) {
 func (fm *fakeMounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
+
+func (fm *fakeMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/pkg/util/mount/exec_mount_unsupported.go
+++ b/pkg/util/mount/exec_mount_unsupported.go
@@ -106,3 +106,7 @@ func (mounter *execMounter) GetMountRefs(pathname string) ([]string, error) {
 func (mounter *execMounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
+
+func (mounter *execMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -228,3 +228,7 @@ func (f *FakeMounter) GetMountRefs(pathname string) ([]string, error) {
 func (f *FakeMounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("GetFSGroup not implemented")
 }
+
+func (f *FakeMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("GetSELinuxSupport not implemented")
+}

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -114,6 +114,9 @@ type Interface interface {
 	GetMountRefs(pathname string) ([]string, error)
 	// GetFSGroup returns FSGroup of the path.
 	GetFSGroup(pathname string) (int64, error)
+	// GetSELinuxSupport returns true if given path is on a mount that supports
+	// SELinux.
+	GetSELinuxSupport(pathname string) (bool, error)
 }
 
 type Subpath struct {

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -591,23 +591,10 @@ func (mounter *SafeFormatAndMount) GetDiskFormat(disk string) (string, error) {
 
 // isShared returns true, if given path is on a mount point that has shared
 // mount propagation.
-func isShared(path string, filename string) (bool, error) {
-	infos, err := parseMountInfo(filename)
+func isShared(mount string, mountInfoPath string) (bool, error) {
+	info, err := findMountInfo(mount, mountInfoPath)
 	if err != nil {
 		return false, err
-	}
-
-	// process /proc/xxx/mountinfo in backward order and find the first mount
-	// point that is prefix of 'path' - that's the mount where path resides
-	var info *mountInfo
-	for i := len(infos) - 1; i >= 0; i-- {
-		if strings.HasPrefix(path, infos[i].mountPoint) {
-			info = &infos[i]
-			break
-		}
-	}
-	if info == nil {
-		return false, fmt.Errorf("cannot find mount point for %q", path)
 	}
 
 	// parse optional parameters
@@ -624,6 +611,10 @@ type mountInfo struct {
 	mountPoint string
 	// list of "optional parameters", mount propagation is one of them
 	optional []string
+	// mount options
+	mountOptions []string
+	// super options: per-superblock options.
+	superOptions []string
 }
 
 // parseMountInfo parses /proc/xxx/mountinfo.
@@ -642,20 +633,44 @@ func parseMountInfo(filename string) ([]mountInfo, error) {
 		}
 		// See `man proc` for authoritative description of format of the file.
 		fields := strings.Fields(line)
-		if len(fields) < 7 {
-			return nil, fmt.Errorf("wrong number of fields in (expected %d, got %d): %s", 8, len(fields), line)
+		if len(fields) < 10 {
+			return nil, fmt.Errorf("wrong number of fields in (expected %d, got %d): %s", 10, len(fields), line)
 		}
 		info := mountInfo{
-			mountPoint: fields[4],
-			optional:   []string{},
+			mountPoint:   fields[4],
+			mountOptions: strings.Split(fields[5], ","),
+			optional:     []string{},
 		}
 		// All fields until "-" are "optional fields".
 		for i := 6; i < len(fields) && fields[i] != "-"; i++ {
 			info.optional = append(info.optional, fields[i])
 		}
+		superOpts := fields[len(fields)-1]
+		info.superOptions = strings.Split(superOpts, ",")
 		infos = append(infos, info)
 	}
 	return infos, nil
+}
+
+func findMountInfo(path, mountInfoPath string) (mountInfo, error) {
+	infos, err := parseMountInfo(mountInfoPath)
+	if err != nil {
+		return mountInfo{}, err
+	}
+
+	// process /proc/xxx/mountinfo in backward order and find the first mount
+	// point that is prefix of 'path' - that's the mount where path resides
+	var info *mountInfo
+	for i := len(infos) - 1; i >= 0; i-- {
+		if pathWithinBase(path, infos[i].mountPoint) {
+			info = &infos[i]
+			break
+		}
+	}
+	if info == nil {
+		return mountInfo{}, fmt.Errorf("cannot find mount point for %q", path)
+	}
+	return *info, nil
 }
 
 // doMakeRShared is common implementation of MakeRShared on Linux. It checks if
@@ -684,6 +699,27 @@ func doMakeRShared(path string, mountInfoFilename string) error {
 	}
 
 	return nil
+}
+
+// getSELinuxSupport is common implementation of GetSELinuxSupport on Linux.
+func getSELinuxSupport(path string, mountInfoFilename string) (bool, error) {
+	info, err := findMountInfo(path, mountInfoFilename)
+	if err != nil {
+		return false, err
+	}
+
+	// "seclabel" can be both in mount options and super options.
+	for _, opt := range info.superOptions {
+		if opt == "seclabel" {
+			return true, nil
+		}
+	}
+	for _, opt := range info.mountOptions {
+		if opt == "seclabel" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (mounter *Mounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
@@ -932,6 +968,10 @@ func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 		return nil, err
 	}
 	return getMountRefsByDev(mounter, realpath)
+}
+
+func (mounter *Mounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return getSELinuxSupport(pathname, procMountInfoPath)
 }
 
 func (mounter *Mounter) GetFSGroup(pathname string) (int64, error) {

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -134,3 +134,7 @@ func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 func (mounter *Mounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
+
+func (mounter *Mounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -456,6 +456,11 @@ func (mounter *Mounter) GetFSGroup(pathname string) (int64, error) {
 	return 0, nil
 }
 
+func (mounter *Mounter) GetSELinuxSupport(pathname string) (bool, error) {
+	// Windows does not support SELinux.
+	return false, nil
+}
+
 // SafeMakeDir makes sure that the created directory does not escape given base directory mis-using symlinks.
 func (mounter *Mounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return doSafeMakeDir(pathname, base, perm)

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -343,3 +343,7 @@ func (mounter *NsenterMounter) GetFSGroup(pathname string) (int64, error) {
 	}
 	return getFSGroup(kubeletpath)
 }
+
+func (mounter *NsenterMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return getSELinuxSupport(pathname, procMountInfoPath)
+}

--- a/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/pkg/util/mount/nsenter_mount_unsupported.go
@@ -106,3 +106,7 @@ func (*NsenterMounter) GetMountRefs(pathname string) ([]string, error) {
 func (*NsenterMounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
+
+func (*NsenterMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -99,6 +99,10 @@ func (mounter *fakeMounter) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
 
+func (mounter *fakeMounter) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 func (mounter *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	name := path.Base(file)
 	if strings.HasPrefix(name, "mount") {

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -252,10 +252,18 @@ func (c *csiMountMgr) SetUpAt(dir string, fsGroup *int64) error {
 }
 
 func (c *csiMountMgr) GetAttributes() volume.Attributes {
+	mounter := c.plugin.host.GetMounter(c.plugin.GetPluginName())
+	path := c.GetPath()
+	supportSelinux, err := mounter.GetSELinuxSupport(path)
+	if err != nil {
+		glog.V(2).Info(log("error checking for SELinux support: %s", err))
+		// Best guess
+		supportSelinux = false
+	}
 	return volume.Attributes{
 		ReadOnly:        c.readOnly,
 		Managed:         !c.readOnly,
-		SupportsSELinux: false,
+		SupportsSELinux: supportSelinux,
 	}
 }
 

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -397,6 +397,10 @@ func (fftc *fakeFileTypeChecker) GetFSGroup(pathname string) (int64, error) {
 	return -1, errors.New("not implemented")
 }
 
+func (fftc *fakeFileTypeChecker) GetSELinuxSupport(pathname string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
 func setUp() error {
 	err := os.MkdirAll("/tmp/ExistingFolder", os.FileMode(0755))
 	if err != nil {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -131,6 +131,7 @@ type Mounter interface {
 	// idempotent.
 	SetUpAt(dir string, fsGroup *int64) error
 	// GetAttributes returns the attributes of the mounter.
+	// This function is called after SetUp()/SetUpAt().
 	GetAttributes() Attributes
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CSI volume plugin should provide correct information in `GetAttributes` call so kubelet can ask container runtime to relabel the volume. Therefore CSI volume plugin needs to check if a random volume mounted by a CSI driver supports SELinux or not by checking for "seclabel" mount or superblock option.


**Which issue(s) this PR fixes**
Fixes #63965

**Release note**:
```release-note
Fixed SELinux relabeling of CSI volumes.
```

@saad-ali @vladimirvivien @davidz627 
@cofyc, FYI, I'm changing `struct mountInfo`.