### PR TITLE
Remove call on completeWork when getWork already covered it

### DIFF
--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -152,10 +152,10 @@ func (e *quotaEvaluator) doWork() {
 		if quit {
 			return true
 		}
-		defer e.completeWork(ns)
 		if len(admissionAttributes) == 0 {
 			return false
 		}
+		defer e.completeWork(ns)
 		e.checkAttributes(ns, admissionAttributes)
 		return false
 	}
@@ -583,6 +583,11 @@ func (e *quotaEvaluator) completeWork(ns string) {
 	e.inProgress.Delete(ns)
 }
 
+// getWork() returns a naemspace, a list of items in that namespace to
+// check, and a boolean indicating whether to shutdown.  If shutdown
+// then the list is empty.  If the list is non-empty then completeWork
+// must eventually be called for the namespace; otherwise completeWork
+// must NOT be called for the namespae.
 func (e *quotaEvaluator) getWork() (string, []*admissionWaiter, bool) {
 	uncastNS, shutdown := e.queue.Get()
 	if shutdown {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In plugin/pkg/admission/resourcequota/controller.go, getWork has an
optimization that obviates --- and actually is inconsistent with --- a
subsequent call on completeWork in the case where the returned list is
empty.  This PR documents that detail of the calling convention and fixes
a violation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63608

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
