### PR TITLE
replace `__internal` with runtime.APIVersionInternal

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -122,7 +122,7 @@ func (s *Scheme) nameFunc(t reflect.Type) string {
 
 	for _, gvk := range gvks {
 		internalGV := gvk.GroupVersion()
-		internalGV.Version = "__internal" // this is hacky and maybe should be passed in
+		internalGV.Version = APIVersionInternal // this is hacky and maybe should be passed in
 		internalGVK := internalGV.WithKind(gvk.Kind)
 
 		if internalType, exists := s.gvkToType[internalGVK]; exists {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -129,25 +129,25 @@ func TestDecode(t *testing.T) {
 	}{
 		{
 			serializer:  &mockSerializer{actual: gvk1},
-			convertor:   &checkConvertor{groupVersion: schema.GroupVersion{Group: "other", Version: "__internal"}},
+			convertor:   &checkConvertor{groupVersion: schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal}},
 			expectedGVK: gvk1,
-			decodes:     schema.GroupVersion{Group: "other", Version: "__internal"},
+			decodes:     schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal},
 		},
 		{
 			serializer:  &mockSerializer{actual: gvk1, obj: decodable1},
-			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "other", Version: "__internal"}},
+			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal}},
 			expectedGVK: gvk1,
 			sameObject:  decodable2,
-			decodes:     schema.GroupVersion{Group: "other", Version: "__internal"},
+			decodes:     schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal},
 		},
 		// defaultGVK.Group is allowed to force a conversion to the destination group
 		{
 			serializer:  &mockSerializer{actual: gvk1, obj: decodable1},
 			defaultGVK:  &schema.GroupVersionKind{Group: "force"},
-			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "force", Version: "__internal"}},
+			convertor:   &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "force", Version: runtime.APIVersionInternal}},
 			expectedGVK: gvk1,
 			sameObject:  decodable2,
-			decodes:     schema.GroupVersion{Group: "force", Version: "__internal"},
+			decodes:     schema.GroupVersion{Group: "force", Version: runtime.APIVersionInternal},
 		},
 		// uses direct conversion for into when objects differ
 		{
@@ -184,10 +184,10 @@ func TestDecode(t *testing.T) {
 			into: &runtime.VersionedObjects{Objects: []runtime.Object{}},
 
 			serializer:     &mockSerializer{actual: gvk1, obj: decodable1},
-			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "other", Version: "__internal"}},
+			convertor:      &checkConvertor{in: decodable1, obj: decodable2, groupVersion: schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal}},
 			expectedGVK:    gvk1,
 			expectedObject: &runtime.VersionedObjects{Objects: []runtime.Object{decodable1, decodable2}},
-			decodes:        schema.GroupVersion{Group: "other", Version: "__internal"},
+			decodes:        schema.GroupVersion{Group: "other", Version: runtime.APIVersionInternal},
 		},
 
 		// decode into the same version as the serialized object


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace `__internal` with runtime.APIVersionInternal

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
