### PR TITLE
In case storage class parameters are empty, create a new map for Portworx volume labels

### DIFF
--- a/pkg/volume/portworx/portworx_util.go
+++ b/pkg/volume/portworx/portworx_util.go
@@ -71,8 +71,13 @@ func (util *PortworxVolumeUtil) CreateVolume(p *portworxVolumeProvisioner) (stri
 		spec = specHandler.DefaultSpec()
 	}
 
-	// Pass all parameters as volume labels for Portworx server-side processing.
-	spec.VolumeLabels = p.options.Parameters
+	// Pass all parameters as volume labels for Portworx server-side processing
+	if len(p.options.Parameters) > 0 {
+		spec.VolumeLabels = p.options.Parameters
+	} else {
+		spec.VolumeLabels = make(map[string]string, 0)
+	}
+
 	// Update the requested size in the spec
 	spec.Size = uint64(requestGiB * volutil.GIB)
 


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**:

Fixes #64894

**Release note**:
```release-note
Fixes an issue where Portworx PVCs remain in pending state when created using a StorageClass with empty parameters
```
