### PR TITLE
Fix output of `kubeadm migrate config`

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -134,6 +134,7 @@ go_test(
         ":go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha2:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",
+        "//cmd/kubeadm/app/util/config:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -202,7 +202,7 @@ func NewCmdConfigMigrate(out io.Writer) *cobra.Command {
 			}
 
 			if newCfgPath == "" {
-				fmt.Fprintf(out, string(outputBytes))
+				fmt.Fprint(out, string(outputBytes))
 			} else {
 				if err := ioutil.WriteFile(newCfgPath, outputBytes, 0644); err != nil {
 					kubeadmutil.CheckErr(fmt.Errorf("failed to write the new configuration to the file %q: %v", newCfgPath, err))


### PR DESCRIPTION
The output should always be valid kubeadmapi.MasterConfiguration YAML.

The general problem was that we printed with fmt.Fprintf but it turns out some of the default values have `%`s in them so this caused Go to think we were missing values that we wanted substituted. We don't want to do any substitution here.

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>
**What this PR does / why we need it**:
This PR fixes a small bug that cause kubeadm migrate config to print YAML that was not valid.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#904

```release-note
NONE
```

/cc @luxas @timothysc 