### PR TITLE
kubeadm: use constant instead of hardcoded path

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -76,7 +76,7 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 	)
 
 	cmd.PersistentFlags().StringVar(
-		&criSocketPath, "cri-socket", "/var/run/dockershim.sock",
+		&criSocketPath, "cri-socket", kubeadmapiv1alpha3.DefaultCRISocket,
 		"The path to the CRI socket to use with crictl when cleaning up containers.",
 	)
 

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -58,7 +58,7 @@ func assertDirEmpty(t *testing.T, path string) {
 func TestNewReset(t *testing.T) {
 	var in io.Reader
 	certsDir := kubeadmapiv1alpha3.DefaultCertificatesDir
-	criSocketPath := "/var/run/dockershim.sock"
+	criSocketPath := kubeadmapiv1alpha3.DefaultCRISocket
 	skipPreFlight := false
 	forceReset := true
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Used DefaultCRISocket constant instead of hardcoded path
/var/run/dockershim.sock

**Release note**:
```release-note
NONE
```
