### PR TITLE
Automated cherry pick of #62753: Fix extra-log flag for node e2e.

### DIFF
--- a/test/e2e_node/services/logs.go
+++ b/test/e2e_node/services/logs.go
@@ -44,12 +44,6 @@ func (l *logFiles) String() string {
 
 // Set function of flag.Value
 func (l *logFiles) Set(value string) error {
-	// Someone else is calling flag.Parse after the flags are parsed in the
-	// test framework. Use this to avoid the flag being parsed twice.
-	// TODO(random-liu): Figure out who is parsing the flags.
-	if flag.Parsed() {
-		return nil
-	}
 	var log LogFileData
 	if err := json.Unmarshal([]byte(value), &log); err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #62753 on release-1.10.

#62753: Fix extra-log flag for node e2e.