### PR TITLE
Remove caching from envelope transformation.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -287,7 +287,7 @@ func GetSecretboxPrefixTransformer(config *SecretboxConfig) (value.PrefixTransfo
 // getEnvelopePrefixTransformer returns a prefix transformer from the provided config.
 // envelopeService is used as the root of trust.
 func getEnvelopePrefixTransformer(config *KMSConfig, envelopeService envelope.Service, prefix string) (value.PrefixTransformer, error) {
-	envelopeTransformer, err := envelope.NewEnvelopeTransformer(envelopeService, config.CacheSize, aestransformer.NewCBCTransformer)
+	envelopeTransformer, err := envelope.NewEnvelopeTransformer(envelopeService, aestransformer.NewCBCTransformer)
 	if err != nil {
 		return value.PrefixTransformer{}, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -50,7 +50,6 @@ resources:
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
-        cachesize: 10
     - aescbc:
         keys:
         - name: key1
@@ -83,7 +82,6 @@ resources:
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
-        cachesize: 10
     - aescbc:
         keys:
         - name: key1
@@ -109,7 +107,6 @@ resources:
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
-        cachesize: 10
     - identity: {}
     - secretbox:
         keys:
@@ -143,7 +140,6 @@ resources:
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
-        cachesize: 10
     - identity: {}
     - aesgcm:
         keys:
@@ -163,7 +159,6 @@ resources:
     - kms:
         name: testprovider
         endpoint: unix:///tmp/testprovider.sock
-        cachesize: 10
     - secretbox:
         keys:
         - name: key1
@@ -221,7 +216,6 @@ resources:
     providers:
     - kms:
         name: testprovider
-        cachesize: 10
 `
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
@@ -78,9 +78,6 @@ type IdentityConfig struct{}
 type KMSConfig struct {
 	// name is the name of the KMS plugin to be used.
 	Name string `json:"name"`
-	// cacheSize is the maximum number of secrets which are cached in memory. The default value is 1000.
-	// +optional
-	CacheSize int `json:"cachesize,omitempty"`
 	// the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
 	Endpoint string `json:"endpoint"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/hashicorp/golang-lru:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -51,15 +51,6 @@ var (
 		[]string{"transformation_type"},
 	)
 
-	envelopeTransformationCacheMissTotal = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "envelope_transformation_cache_misses_total",
-			Help:      "Total number of cache misses while accessing key decryption key(KEK).",
-		},
-	)
-
 	dataKeyGenerationLatencies = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -85,7 +76,6 @@ func RegisterMetrics() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(transformerLatencies)
 		prometheus.MustRegister(transformerFailuresTotal)
-		prometheus.MustRegister(envelopeTransformationCacheMissTotal)
 		prometheus.MustRegister(dataKeyGenerationLatencies)
 		prometheus.MustRegister(dataKeyGenerationFailuresTotal)
 	})
@@ -100,11 +90,6 @@ func RecordTransformation(transformationType string, start time.Time, err error)
 
 	since := sinceInMicroseconds(start)
 	transformerLatencies.WithLabelValues(transformationType).Observe(float64(since))
-}
-
-// RecordCacheMiss records a miss on Key Encryption Key(KEK) - call to KMS was required to decrypt KEK.
-func RecordCacheMiss() {
-	envelopeTransformationCacheMissTotal.Inc()
 }
 
 // RecordDataKeyGeneration records latencies and count of Data Encryption Key generation operations.

--- a/test/integration/master/BUILD
+++ b/test/integration/master/BUILD
@@ -118,6 +118,7 @@ go_library(
         "//cmd/kube-apiserver/app/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR originated from the desire to allow security-conscious customers to disable caching of Key Encryption Key (KEK), which is consistent with best practices of removing key material from memory after use.
Currently, envelope transformer (envelope.go) implements a caching layer to reduce the number of gRPC calls to KMS service (via KMS Plugin). Concretely, envelope transformer maintains an LRU cache - mapping from encrypted data encryption keys (DEKs) to initialized AES transformers (initialized with the plain text version of the corresponding DEK). 
However, in most cases, this caching capability is not triggered (one exception described below), because of the caching implemented at a lower level via cacher.go. In other words, when a kublet (or a user) requests a secret from kube-apiserver, such requests will be satisfied via cacher.go and do not reach envelope.go. Thus, maintaining a cache of DEKs does not (in most cases) lead to performance improvements, but security sensitive key material is maintained in memory.
Therefore, to reduce memory consumption and simplify the logic of envelope.go this PR proposes the removal of caching layer from the envelope transformer.

One exception: when a new secret is created, etcd watcher (watcher.go)  will detect a write to etcd and will sync this write to the cache - in the process triggering envelope transformation (including gRPC call to KMS Plugin).  
However, from this point on, read requests are handled via cacher.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
