### PR TITLE
Use repo prefix when generating image names

### DIFF
--- a/cmd/kubeadm/app/images/BUILD
+++ b/cmd/kubeadm/app/images/BUILD
@@ -27,7 +27,10 @@ go_test(
     name = "go_default_test",
     srcs = ["images_test.go"],
     embed = [":go_default_library"],
-    deps = ["//cmd/kubeadm/app/constants:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -47,11 +47,14 @@ func GetCoreImage(image, repoPrefix, k8sVersion, overrideImage string) string {
 
 // GetAllImages returns a list of container images kubeadm expects to use on a control plane node
 func GetAllImages(cfg *kubeadmapi.MasterConfiguration) []string {
+	repoPrefix := cfg.GetControlPlaneImageRepository()
 	imgs := []string{}
-	imgs = append(imgs, GetCoreImage(constants.KubeAPIServer, cfg.ImageRepository, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
-	imgs = append(imgs, GetCoreImage(constants.KubeControllerManager, cfg.ImageRepository, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
-	imgs = append(imgs, GetCoreImage(constants.KubeScheduler, cfg.ImageRepository, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
-	imgs = append(imgs, fmt.Sprintf("%v/%v-%v:%v", cfg.ImageRepository, constants.KubeProxy, runtime.GOARCH, kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion)))
+	imgs = append(imgs, GetCoreImage(constants.KubeAPIServer, repoPrefix, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
+	imgs = append(imgs, GetCoreImage(constants.KubeControllerManager, repoPrefix, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
+	imgs = append(imgs, GetCoreImage(constants.KubeScheduler, repoPrefix, cfg.KubernetesVersion, cfg.UnifiedControlPlaneImage))
+	imgs = append(imgs, fmt.Sprintf("%v/%v-%v:%v", repoPrefix, constants.KubeProxy, runtime.GOARCH, kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion)))
+
+	// pause, etcd and kube-dns are not available on the ci image repository so use the default image repository.
 	imgs = append(imgs, fmt.Sprintf("%v/pause-%v:%v", cfg.ImageRepository, runtime.GOARCH, "3.1"))
 
 	// if etcd is not external then add the image as it will be required


### PR DESCRIPTION
CI defines its own custom repository. The function responsible
for listing all images now takes this into account.

Closes kubernetes/kubeadm#901

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This fixes ci-cross.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#901

**Special notes for your reviewer**:

```release-note
NONE
```
