### PR TITLE
clean up some flag registration for pieces moving genericclioptions

### DIFF
--- a/pkg/kubectl/bash_comp_utils.go
+++ b/pkg/kubectl/bash_comp_utils.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
 )
 
-func AddJsonFilenameFlag(cmd *cobra.Command, value *[]string, usage string) {
-	cmd.Flags().StringSliceVarP(value, "filename", "f", *value, usage)
+func AddJsonFilenameFlag(fs *pflag.FlagSet, value *[]string, usage string) {
+	fs.StringSliceVarP(value, "filename", "f", *value, usage)
 	annotations := make([]string, 0, len(resource.FileExtensions))
 	for _, ext := range resource.FileExtensions {
 		annotations = append(annotations, strings.TrimLeft(ext, "."))
 	}
-	cmd.Flags().SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
+	fs.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
 }

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -136,8 +136,8 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 	}
 
 	// bind flag structs
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmdutil.AddIncludeUninitializedFlag(cmd)
 	cmd.Flags().BoolVar(&o.overwrite, "overwrite", o.overwrite, "If true, allow annotations to be overwritten, otherwise reject annotation updates that overwrite existing annotations.")
@@ -147,7 +147,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types.")
 	cmd.Flags().StringVar(&o.resourceVersion, "resource-version", o.resourceVersion, i18n.T("If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the annotation"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
 
 	return cmd

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -165,8 +165,8 @@ func NewCmdApply(baseName string, f cmdutil.Factory, ioStreams genericclioptions
 
 	// bind flag structs
 	o.DeleteFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.MarkFlagRequired("filename")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "Automatically resolve conflicts between the modified and live configuration by using values from the modified configuration")

--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -75,10 +75,10 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 	}
 
 	// bind flag structs
-	o.RecordFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	usage := "to use to edit the resource"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "Output format. One of: yaml|json.")
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -103,11 +103,11 @@ func NewCmdApplySetLastApplied(f cmdutil.Factory, ioStreams genericclioptions.IO
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().BoolVar(&o.CreateAnnotation, "create-annotation", o.CreateAnnotation, "Will create 'last-applied-configuration' annotations if current objects doesn't have one")
-	kubectl.AddJsonFilenameFlag(cmd, &o.FilenameOptions.Filenames, "Filename, directory, or URL to files that contains the last-applied-configuration annotations")
+	kubectl.AddJsonFilenameFlag(cmd.Flags(), &o.FilenameOptions.Filenames, "Filename, directory, or URL to files that contains the last-applied-configuration annotations")
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -85,7 +85,7 @@ func NewCmdApplyViewLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", options.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&options.All, "all", options.All, "Select all resources in the namespace of the specified resource types")
 	usage := "that contains the last-applied-configuration annotations"
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &options.FilenameOptions, usage)
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -85,9 +85,9 @@ func NewCmdReconcile(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 
-	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, "identifying the resource to reconcile.")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), o.FilenameOptions, "identifying the resource to reconcile.")
 	cmd.MarkFlagRequired("filename")
 
 	return cmd

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -112,8 +112,8 @@ func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	}
 
 	// bind flag structs
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().StringVar(&o.Generator, "generator", cmdutil.HorizontalPodAutoscalerV1GeneratorName, i18n.T("The name of the API generator to use. Currently there is only 1 generator."))
 	cmd.Flags().Int32Var(&o.Min, "min", -1, "The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value.")
@@ -122,7 +122,7 @@ func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	cmd.Flags().Int32Var(&o.CpuPercent, "cpu-percent", -1, fmt.Sprintf("The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used."))
 	cmd.Flags().StringVar(&o.Name, "name", "", i18n.T("The name for the newly created object. If not specified, the name of the input resource will be used."))
 	cmdutil.AddDryRunFlag(cmd)
-	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, "identifying the resource to autoscale.")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), o.FilenameOptions, "identifying the resource to autoscale.")
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -126,10 +126,10 @@ func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOS
 		},
 	}
 
-	options.PrintFlags.AddFlags(cmd)
+	options.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().Bool("force", false, "Update the CSR even if it is already approved.")
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, "identifying the resource to update")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &options.FilenameOptions, "identifying the resource to update")
 
 	return cmd
 }
@@ -178,10 +178,10 @@ func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 		},
 	}
 
