### PR TITLE
dockershim/network: pass ipRange CNI capabilities

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -50,6 +50,7 @@ type cniNetworkPlugin struct {
 	nsenterPath string
 	confDir     string
 	binDirs     []string
+	podCidr     string
 }
 
 type cniNetwork struct {
@@ -81,6 +82,11 @@ type cniBandwidthEntry struct {
 	// EgressBurst is the bandwidth burst in bits for traffic through container. 0 for no limit. If egressBurst is set, egressRate must also be set
 	// NOTE: it's not used for now and default to 0.
 	EgressBurst int `json:"egressBurst,omitempty"`
+}
+
+// cniIpRange maps to the standard CNI ip range Capability
+type cniIpRange struct {
+	Subnet string `json:"subnet"`
 }
 
 func SplitDirs(dirs string) []string {
@@ -152,6 +158,8 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 			continue
 		}
 
+		glog.V(4).Infof("Using CNI configuration file %s", confFile)
+
 		network := &cniNetwork{
 			name:          confList.Name,
 			NetworkConfig: confList,
@@ -199,7 +207,41 @@ func (plugin *cniNetworkPlugin) checkInitialized() error {
 	if plugin.getDefaultNetwork() == nil {
 		return errors.New("cni config uninitialized")
 	}
+
+	// If the CNI configuration has the ipRanges capability, we need a PodCIDR assigned
+	for _, p := range plugin.getDefaultNetwork().NetworkConfig.Plugins {
+		if p.Network.Capabilities["ipRanges"] {
+			if plugin.podCidr == "" {
+				return errors.New("no PodCIDR set")
+			}
+			break
+		}
+	}
 	return nil
+}
+
+// Event handles any change events. The only event ever sent is the PodCIDR change.
+// No network plugins support changing an already-set PodCIDR
+func (plugin *cniNetworkPlugin) Event(name string, details map[string]interface{}) {
+	if name != network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE {
+		return
+	}
+
+	plugin.Lock()
+	defer plugin.Unlock()
+
+	podCIDR, ok := details[network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE_DETAIL_CIDR].(string)
+	if !ok {
+		glog.Warningf("%s event didn't contain pod CIDR", network.NET_PLUGIN_EVENT_POD_CIDR_CHANGE)
+		return
+	}
+
+	if plugin.podCidr != "" {
+		glog.Warningf("Ignoring subsequent pod CIDR update to %s", podCIDR)
+		return
+	}
+
+	plugin.podCidr = podCIDR
 }
 
 func (plugin *cniNetworkPlugin) Name() string {
@@ -345,6 +387,9 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 		}
 		rt.CapabilityArgs["bandwidth"] = bandwidthParam
 	}
+
+	// Set the PodCIDR
+	rt.CapabilityArgs["ipRanges"] = [][]cniIpRange{{{Subnet: plugin.podCidr}}}
 
 	return rt, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the dynamic (capability args) passed from Kubernetes to the CNI plugin. This means CNI plugin authors can offer more features and / or reduce their dependency on the APIServer.

Currently, we only pass the `portMappings` capability. CNI now supports `bandwidth` for bandwidth limiting and `ipRanges` for preferred IP blocks. This PR adds support for these two new capabilities.

Bandwidth limits are provided - as implemented in kubenet - via the pod annotations `kubernetes.io/ingress-bandwidth` and `kubernetes.io/egress-bandwidth`.

The ipRanges field simply passes the PodCIDR. This does mean that we need to change the NodeReady algorithm. Previously, we would only set NodeNotReady on missing PodCIDR when using Kubenet. Now, if the CNI configuration includes the `ipRanges` capability, we need to do the same.

**Which issue(s) this PR fixes**:
Fixes #64393

**Release note**:

```release-note
The dockershim now sets the "bandwidth" and "ipRanges" CNI capabilities (dynamic parameters). Plugin authors and administrators can now take advantage of this by updating their CNI configuration file. For more information, see the [CNI docs](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration)
```
