### PR TITLE
apply global flag "context" for kubectl config view

### DIFF
--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -865,12 +865,12 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdConfig(cmdutil.NewFactory(genericclioptions.NewTestConfigFlags()), clientcmd.NewDefaultPathOptions(), streams)
+	// "context" is a global flag, inherited from base kubectl command in the real world
+	cmd.PersistentFlags().String("context", "", "The name of the kubeconfig context to use")
 	cmd.SetArgs(argsToUse)
 	cmd.Execute()
 
-	// outBytes, _ := ioutil.ReadFile(fakeKubeFile.Name())
 	config := clientcmd.GetConfigFromFileOrDie(fakeKubeFile.Name())
-
 	return buf.String(), *config
 }
 

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -43,6 +43,7 @@ type ViewOptions struct {
 	Minify       bool
 	RawByteData  bool
 
+	Context      string
 	OutputFormat string
 
 	genericclioptions.IOStreams
@@ -110,6 +111,7 @@ func (o *ViewOptions) Complete(cmd *cobra.Command) error {
 		return err
 	}
 	o.PrintObject = printer.PrintObj
+	o.Context = cmdutil.GetFlagString(cmd, "context")
 
 	return nil
 }
@@ -129,6 +131,9 @@ func (o ViewOptions) Run() error {
 	}
 
 	if o.Minify {
+		if len(o.Context) > 0 {
+			config.CurrentContext = o.Context
+		}
 		if err := clientcmdapi.MinifyConfig(config); err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/config/view_test.go
+++ b/pkg/kubectl/cmd/config/view_test.go
@@ -43,19 +43,19 @@ func TestViewCluster(t *testing.T) {
 			"my-cluster": {Server: "https://192.168.0.1:3434"},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"minikube":  {AuthInfo: "minikube", Cluster: "minikube"},
-			"my-cluser": {AuthInfo: "mu-cluster", Cluster: "my-cluster"},
+			"minikube":   {AuthInfo: "minikube", Cluster: "minikube"},
+			"my-cluster": {AuthInfo: "mu-cluster", Cluster: "my-cluster"},
 		},
 		CurrentContext: "minikube",
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"minikube":  {Token: "minikube-token"},
-			"my-cluser": {Token: "minikube-token"},
+			"minikube":   {Token: "minikube-token"},
+			"mu-cluster": {Token: "minikube-token"},
 		},
 	}
+
 	test := viewClusterTest{
 		description: "Testing for kubectl config view",
 		config:      conf,
-		flags:       []string{},
 		expected: `apiVersion: v1
 clusters:
 - cluster:
@@ -72,7 +72,7 @@ contexts:
 - context:
     cluster: my-cluster
     user: mu-cluster
-  name: my-cluser
+  name: my-cluster
 current-context: minikube
 kind: Config
 preferences: {}
@@ -80,10 +80,13 @@ users:
 - name: minikube
   user:
     token: minikube-token
-- name: my-cluser
+- name: mu-cluster
   user:
-    token: minikube-token` + "\n"}
+    token: minikube-token` + "\n",
+	}
+
 	test.run(t)
+
 }
 
 func TestViewClusterMinify(t *testing.T) {
@@ -95,20 +98,27 @@ func TestViewClusterMinify(t *testing.T) {
 			"my-cluster": {Server: "https://192.168.0.1:3434"},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"minikube":  {AuthInfo: "minikube", Cluster: "minikube"},
-			"my-cluser": {AuthInfo: "mu-cluster", Cluster: "my-cluster"},
+			"minikube":   {AuthInfo: "minikube", Cluster: "minikube"},
+			"my-cluster": {AuthInfo: "mu-cluster", Cluster: "my-cluster"},
 		},
 		CurrentContext: "minikube",
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"minikube":  {Token: "minikube-token"},
-			"my-cluser": {Token: "minikube-token"},
+			"minikube":   {Token: "minikube-token"},
+			"mu-cluster": {Token: "minikube-token"},
 		},
 	}
-	test := viewClusterTest{
-		description: "Testing for kubectl config view --minify=true",
-		config:      conf,
-		flags:       []string{"--minify=true"},
-		expected: `apiVersion: v1
+
+	testCases := []struct {
+		description string
+		config      clientcmdapi.Config
+		flags       []string
+		expected    string
+	}{
+		{
+			description: "Testing for kubectl config view --minify=true",
+			config:      conf,
+			flags:       []string{"--minify=true"},
+			expected: `apiVersion: v1
 clusters:
 - cluster:
     server: https://192.168.99.100:8443
@@ -124,8 +134,41 @@ preferences: {}
 users:
 - name: minikube
   user:
-    token: minikube-token` + "\n"}
-	test.run(t)
+    token: minikube-token` + "\n",
+		},
+		{
+			description: "Testing for kubectl config view --minify=true --context=my-cluster",
+			config:      conf,
+			flags:       []string{"--minify=true", "--context=my-cluster"},
+			expected: `apiVersion: v1
+clusters:
+- cluster:
+    server: https://192.168.0.1:3434
+  name: my-cluster
+contexts:
+- context:
+    cluster: my-cluster
+    user: mu-cluster
+  name: my-cluster
+current-context: my-cluster
+kind: Config
+preferences: {}
+users:
+- name: mu-cluster
+  user:
+    token: minikube-token` + "\n",
+		},
+	}
+
+	for _, test := range testCases {
+		cmdTest := viewClusterTest{
+			description: test.description,
+			config:      test.config,
+			flags:       test.flags,
+			expected:    test.expected,
+		}
+		cmdTest.run(t)
+	}
 }
 
 func (test viewClusterTest) run(t *testing.T) {
@@ -143,7 +186,10 @@ func (test viewClusterTest) run(t *testing.T) {
 	pathOptions.EnvVar = ""
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdConfigView(cmdutil.NewFactory(genericclioptions.NewTestConfigFlags()), streams, pathOptions)
+	// "context" is a global flag, inherited from base kubectl command in the real world
+	cmd.Flags().String("context", "", "The name of the kubeconfig context to use")
 	cmd.Flags().Parse(test.flags)
+
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v,kubectl config view flags: %v", err, test.flags)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`--context` is a global flag, which should be applied to `kubectl config view` as well when minifying.

Currently this command is only available for `current-context`. With this PR, it will be easier for users to view other non current contexts when minifying.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64583

**Special notes for your reviewer**:
/cc soltysh juanvallejo 
 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
apply global flag "context" for kubectl config view --minify
```