-	options.PrintFlags.AddFlags(cmd)
+	options.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().Bool("force", false, "Update the CSR even if it is already denied.")
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, "identifying the resource to update")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &options.FilenameOptions, "identifying the resource to update")
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/config/flags.go
+++ b/pkg/kubectl/cmd/config/flags.go
@@ -62,8 +62,8 @@ func (f *kubectlConfigPrintFlags) ToPrinter() (printers.ResourcePrinter, error) 
 }
 
 func (f *kubectlConfigPrintFlags) AddFlags(cmd *cobra.Command) {
-	f.JSONYamlPrintFlags.AddFlags(cmd)
-	f.NamePrintFlags.AddFlags(cmd)
+	f.JSONYamlPrintFlags.AddFlags(cmd.Flags())
+	f.NamePrintFlags.AddFlags(cmd.Flags())
 	f.TemplateFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -76,10 +76,10 @@ func NewCmdConvert(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 		},
 	}
 
-	options.PrintFlags.AddFlags(cmd)
+	options.PrintFlags.AddFlags(cmd.Flags())
 
 	usage := "to need to get converted."
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &options.FilenameOptions, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&options.local, "local", options.local, "If true, convert will NOT try to contact api-server but run locally.")

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -110,10 +110,10 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	}
 
 	// bind flag structs
-	o.RecordFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	usage := "to use to create the resource"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&o.EditBeforeCreate, "edit", o.EditBeforeCreate, "Edit the API resource before creating")

--- a/pkg/kubectl/cmd/create/flags.go
+++ b/pkg/kubectl/cmd/create/flags.go
@@ -62,8 +62,8 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 }
 
 func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
-	f.JSONYamlPrintFlags.AddFlags(cmd)
-	f.NamePrintFlags.AddFlags(cmd)
+	f.JSONYamlPrintFlags.AddFlags(cmd.Flags())
+	f.NamePrintFlags.AddFlags(cmd.Flags())
 	f.TemplateFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {

--- a/pkg/kubectl/cmd/delete_flags.go
+++ b/pkg/kubectl/cmd/delete_flags.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
@@ -46,12 +47,12 @@ func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
 	return options
 }
 
-func (o *FileNameFlags) AddFlags(cmd *cobra.Command) {
+func (o *FileNameFlags) AddFlags(fs *pflag.FlagSet) {
 	if o.Recursive != nil {
-		cmd.Flags().BoolVarP(o.Recursive, "recursive", "R", *o.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
+		fs.BoolVarP(o.Recursive, "recursive", "R", *o.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 	}
 	if o.Filenames != nil {
-		kubectl.AddJsonFilenameFlag(cmd, o.Filenames, "Filename, directory, or URL to files "+o.Usage)
+		kubectl.AddJsonFilenameFlag(fs, o.Filenames, "Filename, directory, or URL to files "+o.Usage)
 	}
 }
 
@@ -119,7 +120,7 @@ func (f *DeleteFlags) ToOptions(streams genericclioptions.IOStreams) *DeleteOpti
 }
 
 func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
-	f.FileNameFlags.AddFlags(cmd)
+	f.FileNameFlags.AddFlags(cmd.Flags())
 	if f.LabelSelector != nil {
 		cmd.Flags().StringVarP(f.LabelSelector, "selector", "l", *f.LabelSelector, "Selector (label query) to filter on, not including uninitialized ones.")
 	}

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -112,7 +112,7 @@ func NewCmdDescribe(parent string, f cmdutil.Factory, streams genericclioptions.
 		},
 	}
 	usage := "containing the resource to describe"
-	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), o.FilenameOptions, usage)
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.AllNamespaces, "all-namespaces", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.Flags().BoolVar(&o.DescriberSettings.ShowEvents, "show-events", o.DescriberSettings.ShowEvents, "If true, display events related to the described object.")

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -124,7 +124,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	}
 
 	usage := "contains the configuration to diff"
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &options.FilenameOptions, usage)
 	cmd.MarkFlagRequired("filename")
 
 	return cmd

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -88,11 +88,11 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	}
 
 	// bind flag structs
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	usage := "to use to edit the resource"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmdutil.AddValidateOptionFlags(cmd, &o.ValidateOptions)
 	cmd.Flags().BoolVarP(&o.OutputPatch, "output-patch", "", o.OutputPatch, "Output the patch if the resource is edited.")
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -140,8 +140,8 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		ValidArgs: validArgs,
 	}
 
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().String("generator", "service/v2", i18n.T("The name of the API generator to use. There are 2 generators: 'service/v1' and 'service/v2'. The only difference between them is that service port in v1 is named 'default', while it is left unnamed in v2. Default is 'service/v2'."))
 	cmd.Flags().String("protocol", "", i18n.T("The network protocol for the service to be created. Default is 'TCP'."))
