### PR TITLE
apiextensions: validate status.observedGeneration for custom resources

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -397,3 +397,19 @@ func (u *Unstructured) GetClusterName() string {
 func (u *Unstructured) SetClusterName(clusterName string) {
 	u.setNestedField(clusterName, "metadata", "clusterName")
 }
+
+func (u *Unstructured) GetObservedGeneration() int64 {
+	val, found, err := NestedInt64(u.Object, "status", "observedGeneration")
+	if !found || err != nil {
+		return 0
+	}
+	return val
+}
+
+func (u *Unstructured) SetObservedGeneration(observedGeneration int64) {
+	if observedGeneration == 0 {
+		RemoveNestedField(u.Object, "status", "observedGeneration")
+		return
+	}
+	u.setNestedField(observedGeneration, "status", "observedGeneration")
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -30,3 +30,21 @@ func TestNilUnstructuredContent(t *testing.T) {
 	assert.EqualValues(t, expContent, content)
 	assert.Equal(t, uCopy, &u)
 }
+
+func TestObservedGeneration(t *testing.T) {
+	var u Unstructured
+
+	u.SetObservedGeneration(10)
+	if u.GetObservedGeneration() != 10 {
+		t.Fatalf("error getting .status.observedGeneration: expected 10, got %v", u.GetObservedGeneration())
+	}
+
+	u.SetObservedGeneration(0)
+	observedGeneration, found, err := NestedInt64(u.Object, "status", "observedGeneration")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Errorf("unexpected .status.observedGeneration field: %v", observedGeneration)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/features/issues/95#issuecomment-302946176
Fixes https://github.com/kubernetes/kubernetes/issues/7328#issuecomment-359570791, https://github.com/kubernetes/kubernetes/issues/7328#issuecomment-305772161

We already increment `metadata.Generation` on spec updates and users can technically have  a `status.observedGeneration`. The external controller is responsible for updating the value but we should still be validating it.

This PR adds the following validations for `status.observedGeneration`:

1. it should be a non-negative integer.
2. it should never be greater than the `metadata.generation` value.
3. it should never be greater than the previously observed `status.observedGeneration` value.

/cc sttts deads2k 
/assign sttts 
/sig api-machinery
/area custom-resources

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
For custom resources, the `.status.observedGeneration` value is now validated to ensure that it is a non-negative integer and that it is smaller than the `metadata.generation` value and the previously observed `status.observedGeneration` value.
```
