### PR TITLE
stop retrying token creation on terminating namespace

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -19,6 +19,7 @@ package serviceaccount
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -258,6 +259,10 @@ func (e *TokensController) syncServiceAccount() {
 		// ensure a token exists and is referenced by this service account
 		retry, err = e.ensureReferencedToken(sa)
 		if err != nil {
+			// do not retry when the error suggests the namespace is being terminated
+			if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "because it is being terminated") {
+				retry = false
+			}
 			glog.Errorf("error synchronizing serviceaccount %s/%s: %v", saInfo.namespace, saInfo.name, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In case the namespace is being terminated, the token controller should stop retrying the secret creation, otherwise the logs will be flooded by:

`E0521 01:02:28.146192       1 tokens_controller.go:268] error synchronizing serviceaccount e2e-tests-projected-hmz7p/builder: secrets "builder-token-4smnv" is forbidden: unable to create new content in namespace e2e-tests-projected-hmz7p because it is being terminated`

Also because the controller will spend time retrying this unretriable error the regular secrets creation might be delays.

**Release note**:
```release-note
NONE
```