### PR TITLE
fix rbd device works at block mode not get mapped to container 

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -410,10 +410,10 @@ func (plugin *rbdPlugin) ConstructBlockVolumeSpec(podUID types.UID, volumeName, 
 	if len(globalMapPath) == 1 {
 		return nil, fmt.Errorf("failed to retrieve volume plugin information from globalMapPathUUID: %v", globalMapPathUUID)
 	}
-	return getVolumeSpecFromGlobalMapPath(globalMapPath)
+	return getVolumeSpecFromGlobalMapPath(globalMapPath, volumeName)
 }
 
-func getVolumeSpecFromGlobalMapPath(globalMapPath string) (*volume.Spec, error) {
+func getVolumeSpecFromGlobalMapPath(globalMapPath, volumeName string) (*volume.Spec, error) {
 	// Retrieve volume spec information from globalMapPath
 	// globalMapPath example:
 	//   plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}
@@ -423,6 +423,9 @@ func getVolumeSpecFromGlobalMapPath(globalMapPath string) (*volume.Spec, error) 
 	}
 	block := v1.PersistentVolumeBlock
 	rbdVolume := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volumeName,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				RBD: &v1.RBDPersistentVolumeSource{

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -39,6 +39,60 @@ import (
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
 
+const (
+	testVolName    = "vol-1234"
+	testRBDImage   = "volume-a4b47414-a675-47dc-a9cc-c223f13439b0"
+	testRBDPool    = "volumes"
+	testGlobalPath = "plugins/kubernetes.io/rbd/volumeDevices/volumes-image-volume-a4b47414-a675-47dc-a9cc-c223f13439b0"
+)
+
+func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
+	// make our test path for fake GlobalMapPath
+	// /tmp symbolized our pluginDir
+	// /tmp/testGlobalPathXXXXX/plugins/kubernetes.io/rbd/volumeDevices/pdVol1
+	tmpVDir, err := utiltesting.MkTmpdir("rbdBlockTest")
+	if err != nil {
+		t.Fatalf("can't make a temp dir: %v", err)
+	}
+	//deferred clean up
+	defer os.RemoveAll(tmpVDir)
+
+	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
+
+	//Bad Path
+	badspec, err := getVolumeSpecFromGlobalMapPath("", testVolName)
+	if badspec != nil || err == nil {
+		t.Fatalf("Expected not to get spec from GlobalMapPath but did")
+	}
+
+	// Good Path
+	spec, err := getVolumeSpecFromGlobalMapPath(expectedGlobalPath, testVolName)
+	if spec == nil || err != nil {
+		t.Fatalf("Failed to get spec from GlobalMapPath: %v", err)
+	}
+
+	if spec.PersistentVolume.Name != testVolName {
+		t.Errorf("Invalid spec name for GlobalMapPath spec: %s", spec.PersistentVolume.Name)
+	}
+
+	if spec.PersistentVolume.Spec.RBD.RBDPool != testRBDPool {
+		t.Errorf("Invalid RBDPool from GlobalMapPath spec: %s", spec.PersistentVolume.Spec.RBD.RBDPool)
+	}
+
+	if spec.PersistentVolume.Spec.RBD.RBDImage != testRBDImage {
+		t.Errorf("Invalid RBDImage from GlobalMapPath spec: %s", spec.PersistentVolume.Spec.RBD.RBDImage)
+	}
+
+	block := v1.PersistentVolumeBlock
+	specMode := spec.PersistentVolume.Spec.VolumeMode
+	if &specMode == nil {
+		t.Errorf("Invalid volumeMode from GlobalMapPath spec: %v - %v", &specMode, block)
+	}
+	if *specMode != block {
+		t.Errorf("Invalid volumeMode from GlobalMapPath spec: %v - %v", *specMode, block)
+	}
+}
+
 func TestCanSupport(t *testing.T) {
 	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
 	if err != nil {


### PR DESCRIPTION
In my environment, restart docker will caused all of the container restart(our kernel is a bit old). 
Kubelet will also be restart.
After the  container up , I checked the container and find the RBD block device is not mapped to container.
When I inspect the container, its {HostConfig.Devices[]} field is empty.
I did some debug,  then find that  at code https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_pods.go#L113
The volName is empty. 

```release-notes
Fix issues for block device not mapped to container.
```