### PR TITLE
Declare kubectl wait flag in a way consistent with other deletion flags

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -139,8 +139,6 @@ func NewCmdDelete(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 
 	deleteFlags.AddFlags(cmd)
 
-	cmd.Flags().Bool("wait", true, `If true, wait for resources to be gone before returning.  This waits for finalizers.`)
-
 	cmdutil.AddIncludeUninitializedFlag(cmd)
 	return cmd
 }
@@ -165,13 +163,8 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Co
 	}
 	if o.GracePeriod == 0 && !o.ForceDeletion {
 		// To preserve backwards compatibility, but prevent accidental data loss, we convert --grace-period=0
-		// into --grace-period=1 and wait until the object is successfully deleted. Users may provide --force
-		// to bypass this wait.
-		o.WaitForDeletion = true
+		// into --grace-period=1. Users may provide --force to bypass this conversion.
 		o.GracePeriod = 1
-	}
-	if b, err := cmd.Flags().GetBool("wait"); err == nil {
-		o.WaitForDeletion = b
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
@@ -216,6 +209,11 @@ func (o *DeleteOptions) Validate(cmd *cobra.Command) error {
 	}
 	if o.DeleteAll && len(o.FieldSelector) > 0 {
 		return fmt.Errorf("cannot set --all and --field-selector at the same time")
+	}
+
+	if o.GracePeriod == 0 && !o.ForceDeletion && !o.WaitForDeletion {
+		// With the explicit --wait flag we need extra validation for backward compatibility
+		return fmt.Errorf("--grace-period=0 must have either --force specified, or --wait to be set to true")
 	}
 
 	switch {

--- a/pkg/kubectl/cmd/delete_flags.go
+++ b/pkg/kubectl/cmd/delete_flags.go
@@ -39,6 +39,7 @@ type DeleteFlags struct {
 	IgnoreNotFound *bool
 	Now            *bool
 	Timeout        *time.Duration
+	Wait           *bool
 	Output         *string
 }
 
@@ -85,6 +86,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.Timeout != nil {
 		options.Timeout = *f.Timeout
 	}
+	if f.Wait != nil {
+		options.WaitForDeletion = *f.Wait
+	}
 
 	return options
 }
@@ -118,11 +122,12 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.IgnoreNotFound != nil {
 		cmd.Flags().BoolVar(f.IgnoreNotFound, "ignore-not-found", *f.IgnoreNotFound, "Treat \"resource not found\" as a successful delete. Defaults to \"true\" when --all is specified.")
 	}
-
+	if f.Wait != nil {
+		cmd.Flags().BoolVar(f.Wait, "wait", *f.Wait, "If true, wait for resources to be gone before returning. This waits for finalizers.")
+	}
 	if f.Output != nil {
 		cmd.Flags().StringVarP(f.Output, "output", "o", *f.Output, "Output mode. Use \"-o name\" for shorter output (resource/name).")
 	}
-
 }
 
 // NewDeleteCommandFlags provides default flags and values for use with the "delete" command
@@ -139,6 +144,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	labelSelector := ""
 	fieldSelector := ""
 	timeout := time.Duration(0)
+	wait := true
 
 	filenames := []string{}
 	recursive := false
@@ -156,6 +162,7 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		IgnoreNotFound: &ignoreNotFound,
 		Now:            &now,
 		Timeout:        &timeout,
+		Wait:           &wait,
 		Output:         &output,
 	}
 }
@@ -167,6 +174,7 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 
 	force := false
 	timeout := time.Duration(0)
+	wait := false
 
 	filenames := []string{}
 	recursive := false
@@ -180,5 +188,6 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 		// add non-defaults
 		Force:   &force,
 		Timeout: &timeout,
+		Wait:    &wait,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
A follow up PR for #64034 and #63979 that makes declaring wait flag consistent with the other flags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64401

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
