### PR TITLE
use CRICheck in "kubeadm reset"

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -247,6 +247,23 @@ func newFakeDockerChecker(warnings, errors []error) preflight.Checker {
 	return &fakeDockerChecker{warnings: warnings, errors: errors}
 }
 
+type fakeCRIChecker struct {
+	warnings []error
+	errors   []error
+}
+
+func (c *fakeCRIChecker) Check() (warnings, errors []error) {
+	return c.warnings, c.errors
+}
+
+func (c *fakeCRIChecker) Name() string {
+	return "FakeCRI"
+}
+
+func newFakeCRIChecker(warnings, errors []error) preflight.Checker {
+	return &fakeCRIChecker{warnings: warnings, errors: errors}
+}
+
 func TestResetWithDocker(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
 		RunScript: []fakeexec.FakeRunAction{
@@ -309,7 +326,7 @@ func TestResetWithCrictl(t *testing.T) {
 	}
 
 	// 1: socket path not provided, running with docker
-	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "", "crictl")
+	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), newFakeCRIChecker(nil, nil), "", "crictl")
 	if fcmd.RunCalls != 1 {
 		t.Errorf("expected 1 call to Run, got %d", fcmd.RunCalls)
 	}
@@ -318,7 +335,7 @@ func TestResetWithCrictl(t *testing.T) {
 	}
 
 	// 2: socket path provided, now running with crictl (1x CombinedOutput, 2x Run)
-	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "/test.sock", "crictl")
+	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), newFakeCRIChecker(nil, nil), "/test.sock", "crictl")
 	if fcmd.RunCalls != 3 {
 		t.Errorf("expected 3 calls to Run, got %d", fcmd.RunCalls)
 	}
@@ -330,7 +347,7 @@ func TestResetWithCrictl(t *testing.T) {
 	}
 
 	// 3: socket path provided, crictl fails, reset with docker
-	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "/test.sock", "crictl")
+	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), newFakeCRIChecker(nil, nil), "/test.sock", "crictl")
 	if fcmd.RunCalls != 4 {
 		t.Errorf("expected 4 calls to Run, got %d", fcmd.RunCalls)
 	}
@@ -339,7 +356,7 @@ func TestResetWithCrictl(t *testing.T) {
 	}
 
 	// 4: running with no socket and docker fails (1x Run)
-	resetWithCrictl(&fexec, newFakeDockerChecker(nil, []error{errors.New("test error")}), "", "crictl")
+	resetWithCrictl(&fexec, newFakeDockerChecker(nil, []error{errors.New("test error")}), newFakeCRIChecker(nil, nil), "", "crictl")
 	if fcmd.RunCalls != 4 {
 		t.Errorf("expected 4 calls to Run, got %d", fcmd.RunCalls)
 	}
@@ -370,7 +387,7 @@ func TestReset(t *testing.T) {
 		LookPathFunc: func(cmd string) (string, error) { return cmd, nil },
 	}
 
-	reset(&fexec, newFakeDockerChecker(nil, nil), "/test.sock")
+	reset(&fexec, newFakeDockerChecker(nil, nil), newFakeCRIChecker(nil, nil), "/test.sock")
 	if fcmd.RunCalls != 2 {
 		t.Errorf("expected 2 call to Run, got %d", fcmd.RunCalls)
 	}
@@ -379,7 +396,7 @@ func TestReset(t *testing.T) {
 	}
 
 	fexec.LookPathFunc = func(cmd string) (string, error) { return "", errors.New("no crictl") }
-	reset(&fexec, newFakeDockerChecker(nil, nil), "/test.sock")
+	reset(&fexec, newFakeDockerChecker(nil, nil), newFakeCRIChecker(nil, nil), "/test.sock")
 	if fcmd.RunCalls != 3 {
 		t.Errorf("expected 3 calls to Run, got %d", fcmd.RunCalls)
 	}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -89,8 +89,8 @@ type Checker interface {
 
 // CRICheck verifies the container runtime through the CRI.
 type CRICheck struct {
-	socket string
-	exec   utilsexec.Interface
+	Socket string
+	Exec   utilsexec.Interface
 }
 
 // Name returns label for CRICheck.
@@ -101,13 +101,13 @@ func (CRICheck) Name() string {
 // Check validates the container runtime through the CRI.
 func (criCheck CRICheck) Check() (warnings, errors []error) {
 	glog.V(1).Infoln("validating the container runtime through the CRI")
-	crictlPath, err := criCheck.exec.LookPath("crictl")
+	crictlPath, err := criCheck.Exec.LookPath("crictl")
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to find command crictl: %s", err))
 		return warnings, errors
 	}
-	if err := criCheck.exec.Command(crictlPath, "-r", criCheck.socket, "info").Run(); err != nil {
-		errors = append(errors, fmt.Errorf("unable to check if the container runtime at %q is running: %s", criCheck.socket, err))
+	if err := criCheck.Exec.Command(crictlPath, "-r", criCheck.Socket, "info").Run(); err != nil {
+		errors = append(errors, fmt.Errorf("unable to check if the container runtime at %q is running: %s", criCheck.Socket, err))
 		return warnings, errors
 	}
 	return warnings, errors
@@ -970,7 +970,7 @@ func addCommonChecks(execer utilsexec.Interface, cfg kubeadmapi.CommonConfigurat
 
 	// Check whether or not the CRI socket defined is the default
 	if cfg.GetCRISocket() != kubeadmdefaults.DefaultCRISocket {
-		checks = append(checks, CRICheck{socket: cfg.GetCRISocket(), exec: execer})
+		checks = append(checks, CRICheck{Socket: cfg.GetCRISocket(), Exec: execer})
 	} else {
 		checks = append(checks, ServiceCheck{Service: "docker", CheckIfActive: true})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

"kubeadm reset" tries to use CRI if it finds crictl in PATH

It's better to use the same approach as in preflight checks:
use CRICheck only if cri socket is provided by user.

**Release note**:
```release-note
NONE
```
