### PR TITLE
Add missing error handling in schema-related code

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -114,8 +114,12 @@ func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) 
 // NewDefaultComponentConfig returns cloud-controller manager configuration object.
 func NewDefaultComponentConfig(insecurePort int32) (componentconfig.CloudControllerManagerConfiguration, error) {
 	scheme := runtime.NewScheme()
-	componentconfigv1alpha1.AddToScheme(scheme)
-	componentconfig.AddToScheme(scheme)
+	if err := componentconfigv1alpha1.AddToScheme(scheme); err != nil {
+		return componentconfig.CloudControllerManagerConfiguration{}, err
+	}
+	if err := componentconfig.AddToScheme(scheme); err != nil {
+		return componentconfig.CloudControllerManagerConfiguration{}, err
+	}
 
 	versioned := componentconfigv1alpha1.CloudControllerManagerConfiguration{}
 	scheme.Default(&versioned)

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -208,8 +208,12 @@ func NewKubeControllerManagerOptions() (*KubeControllerManagerOptions, error) {
 // NewDefaultComponentConfig returns kube-controller manager configuration object.
 func NewDefaultComponentConfig(insecurePort int32) (componentconfig.KubeControllerManagerConfiguration, error) {
 	scheme := runtime.NewScheme()
-	componentconfigv1alpha1.AddToScheme(scheme)
-	componentconfig.AddToScheme(scheme)
+	if err := componentconfigv1alpha1.AddToScheme(scheme); err != nil {
+		return componentconfig.KubeControllerManagerConfiguration{}, err
+	}
+	if err := componentconfig.AddToScheme(scheme); err != nil {
+		return componentconfig.KubeControllerManagerConfiguration{}, err
+	}
 
 	versioned := componentconfigv1alpha1.KubeControllerManagerConfiguration{}
 	scheme.Default(&versioned)

--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	componentconfigv1alpha1 "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
 )
@@ -35,8 +36,8 @@ var (
 )
 
 func init() {
-	componentconfig.AddToScheme(configScheme)
-	componentconfigv1alpha1.AddToScheme(configScheme)
+	utilruntime.Must(componentconfig.AddToScheme(configScheme))
+	utilruntime.Must(componentconfigv1alpha1.AddToScheme(configScheme))
 }
 
 func loadConfigFromFile(file string) (*componentconfig.KubeSchedulerConfiguration, error) {

--- a/cmd/kubeadm/app/apis/kubeadm/scheme/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
+++ b/cmd/kubeadm/app/apis/kubeadm/scheme/scheme.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"
@@ -39,8 +40,8 @@ func init() {
 
 // AddToScheme builds the Kubeadm scheme using all known versions of the kubeadm api.
 func AddToScheme(scheme *runtime.Scheme) {
-	kubeadm.AddToScheme(scheme)
-	v1alpha1.AddToScheme(scheme)
-	v1alpha2.AddToScheme(scheme)
-	scheme.SetVersionPriority(v1alpha1.SchemeGroupVersion)
+	utilruntime.Must(kubeadm.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha2.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1alpha1.SchemeGroupVersion))
 }

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -53,6 +53,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/github.com/pmezard/go-difflib/difflib:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/config/masterconfig_test.go
+++ b/cmd/kubeadm/app/util/config/masterconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -159,7 +160,7 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	scheme := runtime.NewScheme()
-	v1alpha1.AddToScheme(scheme)
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
 	codecs := serializer.NewCodecFactory(scheme)
 
 	obj := &v1alpha1.MasterConfiguration{}

--- a/pkg/api/ref/BUILD
+++ b/pkg/api/ref/BUILD
@@ -16,6 +16,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/pkg/api/ref/ref_test.go
+++ b/pkg/api/ref/ref_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,7 +55,7 @@ func TestGetReference(t *testing.T) {
 	// then you run into trouble because the types aren't registered in the scheme by anything.  This does the
 	// register manually to allow unit test execution
 	if _, _, err := legacyscheme.Scheme.ObjectKinds(&api.Pod{}); err != nil {
-		api.AddToScheme(legacyscheme.Scheme)
+		require.NoError(t, api.AddToScheme(legacyscheme.Scheme))
 	}
 
 	table := map[string]struct {

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -224,6 +224,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing:go_default_library",

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
@@ -43,7 +44,7 @@ import (
 
 // This init should be removed after switching this command and its tests to user external types.
 func init() {
-	api.AddToScheme(scheme.Scheme)
+	utilruntime.Must(api.AddToScheme(scheme.Scheme))
 }
 
 func initTestErrorHandler(t *testing.T) {

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -36,7 +37,7 @@ import (
 
 // This init should be removed after switching this command and its tests to user external types.
 func init() {
-	api.AddToScheme(scheme.Scheme)
+	utilruntime.Must(api.AddToScheme(scheme.Scheme))
 }
 
 func TestRunExposeService(t *testing.T) {

--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -84,6 +84,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -56,9 +57,9 @@ var openapiSchemaPath = filepath.Join("..", "..", "..", "..", "api", "openapi-sp
 
 // This init should be removed after switching this command and its tests to user external types.
 func init() {
-	api.AddToScheme(scheme.Scheme)
-	scheme.Scheme.AddConversionFuncs(v1.Convert_core_PodSpec_To_v1_PodSpec)
-	scheme.Scheme.AddConversionFuncs(v1.Convert_v1_PodSecurityContext_To_core_PodSecurityContext)
+	utilruntime.Must(api.AddToScheme(scheme.Scheme))
+	utilruntime.Must(scheme.Scheme.AddConversionFuncs(v1.Convert_core_PodSpec_To_v1_PodSpec))
+	utilruntime.Must(scheme.Scheme.AddConversionFuncs(v1.Convert_v1_PodSecurityContext_To_core_PodSecurityContext))
 }
 
 var unstructuredSerializer = resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -46,7 +47,7 @@ import (
 
 // This init should be removed after switching this command and its tests to user external types.
 func init() {
-	api.AddToScheme(scheme.Scheme)
+	utilruntime.Must(api.AddToScheme(scheme.Scheme))
 }
 
 func TestGetRestartPolicy(t *testing.T) {

--- a/pkg/proxy/apis/kubeproxyconfig/scheme/BUILD
+++ b/pkg/proxy/apis/kubeproxyconfig/scheme/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],
 )
 

--- a/pkg/proxy/apis/kubeproxyconfig/scheme/scheme.go
+++ b/pkg/proxy/apis/kubeproxyconfig/scheme/scheme.go
@@ -19,6 +19,7 @@ package scheme
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig"
 	"k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/v1alpha1"
 )
@@ -37,6 +38,6 @@ func init() {
 
 // AddToScheme adds the types of this group into the given scheme.
 func AddToScheme(scheme *runtime.Scheme) {
-	v1alpha1.AddToScheme(scheme)
-	kubeproxyconfig.AddToScheme(scheme)
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kubeproxyconfig.AddToScheme(scheme))
 }

--- a/staging/src/k8s.io/api/BUILD
+++ b/staging/src/k8s.io/api/BUILD
@@ -42,6 +42,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/api/Godeps/Godeps.json
+++ b/staging/src/k8s.io/api/Godeps/Godeps.json
@@ -47,8 +47,20 @@
 			"Rev": "05fbef0ca5da472bbf96c9322b84a53edc03c9fd"
 		},
 		{
+			"ImportPath": "github.com/pmezard/go-difflib/difflib",
+			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+		},
+		{
 			"ImportPath": "github.com/spf13/pflag",
 			"Rev": "583c0c0531f06d5278b7d917446061adc344b5cd"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify/assert",
+			"Rev": "c679ae2cc0cb27ec3293fea7e254e47386f05d69"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify/require",
+			"Rev": "c679ae2cc0cb27ec3293fea7e254e47386f05d69"
 		},
 		{
 			"ImportPath": "golang.org/x/net/http2",

--- a/staging/src/k8s.io/api/roundtrip_test.go
+++ b/staging/src/k8s.io/api/roundtrip_test.go
@@ -52,6 +52,7 @@ import (
 	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/testing/fuzzer"
 	"k8s.io/apimachinery/pkg/api/testing/roundtrip"
 	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
@@ -100,7 +101,7 @@ func TestRoundTripExternalTypes(t *testing.T) {
 		scheme := runtime.NewScheme()
 		codecs := serializer.NewCodecFactory(scheme)
 
-		builder.AddToScheme(scheme)
+		require.NoError(t, builder.AddToScheme(scheme))
 		seed := rand.Int63()
 		// I'm only using the generic fuzzer funcs, but at some point in time we might need to
 		// switch to specialized. For now we're happy with the current serialization test.
@@ -119,7 +120,7 @@ func TestFailRoundTrip(t *testing.T) {
 		metav1.AddToGroupVersion(scheme, groupVersion)
 		return nil
 	})
-	builder.AddToScheme(scheme)
+	require.NoError(t, builder.AddToScheme(scheme))
 	seed := rand.Int63()
 	fuzzer := fuzzer.FuzzerFor(genericfuzzer.Funcs, rand.NewSource(seed), codecs)
 	tmpT := new(testing.T)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
@@ -57,7 +57,7 @@ func addToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 	if err := scheme.AddIgnoredConversionType(&metav1.TypeMeta{}, &metav1.TypeMeta{}); err != nil {
 		return err
 	}
-	scheme.AddConversionFuncs(
+	err := scheme.AddConversionFuncs(
 		metav1.Convert_string_To_labels_Selector,
 		metav1.Convert_labels_Selector_To_string,
 
@@ -70,6 +70,9 @@ func addToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		Convert_internalversion_ListOptions_To_v1_ListOptions,
 		Convert_v1_ListOptions_To_internalversion_ListOptions,
 	)
+	if err != nil {
+		return err
+	}
 	// ListOptions is the only options struct which needs conversion (it exposes labels and fields
 	// as selectors for convenience). The other types have only a single representation today.
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -64,6 +64,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/selection:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // GroupName is the group name for this API.
@@ -53,13 +54,12 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		&GetOptions{},
 		&DeleteOptions{},
 	)
-	scheme.AddConversionFuncs(
+	utilruntime.Must(scheme.AddConversionFuncs(
 		Convert_versioned_Event_to_watch_Event,
 		Convert_versioned_InternalEvent_to_versioned_Event,
 		Convert_watch_Event_to_versioned_Event,
 		Convert_versioned_Event_to_versioned_InternalEvent,
-	)
-
+	))
 	// Register Unversioned types under their own special group
 	scheme.AddUnversionedTypes(Unversioned,
 		&Status{},
@@ -70,8 +70,8 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
-	AddConversionFuncs(scheme)
-	RegisterDefaults(scheme)
+	utilruntime.Must(AddConversionFuncs(scheme))
+	utilruntime.Must(RegisterDefaults(scheme))
 }
 
 // scheme is the registry for the common types that adhere to the meta v1 API spec.
@@ -89,5 +89,5 @@ func init() {
 	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
-	RegisterDefaults(scheme)
+	utilruntime.Must(RegisterDefaults(scheme))
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
@@ -27,6 +27,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -96,18 +97,12 @@ func NewScheme() *Scheme {
 	}
 	s.converter = conversion.NewConverter(s.nameFunc)
 
-	s.AddConversionFuncs(DefaultEmbeddedConversions()...)
+	utilruntime.Must(s.AddConversionFuncs(DefaultEmbeddedConversions()...))
 
 	// Enable map[string][]string conversions by default
-	if err := s.AddConversionFuncs(DefaultStringConversions...); err != nil {
-		panic(err)
-	}
-	if err := s.RegisterInputDefaults(&map[string][]string{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
-		panic(err)
-	}
-	if err := s.RegisterInputDefaults(&url.Values{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields); err != nil {
-		panic(err)
-	}
+	utilruntime.Must(s.AddConversionFuncs(DefaultStringConversions...))
+	utilruntime.Must(s.RegisterInputDefaults(&map[string][]string{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields))
+	utilruntime.Must(s.RegisterInputDefaults(&url.Values{}, JSONKeyMapper, conversion.AllowDifferentFieldTypeNames|conversion.IgnoreMissingFields))
 	return s
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 func TestScheme(t *testing.T) {
@@ -480,9 +481,10 @@ func GetTestScheme() *runtime.Scheme {
 	s.AddKnownTypeWithName(differentExternalGV.WithKind("TestType1"), &runtimetesting.ExternalTestType1{})
 	s.AddUnversionedTypes(externalGV, &runtimetesting.UnversionedType{})
 
-	s.AddConversionFuncs(func(in *runtimetesting.TestType1, out *runtimetesting.ExternalTestType1, s conversion.Scope) {
+	utilruntime.Must(s.AddConversionFuncs(func(in *runtimetesting.TestType1, out *runtimetesting.ExternalTestType1, s conversion.Scope) error {
 		out.A = in.A
-	})
+		return nil
+	}))
 	return s
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/test/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/test/BUILD
@@ -31,6 +31,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 
@@ -49,6 +50,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/test/runtime_serializer_protobuf_protobuf_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/runtime_serializer_protobuf_protobuf_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/testapigroup/v1"
@@ -331,7 +333,7 @@ func TestDecodeObjects(t *testing.T) {
 	scheme := runtime.NewScheme()
 	for i, test := range testCases {
 		scheme.AddKnownTypes(schema.GroupVersion{Version: "v1"}, &v1.Carp{})
-		v1.AddToScheme(scheme)
+		require.NoError(t, v1.AddToScheme(scheme))
 		s := protobuf.NewSerializer(scheme, scheme, "application/protobuf")
 		obj, err := runtime.Decode(s, test.data)
 

--- a/staging/src/k8s.io/apimachinery/pkg/test/util.go
+++ b/staging/src/k8s.io/apimachinery/pkg/test/util.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // List and ListV1 should be kept in sync with k8s.io/kubernetes/pkg/api#List
@@ -61,8 +62,8 @@ func TestScheme() (*runtime.Scheme, apiserializer.CodecFactory) {
 		&v1.CarpList{},
 		&List{},
 	)
-	testapigroup.AddToScheme(scheme)
-	v1.AddToScheme(scheme)
+	utilruntime.Must(testapigroup.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
 
 	codecs := apiserializer.NewCodecFactory(scheme)
 	return scheme, codecs

--- a/staging/src/k8s.io/apiserver/pkg/admission/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/config_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apiserver/pkg/apis/apiserver"
@@ -137,8 +139,8 @@ func TestReadAdmissionConfiguration(t *testing.T) {
 	}
 
 	scheme := runtime.NewScheme()
-	apiserver.AddToScheme(scheme)
-	apiserverapiv1alpha1.AddToScheme(scheme)
+	require.NoError(t, apiserver.AddToScheme(scheme))
+	require.NoError(t, apiserverapiv1alpha1.AddToScheme(scheme))
 
 	for testName, testCase := range testCases {
 		if err = ioutil.WriteFile(configFileName, []byte(testCase.ConfigBody), 0644); err != nil {
@@ -209,8 +211,8 @@ func TestEmbeddedConfiguration(t *testing.T) {
 
 	for desc, test := range testCases {
 		scheme := runtime.NewScheme()
-		apiserver.AddToScheme(scheme)
-		apiserverapiv1alpha1.AddToScheme(scheme)
+		require.NoError(t, apiserver.AddToScheme(scheme))
+		require.NoError(t, apiserverapiv1alpha1.AddToScheme(scheme))
 
 		if err = ioutil.WriteFile(configFileName, []byte(test.ConfigBody), 0644); err != nil {
 			t.Errorf("[%s] unexpected err writing temp file: %v", desc, err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
@@ -58,7 +58,9 @@ func NewClientManager() (ClientManager, error) {
 		return ClientManager{}, err
 	}
 	admissionScheme := runtime.NewScheme()
-	admissionv1beta1.AddToScheme(admissionScheme)
+	if err := admissionv1beta1.AddToScheme(admissionScheme); err != nil {
+		return ClientManager{}, err
+	}
 	return ClientManager{
 		cache: cache,
 		negotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
@@ -35,8 +36,8 @@ var (
 )
 
 func init() {
-	webhookadmission.AddToScheme(scheme)
-	v1alpha1.AddToScheme(scheme)
+	utilruntime.Must(webhookadmission.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 }
 
 // LoadConfig extract the KubeConfigFile from configFile

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
@@ -51,5 +51,6 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example2/v1:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,16 +31,16 @@ import (
 	example2v1 "k8s.io/apiserver/pkg/apis/example2/v1"
 )
 
-func initiateScheme() *runtime.Scheme {
+func initiateScheme(t *testing.T) *runtime.Scheme {
 	s := runtime.NewScheme()
-	example.AddToScheme(s)
-	examplev1.AddToScheme(s)
-	example2v1.AddToScheme(s)
+	require.NoError(t, example.AddToScheme(s))
+	require.NoError(t, examplev1.AddToScheme(s))
+	require.NoError(t, example2v1.AddToScheme(s))
 	return s
 }
 
 func TestConvertToGVK(t *testing.T) {
-	scheme := initiateScheme()
+	scheme := initiateScheme(t)
 	c := convertor{Scheme: scheme}
 	table := map[string]struct {
 		obj         runtime.Object
@@ -134,7 +136,7 @@ func TestConvertToGVK(t *testing.T) {
 // TestRuntimeSchemeConvert verifies that scheme.Convert(x, x, nil) for an unstructured x is a no-op.
 // This did not use to be like that and we had to wrap scheme.Convert before.
 func TestRuntimeSchemeConvert(t *testing.T) {
-	scheme := initiateScheme()
+	scheme := initiateScheme(t)
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"foo": "bar",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example2/v1:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,9 +46,9 @@ var sampleCRD = unstructured.Unstructured{
 
 func TestDispatch(t *testing.T) {
 	scheme := runtime.NewScheme()
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
-	example2v1.AddToScheme(scheme)
+	require.NoError(t, example.AddToScheme(scheme))
+	require.NoError(t, examplev1.AddToScheme(scheme))
+	require.NoError(t, example2v1.AddToScheme(scheme))
 
 	tests := []struct {
 		name        string

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,8 +36,8 @@ import (
 // TestAdmit tests that MutatingWebhook#Admit works as expected
 func TestAdmit(t *testing.T) {
 	scheme := runtime.NewScheme()
-	v1beta1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
 
 	testServer := webhooktesting.NewTestServer(t)
 	testServer.StartTLS()
@@ -103,8 +105,8 @@ func TestAdmit(t *testing.T) {
 // TestAdmitCachedClient tests that MutatingWebhook#Admit should cache restClient
 func TestAdmitCachedClient(t *testing.T) {
 	scheme := runtime.NewScheme()
-	v1beta1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
 
 	testServer := webhooktesting.NewTestServer(t)
 	testServer.StartTLS()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,8 +33,8 @@ import (
 // TestValidate tests that ValidatingWebhook#Validate works as expected
 func TestValidate(t *testing.T) {
 	scheme := runtime.NewScheme()
-	v1beta1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
 
 	testServer := webhooktesting.NewTestServer(t)
 	testServer.StartTLS()
@@ -94,8 +96,8 @@ func TestValidate(t *testing.T) {
 // TestValidateCachedClient tests that ValidatingWebhook#Validate should cache restClient
 func TestValidateCachedClient(t *testing.T) {
 	scheme := runtime.NewScheme()
-	v1beta1.AddToScheme(scheme)
-	corev1.AddToScheme(scheme)
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
 
 	testServer := webhooktesting.NewTestServer(t)
 	testServer.StartTLS()

--- a/staging/src/k8s.io/apiserver/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/scheme.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 	"k8s.io/apiserver/pkg/apis/audit/v1beta1"
 )
@@ -31,6 +32,6 @@ var Codecs = serializer.NewCodecFactory(Scheme)
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	v1alpha1.AddToScheme(Scheme)
-	v1beta1.AddToScheme(Scheme)
+	utilruntime.Must(v1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(v1beta1.AddToScheme(Scheme))
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -33,6 +33,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/admission"
@@ -126,8 +127,8 @@ func init() {
 	scheme.AddUnversionedTypes(grouplessGroupVersion, &metav1.Status{})
 	metav1.AddToGroupVersion(scheme, grouplessGroupVersion)
 
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 func addGrouplessTypes() {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
@@ -51,8 +52,8 @@ var (
 
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 type testPatchType struct {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -26,6 +26,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/selection:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -65,8 +66,8 @@ const validInitializerName = "test.k8s.io"
 
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 type testGracefulStrategy struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -19,6 +19,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/apis/example"
@@ -75,8 +76,8 @@ func init() {
 		&metav1.APIGroup{},
 		&metav1.APIResourceList{},
 	)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 func buildTestOpenAPIDefinition() kubeopenapi.OpenAPIDefinition {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
@@ -42,8 +43,8 @@ import (
 var configScheme = runtime.NewScheme()
 
 func init() {
-	apiserverapi.AddToScheme(configScheme)
-	apiserverapiv1alpha1.AddToScheme(configScheme)
+	utilruntime.Must(apiserverapi.AddToScheme(configScheme))
+	utilruntime.Must(apiserverapiv1alpha1.AddToScheme(configScheme))
 }
 
 // AdmissionOptions holds the admission options

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/BUILD
@@ -26,6 +26,7 @@ go_test(
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	apiv1 "k8s.io/api/core/v1"
 	extensionsapiv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +29,7 @@ import (
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
-	scheme := newFakeScheme()
+	scheme := newFakeScheme(t)
 	apiv1GroupVersion := apiv1.SchemeGroupVersion
 	testCases := []struct {
 		runtimeConfig         map[string]string
@@ -163,10 +165,10 @@ func newFakeAPIResourceConfigSource() *serverstore.ResourceConfig {
 	return ret
 }
 
-func newFakeScheme() *runtime.Scheme {
+func newFakeScheme(t *testing.T) *runtime.Scheme {
 	ret := runtime.NewScheme()
-	apiv1.AddToScheme(ret)
-	extensionsapiv1beta1.AddToScheme(ret)
+	require.NoError(t, apiv1.AddToScheme(ret))
+	require.NoError(t, extensionsapiv1beta1.AddToScheme(ret))
 
 	ret.SetVersionPriority(apiv1.SchemeGroupVersion)
 	ret.SetVersionPriority(extensionsapiv1beta1.SchemeGroupVersion)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/storage/testing:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/tests:go_default_library",
         "//vendor/github.com/coreos/etcd/client:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
+	"github.com/stretchr/testify/require"
+
 	apitesting "k8s.io/apimachinery/pkg/api/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -77,9 +79,9 @@ func testScheme(t *testing.T) (*runtime.Scheme, serializer.CodecFactory) {
 	scheme := runtime.NewScheme()
 	scheme.Log(t)
 	scheme.AddKnownTypes(schema.GroupVersion{Version: runtime.APIVersionInternal}, &storagetesting.TestResource{})
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
-	if err := scheme.AddConversionFuncs(
+	require.NoError(t, example.AddToScheme(scheme))
+	require.NoError(t, examplev1.AddToScheme(scheme))
+	require.NoError(t, scheme.AddConversionFuncs(
 		func(in *storagetesting.TestResource, out *storagetesting.TestResource, s conversion.Scope) error {
 			*out = *in
 			return nil
@@ -88,9 +90,7 @@ func testScheme(t *testing.T) (*runtime.Scheme, serializer.CodecFactory) {
 			*out = *in
 			return nil
 		},
-	); err != nil {
-		panic(err)
-	}
+	))
 	codecs := serializer.NewCodecFactory(scheme)
 	return scheme, codecs
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
@@ -54,8 +55,8 @@ const defaultTestPrefix = "test!"
 
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 
 	capnslog.SetGlobalLogLevel(capnslog.CRITICAL)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
@@ -15,6 +15,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/testingcert:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/storage/etcd/testing/testingcert"
@@ -42,8 +43,8 @@ var codecs = serializer.NewCodecFactory(scheme)
 
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 func TestTLSConnection(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -54,8 +55,8 @@ var (
 
 func init() {
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	example.AddToScheme(scheme)
-	examplev1.AddToScheme(scheme)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1:go_default_library",

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	"k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
 	"k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
@@ -51,9 +52,9 @@ var codecs = serializer.NewCodecFactory(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	v1alpha1.AddToScheme(scheme)
-	v1beta1.AddToScheme(scheme)
-	clientauthentication.AddToScheme(scheme)
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(clientauthentication.AddToScheme(scheme))
 }
 
 var (

--- a/staging/src/k8s.io/client-go/scale/BUILD
+++ b/staging/src/k8s.io/client-go/scale/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/util.go
+++ b/staging/src/k8s.io/client-go/scale/util.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	scalescheme "k8s.io/client-go/scale/scheme"
 	scaleappsint "k8s.io/client-go/scale/scheme/appsint"
@@ -143,13 +144,13 @@ type ScaleConverter struct {
 // Scales in autoscaling/v1 and extensions/v1beta1.
 func NewScaleConverter() *ScaleConverter {
 	scheme := runtime.NewScheme()
-	scaleautoscaling.AddToScheme(scheme)
-	scalescheme.AddToScheme(scheme)
-	scaleext.AddToScheme(scheme)
-	scaleextint.AddToScheme(scheme)
-	scaleappsint.AddToScheme(scheme)
-	scaleappsv1beta1.AddToScheme(scheme)
-	scaleappsv1beta2.AddToScheme(scheme)
+	utilruntime.Must(scaleautoscaling.AddToScheme(scheme))
+	utilruntime.Must(scalescheme.AddToScheme(scheme))
+	utilruntime.Must(scaleext.AddToScheme(scheme))
+	utilruntime.Must(scaleextint.AddToScheme(scheme))
+	utilruntime.Must(scaleappsint.AddToScheme(scheme))
+	utilruntime.Must(scaleappsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(scaleappsv1beta2.AddToScheme(scheme))
 
 	return &ScaleConverter{
 		scheme: scheme,

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/latest/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/latest/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api/v1:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/latest/latest.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/latest/latest.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/v1"
 )
@@ -47,14 +48,8 @@ var (
 
 func init() {
 	Scheme = runtime.NewScheme()
-	if err := api.AddToScheme(Scheme); err != nil {
-		// Programmer error, detect immediately
-		panic(err)
-	}
-	if err := v1.AddToScheme(Scheme); err != nil {
-		// Programmer error, detect immediately
-		panic(err)
-	}
+	utilruntime.Must(api.AddToScheme(Scheme))
+	utilruntime.Must(v1.AddToScheme(Scheme))
 	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
 	Codec = versioning.NewDefaultingCodecForScheme(
 		Scheme,

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/scheme.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/scheme/scheme.go
@@ -19,6 +19,7 @@ package scheme
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
@@ -41,7 +42,7 @@ func init() {
 
 // AddToScheme adds the types of this group into the given scheme.
 func AddToScheme(scheme *runtime.Scheme) {
-	v1beta1.AddToScheme(scheme)
-	v1.AddToScheme(scheme)
-	apiregistration.AddToScheme(scheme)
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(apiregistration.AddToScheme(scheme))
 }

--- a/test/images/webhook/BUILD
+++ b/test/images/webhook/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/test/images/webhook/scheme.go
+++ b/test/images/webhook/scheme.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
@@ -31,6 +32,6 @@ func init() {
 }
 
 func addToScheme(scheme *runtime.Scheme) {
-	corev1.AddToScheme(scheme)
-	admissionregistrationv1beta1.AddToScheme(scheme)
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(admissionregistrationv1beta1.AddToScheme(scheme))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing error handling to a few places.

**Which issue(s) this PR fixes**
Updates #51457. Still more work to do to fix the issue - client generation code needs to be updated (addressed in https://github.com/kubernetes/kubernetes/pull/64664).

**Release note**:
```release-note
NONE
```

/kind bug
/sig api-machinery