### PR TITLE
E2E tests of cluster autoscaler with different gpu types

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -250,7 +250,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
 
 			By("Scale GPU deployment")
-			framework.ScaleRC(f.ClientSet, f.ScalesGetter, f.Namespace.Name, "gpu-pod-rc", 2, false)
+			framework.ScaleRC(f.ClientSet, f.ScalesGetter, f.Namespace.Name, "gpu-pod-rc", 2, true)
 
 			framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
 				func(size int) bool { return size == nodeCount+2 }, scaleUpTimeout))

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -207,101 +207,106 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 	It("should increase cluster size if pending pods are small [Feature:ClusterSizeAutoscalingScaleUp]",
 		func() { simpleScaleUpTest(0) })
 
-	It("Should scale up GPU pool from 0 [Feature:ClusterSizeAutoscalingGpu]", func() {
-		framework.SkipUnlessProviderIs("gke")
+	supportedGpuTypes := []string{"nvidia-tesla-k80", "nvidia-tesla-v100", "nvidia-tesla-p100"}
+	for _, gpuType := range supportedGpuTypes {
 
-		const gpuPoolName = "gpu-pool"
-		addGpuNodePool(gpuPoolName, "nvidia-tesla-k80", 1, 0)
-		defer deleteNodePool(gpuPoolName)
+		It(fmt.Sprintf("Should scale up GPU pool from 0 [GpuType:%s] [Feature:ClusterSizeAutoscalingGpu]", gpuType), func() {
+			framework.SkipUnlessProviderIs("gke")
 
-		installNvidiaDriversDaemonSet()
+			const gpuPoolName = "gpu-pool"
+			addGpuNodePool(gpuPoolName, gpuType, 1, 0)
+			defer deleteNodePool(gpuPoolName)
 
-		By("Enable autoscaler")
-		framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
-		defer disableAutoscaler(gpuPoolName, 0, 1)
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
+			installNvidiaDriversDaemonSet()
 
-		By("Schedule a pod which requires GPU")
-		framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
+			By("Enable autoscaler")
+			framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
+			defer disableAutoscaler(gpuPoolName, 0, 1)
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
 
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
-			func(size int) bool { return size == nodeCount+1 }, scaleUpTimeout))
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
-	})
+			By("Schedule a pod which requires GPU")
+			framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
 
-	It("Should scale up GPU pool from 1 [Feature:ClusterSizeAutoscalingGpu]", func() {
-		framework.SkipUnlessProviderIs("gke")
+			framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+				func(size int) bool { return size == nodeCount+1 }, scaleUpTimeout))
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
+		})
 
-		const gpuPoolName = "gpu-pool"
-		addGpuNodePool(gpuPoolName, "nvidia-tesla-k80", 1, 1)
-		defer deleteNodePool(gpuPoolName)
+		It(fmt.Sprintf("Should scale up GPU pool from 1 [GpuType:%s] [Feature:ClusterSizeAutoscalingGpu]", gpuType), func() {
+			framework.SkipUnlessProviderIs("gke")
 
-		installNvidiaDriversDaemonSet()
+			const gpuPoolName = "gpu-pool"
+			addGpuNodePool(gpuPoolName, gpuType, 1, 1)
+			defer deleteNodePool(gpuPoolName)
 
-		By("Schedule a single pod which requires GPU")
-		framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
+			installNvidiaDriversDaemonSet()
 
-		By("Enable autoscaler")
-		framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 2))
-		defer disableAutoscaler(gpuPoolName, 0, 2)
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
+			By("Schedule a single pod which requires GPU")
+			framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
 
-		framework.ScaleRC(f.ClientSet, f.ScalesGetter, f.Namespace.Name, "gpu-pod-rc", 2, false)
+			By("Enable autoscaler")
+			framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 2))
+			defer disableAutoscaler(gpuPoolName, 0, 2)
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
 
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
-			func(size int) bool { return size == nodeCount+2 }, scaleUpTimeout))
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(2))
-	})
+			By("Scale GPU deployment")
+			framework.ScaleRC(f.ClientSet, f.ScalesGetter, f.Namespace.Name, "gpu-pod-rc", 2, false)
 
-	It("Should not scale GPU pool up if pod does not require GPUs [Feature:ClusterSizeAutoscalingGpu]", func() {
-		framework.SkipUnlessProviderIs("gke")
+			framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+				func(size int) bool { return size == nodeCount+2 }, scaleUpTimeout))
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(2))
+		})
 
