### PR TITLE
Better log line in e2e

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -210,7 +210,7 @@ func (f *Framework) BeforeEach() {
 	}
 
 	if !f.SkipNamespaceCreation {
-		By("Building a namespace api object")
+		By(fmt.Sprintf("Building a namespace api object, basename %s", f.BaseName))
 		namespace, err := f.CreateNamespace(f.BaseName, map[string]string{
 			"e2e-framework": f.BaseName,
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Very minor improvement to logs in e2e tests when creating a namespace.

**Release note**:
```release-note
NONE
```
