### PR TITLE
Update Cluster Autoscaler version to 1.3.0-beta.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.0-beta.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.3.0-beta.0

```release-note
NONE
```

Full release notes will be attached with stable version (1.3.0)