### PR TITLE
Automated cherry pick of #61459: etcd client add dial timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -29,11 +29,13 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 )
 
-// The short keepalive timeout and interval have been chosen to aggressively
-// detect a failed etcd server without introducing much overhead.
 var (
+	// The short keepalive timeout and interval have been chosen to aggressively
+	// detect a failed etcd server without introducing much overhead.
 	keepaliveTime    = 30 * time.Second
 	keepaliveTimeout = 10 * time.Second
+	// dialTimeout is the timeout for failing to establish a connection.
+	dialTimeout = 10 * time.Second
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
@@ -52,6 +54,7 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
+		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,
 		Endpoints:            c.ServerList,


### PR DESCRIPTION
Cherry pick of #61459 on release-1.10.

Fixes https://github.com/kubernetes/kubernetes/issues/62538

#61459: etcd client add dial timeout

```release-note
kube-apiserver now sets a dial timeout when connecting to etcd, to allow it to tolerate/retry connections to a dead etcd server
```
