### PR TITLE
set http ReadTimeout and IdleTimeout

### DIFF
--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -115,6 +115,9 @@ func serveInsecurely(insecureServingInfo *InsecureServingInfo, insecureHandler h
 		Addr:           insecureServingInfo.BindAddress,
 		Handler:        insecureHandler,
 		MaxHeaderBytes: 1 << 20,
+		// TODO: make these configurable
+		ReadTimeout: 30 * time.Second,
+		IdleTimeout: 5 * time.Minute,
 	}
 	glog.Infof("Serving insecurely on %s", insecureServingInfo.BindAddress)
 	ln, _, err := options.CreateListener(insecureServingInfo.BindNetwork, insecureServingInfo.BindAddress)

--- a/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -58,6 +58,9 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 			// enable HTTP2 for go's 1.7 HTTP Server
 			NextProtos: []string{"h2", "http/1.1"},
 		},
+		// TODO: make these configurable
+		ReadTimeout: 30 * time.Second,
+		IdleTimeout: 5 * time.Minute,
 	}
 
 	if s.MinTLSVersion > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Set ReadTimeout to prevent long connections hangup.
Set IdleTimeout to prevent idle connections exist forever.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64496

**Special notes for your reviewer**:

/kind enhancement 

/sig api-machinery

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set http.Server.ReadTimeout and IdleTimeout to prevent too many non-active connections existing. 
```
