### PR TITLE
Modified regional PD test to fetch template name from GCE

### DIFF
--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -145,6 +145,28 @@ func CreateManagedInstanceGroup(size int64, zone, template string) error {
 	return nil
 }
 
+func GetManagedInstanceGroupTemplateName(zone string) (string, error) {
+	// TODO(verult): make this hit the compute API directly instead of
+	// shelling out to gcloud. Use InstanceGroupManager to get Instance Template name.
+
+	stdout, _, err := retryCmd("gcloud", "compute", "instance-groups", "managed",
+		"list",
+		fmt.Sprintf("--filter=name:%s", TestContext.CloudConfig.NodeInstanceGroup),
+		fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
+		fmt.Sprintf("--zones=%s", zone),
+	)
+
+	if err != nil {
+		return "", fmt.Errorf("gcloud compute instance-groups managed list call failed with err: %v", err)
+	}
+
+	templateName, err := parseInstanceTemplateName(stdout)
+	if err != nil {
+		return "", fmt.Errorf("error parsing gcloud output: %v", err)
+	}
+	return templateName, nil
+}
+
 func DeleteManagedInstanceGroup(zone string) error {
 	// TODO(verult): make this hit the compute API directly instead of
 	// shelling out to gcloud.
@@ -157,4 +179,30 @@ func DeleteManagedInstanceGroup(zone string) error {
 		return fmt.Errorf("gcloud compute instance-groups managed delete call failed with err: %v", err)
 	}
 	return nil
+}
+
+func parseInstanceTemplateName(gcloudOutput string) (string, error) {
+	const templateNameField = "INSTANCE_TEMPLATE"
+
+	lines := strings.Split(gcloudOutput, "\n")
+	if len(lines) <= 1 { // Empty output or only contains column names
+		return "", fmt.Errorf("the list is empty")
+	}
+
+	// Otherwise, there should be exactly 1 entry, i.e. 2 lines
+	fieldNames := strings.Fields(lines[0])
+	instanceTemplateColumn := 0
+	for instanceTemplateColumn < len(fieldNames) &&
+		fieldNames[instanceTemplateColumn] != templateNameField {
+		instanceTemplateColumn++
+	}
+
+	if instanceTemplateColumn == len(fieldNames) {
+		return "", fmt.Errorf("the list does not contain instance template information")
+	}
+
+	fields := strings.Fields(lines[1])
+	instanceTemplateName := fields[instanceTemplateColumn]
+
+	return instanceTemplateName, nil
 }

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -205,15 +205,15 @@ func testZonalFailover(c clientset.Interface, ns string) {
 	instanceGroup, err := cloud.GetInstanceGroup(instanceGroupName, podZone)
 	Expect(err).NotTo(HaveOccurred(),
 		"Error getting instance group %s in zone %s", instanceGroupName, podZone)
+	templateName, err := framework.GetManagedInstanceGroupTemplateName(podZone)
+	Expect(err).NotTo(HaveOccurred(),
+		"Error getting instance group template in zone %s", podZone)
 	err = framework.DeleteManagedInstanceGroup(podZone)
 	Expect(err).NotTo(HaveOccurred(),
 		"Error deleting instance group in zone %s", podZone)
 
 	defer func() {
 		framework.Logf("recreating instance group %s", instanceGroup.Name)
-
-		// HACK improve this when Managed Instance Groups are available through the cloud provider API
-		templateName := strings.Replace(instanceGroupName, "group", "template", 1 /* n */)
 
 		framework.ExpectNoError(framework.CreateManagedInstanceGroup(instanceGroup.Size, podZone, templateName),
 			"Error recreating instance group %s in zone %s", instanceGroup.Name, podZone)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Previously, the regional PD failover e2e test assumes a specific relationship between the names of an instance group and its corresponding template. It turns out to not always hold true for different types of clusters. Instead, the test should fetch the correct template name by calling out to GCE.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #59988

Need to cherry pick this back to 1.10 along with #64223 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @saad-ali @wojtek-t 
/sig storage