### PR TITLE
Clear sandbox pod when create fails

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -52,10 +52,30 @@ func (m *kubeGenericRuntimeManager) createPodSandbox(pod *v1.Pod, attempt uint32
 	if err != nil {
 		message := fmt.Sprintf("CreatePodSandbox for pod %q failed: %v", format.Pod(pod), err)
 		glog.Error(message)
+		m.clearFailedPodSandbox(pod, podSandboxConfig, podSandBoxID)
 		return "", message, err
 	}
 
 	return podSandBoxID, "", nil
+}
+
+// clearFailedPodSandbox clear the faild sandbox
+func (m *kubeGenericRuntimeManager) clearFailedPodSandbox(pod *v1.Pod, podSandboxConfig *runtimeapi.PodSandboxConfig, podSandBoxID string) {
+	// Remove pod logs directory
+	err := m.osInterface.RemoveAll(podSandboxConfig.LogDirectory)
+	if err != nil {
+		message := fmt.Sprintf("Remove pod log directory for pod %q failed: %v", format.Pod(pod), err)
+		glog.Errorf(message)
+	}
+
+	// RemovePodSandbox
+	if podSandBoxID != "" {
+		err = m.runtimeService.RemovePodSandbox(podSandBoxID)
+		if err != nil {
+			message := fmt.Sprintf("CreatePodSandbox for pod %q failed: %v", format.Pod(pod), err)
+			glog.Error(message)
+		}
+	}
 }
 
 // generatePodSandboxConfig generates pod sandbox config from v1.Pod.


### PR DESCRIPTION
This fixes #64699

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR clear the sandbox pod if it return err to create during SyncPod. So that we can make sure that the  network will not be miss to setup while the sandbox remains success in docker actuallly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
