### PR TITLE
Fix nodeport repair for ESIPP services

### DIFF
--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -29,7 +29,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/registry/core/rangeallocation"
-	"k8s.io/kubernetes/pkg/registry/core/service"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 )
 
@@ -117,7 +116,7 @@ func (c *Repair) runOnce() error {
 	// Check every Service's ports, and rebuild the state as we think it should be.
 	for i := range list.Items {
 		svc := &list.Items[i]
-		ports := service.CollectServiceNodePorts(svc)
+		ports := collectServiceNodePorts(svc)
 		if len(ports) == 0 {
 			continue
 		}
@@ -184,4 +183,20 @@ func (c *Repair) runOnce() error {
 		return fmt.Errorf("unable to persist the updated port allocations: %v", err)
 	}
 	return nil
+}
+
+func collectServiceNodePorts(service *api.Service) []int {
+	servicePorts := []int{}
+	for i := range service.Spec.Ports {
+		servicePort := &service.Spec.Ports[i]
+		if servicePort.NodePort != 0 {
+			servicePorts = append(servicePorts, int(servicePort.NodePort))
+		}
+	}
+
+	if service.Spec.HealthCheckNodePort != 0 {
+		servicePorts = append(servicePorts, int(service.Spec.HealthCheckNodePort))
+	}
+
+	return servicePorts
 }

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -164,6 +164,12 @@ func TestRepairWithExisting(t *testing.T) {
 				Ports: []api.ServicePort{{NodePort: 111}},
 			},
 		},
+		&api.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "six", Name: "six"},
+			Spec: api.ServiceSpec{
+				HealthCheckNodePort: 144,
+			},
+		},
 	)
 
 	registry := &mockRangeRegistry{
@@ -183,10 +189,10 @@ func TestRepairWithExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !after.Has(111) || !after.Has(122) || !after.Has(133) {
+	if !after.Has(111) || !after.Has(122) || !after.Has(133) || !after.Has(144) {
 		t.Errorf("unexpected portallocator state: %#v", after)
 	}
-	if free := after.Free(); free != 98 {
+	if free := after.Free(); free != 97 {
 		t.Errorf("unexpected portallocator state: %d free", free)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The nodeport allocation repair controller does not scrape the `Service.Spec.healthCheckNodePort` value and would remove the allocation from memory and etcd after 10 minutes.  This opens the door for other services to use the same nodeport and cause collisions. 

**Which issue(s) this PR fixes**:
Fixes #54885
Similar to #64349

**Release note**:
```release-note
Fix issue of colliding nodePorts when the cluster has services with externalTrafficPolicy=Local
```
