### PR TITLE
pkg: kubelet: remote: increase grpc client default size to 16MiB

### DIFF
--- a/pkg/kubelet/remote/utils.go
+++ b/pkg/kubelet/remote/utils.go
@@ -24,9 +24,9 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
-// maxMsgSize use 8MB as the default message size limit.
+// maxMsgSize use 16MB as the default message size limit.
 // grpc library default is 4MB
-const maxMsgSize = 1024 * 1024 * 8
+const maxMsgSize = 1024 * 1024 * 16
 
 // getContextWithTimeout returns a context with timeout.
 func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Increase the gRPC max message size to 16MB in the remote container runtime. I've seen sizes over 8MB in clusters with big (256GB RAM) nodes.

**Release note**:
```release-note
Increase the gRPC max message size to 16MB in the remote container runtime.
```
