### PR TITLE
[GCE] e2e test for expose neg on gce ingress

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -121,8 +121,9 @@ const (
 	// a single character of padding.
 	nameLenLimit = 62
 
-	NEGAnnotation    = "alpha.cloud.google.com/load-balancer-neg"
-	NEGUpdateTimeout = 2 * time.Minute
+	NEGAnnotation       = "cloud.google.com/neg"
+	NEGStatusAnnotation = "cloud.google.com/neg-status"
+	NEGUpdateTimeout    = 2 * time.Minute
 
 	InstanceGroupAnnotation = "ingress.gcp.kubernetes.io/instance-groups"
 
@@ -162,6 +163,15 @@ type IngressConformanceTests struct {
 	EntryLog string
 	Execute  func()
 	ExitLog  string
+}
+
+// NegStatus contains name and zone of the Network Endpoint Group
+// resources associated with this service
+type NegStatus struct {
+	// NetworkEndpointGroups returns the mapping between service port and NEG
+	// resource. key is service port, value is the name of the NEG resource.
+	NetworkEndpointGroups map[int32]string `json:"network_endpoint_groups,omitempty"`
+	Zones                 []string         `json:"zones,omitempty"`
 }
 
 // CreateIngressComformanceTests generates an slice of sequential test cases:
@@ -940,7 +950,7 @@ func (cont *GCEIngressController) backendMode(svcPorts map[string]v1.ServicePort
 		bsMatch := &compute.BackendService{}
 		// Non-NEG BackendServices are named with the Nodeport in the name.
 		// NEG BackendServices' names contain the a sha256 hash of a string.
-		negString := strings.Join([]string{uid, cont.Ns, svcName, sp.TargetPort.String()}, ";")
+		negString := strings.Join([]string{uid, cont.Ns, svcName, fmt.Sprintf("%v", sp.Port)}, ";")
 		negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))[:8]
 		for _, bs := range beList {
 			if strings.Contains(bs.Name, strconv.Itoa(int(sp.NodePort))) ||

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -166,7 +166,8 @@ type IngressConformanceTests struct {
 }
 
 // NegStatus contains name and zone of the Network Endpoint Group
-// resources associated with this service
+// resources associated with this service.
+// Needs to be consistent with the NEG internal structs in ingress-gce.
 type NegStatus struct {
 	// NetworkEndpointGroups returns the mapping between service port and NEG
 	// resource. key is service port, value is the name of the NEG resource.

--- a/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: hostname
+spec:
+  backend:
+    serviceName: hostname
+    servicePort: 80

--- a/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: hostname
+  name: hostname
+spec:
+  template:
+    metadata:
+      labels:
+        run: hostname
+    spec:
+      containers:
+      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.1
+        name: host1
+        command:
+        - /bin/sh
+        - -c
+        - /serve_hostname -http=true -udp=false -port=8000
+        ports:
+        - protocol: TCP
+          containerPort: 8000
+      - image: gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.1
+        name: host2
+        command:
+        - /bin/sh
+        - -c
+        - /serve_hostname -http=true -udp=false -port=8080
+        ports:
+        - protocol: TCP
+          containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/neg-exposed/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/svc.yaml
@@ -3,12 +3,17 @@ kind: Service
 metadata:
   name: hostname
   annotations:
-    cloud.google.com/neg: '{"ingress":true}'
+    cloud.google.com/neg: '{"ingress":true,"exposed_ports":{"80":{},"443":{}}}'
 spec:
   ports:
   - port: 80
+    name: host1
     protocol: TCP
-    targetPort: 9376
+    targetPort: 8000
+  - port: 443
+    name: host2
+    protocol: TCP
+    targetPort: 8080
   selector:
     run: hostname
   sessionAffinity: None

--- a/test/e2e/testing-manifests/ingress/neg/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: hostname
   annotations:
-    alpha.cloud.google.com/load-balancer-neg: "true"
+    cloud.google.com/neg: '{"ingress":true}'
 spec:
   ports:
   - port: 80


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds e2e test for the expose NEG annotation (which allows for standalone NEGs)

**Special notes for your reviewer**:
Note, https://github.com/kubernetes/ingress-gce/pull/350 must be merged first before this is merged.

`[Unreleased]` tag is on this PR because it depends on code from https://github.com/kubernetes/ingress-gce/pull/350 and https://github.com/kubernetes/ingress-gce/pull/284 being in an Ingress release. Will update this test and test-infra once this is released in the next Ingress.

**Release note**:
```release-note
NONE
```
