### PR TITLE
Use glog across kubeadm for consistent output

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -487,7 +487,7 @@ func (i *Init) Run(out io.Writer) error {
 
 	// Exit earlier if we're dryrunning
 	if i.dryRun {
-		fmt.Println("[dryrun] finished dry-running successfully. Above are the resources that would be created")
+		glog.V(1).Infoln("[dryrun] finished dry-running successfully. Above are the resources that would be created")
 		return nil
 	}
 

--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/mholt/caddy/caddyfile:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/mholt/caddy/caddyfile"
 
 	apps "k8s.io/api/apps/v1"
@@ -128,7 +129,7 @@ func kubeDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interfac
 	if err := createKubeDNSAddon(dnsDeploymentBytes, dnsServiceBytes, client); err != nil {
 		return err
 	}
-	fmt.Println("[addons] Applied essential addon: kube-dns")
+	glog.V(1).Infoln("[addons] Applied essential addon: kube-dns")
 	return nil
 }
 
@@ -217,7 +218,7 @@ func coreDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interfac
 	if err := createCoreDNSAddon(coreDNSDeploymentBytes, coreDNSServiceBytes, coreDNSConfigMapBytes, client); err != nil {
 		return err
 	}
-	fmt.Println("[addons] Applied essential addon: CoreDNS")
+	glog.V(1).Infoln("[addons] Applied essential addon: CoreDNS")
 	return nil
 }
 

--- a/cmd/kubeadm/app/phases/addons/proxy/BUILD
+++ b/cmd/kubeadm/app/phases/addons/proxy/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/golang/glog"
+
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -91,7 +93,7 @@ func EnsureProxyAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Inte
 		return fmt.Errorf("error when creating kube-proxy RBAC rules: %v", err)
 	}
 
-	fmt.Println("[addons] Applied essential addon: kube-proxy")
+	glog.V(1).Infoln("[addons] Applied essential addon: kube-proxy")
 	return nil
 }
 

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -522,7 +522,7 @@ func writeCertificateAuthorithyFilesIfNotExist(pkiDir string, baseName string, c
 		// kubeadm doesn't validate the existing certificate Authority more than this;
 		// Basically, if we find a certificate file with the same path; and it is a CA
 		// kubeadm thinks those files are equal and doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
+		glog.V(1).Infof("[certificates] Using the existing %s certificate and key.\n", baseName)
 	} else {
 
 		// Write .crt and .key files to disk
@@ -530,7 +530,7 @@ func writeCertificateAuthorithyFilesIfNotExist(pkiDir string, baseName string, c
 			return fmt.Errorf("failure while saving %s certificate and key: %v", baseName, err)
 		}
 
-		fmt.Printf("[certificates] Generated %s certificate and key.\n", baseName)
+		glog.V(1).Infof("[certificates] Generated %s certificate and key.\n", baseName)
 	}
 	return nil
 }
@@ -558,7 +558,7 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 		// Basically, if we find a certificate file with the same path; and it is signed by
 		// the expected certificate authority, kubeadm thinks those files are equal and
 		// doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s certificate and key.\n", baseName)
+		glog.V(1).Infof("[certificates] Using the existing %s certificate and key.\n", baseName)
 	} else {
 
 		// Write .crt and .key files to disk
@@ -566,9 +566,9 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 			return fmt.Errorf("failure while saving %s certificate and key: %v", baseName, err)
 		}
 
-		fmt.Printf("[certificates] Generated %s certificate and key.\n", baseName)
+		glog.V(1).Infof("[certificates] Generated %s certificate and key.\n", baseName)
 		if pkiutil.HasServerAuth(cert) {
-			fmt.Printf("[certificates] %s serving cert is signed for DNS names %v and IPs %v\n", baseName, cert.DNSNames, cert.IPAddresses)
+			glog.V(1).Infof("[certificates] %s serving cert is signed for DNS names %v and IPs %v\n", baseName, cert.DNSNames, cert.IPAddresses)
 		}
 	}
 
