### PR TITLE
enable-debugging-handlers should default to false

### DIFF
--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -81,7 +81,7 @@ kubeletConfiguration:
     cpuManagerPolicy: none
     cpuManagerReconcilePeriod: 10s
     enableControllerAttachDetach: true
-    enableDebuggingHandlers: true
+    enableDebuggingHandlers: false
     enforceNodeAllocatable:
     - pods
     eventBurst: 10

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -49,7 +49,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.EventBurst = 10
 			obj.EventRecordQPS = 5
 			obj.EnableControllerAttachDetach = true
-			obj.EnableDebuggingHandlers = true
+			obj.EnableDebuggingHandlers = false
 			obj.FileCheckFrequency = metav1.Duration{Duration: 20 * time.Second}
 			obj.HealthzBindAddress = "127.0.0.1"
 			obj.HealthzPort = 10248

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
@@ -89,7 +89,7 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		obj.EventBurst = 10
 	}
 	if obj.EnableDebuggingHandlers == nil {
-		obj.EnableDebuggingHandlers = utilpointer.BoolPtr(true)
+		obj.EnableDebuggingHandlers = utilpointer.BoolPtr(false)
 	}
 	if obj.HealthzPort == nil {
 		obj.HealthzPort = utilpointer.Int32Ptr(10248)

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -145,7 +145,7 @@ func GetHollowKubeletConfig(
 	c.CgroupRoot = ""
 	c.CPUCFSQuota = true
 	c.EnableControllerAttachDetach = false
-	c.EnableDebuggingHandlers = true
+	c.EnableDebuggingHandlers = false
 	c.CgroupsPerQOS = false
 	// hairpin-veth is used to allow hairpin packets. Note that this deviates from
 	// what the "real" kubelet currently does, because there's no way to

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -152,6 +152,9 @@ func (e *E2EServices) startKubelet() (*server, error) {
 	kc.SerializeImagePulls = false
 	kubeletConfigFlags = append(kubeletConfigFlags, "serialize-image-pulls")
 
+	kc.EnableDebuggingHandlers = true
+	kubeletConfigFlags = append(kubeletConfigFlags, "enable-debugging-handlers")
+
 	kc.StaticPodPath = podPath
 	kubeletConfigFlags = append(kubeletConfigFlags, "pod-manifest-path")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Handlers for "/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/runningpods/" etc are installed by default as `enable-debugging-handlers` defaults to `true`, we should be more secure by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64514

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
--enable-debugging-handlers command line parameter in kubelet now default to "false". If you need the kubelet local REST API for debugging or logs, please set it to true explicitly.
```
