### PR TITLE
CoreDNS to use gcr.io repo 

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -161,9 +161,10 @@ func createKubeDNSAddon(deploymentBytes, serviceBytes []byte, client clientset.I
 func coreDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface, k8sVersion *version.Version) error {
 	// Get the YAML manifest conditionally based on the k8s version
 	dnsDeploymentBytes := GetCoreDNSManifest(k8sVersion)
-	coreDNSDeploymentBytes, err := kubeadmutil.ParseTemplate(dnsDeploymentBytes, struct{ MasterTaintKey, Version string }{
-		MasterTaintKey: kubeadmconstants.LabelNodeRoleMaster,
-		Version:        GetDNSVersion(k8sVersion, kubeadmconstants.CoreDNS),
+	coreDNSDeploymentBytes, err := kubeadmutil.ParseTemplate(dnsDeploymentBytes, struct{ ImageRepository, MasterTaintKey, Version string }{
+		ImageRepository: cfg.ImageRepository,
+		MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
+		Version:         GetDNSVersion(k8sVersion, kubeadmconstants.CoreDNS),
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing CoreDNS deployment template: %v", err)

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -115,9 +115,10 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: CoreDNSDeployment,
-			data: struct{ MasterTaintKey, Version string }{
-				MasterTaintKey: "foo",
-				Version:        "foo",
+			data: struct{ ImageRepository, MasterTaintKey, Version string }{
+				ImageRepository: "foo",
+				MasterTaintKey:  "foo",
+				Version:         "foo",
 			},
 			expected: true,
 		},

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -247,7 +247,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: coredns
-        image: coredns/coredns:{{ .Version }}
+        image: {{ .ImageRepository }}/coredns:{{ .Version }}
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Switch CoreDNS to use the gcr.io in kubeadm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CoreDNS deployment configuration now uses k8s.gcr.io imageRepository
```
