### PR TITLE
ignore not found file error when watching manifests

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -179,7 +179,9 @@ func (s *sourceFile) extractFromDir(name string) ([]*v1.Pod, error) {
 		case statInfo.Mode().IsRegular():
 			pod, err := s.extractFromFile(path)
 			if err != nil {
-				glog.Errorf("Can't process manifest file %q: %v", path, err)
+				if !os.IsNotExist(err) {
+					glog.Errorf("Can't process manifest file %q: %v", path, err)
+				}
 			} else {
 				pods = append(pods, pod)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
An alternative of #63910.

When using vim to create a new file in manifest folder, a temporary file, with an arbitrary number (like 4913) as its name, will be created to check if a directory is writable and see the resulting ACL.

These temporary files will be deleted later, which should by ignored when watching the manifest folder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55928, #59009, #48219

**Special notes for your reviewer**:
/cc dims luxas yujuhong liggitt tallclair

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ignore not found file error when watching manifests
```