@@ -593,7 +593,7 @@ func writeKeyFilesIfNotExist(pkiDir string, baseName string, key *rsa.PrivateKey
 		// kubeadm doesn't validate the existing certificate key more than this;
 		// Basically, if we find a key file with the same path kubeadm thinks those files
 		// are equal and doesn't bother writing a new file
-		fmt.Printf("[certificates] Using the existing %s key.\n", baseName)
+		glog.V(1).Infof("[certificates] Using the existing %s key.\n", baseName)
 	} else {
 
 		// Write .key and .pub files to disk
@@ -604,7 +604,7 @@ func writeKeyFilesIfNotExist(pkiDir string, baseName string, key *rsa.PrivateKey
 		if err := pkiutil.WritePublicKey(pkiDir, baseName, &key.PublicKey); err != nil {
 			return fmt.Errorf("failure while saving %s public key: %v", baseName, err)
 		}
-		fmt.Printf("[certificates] Generated %s key and public key.\n", baseName)
+		glog.V(1).Infof("[certificates] Generated %s key and public key.\n", baseName)
 	}
 
 	return nil

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -17,7 +17,6 @@ limitations under the License.
 package etcd
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/golang/glog"
@@ -45,7 +44,7 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.Ma
 		return err
 	}
 
-	fmt.Printf("[etcd] Wrote Static Pod manifest for a local etcd instance to %q\n", kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestDir))
+	glog.V(1).Infof("[etcd] Wrote Static Pod manifest for a local etcd instance to %q\n", kubeadmconstants.GetStaticPodFilepath(kubeadmconstants.Etcd, manifestDir))
 	return nil
 }
 

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -238,7 +238,7 @@ func createKubeConfigFileIfNotExists(outDir, filename string, config *clientcmda
 			return fmt.Errorf("failed to save kubeconfig file %s on disk: %v", kubeConfigFilePath, err)
 		}
 
-		fmt.Printf("[kubeconfig] Wrote KubeConfig file to disk: %q\n", kubeConfigFilePath)
+		glog.V(1).Infof("[kubeconfig] Wrote KubeConfig file to disk: %q\n", kubeConfigFilePath)
 		return nil
 	}
 
@@ -265,7 +265,7 @@ func createKubeConfigFileIfNotExists(outDir, filename string, config *clientcmda
 	// kubeadm doesn't validate the existing kubeconfig file more than this (kubeadm trusts the client certs to be valid)
 	// Basically, if we find a kubeconfig file with the same path; the same CA cert and the same server URL;
 	// kubeadm thinks those files are equal and doesn't bother writing a new file
-	fmt.Printf("[kubeconfig] Using existing up-to-date KubeConfig file: %q\n", kubeConfigFilePath)
+	glog.V(1).Infof("[kubeconfig] Using existing up-to-date KubeConfig file: %q\n", kubeConfigFilePath)
 
 	return nil
 }

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,7 @@ func CreateConfigMap(cfg *kubeadmapi.MasterConfiguration, client clientset.Inter
 	}
 
 	configMapName := configMapName(k8sVersion)
