### PR TITLE
Add a new check to PodFitsResources to guarantee the pod limits must be less than the selected node's allocatable resource

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -82,6 +82,33 @@ var (
 	ErrFakePredicate = newPredicateFailureError("FakePredicateError", "Nodes failed the fake predicate")
 )
 
+// PodLimitsExeccedNodeResourceError is an error type that indicates pod limits execced what kind of node resource
+// and caused the unfitting failure
+type PodLimitsExeccedNodeResourceError struct {
+	ResourceName v1.ResourceName
+	limit        int64
+	allocatable  int64
+}
+
+// NewPodLimitsExeccedNodeResourceError returns an PodLimitsExeccedNodeResourceError.
+func NewPodLimitsExeccedNodeResourceError(resourceName v1.ResourceName, limit, allocatable int64) *PodLimitsExeccedNodeResourceError {
+	return &PodLimitsExeccedNodeResourceError{
+		ResourceName: resourceName,
+		limit:        limit,
+		allocatable:  allocatable,
+	}
+}
+
+func (e *PodLimitsExeccedNodeResourceError) Error() string {
+	return fmt.Sprintf("Pod limits execced node allocatable on resource: %s, limit: %d, allocatable: %d",
+		e.ResourceName, e.limit, e.allocatable)
+}
+
+// GetReason returns the reason of the PodLimitsExeccedNodeResourceError.
+func (e *PodLimitsExeccedNodeResourceError) GetReason() string {
+	return fmt.Sprintf("Insufficient %v", e.ResourceName)
+}
+
 // InsufficientResourceError is an error type that indicates what kind of resource limit is
 // hit and caused the unfitting failure.
 type InsufficientResourceError struct {

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -678,6 +678,20 @@ func GetResourceRequest(pod *v1.Pod) *schedulercache.Resource {
 	return result
 }
 
+func GetResourceLimits(pod *v1.Pod) *schedulercache.Resource {
+	result := &schedulercache.Resource{}
+	for _, container := range pod.Spec.Containers {
+		result.SetMaxResource(container.Resources.Limits)
+	}
+
+	// take max_resource(sum_pod, any_init_container)
+	for _, container := range pod.Spec.InitContainers {
+		result.SetMaxResource(container.Resources.Limits)
+	}
+
+	return result
+}
+
 func podName(pod *v1.Pod) string {
 	return pod.Namespace + "/" + pod.Name
 }
@@ -699,6 +713,16 @@ func PodFitsResources(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *s
 
 	// No extended resources should be ignored by default.
 	ignoredExtendedResources := sets.NewString()
+
+	allocatable := nodeInfo.AllocatableResource()
+
+	podLimit := GetResourceLimits(pod)
+	if podLimit.MilliCPU > allocatable.MilliCPU {
+		predicateFails = append(predicateFails, NewPodLimitsExeccedNodeResourceError(v1.ResourceCPU, podLimit.MilliCPU, allocatable.MilliCPU))
+	}
+	if podLimit.Memory > allocatable.Memory {
+		predicateFails = append(predicateFails, NewPodLimitsExeccedNodeResourceError(v1.ResourceMemory, podLimit.Memory, allocatable.Memory))
+	}
 
 	var podRequest *schedulercache.Resource
 	if predicateMeta, ok := meta.(*predicateMetadata); ok {


### PR DESCRIPTION
…ble resource

**What this PR does / why we need it**:
When we create a burstable type pod, the pod requests may be much more smaller than the pod limits. If the other predicate conditions satisfied and the pod limits exceed the node's allocatable resource, currently the scheduler predicates can also pass. This may cause the pod cann't use resources as large as those set in the pod limit. This pr add a new check to PodFitsResources to guarantee the pod limits must be less than the selected node's allocatable resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
