### PR TITLE
Fix up legacy printer table adapter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1312,7 +1312,7 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 	if len(columns) == 0 {
 		t.Errorf("unexpected number of columns: %v", len(columns))
 	}
-	if columns[0].Name != "Name" || columns[0].Type != "string" || columns[0].Format != "name" {
+	if !strings.EqualFold(columns[0].Name, "Name") || columns[0].Type != "string" || columns[0].Format != "name" {
 		t.Errorf("expect column 0 to be the name column: %#v", columns[0])
 	}
 	for j, column := range columns {


### PR DESCRIPTION
As server-side printing is more widespread, downstream consumers will start leaning on this adapter to transform client-side printers to server-side printers.

This PR:
* Set the name format correctly on column 0
* Tolerates case-differences in the column 0 name (many old printers used NAME)
* Set ListMeta continue/resourceVersion/selfLink correctly when adapting a legacy printer

/cc @smarterclayton 

```release-note
NONE
```