### PR TITLE
cloud node controller: improve error handling for node registration

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -168,6 +169,12 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 		glog.Errorf("%v", err)
 		return
 	}
+
+	if len(nodeAddresses) == 0 {
+		glog.V(5).Infof("Skipping node address update for node %q since cloud provider did not return any", node.Name)
+		return
+	}
+
 	// Check if a hostname address exists in the cloud provided addresses
 	hostnameExists := false
 	for i := range nodeAddresses {
@@ -349,21 +356,18 @@ func (cnc *CloudNodeController) AddCloudNode(obj interface{}) {
 
 		nodeAddresses, err := getNodeAddressesByProviderIDOrName(instances, curNode)
 		if err != nil {
-			glog.Errorf("%v", err)
-			return nil
+			return err
 		}
 
 		// If user provided an IP address, ensure that IP address is found
 		// in the cloud provider before removing the taint on the node
 		if nodeIP, ok := ensureNodeProvidedIPExists(curNode, nodeAddresses); ok {
 			if nodeIP == nil {
-				glog.Errorf("failed to get specified nodeIP in cloudprovider")
-				return nil
+				return errors.New("failed to find kubelet node IP from cloud provider")
 			}
 		}
 
 		if instanceType, err := getInstanceTypeByProviderIDOrName(instances, curNode); err != nil {
-			glog.Errorf("%v", err)
 			return err
 		} else if instanceType != "" {
 			glog.V(2).Infof("Adding node label from cloud provider: %s=%s", kubeletapis.LabelInstanceType, instanceType)


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves error handling for (external) node registration.

**Release note**:
```release-note
NONE
```
