### PR TITLE
Set full qualified image name into node status 

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -98,6 +98,7 @@ go_library(
         "//pkg/util/mount:go_default_library",
         "//pkg/util/node:go_default_library",
         "//pkg/util/oom:go_default_library",
+        "//pkg/util/parsers:go_default_library",
         "//pkg/util/removeall:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/kubelet/images/BUILD
+++ b/pkg/kubelet/images/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/util/sliceutils:go_default_library",
         "//pkg/util/parsers:go_default_library",
-        "//vendor/github.com/docker/distribution/reference:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -182,21 +182,3 @@ func TestSerializedPuller(t *testing.T) {
 		}
 	}
 }
-
-func TestApplyDefaultImageTag(t *testing.T) {
-	for _, testCase := range []struct {
-		Input  string
-		Output string
-	}{
-		{Input: "root", Output: "root:latest"},
-		{Input: "root:tag", Output: "root:tag"},
-		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-	} {
-		image, err := applyDefaultImageTag(testCase.Input)
-		if err != nil {
-			t.Errorf("applyDefaultImageTag(%s) failed: %v", testCase.Input, err)
-		} else if image != testCase.Output {
-			t.Errorf("Expected image reference: %q, got %q", testCase.Output, image)
-		}
-	}
-}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -96,7 +96,7 @@ func generateImageTags() []string {
 	// that kubelet report up to maxNamesPerImageInNodeStatus tags.
 	count := rand.IntnRange(maxNamesPerImageInNodeStatus+1, maxImageTagsForTest+1)
 	for ; count > 0; count-- {
-		tagList = append(tagList, "k8s.gcr.io:v"+strconv.Itoa(count))
+		tagList = append(tagList, "k8s.gcr.io/test-image:v"+strconv.Itoa(count))
 	}
 	return tagList
 }
@@ -638,11 +638,11 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			// images will be sorted from max to min in node status.
 			Images: []v1.ContainerImage{
 				{
-					Names:     []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
+					Names:     []string{"k8s.gcr.io/test-image:v1", "k8s.gcr.io/test-image:v2"},
 					SizeBytes: 123,
 				},
 				{
-					Names:     []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
+					Names:     []string{"k8s.gcr.io/test-image:v3", "k8s.gcr.io/test-image:v4"},
 					SizeBytes: 456,
 				},
 			},
@@ -860,11 +860,11 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			},
 			Images: []v1.ContainerImage{
 				{
-					Names:     []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
+					Names:     []string{"k8s.gcr.io/test-image:v1", "k8s.gcr.io/test-image:v2"},
 					SizeBytes: 123,
 				},
 				{
-					Names:     []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
+					Names:     []string{"k8s.gcr.io/test-image:v3", "k8s.gcr.io/test-image:v4"},
 					SizeBytes: 456,
 				},
 			},

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -124,12 +124,12 @@ func newTestKubelet(t *testing.T, controllerAttachDetachEnabled bool) *TestKubel
 	imageList := []kubecontainer.Image{
 		{
 			ID:       "abc",
-			RepoTags: []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
+			RepoTags: []string{"k8s.gcr.io/test-image:v1", "k8s.gcr.io/test-image:v2"},
 			Size:     123,
 		},
 		{
 			ID:       "efg",
-			RepoTags: []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
+			RepoTags: []string{"k8s.gcr.io/test-image:v3", "k8s.gcr.io/test-image:v4"},
 			Size:     456,
 		},
 	}

--- a/pkg/util/parsers/parsers.go
+++ b/pkg/util/parsers/parsers.go
@@ -85,9 +85,16 @@ func GetFullImageName(image string) (string, error) {
 		return "", err
 	}
 
+	// busybox:tag@digest == busybox:digest
+	if len(tag) != 0 && len(digest) != 0 {
+		return repo + "@" + digest, nil
+	}
+
+	// only has tag
 	if len(tag) != 0 {
 		return repo + ":" + tag, nil
 	}
 
+	// only has digest
 	return repo + "@" + digest, nil
 }

--- a/pkg/util/parsers/parsers_test.go
+++ b/pkg/util/parsers/parsers_test.go
@@ -49,3 +49,50 @@ func TestParseImageName(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyDefaultImageTag(t *testing.T) {
+	for _, testCase := range []struct {
+		Input  string
+		Output string
+	}{
+		{Input: "root", Output: "root:latest"},
+		{Input: "root:tag", Output: "root:tag"},
+		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "docker.io/root:tag", Output: "docker.io/root:tag"},
+		{Input: "docker.io/root", Output: "docker.io/root:latest"},
+		{Input: "gcr.io/root:tag", Output: "gcr.io/root:tag"},
+	} {
+		image, err := ApplyDefaultImageTag(testCase.Input)
+		if err != nil {
+			t.Errorf("ApplyDefaultImageTag(%s) failed: %v", testCase.Input, err)
+		} else if image != testCase.Output {
+			t.Errorf("Expected image reference: %q, got %q", testCase.Output, image)
+		}
+	}
+}
+
+func TestGetFullImageName(t *testing.T) {
+	testCases := []struct {
+		Input  string
+		Output string
+	}{
+		{Input: "root", Output: "docker.io/library/root:latest"},
+		{Input: "root:tag", Output: "docker.io/library/root:tag"},
+		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "docker.io/library/root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "user/repo", Output: "docker.io/user/repo:latest"},
+		{Input: "k8s.gcr.io/root:tag", Output: "k8s.gcr.io/root:tag"},
+		{Input: "user/repo:tag", Output: "docker.io/user/repo:tag"},
+		{Input: "user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "docker.io/user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "url:5000/repo", Output: "url:5000/repo:latest"},
+		{Input: "url:5000/repo:tag", Output: "url:5000/repo:tag"},
+		{Input: "url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	}
+	for _, testCase := range testCases {
+		fullImageName, err := GetFullImageName(testCase.Input)
+		if err != nil {
+			t.Errorf("GetFullImageName(%s) failed: %v", testCase.Input, err)
+		} else if testCase.Output != fullImageName {
+			t.Errorf("Expected output: %q, got: %q", testCase.Output, fullImageName)
+		}
+	}
+}

--- a/pkg/util/parsers/parsers_test.go
+++ b/pkg/util/parsers/parsers_test.go
@@ -78,7 +78,11 @@ func TestGetFullImageName(t *testing.T) {
 	}{
 		{Input: "root", Output: "docker.io/library/root:latest"},
 		{Input: "root:tag", Output: "docker.io/library/root:tag"},
+		{Input: "library/root", Output: "docker.io/library/root:latest"},
+		{Input: "docker.io/root", Output: "docker.io/library/root:latest"},
+		{Input: "docker.io/library/root", Output: "docker.io/library/root:latest"},
 		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "docker.io/library/root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "root:tag@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "docker.io/library/root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 		{Input: "user/repo", Output: "docker.io/user/repo:latest"},
 		{Input: "k8s.gcr.io/root:tag", Output: "k8s.gcr.io/root:tag"},
 		{Input: "user/repo:tag", Output: "docker.io/user/repo:tag"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Different container runtimes return different image names and set the node status. This brings extra burden to other components who rely on those image names as keys to match. 

I currently shipped a workaround in scheduler in #64366, but eventually I would like to keep these parses stuff on node side. 

Also, I moved `ApplyDefaultImageTag` func to util which is a better home for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #64413 

**Special notes for your reviewer**:

I am not sure if there's any external system relies on image names in node status. Please feel free to comment if any.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set full qualified image name into node status 
```
