### PR TITLE
fix scheduler config bug

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -48,6 +48,11 @@ func loadConfigFromFile(file string) (*componentconfig.KubeSchedulerConfiguratio
 	return loadConfig(data)
 }
 
+// LoadConfigFile load the config file to KubeSchedulerConfiguration struct.
+func LoadConfigFile(file string) (*componentconfig.KubeSchedulerConfiguration, error) {
+	return loadConfigFromFile(file)
+}
+
 func loadConfig(data []byte) (*componentconfig.KubeSchedulerConfiguration, error) {
 	configObj, gvk, err := configCodecs.UniversalDecoder().Decode(data, nil, nil)
 	if err != nil {

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -225,6 +225,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 		Broadcaster:     eventBroadcaster,
 		LeaderElection:  leaderElectionConfig,
 	}
+
 	if err := o.ApplyTo(c); err != nil {
 		return nil, err
 	}

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -101,6 +101,15 @@ through the API as necessary.`,
 				return
 			}
 
+			if len(opts.ConfigFile) > 0 {
+				cfg, err := options.LoadConfigFile(opts.ConfigFile)
+				if err != nil {
+					glog.Errorf("load configfile %v error\n", opts.ConfigFile)
+					os.Exit(1)
+				}
+				opts.ComponentConfig = *cfg
+			}
+
 			c, err := opts.Config()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
Signed-off-by: kadisi <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
if kube-scheduler Only config "--config" parameter,  it will report ： `"Neither --kubeconfig nor --master was specified. Using default API client. This might not work."`
and 
`no configuration has been provided` error,

scheduler exit
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix scheduler config bug
```
