### PR TITLE
quota: allow ignored resources to be customized 

### DIFF
--- a/cmd/controller-manager/app/options/resourcequotacontroller.go
+++ b/cmd/controller-manager/app/options/resourcequotacontroller.go
@@ -26,6 +26,7 @@ import (
 type ResourceQuotaControllerOptions struct {
 	ResourceQuotaSyncPeriod      metav1.Duration
 	ConcurrentResourceQuotaSyncs int32
+	RQIgnoredResources           []componentconfig.GroupResource
 }
 
 // AddFlags adds flags related to ResourceQuotaController for controller manager to the specified FlagSet.
@@ -46,6 +47,7 @@ func (o *ResourceQuotaControllerOptions) ApplyTo(cfg *componentconfig.ResourceQu
 
 	cfg.ResourceQuotaSyncPeriod = o.ResourceQuotaSyncPeriod
 	cfg.ConcurrentResourceQuotaSyncs = o.ConcurrentResourceQuotaSyncs
+	cfg.RQIgnoredResources = o.RQIgnoredResources
 
 	return nil
 }

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/controller/garbagecollector:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/master/ports:go_default_library",
+        "//pkg/quota/install:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -42,6 +42,7 @@ import (
 	componentconfigv1alpha1 "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector"
 	"k8s.io/kubernetes/pkg/master/ports"
+	quotainstall "k8s.io/kubernetes/pkg/quota/install"
 	// add the kubernetes feature gates
 	_ "k8s.io/kubernetes/pkg/features"
 
@@ -186,12 +187,19 @@ func NewKubeControllerManagerOptions() *KubeControllerManagerOptions {
 	// TODO: enable HTTPS by default
 	s.SecureServing.BindPort = 0
 
-	gcIgnoredResources := make([]componentconfig.GroupResource, 0, len(garbagecollector.DefaultIgnoredResources()))
-	for r := range garbagecollector.DefaultIgnoredResources() {
+	gcDefaultIgnoredResources := garbagecollector.DefaultIgnoredResources()
+	gcIgnoredResources := make([]componentconfig.GroupResource, 0, len(gcDefaultIgnoredResources))
+	for r := range gcDefaultIgnoredResources {
 		gcIgnoredResources = append(gcIgnoredResources, componentconfig.GroupResource{Group: r.Group, Resource: r.Resource})
 	}
-
 	s.GarbageCollectorController.GCIgnoredResources = gcIgnoredResources
+
+	rqDefaultIgnoredResources := quotainstall.DefaultIgnoredResources()
+	rqIgnoredResources := make([]componentconfig.GroupResource, 0, len(rqDefaultIgnoredResources))
+	for r := range rqDefaultIgnoredResources {
+		rqIgnoredResources = append(rqIgnoredResources, componentconfig.GroupResource{Group: r.Group, Resource: r.Resource})
+	}
+	s.ResourceQuotaController.RQIgnoredResources = rqIgnoredResources
 
 	return &s
 }

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -503,6 +503,8 @@ type ResourceQuotaControllerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive quota
 	// management, but more CPU (and network) load.
 	ConcurrentResourceQuotaSyncs int32
+	// RQIgnoredResources is the list of GroupResources that the resource quota controller should ignore.
+	RQIgnoredResources []GroupResource
 }
 
 type SAControllerConfiguration struct {

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -546,6 +546,8 @@ type ResourceQuotaControllerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive quota
 	// management, but more CPU (and network) load.
 	ConcurrentResourceQuotaSyncs int32 `json:"concurrentResourceQuotaSyncs"`
+	// RQIgnoredResources is the list of GroupResources that the resource quota controller should ignore.
+	RQIgnoredResources []GroupResource `json:"rQIgnoredResources"`
 }
 
 type SAControllerConfiguration struct {

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -1025,6 +1025,7 @@ func Convert_componentconfig_ReplicationControllerConfiguration_To_v1alpha1_Repl
 func autoConvert_v1alpha1_ResourceQuotaControllerConfiguration_To_componentconfig_ResourceQuotaControllerConfiguration(in *ResourceQuotaControllerConfiguration, out *componentconfig.ResourceQuotaControllerConfiguration, s conversion.Scope) error {
 	out.ResourceQuotaSyncPeriod = in.ResourceQuotaSyncPeriod
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.RQIgnoredResources = *(*[]componentconfig.GroupResource)(unsafe.Pointer(&in.RQIgnoredResources))
 	return nil
 }
 
@@ -1036,6 +1037,7 @@ func Convert_v1alpha1_ResourceQuotaControllerConfiguration_To_componentconfig_Re
 func autoConvert_componentconfig_ResourceQuotaControllerConfiguration_To_v1alpha1_ResourceQuotaControllerConfiguration(in *componentconfig.ResourceQuotaControllerConfiguration, out *ResourceQuotaControllerConfiguration, s conversion.Scope) error {
 	out.ResourceQuotaSyncPeriod = in.ResourceQuotaSyncPeriod
 	out.ConcurrentResourceQuotaSyncs = in.ConcurrentResourceQuotaSyncs
+	out.RQIgnoredResources = *(*[]GroupResource)(unsafe.Pointer(&in.RQIgnoredResources))
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -363,7 +363,7 @@ func (in *KubeControllerManagerConfiguration) DeepCopyInto(out *KubeControllerMa
 	out.PodGCController = in.PodGCController
 	out.ReplicaSetController = in.ReplicaSetController
 	out.ReplicationController = in.ReplicationController
-	out.ResourceQuotaController = in.ResourceQuotaController
+	in.ResourceQuotaController.DeepCopyInto(&out.ResourceQuotaController)
 	out.SAController = in.SAController
 	out.ServiceController = in.ServiceController
 	if in.Controllers != nil {
@@ -612,6 +612,11 @@ func (in *ReplicationControllerConfiguration) DeepCopy() *ReplicationControllerC
 func (in *ResourceQuotaControllerConfiguration) DeepCopyInto(out *ResourceQuotaControllerConfiguration) {
 	*out = *in
 	out.ResourceQuotaSyncPeriod = in.ResourceQuotaSyncPeriod
+	if in.RQIgnoredResources != nil {
+		in, out := &in.RQIgnoredResources, &out.RQIgnoredResources
+		*out = make([]GroupResource, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -386,7 +386,7 @@ func (in *KubeControllerManagerConfiguration) DeepCopyInto(out *KubeControllerMa
 	out.PodGCController = in.PodGCController
 	out.ReplicaSetController = in.ReplicaSetController
 	out.ReplicationController = in.ReplicationController
-	out.ResourceQuotaController = in.ResourceQuotaController
+	in.ResourceQuotaController.DeepCopyInto(&out.ResourceQuotaController)
 	out.SAController = in.SAController
 	out.ServiceController = in.ServiceController
 	if in.Controllers != nil {
@@ -642,6 +642,11 @@ func (in *ReplicationControllerConfiguration) DeepCopy() *ReplicationControllerC
 func (in *ResourceQuotaControllerConfiguration) DeepCopyInto(out *ResourceQuotaControllerConfiguration) {
 	*out = *in
 	out.ResourceQuotaSyncPeriod = in.ResourceQuotaSyncPeriod
+	if in.RQIgnoredResources != nil {
+		in, out := &in.RQIgnoredResources, &out.RQIgnoredResources
+		*out = make([]GroupResource, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -70,8 +70,8 @@ type ResourceQuotaControllerOptions struct {
 	Registry quota.Registry
 	// Discover list of supported resources on the server.
 	DiscoveryFunc NamespacedResourcesFunc
-	// A function that returns the list of resources to ignore
-	IgnoredResourcesFunc func() map[schema.GroupResource]struct{}
+	// A list of resources to ignore
+	IgnoredResources map[schema.GroupResource]struct{}
 	// InformersStarted knows if informers were started.
 	InformersStarted <-chan struct{}
 	// InformerFactory interfaces with informers.
@@ -152,7 +152,7 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) (*Resou
 		qm := &QuotaMonitor{
 			informersStarted:  options.InformersStarted,
 			informerFactory:   options.InformerFactory,
-			ignoredResources:  options.IgnoredResourcesFunc(),
+			ignoredResources:  options.IgnoredResources,
 			resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
 			resyncPeriod:      options.ReplenishmentResyncPeriod,
 			replenishmentFunc: rq.replenishQuota,

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -93,7 +93,7 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 		ResourceQuotaInformer:     informerFactory.Core().V1().ResourceQuotas(),
 		ResyncPeriod:              controller.NoResyncPeriodFunc,
 		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
-		IgnoredResourcesFunc:      quotaConfiguration.IgnoredResources,
+		IgnoredResources:          install.DefaultIgnoredResources(),
 		DiscoveryFunc:             mockDiscoveryFunc,
 		Registry:                  generic.NewRegistry(quotaConfiguration.Evaluators()),
 		InformersStarted:          alwaysStarted,

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -110,7 +110,7 @@ func TestQuota(t *testing.T) {
 		InformerFactory:           informers,
 		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
 		DiscoveryFunc:             discoveryFunc,
-		IgnoredResourcesFunc:      qc.IgnoredResources,
+		IgnoredResources:          quotainstall.DefaultIgnoredResources(),
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}
@@ -305,7 +305,7 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 		InformerFactory:           informers,
 		ReplenishmentResyncPeriod: controller.NoResyncPeriodFunc,
 		DiscoveryFunc:             discoveryFunc,
-		IgnoredResourcesFunc:      qc.IgnoredResources,
+		IgnoredResources:          quotainstall.DefaultIgnoredResources(),
 		InformersStarted:          informersStarted,
 		Registry:                  generic.NewRegistry(qc.Evaluators()),
 	}


### PR DESCRIPTION
Allows the list of resources the resource quota controller should ignore to be customizable, so downstream integrators can add their own resources to the list, if necessary.

Fixes https://github.com/kubernetes/kubernetes/pull/64201#discussion_r190562580

Builds on top of https://github.com/kubernetes/kubernetes/pull/64201

/cc sttts deads2k derekwaynecarr
/assign deads2k 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resources to be ignored by the resource quota controller can now be customized.
```
