### PR TITLE
remove LabelsForObject and ResolveImage from factory

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -96,7 +96,6 @@ type ExposeServiceOptions struct {
 	MapBasedSelectorForObject func(runtime.Object) (string, error)
 	PortsForObject            func(runtime.Object) ([]string, error)
 	ProtocolsForObject        func(runtime.Object) (map[string]string, error)
-	LabelsForObject           func(runtime.Object) (map[string]string, error)
 
 	Namespace string
 	Mapper    meta.RESTMapper
@@ -200,7 +199,6 @@ func (o *ExposeServiceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) e
 	if err != nil {
 		return err
 	}
-	o.LabelsForObject = f.LabelsForObject
 
 	o.Namespace, o.EnforceNamespace, err = f.DefaultNamespace()
 	if err != nil {
@@ -294,7 +292,7 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		}
 
 		if kubectl.IsZero(params["labels"]) {
-			labels, err := o.LabelsForObject(info.Object)
+			labels, err := meta.NewAccessor().Labels(info.Object)
 			if err != nil {
 				return err
 			}

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -49,7 +49,7 @@ type SetImageOptions struct {
 	All          bool
 	Output       string
 	Local        bool
-	ResolveImage func(in string) (string, error)
+	ResolveImage ImageResolver
 
 	PrintObj printers.ResourcePrinterFunc
 	Recorder genericclioptions.Recorder
@@ -137,7 +137,7 @@ func (o *SetImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 	o.Output = cmdutil.GetFlagString(cmd, "output")
-	o.ResolveImage = f.ResolveImage
+	o.ResolveImage = resolveImageFunc
 
 	if o.DryRun {
 		o.PrintFlags.Complete("%s (dry run)")
@@ -308,4 +308,14 @@ func getResourcesAndImages(args []string) (resources []string, containerImages m
 func hasWildcardKey(containerImages map[string]string) bool {
 	_, ok := containerImages["*"]
 	return ok
+}
+
+// ImageResolver is a func that receives an image name, and
+// resolves it to an appropriate / compatible image name.
+// Adds flexibility for future image resolving methods.
+type ImageResolver func(in string) (string, error)
+
+// implements ImageResolver
+func resolveImageFunc(in string) (string, error) {
+	return in, nil
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -91,8 +91,6 @@ type ClientAccessFactory interface {
 	PortsForObject(object runtime.Object) ([]string, error)
 	// ProtocolsForObject returns the <port, protocol> mapping associated with the provided object
 	ProtocolsForObject(object runtime.Object) (map[string]string, error)
-	// LabelsForObject returns the labels associated with the provided object
-	LabelsForObject(object runtime.Object) (map[string]string, error)
 
 	// Command will stringify and return all environment arguments ie. a command run by a client
 	// using the factory.
@@ -109,11 +107,6 @@ type ClientAccessFactory interface {
 	// Returns the patched object in bytes and any error that occurred during the encoding or
 	// in case the object is already resumed.
 	Resumer(info *resource.Info) ([]byte, error)
-
-	// ResolveImage resolves the image names. For kubernetes this function is just
-	// passthrough but it allows to perform more sophisticated image name resolving for
-	// third-party vendors.
-	ResolveImage(imageName string) (string, error)
 
 	// Returns the default namespace to use in cases where no
 	// other namespace is specified and whether the namespace was

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -260,10 +260,6 @@ func (f *ring0Factory) ProtocolsForObject(object runtime.Object) (map[string]str
 	}
 }
 
-func (f *ring0Factory) LabelsForObject(object runtime.Object) (map[string]string, error) {
-	return meta.NewAccessor().Labels(object)
-}
-
 // Set showSecrets false to filter out stuff like secrets.
 func (f *ring0Factory) Command(cmd *cobra.Command, showSecrets bool) string {
 	if len(os.Args) == 0 {
@@ -316,10 +312,6 @@ func (f *ring0Factory) Pauser(info *resource.Info) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("pausing is not supported")
 	}
-}
-
-func (f *ring0Factory) ResolveImage(name string) (string, error) {
-	return name, nil
 }
 
 func (f *ring0Factory) Resumer(info *resource.Info) ([]byte, error) {

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -95,57 +94,6 @@ func TestProtocolsForObject(t *testing.T) {
 
 	if !expected.Equal(got) {
 		t.Fatalf("Protocols mismatch! Expected %v, got %v", expected, got)
-	}
-}
-
-func TestLabelsForObject(t *testing.T) {
-	f := NewFactory(genericclioptions.NewTestConfigFlags())
-
-	tests := []struct {
-		name     string
-		object   runtime.Object
-		expected string
-		err      error
-	}{
-		{
-			name: "successful re-use of labels",
-			object: &api.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", Labels: map[string]string{"svc": "test"}},
-				TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-			},
-			expected: "svc=test",
-			err:      nil,
-		},
-		{
-			name: "empty labels",
-			object: &api.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", Labels: map[string]string{}},
-				TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-			},
-			expected: "",
-			err:      nil,
-		},
-		{
-			name: "nil labels",
-			object: &api.Service{
-				ObjectMeta: metav1.ObjectMeta{Name: "zen", Namespace: "test", Labels: nil},
-				TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-			},
-			expected: "",
-			err:      nil,
-		},
-	}
-
-	for _, test := range tests {
-		gotLabels, err := f.LabelsForObject(test.object)
-		if err != test.err {
-			t.Fatalf("%s: Error mismatch: Expected %v, got %v", test.name, test.err, err)
-		}
-		got := kubectl.MakeLabels(gotLabels)
-		if test.expected != got {
-			t.Fatalf("%s: Labels mismatch! Expected %s, got %s", test.name, test.expected, got)
-		}
-
 	}
 }
 


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Removes the `ResolveImage` and `LabelsForObject` methods from factory_client_access, which are not needed.

cc @soltysh 