### PR TITLE
apiextensions: extract orthortogonal behaviour from nopConve

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -33,11 +34,60 @@ func NewCRDConverter(crd *apiextensions.CustomResourceDefinition) (safe, unsafe 
 
 	// The only converter right now is nopConverter. More converters will be returned based on the
 	// CRD object when they introduced.
-	unsafe = &nopConverter{
+	unsafe = &crdConverter{
 		clusterScoped: crd.Spec.Scope == apiextensions.ClusterScoped,
-		validVersions: validVersions,
+		delegate: &nopConverter{
+			validVersions: validVersions,
+		},
 	}
 	return &safeConverterWrapper{unsafe}, unsafe
+}
+
+var _ runtime.ObjectConvertor = &crdConverter{}
+
+// crdConverter extends the delegate with generic CRD conversion behaviour. The delegate will implement the
+// user defined conversion strategy given in the CustomResourceDefinition.
+type crdConverter struct {
+	delegate      runtime.ObjectConvertor
+	clusterScoped bool
+}
+
+func (c *crdConverter) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
+	// We currently only support metadata.namespace and metadata.name.
+	switch {
+	case label == "metadata.name":
+		return label, value, nil
+	case !c.clusterScoped && label == "metadata.namespace":
+		return label, value, nil
+	default:
+		return "", "", fmt.Errorf("field label not supported: %s", label)
+	}
+}
+
+func (c *crdConverter) Convert(in, out, context interface{}) error {
+	return c.delegate.Convert(in, out, context)
+}
+
+// ConvertToVersion converts in object to the given gvk in place and returns the same `in` object.
+func (c *crdConverter) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
+	// Run the converter on the list items instead of list itself
+	if list, ok := in.(*unstructured.UnstructuredList); ok {
+		for i := range list.Items {
+			obj, err := c.delegate.ConvertToVersion(&list.Items[i], target)
+			if err != nil {
+				return nil, err
+			}
+
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return nil, fmt.Errorf("output type %T in not valid for unstructured conversion", obj)
+			}
+			list.Items[i] = *u
+		}
+		return list, nil
+	}
+
+	return c.delegate.ConvertToVersion(in, target)
 }
 
 // safeConverterWrapper is a wrapper over an unsafe object converter that makes copy of the input and then delegate to the unsafe converter.


### PR DESCRIPTION
This is preparation for adding more CR converters. Not every new converter should implement the generic conversion behaviour of CRs.

Fixes parts of https://github.com/kubernetes/kubernetes/issues/64136.