### PR TITLE
remove extra "../" when copying from pod to local

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -287,7 +287,20 @@ func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
 	}()
 	prefix := getPrefix(src.File)
 	prefix = path.Clean(prefix)
+	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
+	// and attempted to navigate beyond "/" in a remote filesystem
+	prefix = stripPathShortcuts(prefix)
 	return untarAll(reader, dest.File, prefix)
+}
+
+// stripPathShortcuts removes any leading or trailing "../" from a given path
+func stripPathShortcuts(p string) string {
+	newPath := path.Clean(p)
+	if len(newPath) > 0 && string(newPath[0]) == "/" {
+		return newPath[1:]
+	}
+
+	return newPath
 }
 
 func makeTar(srcPath, destPath string, writer io.Writer) error {


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Copying via `kubectl cp` from a pod to local will no longer panic if any received tar headers contain an extra "../". This can happen when specifying a remote location beyond "/" - for example:

```
# I am attempting to go backwards beyond "/"
$ kubectl cp mypod:/one/two/../../../etc/hosts ./
```

The above command results in a tar header containing an extra "../" in its name (../etc/hosts), causing a panic [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L388).

Related downstream bug: https://bugzilla.redhat.com/show_bug.cgi?id=1584555

cc @soltysh 