### PR TITLE
scheduler: update tests to use sub-benchmarks (pkg/scheduler/cache)

### DIFF
--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -1069,16 +1069,18 @@ func BenchmarkUpdate1kNodes30kPods(b *testing.B) {
 	}
 }
 
-func BenchmarkExpire100Pods(b *testing.B) {
-	benchmarkExpire(b, 100)
-}
-
-func BenchmarkExpire1kPods(b *testing.B) {
-	benchmarkExpire(b, 1000)
-}
-
-func BenchmarkExpire10kPods(b *testing.B) {
-	benchmarkExpire(b, 10000)
+func BenchmarkExpirePods(b *testing.B) {
+	podNums := []int{
+		100,
+		1000,
+		10000,
+	}
+	for _, podNum := range podNums {
+		name := fmt.Sprintf("%dPods", podNum)
+		b.Run(name, func(b *testing.B) {
+			benchmarkExpire(b, podNum)
+		})
+	}
 }
 
 func benchmarkExpire(b *testing.B, podNum int) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Go 1.7 added the subtest feature which can make table-driven tests much easier to run and debug. Some tests are not using this feature.

Further reading: [Using Subtests and Sub-benchmarks](https://blog.golang.org/subtests)

/kind cleanup

**Release note**:

```release-note
NONE
```