### PR TITLE
Correct image in `kubectl help run`

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -64,7 +64,7 @@ var (
 		kubectl run hazelcast --image=hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
 
 		# Start a single instance of hazelcast and set labels "app=hazelcast" and "env=prod" in the container.
-		kubectl run hazelcast --image=nginx --labels="app=hazelcast,env=prod"
+		kubectl run hazelcast --image=hazelcast --labels="app=hazelcast,env=prod"
 
 		# Start a replicated instance of nginx.
 		kubectl run nginx --image=nginx --replicas=5


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple typo fix -- image for this hazelcast command example was transposed /w nginx

/sig cli
/area kubectl
/kind cleanup
/kind documentation

**Release note**:
```release-note
NONE
```