### PR TITLE
fix kubectl get --show-kind

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -219,6 +219,9 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 
 	o.IncludeUninitialized = cmdutil.ShouldIncludeUninitialized(cmd, false)
 
+	if resource.MultipleTypesRequested(args) {
+		o.PrintFlags.EnsureWithKind()
+	}
 	o.ToPrinter = func(mapping *meta.RESTMapping, withNamespace bool) (printers.ResourcePrinterFunc, error) {
 		// make a new copy of current flags / opts before mutating
 		printFlags := o.PrintFlags.Copy()
@@ -229,9 +232,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 					printFlags.UseOpenAPIColumns(apiSchema, mapping)
 				}
 			}
-			if resource.MultipleTypesRequested(args) {
-				printFlags.EnsureWithKind(mapping.GroupVersionKind.GroupKind())
-			}
+			printFlags.SetKind(mapping.GroupVersionKind.GroupKind())
 		}
 		if withNamespace {
 			printFlags.EnsureWithNamespace()

--- a/pkg/kubectl/cmd/get/get_flags.go
+++ b/pkg/kubectl/cmd/get/get_flags.go
@@ -41,6 +41,11 @@ type PrintFlags struct {
 	OutputFormat *string
 }
 
+// SetKind sets the Kind option of humanreadable flags
+func (f *PrintFlags) SetKind(kind schema.GroupKind) {
+	f.HumanReadableFlags.SetKind(kind)
+}
+
 // EnsureWithNamespace ensures that humanreadable flags return
 // a printer capable of printing with a "namespace" column.
 func (f *PrintFlags) EnsureWithNamespace() error {
@@ -49,8 +54,8 @@ func (f *PrintFlags) EnsureWithNamespace() error {
 
 // EnsureWithKind ensures that humanreadable flags return
 // a printer capable of including resource kinds.
-func (f *PrintFlags) EnsureWithKind(kind schema.GroupKind) error {
-	return f.HumanReadableFlags.EnsureWithKind(kind)
+func (f *PrintFlags) EnsureWithKind() error {
+	return f.HumanReadableFlags.EnsureWithKind()
 }
 
 // Copy returns a copy of PrintFlags for mutation

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -329,6 +329,60 @@ foo       0/0                 0          <unknown>
 	}
 }
 
+func TestGetObjectsShowKind(t *testing.T) {
+	pods, _, _ := testData()
+
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+	codec := legacyscheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: unstructuredSerializer,
+		Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods.Items[0])},
+	}
+	tf.Namespace = "test"
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("show-kind", "true")
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	expected := `NAME      READY     STATUS    RESTARTS   AGE
+pod/foo   0/0                 0          <unknown>
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetObjectsShowLabels(t *testing.T) {
+	pods, _, _ := testData()
+
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+	codec := legacyscheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: unstructuredSerializer,
+		Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods.Items[0])},
+	}
+	tf.Namespace = "test"
+
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOutput(buf)
+	cmd.Flags().Set("show-labels", "true")
+	cmd.Run(cmd, []string{"pods", "foo"})
+
+	expected := `NAME      READY     STATUS    RESTARTS   AGE         LABELS
+foo       0/0                 0          <unknown>   <none>
+`
+	if e, a := expected, buf.String(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
 func TestGetObjectIgnoreNotFound(t *testing.T) {
 	initTestErrorHandler(t)
 

--- a/pkg/kubectl/cmd/get/humanreadable_flags.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags.go
@@ -43,13 +43,14 @@ type HumanPrintFlags struct {
 	WithNamespace      bool
 }
 
-// EnsureWithKind sets the provided GroupKind humanreadable value.
-// If the kind received is non-empty, the "showKind" humanreadable
-// printer option is set to true.
-func (f *HumanPrintFlags) EnsureWithKind(kind schema.GroupKind) error {
-	showKind := !kind.Empty()
-
+// SetKind sets the Kind option
+func (f *HumanPrintFlags) SetKind(kind schema.GroupKind) {
 	f.Kind = kind
+}
+
+// EnsureWithKind sets the "Showkind" humanreadable option to true.
+func (f *HumanPrintFlags) EnsureWithKind() error {
+	showKind := true
 	f.ShowKind = &showKind
 	return nil
 }


### PR DESCRIPTION
This pull request fix `kubectl get --show-kind`
Before this change:
```json
$ kubectl get pods --show-kind
NAME                    READY     STATUS      RESTARTS   AGE
pi-with-timeout-52sjs   0/1       Completed   0          1d
pi-with-timeout-f5pb5   0/1       Completed   0          1d
```
After this change:
```
$ kubectl get pods --show-kind
NAME                        READY     STATUS      RESTARTS   AGE
pod/pi-with-timeout-52sjs   0/1       Completed   0          1d
pod/pi-with-timeout-f5pb5   0/1       Completed   0          1d
```
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @soltysh 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
