### PR TITLE
Increase the rolling-update timeout while waiting for old RC removal

### DIFF
--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -554,7 +554,7 @@ func Rename(c coreclient.ReplicationControllersGetter, rc *api.ReplicationContro
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	err = wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+	err = wait.Poll(5*time.Second, 90*time.Second, func() (bool, error) {
 		_, err := c.ReplicationControllers(rc.Namespace).Get(oldName, metav1.GetOptions{})
 		if err == nil {
 			return false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will hopefully fix the problems in here:
https://k8s-testgrid.appspot.com/sig-cli-master#soak-gce-gci
by increasing the rolling-update timeout up by 50%. 

**Special notes for your reviewer**:
/assign @juanvallejo 

**Release note**:
```release-note
NONE
```
