### PR TITLE
Modify LoopbackHostPort() so it returns an IPv6 Loopback address when given [::] 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
@@ -63,6 +63,8 @@ func LoopbackHostPort(bindAddress string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid server bind address: %q", bindAddress)
 	}
 
+	isIPv6 := net.ParseIP(host).To4() == nil
+
 	// Value is expected to be an IP or DNS name, not "0.0.0.0".
 	if host == "0.0.0.0" || host == "::" {
 		host = "localhost"
@@ -72,7 +74,7 @@ func LoopbackHostPort(bindAddress string) (string, string, error) {
 		addrs, err := net.InterfaceAddrs()
 		if err == nil {
 			for _, address := range addrs {
-				if ipnet, ok := address.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
+				if ipnet, ok := address.(*net.IPNet); ok && ipnet.IP.IsLoopback() && isIPv6 == (ipnet.IP.To4() == nil) {
 					host = ipnet.IP.String()
 					break
 				}

--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -59,9 +59,10 @@ func TestLoopbackHostPort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
-		t.Fatalf("expected host to be loopback, got %q", host)
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() || ip.To4() != nil {
+		t.Fatalf("expected IPv6 host to be loopback, got %q", host)
 	}
+
 	if port != "443" {
 		t.Fatalf("expected 443 as port, got %q", port)
 	}


### PR DESCRIPTION

Currently when LoopbackHostPort() is called with 0.0.0.0 and [::] it returns the first loopback
address returned from net.InterfaceAddrs() which is typically 127.0.0.1 (golang does not
specify an order that interfaces are returned). It would be more appropriate if when calling
LoopbackHostPort() with [::] that an IPv6 loopback address is returned, this prevents some cert.
generation failures.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
