### PR TITLE
update pod state of scheduler cache when UpdatePod

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -317,6 +317,7 @@ func (cache *schedulerCache) UpdatePod(oldPod, newPod *v1.Pod) error {
 		if err := cache.updatePod(oldPod, newPod); err != nil {
 			return err
 		}
+		currState.pod = newPod
 	default:
 		return fmt.Errorf("pod %v is not added to scheduler cache, so cannot be updated", key)
 	}


### PR DESCRIPTION
update pod state map in scheduler cache when call UpdatePod. @k82cn @bsalamat 

```release-note
keep pod state consistent when scheduler cache UpdatePod
```