### PR TITLE
Automated cherry pick of #64300 upstream release 1.10: HandleError include the type of the error object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -61,7 +61,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		// by REST storage - these typically indicate programmer
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
-		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %v", err))
+		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v", err))
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Status",


### PR DESCRIPTION
Cherry pick of #64300 on release-1.10.

#64300: HandleError include the type of the error object.