### PR TITLE
update cadvisor godeps to v0.28.4 to fix container start times

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1382,218 +1382,218 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.28.3",
-			"Rev": "1e567c2ac359c3ed1303e0c80b6cf08edefc841d"
+			"Comment": "v0.28.4",
+			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -391,6 +391,7 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	}
 	spec.Envs = self.envs
 	spec.Image = self.image
+	spec.CreationTime = self.creationTime
 
 	return spec, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/issues/59524 describes why incorrect start times can affect HPA (in addition to just being incorrect).
This makes cadvisor use the start time returned by docker, rather than based on observing modification timestamps for cgroup files.

**Release note**:
```release-note
Fix container StartTime in the kubelet's stats/summary endpoint
```
