### PR TITLE
[e2e service] Make LB cleanup non-GCE specific

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -90,8 +90,8 @@ var _ = SIGDescribe("Services", func() {
 			framework.DescribeSvc(f.Namespace.Name)
 		}
 		for _, lb := range serviceLBNames {
-			framework.Logf("cleaning gce resource for %s", lb)
-			framework.CleanupServiceGCEResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+			framework.Logf("cleaning load balancer resource for %s", lb)
+			framework.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 		}
 		//reset serviceLBNames
 		serviceLBNames = []string{}
@@ -1624,8 +1624,8 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 			framework.DescribeSvc(f.Namespace.Name)
 		}
 		for _, lb := range serviceLBNames {
-			framework.Logf("cleaning gce resource for %s", lb)
-			framework.CleanupServiceGCEResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+			framework.Logf("cleaning load balancer resource for %s", lb)
+			framework.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 		}
 		//reset serviceLBNames
 		serviceLBNames = []string{}
@@ -2025,8 +2025,8 @@ func execAffinityTestForLBService(f *framework.Framework, cs clientset.Interface
 	defer func() {
 		framework.StopServeHostnameService(cs, ns, serviceName)
 		lb := cloudprovider.GetLoadBalancerName(svc)
-		framework.Logf("cleaning gce resource for %s", lb)
-		framework.CleanupServiceGCEResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+		framework.Logf("cleaning load balancer resource for %s", lb)
+		framework.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 	}()
 	ingressIP := framework.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 	port := int(svc.Spec.Ports[0].Port)


### PR DESCRIPTION
**What this PR does / why we need it**:
From https://github.com/kubernetes/kubernetes/pull/63489#issuecomment-394993272, using `CleanupServiceGCEResources()` in service e2e test broke non-GCE providers. Changed to use `CleanupServiceResources()` instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @karataliu @krzysied

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
