### PR TITLE
fix kubectl -o

### DIFF
--- a/pkg/kubectl/cmd/config/flags.go
+++ b/pkg/kubectl/cmd/config/flags.go
@@ -42,6 +42,13 @@ func (f *kubectlConfigPrintFlags) Complete(successTemplate string) error {
 	return f.NamePrintFlags.Complete(successTemplate)
 }
 
+func (f *kubectlConfigPrintFlags) AllowedFormats() []string {
+	formats := f.JSONYamlPrintFlags.AllowedFormats()
+	formats = append(formats, f.NamePrintFlags.AllowedFormats()...)
+	formats = append(formats, f.TemplateFlags.AllowedFormats()...)
+	return formats
+}
+
 func (f *kubectlConfigPrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	outputFormat := ""
 	if f.OutputFormat != nil {
@@ -60,7 +67,7 @@ func (f *kubectlConfigPrintFlags) ToPrinter() (printers.ResourcePrinter, error) 
 		return f.TypeSetter.WrapToPrinter(p, err)
 	}
 
-	return nil, genericclioptions.NoCompatiblePrinterError{Options: f}
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 }
 
 func (f *kubectlConfigPrintFlags) AddFlags(cmd *cobra.Command) {

--- a/pkg/kubectl/cmd/create/flags.go
+++ b/pkg/kubectl/cmd/create/flags.go
@@ -38,6 +38,11 @@ type PrintFlags struct {
 	OutputFormat *string
 }
 
+func (f *PrintFlags) AllowedFormats() []string {
+	return append(append(f.JSONYamlPrintFlags.AllowedFormats(), f.NamePrintFlags.AllowedFormats()...),
+		f.TemplateFlags.AllowedFormats()...)
+}
+
 func (f *PrintFlags) Complete(successTemplate string) error {
 	return f.NamePrintFlags.Complete(successTemplate)
 }
@@ -60,7 +65,7 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 		return f.TypeSetter.WrapToPrinter(p, err)
 	}
 
-	return nil, genericclioptions.NoCompatiblePrinterError{Options: f}
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 }
 
 func (f *PrintFlags) AddFlags(cmd *cobra.Command) {

--- a/pkg/kubectl/cmd/get/get_flags.go
+++ b/pkg/kubectl/cmd/get/get_flags.go
@@ -64,6 +64,15 @@ func (f *PrintFlags) Copy() PrintFlags {
 	return printFlags
 }
 
+func (f *PrintFlags) AllowedFormats() []string {
+	formats := f.JSONYamlPrintFlags.AllowedFormats()
+	formats = append(formats, f.NamePrintFlags.AllowedFormats()...)
+	formats = append(formats, f.TemplateFlags.AllowedFormats()...)
+	formats = append(formats, f.CustomColumnsFlags.AllowedFormats()...)
+	formats = append(formats, f.HumanReadableFlags.AllowedFormats()...)
+	return formats
+}
+
 // UseOpenAPIColumns modifies the output format, as well as the
 // "allowMissingKeys" option for template printers, to values
 // defined in the OpenAPI schema of a resource.
@@ -132,7 +141,7 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 		return p, err
 	}
 
-	return nil, genericclioptions.NoCompatiblePrinterError{Options: f}
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 }
 
 // AddFlags receives a *cobra.Command reference and binds

--- a/pkg/kubectl/cmd/get/humanreadable_flags.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags.go
@@ -61,11 +61,15 @@ func (f *HumanPrintFlags) EnsureWithNamespace() error {
 	return nil
 }
 
+func (f *HumanPrintFlags) AllowedFormats() []string {
+	return []string{"wide"}
+}
+
 // ToPrinter receives an outputFormat and returns a printer capable of
 // handling human-readable output.
 func (f *HumanPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinter, error) {
 	if len(outputFormat) > 0 && outputFormat != "wide" {
-		return nil, genericclioptions.NoCompatiblePrinterError{Options: f}
+		return nil, genericclioptions.NoCompatiblePrinterError{Options: f, AllowedFormats: f.AllowedFormats()}
 	}
 
 	decoder := scheme.Codecs.UniversalDecoder()

--- a/pkg/kubectl/genericclioptions/json_yaml_flags.go
+++ b/pkg/kubectl/genericclioptions/json_yaml_flags.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers"
 )
 
