### PR TITLE
Enabling auto sync etcd members

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -142,18 +142,10 @@ func TestAddFlags(t *testing.T) {
 		},
 		Etcd: &apiserveroptions.EtcdOptions{
 			StorageConfig: storagebackend.Config{
-<<<<<<< HEAD
 				Type:                  "etcd3",
 				ServerList:            nil,
 				Prefix:                "/registry",
-=======
-				Type:       "etcd2",
-				ServerList: nil,
-				Prefix:     "/registry",
-				DeserializationCacheSize: 0,
-				Quorum:                false,
 				AutoSyncInterval:      20 * time.Second,
->>>>>>> support auto sync etcd members
 				KeyFile:               "/var/run/kubernetes/etcd.key",
 				CAFile:                "/var/run/kubernetes/etcdca.crt",
 				CertFile:              "/var/run/kubernetes/etcdce.crt",

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -98,6 +98,7 @@ func TestAddFlags(t *testing.T) {
 		"--enable-logs-handler=false",
 		"--enable-swagger-ui=true",
 		"--endpoint-reconciler-type=" + string(reconcilers.LeaseEndpointReconcilerType),
+		"--etcd-auto-sync-interval=20s",
 		"--etcd-keyfile=/var/run/kubernetes/etcd.key",
 		"--etcd-certfile=/var/run/kubernetes/etcdce.crt",
 		"--etcd-cafile=/var/run/kubernetes/etcdca.crt",
@@ -141,9 +142,18 @@ func TestAddFlags(t *testing.T) {
 		},
 		Etcd: &apiserveroptions.EtcdOptions{
 			StorageConfig: storagebackend.Config{
+<<<<<<< HEAD
 				Type:                  "etcd3",
 				ServerList:            nil,
 				Prefix:                "/registry",
+=======
+				Type:       "etcd2",
+				ServerList: nil,
+				Prefix:     "/registry",
+				DeserializationCacheSize: 0,
+				Quorum:                false,
+				AutoSyncInterval:      20 * time.Second,
+>>>>>>> support auto sync etcd members
 				KeyFile:               "/var/run/kubernetes/etcd.key",
 				CAFile:                "/var/run/kubernetes/etcdca.crt",
 				CertFile:              "/var/run/kubernetes/etcdce.crt",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -151,6 +151,11 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.StorageConfig.ServerList, "etcd-servers", s.StorageConfig.ServerList,
 		"List of etcd servers to connect with (scheme://ip:port), comma separated.")
 
+	fs.DurationVar(&s.StorageConfig.AutoSyncInterval, "etcd-auto-sync-interval", s.StorageConfig.AutoSyncInterval, ""+
+		"The interval at which to update etcd endpoints to the latest members as reported by the cluster. "+
+		"Do not enable if the api server has a different network view of the etcd cluster members than the etcd cluster reports "+
+		"(for example, if accessing etcd via a load-balancer). Disabled when set to 0.")
+
 	fs.StringVar(&s.StorageConfig.Prefix, "etcd-prefix", s.StorageConfig.Prefix,
 		"The prefix to prepend to all resource paths in etcd.")
 
@@ -181,6 +186,7 @@ func (s *EtcdOptions) ApplyTo(c *server.Config) error {
 	if s == nil {
 		return nil
 	}
+
 	if err := s.addEtcdHealthEndpoint(c); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	Prefix string
 	// ServerList is the list of storage servers to connect with.
 	ServerList []string
+	// AutoSyncInterval is the interval to update endpoints with its latest members.
+	// 0 disables auto-sync.
+	AutoSyncInterval time.Duration
 	// TLS credentials
 	KeyFile  string
 	CertFile string

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
@@ -34,8 +34,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory",
     importpath = "k8s.io/apiserver/pkg/storage/storagebackend/factory",
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/BUILD
@@ -34,6 +34,8 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory",
     importpath = "k8s.io/apiserver/pkg/storage/storagebackend/factory",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -78,12 +78,14 @@ func newETCD3HealthCheck(c storagebackend.Config) (func() error, error) {
 		if err != nil {
 			return fmt.Errorf("error listing etcd members: %v", err)
 		}
-		endpoints := []string{}
-		for _, m := range memberList.Members {
-			endpoints = append(endpoints, m.ClientURLs...)
-		}
-		if sets.NewString(endpoints...).Intersection(serverList).Len() == 0 {
-			return fmt.Errorf("current etcd cluster endpoints should share at least one with `--etcd-servers` flag")
+		if c.AutoSyncInterval > 0 {
+			endpoints := []string{}
+			for _, m := range memberList.Members {
+				endpoints = append(endpoints, m.ClientURLs...)
+			}
+			if sets.NewString(endpoints...).Intersection(serverList).Len() == 0 {
+				return fmt.Errorf("current etcd cluster endpoints should share at least one with `--etcd-servers` flag")
+			}
 		}
 		return nil
 	}, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -94,6 +94,7 @@ func newETCD3Client(c storagebackend.Config) (*clientv3.Client, error) {
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
+		AutoSyncInterval:     c.AutoSyncInterval,
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,


### PR DESCRIPTION
enabling apiserver to auto sync etcd members periodically. 

Fixes #64742

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose `--etcd-auto-sync-interval` flag to support auto sync etcd members periodically. 0 for disabling auto sync. Warning: if etcd servers is behind a LoadBalancer, donot set auto sync.
```
