### PR TITLE
Fix standalone dockershim.

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -85,7 +85,7 @@ const (
 type CRIService interface {
 	runtimeapi.RuntimeServiceServer
 	runtimeapi.ImageServiceServer
-	Start(<-chan struct{}) error
+	Start() error
 }
 
 // DockerService is an interface that embeds the new RuntimeService and
@@ -400,17 +400,11 @@ func (ds *dockerService) GetPodPortMappings(podSandboxID string) ([]*hostport.Po
 }
 
 // Start initializes and starts components in dockerService.
-func (ds *dockerService) Start(stopCh <-chan struct{}) error {
+func (ds *dockerService) Start() error {
 	// Initialize the legacy cleanup flag.
 	if ds.startLocalStreamingServer {
 		go func() {
-			<-stopCh
-			if err := ds.streamingServer.Stop(); err != nil {
-				glog.Errorf("Failed to stop streaming server: %v", err)
-			}
-		}()
-		go func() {
-			if err := ds.streamingServer.Start(true); err != nil && err != http.ErrServerClosed {
+			if err := ds.streamingServer.Start(true); err != nil {
 				glog.Fatalf("Streaming server stopped unexpectedly: %v", err)
 			}
 		}()

--- a/pkg/kubelet/dockershim/remote/docker_server.go
+++ b/pkg/kubelet/dockershim/remote/docker_server.go
@@ -49,9 +49,9 @@ func NewDockerServer(endpoint string, s dockershim.CRIService) *DockerServer {
 }
 
 // Start starts the dockershim grpc server.
-func (s *DockerServer) Start(stopCh <-chan struct{}) error {
+func (s *DockerServer) Start() error {
 	// Start the internal service.
-	if err := s.service.Start(stopCh); err != nil {
+	if err := s.service.Start(); err != nil {
 		glog.Errorf("Unable to start docker service")
 		return err
 	}
@@ -70,18 +70,8 @@ func (s *DockerServer) Start(stopCh <-chan struct{}) error {
 	runtimeapi.RegisterImageServiceServer(s.server, s.service)
 	go func() {
 		if err := s.server.Serve(l); err != nil {
-			glog.Errorf("Failed to serve connections: %v", err)
+			glog.Fatalf("Failed to serve connections: %v", err)
 		}
 	}()
-	go func() {
-		<-stopCh
-		s.Stop()
-	}()
 	return nil
-}
-
-// Stop stops the dockershim grpc server.
-func (s *DockerServer) Stop() {
-	glog.V(2).Infof("Stop docker server")
-	s.server.Stop()
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -221,8 +221,7 @@ type Builder func(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32,
-	stopCh <-chan struct{}) (Bootstrap, error)
+	nodeStatusMaxImages int32) (Bootstrap, error)
 
 // Dependencies is a bin for things we might consider "injected dependencies" -- objects constructed
 // at runtime that are necessary for running the Kubelet. This is a temporary solution for grouping
@@ -348,8 +347,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32,
-	stopCh <-chan struct{}) (*Kubelet, error) {
+	nodeStatusMaxImages int32) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
 	}
@@ -630,7 +628,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			remoteImageEndpoint)
 		glog.V(2).Infof("Starting the GRPC server for the docker CRI shim.")
 		server := dockerremote.NewDockerServer(remoteRuntimeEndpoint, ds)
-		if err := server.Start(stopCh); err != nil {
+		if err := server.Start(); err != nil {
 			return nil, err
 		}
 

--- a/pkg/kubemark/BUILD
+++ b/pkg/kubemark/BUILD
@@ -46,7 +46,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/informers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
@@ -90,7 +89,7 @@ func NewHollowKubelet(
 
 // Starts this HollowKubelet and blocks.
 func (hk *HollowKubelet) Run() {
-	if err := kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false, wait.NeverStop); err != nil {
+	if err := kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false); err != nil {
 		glog.Fatalf("Failed to run HollowKubelet: %v. Exiting.", err)
 	}
 	select {}


### PR DESCRIPTION
Ref https://github.com/kubernetes-incubator/cri-tools/pull/320#issuecomment-394554484.

This PR fixes a bug that standalone dockershim exits immediately.

This PR:
1) Changes standalone dockershim to wait on `stopCh`, so that it won't exit immediately.
2) Removes `stopCh` from dockershim internal. It doesn't help much for graceful stop, because kubelet will exit immediately anyway. https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L748

@kubernetes/sig-node-pr-reviews @yujuhong @feiskyer 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
