### PR TITLE
Tolarate negative values when calculating job scale progress

### DIFF
--- a/pkg/kubectl/cmd/scalejob/scalejob.go
+++ b/pkg/kubectl/cmd/scalejob/scalejob.go
@@ -144,7 +144,7 @@ func jobHasDesiredParallelism(jobClient batchclient.JobsGetter, job *batch.Job) 
 
 		// otherwise count successful
 		progress := *job.Spec.Completions - job.Status.Active - job.Status.Succeeded
-		return progress == 0, nil
+		return progress <= 0, nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It might happen that the job controller will complete a job, but the status will still contain information about active pods which during scale down operation will be giving false (non 0) value in [this calculation](https://github.com/kubernetes/kubernetes/blob/1b950d1e8ed03cf654a5c2c1f3afe52fe4e98ed9/pkg/kubectl/cmd/scalejob/scalejob.go#L147). To prevent that situation we should tolerate non-zero values there. 

/assign @liggitt 

**Release note**:
```release-note
NONE
```
