### PR TITLE
fix parsing 'crictl pods -q' output

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -215,7 +215,7 @@ func resetWithCrictl(execer utilsexec.Interface, dockerCheck preflight.Checker, 
 			resetWithDocker(execer, dockerCheck)
 			return
 		}
-		sandboxes := strings.Split(string(output), " ")
+		sandboxes := strings.Fields(string(output))
 		glog.V(1).Infoln("[reset] Stopping and removing running containers using crictl")
 		for _, s := range sandboxes {
 			if strings.TrimSpace(s) == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix parsing 'crictl pods -q' output
Output of crictl pods -q is a list of running pod ids, one id per line.
Current code splits this output incorrectly which makes next command
'crictl stopp' fail if there is more than one pod running.

Should be fixed by using strings.Fields instead of strings.Split.

**Release note**:
```release-note
NONE
```
