### PR TITLE
kubeadm: Fix small-ish bugs for v1.11

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
@@ -116,6 +116,7 @@ func UpgradeCloudProvider(in *MasterConfiguration, out *kubeadm.MasterConfigurat
 
 		out.APIServerExtraArgs["cloud-provider"] = in.CloudProvider
 		out.ControllerManagerExtraArgs["cloud-provider"] = in.CloudProvider
+		out.NodeRegistration.KubeletExtraArgs["cloud-provider"] = in.CloudProvider
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
@@ -131,10 +131,10 @@ type NodeRegistrationOptions struct {
 	// Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm joiń` operation.
 	// This field is also used in the CommonName field of the kubelet's client certificate to the API server.
 	// Defaults to the hostname of the node if not provided.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
-	CRISocket string `json:"criSocket"`
+	CRISocket string `json:"criSocket,omitempty"`
 
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
 	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your master node, set this field to an

--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/validation:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",

--- a/cmd/kubeadm/app/cmd/options/token.go
+++ b/cmd/kubeadm/app/cmd/options/token.go
@@ -52,8 +52,13 @@ func (bto *BootstrapTokenOptions) AddTokenFlag(fs *pflag.FlagSet) {
 
 // AddTTLFlag adds the --token-ttl flag to the given flagset
 func (bto *BootstrapTokenOptions) AddTTLFlag(fs *pflag.FlagSet) {
+	bto.AddTTLFlagWithName(fs, "token-ttl")
+}
+
+// AddTTLFlagWithName adds the --token-ttl flag with a custom flag name given flagset
+func (bto *BootstrapTokenOptions) AddTTLFlagWithName(fs *pflag.FlagSet, flagName string) {
 	fs.DurationVar(
-		&bto.TTL.Duration, "token-ttl", bto.TTL.Duration,
+		&bto.TTL.Duration, flagName, bto.TTL.Duration,
 		"The duration before the token is automatically deleted (e.g. 1s, 2m, 3h). If set to '0', the token will never expire",
 	)
 }

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -80,8 +80,8 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 		"The path to the CRI socket to use with crictl when cleaning up containers.",
 	)
 
-	cmd.PersistentFlags().BoolVar(
-		&forceReset, "force", false,
+	cmd.PersistentFlags().BoolVarP(
+		&forceReset, "force", "f", false,
 		"Reset the node without prompting for confirmation.",
 	)
 

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -138,7 +138,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 		"config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
 	createCmd.Flags().BoolVar(&printJoinCommand,
 		"print-join-command", false, "Instead of printing only the token, print the full 'kubeadm join' flag needed to join the cluster using the token.")
-	bto.AddTTLFlag(createCmd.Flags())
+	bto.AddTTLFlagWithName(createCmd.Flags(), "ttl")
 	bto.AddUsagesFlag(createCmd.Flags())
 	bto.AddGroupsFlag(createCmd.Flags())
 	bto.AddDescriptionFlag(createCmd.Flags())

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pmezard/go-difflib/difflib:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -53,12 +53,7 @@ type upgradeVariables struct {
 }
 
 // enforceRequirements verifies that it's okay to upgrade and then returns the variables needed for the rest of the procedure
-func enforceRequirements(flags *cmdUpgradeFlags, dryRun bool, newK8sVersion string) (*upgradeVariables, error) {
-
-	// Set the default for the kubeconfig path if the user didn't override with the flags
-	if flags.kubeConfigPath == "" {
-		flags.kubeConfigPath = "/etc/kubernetes/admin.conf"
-	}
+func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion string) (*upgradeVariables, error) {
 
 	client, err := getClient(flags.kubeConfigPath, dryRun)
 	if err != nil {

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -65,9 +65,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  dnsDomain: ""
 	  podSubnet: ""
 	  serviceSubnet: ""
-	nodeRegistration:
-	  criSocket: ""
-	  name: ""
+	nodeRegistration: {}
 	unifiedControlPlaneImage: ""
 `),
 		},
@@ -109,9 +107,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  dnsDomain: ""
 	  podSubnet: ""
 	  serviceSubnet: 10.96.0.1/12
-	nodeRegistration:
-	  criSocket: ""
-	  name: ""
+	nodeRegistration: {}
 	unifiedControlPlaneImage: ""
 `),
 		},

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -18,6 +18,7 @@ package upgrade
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 
 	"github.com/golang/glog"
@@ -39,7 +40,8 @@ type diffFlags struct {
 	schedulerManifestPath         string
 	newK8sVersionStr              string
 	contextLines                  int
-	parent                        *cmdUpgradeFlags
+	cfgPath                       string
+	out                           io.Writer
 }
 
 var (
@@ -49,19 +51,22 @@ var (
 )
 
 // NewCmdDiff returns the cobra command for `kubeadm upgrade diff`
-func NewCmdDiff(parentflags *cmdUpgradeFlags) *cobra.Command {
+func NewCmdDiff(out io.Writer) *cobra.Command {
 	flags := &diffFlags{
-		parent: parentflags,
+		out: out,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "diff [version]",
 		Short: "Show what differences would be applied to existing static pod manifests. See also: kubeadm upgrade apply --dry-run",
 		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: Run preflight checks for diff to check that the manifests already exist.
 			kubeadmutil.CheckErr(runDiff(flags, args))
 		},
 	}
 
+	// TODO: Use the generic options.AddConfigFlag method instead
+	cmd.Flags().StringVar(&flags.cfgPath, "config", flags.cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental!")
 	cmd.Flags().StringVar(&flags.apiServerManifestPath, "api-server-manifest", defaultAPIServerManifestPath, "path to API server manifest")
 	cmd.Flags().StringVar(&flags.controllerManagerManifestPath, "controller-manager-manifest", defaultControllerManagerManifestPath, "path to controller manifest")
 	cmd.Flags().StringVar(&flags.schedulerManifestPath, "scheduler-manifest", defaultSchedulerManifestPath, "path to scheduler manifest")
@@ -73,8 +78,8 @@ func NewCmdDiff(parentflags *cmdUpgradeFlags) *cobra.Command {
 func runDiff(flags *diffFlags, args []string) error {
 
 	// If the version is specified in config file, pick up that value.
-	glog.V(1).Infof("fetching configuration from file", flags.parent.cfgPath)
-	cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(flags.parent.cfgPath, &kubeadmv1alpha2.MasterConfiguration{})
+	glog.V(1).Infof("fetching configuration from file", flags.cfgPath)
+	cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(flags.cfgPath, &kubeadmv1alpha2.MasterConfiguration{})
 	if err != nil {
 		return err
 	}
@@ -136,7 +141,7 @@ func runDiff(flags *diffFlags, args []string) error {
 			Context:  flags.contextLines,
 		}
 
-		difflib.WriteUnifiedDiff(flags.parent.out, diff)
+		difflib.WriteUnifiedDiff(flags.out, diff)
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -27,12 +27,9 @@ const (
 )
 
 func TestRunDiff(t *testing.T) {
-	parentFlags := &cmdUpgradeFlags{
+	flags := &diffFlags{
 		cfgPath: "",
 		out:     ioutil.Discard,
-	}
-	flags := &diffFlags{
-		parent: parentFlags,
 	}
 
 	testCases := []struct {
@@ -79,7 +76,7 @@ func TestRunDiff(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			parentFlags.cfgPath = tc.cfgPath
+			flags.cfgPath = tc.cfgPath
 			if tc.setManifestPath {
 				flags.apiServerManifestPath = tc.manifestPath
 				flags.controllerManagerManifestPath = tc.manifestPath

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -21,13 +21,15 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 )
 
-// cmdUpgradeFlags holds the values for the common flags in `kubeadm upgrade`
-type cmdUpgradeFlags struct {
+// applyPlanFlags holds the values for the common flags in `kubeadm upgrade apply` and `kubeadm upgrade plan`
+type applyPlanFlags struct {
 	kubeConfigPath            string
 	cfgPath                   string
 	featureGatesString        string
@@ -42,7 +44,7 @@ type cmdUpgradeFlags struct {
 
 // NewCmdUpgrade returns the cobra command for `kubeadm upgrade`
 func NewCmdUpgrade(out io.Writer) *cobra.Command {
-	flags := &cmdUpgradeFlags{
+	flags := &applyPlanFlags{
 		kubeConfigPath:            "/etc/kubernetes/admin.conf",
 		cfgPath:                   "",
 		featureGatesString:        "",
@@ -60,21 +62,24 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 		RunE:  cmdutil.SubCmdRunE("upgrade"),
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.kubeConfigPath, "kubeconfig", flags.kubeConfigPath, "The KubeConfig file to use when talking to the cluster.")
-	cmd.PersistentFlags().StringVar(&flags.cfgPath, "config", flags.cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental!")
-	cmd.PersistentFlags().BoolVar(&flags.allowExperimentalUpgrades, "allow-experimental-upgrades", flags.allowExperimentalUpgrades, "Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.")
-	cmd.PersistentFlags().BoolVar(&flags.allowRCUpgrades, "allow-release-candidate-upgrades", flags.allowRCUpgrades, "Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.")
-	cmd.PersistentFlags().BoolVar(&flags.printConfig, "print-config", flags.printConfig, "Specifies whether the configuration file that will be used in the upgrade should be printed or not.")
-	cmd.PersistentFlags().StringSliceVar(&flags.ignorePreflightErrors, "ignore-preflight-errors", flags.ignorePreflightErrors, "A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.")
-	cmd.PersistentFlags().BoolVar(&flags.skipPreFlight, "skip-preflight-checks", flags.skipPreFlight, "Skip preflight checks that normally run before modifying the system.")
-	cmd.PersistentFlags().MarkDeprecated("skip-preflight-checks", "it is now equivalent to --ignore-preflight-errors=all")
-	cmd.PersistentFlags().StringVar(&flags.featureGatesString, "feature-gates", flags.featureGatesString, "A set of key=value pairs that describe feature gates for various features."+
-		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
-
 	cmd.AddCommand(NewCmdApply(flags))
 	cmd.AddCommand(NewCmdPlan(flags))
-	cmd.AddCommand(NewCmdDiff(flags))
-	cmd.AddCommand(NewCmdNode(flags))
-
+	cmd.AddCommand(NewCmdDiff(out))
+	cmd.AddCommand(NewCmdNode())
 	return cmd
+}
+
+func addApplyPlanFlags(fs *pflag.FlagSet, flags *applyPlanFlags) {
+	// TODO: Use the generic options.AddKubeConfigFlag and options.AddConfigFlag methods instead
+	fs.StringVar(&flags.kubeConfigPath, "kubeconfig", flags.kubeConfigPath, "The KubeConfig file to use when talking to the cluster.")
+	fs.StringVar(&flags.cfgPath, "config", flags.cfgPath, "Path to kubeadm config file. WARNING: Usage of a configuration file is experimental!")
+
+	fs.BoolVar(&flags.allowExperimentalUpgrades, "allow-experimental-upgrades", flags.allowExperimentalUpgrades, "Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.")
+	fs.BoolVar(&flags.allowRCUpgrades, "allow-release-candidate-upgrades", flags.allowRCUpgrades, "Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.")
+	fs.BoolVar(&flags.printConfig, "print-config", flags.printConfig, "Specifies whether the configuration file that will be used in the upgrade should be printed or not.")
+	fs.StringSliceVar(&flags.ignorePreflightErrors, "ignore-preflight-errors", flags.ignorePreflightErrors, "A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.")
+	fs.BoolVar(&flags.skipPreFlight, "skip-preflight-checks", flags.skipPreFlight, "Skip preflight checks that normally run before modifying the system.")
+	fs.MarkDeprecated("skip-preflight-checks", "it is now equivalent to --ignore-preflight-errors=all")
+	fs.StringVar(&flags.featureGatesString, "feature-gates", flags.featureGatesString, "A set of key=value pairs that describe feature gates for various features."+
+		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 }

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -29,14 +29,21 @@ import (
 
 // Run creates and executes new kubeadm command
 func Run() error {
-	// We do not want these flags to show up in --help
-	pflag.CommandLine.MarkHidden("version")
-	pflag.CommandLine.MarkHidden("google-json-key")
-	pflag.CommandLine.MarkHidden("log-flush-frequency")
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	pflag.Set("logtostderr", "true")
+	// We do not want these flags to show up in --help
+	// These MarkHidden calls must be after the lines above
+	pflag.CommandLine.MarkHidden("version")
+	pflag.CommandLine.MarkHidden("google-json-key")
+	pflag.CommandLine.MarkHidden("log-flush-frequency")
+	pflag.CommandLine.MarkHidden("alsologtostderr")
+	pflag.CommandLine.MarkHidden("log-backtrace-at")
+	pflag.CommandLine.MarkHidden("log-dir")
+	pflag.CommandLine.MarkHidden("logtostderr")
+	pflag.CommandLine.MarkHidden("stderrthreshold")
+	pflag.CommandLine.MarkHidden("vmodule")
 
 	cmd := cmd.NewKubeadmCommand(os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//cmd/kubeadm/app/phases/controlplane:go_default_library",
         "//cmd/kubeadm/app/phases/etcd:go_default_library",
         "//cmd/kubeadm/app/phases/kubelet:go_default_library",
+        "//cmd/kubeadm/app/phases/patchnode:go_default_library",
         "//cmd/kubeadm/app/phases/selfhosting:go_default_library",
         "//cmd/kubeadm/app/phases/uploadconfig:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -210,10 +210,7 @@ func (spm *fakeStaticPodPathManager) CleanupDirs() error {
 	if err := os.RemoveAll(spm.BackupManifestDir()); err != nil {
 		return err
 	}
-	if err := os.RemoveAll(spm.BackupEtcdDir()); err != nil {
-		return err
-	}
-	return nil
+	return os.RemoveAll(spm.BackupEtcdDir())
 }
 
 type fakeTLSEtcdClient struct{ TLS bool }

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -72,6 +72,10 @@ func TestUploadConfiguration(t *testing.T) {
 						},
 					},
 				},
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					Name:      "node-foo",
+					CRISocket: "/var/run/custom-cri.sock",
+				},
 			}
 			client := clientsetfake.NewSimpleClientset()
 			if tt.errOnCreate != nil {
@@ -120,6 +124,11 @@ func TestUploadConfiguration(t *testing.T) {
 				// If the decoded cfg has a BootstrapTokens array, verify the sensitive information we had isn't still there.
 				if len(decodedCfg.BootstrapTokens) > 0 && decodedCfg.BootstrapTokens[0].Token != nil && decodedCfg.BootstrapTokens[0].Token.String() == cfg.BootstrapTokens[0].Token.String() {
 					t.Errorf("Decoded value contains .BootstrapTokens (sensitive info), decoded = %#v, expected = empty", decodedCfg.BootstrapTokens)
+				}
+
+				// Make sure no information from NodeRegistrationOptions was uploaded.
+				if decodedCfg.NodeRegistration.Name == cfg.NodeRegistration.Name || decodedCfg.NodeRegistration.CRISocket != kubeadmapiv1alpha2.DefaultCRISocket {
+					t.Errorf("Decoded value contains .NodeRegistration (node-specific info shouldn't be uploaded), decoded = %#v, expected = empty", decodedCfg.NodeRegistration)
 				}
 
 				if decodedExtCfg.Kind != "MasterConfiguration" {

--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -53,7 +53,6 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
-        "//pkg/apis/core/validation:go_default_library",
         "//pkg/registry/core/service/ipallocator:go_default_library",
         "//pkg/util/initsystem:go_default_library",
         "//pkg/util/ipvs:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes a bunch of bugs I noticed when I was reading the source code:
 - `--cloud-provider` should also be propagated to the kubelet when converting configs from v1alpha1 to v1alpha2
 - The validation for `.NodeRegistration.Name` is practically non-existent, just verifies the name isn't in upper case. Instead we currently do that validation in preflight checks, which is in the totally wrong place.
 - Now that we pull images in preflight checks, the timeout for the kubelet to start the Static Pods should be kinda short, as it doesn't depend on internet connection
 - I think the shorthand for `kubeadm reset --force` ought to be `-f`
 - The common flags between `upgrade apply` and `upgrade plan` were registered as global flags for the `upgrade` command, although they make no sense for `upgrade diff` and/or `upgrade node config`. Hence, I moved them to be locally registered.
 - Just because we vendor `glog` we have a lot of unnecessary/annoying flags registered in glog's `init()` function. Let's hide these properly.
 - I saw that `kubeadm upgrade apply` doesn't write down the new kubelet config that should be used, now that is the case. Also, the CRISocket annotation information is now preserved properly on upgrade (and is configurable using the `--cri-socket` flag)
 - If `kubeadm join` is run against a v1.10 cluster without the `kubelet-config-1.10` configmap,  it shouldn't fail.

What I will still investigate:
 - `kubeadm token create` should have a flag called `--ttl`, not `--token-ttl` as it is now (this snuck in in this dev cycle)
 - That `--dry-run` works properly for `upgrade`, end to end.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 