### PR TITLE
e2e: Remove flaky from CSI E2E test

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -50,7 +50,7 @@ var csiTestDrivers = map[string]func(f *framework.Framework, config framework.Vo
 	"[Feature: GCE PD CSI Plugin] gcePD": initCSIgcePD,
 }
 
-var _ = utils.SIGDescribe("CSI Volumes [Flaky]", func() {
+var _ = utils.SIGDescribe("CSI Volumes", func() {
 	f := framework.NewDefaultFramework("csi-mock-plugin")
 
 	var (


### PR DESCRIPTION
**What this PR does / why we need it**:
The tests have been passing consistently and now we can remove the Flaky tag.

See results here: https://k8s-testgrid.appspot.com/sig-storage#gce-flaky&width=5

**Release note**:

```release-note
NONE
```
