### PR TITLE
kubeadm: Use loadPodSpecFromFile instead of LoadPodFromFile

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -17,7 +17,6 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
-        "//pkg/volume/util:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
@@ -37,12 +36,13 @@ go_library(
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
-        "//pkg/volume/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -18,6 +18,7 @@ package selfhosting
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -26,12 +27,13 @@ import (
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
-	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 const (
@@ -85,12 +87,11 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 			continue
 		}
 
-		// Load the Static Pod file in order to be able to create a self-hosted variant of that file
-		pod, err := volumeutil.LoadPodFromFile(manifestPath)
+		// Load the Static Pod spec in order to be able to create a self-hosted variant of that file
+		podSpec, err := loadPodSpecFromFile(manifestPath)
 		if err != nil {
 			return err
 		}
-		podSpec := &pod.Spec
 
 		// Build a DaemonSet object from the loaded PodSpec
 		ds := BuildDaemonSet(componentName, podSpec, mutators)
@@ -173,4 +174,24 @@ func BuildSelfhostedComponentLabels(component string) map[string]string {
 // BuildSelfHostedComponentLabelQuery creates the right query for matching a self-hosted Pod
 func BuildSelfHostedComponentLabelQuery(componentName string) string {
 	return fmt.Sprintf("k8s-app=%s", kubeadmconstants.AddSelfHostedPrefix(componentName))
+}
+
+func loadPodSpecFromFile(filePath string) (*v1.PodSpec, error) {
+	podDef, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file path %s: %+v", filePath, err)
+	}
+
+	if len(podDef) == 0 {
+		return nil, fmt.Errorf("file was empty: %s", filePath)
+	}
+
+	codec := clientscheme.Codecs.UniversalDecoder()
+	pod := &v1.Pod{}
+
+	if err = runtime.DecodeInto(codec, podDef, pod); err != nil {
+		return nil, fmt.Errorf("failed decoding pod: %v", err)
+	}
+
+	return &pod.Spec, nil
 }


### PR DESCRIPTION
Signed-off-by: Rostislav M. Georgiev <rostislavg@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Implement and use loadPodSpecFromFile which loads and returns PodSpec object
from YAML or JSON file. Use this function in the places where LoadPodFromFile
is used to load Pod object and then return the PodSpec portion of it. This
also removes the dependency on //pkg/volume/util and its dependencies (thus,
making kubeadm more lean).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs kubernetes/kubeadm#839

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @luxas
/assign @timothysc

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
