### PR TITLE
[wip] separate CRD tests by independent group names

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 func TestFinalization(t *testing.T) {
+	group := "finilizer-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	require.NoError(t, err)
 	defer close(stopCh)
 
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
@@ -43,7 +44,7 @@ func TestFinalization(t *testing.T) {
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
-	instance := testserver.NewNoxuInstance(ns, name)
+	instance := testserver.NewNoxuInstance(ns, name, group)
 	instance.SetFinalizers([]string{"noxu.example.com/finalizer"})
 	createdNoxuInstance, err := instantiateCustomResource(t, instance, noxuResourceClient, noxuDefinition)
 	require.NoError(t, err)
@@ -94,12 +95,13 @@ func TestFinalization(t *testing.T) {
 }
 
 func TestFinalizationAndDeletion(t *testing.T) {
+	group := "finilization-and-delete-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	require.NoError(t, err)
 	defer close(stopCh)
 
 	// Create a CRD.
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
@@ -108,7 +110,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	name := "foo123"
 	noxuResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
 
-	instance := testserver.NewNoxuInstance(ns, name)
+	instance := testserver.NewNoxuInstance(ns, name, group)
 	instance.SetFinalizers([]string{"noxu.example.com/finalizer"})
 	createdNoxuInstance, err := instantiateCustomResource(t, instance, noxuResourceClient, noxuDefinition)
 	require.NoError(t, err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -37,13 +37,14 @@ import (
 )
 
 func TestPostInvalidObjectMeta(t *testing.T) {
+	group := "invalid-meta-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
 
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +52,7 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 
 	noxuResourceClient := newNamespacedCustomResourceClient("default", dynamicClient, noxuDefinition)
 
-	obj := testserver.NewNoxuInstance("default", "foo")
+	obj := testserver.NewNoxuInstance("default", "foo", group)
 	unstructured.SetNestedField(obj.UnstructuredContent(), int64(42), "metadata", "unknown")
 	unstructured.SetNestedField(obj.UnstructuredContent(), map[string]interface{}{"foo": int64(42), "bar": "abc"}, "metadata", "labels")
 	_, err = instantiateCustomResource(t, obj, noxuResourceClient, noxuDefinition)
@@ -80,6 +81,7 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 }
 
 func TestInvalidObjectMetaInStorage(t *testing.T) {
+	group := "invalid-meta-in-storage-test.example.com"
 	serverConfig, err := testserver.DefaultServerConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +103,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +133,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Creating object with invalid labels manually in etcd")
 
-	original := testserver.NewNoxuInstance("default", "foo")
+	original := testserver.NewNoxuInstance("default", "foo", group)
 	unstructured.SetNestedField(original.UnstructuredContent(), int64(42), "metadata", "unknown")
 	unstructured.SetNestedField(original.UnstructuredContent(), map[string]interface{}{"foo": int64(42), "bar": "abc"}, "metadata", "labels")
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -41,6 +41,7 @@ import (
 )
 
 func TestMultipleResourceInstances(t *testing.T) {
+	group := "multiplace-instance-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +49,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 	defer close(stopCh)
 
 	ns := "not-the-default"
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +81,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 	}
 
 	for key, val := range instances {
-		val.Instance, err = instantiateCustomResource(t, testserver.NewNoxuInstance(ns, key), noxuNamespacedResourceClient, noxuDefinition)
+		val.Instance, err = instantiateCustomResource(t, testserver.NewNoxuInstance(ns, key, group), noxuNamespacedResourceClient, noxuDefinition)
 		if err != nil {
 			t.Fatalf("unable to create Noxu Instance %q:%v", key, err)
 		}
@@ -165,6 +166,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 }
 
 func TestMultipleRegistration(t *testing.T) {
+	group := "multi-registeration-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	if err != nil {
 		t.Fatal(err)
@@ -173,13 +175,13 @@ func TestMultipleRegistration(t *testing.T) {
 
 	ns := "not-the-default"
 	sameInstanceName := "foo"
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	noxuNamespacedResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
-	createdNoxuInstance, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition)
+	createdNoxuInstance, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName, group), noxuNamespacedResourceClient, noxuDefinition)
 	if err != nil {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
@@ -192,13 +194,13 @@ func TestMultipleRegistration(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	curletDefinition := testserver.NewCurletCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	curletDefinition := testserver.NewCurletCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	curletDefinition, err = testserver.CreateNewCustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	curletNamespacedResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, curletDefinition)
-	createdCurletInstance, err := instantiateCustomResource(t, testserver.NewCurletInstance(ns, sameInstanceName), curletNamespacedResourceClient, curletDefinition)
+	createdCurletInstance, err := instantiateCustomResource(t, testserver.NewCurletInstance(ns, sameInstanceName, group), curletNamespacedResourceClient, curletDefinition)
 	if err != nil {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
@@ -221,12 +223,13 @@ func TestMultipleRegistration(t *testing.T) {
 }
 
 func TestDeRegistrationAndReRegistration(t *testing.T) {
+	group := "de-re-registration-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	func() {
@@ -235,7 +238,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 			t.Fatal(err)
 		}
 		noxuNamespacedResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
-		if _, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition); err != nil {
+		if _, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName, group), noxuNamespacedResourceClient, noxuDefinition); err != nil {
 			t.Fatal(err)
 		}
 		if err := testserver.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
@@ -271,7 +274,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if e, a := 0, len(initialList.Items); e != a {
 			t.Fatalf("expected %v, got %v", e, a)
 		}
-		createdNoxuInstance, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition)
+		createdNoxuInstance, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns, sameInstanceName, group), noxuNamespacedResourceClient, noxuDefinition)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -310,6 +313,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 }
 
 func TestEtcdStorage(t *testing.T) {
+	group := "etcd-storage-test.example.com"
 	config, err := testserver.DefaultServerConfig()
 	if err != nil {
 		t.Fatal(err)
@@ -332,24 +336,24 @@ func TestEtcdStorage(t *testing.T) {
 	etcdPrefix := getPrefixFromConfig(t, config)
 
 	ns1 := "another-default-is-possible"
-	curletDefinition := testserver.NewCurletCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	curletDefinition := testserver.NewCurletCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped, group)
 	curletDefinition, err = testserver.CreateNewCustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	curletNamespacedResourceClient := newNamespacedCustomResourceClient(ns1, dynamicClient, curletDefinition)
-	if _, err := instantiateCustomResource(t, testserver.NewCurletInstance(ns1, "bar"), curletNamespacedResourceClient, curletDefinition); err != nil {
+	if _, err := instantiateCustomResource(t, testserver.NewCurletInstance(ns1, "bar", group), curletNamespacedResourceClient, curletDefinition); err != nil {
 		t.Fatalf("unable to create curlet cluster scoped Instance:%v", err)
 	}
 
 	ns2 := "the-cruel-default"
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 	noxuNamespacedResourceClient := newNamespacedCustomResourceClient(ns2, dynamicClient, noxuDefinition)
-	if _, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns2, "foo"), noxuNamespacedResourceClient, noxuDefinition); err != nil {
+	if _, err := instantiateCustomResource(t, testserver.NewNoxuInstance(ns2, "foo", group), noxuNamespacedResourceClient, noxuDefinition); err != nil {
 		t.Fatalf("unable to create noxu namespace scoped Instance:%v", err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
@@ -42,13 +42,13 @@ const (
 )
 
 //NewRandomNameCustomResourceDefinition generates a CRD with random name to avoid name conflict in e2e tests
-func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope, group string) *apiextensionsv1beta1.CustomResourceDefinition {
 	// ensure the singular doesn't end in an s for now
 	gName := names.SimpleNameGenerator.GenerateName("foo") + "a"
 	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: gName + "s.mygroup.example.com"},
+		ObjectMeta: metav1.ObjectMeta{Name: gName + "s." + group},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
+			Group:   group,
 			Version: "v1beta1",
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:   gName + "s",
@@ -61,11 +61,11 @@ func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceSc
 	}
 }
 
-func NewNoxuCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+func NewNoxuCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope, group string) *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "noxus.mygroup.example.com"},
+		ObjectMeta: metav1.ObjectMeta{Name: "noxus." + group},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
+			Group:   group,
 			Version: "v1beta1",
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:     "noxus",
@@ -80,10 +80,10 @@ func NewNoxuCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *
 	}
 }
 
