### PR TITLE
Redirect deprecated OpenAPI endpoint to new one

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -386,16 +386,7 @@ func (d *DiscoveryClient) ServerVersion() (*version.Info, error) {
 func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	data, err := d.restClient.Get().AbsPath("/openapi/v2").SetHeader("Accept", mimePb).Do().Raw()
 	if err != nil {
-		if errors.IsForbidden(err) || errors.IsNotFound(err) || errors.IsNotAcceptable(err) {
-			// single endpoint not found/registered in old server, try to fetch old endpoint
-			// TODO(roycaihw): remove this in 1.11
-			data, err = d.restClient.Get().AbsPath("/swagger-2.0.0.pb-v1").Do().Raw()
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	document := &openapi_v2.Document{}
 	err = proto.Unmarshal(data, document)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
@@ -92,32 +92,6 @@ func (h handlerTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(h.data)
 }
 
-type handlerDeprecatedTest struct {
-	etag string
-	data []byte
-}
-
-var _ http.Handler = handlerDeprecatedTest{}
-
-func (h handlerDeprecatedTest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// old server returns 403 on new endpoint
-	if r.URL.Path == "/openapi/v2" {
-		w.WriteHeader(http.StatusForbidden)
-		return
-	}
-	if len(h.etag) > 0 {
-		w.Header().Add("Etag", h.etag)
-	}
-	ifNoneMatches := r.Header["If-None-Match"]
-	for _, match := range ifNoneMatches {
-		if match == h.etag {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-	}
-	w.Write(h.data)
-}
-
 func assertDownloadedSpec(actualSpec *spec.Swagger, actualEtag string, err error,
 	expectedSpecID string, expectedEtag string) error {
 	if err != nil {
@@ -157,9 +131,4 @@ func TestDownloadOpenAPISpec(t *testing.T) {
 	actualSpec, actualEtag, _, err = s.Download(
 		handlerTest{data: []byte("{\"id\": \"test\"}"), etag: "etag_test1"}, "etag_test2")
 	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "etag_test1"))
-
-	// Test old server fallback path
-	actualSpec, actualEtag, _, err = s.Download(handlerDeprecatedTest{data: []byte("{\"id\": \"test\"}")}, "")
-	assert.NoError(t, assertDownloadedSpec(actualSpec, actualEtag, err, "test", "\"6E8F849B434D4B98A569B9D7718876E9-356ECAB19D7FBE1336BABB1E70F8F3025050DE218BE78256BE81620681CFC9A268508E542B8B55974E17B2184BBFC8FFFAA577E51BE195D32B3CA2547818ABE4\""))
-
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/downloader.go
@@ -109,23 +109,6 @@ func (s *Downloader) Download(handler http.Handler, etag string) (returnSpec *sp
 	writer := newInMemoryResponseWriter()
 	handler.ServeHTTP(writer, req)
 
-	// single endpoint not found/registered in old server, try to fetch old endpoint
-	// TODO(roycaihw): remove this in 1.11
-	if writer.respCode == http.StatusForbidden || writer.respCode == http.StatusNotFound {
-		req, err = http.NewRequest("GET", "/swagger.json", nil)
-		if err != nil {
-			return nil, "", 0, err
-		}
-
-		// Only pass eTag if it is not generated locally
-		if len(etag) > 0 && !strings.HasPrefix(etag, locallyGeneratedEtagPrefix) {
-			req.Header.Add("If-None-Match", etag)
-		}
-
-		writer = newInMemoryResponseWriter()
-		handler.ServeHTTP(writer, req)
-	}
-
 	switch writer.respCode {
 	case http.StatusNotModified:
 		if len(etag) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In 1.11 we will redirect the deprecated endpoints (`/swagger.json`, `/swagger-2.0.0.json`, `/swagger-2.0.0.pb-v1`, `/swagger-2.0.0.pb-v1.gz`) to the new one `/openapi/v2`. We will removed the deprecated endpoints in 1.14. ref https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref https://github.com/kubernetes/kubernetes/pull/59293

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecated format-separated endpoints for OpenAPI spec are now redirected to the new single `/openapi/v2` endpoint
```

/sig api-machinery