### PR TITLE
Change dockershim to return error if host path does not exist.

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -114,6 +114,10 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 	if iSpec := config.GetImage(); iSpec != nil {
 		image = iSpec.Image
 	}
+	binds, err := ds.generateMountBindings(config.GetMounts())
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate mount bindings: %v", err)
+	}
 	createConfig := dockertypes.ContainerCreateConfig{
 		Name: makeContainerName(sandboxConfig, config),
 		Config: &dockercontainer.Config{
@@ -135,7 +139,7 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 			},
 		},
 		HostConfig: &dockercontainer.HostConfig{
-			Binds: generateMountBindings(config.GetMounts()),
+			Binds: binds,
 		},
 	}
 


### PR DESCRIPTION
Change dockershim to conform to https://github.com/kubernetes-incubator/cri-tools/pull/320.

@feiskyer @yujuhong @kubernetes/sig-node-pr-reviews 
Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
