### PR TITLE
Adding tests for ImageLocalityPriority

### DIFF
--- a/pkg/scheduler/algorithm/priorities/image_locality.go
+++ b/pkg/scheduler/algorithm/priorities/image_locality.go
@@ -72,7 +72,7 @@ func calculateScoreFromSize(sumSize int64) int {
 func totalImageSize(nodeInfo *schedulercache.NodeInfo, containers []v1.Container) int64 {
 	var total int64
 
-	imageSizes := nodeInfo.Images()
+	imageSizes := nodeInfo.ImageSizes()
 	for _, container := range containers {
 		if size, ok := imageSizes[container.Image]; ok {
 			total += size

--- a/pkg/scheduler/schedulercache/node_info.go
+++ b/pkg/scheduler/schedulercache/node_info.go
@@ -293,8 +293,8 @@ func (n *NodeInfo) UsedPorts() util.HostPortInfo {
 	return n.usedPorts
 }
 
-// Images returns the image size information on this node.
-func (n *NodeInfo) Images() map[string]int64 {
+// ImageSizes returns the image size information on this node.
+func (n *NodeInfo) ImageSizes() map[string]int64 {
 	if n == nil {
 		return nil
 	}

--- a/pkg/scheduler/schedulercache/node_info_test.go
+++ b/pkg/scheduler/schedulercache/node_info_test.go
@@ -235,6 +235,46 @@ func TestSetMaxResource(t *testing.T) {
 	}
 }
 
+func TestImageSizes(t *testing.T) {
+	ni := fakeNodeInfo()
+	ni.node = &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: v1.NodeStatus{
+			Images: []v1.ContainerImage{
+				{
+					Names: []string{
+						"gcr.io/10",
+						"gcr.io/10:v1",
+					},
+					SizeBytes: int64(10 * 1024 * 1024),
+				},
+				{
+					Names: []string{
+						"gcr.io/50",
+						"gcr.io/50:v1",
+					},
+					SizeBytes: int64(50 * 1024 * 1024),
+				},
+			},
+		},
+	}
+
+	ni.updateImageSizes()
+	expected := map[string]int64{
+		"gcr.io/10":    10 * 1024 * 1024,
+		"gcr.io/10:v1": 10 * 1024 * 1024,
+		"gcr.io/50":    50 * 1024 * 1024,
+		"gcr.io/50:v1": 50 * 1024 * 1024,
+	}
+
+	imageSizes := ni.ImageSizes()
+	if !reflect.DeepEqual(expected, imageSizes) {
+		t.Errorf("expected: %#v, got: %#v", expected, imageSizes)
+	}
+}
+
 func TestNewNodeInfo(t *testing.T) {
 	nodeName := "test-node"
 	pods := []*v1.Pod{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds tests for ImageLocalityPriority scheduling policy, as follow-ups of [#63842](https://github.com/kubernetes/kubernetes/issues/63842) and [#63345](https://github.com/kubernetes/kubernetes/issues/63345). It includes the unit test for ImageSizes function of NodeInfo in the scheduler cache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

@resouer 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
