### PR TITLE
Version mismatch is now a skippable error

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/policy.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy.go
@@ -118,8 +118,7 @@ func EnforceVersionPolicies(versionGetter VersionGetter, newK8sVersionStr string
 
 	if kubeadmVersion.Major() > newK8sVersion.Major() ||
 		kubeadmVersion.Minor() > newK8sVersion.Minor() {
-		skewErrors.Mandatory = append(skewErrors.Mandatory, fmt.Errorf("Kubeadm version %s can only be used to upgrade to Kubernetes versions %d.%d", kubeadmVersionStr, kubeadmVersion.Major(), kubeadmVersion.Minor()))
-
+		skewErrors.Skippable = append(skewErrors.Skippable, fmt.Errorf("Kubeadm version %s can only be used to upgrade to Kubernetes version %d.%d", kubeadmVersionStr, kubeadmVersion.Major(), kubeadmVersion.Minor()))
 	}
 
 	// Detect if the version is unstable and the user didn't allow that

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -75,7 +75,8 @@ func TestEnforceVersionPolicies(t *testing.T) {
 				kubeadmVersion: "v1.10.3",
 			},
 			newK8sVersion:         "v1.9.10",
-			expectedMandatoryErrs: 2, // version must be higher than v1.10.0, can't upgrade old k8s with newer kubeadm
+			expectedMandatoryErrs: 1, // version must be higher than v1.10.0
+			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
 		{
 			name: "upgrading two minor versions in one go is not supported",
@@ -96,7 +97,8 @@ func TestEnforceVersionPolicies(t *testing.T) {
 				kubeadmVersion: "v1.12.0",
 			},
 			newK8sVersion:         "v1.10.3",
-			expectedMandatoryErrs: 2, // can't downgrade two minor versions, can't upgrade old k8s with newer kubeadm
+			expectedMandatoryErrs: 1, // can't downgrade two minor versions
+			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
 		{
 			name: "kubeadm version must be higher than the new kube version. However, patch version skews may be forced",
@@ -187,7 +189,7 @@ func TestEnforceVersionPolicies(t *testing.T) {
 				kubeadmVersion: "v1.11.0",
 			},
 			newK8sVersion:         "v1.10.6",
-			expectedMandatoryErrs: 1, // can't upgrade old k8s with newer kubeadm
+			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, kubeadm enforced the same major and minor versions as the version of kubernetes it was installing. This is still enforced by default, but now the `--force` flag can override it. This is useful for testing and other edge cases.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[kubeadm/877](https://github.com/kubernetes/kubeadm/issues/877)

**Special notes for your reviewer**:

**Release note**:
```release-note
kubeadm upgrade apply can now ignore version errors with --force
```
