### PR TITLE
error out empty hostname

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -114,7 +114,10 @@ func newProxyServer(
 	}
 
 	// Create event recorder
-	hostname := utilnode.GetHostname(config.HostnameOverride)
+	hostname, err := utilnode.GetHostname(config.HostnameOverride)
+	if err != nil {
+		return nil, err
+	}
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "kube-proxy", Host: hostname})
 

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -72,7 +72,10 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	}
 
 	// Create event recorder
-	hostname := utilnode.GetHostname(config.HostnameOverride)
+	hostname, err := utilnode.GetHostname(config.HostnameOverride)
+	if err != nil {
+		return nil, err
+	}
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme, v1.EventSource{Component: "kube-proxy", Host: hostname})
 

--- a/cmd/kubeadm/app/cmd/phases/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/certs_test.go
@@ -189,7 +189,10 @@ func TestSubCmdCertsApiServerForwardsFlags(t *testing.T) {
 		t.Fatalf("Error loading API server certificate: %v", err)
 	}
 
-	hostname := node.GetHostname("")
+	hostname, err := node.GetHostname("")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for i, name := range []string{hostname, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.mycluster.local"} {
 		if APIserverCert.DNSNames[i] != name {

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -46,6 +46,10 @@ type kubeletFlagsOpts struct {
 // WriteKubeletDynamicEnvFile writes a environment file with dynamic flags to the kubelet.
 // Used at "kubeadm init" and "kubeadm join" time.
 func WriteKubeletDynamicEnvFile(nodeRegOpts *kubeadmapi.NodeRegistrationOptions, featureGates map[string]bool, registerTaintsUsingFlags bool, kubeletDir string) error {
+	hostName, err := nodeutil.GetHostname("")
+	if err != nil {
+		return err
+	}
 
 	flagOpts := kubeletFlagsOpts{
 		nodeRegOpts:              nodeRegOpts,
@@ -53,7 +57,7 @@ func WriteKubeletDynamicEnvFile(nodeRegOpts *kubeadmapi.NodeRegistrationOptions,
 		registerTaintsUsingFlags: registerTaintsUsingFlags,
 		execer:          utilsexec.New(),
 		pidOfFunc:       procfs.PidOf,
-		defaultHostname: nodeutil.GetHostname(""),
+		defaultHostname: hostName,
 	}
 	stringMap := buildKubeletArgMap(flagOpts)
 	argList := kubeadmutil.BuildArgumentListFromMap(stringMap, nodeRegOpts.KubeletExtraArgs)

--- a/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
@@ -108,7 +108,10 @@ func TestMarkMaster(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		hostname := node.GetHostname("")
+		hostname, err := node.GetHostname("")
+		if err != nil {
+			t.Fatalf("MarkMaster(%s): unexpected error: %v", tc.name, err)
+		}
 		masterNode := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: hostname,

--- a/cmd/kubeadm/app/util/config/masterconfig.go
+++ b/cmd/kubeadm/app/util/config/masterconfig.go
@@ -94,7 +94,10 @@ func SetInitDynamicDefaults(cfg *kubeadmapi.InitConfiguration) error {
 		cfg.BootstrapTokens[i].Token = token
 	}
 
-	cfg.NodeRegistration.Name = nodeutil.GetHostname(cfg.NodeRegistration.Name)
+	cfg.NodeRegistration.Name, err = nodeutil.GetHostname(cfg.NodeRegistration.Name)
+	if err != nil {
+		return err
+	}
 
 	// Only if the slice is nil, we should append the master taint. This allows the user to specify an empty slice for no default master taint
 	if cfg.NodeRegistration.Taints == nil {

--- a/cmd/kubeadm/app/util/config/nodeconfig.go
+++ b/cmd/kubeadm/app/util/config/nodeconfig.go
@@ -32,7 +32,11 @@ import (
 
 // SetJoinDynamicDefaults checks and sets configuration values for the JoinConfiguration object
 func SetJoinDynamicDefaults(cfg *kubeadmapi.JoinConfiguration) error {
-	cfg.NodeRegistration.Name = node.GetHostname(cfg.NodeRegistration.Name)
+	nodeName, err := node.GetHostname(cfg.NodeRegistration.Name)
+	if err != nil {
+		return err
+	}
+	cfg.NodeRegistration.Name = nodeName
 	return nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -369,7 +369,10 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		}
 	}
 
-	hostname := nodeutil.GetHostname(hostnameOverride)
+	hostname, err := nodeutil.GetHostname(hostnameOverride)
+	if err != nil {
+		return nil, err
+	}
 	// Query the cloud provider for our node name, default to hostname
 	nodeName := types.NodeName(hostname)
 	if kubeDeps.Cloud != nil {

--- a/pkg/util/node/BUILD
+++ b/pkg/util/node/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
 

--- a/pkg/util/node/node_test.go
+++ b/pkg/util/node/node_test.go
@@ -89,3 +89,35 @@ func TestGetPreferredAddress(t *testing.T) {
 		}
 	}
 }
+
+func TestGetHostname(t *testing.T) {
+	testCases := []struct {
+		hostName         string
+		expectedHostName string
+		expectError      bool
+	}{
+		{
+			hostName:    "   ",
+			expectError: true,
+		},
+		{
+			hostName:         " abc  ",
+			expectedHostName: "abc",
+			expectError:      false,
+		},
+	}
+
+	for idx, test := range testCases {
+		hostName, err := GetHostname(test.hostName)
+		if err != nil && !test.expectError {
+			t.Errorf("[%d]: unexpected error: %s", idx, err)
+		}
+		if err == nil && test.expectError {
+			t.Errorf("[%d]: expected error, got none", idx)
+		}
+		if test.expectedHostName != hostName {
+			t.Errorf("[%d]: expected output %q, got %q", idx, test.expectedHostName, hostName)
+		}
+
+	}
+}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -318,7 +318,11 @@ func (util *RBDUtil) rbdUnlock(b rbdMounter) error {
 	}
 
 	// Construct lock id using host name and a magic prefix.
-	lock_id := kubeLockMagic + node.GetHostname("")
+	hostName, err := node.GetHostname("")
+	if err != nil {
+		return err
+	}
+	lock_id := kubeLockMagic + hostName
 
 	mon := util.kernelRBDMonitorsOpt(b.Mon)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
For linux, the hostname is read from file `/proc/sys/kernel/hostname` directly, which can be overwritten with whitespaces.

Should error out such invalid hostnames.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#835

**Special notes for your reviewer**:
/cc luxas timothysc 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
nodes: improve handling of erroneous host names
```
