### PR TITLE
kubelet: do not panic on invalid restore state

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -137,9 +137,12 @@ func NewManager(cpuPolicyName string, reconcilePeriod time.Duration, machineInfo
 		policy = NewNonePolicy()
 	}
 
-	stateImpl := state.NewFileState(
+	stateImpl, err := state.NewFileState(
 		path.Join(stateFileDirecory, CPUManagerStateFileName),
 		policy.Name())
+	if err != nil {
+		glog.Exit(err)
+	}
 
 	manager := &manager{
 		policy:                     policy,


### PR DESCRIPTION
**What this PR does / why we need it**:
When kubelet starts with an invalid cpu_manager_state file, the kubelet process panics causing a stack strace to display in the logs. The invalid cpu_manager_state error is hard to find because of the large strack trace. This PR causes the error message to display, and the process to exit without the stack trace.

/bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @sjenning 

**Release note**:
```release-note
NONE
```
