### PR TITLE
Fix kubectl drain --timeout option when eviction is used

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -610,6 +610,7 @@ func (o *DrainOptions) evictPods(pods []corev1.Pod, policyGroupVersion string, g
 	} else {
 		globalTimeout = o.Timeout
 	}
+	globalTimeoutCh := time.After(globalTimeout)
 	for {
 		select {
 		case err := <-errCh:
@@ -619,7 +620,7 @@ func (o *DrainOptions) evictPods(pods []corev1.Pod, policyGroupVersion string, g
 			if doneCount == len(pods) {
 				return nil
 			}
-		case <-time.After(globalTimeout):
+		case <-globalTimeoutCh:
 			return fmt.Errorf("Drain did not complete within %v", globalTimeout)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Timeout option of kubectl drain command is currently broken when using eviction to delete pods.

A new timer is made on each for loop iteration which means it gets reset each time a pod is evicted.

**Release note**:
```release-note
Fix kubectl drain --timeout option when eviction is used.
```

@kubernetes/sig-cli-pr-reviews