### PR TITLE
Teach Kubelet about Pod Ready++

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -261,9 +261,18 @@ func GetPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (i
 	if status == nil {
 		return -1, nil
 	}
-	for i := range status.Conditions {
-		if status.Conditions[i].Type == conditionType {
-			return i, &status.Conditions[i]
+	return GetPodConditionFromList(status.Conditions, conditionType)
+}
+
+// GetPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func GetPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
 		}
 	}
 	return -1, nil

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2042,10 +2042,17 @@ func (kl *Kubelet) HandlePodRemoves(pods []*v1.Pod) {
 // HandlePodReconcile is the callback in the SyncHandler interface for pods
 // that should be reconciled.
 func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
+	start := kl.clock.Now()
 	for _, pod := range pods {
 		// Update the pod in pod manager, status manager will do periodically reconcile according
 		// to the pod manager.
 		kl.podManager.UpdatePod(pod)
+
+		// Reconcile Pod "Ready" condition if necessary. Trigger sync pod for reconciliation.
+		if status.NeedToReconcilePodReadiness(pod) {
+			mirrorPod, _ := kl.podManager.GetMirrorPodByPod(pod)
+			kl.dispatchWork(pod, kubetypes.SyncPodSync, mirrorPod, start)
+		}
 
 		// After an evicted pod is synced, all dead containers in the pod can be removed.
 		if eviction.PodIsEvicted(pod.Status) {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1354,7 +1354,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	}
 	kl.probeManager.UpdatePodStatus(pod.UID, s)
 	s.Conditions = append(s.Conditions, status.GeneratePodInitializedCondition(spec, s.InitContainerStatuses, s.Phase))
-	s.Conditions = append(s.Conditions, status.GeneratePodReadyCondition(spec, s.ContainerStatuses, s.Phase))
+	s.Conditions = append(s.Conditions, status.GeneratePodReadyCondition(spec, s.Conditions, s.ContainerStatuses, s.Phase))
 	// Status manager will take care of the LastTransitionTimestamp, either preserve
 	// the timestamp from apiserver, or set a new one. When kubelet sees the pod,
 	// `PodScheduled` condition must be true.
@@ -1407,6 +1407,12 @@ func (kl *Kubelet) convertStatusToAPIStatus(pod *v1.Pod, podStatus *kubecontaine
 		true,
 	)
 
+	// Preserves conditions not controlled by kubelet
+	for _, c := range pod.Status.Conditions {
+		if !kubetypes.PodConditionByKubelet(c.Type) {
+			apiPodStatus.Conditions = append(apiPodStatus.Conditions, c)
+		}
+	}
 	return &apiPodStatus
 }
 

--- a/pkg/kubelet/status/generate_test.go
+++ b/pkg/kubelet/status/generate_test.go
@@ -27,21 +27,24 @@ import (
 func TestGeneratePodReadyCondition(t *testing.T) {
 	tests := []struct {
 		spec              *v1.PodSpec
+		conditions        []v1.PodCondition
 		containerStatuses []v1.ContainerStatus
 		podPhase          v1.PodPhase
-		expected          v1.PodCondition
+		expectReady       v1.PodCondition
 	}{
 		{
 			spec:              nil,
+			conditions:        nil,
 			containerStatuses: nil,
 			podPhase:          v1.PodRunning,
-			expected:          getReadyCondition(false, UnknownContainerStatuses, ""),
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, UnknownContainerStatuses, ""),
 		},
 		{
 			spec:              &v1.PodSpec{},
+			conditions:        nil,
 			containerStatuses: []v1.ContainerStatus{},
 			podPhase:          v1.PodRunning,
-			expected:          getReadyCondition(true, "", ""),
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionTrue, "", ""),
 		},
 		{
 			spec: &v1.PodSpec{
@@ -49,9 +52,10 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 					{Name: "1234"},
 				},
 			},
+			conditions:        nil,
 			containerStatuses: []v1.ContainerStatus{},
 			podPhase:          v1.PodRunning,
-			expected:          getReadyCondition(false, ContainersNotReady, "containers with unknown status: [1234]"),
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ContainersNotReady, "containers with unknown status: [1234]"),
 		},
 		{
 			spec: &v1.PodSpec{
@@ -60,12 +64,13 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 					{Name: "5678"},
 				},
 			},
+			conditions: nil,
 			containerStatuses: []v1.ContainerStatus{
 				getReadyStatus("1234"),
 				getReadyStatus("5678"),
 			},
-			podPhase: v1.PodRunning,
-			expected: getReadyCondition(true, "", ""),
+			podPhase:    v1.PodRunning,
+			expectReady: getPodCondition(v1.PodReady, v1.ConditionTrue, "", ""),
 		},
 		{
 			spec: &v1.PodSpec{
@@ -74,11 +79,12 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 					{Name: "5678"},
 				},
 			},
+			conditions: nil,
 			containerStatuses: []v1.ContainerStatus{
 				getReadyStatus("1234"),
 			},
