### PR TITLE
Change no-negcache to neg-ttl=5s in kube-dns

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -165,7 +165,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
-        - --no-negcache
+        - --neg-ttl=5
         - --log-facility=-
         - --server=/__PILLAR__DNS__DOMAIN__/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -165,7 +165,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
-        - --no-negcache
+        - --neg-ttl=5
         - --log-facility=-
         - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -165,7 +165,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
-        - --no-negcache
+        - --neg-ttl=5
         - --log-facility=-
         - --server=/$DNS_DOMAIN/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -121,7 +121,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
-        - --no-negcache
+        - --neg-ttl=5
         - --log-facility=-
         - --server=/{{ .DNSDomain }}/{{ .DNSBindAddr }}#10053
         - --server=/in-addr.arpa/{{ .DNSBindAddr }}#10053

--- a/test/kubemark/resources/kube_dns_template.yaml
+++ b/test/kubemark/resources/kube_dns_template.yaml
@@ -140,7 +140,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
-        - --no-negcache
+        - --neg-ttl=5
         - --log-facility=-
         - --server=/{{dns_domain}}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/53604 a change was introduced which disables negative DNS caching in dnsmasq to mitigate failing service discovery due to long negative DNS cache TTL.

Every major cloud provider has a limit for the number of queries to their DNS servers, kube-dns should do as much as possible to reduce the number of queries hitting these upstream DNS servers. One kube-dns instance could be serving hundreds of containers and none of them are doing DNS caching.

Imagine an application which doesn't have database connection pooling that connects to a database which runs outside of Kubernetes and is accessed by its hostname. This leads to a query for every connection attempt to the upstream DNS servers because the resolver will always try to also look up AAAA records which in most cases don't exist; with `--no-negcache` these will never be cached. One could argue that the app is broken but traditionally the argument has always been that you should implement DNS caching, in Kubernetes the right place to do this is kube-dns.

Instead of disabling negative DNS caching, this PR reintroduces it with a very low TTL. In our environment, setting `--neg-ttl=5` reduced the amount of queries to the upstream DNS server across the cluster by a factor of 10. A cache of 5s is a reasonable tradeoff between speed of service-discovery, performance and cache effectiveness.

**Which issue(s) this PR fixes**: https://github.com/kubernetes/dns/issues/239

**Release note**:
```release-note
Activate negative DNS caching with a TTL of 5s in kube-dns dnsmasq.
```
