### PR TITLE
Detach volume when node become NotReady

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -635,6 +635,7 @@ func (os *OpenStack) DiskIsAttachedByName(nodeName types.NodeName, volumeID stri
 	if ind := strings.LastIndex(instanceID, "/"); ind >= 0 {
 		instanceID = instanceID[(ind + 1):]
 	}
+
 	attached, err := os.DiskIsAttached(instanceID, volumeID)
 	return attached, instanceID, err
 }
@@ -675,6 +676,24 @@ func (os *OpenStack) DisksAreAttachedByName(nodeName types.NodeName, volumeIDs [
 	if ind := strings.LastIndex(instanceID, "/"); ind >= 0 {
 		instanceID = instanceID[(ind + 1):]
 	}
+
+	// if instance's status is not 'ACTIVE'(node is NotReady, for example 'SHUTOFF'), we should detach the volume
+	// from instance and allow the volume is attached to other instance.
+	if srv.Status != "ACTIVE" {
+		for _, volumeID := range volumeIDs {
+			attached, _ := os.DiskIsAttached(instanceID, volumeID)
+			if attached == true {
+				detachErr := os.DetachDisk(instanceID, volumeID)
+				if detachErr != nil {
+					msg := fmt.Sprintf("the status of instance %s is %s, try to detach volume %s, but get error: %v",
+						instanceID, srv.Status, volumeID, detachErr)
+					glog.Error(msg)
+					// do not return, need check volume again
+				}
+			}
+		}
+	}
+
 	return os.DisksAreAttached(instanceID, volumeIDs)
 }
 


### PR DESCRIPTION
Fix #53059
Currently if node's status become 'NotReady'(for example node is
'SHUTOFF'), kubernetes reschedules the pod automatically, but the
pod's volume has not been detached at cinder side. We should
detach the volume from instance and allow the volume is attached
to other instance.

**Release note**:
```release-note
NONE
```

/assign @dims 
/assign @zetaab 