### PR TITLE
apimachinery: unify accessors to not deepcopy

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -162,55 +162,9 @@ func (meta *ObjectMeta) GetInitializers() *Initializers               { return m
 func (meta *ObjectMeta) SetInitializers(initializers *Initializers)   { meta.Initializers = initializers }
 func (meta *ObjectMeta) GetFinalizers() []string                      { return meta.Finalizers }
 func (meta *ObjectMeta) SetFinalizers(finalizers []string)            { meta.Finalizers = finalizers }
-
-func (meta *ObjectMeta) GetOwnerReferences() []OwnerReference {
-	if meta.OwnerReferences == nil {
-		return nil
-	}
-	ret := make([]OwnerReference, len(meta.OwnerReferences))
-	for i := 0; i < len(meta.OwnerReferences); i++ {
-		ret[i].Kind = meta.OwnerReferences[i].Kind
-		ret[i].Name = meta.OwnerReferences[i].Name
-		ret[i].UID = meta.OwnerReferences[i].UID
-		ret[i].APIVersion = meta.OwnerReferences[i].APIVersion
-		if meta.OwnerReferences[i].Controller != nil {
-			value := *meta.OwnerReferences[i].Controller
-			ret[i].Controller = &value
-		}
-		if meta.OwnerReferences[i].BlockOwnerDeletion != nil {
-			value := *meta.OwnerReferences[i].BlockOwnerDeletion
-			ret[i].BlockOwnerDeletion = &value
-		}
-	}
-	return ret
-}
-
+func (meta *ObjectMeta) GetOwnerReferences() []OwnerReference         { return meta.OwnerReferences }
 func (meta *ObjectMeta) SetOwnerReferences(references []OwnerReference) {
-	if references == nil {
-		meta.OwnerReferences = nil
-		return
-	}
-	newReferences := make([]OwnerReference, len(references))
-	for i := 0; i < len(references); i++ {
-		newReferences[i].Kind = references[i].Kind
-		newReferences[i].Name = references[i].Name
-		newReferences[i].UID = references[i].UID
-		newReferences[i].APIVersion = references[i].APIVersion
-		if references[i].Controller != nil {
-			value := *references[i].Controller
-			newReferences[i].Controller = &value
-		}
-		if references[i].BlockOwnerDeletion != nil {
-			value := *references[i].BlockOwnerDeletion
-			newReferences[i].BlockOwnerDeletion = &value
-		}
-	}
-	meta.OwnerReferences = newReferences
+	meta.OwnerReferences = references
 }
-
-func (meta *ObjectMeta) GetClusterName() string {
-	return meta.ClusterName
-}
-func (meta *ObjectMeta) SetClusterName(clusterName string) {
-	meta.ClusterName = clusterName
-}
+func (meta *ObjectMeta) GetClusterName() string            { return meta.ClusterName }
+func (meta *ObjectMeta) SetClusterName(clusterName string) { meta.ClusterName = clusterName }


### PR DESCRIPTION
The Get/SetOwnerReferences accessor funcs do deepcopies, in contrast to all other accessor funcs of metav1.ObjectMeta. For unstructured.Unstructured we naturally do deepcopies. 

In other words: the interface does guarantee neither the first nor the second. 

This PR documents this and remove the unneccessary deepcopy for owner references (which leads to huge heap allocation e.g. in the DaemonSet controller).

This is for post-1.11. **do not assign a milestone**.

```dev-release-note
The metav1.ObjectMeta accessor does not deepcopy owner references anymore. In general, the accessor interface does not enforce deepcopy nor does it forbid it (e.g. for unstructured.Unstructured).
```