### PR TITLE
client-go: document README exception in .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/staging/src/k8s.io/client-go/.github/PULL_REQUEST_TEMPLATE.md
+++ b/staging/src/k8s.io/client-go/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,3 @@
-Sorry, we do not accept changes directly against this repository. Please see 
-CONTRIBUTING.md for information on where and how to contribute instead.
+Sorry, we do not accept changes directly against this repository, unless the
+change is to the `README.md` itself. Please see 
+`CONTRIBUTING.md` for information on where and how to contribute instead.


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/client-go/pull/423.