### PR TITLE
remove ResourceLocation unused arguments

### DIFF
--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -66,7 +66,7 @@ func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object,
 	if !ok {
 		return nil, fmt.Errorf("Invalid options object: %#v", opts)
 	}
-	location, transport, err := node.ResourceLocation(r.Store, r.Connection, r.ProxyTransport, ctx, id)
+	location, transport, err := node.ResourceLocation(r.Connection, r.ProxyTransport, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -139,7 +139,7 @@ var _ = rest.Redirector(&REST{})
 
 // ResourceLocation returns a URL to which one can send traffic for the specified node.
 func (r *REST) ResourceLocation(ctx context.Context, id string) (*url.URL, http.RoundTripper, error) {
-	return node.ResourceLocation(r, r.connection, r.proxyTransport, ctx, id)
+	return node.ResourceLocation(r.connection, r.proxyTransport, id)
 }
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -194,7 +194,7 @@ func NodeNameTriggerFunc(obj runtime.Object) []pkgstorage.MatchValue {
 }
 
 // ResourceLocation returns a URL and transport which one can use to send traffic for the specified node.
-func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper, ctx context.Context, id string) (*url.URL, http.RoundTripper, error) {
+func ResourceLocation(connection client.ConnectionInfoGetter, proxyTransport http.RoundTripper, id string) (*url.URL, http.RoundTripper, error) {
 	schemeReq, name, portReq, valid := utilnet.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid node request %q", id))


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
