### PR TITLE
kubeadm uses its own scheme instead of kubectl scheme

### DIFF
--- a/cmd/kubeadm/app/util/audit/BUILD
+++ b/cmd/kubeadm/app/util/audit/BUILD
@@ -8,8 +8,10 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/install:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
 )
 
@@ -18,8 +20,9 @@ go_test(
     srcs = ["utils_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/kubectl/scheme:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/install:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/audit/utils_test.go
+++ b/cmd/kubeadm/app/util/audit/utils_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/apis/audit/install"
 	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 func cleanup(t *testing.T, path string) {
@@ -50,8 +51,11 @@ func TestCreateDefaultAuditLogPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read %v: %v", auditPolicyFile, err)
 	}
+	scheme := runtime.NewScheme()
+	install.Install(scheme)
+	codecs := serializer.NewCodecFactory(scheme)
 	policy := auditv1beta1.Policy{}
-	err = runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), policyBytes, &policy)
+	err = runtime.DecodeInto(codecs.UniversalDecoder(), policyBytes, &policy)
 	if err != nil {
 		t.Fatalf("failed to decode written policy: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
kubeadm uses its own scheme instead of kubectl scheme
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
