### PR TITLE
UX improvement for preflight check for external etcd client certificates

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -892,13 +892,13 @@ func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.MasterConfi
 	if cfg.Etcd.External != nil {
 		// Only check etcd version when external endpoints are specified
 		if cfg.Etcd.External.CAFile != "" {
-			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.CAFile})
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.CAFile, Label: "ExternalEtcdClientCertificates"})
 		}
 		if cfg.Etcd.External.CertFile != "" {
-			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.CertFile})
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.CertFile, Label: "ExternalEtcdClientCertificates"})
 		}
 		if cfg.Etcd.External.KeyFile != "" {
-			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.KeyFile})
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.External.KeyFile, Label: "ExternalEtcdClientCertificates"})
 		}
 		checks = append(checks, ExternalEtcdVersionCheck{Etcd: cfg.Etcd})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
UX improvement for preflight check for external etcd client certificates

By using same preflight check label for all etcd client certificates, it will
allow user to use single identifier, and as result shorter command line
arguments to kubeadm, in case multiple issues found with those files.

Fixes: 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#834

**Special notes for your reviewer**:

**Release note**:
```release-note
Label ExternalEtcdClientCertificates can be used for ignoring all preflight check issues related to client certificate files for external etcd.
```
