### PR TITLE
Measure scheduler throughput in density test

### DIFF
--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -655,6 +655,7 @@ type RCStartupStatus struct {
 	RunningButNotReady    int
 	Waiting               int
 	Pending               int
+	Scheduled             int
 	Unknown               int
 	Inactive              int
 	FailedContainers      int
@@ -707,6 +708,10 @@ func ComputeRCStartupStatus(pods []*v1.Pod, expected int) RCStartupStatus {
 			startupStatus.Inactive++
 		} else if p.Status.Phase == v1.PodUnknown {
 			startupStatus.Unknown++
+		}
+		// Record count of scheduled pods (useful for computing scheduler throughput).
+		if p.Spec.NodeName != "" {
+			startupStatus.Scheduled++
 		}
 	}
 	return startupStatus


### PR DESCRIPTION
This is a step towards exposing scheduler-related metrics on [perf-dash](http://perf-dash.k8s.io/).
This particular PR adds scheduler throughput computation and makes the results available in our test artifacts.
So if you do some experiments, you'll have some historical baseline data to compare against.

xref https://github.com/kubernetes/kubernetes/issues/63493

fyi - @wojtek-t @davidopp @bsalamat @misterikkit 
cc @kubernetes/sig-scheduling-misc @kubernetes/sig-scalability-misc 

```release-note
NONE
```