### PR TITLE
set EnableHTTPSTrafficOnly in azure storage account creation

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_storageaccount.go
+++ b/pkg/cloudprovider/providers/azure/azure_storageaccount.go
@@ -112,7 +112,8 @@ func (az *Cloud) ensureStorageAccount(accountName, accountType, location, genAcc
 			glog.V(2).Infof("azure - no matching account found, begin to create a new account %s in resource group %s, location: %s, accountType: %s",
 				accountName, az.ResourceGroup, location, accountType)
 			cp := storage.AccountCreateParameters{
-				Sku:      &storage.Sku{Name: storage.SkuName(accountType)},
+				Sku: &storage.Sku{Name: storage.SkuName(accountType)},
+				AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{EnableHTTPSTrafficOnly: to.BoolPtr(true)},
 				Tags:     map[string]*string{"created-by": to.StringPtr("azure")},
 				Location: &location}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
**PEN test shows there is security risk if https traffic is not enabled by default**
Enforce azure storage account creation with https traffic only, this PR will apply for both azure disk & azure file features. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64956

**Special notes for your reviewer**:
Tests with azure disk & azure file all pass

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Enforce azure storage account creation with https traffic only
```

/sig azure
/kind feature
/assign @khenidak 