### PR TITLE
Refactor common parts of NOP CRD Converter to prepare for future converters

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/converter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -33,35 +34,121 @@ func NewCRDConverter(crd *apiextensions.CustomResourceDefinition) (safe, unsafe 
 
 	// The only converter right now is nopConverter. More converters will be returned based on the
 	// CRD object when they introduced.
-	unsafe = &nopConverter{
+	converter := &nopConverter{}
+
+	unsafe = &crdConverter{
 		clusterScoped: crd.Spec.Scope == apiextensions.ClusterScoped,
 		validVersions: validVersions,
+		converter:     converter,
+		safeConverter: false,
 	}
-	return &safeConverterWrapper{unsafe}, unsafe
+	safe = &crdConverter{
+		clusterScoped: crd.Spec.Scope == apiextensions.ClusterScoped,
+		validVersions: validVersions,
+		converter:     converter,
+		safeConverter: true,
+	}
+	return safe, unsafe
 }
 
-// safeConverterWrapper is a wrapper over an unsafe object converter that makes copy of the input and then delegate to the unsafe converter.
-type safeConverterWrapper struct {
-	unsafe runtime.ObjectConvertor
+// crdConverterInterface is the interface all CRD converters must implement.
+type crdConverterInterface interface {
+	// ConvertCustomResource converts obj to given version in place. The listHandled return value is optimization
+	// for converters that want to convert the whole UnstructuredList including its items (e.g. webhooks).
+	ConvertCustomResource(obj runtime.Unstructured, target runtime.GroupVersioner) (listHandled bool, err error)
 }
 
-var _ runtime.ObjectConvertor = &nopConverter{}
-
-// ConvertFieldLabel delegate the call to the unsafe converter.
-func (c *safeConverterWrapper) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
-	return c.unsafe.ConvertFieldLabel(version, kind, label, value)
+// crdConverter is an implementation of common converter functionalities for CRDs. It calls into
+// the converter interface for actual conversion.
+type crdConverter struct {
+	clusterScoped bool
+	// validVersions is list of valid versions for this CRD. both in and out objects will be validated toward this list first.
+	validVersions map[schema.GroupVersion]bool
+	// converter is the actual converter that converts an object in place to the given version.
+	converter crdConverterInterface
+	// safeConverter is the flag to set this converter to safe or unsafe one. If true, no input to the converter would be mutated.
+	safeConverter bool
 }
 
-// Convert makes a copy of in object and then delegate the call to the unsafe converter.
-func (c *safeConverterWrapper) Convert(in, out, context interface{}) error {
-	inObject, ok := in.(runtime.Object)
+var _ runtime.ObjectConvertor = &crdConverter{}
+
+func (c *crdConverter) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
+	// We currently only support metadata.namespace and metadata.name.
+	switch {
+	case label == "metadata.name":
+		return label, value, nil
+	case !c.clusterScoped && label == "metadata.namespace":
+		return label, value, nil
+	default:
+		return "", "", fmt.Errorf("field label not supported: %s", label)
+	}
+}
+
+func (c *crdConverter) Convert(in, out, context interface{}) error {
+	unstructIn, ok := in.(runtime.Unstructured)
 	if !ok {
-		return fmt.Errorf("input type %T in not valid for object conversion", in)
+		return fmt.Errorf("input type %T in not valid for unstructured conversion", in)
 	}
-	return c.unsafe.Convert(inObject.DeepCopyObject(), out, context)
+
+	unstructOut, ok := out.(runtime.Unstructured)
+	if !ok {
+		return fmt.Errorf("output type %T in not valid for unstructured conversion", out)
+	}
+
+	outGVK := unstructOut.GetObjectKind().GroupVersionKind()
+	if !c.validVersions[outGVK.GroupVersion()] {
+		return fmt.Errorf("request to convert CRD from an invalid group/version: %s", outGVK.String())
+	}
+	inGVK := unstructIn.GetObjectKind().GroupVersionKind()
+	if !c.validVersions[inGVK.GroupVersion()] {
+		return fmt.Errorf("request to convert CRD to an invalid group/version: %s", inGVK.String())
+	}
+
+	unstructOut.SetUnstructuredContent(unstructIn.UnstructuredContent())
+	_, err := c.ConvertToVersion(unstructOut, outGVK.GroupVersion())
+	return err
 }
 
-// ConvertToVersion makes a copy of in object and then delegate the call to the unsafe converter.
-func (c *safeConverterWrapper) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
-	return c.unsafe.ConvertToVersion(in.DeepCopyObject(), target)
+// ConvertToVersion converts in object to the given gvk in place and returns the same `in` object.
+func (c *crdConverter) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
+	var err error
+	if c.safeConverter {
+		in = in.DeepCopyObject()
+	}
+	listHandled, err := c.validateAndConvert(in, target)
+	if err != nil {
+		return nil, err
+	}
+	if listHandled {
+		return in, nil
+	}
+
+	// Run the converter on the list items instead of list itself
+	if list, ok := in.(*unstructured.UnstructuredList); ok {
+		err = list.EachListItem(func(item runtime.Object) error {
+			_, err := c.validateAndConvert(item, target)
+			return err
+		})
+	}
+	return in, nil
+}
+
+func (c *crdConverter) validateAndConvert(obj runtime.Object, target runtime.GroupVersioner) (bool, error) {
+	sourceKind := obj.GetObjectKind().GroupVersionKind()
+	if !c.validVersions[sourceKind.GroupVersion()] {
+		return false, fmt.Errorf("request to convert CRD to an invalid group/version: %s", sourceKind.String())
+	}
+	targetKind, ok := target.KindForGroupVersionKinds([]schema.GroupVersionKind{sourceKind})
+	if !ok {
+		return false, fmt.Errorf("%v is not suitable for converting to %q", sourceKind, target)
+	}
+	if targetKind == sourceKind {
+		// No need for conversion. Source and Target are the same GVK.
+		return false, nil
+	}
+	unstructObj, ok := obj.(runtime.Unstructured)
+	if !ok {
+		return false, fmt.Errorf("input type %T in not valid for unstructured conversion", obj)
+	}
+	return c.converter.ConvertCustomResource(unstructObj, target)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
@@ -19,82 +19,23 @@ package conversion
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // nopConverter is a converter that only sets the apiVersion fields, but does not real conversion. It supports fields selectors.
 type nopConverter struct {
-	clusterScoped bool
-	validVersions map[schema.GroupVersion]bool
 }
 
-var _ runtime.ObjectConvertor = &nopConverter{}
+var _ crdConverterInterface = &nopConverter{}
 
-func (c *nopConverter) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
-	// We currently only support metadata.namespace and metadata.name.
-	switch {
-	case label == "metadata.name":
-		return label, value, nil
-	case !c.clusterScoped && label == "metadata.namespace":
-		return label, value, nil
-	default:
-		return "", "", fmt.Errorf("field label not supported: %s", label)
-	}
-}
-
-func (c *nopConverter) Convert(in, out, context interface{}) error {
-	unstructIn, ok := in.(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("input type %T in not valid for unstructured conversion", in)
-	}
-
-	unstructOut, ok := out.(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("output type %T in not valid for unstructured conversion", out)
-	}
-
-	outGVK := unstructOut.GroupVersionKind()
-	if !c.validVersions[outGVK.GroupVersion()] {
-		return fmt.Errorf("request to convert CRD from an invalid group/version: %s", outGVK.String())
-	}
-	inGVK := unstructIn.GroupVersionKind()
-	if !c.validVersions[inGVK.GroupVersion()] {
-		return fmt.Errorf("request to convert CRD to an invalid group/version: %s", inGVK.String())
-	}
-
-	unstructOut.SetUnstructuredContent(unstructIn.UnstructuredContent())
-	_, err := c.ConvertToVersion(unstructOut, outGVK.GroupVersion())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *nopConverter) convertToVersion(in runtime.Object, target runtime.GroupVersioner) error {
-	kind := in.GetObjectKind().GroupVersionKind()
+func (c *nopConverter) ConvertCustomResource(obj runtime.Unstructured, target runtime.GroupVersioner) (bool, error) {
+	kind := obj.GetObjectKind().GroupVersionKind()
 	gvk, ok := target.KindForGroupVersionKinds([]schema.GroupVersionKind{kind})
 	if !ok {
 		// TODO: should this be a typed error?
-		return fmt.Errorf("%v is unstructured and is not suitable for converting to %q", kind, target)
+		return false, fmt.Errorf("%v is unstructured and is not suitable for converting to %q", kind, target)
 	}
-	if !c.validVersions[gvk.GroupVersion()] {
-		return fmt.Errorf("request to convert CRD to an invalid group/version: %s", gvk.String())
-	}
-	in.GetObjectKind().SetGroupVersionKind(gvk)
-	return nil
-}
-
-// ConvertToVersion converts in object to the given gvk in place and returns the same `in` object.
-func (c *nopConverter) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
-	var err error
-	// Run the converter on the list items instead of list itself
-	if list, ok := in.(*unstructured.UnstructuredList); ok {
-		err = list.EachListItem(func(item runtime.Object) error {
-			return c.convertToVersion(item, target)
-		})
-	}
-	err = c.convertToVersion(in, target)
-	return in, err
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+	return false, nil
 }


### PR DESCRIPTION
- Added a common crdConverter which holds common logic between all converters
- Added a safe flag to crdConverter to get rid of `safeConverterWrapper`
- Use an interface between crdConverter and all converters (here is only nopConverter) that is customized/optimized for CRDs

ref: #64136 
similar to #64208

```release-note
None
```