### PR TITLE
Fix error message

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
@@ -44,7 +44,7 @@ func (e Equalities) AddFunc(eqFunc interface{}) error {
 		return fmt.Errorf("expected func, got: %v", ft)
 	}
 	if ft.NumIn() != 2 {
-		return fmt.Errorf("expected three 'in' params, got: %v", ft)
+		return fmt.Errorf("expected two 'in' params, got: %v", ft)
 	}
 	if ft.NumOut() != 1 {
 		return fmt.Errorf("expected one 'out' param, got: %v", ft)

--- a/third_party/forked/golang/reflect/deep_equal.go
+++ b/third_party/forked/golang/reflect/deep_equal.go
@@ -44,7 +44,7 @@ func (e Equalities) AddFunc(eqFunc interface{}) error {
 		return fmt.Errorf("expected func, got: %v", ft)
 	}
 	if ft.NumIn() != 2 {
-		return fmt.Errorf("expected three 'in' params, got: %v", ft)
+		return fmt.Errorf("expected two 'in' params, got: %v", ft)
 	}
 	if ft.NumOut() != 1 {
 		return fmt.Errorf("expected one 'out' param, got: %v", ft)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a minor mistake in an error message in `Equalities.DeepEqual`. I've tried to trace this mistake but could not find out where it originated.

**Release note**:
```release-note
NONE
```
