### PR TITLE
Added OS verification for third party etcd binary

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -102,11 +102,13 @@ kube::etcd::cleanup() {
 
 kube::etcd::install() {
   (
+    local os
     cd "${KUBE_ROOT}/third_party"
-    if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-* ]]; then
+    os=$(uname | tr "[:upper:]" "[:lower:]")
+    if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
       return  # already installed
     fi
-    if [[ $(uname) == "Darwin" ]]; then
+    if [[ ${os} == "darwin" ]]; then
       download_file="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
       url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
       kube::util::download_file "${url}" "${download_file}"
@@ -119,6 +121,7 @@ kube::etcd::install() {
       kube::util::download_file "${url}" "${download_file}"
       tar xzf "${download_file}"
       ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
+      rm "${download_file}"
     fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
     kube::log::info "export PATH=$(pwd)/etcd:\${PATH}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enables downloading and relinking etcd to correct OS specific binary/package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64754 

**Special notes for your reviewer**:
There are some incidents when etcd binaries are present for darwin (etcd-v3.2.18-darwin-amd64) in `${KUBE_ROOT}/third_party` directory but local-cluster creation is invoked from linux system. This leads to cluster creation failure due to missing appropriate os dependent etcd binary (etcd-v3.2.18-linux-amd64). So in this PR, we are verifying OS and relinking `etcd` softlink to appropriate `etc-${version}-${os}-*` binary.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
