### PR TITLE
Remove an old TODO.

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -877,8 +877,6 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 	if len(restartPolicy) == 0 {
 		restartPolicy = v1.RestartPolicyAlways
 	}
-	// TODO: Figure out why we set ImagePullPolicy here, whether we can make it
-	// consistent with the other places imagePullPolicy is set using flag.
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -888,13 +886,12 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 			ServiceAccountName: params["serviceaccount"],
 			Containers: []v1.Container{
 				{
-					Name:            name,
-					Image:           params["image"],
-					ImagePullPolicy: v1.PullIfNotPresent,
-					Stdin:           stdin,
-					StdinOnce:       !leaveStdinOpen && stdin,
-					TTY:             tty,
-					Resources:       resourceRequirements,
+					Name:      name,
+					Image:     params["image"],
+					Stdin:     stdin,
+					StdinOnce: !leaveStdinOpen && stdin,
+					TTY:       tty,
+					Resources: resourceRequirements,
 				},
 			},
 			DNSPolicy:     v1.DNSClusterFirst,

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -424,9 +424,8 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
+							Name:  "foo",
+							Image: "someimage",
 						},
 					},
 					DNSPolicy:     v1.DNSClusterFirst,
@@ -493,9 +492,8 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
+							Name:  "foo",
+							Image: "someimage",
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: 80,
@@ -523,9 +521,8 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
+							Name:  "foo",
+							Image: "someimage",
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: 80,
@@ -563,9 +560,8 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
+							Name:  "foo",
+							Image: "someimage",
 						},
 					},
 					DNSPolicy:     v1.DNSClusterFirst,
@@ -589,11 +585,10 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
-							Stdin:           true,
-							StdinOnce:       true,
+							Name:      "foo",
+							Image:     "someimage",
+							Stdin:     true,
+							StdinOnce: true,
 						},
 					},
 					DNSPolicy:     v1.DNSClusterFirst,
@@ -618,11 +613,10 @@ func TestGeneratePod(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:            "foo",
-							Image:           "someimage",
-							ImagePullPolicy: v1.PullIfNotPresent,
-							Stdin:           true,
-							StdinOnce:       false,
+							Name:      "foo",
+							Image:     "someimage",
+							Stdin:     true,
+							StdinOnce: false,
 						},
 					},
 					DNSPolicy:     v1.DNSClusterFirst,


### PR DESCRIPTION
The ImagePullPolicy is immediately overwritten by the call to `updatePodSpec` below the initialization, so it's not needed where it is.