### PR TITLE
Automated cherry pick of #63806: kubeadm - do not generate etcd ca/certs for external etcd

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -37,14 +37,21 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
 		CreateCACertAndKeyFiles,
 		CreateAPIServerCertAndKeyFiles,
 		CreateAPIServerKubeletClientCertAndKeyFiles,
+		CreateServiceAccountKeyAndPublicKeyFiles,
+		CreateFrontProxyCACertAndKeyFiles,
+		CreateFrontProxyClientCertAndKeyFiles,
+	}
+	etcdCertActions := []func(cfg *kubeadmapi.MasterConfiguration) error{
 		CreateEtcdCACertAndKeyFiles,
 		CreateEtcdServerCertAndKeyFiles,
 		CreateEtcdPeerCertAndKeyFiles,
 		CreateEtcdHealthcheckClientCertAndKeyFiles,
 		CreateAPIServerEtcdClientCertAndKeyFiles,
-		CreateServiceAccountKeyAndPublicKeyFiles,
-		CreateFrontProxyCACertAndKeyFiles,
-		CreateFrontProxyClientCertAndKeyFiles,
+	}
+
+	// Currently this is the only way we have to identify static pod etcd vs external etcd
+	if len(cfg.Etcd.Endpoints) == 0 {
+		certActions = append(certActions, etcdCertActions...)
 	}
 
 	for _, action := range certActions {

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -601,6 +601,7 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 		setupFunc     func(cfg *kubeadmapi.MasterConfiguration) error
 		createFunc    func(cfg *kubeadmapi.MasterConfiguration) error
 		expectedFiles []string
+		externalEtcd  bool
 	}{
 		{
 			createFunc: CreatePKIAssets,
@@ -613,6 +614,18 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 				kubeadmconstants.EtcdPeerCertName, kubeadmconstants.EtcdPeerKeyName,
 				kubeadmconstants.EtcdHealthcheckClientCertName, kubeadmconstants.EtcdHealthcheckClientKeyName,
 				kubeadmconstants.APIServerEtcdClientCertName, kubeadmconstants.APIServerEtcdClientKeyName,
+				kubeadmconstants.ServiceAccountPrivateKeyName, kubeadmconstants.ServiceAccountPublicKeyName,
+				kubeadmconstants.FrontProxyCACertName, kubeadmconstants.FrontProxyCAKeyName,
+				kubeadmconstants.FrontProxyClientCertName, kubeadmconstants.FrontProxyClientKeyName,
+			},
+		},
+		{
+			createFunc:   CreatePKIAssets,
+			externalEtcd: true,
+			expectedFiles: []string{
+				kubeadmconstants.CACertName, kubeadmconstants.CAKeyName,
+				kubeadmconstants.APIServerCertName, kubeadmconstants.APIServerKeyName,
+				kubeadmconstants.APIServerKubeletClientCertName, kubeadmconstants.APIServerKubeletClientKeyName,
 				kubeadmconstants.ServiceAccountPrivateKeyName, kubeadmconstants.ServiceAccountPublicKeyName,
 				kubeadmconstants.FrontProxyCACertName, kubeadmconstants.FrontProxyCAKeyName,
 				kubeadmconstants.FrontProxyClientCertName, kubeadmconstants.FrontProxyClientKeyName,
@@ -681,6 +694,10 @@ func TestCreateCertificateFilesMethods(t *testing.T) {
 			Networking:      kubeadmapi.Networking{ServiceSubnet: "10.96.0.0/12", DNSDomain: "cluster.local"},
 			NodeName:        "valid-hostname",
 			CertificatesDir: tmpdir,
+		}
+
+		if test.externalEtcd {
+			cfg.Etcd.Endpoints = []string{"192.168.1.1:2379"}
 		}
 
 		// executes setup func (if necessary)


### PR DESCRIPTION
Cherry pick of #63806 on release-1.10.

#63806: kubeadm - do not generate etcd ca/certs for external etcd