### PR TITLE
avoid wrongly replaying old events in kube-controller-manager

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -414,8 +414,12 @@ loop:
 			default:
 				utilruntime.HandleError(fmt.Errorf("%s: unable to understand watch event %#v", r.name, event))
 			}
-			*resourceVersion = newResourceVersion
-			r.setLastSyncResourceVersion(newResourceVersion)
+			newVer, newErr := strconv.ParseInt(newResourceVersion, 10, 64)
+			oldVer, oldErr := strconv.ParseInt(*resourceVersion, 10, 64)
+			if newErr == nil && oldErr == nil && newVer > oldVer {
+				*resourceVersion = newResourceVersion
+				r.setLastSyncResourceVersion(newResourceVersion)
+			}
 			eventCount++
 		}
 	}


### PR DESCRIPTION
The resourceVersion in event stream doesn't monotonic increase, it's
the version of related resource itself, not a sequence number of the
event.

For example,  create & delete & create some service resources, then
delete an old service that has bigger age, this will append a
"DELETED" event into the service change event stream, this last event
has a small resourceVersion, this will force kube-controller-manager
to poll api-server with "/api/v1/resources?resourceVersion=<smallVer>&timeoutSeconds=<xxx>&watch=true",
if no new service event happens, next poll will continue with same small
resource version, thus those *old* "ADDED / DELETED / ADDED" service
event will be replayed again and again,  then EndpointController will
delete and create corresponding endpoints again and again, this totally
breaks the reliabity of Kubernetes service, users will see errors like
"HTTP 504 Gateway timeout".

See: https://github.com/kubernetes/kubernetes/blob/v1.12.0-alpha.0/pkg/controller/endpoint/endpoints_controller.go#L396

This bug has existed for a very long time and is very severe, here are
two workarounds if someone can't upgrade there Kubernetes clusters:

1. "docker restart" kube-controller-manager, this forces it starts watching at the end of event stream.
2. "kubectl edit" or create a service, so that an event with highest resourceVersion will be appended to the service event stream.

This bug seems also causes replaying of old configmap and secret change
event stream, I'm not sure how servere it is.

This fixes issue #57897.
