### PR TITLE
Adds a crictl package for kubeadm installs

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
+load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 
 # We do not include kube-scheduler, kube-controller-manager,
 # kube-apiserver, and kube-proxy in this list even though we
@@ -13,6 +14,7 @@ release_filegroup(
     name = "debs",
     srcs = [
         ":cloud-controller-manager.deb",
+        ":cri_tools.deb",
         ":kubeadm.deb",
         ":kubectl.deb",
         ":kubelet.deb",
@@ -84,6 +86,12 @@ pkg_tar(
     name = "kubernetes-cni-data",
     package_dir = "/opt/cni/bin",
     deps = ["@kubernetes_cni//file"],
+)
+
+pkg_tar(
+    name = "cri_tools-data",
+    package_dir = "/usr/bin",
+    deps = ["@cri_tools//file"],
 )
 
 k8s_deb(
@@ -165,6 +173,12 @@ k8s_deb(
 The Container Networking Interface tools for provisioning container networks.
 """,
     version_file = "//build:cni_package_version",
+)
+
+k8s_deb(
+    name = "cri_tools",
+    description = """Container Runtime Interface tools (crictl)""",
+    version = CRI_TOOLS_VERSION,
 )
 
 filegroup(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,4 +1,5 @@
 load("//build:workspace_mirror.bzl", "mirror")
+load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -56,6 +57,12 @@ http_file(
     name = "kubernetes_cni",
     sha256 = "f04339a21b8edf76d415e7f17b620e63b8f37a76b2f706671587ab6464411f2d",
     urls = mirror("https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"),
+)
+
+http_file(
+    name = "cri_tools",
+    sha256 = "bdc838174778223a1af4bdeaaed4bd266120c0e152588f78750fb86221677fb4",
+    urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-amd64.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION)),
 )
 
 docker_pull(

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -1,10 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@bazel_tools//tools/build_defs/pkg:rpm.bzl", "pkg_rpm")
+load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 
 filegroup(
     name = "rpms",
     srcs = [
+        ":cri-tools",
         ":kubeadm",
         ":kubectl",
         ":kubelet",
@@ -63,6 +65,18 @@ pkg_rpm(
     spec_file = "kubernetes-cni.spec",
     tags = ["manual"],
     version_file = "//build:cni_package_version",
+)
+
+pkg_rpm(
+    name = "cri-tools",
+    architecture = "x86_64",
+    data = [
+        "@cri_tools//file",
+    ],
+    spec_file = "cri-tools.spec",
+    tags = ["manual"],
+    # dashes are not allowed in rpm versions
+    version = CRI_TOOLS_VERSION.replace("-", "_"),
 )
 
 filegroup(

--- a/build/rpms/cri-tools.spec
+++ b/build/rpms/cri-tools.spec
@@ -1,0 +1,21 @@
+Name: cri-tools
+Version: OVERRIDE_THIS
+Release: 00
+License: ASL 2.0
+Summary: Container Runtime Interface tools
+
+URL: https://kubernetes.io
+
+%description
+Binaries to interface with the container runtime.
+
+%prep
+# TODO(chuckha): update this to use %{version} when the dash is removed from the release
+tar -xzf {crictl-v1.0.0-beta.1-linux-amd64.tar.gz}
+
+%install
+install -m 755 -d %{buildroot}%{_bindir}
+install -p -m 755 -t %{buildroot}%{_bindir} crictl
+
+%files
+%{_bindir}/crictl

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -1,0 +1,15 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CRI_TOOLS_VERSION = "1.0.0-beta.1"


### PR DESCRIPTION
Closes kubernetes/kubeadm#811

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This PR packages crictl into a deb and rpm so we can reference / rely on it in kubeadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#811

**Special notes for your reviewer**:
I think this change doesn't actually deploy the deb, I'll have to port this over to test-infra, but this is the first step.

Also I might need help on the release note

**Release note**:
```release-note
kubernetes now packages cri-tools (crictl) in addition to all the other kubeadm tools in a deb and rpm.
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @luxas @timstclair