### PR TITLE
fix the e2e node helpers that let tests reconfigure Kubelet

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -172,7 +172,6 @@ func setKubeletConfiguration(f *framework.Framework, kubeCfg *kubeletconfig.Kube
 		ConfigMap: &apiv1.ConfigMapNodeConfigSource{
 			Namespace:        "kube-system",
 			Name:             cm.Name,
-			UID:              cm.UID,
 			KubeletConfigKey: "kubelet",
 		},
 	}


### PR DESCRIPTION
The dynamic config tests were updated with the validation change, but
the tests that try to use dynamic config via this helper were not.

Should fix the failures here: https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-serial-gce-e2e

```release-note
NONE
```
