### PR TITLE
apiextensions: allow Description at root with status subresource

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -291,7 +291,7 @@ func ValidateCustomResourceDefinitionValidation(customResourceValidation *apiext
 	}
 
 	if schema := customResourceValidation.OpenAPIV3Schema; schema != nil {
-		// if subresources are enabled, only "properties" and "required" is allowed inside the root schema
+		// if subresources are enabled, only "properties", "required" and "description" are allowed inside the root schema
 		if utilfeature.DefaultFeatureGate.Enabled(apiextensionsfeatures.CustomResourceSubresources) && statusSubresourceEnabled {
 			v := reflect.ValueOf(schema).Elem()
 			for i := 0; i < v.NumField(); i++ {
@@ -300,8 +300,8 @@ func ValidateCustomResourceDefinitionValidation(customResourceValidation *apiext
 					continue
 				}
 
-				if name := v.Type().Field(i).Name; name != "Properties" && name != "Required" {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("openAPIV3Schema"), *schema, fmt.Sprintf(`must only have "properties" or "required" at the root if the status subresource is enabled`)))
+				if name := v.Type().Field(i).Name; name != "Properties" && name != "Required" && name != "Description" {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("openAPIV3Schema"), *schema, fmt.Sprintf(`must only have "properties", "required" or "description" at the root if the status subresource is enabled`)))
 					break
 				}
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -849,14 +849,15 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			wantError:     true,
 		},
 		{
-			name: "properties and required with status",
+			name: "properties, required and description with status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"spec":   {},
 						"status": {},
 					},
-					Required: []string{"spec", "status"},
+					Required:    []string{"spec", "status"},
+					Description: "This is a description",
 				},
 			},
 			statusEnabled: true,

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -359,7 +359,8 @@ func TestValidationSchema(t *testing.T) {
 				},
 			},
 		},
-		Required: []string{"spec"},
+		Required:    []string{"spec"},
+		Description: "This is a description at the root of the schema",
 	}
 	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {


### PR DESCRIPTION
Allows `Description` at the root of the schema when the status subresource is enabled.

**Release note**:
I'll update the original PR, which allowed `Required`, to de-duplicate the release notes.

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts 
