### PR TITLE
Skip Sysctl tests against v1.11.0-alpha.0 and newer

### DIFF
--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -22,11 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var sysctlFeatureFromAnnotationsToAPIFields = utilversion.MustParseSemantic("v1.11.0-alpha.0")
 
 var _ = framework.KubeDescribe("Sysctls", func() {
 	f := framework.NewDefaultFramework("sysctl")
@@ -54,6 +57,14 @@ var _ = framework.KubeDescribe("Sysctls", func() {
 	}
 
 	BeforeEach(func() {
+		var err error
+		skipSysctlTests, err := framework.ServerVersionGTE(sysctlFeatureFromAnnotationsToAPIFields, f.ClientSet.Discovery())
+		Expect(err).NotTo(HaveOccurred())
+
+		if skipSysctlTests {
+			framework.Skipf("Skipping all Sysctls tests. Running version > %q", sysctlFeatureFromAnnotationsToAPIFields)
+		}
+
 		podClient = f.PodClient()
 	})
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

1.10 e2e tests get run against 1.11.0+ masters during upgrade tests.
This fails as Sysctl moved from annotations to fields, so we should
check the version and avoid running these tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64845

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
