### PR TITLE
Quobyte API update

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2528,7 +2528,7 @@
 		},
 		{
 			"ImportPath": "github.com/quobyte/api",
-			"Rev": "f2b94aa4aa4f8fcf279fe667ccd916abe6a064d5"
+			"Rev": "206ef832283c1a0144bbc762be2634d49987b5ff"
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher/client",

--- a/vendor/github.com/quobyte/api/rpc_client.go
+++ b/vendor/github.com/quobyte/api/rpc_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -110,5 +111,8 @@ func (client QuobyteClient) sendRequest(method string, request interface{}, resp
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Printf("Warning: HTTP status code for request is %s\n", strconv.Itoa(resp.StatusCode))
+	}
 	return decodeResponse(resp.Body, &response)
 }

--- a/vendor/github.com/quobyte/api/types.go
+++ b/vendor/github.com/quobyte/api/types.go
@@ -22,6 +22,14 @@ type resolveVolumeNameRequest struct {
         retryPolicy
 }
 
+type resolveTenantNameRequest struct {
+	TenantName string `json:"tenant_name,omitempty"`
+}
+
+type resolveTenantNameResponse struct {
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
 type volumeUUID struct {
 	VolumeUUID string `json:"volume_uuid,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Quobyte vendor API update
The current version supports both UUID/name of the volume for the storage class.

**Release note**:
```release-note
NONE
```
