### PR TITLE
Errorf format %q has arg b.labelSelector of wrong type *string

### DIFF
--- a/pkg/kubectl/genericclioptions/resource/builder.go
+++ b/pkg/kubectl/genericclioptions/resource/builder.go
@@ -1043,7 +1043,7 @@ func (b *Builder) visitByPaths() *Result {
 	if b.labelSelector != nil {
 		selector, err := labels.Parse(*b.labelSelector)
 		if err != nil {
-			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", b.labelSelector, err))
+			return result.withError(fmt.Errorf("the provided selector %q is not valid: %v", *b.labelSelector, err))
 		}
 		visitors = NewFilteredVisitor(visitors, FilterByLabelSelector(selector))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
/kind bug

Errorf format %q has arg b.labelSelector of wrong type *string

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
