### PR TITLE
Allow for mixed UDP/TCP ports on LoadBalancer Services

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3618,17 +3618,11 @@ func ValidateService(service *core.Service) field.ErrorList {
 
 	if service.Spec.Type == core.ServiceTypeLoadBalancer {
 		portsPath := specPath.Child("ports")
-		includeProtocols := sets.NewString()
 		for i := range service.Spec.Ports {
 			portPath := portsPath.Index(i)
 			if !supportedPortProtocols.Has(string(service.Spec.Ports[i].Protocol)) {
 				allErrs = append(allErrs, field.Invalid(portPath.Child("protocol"), service.Spec.Ports[i].Protocol, "cannot create an external load balancer with non-TCP/UDP ports"))
-			} else {
-				includeProtocols.Insert(string(service.Spec.Ports[i].Protocol))
 			}
-		}
-		if includeProtocols.Len() > 1 {
-			allErrs = append(allErrs, field.Invalid(portsPath, service.Spec.Ports, "cannot create an external load balancer with mix protocols"))
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows for LoadBalancer Services to have both TCP and UDP ports.

Some LoadBalancer implementations support mixed TCP and UDP services on a single Service of type=LoadBalancer, like [metallb](https://metallb.universe.tf/usage/).

So far users are forced to workaround this by creating 2 services like so:
```
apiVersion: v1
kind: Service
metadata:
  name: example-tcp
  annotations:
    metallb.universe.tf/allow-shared-ip: mykey
spec:
  ports:
  - port: 1234
    targetPort: 1234
    protocol: TCP
  selector:
    app: example
  type: LoadBalancer
  loadBalancerIP: 192.168.1.240

---
apiVersion: v1
kind: Service
metadata:
  name: example-udp
  annotations:
    metallb.universe.tf/allow-shared-ip: mykey
spec:
  ports:
  - port: 1234
    targetPort: 1234
    protocol: UDP
  selector:
    app: example
  type: LoadBalancer
  loadBalancerIP: 192.168.1.240
```
Instead of a clearer service manifest:
```
apiVersion: v1
kind: Service
metadata:
  name: example-app
spec:
  ports:
  - port: 1234
    targetPort: 1234
    protocol: TCP
  - port: 1234
    targetPort: 1234
    protocol: UDP
  selector:
    app: example
  type: LoadBalancer
  loadBalancerIP: 192.168.1.240
```

**Which issue(s) this PR fixes**
Fixes #23880, #35752

**Special notes for your reviewer**:
This is kind of like if the `Ingress` manifests didn't allow for mixed HTTP and HTTPS Ingress because not all Ingress controller implementation supported it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow for mixed UDP/TCP ports on type=LoadBalancer Services
```
