### PR TITLE
Fix kubeadm for v1alpha1 configs

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -91,3 +91,13 @@ go_test(
     embed = [":go_default_library"],
     deps = ["//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library"],
 )
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["conversion_test.go"],
+    deps = [
+        ":go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
@@ -145,13 +145,11 @@ func UpgradeNodeRegistrationOptionsForMaster(in *MasterConfiguration, out *kubea
 	}
 }
 
+// UpgradeBootstrapTokens should create at least one empty bootstrap token in the out config.
 func UpgradeBootstrapTokens(in *MasterConfiguration, out *kubeadm.MasterConfiguration) error {
-	if len(in.Token) == 0 {
-		return nil
-	}
-
 	bts, err := kubeadm.NewBootstrapTokenString(in.Token)
-	if err != nil {
+	// Ignore the error if the incoming token was empty.
+	if err != nil && in.Token != "" {
 		return fmt.Errorf("can't parse .Token, and hence can't convert v1alpha1 API to a newer version: %v", err)
 	}
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+)
+
+func TestUpgradeBootstrapTokens(t *testing.T) {
+	testcases := []struct {
+		name        string
+		in          *v1alpha1.MasterConfiguration
+		expectedOut *kubeadm.MasterConfiguration
+		expectError bool
+	}{
+		{
+			name: "empty configs should create at least one token",
+			in:   &v1alpha1.MasterConfiguration{},
+			expectedOut: &kubeadm.MasterConfiguration{
+				BootstrapTokens: []kubeadm.BootstrapToken{
+					{
+						Token: nil,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "fail at parsing incoming token",
+			in: &v1alpha1.MasterConfiguration{
+				Token: "some fake token",
+			},
+			expectError: true,
+		},
+		{
+			name: "input has values",
+			in: &v1alpha1.MasterConfiguration{
+				Token: "abcdef.abcdefghijklmnop",
+				TokenTTL: &metav1.Duration{
+					Duration: time.Duration(10 * time.Hour),
+				},
+				TokenUsages: []string{"action"},
+				TokenGroups: []string{"group", "group2"},
+			},
+			expectedOut: &kubeadm.MasterConfiguration{
+				BootstrapTokens: []kubeadm.BootstrapToken{
+					{
+						Token: &kubeadm.BootstrapTokenString{
+							ID:     "abcdef",
+							Secret: "abcdefghijklmnop",
+						},
+						TTL: &metav1.Duration{
+							Duration: time.Duration(10 * time.Hour),
+						},
+						Usages: []string{"action"},
+						Groups: []string{"group", "group2"},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &kubeadm.MasterConfiguration{}
+			err := v1alpha1.UpgradeBootstrapTokens(tc.in, out)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected an error but did not get one.")
+				}
+				// do not continue if we got an expected error
+				return
+			}
+
+			if !reflect.DeepEqual(out.BootstrapTokens, tc.expectedOut.BootstrapTokens) {
+				t.Fatalf("\nexpected: %v\ngot: %v", tc.expectedOut.BootstrapTokens, out.BootstrapTokens)
+			}
+		})
+	}
+
+}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -482,8 +482,8 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	// PHASE 7: Make the control plane self-hosted if feature gate is enabled
-	glog.V(1).Infof("[init] feature gate is enabled. Making control plane self-hosted")
 	if features.Enabled(i.cfg.FeatureGates, features.SelfHosting) {
+		glog.V(1).Infof("[init] feature gate is enabled. Making control plane self-hosted")
 		// Temporary control plane is up, now we create our self hosted control
 		// plane components and remove the static manifests:
 		glog.Infoln("[self-hosted] creating self-hosted control plane")

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -6,7 +6,6 @@ cmd/kube-controller-manager/app
 cmd/kube-proxy/app
 cmd/kube-scheduler/app
 cmd/kubeadm/app
-cmd/kubeadm/app/apis/kubeadm/v1alpha1
 cmd/kubeadm/app/apis/kubeadm/v1alpha2
 cmd/kubeadm/app/util/config
 cmd/kubelet/app


### PR DESCRIPTION
Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This PR allows v1alpha1 configurations to still work when running `kubeadm init`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#884

**Special notes for your reviewer**:

```release-note
NONE
```
