### PR TITLE
Increase the timeout when waiting for the job to be gone

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1545,7 +1545,7 @@ metadata:
 			Expect(runOutput).To(ContainSubstring("abcd1234"))
 			Expect(runOutput).To(ContainSubstring("stdin closed"))
 
-			err := framework.WaitForJobGone(c, ns, jobName, 10*time.Second)
+			err := framework.WaitForJobGone(c, ns, jobName, wait.ForeverTestTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying the job " + jobName + " was deleted")


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses one of the issues mentioned in https://github.com/kubernetes/kubernetes/issues/64362

/assign @sttts 

**Release note**:
```release-note
NONE
```