@@ -160,7 +160,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().String("cluster-ip", "", i18n.T("ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service."))
 
 	usage := "identifying the resource to expose a service"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	return cmd

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -175,7 +175,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	addOpenAPIPrintColumnFlags(cmd, o)
 	addServerPrintColumnFlags(cmd, o)
 	cmd.Flags().BoolVar(&o.Export, "export", o.Export, "If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.")
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, "identifying the resource to get from a server.")
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/get/get_flags.go
+++ b/pkg/kubectl/cmd/get/get_flags.go
@@ -133,8 +133,8 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 // AddFlags receives a *cobra.Command reference and binds
 // flags related to humanreadable and template printing.
 func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
-	f.JSONYamlPrintFlags.AddFlags(cmd)
-	f.NamePrintFlags.AddFlags(cmd)
+	f.JSONYamlPrintFlags.AddFlags(cmd.Flags())
+	f.NamePrintFlags.AddFlags(cmd.Flags())
 	f.TemplateFlags.AddFlags(cmd)
 	f.HumanReadableFlags.AddFlags(cmd)
 	f.CustomColumnsFlags.AddFlags(cmd)

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -137,8 +137,8 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		},
 	}
 
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&o.overwrite, "overwrite", o.overwrite, "If true, allow labels to be overwritten, otherwise reject label updates that overwrite existing labels.")
 	cmd.Flags().BoolVar(&o.list, "list", o.list, "If true, display the labels for a given resource.")
@@ -148,7 +148,7 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().StringVar(&o.resourceVersion, "resource-version", o.resourceVersion, i18n.T("If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the labels"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddIncludeUninitializedFlag(cmd)
 

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -119,14 +119,14 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		},
 	}
 
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().StringVarP(&o.Patch, "patch", "p", "", "The patch to be applied to the resource JSON file.")
 	cmd.MarkFlagRequired("patch")
 	cmd.Flags().StringVar(&o.PatchType, "type", "strategic", fmt.Sprintf("The type of patch being provided; one of %v", sets.StringKeySet(patchTypes).List()))
 	cmdutil.AddDryRunFlag(cmd)
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
 
 	return cmd

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -120,9 +120,9 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 	o.DeleteFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -144,13 +144,13 @@ func NewCmdRollingUpdate(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().DurationVar(&o.Period, "update-period", o.Period, `Time to wait between updating pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	cmd.Flags().DurationVar(&o.Interval, "poll-interval", o.Interval, `Time delay between polling for replication controller status after the update. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", o.Timeout, `Max time to wait for a replication controller to update before giving up. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	usage := "Filename or URL to file to use to create the new replication controller."
-	kubectl.AddJsonFilenameFlag(cmd, &o.FilenameOptions.Filenames, usage)
+	kubectl.AddJsonFilenameFlag(cmd.Flags(), &o.FilenameOptions.Filenames, usage)
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, i18n.T("Image to use for upgrading the replication controller. Must be distinct from the existing image (either new image or new image tag).  Can not be used with --filename/-f"))
 	cmd.Flags().StringVar(&o.DeploymentKey, "deployment-label-key", o.DeploymentKey, i18n.T("The key to use to differentiate between two different controllers, default 'deployment'.  Only relevant when --image is specified, ignored otherwise"))
 	cmd.Flags().StringVar(&o.Container, "container", o.Container, i18n.T("Container name which will have its image upgraded. Only relevant when --image is specified, ignored otherwise. Required when using --image on a multi-container pod"))

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -60,7 +60,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().Int64("revision", 0, "See the details, including podTemplate of the revision specified")
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, options, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), options, usage)
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -92,7 +92,7 @@ func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 	}
 
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -90,7 +90,7 @@ func NewCmdRolloutResume(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	}
 
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -93,7 +93,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	}
 
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), o.FilenameOptions, usage)
 	cmd.Flags().BoolVarP(&o.Watch, "watch", "w", o.Watch, "Watch the status of the rollout until it's done.")
 	cmd.Flags().Int64Var(&o.Revision, "revision", o.Revision, "Pin to a specific revision for showing its status. Defaults to 0 (last revision).")
 	return cmd

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -94,7 +94,7 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().Int64Var(&o.ToRevision, "to-revision", o.ToRevision, "The revision to rollback to. Default to 0 (last revision).")
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
 	return cmd
 }

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -153,8 +153,8 @@ func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	}
 
 	o.DeleteFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	addRunFlags(cmd, o)
 	cmdutil.AddApplyAnnotationFlags(cmd)

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -129,8 +129,8 @@ func NewCmdScale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 		ValidArgs: validArgs,
 	}
 
