### PR TITLE
Fixes data races for pkg/kubelet/config/file_linux_test.go

### DIFF
--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -321,10 +321,6 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 
 			if watchDir {
 				NewSourceFile(dirName, hostname, 100*time.Millisecond, ch)
-				defer func() {
-					// Remove the file
-					deleteFile(dirName, fileName, ch, t)
-				}()
 			} else {
 				NewSourceFile(file, hostname, 100*time.Millisecond, ch)
 			}
@@ -361,22 +357,6 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			}
 		}()
 	}
-}
-
-func deleteFile(dir, file string, ch chan interface{}, t *testing.T) {
-	path := filepath.Join(dir, file)
-	if _, err := os.Stat(path); err != nil {
-		// The file might absent if it's renamed, deleted..
-		return
-	}
-	go func() {
-		err := os.Remove(path)
-		if err != nil {
-			t.Errorf("unable to remove test file %s: %s", path, err)
-		}
-	}()
-
-	expectEmptyUpdate(t, ch)
 }
 
 func expectUpdate(t *testing.T, ch chan interface{}, testCase *testCase) {

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -131,6 +131,7 @@ func TestWatchFileChanged(t *testing.T) {
 }
 
 type testCase struct {
+	lock       *sync.Mutex
 	desc       string
 	linkedFile string
 	pod        runtime.Object
@@ -141,6 +142,7 @@ func getTestCases(hostname types.NodeName) []*testCase {
 	grace := int64(30)
 	return []*testCase{
 		{
+			lock: &sync.Mutex{},
 			desc: "Simple pod",
 			pod: &v1.Pod{
 				TypeMeta: metav1.TypeMeta{
@@ -304,11 +306,10 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			}
 
 			var file string
-			lock := &sync.Mutex{}
 			ch := make(chan interface{})
 			func() {
-				lock.Lock()
-				defer lock.Unlock()
+				testCase.lock.Lock()
+				defer testCase.lock.Unlock()
 
 				if symlink {
 					file = testCase.writeToFile(linkedDirName, fileName, t)
@@ -332,8 +333,8 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 
 			changeFile := func() {
 				// Edit the file content
-				lock.Lock()
-				defer lock.Unlock()
+				testCase.lock.Lock()
+				defer testCase.lock.Unlock()
 
 				pod := testCase.pod.(*v1.Pod)
 				pod.Spec.Containers[0].Name = "image2"
@@ -352,9 +353,7 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			expectUpdate(t, ch, testCase)
 
 			if watchDir {
-				from := fileName
-				fileName = fileName + "_ch"
-				go changeFileName(dirName, from, fileName, t)
+				go changeFileName(dirName, fileName, fileName+"_ch", t)
 				// expect an update by MOVED_FROM inotify event cause changing file name
 				expectEmptyUpdate(t, ch)
 				// expect an update by MOVED_TO inotify event cause changing file name
@@ -365,8 +364,12 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 }
 
 func deleteFile(dir, file string, ch chan interface{}, t *testing.T) {
+	path := filepath.Join(dir, file)
+	if _, err := os.Stat(path); err != nil {
+		// The file might absent if it's renamed, deleted..
+		return
+	}
 	go func() {
-		path := filepath.Join(dir, file)
 		err := os.Remove(path)
 		if err != nil {
 			t.Errorf("unable to remove test file %s: %s", path, err)
@@ -397,6 +400,8 @@ func expectUpdate(t *testing.T, ch chan interface{}, testCase *testCase) {
 				}
 			}
 
+			testCase.lock.Lock()
+			defer testCase.lock.Unlock()
 			if !apiequality.Semantic.DeepEqual(testCase.expected, update) {
 				t.Fatalf("%s: Expected: %#v, Got: %#v", testCase.desc, testCase.expected, update)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64655

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
