### PR TITLE
Deprecate the in-tree keystone plugin

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
@@ -140,6 +140,7 @@ func newOpenstackAuthProvider(_ string, config map[string]string, persister rest
 	var ttlDuration time.Duration
 	var err error
 
+	glog.Warningf("WARNING: in-tree openstack auth plugin is now deprecated. please use the \"client-keystone-auth\" kubectl/client-go credential plugin instead")
 	ttl, found := config["ttl"]
 	if !found {
 		ttlDuration = DefaultTTLDuration


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We now have the `client-keystone-auth` in cloud-provider-openstack
repository:
https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-client-keystone-auth.md

So let's drop the in-tree one, so we can remove it in 1.12


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
in-tree support for openstack credentials is now deprecated. please use the "client-keystone-auth" from the cloud-provider-openstack repository. details on how to use this new capability is documented here - https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/using-client-keystone-auth.md
```