-			podPhase: v1.PodRunning,
-			expected: getReadyCondition(false, ContainersNotReady, "containers with unknown status: [5678]"),
+			podPhase:    v1.PodRunning,
+			expectReady: getPodCondition(v1.PodReady, v1.ConditionFalse, ContainersNotReady, "containers with unknown status: [5678]"),
 		},
 		{
 			spec: &v1.PodSpec{
@@ -87,12 +93,13 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 					{Name: "5678"},
 				},
 			},
+			conditions: nil,
 			containerStatuses: []v1.ContainerStatus{
 				getReadyStatus("1234"),
 				getNotReadyStatus("5678"),
 			},
-			podPhase: v1.PodRunning,
-			expected: getReadyCondition(false, ContainersNotReady, "containers with unready status: [5678]"),
+			podPhase:    v1.PodRunning,
+			expectReady: getPodCondition(v1.PodReady, v1.ConditionFalse, ContainersNotReady, "containers with unready status: [5678]"),
 		},
 		{
 			spec: &v1.PodSpec{
@@ -100,18 +107,116 @@ func TestGeneratePodReadyCondition(t *testing.T) {
 					{Name: "1234"},
 				},
 			},
+			conditions: nil,
 			containerStatuses: []v1.ContainerStatus{
 				getNotReadyStatus("1234"),
 			},
-			podPhase: v1.PodSucceeded,
-			expected: getReadyCondition(false, PodCompleted, ""),
+			podPhase:    v1.PodSucceeded,
+			expectReady: getPodCondition(v1.PodReady, v1.ConditionFalse, PodCompleted, ""),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+				},
+			},
+			conditions:        nil,
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ReadinessGatesNotReady, `corresponding condition of pod readiness gate "gate1" does not exist.`),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionFalse, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ReadinessGatesNotReady, `the status of pod readiness gate "gate1" is not "True", but False`),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionTrue, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionTrue, "", ""),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+					{ConditionType: v1.PodConditionType("gate2")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionTrue, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ReadinessGatesNotReady, `corresponding condition of pod readiness gate "gate2" does not exist.`),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+					{ConditionType: v1.PodConditionType("gate2")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionTrue, "", ""),
+				getPodCondition("gate2", v1.ConditionFalse, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ReadinessGatesNotReady, `the status of pod readiness gate "gate2" is not "True", but False`),
+		},
+		{
+			spec: &v1.PodSpec{
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+					{ConditionType: v1.PodConditionType("gate2")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionTrue, "", ""),
+				getPodCondition("gate2", v1.ConditionTrue, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionTrue, "", ""),
+		},
+		{
+			spec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "1234"},
+				},
+				ReadinessGates: []v1.PodReadinessGate{
+					{ConditionType: v1.PodConditionType("gate1")},
+				},
+			},
+			conditions: []v1.PodCondition{
+				getPodCondition("gate1", v1.ConditionTrue, "", ""),
+			},
+			containerStatuses: []v1.ContainerStatus{getNotReadyStatus("1234")},
+			podPhase:          v1.PodRunning,
+			expectReady:       getPodCondition(v1.PodReady, v1.ConditionFalse, ContainersNotReady, "containers with unready status: [1234]"),
 		},
 	}
 
 	for i, test := range tests {
-		condition := GeneratePodReadyCondition(test.spec, test.containerStatuses, test.podPhase)
-		if !reflect.DeepEqual(condition, test.expected) {
-			t.Errorf("On test case %v, expected:\n%+v\ngot\n%+v\n", i, test.expected, condition)
+		ready := GeneratePodReadyCondition(test.spec, test.conditions, test.containerStatuses, test.podPhase)
+		if !reflect.DeepEqual(ready, test.expectReady) {
+			t.Errorf("On test case %v, expectReady:\n%+v\ngot\n%+v\n", i, test.expectReady, ready)
 		}
 	}
 }
@@ -220,13 +325,9 @@ func TestGeneratePodInitializedCondition(t *testing.T) {
 	}
 }
 
-func getReadyCondition(ready bool, reason, message string) v1.PodCondition {
-	status := v1.ConditionFalse
-	if ready {
-		status = v1.ConditionTrue
-	}
+func getPodCondition(conditionType v1.PodConditionType, status v1.ConditionStatus, reason, message string) v1.PodCondition {
 	return v1.PodCondition{
-		Type:    v1.PodReady,
+		Type:    conditionType,
 		Status:  status,
 		Reason:  reason,
 		Message: message,


### PR DESCRIPTION
Follow up PR of https://github.com/kubernetes/kubernetes/pull/62306 and https://github.com/kubernetes/kubernetes/pull/64057, **Only the last 3 commits are new.** Will rebase once the previous ones are merged.

ref: https://github.com/kubernetes/community/blob/master/keps/sig-network/0007-pod-ready%2B%2B.md


kind/feature
priority/important-soon
sig/network
sig/node

/assign @yujuhong


```release-note
NONE
```