### PR TITLE
Mark conformance test as not flaky

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -46,13 +46,12 @@ var _ = SIGDescribe("Pods Extended", func() {
 		BeforeEach(func() {
 			podClient = f.PodClient()
 		})
-		// Flaky issue #36821.
 		/*
 			Release : v1.9
 			Testname: Pods, delete grace period
 			Description: Create a pod, make sure it is running, create a watch to observe Pod creation. Create a 'kubectl local proxy', capture the port the proxy is listening. Using the http client send a ‘delete’ with gracePeriodSeconds=30. Pod SHOULD get deleted within 30 seconds.
 		*/
-		framework.ConformanceIt("should be submitted and removed  [Flaky]", func() {
+		framework.ConformanceIt("should be submitted and removed ", func() {
 			By("creating the pod")
 			name := "pod-submit-remove-" + string(uuid.NewUUID())
 			value := strconv.Itoa(time.Now().Nanosecond())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

At one point there was a bug that this test was flaky and hence
the tag was added. The problem does not seem to have reappeared, so
let's drop the tag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Please see discussion on https://github.com/kubernetes/kubernetes/issues/36821 and https://github.com/kubernetes/kubernetes/issues/62161#issuecomment-380277665 
If this test is still flaky then we should remove this from conformance suite

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
