### PR TITLE
scheduler: enable secure port, authz+authn and deprecate insecure port

### DIFF
--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -242,7 +242,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *KubeSchedulerConfiguration) {
 		}
 		obj.HealthzBindAddress = net.JoinHostPort(host, port)
 	} else {
-		obj.HealthzBindAddress = net.JoinHostPort("0.0.0.0", strconv.Itoa(ports.SchedulerPort))
+		obj.HealthzBindAddress = net.JoinHostPort("0.0.0.0", strconv.Itoa(ports.InsecureSchedulerPort))
 	}
 
 	if host, port, err := net.SplitHostPort(obj.MetricsBindAddress); err == nil {
@@ -251,7 +251,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *KubeSchedulerConfiguration) {
 		}
 		obj.MetricsBindAddress = net.JoinHostPort(host, port)
 	} else {
-		obj.MetricsBindAddress = net.JoinHostPort("0.0.0.0", strconv.Itoa(ports.SchedulerPort))
+		obj.MetricsBindAddress = net.JoinHostPort("0.0.0.0", strconv.Itoa(ports.InsecureSchedulerPort))
 	}
 
 	if len(obj.ClientConnection.ContentType) == 0 {

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -23,9 +23,9 @@ const (
 	// KubeletPort is the default port for the kubelet server on each host machine.
 	// May be overridden by a flag at startup.
 	KubeletPort = 10250
-	// SchedulerPort is the default port for the scheduler status server.
+	// DEPRECATED: InsecureSchedulerPort is the default port for the scheduler status server.
 	// May be overridden by a flag at startup.
-	SchedulerPort = 10251
+	InsecureSchedulerPort = 10251
 	// InsecureKubeControllerManagerPort is the default port for the controller manager status server.
 	// May be overridden by a flag at startup.
 	InsecureKubeControllerManagerPort = 10252
@@ -41,4 +41,7 @@ const (
 	// ProxyHealthzPort is the default port for the proxy healthz server.
 	// May be overridden by a flag at startup.
 	ProxyHealthzPort = 10256
+	// SchedulerPort is the default port for the scheduler status server.
+	// May be overridden by a flag at startup.
+	SchedulerPort = 10259
 )

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -251,7 +251,7 @@ type componentStatusStorage struct {
 func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.Server {
 	serversToValidate := map[string]*componentstatus.Server{
 		"controller-manager": {Addr: "127.0.0.1", Port: ports.InsecureKubeControllerManagerPort, Path: "/healthz"},
-		"scheduler":          {Addr: "127.0.0.1", Port: ports.SchedulerPort, Path: "/healthz"},
+		"scheduler":          {Addr: "127.0.0.1", Port: ports.InsecureSchedulerPort, Path: "/healthz"},
 	}
 
 	for ix, machine := range s.storageFactory.Backends() {

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -281,7 +281,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		// Requires master ssh access.
 		framework.SkipUnlessProviderIs("gce", "aws")
 		restarter := NewRestartConfig(
-			framework.GetMasterHost(), "kube-scheduler", ports.SchedulerPort, restartPollInterval, restartTimeout)
+			framework.GetMasterHost(), "kube-scheduler", ports.InsecureSchedulerPort, restartPollInterval, restartTimeout)
 
 		// Create pods while the scheduler is down and make sure the scheduler picks them up by
 		// scaling the rc to the same size.

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -127,7 +127,7 @@ func (g *MetricsGrabber) GrabFromScheduler() (SchedulerMetrics, error) {
 	if !g.registeredMaster {
 		return SchedulerMetrics{}, fmt.Errorf("Master's Kubelet is not registered. Skipping Scheduler's metrics gathering.")
 	}
-	output, err := g.getMetricsFromPod(g.client, fmt.Sprintf("%v-%v", "kube-scheduler", g.masterName), metav1.NamespaceSystem, ports.SchedulerPort)
+	output, err := g.getMetricsFromPod(g.client, fmt.Sprintf("%v-%v", "kube-scheduler", g.masterName), metav1.NamespaceSystem, ports.InsecureSchedulerPort)
 	if err != nil {
 		return SchedulerMetrics{}, err
 	}

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -463,7 +463,7 @@ func getSchedulingLatency(c clientset.Interface) (*SchedulingMetrics, error) {
 			Context(ctx).
 			Namespace(metav1.NamespaceSystem).
 			Resource("pods").
-			Name(fmt.Sprintf("kube-scheduler-%v:%v", TestContext.CloudConfig.MasterName, ports.SchedulerPort)).
+			Name(fmt.Sprintf("kube-scheduler-%v:%v", TestContext.CloudConfig.MasterName, ports.InsecureSchedulerPort)).
 			SubResource("proxy").
 			Suffix("metrics").
 			Do().Raw()

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -172,7 +172,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 		masterAddr := framework.GetMasterAddress(cs)
 		flag, _ := framework.TestNotReachableHTTPTimeout(masterAddr, ports.InsecureKubeControllerManagerPort, framework.FirewallTestTcpTimeout)
 		Expect(flag).To(BeTrue())
-		flag, _ = framework.TestNotReachableHTTPTimeout(masterAddr, ports.SchedulerPort, framework.FirewallTestTcpTimeout)
+		flag, _ = framework.TestNotReachableHTTPTimeout(masterAddr, ports.InsecureSchedulerPort, framework.FirewallTestTcpTimeout)
 		Expect(flag).To(BeTrue())
 		flag, _ = framework.TestNotReachableHTTPTimeout(nodeAddrs[0], ports.KubeletPort, framework.FirewallTestTcpTimeout)
 		Expect(flag).To(BeTrue())


### PR DESCRIPTION
```release-note
kube-scheduler listens on 0.0.0.0:10259 by default with enabled delegated authn/authz. The insecure port 10251 is deprecated.
```