### PR TITLE
[FEATURE BRANCH] Allow patch with apply content type to create

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -27,6 +27,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/apis/example"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -402,7 +403,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 			trace: utiltrace.New("Patch" + name),
 		}
 
-		resultObj, err := p.patchResource(ctx, RequestScope{})
+		resultObj, _, err := p.patchResource(ctx, RequestScope{})
 		if len(tc.expectedError) != 0 {
 			if err == nil || err.Error() != tc.expectedError {
 				t.Errorf("%s: expected error %v, but got %v", tc.name, tc.expectedError, err)
@@ -739,6 +740,9 @@ func TestPatchWithVersionConflictThenAdmissionFailure(t *testing.T) {
 	tc.Run(t)
 }
 
+// TODO: Add test case for "apply with existing uid" verify it gives a conflict error,
+// not a creation or an authz creation forbidden message
+
 func TestHasUID(t *testing.T) {
 	testcases := []struct {
 		obj    runtime.Object
@@ -847,4 +851,12 @@ func setTcPod(tcPod *example.Pod, name string, namespace string, uid types.UID, 
 	if len(nodeName) != 0 {
 		tcPod.Spec.NodeName = nodeName
 	}
+}
+
+func (f mutateObjectUpdateFunc) Handles(operation admission.Operation) bool {
+	return true
+}
+
+func (f mutateObjectUpdateFunc) Admit(a admission.Attributes) (err error) {
+	return f(a.GetObject(), a.GetOldObject())
 }

--- a/test/integration/apiserver/BUILD
+++ b/test/integration/apiserver/BUILD
@@ -10,7 +10,7 @@ go_test(
     size = "large",
     srcs = [
         "apiserver_test.go",
-	"apply_test.go",
+        "apply_test.go",
         "main_test.go",
         "patch_test.go",
         "print_test.go",

--- a/test/integration/apiserver/BUILD
+++ b/test/integration/apiserver/BUILD
@@ -10,6 +10,7 @@ go_test(
     size = "large",
     srcs = [
         "apiserver_test.go",
+	"apply_test.go",
         "main_test.go",
         "patch_test.go",
         "print_test.go",

--- a/test/integration/apiserver/apply_test.go
+++ b/test/integration/apiserver/apply_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestApplyAlsoCreates(t *testing.T) {
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	_, err := client.CoreV1().RESTClient().Patch(types.StrategicMergePatchType).
+		Namespace("default").
+		Resource("pods").
+		Name("test-pod").
+		Body([]byte(`{"name": "test-pod"}`)).
+		Do().
+		Get()
+	if err != nil {
+		t.Fatalf("Failed to create object using Apply patch: %v", err)
+	}
+
+	obj, err := client.CoreV1().RESTClient().Get().Namespace("").Resource("pods").Name("test-pod").Do().Get()
+	if err != nil {
+		t.Fatalf("Failed to retrieve object: %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a PATCH request is made with the apply content type, first attempt to get the resource and if it doesn't exist create a new one (equivalent to sending a POST), if it does exist then loop getting applying and updating (PUT) as normal.

/sig api-machinery
/kind feature
cc @apelisse @seans3 @lavalamp 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```