### PR TITLE
Update dashboard OWNERS

### DIFF
--- a/cluster/addons/dashboard/OWNERS
+++ b/cluster/addons/dashboard/OWNERS
@@ -1,6 +1,12 @@
 approvers:
-- floreks
-- maciaszczykm
+- bryk
 reviewers:
+- cheld
+- cupofcat
+- danielromlein
 - floreks
+- ianlewis
+- konryd
 - maciaszczykm
+- mhenc
+- rf232


### PR DESCRIPTION
Update dashboard OWNERS based on @maciaszczykm 's comment: https://github.com/kubernetes/kubernetes/pull/62756#issuecomment-391453524

I pulled the list of reviewers from the @kubernetes/dashboard-maintainers list.

```release-note
NONE
```