### PR TITLE
Remove some unnecessarily gendered pronouns in comments

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -156,7 +156,7 @@ func (r *Reset) Run(out io.Writer) error {
 	dirsToClean := []string{"/var/lib/kubelet", "/etc/cni/net.d", "/var/lib/dockershim", "/var/run/kubernetes"}
 
 	// Only clear etcd data when the etcd manifest is found. In case it is not found, we must assume that the user
-	// provided external etcd endpoints. In that case, it is his own responsibility to reset etcd
+	// provided external etcd endpoints. In that case, it is their own responsibility to reset etcd
 	etcdManifestPath := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName, "etcd.yaml")
 	glog.V(1).Infof("[reset] checking for etcd manifest")
 	if _, err := os.Stat(etcdManifestPath); err == nil {

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -56,7 +56,7 @@ func init() {
 	// For example:
 	// https://github.com/kubernetes/kubernetes/blob/36a218e/plugin/pkg/scheduler/factory/factory.go#L422
 
-	// Registers predicates and priorities that are not enabled by default, but user can pick when creating his
+	// Registers predicates and priorities that are not enabled by default, but user can pick when creating their
 	// own set of priorities/predicates.
 
 	// PodFitsPorts has been replaced by PodFitsHostPorts for better user understanding.

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -135,7 +135,7 @@ func (f *FakeExtender) ProcessPreemption(
 	nodeToVictimsCopy := map[*v1.Node]*schedulerapi.Victims{}
 	// We don't want to change the original nodeToVictims
 	for k, v := range nodeToVictims {
-		// In real world implementation, extender's user should have his own way to get node object
+		// In real world implementation, extender's user should have their own way to get node object
 		// by name if needed (e.g. query kube-apiserver etc).
 		//
 		// For test purpose, we just use node from parameters directly.

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -167,7 +167,7 @@ func WithMaxInFlightLimit(
 					metrics.DroppedRequests.WithLabelValues(metrics.ReadOnlyKind).Inc()
 				}
 				// at this point we're about to return a 429, BUT not all actors should be rate limited.  A system:master is so powerful
-				// that he should always get an answer.  It's a super-admin or a loopback connection.
+				// that they should always get an answer.  It's a super-admin or a loopback connection.
 				if currUser, ok := apirequest.UserFrom(ctx); ok {
 					for _, group := range currUser.GetGroups() {
 						if group == user.SystemPrivilegedGroup {


### PR DESCRIPTION
**What this PR does / why we need it**:

A bunch of comments are unnecessarily gendered. I've changed them to gender-neutral they/theirs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