+func (f *JSONYamlPrintFlags) AllowedFormats() []string {
+	return []string{"json", "yaml"}
+}
+
 // JSONYamlPrintFlags provides default flags necessary for json/yaml printing.
 // Given the following flag values, a printer can be requested that knows
 // how to handle printing based on these values.
@@ -44,7 +48,7 @@ func (f *JSONYamlPrintFlags) ToPrinter(outputFormat string) (printers.ResourcePr
 	case "yaml":
 		printer = &printers.YAMLPrinter{}
 	default:
-		return nil, NoCompatiblePrinterError{Options: f, OutputFormat: &outputFormat}
+		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 	}
 
 	return printer, nil

--- a/pkg/kubectl/genericclioptions/name_flags.go
+++ b/pkg/kubectl/genericclioptions/name_flags.go
@@ -40,6 +40,10 @@ func (f *NamePrintFlags) Complete(successTemplate string) error {
 	return nil
 }
 
+func (f *NamePrintFlags) AllowedFormats() []string {
+	return []string{"name"}
+}
+
 // ToPrinter receives an outputFormat and returns a printer capable of
 // handling --output=name printing.
 // Returns false if the specified outputFormat does not match a supported format.
@@ -57,7 +61,7 @@ func (f *NamePrintFlags) ToPrinter(outputFormat string) (printers.ResourcePrinte
 	case "":
 		return namePrinter, nil
 	default:
-		return nil, NoCompatiblePrinterError{Options: f, OutputFormat: &outputFormat}
+		return nil, NoCompatiblePrinterError{OutputFormat: &outputFormat, AllowedFormats: f.AllowedFormats()}
 	}
 }
 

--- a/pkg/printers/kube_template_flags.go
+++ b/pkg/printers/kube_template_flags.go
@@ -33,6 +33,10 @@ type KubeTemplatePrintFlags struct {
 	TemplateArgument *string
 }
 
+func (f *KubeTemplatePrintFlags) AllowedFormats() []string {
+	return append(f.GoTemplatePrintFlags.AllowedFormats(), f.JSONPathPrintFlags.AllowedFormats()...)
+}
+
 func (f *KubeTemplatePrintFlags) ToPrinter(outputFormat string) (ResourcePrinter, error) {
 	if p, err := f.JSONPathPrintFlags.ToPrinter(outputFormat); !genericclioptions.IsNoCompatiblePrinterError(err) {
 		return p, err


### PR DESCRIPTION
Fix kubectl -o error message:
Before this change:
```
kubectl get pods -o foo
error: unable to match a printer suitable for the output format "" and the options specified: &get.PrintFlags{JSONYamlPrintFlags:(*genericclioptions.JSONYamlPrintFlags)(0x23aa610), NamePrintFlags:(*genericclioptions.NamePrintFlags)(0xc42058b4e0), TemplateFlags:(*printers.KubeTemplatePrintFlags)(0xc4206765e0), CustomColumnsFlags:(*printers.CustomColumnsPrintFlags)(0xc420676620), HumanReadableFlags:(*get.HumanPrintFlags)(0xc4204eb180), NoHeaders:(*bool)(0xc4206fefbc), OutputFormat:(*string)(0xc42058b4d0)}
```

After this change:
```
Kubectl get pods -o foo
error: unable to match a printer suitable for the output format "foo", allowed formats are: json,yaml,name,template,go-template,go-template-file,templatefile,jsonpath,jsonpath-file,custom-columns-file,custom-columns,wide
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl will list all allowed print formats when an invalid format is passed.
```
