### PR TITLE
Fix test tag on dynamic config tests

### DIFF
--- a/test/e2e_node/dynamic_kubelet_config_test.go
+++ b/test/e2e_node/dynamic_kubelet_config_test.go
@@ -69,7 +69,7 @@ type nodeConfigTestCase struct {
 }
 
 // This test is marked [Disruptive] because the Kubelet restarts several times during this test.
-var _ = framework.KubeDescribe("[Feature:DynamicKubeletConfig][NodeAlphaFeature:DynamicKubeletConfig][Serial] [Disruptive]", func() {
+var _ = framework.KubeDescribe("[Feature:DynamicKubeletConfig][NodeFeature:DynamicKubeletConfig][Serial][Disruptive]", func() {
 	f := framework.NewDefaultFramework("dynamic-kubelet-configuration-test")
 	var beforeNode *apiv1.Node
 	var beforeConfigMap *apiv1.ConfigMap


### PR DESCRIPTION
The test accidentally got turned off when the NodeAlphaFeature tag was
added in #64125. This PR updates the tag to turn it back on.

```release-note
NONE
```
