### PR TITLE
modify kubectl get job -o wide information

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -154,7 +154,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 		{Name: "Containers", Type: "string", Priority: 1, Description: "Names of each container in the template."},
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
-		{Name: "Selector", Type: "string", Priority: 1, Description: batchv1.JobSpec{}.SwaggerDoc()["selector"]},
+		{Name: "Start Time", Type: "string", Priority: 1, Description: batchv1.JobStatus{}.SwaggerDoc()["startTime"]},
 	}
 	h.TableHandler(jobColumnDefinitions, printJob)
 	h.TableHandler(jobColumnDefinitions, printJobList)
@@ -758,7 +758,7 @@ func printJob(obj *batch.Job, options printers.PrintOptions) ([]metav1beta1.Tabl
 	row.Cells = append(row.Cells, obj.Name, completions, int64(obj.Status.Succeeded), translateTimestamp(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
-		row.Cells = append(row.Cells, names, images, metav1.FormatLabelSelector(obj.Spec.Selector))
+		row.Cells = append(row.Cells, names, images, obj.Status.StartTime)
 	}
 	return []metav1beta1.TableRow{row}, nil
 }

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -758,7 +758,7 @@ func printJob(obj *batch.Job, options printers.PrintOptions) ([]metav1beta1.Tabl
 	row.Cells = append(row.Cells, obj.Name, completions, int64(obj.Status.Succeeded), translateTimestamp(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
-		row.Cells = append(row.Cells, names, images, obj.Status.StartTime)
+		row.Cells = append(row.Cells, names, images, fmt.Sprint(obj.Status.StartTime))
 	}
 	return []metav1beta1.TableRow{row}, nil
 }

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -758,7 +758,7 @@ func printJob(obj *batch.Job, options printers.PrintOptions) ([]metav1beta1.Tabl
 	row.Cells = append(row.Cells, obj.Name, completions, int64(obj.Status.Succeeded), translateTimestamp(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
-		row.Cells = append(row.Cells, names, images, fmt.Sprint(obj.Status.StartTime))
+		row.Cells = append(row.Cells, names, images, obj.Status.StartTime)
 	}
 	return []metav1beta1.TableRow{row}, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1347,7 +1347,7 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 		for j, cell := range row.Cells {
 			// do not add to this test without discussion - may break clients
 			switch cell.(type) {
-			case float64, int64, int32, int, string, bool:
+			case float64, int64, int32, int, string, bool, *metav1.Time:
 			case []interface{}:
 			case nil:
 			default:


### PR DESCRIPTION
1. I think this "selector" info is not nessecery, because it is auto-generated generally.
2. I think start time is neccesary for job workloads.

After:
```bash
./_output/bin/kubectl get job -o wide
NAME          DESIRED   SUCCESSFUL   AGE       CONTAINERS        IMAGES          START TIME
sample-job    1         1            76d       sleep-container   centos:latest   2018-03-21 16:30:58 +0900 JST
```

Before:
```bash
$ kubectl get job -o wide
NAME          DESIRED   SUCCESSFUL   AGE       CONTAINERS        IMAGES          SELECTOR
sample-job    1         1            76d       sleep-container   centos:latest   controller-uid=cc902581-2cd9-11e8-9d2f-42010a920127
```

For example, job labels are auto-generated "contoller-uid" and some labels.
And generally, job selector is also "controller-uid".
I think this information is not nessecery.
But generally, I think start time is neccesary for job workloads.

```json
$ kubectl get job sample-job -o json | jq .spec.template.metadata.labels
{
  "controller-uid": "cc902581-2cd9-11e8-9d2f-42010a920127",
  "job-name": "sample-job"
}

$ kubectl get job sample-job -o json | jq .spec.selector
{
  "matchLabels": {
    "controller-uid": "cc902581-2cd9-11e8-9d2f-42010a920127"
  }
}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
we need more valuable output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
If we don't need Starttime, I remove "add starttime".
but I think selector don't need.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add starttime column for job at kubectl output 
```
