### PR TITLE
Do not use DeepEqual to compare slices in test.

### DIFF
--- a/pkg/scheduler/core/equivalence_cache_test.go
+++ b/pkg/scheduler/core/equivalence_cache_test.go
@@ -378,6 +378,14 @@ func TestUpdateResult(t *testing.T) {
 	}
 }
 
+// slicesEqual wraps reflect.DeepEqual, but returns true when comparing nil and empty slice.
+func slicesEqual(a, b []algorithm.PredicateFailureReason) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
 func TestLookupResult(t *testing.T) {
 	tests := []struct {
 		name                              string
@@ -504,9 +512,9 @@ func TestLookupResult(t *testing.T) {
 		if fit != test.expectedPredicateItem.fit {
 			t.Errorf("Failed: %s, expected fit: %v, but got: %v", test.name, test.cachedItem.fit, fit)
 		}
-		if !reflect.DeepEqual(reasons, test.expectedPredicateItem.reasons) {
+		if !slicesEqual(reasons, test.expectedPredicateItem.reasons) {
 			t.Errorf("Failed: %s, expected reasons: %v, but got: %v",
-				test.name, test.cachedItem.reasons, reasons)
+				test.name, test.expectedPredicateItem.reasons, reasons)
 		}
 	}
 }


### PR DESCRIPTION
This wraps DeepEqual with a helper that considers nil slices and empty
slices to be equal.

Scheduler code might use a nil slice or empty slice to represent an
empty list, so tests should not be sensitive to the difference.  Tests
could fail because DeepEqual considers nil to be different from an empty
slice.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Avoid breaking tests in cases where application behavior is not changed.

**Special notes for your reviewer**:
This brittle test keeps breaking in a number of my PRs. Hoping to get this fix merged independently.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig scheduling
/kind cleanup