### PR TITLE
Fix dead-link to dns-horizontal-autoscaler

### DIFF
--- a/cluster/addons/dns/kube-dns/README.md
+++ b/cluster/addons/dns/kube-dns/README.md
@@ -9,7 +9,7 @@ can use the DNS Service’s IP to resolve DNS names.
 ## Manually scale kube-dns Deployment
 
 kube-dns creates only one DNS Pod by default. If
-[dns-horizontal-autoscaler](../dns-horizontal-autoscaler/)
+[dns-horizontal-autoscaler](../../dns-horizontal-autoscaler/)
 is not enabled, you may need to manually scale kube-dns Deployment.
 
 Please use below `kubectl scale` command to scale:


### PR DESCRIPTION

**What this PR does / why we need it**:

It looks like dns-horizontal-autoscaler doesn't exist in the dns repository anymore, but one level higher.
This PR fixes the dead link.