### PR TITLE
Fix TestSchedulerWithVolumeBinding to avoid setting predicate ordering.

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -660,8 +660,6 @@ func makePredicateError(failReason string) error {
 }
 
 func TestSchedulerWithVolumeBinding(t *testing.T) {
-	order := []string{predicates.CheckVolumeBindingPred, predicates.GeneralPred}
-	predicates.SetPredicatesOrdering(order)
 	findErr := fmt.Errorf("find err")
 	assumeErr := fmt.Errorf("assume err")
 	bindErr := fmt.Errorf("bind err")


### PR DESCRIPTION
It is causing data race condition as predicate ordering is changing global
variable `predicatesOrdering`. Infact this test does not require any special
predicate order and should work on default predicate ordering as far as
VolumeScheduling feature is enabled.

See these logs:

```
==================
==================
WARNING: DATA RACE
Read at 0x00c420894180 by goroutine 156:
  k8s.io/kubernetes/pkg/scheduler/core.podFitsOnNode()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:503 +0xbb
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit.func1()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:353 +0x2f0
  k8s.io/kubernetes/vendor/k8s.io/client-go/util/workqueue.Parallelize.func1()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:47 +0xa3

Previous write at 0x00c420894180 by goroutine 186:
  k8s.io/kubernetes/pkg/scheduler.TestSchedulerWithVolumeBinding()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/scheduler_test.go:663 +0x71
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:777 +0x16d

Goroutine 156 (running) created at:
  k8s.io/kubernetes/vendor/k8s.io/client-go/util/workqueue.Parallelize()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:43 +0x139
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:378 +0xe8a
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).Schedule()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:131 +0x385
  k8s.io/kubernetes/pkg/scheduler.(*Scheduler).schedule()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:192 +0xcd
  k8s.io/kubernetes/pkg/scheduler.(*Scheduler).scheduleOne()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:447 +0x598
  k8s.io/kubernetes/pkg/scheduler.(*Scheduler).(k8s.io/kubernetes/pkg/scheduler.scheduleOne)-fm()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/pkg/scheduler/scheduler.go:182 +0x41
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x61
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134 +0xcd
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Until()
      /home/avagarwa/upstream-code/gocode/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x5a

Goroutine 186 (running) created at:
  testing.(*T).Run()
      /usr/lib/golang/src/testing/testing.go:824 +0x564
  testing.runTests.func1()
      /usr/lib/golang/src/testing/testing.go:1063 +0xa4
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:777 +0x16d
  testing.runTests()
      /usr/lib/golang/src/testing/testing.go:1061 +0x4e1
  testing.(*M).Run()
      /usr/lib/golang/src/testing/testing.go:978 +0x2cd
  main.main()
      _testmain.go:52 +0x22a
==================
--- FAIL: TestSchedulerWithVolumeBinding (18.04s)
	testing.go:730: race detected during execution of test
FAIL
```

It is pretty easy to reproduce this race by following these steps:

```
cd pkg/scheduler
go test -c -race
stress -p 100 ./scheduler.test
```

Predicate ordering to this unit test was added here: https://github.com/kubernetes/kubernetes/pull/57168
Since the whole scheduler instance uses just one ordering at time, not sure what is the advantage. 

@kubernetes/sig-scheduling-bugs @bsalamat @k82cn @frobware @smarterclayton @sjenning 

```release-note
None
```