### PR TITLE
add a missing releasenote

### DIFF
--- a/CHANGELOG-1.7.md
+++ b/CHANGELOG-1.7.md
@@ -584,7 +584,7 @@ filename | sha256 hash
 * Fixes server name verification of aggregated API servers and webhook admission endpoints ([#56415](https://github.com/kubernetes/kubernetes/pull/56415), [@liggitt](https://github.com/liggitt))
 * Fix a typo in prometheus-to-sd configuration, that drops some stackdriver metrics. ([#56473](https://github.com/kubernetes/kubernetes/pull/56473), [@loburm](https://github.com/loburm))
 * Update jquery and bootstrap dependencies ([#56447](https://github.com/kubernetes/kubernetes/pull/56447), [@dashpole](https://github.com/dashpole))
-
+* Fix bug in container lifecycle event messaging ([#56959](https://github.com/kubernetes/kubernetes/pull/56959),[@lichuqiang](https://github.com/lichuqiang))
 
 
 # v1.7.11

--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -729,6 +729,7 @@ filename | sha256 hash
 * fix azure disk storage account init issue ([#55927](https://github.com/kubernetes/kubernetes/pull/55927), [@andyzhangx](https://github.com/andyzhangx))
 * falls back to parse Docker runtime version as generic if not semver ([#54040](https://github.com/kubernetes/kubernetes/pull/54040), [@dixudx](https://github.com/dixudx))
 * BUG FIX: Check both name and ports for azure health probes ([#56918](https://github.com/kubernetes/kubernetes/pull/56918), [@feiskyer](https://github.com/feiskyer))
+* Fix bug in container lifecycle event messaging ([#56959](https://github.com/kubernetes/kubernetes/pull/56959),[@lichuqiang](https://github.com/lichuqiang))
 
 
 

--- a/CHANGELOG-1.9.md
+++ b/CHANGELOG-1.9.md
@@ -1395,6 +1395,7 @@ This release passes 129/145 Kubernetes e2e conformance tests.
 *   Kubelet no longer removes unregistered extended resource capacities from node status; cluster admins will have to manually remove extended resources exposed via device plugins when they the remove plugins themselves. ([#53353](https://github.com/kubernetes/kubernetes/pull/53353),[ @jiayingz](https://github.com/jiayingz))
 *   The stats summary network value now takes into account multiple network interfaces, and not just eth0. ([#52144](https://github.com/kubernetes/kubernetes/pull/52144),[ @andyxning](https://github.com/andyxning))
 *   Base images have been bumped to Debian Stretch (9). ([#52744](https://github.com/kubernetes/kubernetes/pull/52744),[ @rphillips](https://github.com/rphillips))
+*   Fix bug in container lifecycle event messaging ([#56959](https://github.com/kubernetes/kubernetes/pull/56959),[@lichuqiang](https://github.com/lichuqiang))
 
 ### **OpenStack**
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We use the poststarthook to start some important service in our production environment and we need the event message for debugging.There was a issue discussed about this https://github.com/kubernetes/kubernetes/issues/54671 
And i found  the issue have already been fixed ,but it didn't be  mentioned in release note. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
release note missing
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
