### PR TITLE
improve memory footprint of daemonset simulate

### DIFF
--- a/pkg/controller/daemon/BUILD
+++ b/pkg/controller/daemon/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1274,7 +1275,8 @@ func (dsc *DaemonSetsController) simulate(newPod *v1.Pod, node *v1.Node, ds *app
 		}
 		// ignore pods that belong to the daemonset when taking into account whether
 		// a daemonset should bind to a node.
-		if metav1.IsControlledBy(pod, ds) {
+		// TODO: replace this with metav1.IsControlledBy() in 1.12
+		if isControlledByDaemonSet(pod, ds.GetUID()) {
 			continue
 		}
 		pods = append(pods, pod)
@@ -1495,4 +1497,13 @@ func (o podByCreationTimestampAndPhase) Less(i, j int) bool {
 		return o[i].Name < o[j].Name
 	}
 	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+func isControlledByDaemonSet(p *v1.Pod, uuid types.UID) bool {
+	for _, ref := range p.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller && ref.UID == uuid {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an alternative for https://github.com/kubernetes/kubernetes/pull/64915 (it might be not needed if that PR will merge)

During memory profiling of OpenShift, we noticed a significant amount of object allocations done by `IsControlledBy()`. @sttts found that the `GetObjectReferences()` method is doing a deep-copy of the object references. 

![screen shot 2018-06-08 at 14 22 59](https://user-images.githubusercontent.com/44136/41157922-7af953f2-6b27-11e8-9a16-bda8c3edfe07.png)

This PR simplify the `IsControlledBy()` to just iterate over the ownerRefs, without copying them. 

**Release note**:

```release-note
NONE
```