### PR TITLE
Improve the help of kubeadm completion

### DIFF
--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -51,16 +51,17 @@ var (
 		The shell code must be evaluated to provide interactive
 		completion of kubeadm commands. This can be done by sourcing it from
 		the .bash_profile.
+		
+		Note: this requires the bash-completion framework.
 
-		Note: this requires the bash-completion framework, which is not installed
-		by default on Mac. This can be installed by using homebrew:
-
+		To install it on Mac use homebrew:
 		    $ brew install bash-completion
-
 		Once installed, bash_completion must be evaluated. This can be done by adding the
 		following line to the .bash_profile
-
 		    $ source $(brew --prefix)/etc/bash_completion
+
+		If bash-completion is not installed on Linux, please install the 'bash-completion' package
+		via your distribution's package manager.
 
 		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2`)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add note that 'bash-completion' is required on Linux too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [kubernetes/kubeadm/#860](https://github.com/kubernetes/kubeadm/issues/860)

**Special notes for your reviewer**:
cc @neolit123

**Release note**:
```release-note
NONE
```
