### PR TITLE
we should use Warningf instead of Warning when we are using format string

### DIFF
--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -209,7 +209,7 @@ func (c *Controller) onDelete(node *v1.Node) error {
 		syncer.Delete(node)
 		delete(c.syncers, node.Name)
 	} else {
-		glog.Warning("Node %q was already deleted", node.Name)
+		glog.Warningf("Node %q was already deleted", node.Name)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
we should use Warningf instead of Warning when we are using format string
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
