### PR TITLE
apimachinery: remove unused UnstructuredObjectConverter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -18,7 +18,6 @@ package unstructured
 
 import (
 	gojson "encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -449,45 +448,4 @@ func (c JSONFallbackEncoder) Encode(obj runtime.Object, w io.Writer) error {
 		}
 	}
 	return err
-}
-
-// UnstructuredObjectConverter is an ObjectConverter for use with
-// Unstructured objects. Since it has no schema or type information,
-// it will only succeed for no-op conversions. This is provided as a
-// sane implementation for APIs that require an object converter.
-type UnstructuredObjectConverter struct{}
-
-func (UnstructuredObjectConverter) Convert(in, out, context interface{}) error {
-	unstructIn, ok := in.(*Unstructured)
-	if !ok {
-		return fmt.Errorf("input type %T in not valid for unstructured conversion", in)
-	}
-
-	unstructOut, ok := out.(*Unstructured)
-	if !ok {
-		return fmt.Errorf("output type %T in not valid for unstructured conversion", out)
-	}
-
-	// maybe deep copy the map? It is documented in the
-	// ObjectConverter interface that this function is not
-	// guaranteed to not mutate the input. Or maybe set the input
-	// object to nil.
-	unstructOut.Object = unstructIn.Object
-	return nil
-}
-
-func (UnstructuredObjectConverter) ConvertToVersion(in runtime.Object, target runtime.GroupVersioner) (runtime.Object, error) {
-	if kind := in.GetObjectKind().GroupVersionKind(); !kind.Empty() {
-		gvk, ok := target.KindForGroupVersionKinds([]schema.GroupVersionKind{kind})
-		if !ok {
-			// TODO: should this be a typed error?
-			return nil, fmt.Errorf("%v is unstructured and is not suitable for converting to %q", kind, target)
-		}
-		in.GetObjectKind().SetGroupVersionKind(gvk)
-	}
-	return in, nil
-}
-
-func (UnstructuredObjectConverter) ConvertFieldLabel(version, kind, label, value string) (string, string, error) {
-	return "", "", errors.New("unstructured cannot convert field labels")
 }


### PR DESCRIPTION
This is not in apiextensions-apiserver for CR conversion.