### PR TITLE
Fix dynamic kubelet config tests

### DIFF
--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -138,7 +138,7 @@ func isKubeletConfigEnabled(f *framework.Framework) (bool, error) {
 	}
 	v, ok := cfgz.FeatureGates[string(features.DynamicKubeletConfig)]
 	if !ok {
-		return false, nil
+		return true, nil
 	}
 	return v, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The default for dynamic kubelet config is now true, so if it is unset, assume it is enabled for testing.

**Release note**:
```release-note
NONE
```

/sig node
/kind bug
/priority critical-urgent

/assign @mtaufen 