### PR TITLE
add unit tests to pkg/kubectl/genericclioptions/resource

### DIFF
--- a/pkg/kubectl/genericclioptions/resource/BUILD
+++ b/pkg/kubectl/genericclioptions/resource/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",


### PR DESCRIPTION
add unit tests to cover Refresh from Info struct in pkg/kubectl/genericclioptions/resource/visitor.go

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**What this PR does / why we need it**:
Increases unit test coverage on package `pkg/kubectl/genericclioptions/resource`. Part of work on [Kubectl #93](https://github.com/kubernetes/kubectl/issues/93)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