-func NewVersionedNoxuInstance(namespace, name, version string) *unstructured.Unstructured {
+func NewVersionedNoxuInstance(namespace, name, group, version string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "mygroup.example.com/" + version,
+			"apiVersion": group + "/" + version,
 			"kind":       "WishIHadChosenNoxu",
 			"metadata": map[string]interface{}{
 				"namespace": namespace,
@@ -100,15 +100,15 @@ func NewVersionedNoxuInstance(namespace, name, version string) *unstructured.Uns
 	}
 }
 
-func NewNoxuInstance(namespace, name string) *unstructured.Unstructured {
-	return NewVersionedNoxuInstance(namespace, name, "v1beta1")
+func NewNoxuInstance(namespace, name, group string) *unstructured.Unstructured {
+	return NewVersionedNoxuInstance(namespace, name, group, "v1beta1")
 }
 
-func NewMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+func NewMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope, groupName string) *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "noxus.mygroup.example.com"},
+		ObjectMeta: metav1.ObjectMeta{Name: "noxus." + groupName},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
+			Group:   groupName,
 			Version: "v1beta1",
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:     "noxus",
@@ -140,11 +140,11 @@ func NewMultipleVersionNoxuCRD(scope apiextensionsv1beta1.ResourceScope) *apiext
 	}
 }
 
