### PR TITLE
Add KUBE_CGO_OVERRIDES env var to force enabling CGO

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -226,6 +226,9 @@ readonly KUBE_STATIC_OVERRIDES
 
 kube::golang::is_statically_linked_library() {
   local e
+  # Explicitly enable cgo when building kubectl for darwin from darwin.
+  [[ "$(go env GOHOSTOS)" == "darwin" && "$(go env GOOS)" == "darwin" &&
+    "$1" == *"/kubectl" ]] && return 1
   if [[ -n "${KUBE_CGO_OVERRIDES:+x}" ]]; then
     for e in "${KUBE_CGO_OVERRIDES[@]}"; do [[ "$1" == *"/$e" ]] && return 1; done;
   fi

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -213,12 +213,24 @@ readonly KUBE_STATIC_LIBRARIES=(
   kubectl
 )
 
+# KUBE_CGO_OVERRIDES is a space-separated list of binaries which should be built
+# with CGO enabled, assuming CGO is supported on the target platform.
+# This overrides any entry in KUBE_STATIC_LIBRARIES.
+IFS=" " read -ra KUBE_CGO_OVERRIDES <<< "${KUBE_CGO_OVERRIDES:-}"
+readonly KUBE_CGO_OVERRIDES
+# KUBE_STATIC_OVERRIDES is a space-separated list of binaries which should be
+# built with CGO disabled. This is in addition to the list in
+# KUBE_STATIC_LIBRARIES.
+IFS=" " read -ra KUBE_STATIC_OVERRIDES <<< "${KUBE_STATIC_OVERRIDES:-}"
+readonly KUBE_STATIC_OVERRIDES
+
 kube::golang::is_statically_linked_library() {
   local e
+  if [[ -n "${KUBE_CGO_OVERRIDES:+x}" ]]; then
+    for e in "${KUBE_CGO_OVERRIDES[@]}"; do [[ "$1" == *"/$e" ]] && return 1; done;
+  fi
   for e in "${KUBE_STATIC_LIBRARIES[@]}"; do [[ "$1" == *"/$e" ]] && return 0; done;
-  # Allow individual overrides--e.g., so that you can get a static build of
-  # kubectl for inclusion in a container.
-  if [ -n "${KUBE_STATIC_OVERRIDES:+x}" ]; then
+  if [[ -n "${KUBE_STATIC_OVERRIDES:+x}" ]]; then
     for e in "${KUBE_STATIC_OVERRIDES[@]}"; do [[ "$1" == *"/$e" ]] && return 0; done;
   fi
   return 1;


### PR DESCRIPTION
**What this PR does / why we need it**: as detailed in https://github.com/kubernetes/release/issues/469 (and elsewhere), there is a desire to have `kubectl` built with CGO enabled on mac OS.

There currently isn't a great way to do this in our official cross builds, but we should allow mac users to build their own kubectl with CGO enabled if they desire, e.g. through homebrew.

This change enables that; you can now do `KUBE_CGO_OVERRIDES=kubectl make WHAT=cmd/kubectl` and get a cgo-enabled `kubectl`.

The default build outputs remain unchanged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl built for darwin from darwin now enables cgo to use the system-native C libraries for DNS resolution. Cross-compiled kubectl (e.g. from an official kubernetes release) still uses the go-native netgo DNS implementation. 
```

/assign @BenTheElder @cblecker 
cc @bks7 @bitglue
