### PR TITLE
Remove Feature:Volume from tests

### DIFF
--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -263,7 +263,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 	// (/usr/bin/nova, /usr/bin/cinder and /usr/bin/keystone)
 	// and that the usual OpenStack authentication env. variables are set
 	// (OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME at least).
-	Describe("Cinder [Feature:Volumes]", func() {
+	Describe("Cinder", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("openstack")
 			config := framework.VolumeTestConfig{
@@ -438,7 +438,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// vSphere
 	////////////////////////////////////////////////////////////////////////
-	Describe("vsphere [Feature:Volumes]", func() {
+	Describe("vsphere", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("vsphere")
 			vspheretest.Bootstrap(f)
@@ -485,7 +485,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Azure Disk
 	////////////////////////////////////////////////////////////////////////
-	Describe("Azure Disk [Feature:Volumes]", func() {
+	Describe("Azure Disk", func() {
 		It("should be mountable [Slow]", func() {
 			framework.SkipUnlessProviderIs("azure")
 			config := framework.VolumeTestConfig{


### PR DESCRIPTION
These tests don't depend on any alpha/beta feature and they have correct `SkipUnlessProviderIs` tests so they run only on proper cloud.

/kind feature
/sig storage

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
