### PR TITLE
Use default seccomp profile for istio addons

### DIFF
--- a/cluster/addons/istio/auth/istio-auth.yaml
+++ b/cluster/addons/istio/auth/istio-auth.yaml
@@ -296,6 +296,7 @@ spec:
         istio: mixer
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-mixer-service-account
       containers:
@@ -1615,6 +1616,7 @@ spec:
         istio: pilot
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-pilot-service-account
       containers:
@@ -1718,6 +1720,7 @@ spec:
         istio: ingress
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-ingress-service-account
       containers:
@@ -1810,6 +1813,7 @@ spec:
         istio: istio-ca
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-ca-service-account
       containers:
@@ -1858,6 +1862,7 @@ spec:
         app: grafana
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: grafana
       containers:
@@ -2115,6 +2120,7 @@ spec:
         app: prometheus
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: prometheus
       containers:
@@ -2199,6 +2205,7 @@ spec:
         app: servicegraph
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: servicegraph
@@ -2241,6 +2248,7 @@ spec:
         app: zipkin
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: zipkin

--- a/cluster/addons/istio/noauth/istio.yaml
+++ b/cluster/addons/istio/noauth/istio.yaml
@@ -296,6 +296,7 @@ spec:
         istio: mixer
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-mixer-service-account
       containers:
@@ -1615,6 +1616,7 @@ spec:
         istio: pilot
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-pilot-service-account
       containers:
@@ -1718,6 +1720,7 @@ spec:
         istio: ingress
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-ingress-service-account
       containers:
@@ -1810,6 +1813,7 @@ spec:
         istio: istio-ca
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: istio-ca-service-account
       containers:
@@ -1858,6 +1862,7 @@ spec:
         app: grafana
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: grafana
       containers:
@@ -2115,6 +2120,7 @@ spec:
         app: prometheus
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       serviceAccountName: prometheus
       containers:
@@ -2199,6 +2205,7 @@ spec:
         app: servicegraph
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: servicegraph
@@ -2241,6 +2248,7 @@ spec:
         app: zipkin
       annotations:
         sidecar.istio.io/inject: "false"
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       containers:
       - name: zipkin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR sets the default seccomp profile of istio addons to 'docker/default'. This PR is a followup of #62662. We are using 'docker/default' instead of 'runtime/default' in addons in order to handle node version skew. When seccomp profile is applied automatically by default later, we can remove those annotations.

This is PR is part of #39845.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