-func NewNoxu2CustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+func NewNoxu2CustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope, group string) *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "noxus2.mygroup.example.com"},
+		ObjectMeta: metav1.ObjectMeta{Name: "noxus2." + group},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
+			Group:   group,
 			Version: "v1alpha1",
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:     "noxus2",
@@ -158,11 +158,11 @@ func NewNoxu2CustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) 
 	}
 }
 
-func NewCurletCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
+func NewCurletCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope, group string) *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: "curlets.mygroup.example.com"},
+		ObjectMeta: metav1.ObjectMeta{Name: "curlets." + group},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "mygroup.example.com",
+			Group:   group,
 			Version: "v1beta1",
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:   "curlets",
@@ -175,10 +175,10 @@ func NewCurletCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope)
 	}
 }
 
-func NewCurletInstance(namespace, name string) *unstructured.Unstructured {
+func NewCurletInstance(namespace, name, group string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "mygroup.example.com/v1beta1",
+			"apiVersion": group + "/v1beta1",
 			"kind":       "Curlet",
 			"metadata": map[string]interface{}{
 				"namespace": namespace,

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -31,13 +31,14 @@ import (
 )
 
 func TestForProperValidationErrors(t *testing.T) {
+	group := "validation-test.example.com"
 	stopCh, apiExtensionClient, dynamicClient, err := testserver.StartDefaultServerWithClients()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
 
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.NamespaceScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +55,7 @@ func TestForProperValidationErrors(t *testing.T) {
 		{
 			name: "bad version",
 			instanceFn: func() *unstructured.Unstructured {
-				instance := testserver.NewVersionedNoxuInstance(ns, "foo", "v2")
+				instance := testserver.NewVersionedNoxuInstance(ns, "foo", "mygroup.example.com", "v2")
 				return instance
 			},
 			expectedError: "the API version in the data (mygroup.example.com/v2) does not match the expected API version (mygroup.example.com/v1beta1)",
@@ -62,7 +63,7 @@ func TestForProperValidationErrors(t *testing.T) {
 		{
 			name: "bad kind",
 			instanceFn: func() *unstructured.Unstructured {
-				instance := testserver.NewNoxuInstance(ns, "foo")
+				instance := testserver.NewNoxuInstance(ns, "foo", group)
 				instance.Object["kind"] = "SomethingElse"
 				return instance
 			},

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -32,7 +32,7 @@ func TestVersionedNamspacedScopedCRD(t *testing.T) {
 	}
 	defer close(stopCh)
 
-	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped, "namespaced-version-test.example.com")
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +49,7 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 	}
 	defer close(stopCh)
 
-	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped, "cluster-version-test.example.com")
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
@@ -60,13 +60,13 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 }
 
 func TestStoragedVersionInNamespacedCRDStatus(t *testing.T) {
-	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped)
+	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.NamespaceScoped, "namespaced-version-status-test.example.com")
 	ns := "not-the-default"
 	testStoragedVersionInCRDStatus(t, ns, noxuDefinition)
 }
 
 func TestStoragedVersionInClusterScopedCRDStatus(t *testing.T) {
-	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := testserver.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped, "cluster-version-status-test.example.com")
 	ns := ""
 	testStoragedVersionInCRDStatus(t, ns, noxuDefinition)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestYAML(t *testing.T) {
+	group := "yaml-test.example.com"
 	stopCh, config, err := testserver.StartDefaultServer()
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +51,7 @@ func TestYAML(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped, group)
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously all CRD tests were using the same group-name. This resulted in flaky test specially in watch tests. For example, some of the tests are not clearing watch events for delete and other tests that expected specific watch events would fail. Most of the tests uses different namespaces, but that does not work for cluster scope tests that capture watch events on all namespaces.

fixes #64571