### PR TITLE
Remove optimization from getWork in resourcequota/controller.go

### DIFF
--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -583,6 +583,11 @@ func (e *quotaEvaluator) completeWork(ns string) {
 	e.inProgress.Delete(ns)
 }
 
+// getWork returns a namespace, a list of work items in that
+// namespace, and a shutdown boolean.  If not shutdown then the return
+// must eventually be followed by a call on completeWork for the
+// returned namespace (regardless of whether the work item list is
+// empty).
 func (e *quotaEvaluator) getWork() (string, []*admissionWaiter, bool) {
 	uncastNS, shutdown := e.queue.Get()
 	if shutdown {
@@ -599,15 +604,8 @@ func (e *quotaEvaluator) getWork() (string, []*admissionWaiter, bool) {
 	work := e.work[ns]
 	delete(e.work, ns)
 	delete(e.dirtyWork, ns)
-
-	if len(work) != 0 {
-		e.inProgress.Insert(ns)
-		return ns, work, false
-	}
-
-	e.queue.Done(ns)
-	e.inProgress.Delete(ns)
-	return ns, []*admissionWaiter{}, false
+	e.inProgress.Insert(ns)
+	return ns, work, false
 }
 
 // prettyPrint formats a resource list for usage in errors


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This change simplifies the code in
plugin/pkg/admission/resourcequota/controller.go by removing the
optimization in getWork that required the caller to NOT call
completeWork if getWork returns the empty list of work.  BTW, the
caller was not obeying that requirement; now the caller's behavior
(which is unchanged) is right.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63608 

**Special notes for your reviewer**:
This is a simpler alternative to #64377 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed issue 63608, which is that under rare circumstances the ResourceQuota admission controller could lose track of an request in progress and time out after waiting 10 seconds for a decision to be made.
```
