### PR TITLE
should check container id available firstly for fake_client in libdocker

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -586,7 +586,11 @@ func (f *FakeDockerClient) StartContainer(id string) error {
 		return err
 	}
 	f.appendContainerTrace("Started", id)
+	timestamp := f.Clock.Now()
 	container, ok := f.ContainerMap[id]
+	if !ok {
+		container = convertFakeContainer(&FakeContainer{ID: id, Name: id, CreatedAt: timestamp})
+	}
 	if container.HostConfig.NetworkMode.IsContainer() {
 		hostContainerID := container.HostConfig.NetworkMode.ConnectedContainer()
 		found := false
@@ -598,10 +602,6 @@ func (f *FakeDockerClient) StartContainer(id string) error {
 		if !found {
 			return fmt.Errorf("failed to start container \"%s\": Error response from daemon: cannot join network of a non running container: %s", id, hostContainerID)
 		}
-	}
-	timestamp := f.Clock.Now()
-	if !ok {
-		container = convertFakeContainer(&FakeContainer{ID: id, Name: id, CreatedAt: timestamp})
 	}
 	container.State.Running = true
 	container.State.Pid = os.Getpid()


### PR DESCRIPTION
Should check if the container id is in then ContainerMap firstly, otherwise will trigger nil pointer.

Signed-off-by: ddongchen <dong008259@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
For fake client in libcontainer.  when call StartContainer, it first check if the container id is in the ContainerMap. It should check the result before call the container object directly, for the object may be nill, then trigger nil pointer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bug-fixes
```
