### PR TITLE
Download conntrack binary via configure scripts.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1200,6 +1200,9 @@ function start-kubelet {
   local kubelet_opts="${KUBELET_ARGS} ${KUBELET_CONFIG_FILE_ARG:-}"
   echo "KUBELET_OPTS=\"${kubelet_opts}\"" > "${kubelet_env_file}"
   echo "KUBE_COVERAGE_FILE=\"/var/log/kubelet.cov\"" >> "${kubelet_env_file}"
+  # Include KUBE_HOME/bin in path so that kubelet can find conntrack binary
+  local -r new_path="${PATH}:${KUBE_HOME}/bin"
+  echo "PATH=\"${new_path}\"" >> "${kubelet_env_file}"
 
   # Write the systemd service file for kubelet.
   cat <<EOF >/etc/systemd/system/kubelet.service

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -31,6 +31,7 @@ DEFAULT_NPD_SHA1="650ecfb2ae495175ee43706d0bd862a1ea7f1395"
 DEFAULT_CRICTL_VERSION="v1.12.0"
 DEFAULT_CRICTL_SHA1="82ef8b44849f9da0589c87e9865d4716573eec7f"
 DEFAULT_MOUNTER_TAR_SHA="8003b798cf33c7f91320cd6ee5cec4fa22244571"
+DEFAULT_CONNTRACK_SHA1="0af7a8981074d84331f969f1616176a9b60aa22e"
 ###
 
 # Use --retry-connrefused opt only if it's supported by curl.
@@ -285,6 +286,17 @@ function install-exec-auth-plugin {
   mv "${KUBE_HOME}/LICENSE" "${KUBE_BIN}/gke-exec-auth-plugin-license"
 }
 
+function download-conntrack-binaries {
+  if [ -e "${KUBE_BIN}/conntrack" ]; then
+    echo "conntrack already installed."
+    return
+  fi
+  local -r ct_sha1="${DEFAULT_CONNTRACK_SHA1}"
+  echo "Downloading conntrack binary"
+  download-or-bust "${ct_sha1}" "https://storage.googleapis.com/kubernetes-release/conntrack/conntrack"
+  mv conntrack "${KUBE_BIN}"/conntrack
+}
+
 function install-kube-manifests {
   # Put kube-system pods manifests in ${KUBE_HOME}/kube-manifests/.
   local dst_dir="${KUBE_HOME}/kube-manifests"
@@ -412,6 +424,8 @@ function install-kube-binary-config {
      [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
     install-cni-binaries
   fi
+
+  download-conntrack-binaries
 
   # Put kube-system pods manifests in ${KUBE_HOME}/kube-manifests/.
   install-kube-manifests


### PR DESCRIPTION
Point to this conntrack path in kubelet hostport code that clears stale UDP conntrack entries.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR downloads the conntrack tool to a custom location in nodes running Container-Optimized OS or Ubuntu. The code to clear conntrack entries for a HostPort UDP service will only kick in if conntrack binary is installed on the node and it is not, by default. With the changes in this PR, the stale UDP connections will be cleared.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #59033

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
