### PR TITLE
Bump version of prometheus-to-sd

### DIFF
--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -71,7 +71,7 @@ spec:
             - --sink=stackdriver:?cluster_name={{ cluster_name }}&use_old_resources={{ use_old_resources }}&use_new_resources={{ use_new_resources }}&min_interval_sec=100&batch_export_timeout_sec=110
         # BEGIN_PROMETHEUS_TO_SD
         - name: prom-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+          image: gcr.io/google-containers/prometheus-to-sd:v0.2.6
           command:
             - /monitor
             - --source=heapster:http://localhost:8082?whitelisted=stackdriver_requests_count,stackdriver_timeseries_count

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -52,7 +52,7 @@ spec:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.6
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -82,7 +82,7 @@ spec:
               fi;
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.6
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -51,7 +51,7 @@ spec:
             cpu: "30m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google_containers/prometheus-to-sd:v0.2.2
+        image: gcr.io/google_containers/prometheus-to-sd:v0.2.6
         # Request and limit resources to get guaranteed QoS.
         resources:
           requests:


### PR DESCRIPTION
```release-note
Bump version of prometheus-to-sd to 0.2.6 to decrease log noise and include latest security patches.
```
