### PR TITLE
CRD Test: Fix resource creation/deletion for multi-version CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -226,7 +226,7 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta
 					t.Fatal(err)
 				}
 				if e, a := createdObjectMeta.GetUID(), deletedObjectMeta.GetUID(); e != a {
-					t.Errorf("expected %v, got %v", e, a)
+					t.Errorf("expected equal UID for (expected) %v, and (actual) %v", createdNoxuInstance, watchEvent.Object)
 				}
 
 			case <-time.After(5 * time.Second):

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -361,7 +361,7 @@ func TestValidationSchema(t *testing.T) {
 		},
 		Required: []string{"spec"},
 	}
-	noxuDefinition, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	_, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("unable to created crd %v: %v", noxuDefinition.Name, err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/cmd/server:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",


### PR DESCRIPTION
During CRD testing setup, a setup instance CRD is created and watched to make sure the watch cache is prime. The deletion watch event for this instance can result in test failure for any watch test as they expect exact watch events. Previous code did not take multiple versioned CRDs into account. This change will make sure we wait for deletion for all versions before continue with any test.

@sttts @liggitt 

Fixes #64571