### PR TITLE
Makefile: avoid recursive evaluation of shell commands

### DIFF
--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 IMAGE=kube-cross
-TAG=$(shell cat VERSION)
+TAG:=$(shell cat VERSION)
 
 
 all: push

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -21,7 +21,7 @@ IMAGE = $(REGISTRY)/pause
 IMAGE_WITH_ARCH = $(IMAGE)-$(ARCH)
 
 TAG = 3.1
-REV = $(shell git describe --contains --always --match='v*')
+REV := $(shell git describe --contains --always --match='v*')
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x
 ARCH ?= amd64

--- a/test/images/clusterapi-tester/Makefile
+++ b/test/images/clusterapi-tester/Makefile
@@ -16,7 +16,7 @@ SRCS = clusterapi-tester
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/entrypoint-tester/Makefile
+++ b/test/images/entrypoint-tester/Makefile
@@ -16,7 +16,7 @@ SRCS=ep
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/fakegitserver/Makefile
+++ b/test/images/fakegitserver/Makefile
@@ -16,7 +16,7 @@ SRCS = fakegitserver
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 IGNORE := $(shell git rev-parse HEAD > $(TARGET)/GITHASH.txt)

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -16,7 +16,7 @@ SRCS=goproxy
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/liveness/Makefile
+++ b/test/images/liveness/Makefile
@@ -16,7 +16,7 @@ SRCS = liveness
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/logs-generator/Makefile
+++ b/test/images/logs-generator/Makefile
@@ -16,7 +16,7 @@ SRCS=logs-generator
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/mounttest/Makefile
+++ b/test/images/mounttest/Makefile
@@ -16,7 +16,7 @@ SRCS=mounttest
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/n-way-http/Makefile
+++ b/test/images/n-way-http/Makefile
@@ -16,7 +16,7 @@ SRCS=n-way-http
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/net/Makefile
+++ b/test/images/net/Makefile
@@ -16,7 +16,7 @@ SRCS=net
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/netexec/Makefile
+++ b/test/images/netexec/Makefile
@@ -16,7 +16,7 @@ SRCS=netexec
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/nettest/Makefile
+++ b/test/images/nettest/Makefile
@@ -16,7 +16,7 @@ SRCS=nettest
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/no-snat-test-proxy/Makefile
+++ b/test/images/no-snat-test-proxy/Makefile
@@ -16,7 +16,7 @@ SRCS=no-snat-test-proxy
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/no-snat-test/Makefile
+++ b/test/images/no-snat-test/Makefile
@@ -16,7 +16,7 @@ SRCS=no-snat-test
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/nonewprivs/Makefile
+++ b/test/images/nonewprivs/Makefile
@@ -16,7 +16,7 @@ SRCS = nnp
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -16,7 +16,7 @@ SRCS=portforwardtester
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/porter/Makefile
+++ b/test/images/porter/Makefile
@@ -16,7 +16,7 @@ SRCS=porter
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -16,7 +16,7 @@ SRCS = consumer consume-cpu/consume-cpu
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/resource-consumer/controller/Makefile
+++ b/test/images/resource-consumer/controller/Makefile
@@ -16,7 +16,7 @@ SRCS=controller
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = resource-consumer/$(notdir $(shell pwd))
+SRC_DIR := resource-consumer/$(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/serve-hostname/Makefile
+++ b/test/images/serve-hostname/Makefile
@@ -16,7 +16,7 @@ SRCS=serve_hostname
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:

--- a/test/images/test-webserver/Makefile
+++ b/test/images/test-webserver/Makefile
@@ -16,7 +16,7 @@ SRCS = test-webserver
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest
-SRC_DIR = $(notdir $(shell pwd))
+SRC_DIR := $(notdir $(shell pwd))
 export
 
 bin:


### PR DESCRIPTION
Change the recursively evaluated variables to simply evaluated
variables.

More details at e.g. http://electric-cloud.com/blog/2009/03/makefile-performance-shell/

```release-note
NONE
```