### PR TITLE
kubelet: do not panic on invalid restore state

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_file.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_file.go
@@ -52,9 +52,9 @@ func NewFileState(filePath string, policyName string) State {
 	if err := stateFile.tryRestoreState(); err != nil {
 		// could not restore state, init new state file
 		msg := fmt.Sprintf("[cpumanager] state file: unable to restore state from disk (%s)\n", err.Error()) +
-			"Panicking because we cannot guarantee sane CPU affinity for existing containers.\n" +
+			"Exiting because we cannot guarantee sane CPU affinity for existing containers.\n" +
 			fmt.Sprintf("Please drain this node and delete the CPU manager state file \"%s\" before restarting Kubelet.", stateFile.stateFilePath)
-		panic(msg)
+		glog.Exit(msg)
 	}
 
 	return stateFile


### PR DESCRIPTION
**What this PR does / why we need it**:
When kubelet starts with an invalid cpu_manager_state file, the kubelet process panics causing a stack strace to display in the logs. The invalid cpu_manager_state error is hard to find because of the large strack trace. This PR causes the error message to display, and the process to exit without the stack trace.

/bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @sjenning 

**Release note**:
```release-note
NONE
```
