### PR TITLE
Automated cherry pick of #64098: Fix running e2e tests with completed kube-system pods

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -679,10 +679,8 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 			case res && err == nil:
 				nOk++
 			case pod.Status.Phase == v1.PodSucceeded:
-				Logf("The status of Pod %s is Succeeded which is unexpected", pod.ObjectMeta.Name)
-				badPods = append(badPods, pod)
-				// it doesn't make sense to wait for this pod
-				return false, errors.New("unexpected Succeeded pod state")
+				// pod status is succeeded, it doesn't make sense to wait for this pod
+				continue
 			case pod.Status.Phase != v1.PodFailed:
 				Logf("The status of Pod %s is %s (Ready = false), waiting for it to be either Running (with Ready = true) or Failed", pod.ObjectMeta.Name, pod.Status.Phase)
 				notReady++

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -679,7 +679,8 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 			case res && err == nil:
 				nOk++
 			case pod.Status.Phase == v1.PodSucceeded:
-				// pod status is succeeded, it doesn't make sense to wait for this pod
+				Logf("The status of Pod %s is Succeeded, skipping waiting", pod.ObjectMeta.Name)
+				// it doesn't make sense to wait for this pod
 				continue
 			case pod.Status.Phase != v1.PodFailed:
 				Logf("The status of Pod %s is %s (Ready = false), waiting for it to be either Running (with Ready = true) or Failed", pod.ObjectMeta.Name, pod.Status.Phase)


### PR DESCRIPTION
Cherry pick of #64098 on release-1.10.

#64098: Fix running e2e tests with completed kube-system pods

```release-note
NONE
```