### PR TITLE
Adds support for passing list of external IPs when creating services

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -127,7 +127,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	}
 
 	cmd := &cobra.Command{
-		Use: "expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]",
+		Use: "expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP] [--target-port=number-or-name] [--name=name] [--external-ips=external-ips-of-service] [--type=type]",
 		DisableFlagsInUseLine: true,
 		Short:   i18n.T("Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service"),
 		Long:    exposeLong,
@@ -152,7 +152,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().String("container-port", "", i18n.T("Synonym for --target-port"))
 	cmd.Flags().MarkDeprecated("container-port", "--container-port will be removed in the future, please use --target-port instead")
 	cmd.Flags().String("target-port", "", i18n.T("Name or number for the port on the container that the service should direct traffic to. Optional."))
-	cmd.Flags().String("external-ip", "", i18n.T("Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP."))
+	cmd.Flags().String("external-ips", "", i18n.T("Additional external IP addresses (not managed by Kubernetes) to accept for the service. If these IPs are routed to a node, the service can be accessed by these IPs in addition to its generated service IP."))
 	cmd.Flags().String("overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
 	cmd.Flags().String("name", "", i18n.T("The name for the newly created object."))
 	cmd.Flags().String("session-affinity", "", i18n.T("If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'"))

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -57,11 +57,11 @@ func paramNames() []GeneratorParam {
 		// port will be used if a user specifies --port OR the exposed object
 		// has one port
 		{"port", false},
-		// ports will be used iff a user doesn't specify --port AND the
+		// ports will be used if a user doesn't specify --port AND the
 		// exposed object has multiple ports
 		{"ports", false},
 		{"labels", false},
-		{"external-ip", false},
+		{"external-ips", false},
 		{"load-balancer-ip", false},
 		{"type", false},
 		{"protocol", false},
@@ -209,9 +209,8 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
 		}
 	}
-	if len(params["external-ip"]) > 0 {
-		// Allow for list of comma separated IPs
-		service.Spec.ExternalIPs = strings.Split(params["external-ip"], ",")
+	if len(params["external-ips"]) > 0 {
+		service.Spec.ExternalIPs = strings.Split(params["external-ips"], ",")
 	}
 	if len(params["type"]) != 0 {
 		service.Spec.Type = v1.ServiceType(params["type"])

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -210,7 +210,8 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 		}
 	}
 	if len(params["external-ip"]) > 0 {
-		service.Spec.ExternalIPs = []string{params["external-ip"]}
+		// Allow for list of comma separated IPs
+		service.Spec.ExternalIPs = strings.Split(params["external-ip"], ",")
 	}
 	if len(params["type"]) != 0 {
 		service.Spec.Type = v1.ServiceType(params["type"])

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -129,7 +129,7 @@ func TestGenerateService(t *testing.T) {
 				"port":           "80",
 				"protocol":       "UDP",
 				"container-port": "foobar",
-				"external-ip":    "1.2.3.4",
+				"external-ips":   "1.2.3.4",
 			},
 			expected: v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ func TestGenerateService(t *testing.T) {
 				"port":           "80",
 				"protocol":       "UDP",
 				"container-port": "foobar",
-				"external-ip":    "1.2.3.4,5.6.7.8",
+				"external-ips":   "1.2.3.4,5.6.7.8",
 			},
 			expected: v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -189,7 +189,7 @@ func TestGenerateService(t *testing.T) {
 				"port":           "80",
 				"protocol":       "UDP",
 				"container-port": "foobar",
-				"external-ip":    "1.2.3.4",
+				"external-ips":   "1.2.3.4",
 				"type":           "LoadBalancer",
 			},
 			expected: v1.Service{

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -159,6 +159,36 @@ func TestGenerateService(t *testing.T) {
 				"port":           "80",
 				"protocol":       "UDP",
 				"container-port": "foobar",
+				"external-ip":    "1.2.3.4,5.6.7.8",
+			},
+			expected: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"foo": "bar",
+						"baz": "blah",
+					},
+					Ports: []v1.ServicePort{
+						{
+							Port:       80,
+							Protocol:   "UDP",
+							TargetPort: intstr.FromString("foobar"),
+						},
+					},
+					ExternalIPs: []string{"1.2.3.4", "5.6.7.8"},
+				},
+			},
+		},
+		{
+			generator: ServiceGeneratorV2{},
+			params: map[string]interface{}{
+				"selector":       "foo=bar,baz=blah",
+				"name":           "test",
+				"port":           "80",
+				"protocol":       "UDP",
+				"container-port": "foobar",
 				"external-ip":    "1.2.3.4",
 				"type":           "LoadBalancer",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will allow users to pass on a list of external IPs when creating services/exposing deployments/services. Currently the expose command only takes in a single IP, which is then mapped to `externalIPs`. This change will bring uniformity to the cli and the service definitions.

**Which issue(s) this PR fixes**:
n/a

**Additional notes**
I would to receive feedback on whether this is the right approach.

/hold
/sig cli
