### PR TITLE
add test: verify kubelet.config.Restore only happen once

### DIFF
--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -451,4 +451,10 @@ func TestPodRestore(t *testing.T) {
 		t.Fatalf("Restore returned error: %v", err)
 	}
 	expectPodUpdate(t, ch, CreatePodUpdate(kubetypes.RESTORE, kubetypes.ApiserverSource, pod))
+
+	// Verify Restore only happen once
+	if err := config.Restore(tmpDir, channel); err != nil {
+		t.Fatalf("The second restore returned error: %v", err)
+	}
+	expectNoPodUpdate(t, ch)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This patch is to add additional test coverage of pod config restore, 
it verifies that restore can only happen once.

in the second restore attempt, we should expect no error and no channel update.

**Which issue(s) this PR fixes**:

this is a test improvement based on test been added at https://github.com/kubernetes/kubernetes/pull/63553


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig node
/cc @rphillips @jiayingz @vikaschoudhary16 @anfernee @Random-Liu  @dchen1107  @derekwaynecarr 
@vishh @yujuhong @tallclair