-	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
+	glog.V(1).Infof("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
 
 	kubeletBytes, err := getConfigBytes(cfg.KubeletConfiguration.BaseConfig)
 	if err != nil {
@@ -163,7 +164,7 @@ func getConfigBytes(kubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) ([
 
 // writeConfigBytesToDisk writes a byte slice down to disk at the specific location of the kubelet config file
 func writeConfigBytesToDisk(b []byte) error {
-	fmt.Printf("[kubelet] Writing kubelet configuration to file %q\n", kubeadmconstants.KubeletConfigurationFile)
+	glog.V(1).Infof("[kubelet] Writing kubelet configuration to file %q\n", kubeadmconstants.KubeletConfigurationFile)
 
 	if err := ioutil.WriteFile(kubeadmconstants.KubeletConfigurationFile, b, 0644); err != nil {
 		return fmt.Errorf("failed to write kubelet configuration to the file %q: %v", kubeadmconstants.KubeletConfigurationFile, err)

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -81,7 +81,7 @@ func buildKubeletArgMap(nodeRegOpts *kubeadmapi.NodeRegistrationOptions, registe
 
 // writeKubeletFlagBytesToDisk writes a byte slice down to disk at the specific location of the kubelet flag overrides file
 func writeKubeletFlagBytesToDisk(b []byte) error {
-	fmt.Printf("[kubelet] Writing kubelet environment file with flags to file %q\n", constants.KubeletEnvFile)
+	glog.V(1).Infof("[kubelet] Writing kubelet environment file with flags to file %q\n", constants.KubeletEnvFile)
 
 	// creates target folder if not already exists
 	if err := os.MkdirAll(filepath.Dir(constants.KubeletEnvFile), 0700); err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -89,7 +89,7 @@ func CheckClusterHealth(client clientset.Interface, ignoreChecksErrors sets.Stri
 		})
 	}
 
-	return preflight.RunChecks(healthChecks, os.Stderr, ignoreChecksErrors)
+	return preflight.RunChecks(healthChecks, &preflight.Log{os.Stderr}, ignoreChecksErrors)
 }
 
 // apiServerHealthy checks whether the API server's /healthz endpoint is healthy

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -278,7 +278,7 @@ func TestRunChecks(t *testing.T) {
 		output   string
 	}{
 		{[]Checker{}, true, ""},
-		{[]Checker{preflightCheckTest{"warning"}}, true, "\t[WARNING preflightCheckTest]: warning\n"}, // should just print warning
+		{[]Checker{preflightCheckTest{"warning"}}, true, "\t[WARNING] preflightCheckTest: warning\n"}, // should just print warning
 		{[]Checker{preflightCheckTest{"error"}}, false, ""},
 		{[]Checker{preflightCheckTest{"test"}}, false, ""},
 		{[]Checker{DirAvailableCheck{Path: "/does/not/exist"}}, true, ""},
@@ -287,13 +287,13 @@ func TestRunChecks(t *testing.T) {
 		{[]Checker{FileContentCheck{Path: "/does/not/exist"}}, false, ""},
 		{[]Checker{FileContentCheck{Path: "/"}}, true, ""},
 		{[]Checker{FileContentCheck{Path: "/", Content: []byte("does not exist")}}, false, ""},
-		{[]Checker{InPathCheck{executable: "foobarbaz", exec: exec.New()}}, true, "\t[WARNING FileExisting-foobarbaz]: foobarbaz not found in system path\n"},
+		{[]Checker{InPathCheck{executable: "foobarbaz", exec: exec.New()}}, true, "\t[WARNING] FileExisting-foobarbaz: foobarbaz not found in system path\n"},
 		{[]Checker{InPathCheck{executable: "foobarbaz", mandatory: true, exec: exec.New()}}, false, ""},
-		{[]Checker{InPathCheck{executable: "foobar", mandatory: false, exec: exec.New(), suggestion: "install foobar"}}, true, "\t[WARNING FileExisting-foobar]: foobar not found in system path\nSuggestion: install foobar\n"},
+		{[]Checker{InPathCheck{executable: "foobar", mandatory: false, exec: exec.New(), suggestion: "install foobar"}}, true, "\t[WARNING] FileExisting-foobar: foobar not found in system path\nSuggestion: install foobar\n"},
 	}
 	for _, rt := range tokenTest {
 		buf := new(bytes.Buffer)
-		actual := RunChecks(rt.p, buf, sets.NewString())
+		actual := RunChecks(rt.p, &Log{buf}, sets.NewString())
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed RunChecks:\n\texpected: %t\n\t  actual: %t",

--- a/cmd/kubeadm/app/util/apiclient/BUILD
+++ b/cmd/kubeadm/app/util/apiclient/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +81,7 @@ func (w *KubeWaiter) WaitForAPI() error {
 			return false, nil
 		}
 
-		fmt.Printf("[apiclient] All control plane components are healthy after %f seconds\n", time.Since(start).Seconds())
+		glog.V(1).Infof("[apiclient] All control plane components are healthy after %f seconds\n", time.Since(start).Seconds())
 		return true, nil
 	})
 }


### PR DESCRIPTION
Fixes kubernetes/kubeadm#852

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This pr makes the output of `kubeadm init` consistent

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#852

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