-		const gpuPoolName = "gpu-pool"
-		addGpuNodePool(gpuPoolName, "nvidia-tesla-k80", 1, 0)
-		defer deleteNodePool(gpuPoolName)
+		It(fmt.Sprintf("Should not scale GPU pool up if pod does not require GPUs [GpuType:%s] [Feature:ClusterSizeAutoscalingGpu]", gpuType), func() {
+			framework.SkipUnlessProviderIs("gke")
 
-		installNvidiaDriversDaemonSet()
+			const gpuPoolName = "gpu-pool"
+			addGpuNodePool(gpuPoolName, gpuType, 1, 0)
+			defer deleteNodePool(gpuPoolName)
 
-		By("Enable autoscaler")
-		framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
-		defer disableAutoscaler(gpuPoolName, 0, 1)
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
+			installNvidiaDriversDaemonSet()
 
-		By("Schedule bunch of pods beyond point of filling default pool but do not request any GPUs")
-		ReserveMemory(f, "memory-reservation", 100, nodeCount*memAllocatableMb, false, 1*time.Second)
-		defer framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, "memory-reservation")
+			By("Enable autoscaler")
+			framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
+			defer disableAutoscaler(gpuPoolName, 0, 1)
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
 
-		// Verify that cluster size is increased
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
-			func(size int) bool { return size >= nodeCount+1 }, scaleUpTimeout))
+			By("Schedule bunch of pods beyond point of filling default pool but do not request any GPUs")
+			ReserveMemory(f, "memory-reservation", 100, nodeCount*memAllocatableMb, false, 1*time.Second)
+			defer framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, "memory-reservation")
+			// Verify that cluster size is increased
+			framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+				func(size int) bool { return size >= nodeCount+1 }, scaleUpTimeout))
 
-		// Expect gpu pool to stay intact
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
-	})
+			// Expect gpu pool to stay intact
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
+		})
 
-	It("Should scale down GPU pool from 1 [Feature:ClusterSizeAutoscalingGpu]", func() {
-		framework.SkipUnlessProviderIs("gke")
+		It(fmt.Sprintf("Should scale down GPU pool from 1 [GpuType:%s] [Feature:ClusterSizeAutoscalingGpu]", gpuType), func() {
+			framework.SkipUnlessProviderIs("gke")
 
-		const gpuPoolName = "gpu-pool"
-		addGpuNodePool(gpuPoolName, "nvidia-tesla-k80", 1, 1)
-		defer deleteNodePool(gpuPoolName)
+			const gpuPoolName = "gpu-pool"
+			addGpuNodePool(gpuPoolName, gpuType, 1, 1)
+			defer deleteNodePool(gpuPoolName)
 
-		installNvidiaDriversDaemonSet()
+			installNvidiaDriversDaemonSet()
 
-		By("Schedule a single pod which requires GPU")
-		framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
+			By("Schedule a single pod which requires GPU")
+			framework.ExpectNoError(scheduleGpuPod(f, "gpu-pod-rc"))
 
-		By("Enable autoscaler")
-		framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
-		defer disableAutoscaler(gpuPoolName, 0, 1)
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
+			By("Enable autoscaler")
+			framework.ExpectNoError(enableAutoscaler(gpuPoolName, 0, 1))
+			defer disableAutoscaler(gpuPoolName, 0, 1)
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(1))
 
-		framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, "gpu-pod-rc")
+			By("Remove the only POD requiring GPU")
+			framework.DeleteRCAndWaitForGC(f.ClientSet, f.Namespace.Name, "gpu-pod-rc")
 
-		framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
-			func(size int) bool { return size == nodeCount }, scaleDownTimeout))
-		Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
-	})
+			framework.ExpectNoError(WaitForClusterSizeFunc(f.ClientSet,
+				func(size int) bool { return size == nodeCount }, scaleDownTimeout))
+			Expect(len(getPoolNodes(f, gpuPoolName))).Should(Equal(0))
+		})
+	}
 
 	It("should increase cluster size if pending pods are small and one node is broken [Feature:ClusterSizeAutoscalingScaleUp]",
 		func() {


### PR DESCRIPTION
* Iterate over all supported GPU types (k80, p100, v100 for now) when running cluster autoscaler tests which verify GPU and CA interoperability.
* Verify if GPU pods are actually scaled up in "scale from 1" e2e test

```release-note
NONE
```
