### PR TITLE
Mount the kubeletConfigPath rw when running containerized node e2e tests

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -219,7 +219,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 
 			// if we will generate a kubelet config file, we need to mount that path into the container too
 			if genKubeletConfigFile {
-				cmdArgs = append(cmdArgs, "-v", filepath.Dir(kubeletConfigPath)+":"+filepath.Dir(kubeletConfigPath)+":ro")
+				cmdArgs = append(cmdArgs, "-v", filepath.Dir(kubeletConfigPath)+":"+filepath.Dir(kubeletConfigPath)+":rw")
 			}
 
 			cmdArgs = append(cmdArgs, hyperkubeImage, "/hyperkube", "kubelet", "--containerized")


### PR DESCRIPTION
The kubelet needs to create dynamic-kubelet-config directory under the kubeletConfigPath
when initialing dynamic config directory.

**What this PR does / why we need it**:
Without the patch the https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-containerized-conformance-aws-e2e-rhel fails.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Started to occur after merging https://github.com/kubernetes/kubernetes/pull/64275

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
