### PR TITLE
Allow kubectl plugins to specify the full usage example in plugin.yaml

### DIFF
--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -79,7 +79,7 @@ func NewCmdForPlugin(f cmdutil.Factory, plugin *plugins.Plugin, runner plugins.P
 	}
 
 	cmd := &cobra.Command{
-		Use:     plugin.Name,
+		Use:     plugin.GetUse(),
 		Short:   plugin.ShortDesc,
 		Long:    templates.LongDesc(plugin.LongDesc),
 		Example: templates.Examples(plugin.Example),

--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -79,7 +79,7 @@ func NewCmdForPlugin(f cmdutil.Factory, plugin *plugins.Plugin, runner plugins.P
 	}
 
 	cmd := &cobra.Command{
-		Use:     plugin.GetUse(),
+		Use:     plugin.GetUsage(),
 		Short:   plugin.ShortDesc,
 		Long:    templates.LongDesc(plugin.LongDesc),
 		Example: templates.Examples(plugin.Example),

--- a/pkg/kubectl/plugins/plugins.go
+++ b/pkg/kubectl/plugins/plugins.go
@@ -46,12 +46,22 @@ type Plugin struct {
 // plugin as a command. Usually comes from a descriptor file.
 type Description struct {
 	Name      string  `json:"name"`
+	Use       string  `json:"use"`
 	ShortDesc string  `json:"shortDesc"`
 	LongDesc  string  `json:"longDesc,omitempty"`
 	Example   string  `json:"example,omitempty"`
 	Command   string  `json:"command"`
 	Flags     []Flag  `json:"flags,omitempty"`
 	Tree      Plugins `json:"tree,omitempty"`
+}
+
+// GetUse returns the Usage line for the command if
+// it is specified. Otherwise, it returns the command Name.
+func (d Description) GetUse() string {
+	if d.Use == "" {
+		return d.Name
+	}
+	return d.Use
 }
 
 // Source holds the location of a given plugin in the filesystem.

--- a/pkg/kubectl/plugins/plugins.go
+++ b/pkg/kubectl/plugins/plugins.go
@@ -46,7 +46,7 @@ type Plugin struct {
 // plugin as a command. Usually comes from a descriptor file.
 type Description struct {
 	Name      string  `json:"name"`
-	Use       string  `json:"use"`
+	Usage     string  `json:"use"`
 	ShortDesc string  `json:"shortDesc"`
 	LongDesc  string  `json:"longDesc,omitempty"`
 	Example   string  `json:"example,omitempty"`
@@ -55,13 +55,13 @@ type Description struct {
 	Tree      Plugins `json:"tree,omitempty"`
 }
 
-// GetUse returns the Usage line for the command if
+// GetUsage returns the Usage line for the command if
 // it is specified. Otherwise, it returns the command Name.
-func (d Description) GetUse() string {
-	if d.Use == "" {
+func (d Description) GetUsage() string {
+	if d.Usage == "" {
 		return d.Name
 	}
-	return d.Use
+	return d.Usage
 }
 
 // Source holds the location of a given plugin in the filesystem.

--- a/pkg/kubectl/plugins/plugins_test.go
+++ b/pkg/kubectl/plugins/plugins_test.go
@@ -59,7 +59,7 @@ func TestPlugin(t *testing.T) {
 			plugin: &Plugin{
 				Description: Description{
 					Name:      "test",
-					Use:       "test spaces",
+					Usage:     "test spaces",
 					ShortDesc: "The test",
 					Command:   "echo 1",
 				},
@@ -174,6 +174,38 @@ func TestPlugin(t *testing.T) {
 		err := test.plugin.Validate()
 		if err != test.expectedErr {
 			t.Errorf("%s: expected error %v, got %v", test.plugin.Name, test.expectedErr, err)
+		}
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	tests := []struct {
+		plugin        *Plugin
+		expectedUsage string
+	}{
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name: "name-only",
+				},
+			},
+			expectedUsage: "name-only",
+		},
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name:  "usage",
+					Usage: "usage foo bar",
+				},
+			},
+			expectedUsage: "usage foo bar",
+		},
+	}
+
+	for _, test := range tests {
+		usage := test.plugin.GetUsage()
+		if usage != test.expectedUsage {
+			t.Errorf("%s: expected GetUsage to return %s, but got %s", test.plugin.Name, test.expectedUsage, usage)
 		}
 	}
 }

--- a/pkg/kubectl/plugins/plugins_test.go
+++ b/pkg/kubectl/plugins/plugins_test.go
@@ -59,6 +59,16 @@ func TestPlugin(t *testing.T) {
 			plugin: &Plugin{
 				Description: Description{
 					Name:      "test",
+					Use:       "test spaces",
+					ShortDesc: "The test",
+					Command:   "echo 1",
+				},
+			},
+		},
+		{
+			plugin: &Plugin{
+				Description: Description{
+					Name:      "test",
 					ShortDesc: "The test",
 					Command:   "echo 1",
 					Flags: []Flag{


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this commit, plugins could only specify the name of the command
in plugin.yaml. This meant that the Usage line in the command's help
output did not give the user the full information. Here's an example of
the help output before this commit:
```
Usage:
  kubectl plugin svcat provision [options]
```
With this commit, plugins can now specify the full usage example through
a new "Use" field in plugin.yaml. The previous example now becomes:
```
Usage:
  kubectl plugin svcat provision NAME --plan PLAN --class CLASS [options]
```

**Release note**:
```release-note
NONE
```