-	o.RecordFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
+	o.RecordFlags.AddFlags(cmd.Flags())
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "Select all resources in the namespace of the specified resource types")
@@ -139,7 +139,7 @@ func NewCmdScale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().IntVar(&o.Replicas, "replicas", o.Replicas, "The new desired number of replicas. Required.")
 	cmd.MarkFlagRequired("replicas")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 0, "The length of time to wait before giving up on a scale operation, zero means don't wait. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to set a new size")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, "identifying the resource to set a new size")
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -151,7 +151,7 @@ func NewCmdEnv(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 		},
 	}
 	usage := "the resource to update the env"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmd.Flags().StringVarP(&o.ContainerSelector, "containers", "c", o.ContainerSelector, "The names of containers in the selected pod templates to change - may use wildcards")
 	cmd.Flags().StringVarP(&o.From, "from", "", "", "The name of a resource from which to inject environment variables")
 	cmd.Flags().StringVarP(&o.Prefix, "prefix", "", "", "Prefix to append to variable names")
@@ -163,7 +163,7 @@ func NewCmdEnv(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "If true, select all resources in the namespace of the specified resource types")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "If true, allow environment to be overwritten, otherwise reject updates that overwrite existing environment.")
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 
 	cmdutil.AddDryRunFlag(cmd)
 	return cmd

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -112,11 +112,11 @@ func NewCmdImage(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, set image will NOT contact api-server but run locally.")

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -126,13 +126,13 @@ func NewCmdResources(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	//usage := "Filename, directory, or URL to a file identifying the resource to get from the server"
 	//kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, usage)
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, usage)
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, not including uninitialized ones,supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVarP(&o.ContainerSelector, "containers", "c", o.ContainerSelector, "The names of containers in the selected pod templates to change, all containers are selected by default - may use wildcards")

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -105,14 +105,14 @@ func NewCmdSelector(f cmdutil.Factory, streams genericclioptions.IOStreams) *cob
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().BoolVar(&o.local, "local", o.local, "If true, set selector will NOT contact api-server but run locally.")
 	cmd.Flags().String("resource-version", "", "If non-empty, the selectors update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.")
 	usage := "the resource to update the selectors"
-	cmdutil.AddFilenameOptionFlags(cmd, &o.fileOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.fileOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddIncludeUninitializedFlag(cmd)
 

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -105,11 +105,11 @@ func NewCmdServiceAccount(f cmdutil.Factory, streams genericclioptions.IOStreams
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
-	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
+	o.RecordFlags.AddFlags(cmd.Flags())
 
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, &o.fileNameOptions, usage)
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.fileNameOptions, usage)
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().BoolVar(&o.local, "local", o.local, "If true, set serviceaccount will NOT contact api-server but run locally.")
 	cmdutil.AddDryRunFlag(cmd)

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -103,9 +103,9 @@ func NewCmdSubject(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 		},
 	}
 
-	o.PrintFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd.Flags())
 
-	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "the resource to update the subjects")
+	cmdutil.AddFilenameOptionFlags(cmd.Flags(), &o.FilenameOptions, "the resource to update the subjects")
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, set subject will NOT contact api-server but run locally.")

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -113,7 +113,7 @@ func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 		ValidArgs: validArgs,
 	}
 
