### PR TITLE
Save kubeadm manifest backup directories

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -53,6 +53,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/upgrade:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -17,8 +17,13 @@ limitations under the License.
 package upgrade
 
 import (
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestSetImplicitFlags(t *testing.T) {
@@ -144,4 +149,91 @@ func TestSetImplicitFlags(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestGetPathManagerForUpgrade(t *testing.T) {
+
+	haEtcd := &kubeadmapi.MasterConfiguration{
+		Etcd: kubeadmapi.Etcd{
+			External: &kubeadmapi.ExternalEtcd{
+				Endpoints: []string{"10.100.0.1:2379", "10.100.0.2:2379", "10.100.0.3:2379"},
+			},
+		},
+	}
+
+	noHAEtcd := &kubeadmapi.MasterConfiguration{}
+
+	tests := []struct {
+		name             string
+		cfg              *kubeadmapi.MasterConfiguration
+		etcdUpgrade      bool
+		shouldDeleteEtcd bool
+	}{
+		{
+			name:             "ha etcd but no etcd upgrade",
+			cfg:              haEtcd,
+			etcdUpgrade:      false,
+			shouldDeleteEtcd: true,
+		},
+		{
+			name:             "non-ha etcd with etcd upgrade",
+			cfg:              noHAEtcd,
+			etcdUpgrade:      true,
+			shouldDeleteEtcd: false,
+		},
+		{
+			name:             "ha etcd and etcd upgrade",
+			cfg:              haEtcd,
+			etcdUpgrade:      true,
+			shouldDeleteEtcd: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Use a temporary directory
+			tmpdir, err := ioutil.TempDir("", "TestGetPathManagerForUpgrade")
+			if err != nil {
+				t.Fatalf("unexpected error making temporary directory: %v", err)
+			}
+			oldK8sDir := constants.KubernetesDir
+			constants.KubernetesDir = tmpdir
+			defer func() {
+				constants.KubernetesDir = oldK8sDir
+				os.RemoveAll(tmpdir)
+			}()
+
+			pathmgr, err := GetPathManagerForUpgrade(test.cfg, test.etcdUpgrade)
+			if err != nil {
+				t.Fatalf("unexpected error creating path manager: %v", err)
+			}
+
+			if _, err := os.Stat(pathmgr.BackupManifestDir()); os.IsNotExist(err) {
+				t.Errorf("expected manifest dir %s to exist, but it did not (%v)", pathmgr.BackupManifestDir(), err)
+			}
+
+			if _, err := os.Stat(pathmgr.BackupEtcdDir()); os.IsNotExist(err) {
+				t.Errorf("expected etcd dir %s to exist, but it did not (%v)", pathmgr.BackupEtcdDir(), err)
+			}
+
+			if err := pathmgr.CleanupDirs(); err != nil {
+				t.Fatalf("unexpected error cleaning up directories: %v", err)
+			}
+
+			if _, err := os.Stat(pathmgr.BackupManifestDir()); os.IsNotExist(err) {
+				t.Errorf("expected manifest dir %s to exist, but it did not (%v)", pathmgr.BackupManifestDir(), err)
+			}
+
+			if test.shouldDeleteEtcd {
+				if _, err := os.Stat(pathmgr.BackupEtcdDir()); !os.IsNotExist(err) {
+					t.Errorf("expected etcd dir %s not to exist, but it did (%v)", pathmgr.BackupEtcdDir(), err)
+				}
+			} else {
+				if _, err := os.Stat(pathmgr.BackupEtcdDir()); os.IsNotExist(err) {
+					t.Errorf("expected etcd dir %s to exist, but it did not", pathmgr.BackupEtcdDir())
+				}
+			}
+		})
+	}
+
 }

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -203,6 +203,19 @@ func (spm *fakeStaticPodPathManager) BackupEtcdDir() string {
 	return spm.backupEtcdDir
 }
 
+func (spm *fakeStaticPodPathManager) CleanupDirs() error {
+	if err := os.RemoveAll(spm.TempManifestDir()); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(spm.BackupManifestDir()); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(spm.BackupEtcdDir()); err != nil {
+		return err
+	}
+	return nil
+}
+
 type fakeTLSEtcdClient struct{ TLS bool }
 
 func (c fakeTLSEtcdClient) HasTLS() bool {
@@ -512,4 +525,82 @@ func getConfig(version, certsDir, etcdDataDir string) (*kubeadmapi.MasterConfigu
 	}
 	kubeadmscheme.Scheme.Convert(externalcfg, internalcfg, nil)
 	return internalcfg, nil
+}
+
+func getTempDir(t *testing.T, name string) (string, func()) {
+	dir, err := ioutil.TempDir(os.TempDir(), name)
+	if err != nil {
+		t.Fatalf("couldn't make temporary directory: %v", err)
+	}
+
+	return dir, func() {
+		os.RemoveAll(dir)
+	}
+}
+
+func TestCleanupDirs(t *testing.T) {
+	tests := []struct {
+		name                   string
+		keepManifest, keepEtcd bool
+	}{
+		{
+			name:         "save manifest backup",
+			keepManifest: true,
+		},
+		{
+			name:         "save both etcd and manifest",
+			keepManifest: true,
+			keepEtcd:     true,
+		},
+		{
+			name: "save nothing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			realManifestDir, cleanup := getTempDir(t, "realManifestDir")
+			defer cleanup()
+
+			tempManifestDir, cleanup := getTempDir(t, "tempManifestDir")
+			defer cleanup()
+
+			backupManifestDir, cleanup := getTempDir(t, "backupManifestDir")
+			defer cleanup()
+
+			backupEtcdDir, cleanup := getTempDir(t, "backupEtcdDir")
+			defer cleanup()
+
+			mgr := NewKubeStaticPodPathManager(realManifestDir, tempManifestDir, backupManifestDir, backupEtcdDir, test.keepManifest, test.keepEtcd)
+			err := mgr.CleanupDirs()
+			if err != nil {
+				t.Errorf("unexpected error cleaning up: %v", err)
+			}
+
+			if _, err := os.Stat(tempManifestDir); !os.IsNotExist(err) {
+				t.Errorf("%q should not have existed", tempManifestDir)
+			}
+			_, err = os.Stat(backupManifestDir)
+			if test.keepManifest {
+				if err != nil {
+					t.Errorf("unexpected error getting backup manifest dir")
+				}
+			} else {
+				if !os.IsNotExist(err) {
+					t.Error("expected backup manifest to not exist")
+				}
+			}
+
+			_, err = os.Stat(backupEtcdDir)
+			if test.keepEtcd {
+				if err != nil {
+					t.Errorf("unexpected error getting backup etcd dir")
+				}
+			} else {
+				if !os.IsNotExist(err) {
+					t.Error("expected backup etcd dir to not exist")
+				}
+			}
+		})
+	}
 }

--- a/cmd/kubeadm/app/util/etcd/BUILD
+++ b/cmd/kubeadm/app/util/etcd/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/staticpod:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
@@ -17,7 +18,10 @@ go_test(
     name = "go_default_test",
     srcs = ["etcd_test.go"],
     embed = [":go_default_library"],
-    deps = ["//cmd/kubeadm/test:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/test:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
@@ -215,4 +216,9 @@ func (c Client) WaitForClusterAvailable(delay time.Duration, retries int, retryI
 		return resp, nil
 	}
 	return false, fmt.Errorf("timeout waiting for etcd cluster to be available")
+}
+
+// CheckConfigurationIsHA returns true if the given MasterConfiguration etcd block appears to be an HA configuration.
+func CheckConfigurationIsHA(cfg *kubeadmapi.Etcd) bool {
+	return cfg.External != nil && len(cfg.External.Endpoints) > 1
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubeadm will now preserves previous manifests after `kubeadm upgrade apply`. Previously these files would be deleted after the upgrade succeeded

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [kubeadm/489](https://github.com/kubernetes/kubeadm/issues/489)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm now preserves previous manifests after upgrades
```
