### PR TITLE
kubeadm: Let the `--node-name` flag flow down to `--hostname-override` for the kubelet

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/apis/rbac/v1:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/scheme:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1beta1:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/util/procfs:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
@@ -37,12 +38,14 @@ go_test(
     srcs = [
         "config_test.go",
         "dynamic_test.go",
+        "flags_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1beta1:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -28,6 +28,7 @@ import (
 	kubeadmapiv1alpha2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilsexec "k8s.io/utils/exec"
 )
@@ -78,7 +79,12 @@ func buildKubeletArgMap(nodeRegOpts *kubeadmapi.NodeRegistrationOptions, registe
 		kubeletFlags["resolv-conf"] = "/run/systemd/resolve/resolv.conf"
 	}
 
-	// TODO: Pass through --hostname-override if a custom name is used?
+	// Make sure the node name we're passed will work with Kubelet
+	if nodeRegOpts.Name != "" && nodeRegOpts.Name != nodeutil.GetHostname("") {
+		glog.V(1).Info("setting kubelet hostname-override to %q", nodeRegOpts.Name)
+		kubeletFlags["hostname-override"] = nodeRegOpts.Name
+	}
+
 	// TODO: Conditionally set `--cgroup-driver` to either `systemd` or `cgroupfs` for CRI other than Docker
 
 	return kubeletFlags

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
+)
+
+func TestBuildKubeletArgMap(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		hostname         string
+		expectedHostname string
+	}{
+		{
+			name:             "manually set to current hostname",
+			hostname:         nodeutil.GetHostname(""),
+			expectedHostname: "",
+		},
+		{
+			name:             "unset hostname",
+			hostname:         "",
+			expectedHostname: "",
+		},
+		{
+			name:             "override hostname",
+			hostname:         "my-node",
+			expectedHostname: "my-node",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := &kubeadmapi.NodeRegistrationOptions{
+				Name: test.hostname,
+			}
+
+			m := buildKubeletArgMap(opts, false)
+			if m["hostname-override"] != test.expectedHostname {
+				t.Errorf("expected hostname %q, got %q", test.expectedHostname, m["hostname-override"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubeadm-initialised kubelet uses provided hostname if present

If --node-name is passed in to `kubeadm init`, `--hostname-override` will be
passed to kubelet. This prevents timeout errors for `kubeadm init`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#846

**Special notes for your reviewer**:
Depends on #64624 to work fully, but can safely merged before hand.

**Release note**:

```release-note
[action required] The `--node-name` flag for kubeadm now dictates the Node API object name the
kubelet uses for registration, in all cases but where you might use an in-tree cloud provider.
If you're not using an in-tree cloud provider, `--node-name` will set the Node API object name.
If you're using an in-tree cloud provider, you MUST make `--node-name` match the name the
in-tree cloud provider decides to use.
```
