### PR TITLE
fix resource builder flags API

### DIFF
--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -68,6 +68,7 @@ go_test(
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/genericclioptions:go_default_library",
+        "//pkg/kubectl/genericclioptions/printers:go_default_library",
         "//pkg/kubectl/genericclioptions/resource:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/pkg/kubectl/cmd/set/set_selector_test.go
+++ b/pkg/kubectl/cmd/set/set_selector_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package set
 
 import (
-	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -28,13 +27,9 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/rest/fake"
-	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
 )
 
 func TestUpdateSelectorForObjectTypes(t *testing.T) {
@@ -317,27 +312,30 @@ func TestGetResourcesAndSelector(t *testing.T) {
 }
 
 func TestSelectorTest(t *testing.T) {
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	tf.Client = &fake.RESTClient{
-		GroupVersion:         schema.GroupVersion{Version: ""},
-		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
-			return nil, nil
-		}),
+	info := &resource.Info{
+		Object: &v1.Service{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "some-ns", Name: "cassandra"},
+		},
 	}
-	tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 
-	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
-	cmd := NewCmdSelector(tf, streams)
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("local", "true")
-	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/statefulset/cassandra/service.yaml")
+	labelToSet, err := metav1.ParseToLabelSelector("environment=qa")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	cmd.Run(cmd, []string{"environment=qa"})
+	iostreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	o := &SetSelectorOptions{
+		selector:       labelToSet,
+		ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(info),
+		Recorder:       genericclioptions.NoopRecorder{},
+		PrintObj:       (&printers.NamePrinter{}).PrintObj,
+		IOStreams:      iostreams,
+	}
 
+	if err := o.RunSelector(); err != nil {
+		t.Fatal(err)
+	}
 	if !strings.Contains(buf.String(), "service/cassandra") {
 		t.Errorf("did not set selector: %s", buf.String())
 	}

--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -53,9 +53,12 @@ type WaitFlags struct {
 // NewWaitFlags returns a default WaitFlags
 func NewWaitFlags(restClientGetter genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *WaitFlags {
 	return &WaitFlags{
-		RESTClientGetter:     restClientGetter,
-		PrintFlags:           genericclioptions.NewPrintFlags("condition met"),
-		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags(),
+		RESTClientGetter: restClientGetter,
+		PrintFlags:       genericclioptions.NewPrintFlags("condition met"),
+		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
+			WithLabelSelector("").
+			WithAllNamespaces(false).
+			WithLatest(),
 
 		Timeout: 30 * time.Second,
 

--- a/pkg/kubectl/cmd/wait/wait_test.go
+++ b/pkg/kubectl/cmd/wait/wait_test.go
@@ -219,7 +219,7 @@ func TestWaitForDeletion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
 			o := &WaitOptions{
-				ResourceFinder: genericclioptions.NewSimpleResourceFinder(test.info),
+				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.info),
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
 
@@ -451,7 +451,7 @@ func TestWaitForCondition(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
 			o := &WaitOptions{
-				ResourceFinder: genericclioptions.NewSimpleResourceFinder(test.info),
+				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.info),
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
 

--- a/pkg/kubectl/genericclioptions/builder_flags.go
+++ b/pkg/kubectl/genericclioptions/builder_flags.go
@@ -18,6 +18,7 @@ package genericclioptions
 
 import (
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
 )
 
@@ -29,8 +30,11 @@ type ResourceBuilderFlags struct {
 	LabelSelector *string
 	FieldSelector *string
 	AllNamespaces *bool
+	All           *bool
+	Local         *bool
 
-	All bool
+	Scheme *runtime.Scheme
+	Latest bool
 }
 
 // NewResourceBuilderFlags returns a default ResourceBuilderFlags
@@ -43,14 +47,51 @@ func NewResourceBuilderFlags() *ResourceBuilderFlags {
 			Filenames: &filenames,
 			Recursive: boolPtr(true),
 		},
-
-		LabelSelector: strPtr(""),
-		AllNamespaces: boolPtr(false),
 	}
+}
+
+func (o *ResourceBuilderFlags) WithFile(recurse bool, files ...string) *ResourceBuilderFlags {
+	o.FileNameFlags = &FileNameFlags{
+		Usage:     "identifying the resource.",
+		Filenames: &files,
+		Recursive: boolPtr(recurse),
+	}
+
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLabelSelector(selector string) *ResourceBuilderFlags {
+	o.LabelSelector = &selector
+	return o
 }
 
 func (o *ResourceBuilderFlags) WithFieldSelector(selector string) *ResourceBuilderFlags {
 	o.FieldSelector = &selector
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithAllNamespaces(defaultVal bool) *ResourceBuilderFlags {
+	o.AllNamespaces = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithAll(defaultVal bool) *ResourceBuilderFlags {
+	o.All = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLocal(defaultVal bool) *ResourceBuilderFlags {
+	o.Local = &defaultVal
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithScheme(scheme *runtime.Scheme) *ResourceBuilderFlags {
+	o.Scheme = scheme
+	return o
+}
+
+func (o *ResourceBuilderFlags) WithLatest() *ResourceBuilderFlags {
+	o.Latest = true
 	return o
 }
 
@@ -67,6 +108,12 @@ func (o *ResourceBuilderFlags) AddFlags(flagset *pflag.FlagSet) {
 	if o.AllNamespaces != nil {
 		flagset.BoolVar(o.AllNamespaces, "all-namespaces", *o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	}
+	if o.All != nil {
+		flagset.BoolVar(o.All, "all", *o.All, "Select all resources in the namespace of the specified resource types")
+	}
+	if o.Local != nil {
+		flagset.BoolVar(o.Local, "local", *o.Local, "If true, annotation will NOT contact api-server but run locally.")
+	}
 }
 
 // ToBuilder gives you back a resource finder to visit resources that are located
@@ -74,24 +121,45 @@ func (o *ResourceBuilderFlags) ToBuilder(restClientGetter RESTClientGetter, reso
 	namespace, enforceNamespace, namespaceErr := restClientGetter.ToRawKubeConfigLoader().Namespace()
 
 	builder := resource.NewBuilder(restClientGetter).
-		Unstructured().
-		NamespaceParam(namespace).DefaultNamespace().
-		ResourceTypeOrNameArgs(o.All, resources...)
+		NamespaceParam(namespace).DefaultNamespace()
+
+	if o.Scheme != nil {
+		builder.WithScheme(o.Scheme, o.Scheme.PrioritizedVersionsAllGroups()...)
+	} else {
+		builder.Unstructured()
+	}
+
 	if o.FileNameFlags != nil {
 		opts := o.FileNameFlags.ToOptions()
-		builder = builder.FilenameParam(enforceNamespace, &opts)
+		builder.FilenameParam(enforceNamespace, &opts)
 	}
-	if o.LabelSelector != nil {
-		builder = builder.LabelSelectorParam(*o.LabelSelector)
-	}
-	if o.FieldSelector != nil {
-		builder = builder.FieldSelectorParam(*o.FieldSelector)
+
+	if o.Local == nil || !*o.Local {
+		// resource type/name tuples only work non-local
+		if o.All != nil {
+			builder.ResourceTypeOrNameArgs(*o.All, resources...)
+		} else {
+			builder.ResourceTypeOrNameArgs(false, resources...)
+		}
+		// label selectors only work non-local (for now)
+		if o.LabelSelector != nil {
+			builder.LabelSelectorParam(*o.LabelSelector)
+		}
+		// field selectors only work non-local (forever)
+		if o.FieldSelector != nil {
+			builder.FieldSelectorParam(*o.FieldSelector)
+		}
+		// latest only works non-local (forever)
+		if o.Latest {
+			builder.Latest()
+		}
+	} else {
+		builder.Local()
 	}
 
 	return &ResourceFindBuilderWrapper{
 		builder: builder.
-			Latest().
-			Flatten().
+			Flatten(). // I think we're going to recommend this everywhere
 			AddError(namespaceErr),
 	}
 }

--- a/pkg/kubectl/genericclioptions/builder_flags_fake.go
+++ b/pkg/kubectl/genericclioptions/builder_flags_fake.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewSimpleResourceFinder builds a super simple ResourceFinder that just iterates over the objects you provided
-func NewSimpleResourceFinder(infos ...*resource.Info) ResourceFinder {
+func NewSimpleFakeResourceFinder(infos ...*resource.Info) ResourceFinder {
 	return &fakeResourceFinder{
 		Infos: infos,
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/64512

This pull expands the utility of the resource builder flags and demonstrates a second use-case with `kubectl set selector`.

@kubernetes/sig-cli-maintainers 
/assign @juanvallejo 
/assign @soltysh 

```release-note
NONE
```