### PR TITLE
print nodes for those metrics is somehow unreachable

### DIFF
--- a/pkg/kubectl/metricsutil/metrics_printer.go
+++ b/pkg/kubectl/metricsutil/metrics_printer.go
@@ -76,6 +76,12 @@ func (printer *TopCmdPrinter) PrintNodeMetrics(metrics []metricsapi.NodeMetrics,
 			Metrics:   usage,
 			Available: availableResources[m.Name],
 		})
+		delete(availableResources, m.Name)
+	}
+
+	// print lines for nodes of which the metrics is unreachable.
+	for nodeName := range availableResources {
+		printMissingMetricsNodeLine(w, nodeName)
 	}
 	return nil
 }
@@ -168,6 +174,14 @@ func printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, printContain
 func printMetricsLine(out io.Writer, metrics *ResourceMetricsInfo) {
 	printValue(out, metrics.Name)
 	printAllResourceUsages(out, metrics)
+	fmt.Fprint(out, "\n")
+}
+
+func printMissingMetricsNodeLine(out io.Writer, nodeName string) {
+	printValue(out, nodeName)
+	for i := 0; i < len(MeasuredResources); i++ {
+		printValue(out, "-\t-\t")
+	}
 	fmt.Fprint(out, "\n")
 }
 

--- a/pkg/kubectl/metricsutil/metrics_printer.go
+++ b/pkg/kubectl/metricsutil/metrics_printer.go
@@ -179,8 +179,12 @@ func printMetricsLine(out io.Writer, metrics *ResourceMetricsInfo) {
 
 func printMissingMetricsNodeLine(out io.Writer, nodeName string) {
 	printValue(out, nodeName)
+	unknownMetricsStatus := "<unknown>"
 	for i := 0; i < len(MeasuredResources); i++ {
-		printValue(out, "-\t-\t")
+		printValue(out, unknownMetricsStatus)
+		printValue(out, "\t")
+		printValue(out, unknownMetricsStatus)
+		printValue(out, "\t")
 	}
 	fmt.Fprint(out, "\n")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When we use `kubectl top nodes`, some nodes will be ignored when their metrics cannot be fetched from metrics serve. It might be misleading for users.

This PR helps print the missing nodes like:

```
NAME                CPU(cores)   CPU%      MEMORY(bytes)   MEMORY%  
missing-nodes       -            -         -               -
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63986

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes missing nodes lines when kubectl top nodes
```
