### PR TITLE
fix kubeadm init does not inform the users it is pulling images

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -259,6 +259,10 @@ func NewInit(cfgPath string, externalcfg *kubeadmapiv1alpha2.MasterConfiguration
 	if err := preflight.RunInitMasterChecks(utilsexec.New(), cfg, ignorePreflightErrors); err != nil {
 		return nil, err
 	}
+
+	fmt.Println("[preflight/images] Pulling images required for setting up a Kubernetes cluster")
+	fmt.Println("[preflight/images] This might take a minute or two, depending on the speed of your internet connection")
+	fmt.Println("[preflight/images] You can also perform this action in beforehand using 'kubeadm config images pull'")
 	if err := preflight.RunPullImagesCheck(utilsexec.New(), cfg, ignorePreflightErrors); err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -843,6 +843,7 @@ func (ImagePullCheck) Name() string {
 // Check pulls images required by kubeadm. This is a mutating check
 func (i ImagePullCheck) Check() (warnings, errors []error) {
 	for _, image := range i.ImageList {
+		glog.V(1).Infoln("pulling ", image)
 		if err := i.Images.Exists(image); err == nil {
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubeadm should print a message informing the user that it is pre-pulling images before starting the init sequence, making users aware of the action in progress, which can take some time in environments with poor internet connection.

**Which issue(s) this PR fixes**:
fixes https://github.com/kubernetes/kubeadm/issues/908

**Release note**:
```release-note
NONE
```