### PR TITLE
Update nvidia-gpu-device-plugin to apps/v1 and use RollingUpdate updateStrategy.

### DIFF
--- a/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+++ b/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-gpu-device-plugin
@@ -7,6 +7,9 @@ metadata:
     k8s-app: nvidia-gpu-device-plugin
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      k8s-app: nvidia-gpu-device-plugin
   template:
     metadata:
       labels:
@@ -52,3 +55,5 @@ spec:
           mountPath: /device-plugin
         - name: dev
           mountPath: /dev
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
Even though RollingUpdate is the default updateStrategy, we need to
specify it explicitly here because otherwise updating from
extensions/v1beta1 to apps/v1 doesn't change the updateStrategy.

Related to #57125 and #63634

```release-note
Update nvidia-gpu-device-plugin DaemonSet config to use RollingUpdate updateStrategy instead of OnDelete.
```

/assign @vishh @jiayingz 
/cc @janetkuo 