### PR TITLE
kubeadm: remove redundant flags settings for kubelet

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -70,8 +70,6 @@ func buildKubeletArgMap(opts kubeletFlagsOpts) map[string]string {
 	if opts.nodeRegOpts.CRISocket == kubeadmapiv1alpha2.DefaultCRISocket {
 		// These flags should only be set when running docker
 		kubeletFlags["network-plugin"] = "cni"
-		kubeletFlags["cni-conf-dir"] = "/etc/cni/net.d"
-		kubeletFlags["cni-bin-dir"] = "/opt/cni/bin"
 		driver, err := kubeadmutil.GetCgroupDriverDocker(opts.execer)
 		if err != nil {
 			glog.Warningf("cannot automatically assign a '--cgroup-driver' value when starting the Kubelet: %v\n", err)

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -119,8 +119,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin": "cni",
-				"cni-conf-dir":   "/etc/cni/net.d",
-				"cni-bin-dir":    "/opt/cni/bin",
 			},
 		},
 		{
@@ -136,8 +134,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin":    "cni",
-				"cni-conf-dir":      "/etc/cni/net.d",
-				"cni-bin-dir":       "/opt/cni/bin",
 				"hostname-override": "override-name",
 			},
 		},
@@ -154,8 +150,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin": "cni",
-				"cni-conf-dir":   "/etc/cni/net.d",
-				"cni-bin-dir":    "/opt/cni/bin",
 				"cgroup-driver":  "systemd",
 			},
 		},
@@ -172,8 +166,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin": "cni",
-				"cni-conf-dir":   "/etc/cni/net.d",
-				"cni-bin-dir":    "/opt/cni/bin",
 				"cgroup-driver":  "cgroupfs",
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
#63580 fixes flag bindings for `--cni-conf-dir` and `cni-bin-dir`. No need to explicitly specify default value when building kubelet args in kubeadm.

Depends on #63580

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
/kind cleanup
/area kubeadm
/sig cluster-lifecycle
/cc timothysc luxas 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: remove redundant flags settings for kubelet
```
