### PR TITLE
Update function hasClusterTag to fix issue #64230

### DIFF
--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -137,7 +137,7 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 	clusterTagKey := t.clusterTagKey()
 	for _, tag := range tags {
 		tagKey := aws.StringValue(tag.Key)
-                // Check if this is a newer-style cluster tag before checking if legacy tag value matches ClusterID
+		// Check if this is a newer-style cluster tag before checking if legacy tag value matches ClusterID
 		if tagKey == clusterTagKey {
 			return true
 		}

--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -137,13 +137,13 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 	clusterTagKey := t.clusterTagKey()
 	for _, tag := range tags {
 		tagKey := aws.StringValue(tag.Key)
-		// Check if this is a newer-style cluster tag before checking if legacy tag value matches ClusterID
-		if tagKey == clusterTagKey {
+		// For 1.6, we continue to recognize the legacy tags, for the 1.5 -> 1.6 upgrade
+		// Note that we want to continue traversing tag list if we see a legacy tag with value != ClusterID
+		if (tagKey == TagNameKubernetesClusterLegacy) && (aws.StringValue(tag.Value) == t.ClusterID) {
 			return true
 		}
-		// For 1.6, we continue to recognize the legacy tags, for the 1.5 -> 1.6 upgrade
-		if tagKey == TagNameKubernetesClusterLegacy {
-			return aws.StringValue(tag.Value) == t.ClusterID
+		if tagKey == clusterTagKey {
+			return true
 		}
 	}
 	return false

--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -137,13 +137,13 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 	clusterTagKey := t.clusterTagKey()
 	for _, tag := range tags {
 		tagKey := aws.StringValue(tag.Key)
+                // Check if this is a newer-style cluster tag before checking if legacy tag value matches ClusterID
+		if tagKey == clusterTagKey {
+			return true
+		}
 		// For 1.6, we continue to recognize the legacy tags, for the 1.5 -> 1.6 upgrade
 		if tagKey == TagNameKubernetesClusterLegacy {
 			return aws.StringValue(tag.Value) == t.ClusterID
-		}
-
-		if tagKey == clusterTagKey {
-			return true
 		}
 	}
 	return false


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue #64230, by changing function hasClusterTag, in aws/tags.go, to ensure that, when called with a list of tags containing a tag with a key which matches clusterTagKey, function will return true even if a tag with key TagNameKubernetesClusterLegacy also exists in the list with a value other than the ClusterID.

**Which issue(s) this PR fixes**:
Fixes #64230

**Special notes for your reviewer**:
Notes are in issue

**Release note**:
```release-note
NONE
```
