### PR TITLE
kubeadm: conditionally set the kubelet cgroup driver for Docker

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -20,12 +20,14 @@ go_library(
         "//pkg/kubelet/apis/kubeletconfig/scheme:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1beta1:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "arguments.go",
+        "cgroupdriver.go",
         "copy.go",
         "endpoint.go",
         "error.go",
@@ -29,6 +30,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 
@@ -36,6 +38,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "arguments_test.go",
+        "cgroupdriver_test.go",
         "endpoint_test.go",
         "error_test.go",
         "marshal_test.go",

--- a/cmd/kubeadm/app/util/cgroupdriver.go
+++ b/cmd/kubeadm/app/util/cgroupdriver.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	utilsexec "k8s.io/utils/exec"
+)
+
+// TODO: add support for detecting the cgroup driver for CRI other than
+// Docker. Currently only Docker driver detection is supported:
+// Discussion:
+//     https://github.com/kubernetes/kubeadm/issues/844
+
+// GetCgroupDriverDocker runs 'docker info' to obtain the docker cgroup driver
+func GetCgroupDriverDocker(execer utilsexec.Interface) (string, error) {
+	info, err := callDockerInfo(execer)
+	if err != nil {
+		return "", err
+	}
+	return getCgroupDriverFromDockerInfo(info)
+}
+
+func validateCgroupDriver(driver string) error {
+	if driver != "cgroupfs" && driver != "systemd" {
+		return fmt.Errorf("unknown cgroup driver %q", driver)
+	}
+	return nil
+}
+
+// TODO: Docker 1.13 has a new way to obatain the cgroup driver:
+//     docker info -f "{{.CgroupDriver}}
+// If the minimum supported Docker version in K8s becomes 1.13, move to
+// this syntax.
+func callDockerInfo(execer utilsexec.Interface) (string, error) {
+	out, err := execer.Command("docker", "info").Output()
+	if err != nil {
+		return "", fmt.Errorf("cannot execute 'docker info': %v", err)
+	}
+	return string(out), nil
+}
+
+func getCgroupDriverFromDockerInfo(info string) (string, error) {
+	lineSeparator := ": "
+	prefix := "Cgroup Driver"
+	for _, line := range strings.Split(info, "\n") {
+		if !strings.Contains(line, prefix+lineSeparator) {
+			continue
+		}
+		lineSplit := strings.Split(line, lineSeparator)
+		// At this point len(lineSplit) is always >= 2
+		driver := lineSplit[1]
+		if err := validateCgroupDriver(driver); err != nil {
+			return "", err
+		}
+		return driver, nil
+	}
+	return "", fmt.Errorf("cgroup driver is not defined in 'docker info'")
+}

--- a/cmd/kubeadm/app/util/cgroupdriver_test.go
+++ b/cmd/kubeadm/app/util/cgroupdriver_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestGetCgroupDriverDocker(t *testing.T) {
+	testCases := []struct {
+		name          string
+		info          string
+		expectedError bool
+	}{
+		{
+			name:          "valid: value is 'cgroupfs'",
+			info:          `Cgroup Driver: cgroupfs`,
+			expectedError: false,
+		},
+		{
+			name:          "valid: value is 'systemd'",
+			info:          `Cgroup Driver: systemd`,
+			expectedError: false,
+		},
+		{
+			name:          "invalid: missing 'Cgroup Driver' key and value",
+			info:          "",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: only a 'Cgroup Driver' key is present",
+			info:          `Cgroup Driver`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid: empty 'Cgroup Driver' value",
+			info:          `Cgroup Driver: `,
+			expectedError: true,
+		},
+		{
+			name:          "invalid: unknown 'Cgroup Driver' value",
+			info:          `Cgroup Driver: invalid-value`,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := getCgroupDriverFromDockerInfo(tc.info); (err != nil) != tc.expectedError {
+				t.Fatalf("expected error: %v, saw: %v, error: %v", tc.expectedError, (err != nil), err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new utility file - util/cgroupdriver.go.
Currently it only contains the public function GetCgroupDriverDocker().
The function uses 'docker info' to obtain the cgroup driver
for Docker.

On a later stage this file can contain more methods for different
CRI.

Use GetCgroupDriverDocker() in phases/kubelet/flags.go
to conditionally set the 'cgroup-driver' argument. On error
print a warning and don't set the argument value.

Add unit tests in cgroupdriver_test.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#844

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: conditionally set the kubelet cgroup driver for Docker
```

/area kubeadm
/kind enhancement
@kubernetes/sig-cluster-lifecycle-pr-reviews 
@luxas
