### PR TITLE
Add Node-exclusive tags to tests in test/e2e/common

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -34,7 +34,7 @@ var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 		    Description: Make sure config map value can be used as an environment
 			variable in the container (on container.env field)
 	*/
-	framework.ConformanceIt("should be consumable via environment variable ", func() {
+	framework.ConformanceIt("should be consumable via environment variable [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))
@@ -82,7 +82,7 @@ var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 		    Description: Make sure config map value can be used as an source for
 			environment variables in the container (on container.envFrom field)
 	*/
-	framework.ConformanceIt("should be consumable via the environment ", func() {
+	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newEnvFromConfigMap(f, name)
 		By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -37,7 +37,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure config map without mappings works by mounting it
 			to a volume with a custom path (mapping) on the pod with no other settings.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
@@ -46,7 +46,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure config map without mappings works by mounting it
 			to a volume with a custom path (mapping) on the pod with defaultMode set
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
@@ -61,7 +61,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure config map without mappings works by mounting it
 			to a volume with a custom path (mapping) on the pod as non-root.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
@@ -75,7 +75,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 			a custom path (mapping) on the pod with no other settings and make sure
 			the pod actually consumes it.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
@@ -84,7 +84,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure config map works with an item mode (e.g. 0400)
 			for the config map item.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
 		mode := int32(0400)
 		doConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
@@ -93,7 +93,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 	   Testname: configmap-simple-user-mapped
 	   Description: Make sure config map works when it is mounted as non-root.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
@@ -106,7 +106,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure update operation is working on config map and
 			the result is observed on volumes mounted in containers.
 	*/
-	framework.ConformanceIt("updates should be reflected in volume ", func() {
+	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -280,7 +280,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure Create, Update, Delete operations are all working
 			on config map and the result is observed on volumes mounted in containers.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume ", func() {
+	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -463,7 +463,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		    Description: Make sure config map works when it mounted as two different
 			volumes on the same node.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in the same pod ", func() {
+	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (
 			name             = "configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "configmap-volume"

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -51,7 +51,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
@@ -65,7 +65,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with FSGroup", func() {
+	It("should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
@@ -97,7 +97,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root with FSGroup", func() {
+	It("should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
@@ -184,7 +184,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
-	It("binary data should be reflected in volume ", func() {
+	It("binary data should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -54,7 +54,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure that pod with readiness probe should not be
 			ready before initial delay and never restart.
 	*/
-	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart ", func() {
+	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart [NodeConformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withInitialDelay().build(), nil))
 		f.WaitForPodReady(p.Name)
 
@@ -86,7 +86,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure that pod with readiness probe that fails should
 			never be ready and never restart.
 	*/
-	framework.ConformanceIt("with readiness probe that fails should never be ready and never restart ", func() {
+	framework.ConformanceIt("with readiness probe that fails should never be ready and never restart [NodeConformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withFailing().build(), nil))
 		Consistently(func() (bool, error) {
 			p, err := podClient.Get(p.Name, metav1.GetOptions{})
@@ -111,7 +111,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure the pod is restarted with a cat /tmp/health
 			liveness probe.
 	*/
-	framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" liveness probe", func() {
+	framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "liveness-exec",
@@ -143,7 +143,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure the pod is not restarted with a cat /tmp/health
 			liveness probe.
 	*/
-	framework.ConformanceIt("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe", func() {
+	framework.ConformanceIt("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "liveness-exec",
@@ -175,7 +175,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure when http liveness probe fails, the pod should
 			be restarted.
 	*/
-	framework.ConformanceIt("should be restarted with a /healthz http liveness probe ", func() {
+	framework.ConformanceIt("should be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "liveness-http",
@@ -209,7 +209,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure when a pod gets restarted, its start count
 			should increase.
 	*/
-	framework.ConformanceIt("should have monotonically increasing restart count  [Slow]", func() {
+	framework.ConformanceIt("should have monotonically increasing restart count [Slow][NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "liveness-http",
@@ -242,7 +242,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		    Description: Make sure when http liveness probe succeeds, the pod
 			should not be restarted.
 	*/
-	framework.ConformanceIt("should *not* be restarted with a /healthz http liveness probe ", func() {
+	framework.ConformanceIt("should *not* be restarted with a /healthz http liveness probe [NodeConformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "liveness-http",

--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -33,7 +33,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 			provided for a Container, ensure that the docker image's default
 			command and args are used.
 	*/
-	framework.ConformanceIt("should use the image defaults if command and args are blank ", func() {
+	framework.ConformanceIt("should use the image defaults if command and args are blank [NodeConformance]", func() {
 		f.TestContainerOutput("use defaults", entrypointTestPod(), 0, []string{
 			"[/ep default arguments]",
 		})
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 			Container, ensure that they take precedent to the docker image's
 			default arguments, but that the default command is used.
 	*/
-	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) ", func() {
+	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
@@ -62,7 +62,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 			Container, ensure that it takes precedent to the docker image's default
 			command.
 	*/
-	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) ", func() {
+	framework.ConformanceIt("should be able to override the image's default command (docker entrypoint) [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 
@@ -77,7 +77,7 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 			provided for a Container, ensure that they take precedent to the docker
 			image's default command and arguments.
 	*/
-	framework.ConformanceIt("should be able to override the image's default command and arguments ", func() {
+	framework.ConformanceIt("should be able to override the image's default command and arguments [NodeConformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -42,7 +42,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		    Description: Ensure that downward API can provide pod's name, namespace
 			and IP address as environment variables.
 	*/
-	framework.ConformanceIt("should provide pod name, namespace and IP address as env vars ", func() {
+	framework.ConformanceIt("should provide pod name, namespace and IP address as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -88,7 +88,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		    Description: Ensure that downward API can provide an IP address for
 			host node as an environment variable.
 	*/
-	framework.ConformanceIt("should provide host IP as an env var ", func() {
+	framework.ConformanceIt("should provide host IP as an env var [NodeConformance]", func() {
 		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
@@ -115,7 +115,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		    Description: Ensure that downward API can provide CPU/memory limit
 			and CPU/memory request as environment variables.
 	*/
-	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars ", func() {
+	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -167,7 +167,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 			allocatable values for CPU and memory as environment variables if CPU
 			and memory limits are not specified for a container.
 	*/
-	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable ", func() {
+	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable [NodeConformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -217,7 +217,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		    Description: Ensure that downward API can provide pod UID as an
 			environment variable.
 	*/
-	framework.ConformanceIt("should provide pod UID as env vars ", func() {
+	framework.ConformanceIt("should provide pod UID as env vars [NodeConformance]", func() {
 		framework.SkipUnlessServerVersionGTE(podUIDVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -240,7 +240,7 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 	})
 })
 
-var _ = framework.KubeDescribe("Downward API [Serial] [Disruptive]", func() {
+var _ = framework.KubeDescribe("Downward API [Serial] [Disruptive] [NodeFeature:EphemeralStorage]", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
 	Context("Downward API tests for local ephemeral storage", func() {

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -44,7 +44,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can provide pod's name through
 			DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide podname only ", func() {
+	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
@@ -58,7 +58,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can set default file permission
 			mode for DownwardAPIVolumeFiles if no mode is specified.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files ", func() {
+	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -73,7 +73,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can set file permission mode for
 			DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should set mode on item file ", func() {
+	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
@@ -117,7 +117,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API updates labels in
 			DownwardAPIVolumeFiles when pod's labels get modified.
 	*/
-	framework.ConformanceIt("should update labels on modification ", func() {
+	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -149,7 +149,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API updates annotations in
 			DownwardAPIVolumeFiles when pod's annotations get modified.
 	*/
-	framework.ConformanceIt("should update annotations on modification ", func() {
+	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -183,7 +183,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can provide container's CPU limit
 			through DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's cpu limit ", func() {
+	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -197,7 +197,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can provide container's memory
 			limit through DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's memory limit ", func() {
+	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
@@ -211,7 +211,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can provide container's CPU
 			request through DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's cpu request ", func() {
+	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
@@ -225,7 +225,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		    Description: Ensure that downward API can provide container's memory
 			request through DownwardAPIVolumeFiles.
 	*/
-	framework.ConformanceIt("should provide container's memory request ", func() {
+	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
@@ -240,7 +240,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 			allocatable value for CPU through DownwardAPIVolumeFiles if CPU
 			limit is not specified for a container.
 	*/
-	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set ", func() {
+	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -253,7 +253,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 			allocatable value for memory through DownwardAPIVolumeFiles if memory
 			limit is not specified for a container.
 	*/
-	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set ", func() {
+	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -83,7 +83,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup", func() {
+	It("should provide podname as non-root with fsgroup [NodeFeature:FSGroup]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -97,7 +97,7 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup and defaultMode", func() {
+	It("should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -72,7 +72,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure the volume has 0777 unix file permissions and tmpfs
 			mount type.
 	*/
-	framework.ConformanceIt("volume on tmpfs should have the correct mode", func() {
+	framework.ConformanceIt("volume on tmpfs should have the correct mode [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -82,7 +82,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a root owned file with 0644 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (root,0644,tmpfs)", func() {
+	framework.ConformanceIt("should support (root,0644,tmpfs) [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -92,7 +92,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a root owned file with 0666 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (root,0666,tmpfs)", func() {
+	framework.ConformanceIt("should support (root,0666,tmpfs) [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -102,7 +102,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a root owned file with 0777 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (root,0777,tmpfs)", func() {
+	framework.ConformanceIt("should support (root,0777,tmpfs) [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
@@ -112,7 +112,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a user owned file with 0644 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,tmpfs)", func() {
+	framework.ConformanceIt("should support (non-root,0644,tmpfs) [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -122,7 +122,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a user owned file with 0666 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,tmpfs)", func() {
+	framework.ConformanceIt("should support (non-root,0666,tmpfs) [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -132,7 +132,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			of 'Memory', ensure a user owned file with 0777 unix file permissions
 			is created correctly, has tmpfs mount type, and enforces the permissions.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,tmpfs)", func() {
+	framework.ConformanceIt("should support (non-root,0777,tmpfs) [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
@@ -141,7 +141,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 		    Description: For a Pod created with an 'emptyDir' Volume, ensure the
 			volume has 0777 unix file permissions.
 	*/
-	framework.ConformanceIt("volume on default medium should have the correct mode", func() {
+	framework.ConformanceIt("volume on default medium should have the correct mode [NodeConformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -151,7 +151,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			root owned file with 0644 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (root,0644,default)", func() {
+	framework.ConformanceIt("should support (root,0644,default) [NodeConformance]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -161,7 +161,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			root owned file with 0666 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (root,0666,default)", func() {
+	framework.ConformanceIt("should support (root,0666,default) [NodeConformance]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -171,7 +171,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			root owned file with 0777 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (root,0777,default)", func() {
+	framework.ConformanceIt("should support (root,0777,default) [NodeConformance]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
@@ -181,7 +181,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			user owned file with 0644 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (non-root,0644,default)", func() {
+	framework.ConformanceIt("should support (non-root,0644,default) [NodeConformance]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -191,7 +191,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			user owned file with 0666 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (non-root,0666,default)", func() {
+	framework.ConformanceIt("should support (non-root,0666,default) [NodeConformance]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
@@ -201,7 +201,7 @@ var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 			user owned file with 0777 unix file permissions is created and enforced
 			correctly.
 	*/
-	framework.ConformanceIt("should support (non-root,0777,default)", func() {
+	framework.ConformanceIt("should support (non-root,0777,default) [NodeConformance]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 })

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -40,7 +40,7 @@ var (
 var _ = Describe("[sig-storage] EmptyDir volumes", func() {
 	f := framework.NewDefaultFramework("emptydir")
 
-	Context("when FSGroup is specified", func() {
+	Context("when FSGroup is specified [NodeFeature:FSGroup]", func() {
 		It("new files should be created with FSGroup ownership when container is root", func() {
 			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -34,7 +34,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		    Description: Make sure environment variables can be set using an
 			expansion of previously defined environment variables
 	*/
-	framework.ConformanceIt("should allow composing env vars into new env vars ", func() {
+	framework.ConformanceIt("should allow composing env vars into new env vars [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -79,7 +79,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		    Description: Make sure a container's commands can be set using an
 			expansion of environment variables.
 	*/
-	framework.ConformanceIt("should allow substituting values in a container's command ", func() {
+	framework.ConformanceIt("should allow substituting values in a container's command [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +114,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		    Description: Make sure a container's args can be set using an
 			expansion of environment variables.
 	*/
-	framework.ConformanceIt("should allow substituting values in a container's args ", func() {
+	framework.ConformanceIt("should allow substituting values in a container's args [NodeConformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -61,7 +61,7 @@ var _ = Describe("[sig-storage] HostPath", func() {
 	})
 
 	// This test requires mounting a folder into a container with write privileges.
-	It("should support r/w", func() {
+	It("should support r/w [NodeConformance]", func() {
 		filePath := path.Join(volumePath, "test-file")
 		retryDuration := 180
 		source := &v1.HostPathVolumeSource{
@@ -85,7 +85,7 @@ var _ = Describe("[sig-storage] HostPath", func() {
 		})
 	})
 
-	It("should support subPath", func() {
+	It("should support subPath [NodeConformance]", func() {
 		subPath := "sub-path"
 		fileName := "test-file"
 		retryDuration := 180

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -45,7 +45,7 @@ var _ = Describe("[sig-storage] HostPath", func() {
 			volume is a directory with 0777 unix file permissions and that is has
 			the sticky bit (mode flag t) set.
 	*/
-	framework.ConformanceIt("should give a volume the correct mode", func() {
+	framework.ConformanceIt("should give a volume the correct mode [NodeConformance]", func() {
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",
 		}

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -35,7 +35,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("InitContainer", func() {
+var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 	f := framework.NewDefaultFramework("init-container")
 	var podClient *framework.PodClient
 	BeforeEach(func() {

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -55,7 +55,7 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 		    Description: Make sure Kubelet correctly manages /etc/hosts and mounts
 			it into the container.
 	*/
-	framework.ConformanceIt("should test kubelet managed /etc/hosts file ", func() {
+	framework.ConformanceIt("should test kubelet managed /etc/hosts file [NodeConformance]", func() {
 		By("Setting up the test")
 		config.setup()
 

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -35,7 +35,7 @@ var _ = Describe("[sig-network] Networking", func() {
 			    Description: Try to hit test endpoints from a test container and make
 				sure each of them can report a unique hostname.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: http ", func() {
+		framework.ConformanceIt("should function for intra-pod communication: http [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("http", endpointPod.Status.PodIP, framework.EndpointHttpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -47,7 +47,7 @@ var _ = Describe("[sig-network] Networking", func() {
 			    Description: Try to hit test endpoints from a test container using udp
 				and make sure each of them can report a unique hostname.
 		*/
-		framework.ConformanceIt("should function for intra-pod communication: udp ", func() {
+		framework.ConformanceIt("should function for intra-pod communication: udp [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromTestContainer("udp", endpointPod.Status.PodIP, framework.EndpointUdpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -59,7 +59,7 @@ var _ = Describe("[sig-network] Networking", func() {
 			    Description: Try to hit test endpoints from the pod and make sure each
 				of them can report a unique hostname.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: http ", func() {
+		framework.ConformanceIt("should function for node-pod communication: http [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("http", endpointPod.Status.PodIP, framework.EndpointHttpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
@@ -71,7 +71,7 @@ var _ = Describe("[sig-network] Networking", func() {
 			    Description: Try to hit test endpoints from the pod using udp and make sure
 				each of them can report a unique hostname.
 		*/
-		framework.ConformanceIt("should function for node-pod communication: udp ", func() {
+		framework.ConformanceIt("should function for node-pod communication: udp [NodeConformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
 				config.DialFromNode("udp", endpointPod.Status.PodIP, framework.EndpointUdpPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -467,7 +467,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}, maxRetries, "Container should have service environment variables set")
 	})
 
-	It("should support remote command execution over websockets", func() {
+	It("should support remote command execution over websockets [NodeConformance]", func() {
 		config, err := framework.LoadConfig()
 		Expect(err).NotTo(HaveOccurred(), "unable to get base config")
 
@@ -543,7 +543,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}, time.Minute, 10*time.Second).Should(BeNil())
 	})
 
-	It("should support retrieving logs from the container over websockets", func() {
+	It("should support retrieving logs from the container over websockets [NodeConformance]", func() {
 		config, err := framework.LoadConfig()
 		Expect(err).NotTo(HaveOccurred(), "unable to get base config")
 
@@ -600,7 +600,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		}
 	})
 
-	It("should have their auto-restart back-off timer reset on image update [Slow]", func() {
+	It("should have their auto-restart back-off timer reset on image update [Slow][NodeConformance]", func() {
 		podName := "pod-back-off-image"
 		containerName := "back-off"
 		pod := &v1.Pod{
@@ -641,7 +641,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	})
 
 	// Slow issue #19027 (20 mins)
-	It("should cap back-off at MaxContainerBackOff [Slow]", func() {
+	It("should cap back-off at MaxContainerBackOff [Slow][NodeConformance]", func() {
 		podName := "back-off-cap"
 		containerName := "back-off-cap"
 		pod := &v1.Pod{

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -133,7 +133,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		    Description: Make sure when a pod is created that it is assigned a host IP
 			Address.
 	*/
-	framework.ConformanceIt("should get a host IP ", func() {
+	framework.ConformanceIt("should get a host IP [NodeConformance]", func() {
 		name := "pod-hostip-" + string(uuid.NewUUID())
 		testHostIP(podClient, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		    Description: Makes sure a pod is created, a watch can be setup for the pod,
 			pod creation was observed, pod is deleted, and pod deletion is observed.
 	*/
-	framework.ConformanceIt("should be submitted and removed ", func() {
+	framework.ConformanceIt("should be submitted and removed [NodeConformance]", func() {
 		By("creating the pod")
 		name := "pod-submit-remove-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -280,7 +280,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 	   Testname: pods-updated-successfully
 	   Description: Make sure it is possible to successfully update a pod's labels.
 	*/
-	framework.ConformanceIt("should be updated ", func() {
+	framework.ConformanceIt("should be updated [NodeConformance]", func() {
 		By("creating the pod")
 		name := "pod-update-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -335,7 +335,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 			activeDeadlineSecondsValue, and then waits for the deadline to pass
 			and verifies the pod is terminated.
 	*/
-	framework.ConformanceIt("should allow activeDeadlineSeconds to be updated ", func() {
+	framework.ConformanceIt("should allow activeDeadlineSeconds to be updated [NodeConformance]", func() {
 		By("creating the pod")
 		name := "pod-update-activedeadlineseconds-" + string(uuid.NewUUID())
 		value := strconv.Itoa(time.Now().Nanosecond())
@@ -381,7 +381,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 		    Description: Make sure that when a pod is created it contains environment
 			variables for each active service.
 	*/
-	framework.ConformanceIt("should contain environment variables for services ", func() {
+	framework.ConformanceIt("should contain environment variables for services [NodeConformance]", func() {
 		// Make a pod that will be a service.
 		// This pod serves its hostname via HTTP.
 		serverName := "server-envvars-" + string(uuid.NewUUID())

--- a/test/e2e/common/privileged.go
+++ b/test/e2e/common/privileged.go
@@ -36,7 +36,7 @@ type PrivilegedPodTestConfig struct {
 	pod *v1.Pod
 }
 
-var _ = framework.KubeDescribe("PrivilegedPod", func() {
+var _ = framework.KubeDescribe("PrivilegedPod [NodeConformance]", func() {
 	config := &PrivilegedPodTestConfig{
 		f:                      framework.NewDefaultFramework("e2e-privileged-pod"),
 		privilegedPod:          "privileged-pod",

--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -84,7 +84,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		doProjectedSecretE2EWithMapping(f, &mode)
 	})
 
-	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace", func() {
+	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]", func() {
 		var (
 			namespace2  *v1.Namespace
 			err         error
@@ -419,7 +419,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeFeature:FSGroup]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
@@ -433,7 +433,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with FSGroup", func() {
+	It("should be consumable from pods in volume as non-root with FSGroup [NodeFeature:FSGroup]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
@@ -466,7 +466,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root with FSGroup", func() {
+	It("should be consumable from pods in volume with mappings as non-root with FSGroup [NodeFeature:FSGroup]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
@@ -904,7 +904,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup", func() {
+	It("should provide podname as non-root with fsgroup [NodeFeature:FSGroup]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -918,7 +918,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup and defaultMode", func() {
+	It("should provide podname as non-root with fsgroup and defaultMode [NodeFeature:FSGroup]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)

--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -39,7 +39,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 	   Testname: projected-secret-no-defaultMode
 	   Description: Simple projected Secret test with no defaultMode set.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume", func() {
+	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
@@ -47,7 +47,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 	   Testname: projected-secret-with-defaultMode
 	   Description: Simple projected Secret test with defaultMode set.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -57,7 +57,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Simple projected Secret test as non-root with
 			defaultMode and fsGroup set.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
@@ -70,7 +70,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			mounting it to a volume with a custom path (mapping) on the pod with
 			no other settings and make sure the pod actually consumes it.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedSecretE2EWithMapping(f, nil)
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Repeat the projected-secret-simple-mapped but this time
 			with an item mode (e.g. 0400) for the secret map item.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedSecretE2EWithMapping(f, &mode)
 	})
@@ -110,7 +110,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Make sure secrets works when mounted as two different
 			volumes on the same node.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in a pod", func() {
+	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -203,7 +203,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 	   Testname: projected-secret-simple-optional
 	   Description: Make sure secrets works when optional updates included.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume", func() {
+	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -405,7 +405,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Make sure that a projected volume with a configMap with
 			no mappings succeeds properly.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume", func() {
+	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
@@ -414,7 +414,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Make sure that a projected volume configMap is consumable
 			with defaultMode set.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
@@ -429,7 +429,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Make sure that a projected volume configMap is consumable
 			by a non-root userID.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
@@ -443,7 +443,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			map and mounting it to a volume with a custom path (mapping) on the
 			pod with no other settings and make sure the pod actually consumes it.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
@@ -452,7 +452,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Repeat the projected-secret-simple-mapped but this time
 			with an item mode (e.g. 0400) for the secret map item
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set [NodeConformance]", func() {
 		mode := int32(0400)
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
@@ -462,7 +462,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Repeat the projected-config-map-simple-mapped but this
 			time with a user other than root.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
@@ -476,7 +476,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			that the values in these configMaps can be updated, deleted,
 			and created.
 	*/
-	framework.ConformanceIt("updates should be reflected in volume", func() {
+	framework.ConformanceIt("updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -565,7 +565,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			configMaps, that the values in these configMaps can be updated,
 			deleted, and created.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume", func() {
+	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -766,7 +766,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Make sure config map works when it mounted as two
 			different volumes on the same node.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in the same pod", func() {
+	framework.ConformanceIt("should be consumable in multiple volumes in the same pod [NodeConformance]", func() {
 		var (
 			name             = "projected-configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "projected-configmap-volume"
@@ -864,7 +864,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can provide pod's name through
 			DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should provide podname only", func() {
+	framework.ConformanceIt("should provide podname only [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podinfo/podname")
 
@@ -879,7 +879,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			mode for DownwardAPIVolumeFiles if no mode is specified in a projected
 			volume.
 	*/
-	framework.ConformanceIt("should set DefaultMode on files", func() {
+	framework.ConformanceIt("should set DefaultMode on files [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", nil, &defaultMode)
@@ -894,7 +894,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can set file permission mode for
 			DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should set mode on item file", func() {
+	framework.ConformanceIt("should set mode on item file [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podinfo/podname", &mode, nil)
@@ -939,7 +939,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			DownwardAPIVolumeFiles when pod's labels get modified in a projected
 			volume.
 	*/
-	framework.ConformanceIt("should update labels on modification", func() {
+	framework.ConformanceIt("should update labels on modification [NodeConformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -972,7 +972,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			DownwardAPIVolumeFiles when pod's annotations get modified in a
 			projected volume.
 	*/
-	framework.ConformanceIt("should update annotations on modification", func() {
+	framework.ConformanceIt("should update annotations on modification [NodeConformance]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -1006,7 +1006,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can provide container's CPU
 			limit through DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should provide container's cpu limit", func() {
+	framework.ConformanceIt("should provide container's cpu limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -1020,7 +1020,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can provide container's memory
 			limit through DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should provide container's memory limit", func() {
+	framework.ConformanceIt("should provide container's memory limit [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
@@ -1034,7 +1034,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can provide container's CPU
 			request through DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should provide container's cpu request", func() {
+	framework.ConformanceIt("should provide container's cpu request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/cpu_request")
 
@@ -1048,7 +1048,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: Ensure that downward API can provide container's memory
 			request through DownwardAPIVolumeFiles in a projected volume.
 	*/
-	framework.ConformanceIt("should provide container's memory request", func() {
+	framework.ConformanceIt("should provide container's memory request [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_request")
 
@@ -1063,7 +1063,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			allocatable value for CPU through DownwardAPIVolumeFiles if CPU limit
 			is not specified for a container in a projected volume.
 	*/
-	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set", func() {
+	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/cpu_limit")
 
@@ -1076,7 +1076,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 			allocatable value for memory through DownwardAPIVolumeFiles if memory
 			limit is not specified for a container in a projected volume.
 	*/
-	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set", func() {
+	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set [NodeConformance]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/podinfo/memory_limit")
 
@@ -1089,7 +1089,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 		    Description: This test projects a secret and configmap into the same
 			directory to ensure projection is working as intended.
 	*/
-	framework.ConformanceIt("should project all components that make up the projection API [Projection]", func() {
+	framework.ConformanceIt("should project all components that make up the projection API [Projection][NodeConformance]", func() {
 		var err error
 		podName := "projected-volume-" + string(uuid.NewUUID())
 		secretName := "secret-projected-all-test-volume-" + string(uuid.NewUUID())

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -35,7 +35,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 		    Description: Ensure that secret can be consumed via environment
 			variables.
 	*/
-	framework.ConformanceIt("should be consumable from pods in env vars ", func() {
+	framework.ConformanceIt("should be consumable from pods in env vars [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := secretForTest(f.Namespace.Name, name)
 
@@ -84,7 +84,7 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 		    Description: Ensure that secret can be consumed via source of a set
 			of ConfigMaps.
 	*/
-	framework.ConformanceIt("should be consumable via the environment ", func() {
+	framework.ConformanceIt("should be consumable via the environment [NodeConformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := newEnvFromSecret(f.Namespace.Name, name)
 		By(fmt.Sprintf("creating secret %v/%v", f.Namespace.Name, secret.Name))

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -38,7 +38,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that secret can be mounted without mapping to a
 			pod volume.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
@@ -47,7 +47,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that secret can be mounted without mapping to a
 			pod volume in default mode.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set [NodeConformance]", func() {
 		defaultMode := int32(0400)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
@@ -57,7 +57,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that secret can be mounted without mapping to a pod
 			volume as non-root in default mode with fsGroup set.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [NodeConformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
@@ -69,7 +69,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that secret can be mounted with mapping to a pod
 			volume.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
 		doSecretE2EWithMapping(f, nil)
 	})
 
@@ -78,7 +78,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that secret can be mounted with mapping to a pod
 			volume in item mode.
 	*/
-	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set ", func() {
+	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item Mode set [NodeConformance]", func() {
 		mode := int32(0400)
 		doSecretE2EWithMapping(f, &mode)
 	})
@@ -108,7 +108,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 	   Testname: secret-multiple-volume-mounts
 	   Description: Ensure that secret can be mounted to multiple pod volumes.
 	*/
-	framework.ConformanceIt("should be consumable in multiple volumes in a pod ", func() {
+	framework.ConformanceIt("should be consumable in multiple volumes in a pod [NodeConformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -186,7 +186,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		    Description: Ensure that optional update change to secret can be
 			reflected on a mounted volume.
 	*/
-	framework.ConformanceIt("optional updates should be reflected in volume ", func() {
+	framework.ConformanceIt("optional updates should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -83,7 +83,7 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		doSecretE2EWithMapping(f, &mode)
 	})
 
-	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace", func() {
+	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [NodeConformance]", func() {
 		var (
 			namespace2  *v1.Namespace
 			err         error

--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Sysctls", func() {
+var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 	f := framework.NewDefaultFramework("sysctl")
 	var podClient *framework.PodClient
 


### PR DESCRIPTION
Original issue: #59001

Add node-exclusive tags based on the [proposal](https://docs.google.com/document/d/1BdNVUGtYO6NDx10x_fueRh_DLT-SVdlPC_SsXjYCHOE/edit#)

Previous PR: #64125
Depends on: #64128

Follow-up PRs will:
 - Change the test job configurations to use the new tests
 - Remove the unused, non-node-exclusive tags in `test/e2e_node`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
