### PR TITLE
Fix panic in e2e.test --help

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flag/map_string_bool.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/map_string_bool.go
@@ -40,6 +40,9 @@ func NewMapStringBool(m *map[string]bool) *MapStringBool {
 // String implements github.com/spf13/pflag.Value
 func (m *MapStringBool) String() string {
 	pairs := []string{}
+	if m.Map == nil {
+		return ""
+	}
 	for k, v := range *m.Map {
 		pairs = append(pairs, fmt.Sprintf("%s=%t", k, v))
 	}
@@ -83,5 +86,5 @@ func (*MapStringBool) Type() string {
 
 // Empty implements OmitEmpty
 func (m *MapStringBool) Empty() bool {
-	return len(*m.Map) == 0
+	return m.Map == nil || len(*m.Map) == 0
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flag/map_string_bool_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/map_string_bool_test.go
@@ -32,6 +32,7 @@ func TestStringMapStringBool(t *testing.T) {
 		{"empty", NewMapStringBool(&map[string]bool{}), ""},
 		{"one key", NewMapStringBool(&map[string]bool{"one": true}), "one=true"},
 		{"two keys", NewMapStringBool(&map[string]bool{"one": true, "two": false}), "one=true,two=false"},
+		{"uninitialized", NewMapStringBool(nil), ""},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -151,6 +152,7 @@ func TestEmptyMapStringBool(t *testing.T) {
 		{"nil", NewMapStringBool(&nilMap), true},
 		{"empty", NewMapStringBool(&map[string]bool{}), true},
 		{"populated", NewMapStringBool(&map[string]bool{"foo": true}), false},
+		{"uninitialized", NewMapStringBool(nil), true},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't panic when `mapStringBool` is not initialized.

**Which issue(s) this PR fixes**
Fixes #64090

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
****

/sig api-machinery (?)


