### PR TITLE
Automated cherry pick of #63303: Return attach error to A/D controller.

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -102,17 +102,11 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 		glog.V(4).Info(log("attachment [%v] for volume [%v] created successfully", attachID, csiSource.VolumeHandle))
 	}
 
-	// probe for attachment update here
-	// NOTE: any error from waiting for attachment is logged only.  This is because
-	// the primary intent of the enclosing method is to create VolumeAttachment.
-	// DONOT return that error here as it is mitigated in attacher.WaitForAttach.
-	volAttachmentOK := true
 	if _, err := c.waitForVolumeAttachment(csiSource.VolumeHandle, attachID, csiTimeout); err != nil {
-		volAttachmentOK = false
-		glog.Error(log("attacher.Attach attempted to wait for attachment to be ready, but failed with: %v", err))
+		return "", err
 	}
 
-	glog.V(4).Info(log("attacher.Attach finished OK with VolumeAttachment verified=%t: attachment object [%s]", volAttachmentOK, attachID))
+	glog.V(4).Info(log("attacher.Attach finished OK with VolumeAttachment object [%s]", attachID))
 
 	return attachID, nil
 }

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -59,12 +59,13 @@ func makeTestAttachment(attachID, nodeName, pvName string) *storage.VolumeAttach
 func TestAttacherAttach(t *testing.T) {
 
 	testCases := []struct {
-		name       string
-		nodeName   string
-		driverName string
-		volumeName string
-		attachID   string
-		shouldFail bool
+		name                string
+		nodeName            string
+		driverName          string
+		volumeName          string
+		attachID            string
+		injectAttacherError bool
+		shouldFail          bool
 	}{
 		{
 			name:       "test ok 1",
@@ -104,6 +105,15 @@ func TestAttacherAttach(t *testing.T) {
 			attachID:   getAttachmentName("vol02", "driver02", "node02"),
 			shouldFail: true,
 		},
+		{
+			name:                "attacher error",
+			nodeName:            "node02",
+			driverName:          "driver02",
+			volumeName:          "vol02",
+			attachID:            getAttachmentName("vol02", "driver02", "node02"),
+			injectAttacherError: true,
+			shouldFail:          true,
+		},
 	}
 
 	// attacher loop
@@ -126,6 +136,9 @@ func TestAttacherAttach(t *testing.T) {
 			attachID, err := csiAttacher.Attach(spec, types.NodeName(nodename))
 			if !fail && err != nil {
 				t.Errorf("expecting no failure, but got err: %v", err)
+			}
+			if fail && err == nil {
+				t.Errorf("expecting failure, but got no err")
 			}
 			if attachID != id && !fail {
 				t.Errorf("expecting attachID %v, got %v", id, attachID)
@@ -154,7 +167,14 @@ func TestAttacherAttach(t *testing.T) {
 		if attach == nil {
 			t.Logf("attachment not found for id:%v", tc.attachID)
 		} else {
-			attach.Status.Attached = true
+			if tc.injectAttacherError {
+				attach.Status.Attached = false
+				attach.Status.AttachError = &storage.VolumeError{
+					Message: "attacher error",
+				}
+			} else {
+				attach.Status.Attached = true
+			}
 			_, err = csiAttacher.k8s.StorageV1beta1().VolumeAttachments().Update(attach)
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
Cherry pick of #63303 on release-1.10.

#63303: Return attach error to A/D controller.

```release-note
Fixed error reporting of CSI volumes attachment.
```