### PR TITLE
Fix panic caused by no cloudprovider in test

### DIFF
--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -98,15 +98,23 @@ func (plugin *awsElasticBlockStorePlugin) SupportsBulkVolumeVerification() bool 
 }
 
 func (plugin *awsElasticBlockStorePlugin) GetVolumeLimits() (map[string]int64, error) {
+	volumeLimits := map[string]int64{
+		util.EBSVolumeLimitKey: 39,
+	}
 	cloud := plugin.host.GetCloudProvider()
+
+	// if we can't fetch cloudprovider we return an error
+	// hoping external CCM or admin can set it. Returning
+	// default values from here will mean, no one can
+	// override them.
+	if cloud == nil {
+		return nil, fmt.Errorf("No cloudprovider present")
+	}
 
 	if cloud.ProviderName() != aws.ProviderName {
 		return nil, fmt.Errorf("Expected aws cloud, found %s", cloud.ProviderName())
 	}
 
-	volumeLimits := map[string]int64{
-		util.EBSVolumeLimitKey: 39,
-	}
 	instances, ok := cloud.Instances()
 	if !ok {
 		glog.V(3).Infof("Failed to get instances from cloud provider")

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -112,14 +112,24 @@ func (plugin *azureDataDiskPlugin) SupportsBulkVolumeVerification() bool {
 }
 
 func (plugin *azureDataDiskPlugin) GetVolumeLimits() (map[string]int64, error) {
+	volumeLimits := map[string]int64{
+		util.AzureVolumeLimitKey: 16,
+	}
+
 	cloud := plugin.host.GetCloudProvider()
+
+	// if we can't fetch cloudprovider we return an error
+	// hoping external CCM or admin can set it. Returning
+	// default values from here will mean, no one can
+	// override them.
+	if cloud == nil {
+		return nil, fmt.Errorf("No cloudprovider present")
+	}
+
 	if cloud.ProviderName() != azure.CloudProviderName {
 		return nil, fmt.Errorf("Expected Azure cloudprovider, got %s", cloud.ProviderName())
 	}
 
-	volumeLimits := map[string]int64{
-		util.AzureVolumeLimitKey: 16,
-	}
 	return volumeLimits, nil
 }
 

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -103,15 +103,23 @@ func (plugin *gcePersistentDiskPlugin) GetAccessModes() []v1.PersistentVolumeAcc
 }
 
 func (plugin *gcePersistentDiskPlugin) GetVolumeLimits() (map[string]int64, error) {
+	volumeLimits := map[string]int64{
+		util.GCEVolumeLimitKey: 16,
+	}
 	cloud := plugin.host.GetCloudProvider()
+
+	// if we can't fetch cloudprovider we return an error
+	// hoping external CCM or admin can set it. Returning
+	// default values from here will mean, no one can
+	// override them.
+	if cloud == nil {
+		return nil, fmt.Errorf("No cloudprovider present")
+	}
 
 	if cloud.ProviderName() != gcecloud.ProviderName {
 		return nil, fmt.Errorf("Expected gce cloud got %s", cloud.ProviderName())
 	}
 
-	volumeLimits := map[string]int64{
-		util.GCEVolumeLimitKey: 16,
-	}
 	return volumeLimits, nil
 }
 


### PR DESCRIPTION
We should not panic when no cloudprovider is present

Fixes https://github.com/kubernetes/kubernetes/issues/64704

Also added a test to cover the panic.

/sig storage
/sig node

```release-note
None
```