-	options.PrintFlags.AddFlags(cmd)
+	options.PrintFlags.AddFlags(cmd.Flags())
 
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().StringVarP(&options.selector, "selector", "l", options.selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"github.com/spf13/pflag"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -397,9 +398,9 @@ func AddValidateOptionFlags(cmd *cobra.Command, options *ValidateOptions) {
 	cmd.Flags().BoolVar(&options.EnableValidation, "validate", options.EnableValidation, "If true, use a schema to validate the input before sending it")
 }
 
-func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {
-	kubectl.AddJsonFilenameFlag(cmd, &options.Filenames, "Filename, directory, or URL to files "+usage)
-	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
+func AddFilenameOptionFlags(fs *pflag.FlagSet, options *resource.FilenameOptions, usage string) {
+	kubectl.AddJsonFilenameFlag(fs, &options.Filenames, "Filename, directory, or URL to files "+usage)
+	fs.BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 }
 
 // AddDryRunFlag adds dry-run flag to a command. Usually used by mutations.

--- a/pkg/kubectl/genericclioptions/BUILD
+++ b/pkg/kubectl/genericclioptions/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/evanphx/json-patch:go_default_library",
-        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/kubectl/genericclioptions/record_flags.go
+++ b/pkg/kubectl/genericclioptions/record_flags.go
@@ -18,8 +18,8 @@ package genericclioptions
 
 import (
 	"github.com/evanphx/json-patch"
-	"github.com/spf13/cobra"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -71,13 +71,13 @@ func (f *RecordFlags) Complete(changeCause string) error {
 
 // AddFlags binds the requested flags to the provided flagset
 // TODO have this only take a flagset
-func (f *RecordFlags) AddFlags(cmd *cobra.Command) {
+func (f *RecordFlags) AddFlags(fs *pflag.FlagSet) {
 	if f == nil {
 		return
 	}
 
 	if f.Record != nil {
-		cmd.Flags().BoolVar(f.Record, "record", *f.Record, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
+		fs.BoolVar(f.Record, "record", *f.Record, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
 	}
 }
 

--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "customcolumn.go",
         "customcolumn_flags.go",
+        "fake.go",
         "flags.go",
         "humanreadable.go",
         "interface.go",
@@ -31,6 +32,7 @@ go_library(
         "//pkg/kubectl/scheme:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/pkg/printers/fake.go
+++ b/pkg/printers/fake.go
@@ -1,0 +1,13 @@
+package printers
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func NewDiscardingPrinter() ResourcePrinterFunc {
+	return ResourcePrinterFunc(func(runtime.Object, io.Writer) error {
+		return nil
+	})
+}

--- a/pkg/printers/flags.go
+++ b/pkg/printers/flags.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -104,12 +104,12 @@ func (f *PrintFlags) ToPrinter() (ResourcePrinter, error) {
 	return nil, NoCompatiblePrinterError{Options: f, OutputFormat: f.OutputFormat}
 }
 
-func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
-	f.JSONYamlPrintFlags.AddFlags(cmd)
-	f.NamePrintFlags.AddFlags(cmd)
+func (f *PrintFlags) AddFlags(fs *pflag.FlagSet) {
+	f.JSONYamlPrintFlags.AddFlags(fs)
+	f.NamePrintFlags.AddFlags(fs)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+		fs.StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
 	}
 }
 

--- a/pkg/printers/json_yaml_flags.go
+++ b/pkg/printers/json_yaml_flags.go
@@ -19,7 +19,7 @@ package printers
 import (
 	"strings"
 
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // JSONYamlPrintFlags provides default flags necessary for json/yaml printing.
@@ -50,7 +50,7 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (ResourcePrinter, er
 
 // AddFlags receives a *cobra.Command reference and binds
 // flags related to JSON or Yaml printing to it
-func (f *JSONYamlPrintFlags) AddFlags(c *cobra.Command) {}
+func (f *JSONYamlPrintFlags) AddFlags(fs *pflag.FlagSet) {}
 
 // NewJSONYamlPrintFlags returns flags associated with
 // yaml or json printing, with default values set.

--- a/pkg/printers/name_flags.go
+++ b/pkg/printers/name_flags.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // NamePrintFlags provides default flags necessary for printing
@@ -61,7 +61,7 @@ func (f *NamePrintFlags) ToPrinter(outputFormat string) (ResourcePrinter, error)
 
 // AddFlags receives a *cobra.Command reference and binds
 // flags related to name printing to it
-func (f *NamePrintFlags) AddFlags(c *cobra.Command) {}
+func (f *NamePrintFlags) AddFlags(fs *pflag.FlagSet) {}
 
 // NewNamePrintFlags returns flags associated with
 // --name printing, with default values set.


### PR DESCRIPTION
Tightened some flag registration signatures I found looking at other pulls.  Adding a mock for printers I need for wait.

/assign @juanvallejo 

```release-note
NONE
```