### PR TITLE
Tweak scheduler CPU allocation

### DIFF
--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -20,7 +20,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "75m"
+        "cpu": "70m"
       }
     },
     "command": [


### PR DESCRIPTION
Reduce scheduler CPU request by 5m to make room for additional components on master.
Currently we are unable to schedule custom components on master due to full CPU allocation. 5m CPU will give us minimal room for scheduling new component.

```release-note
NONE
```