### PR TITLE
Update cadvisor godeps to v0.30.1 to revert cadvisor#1916

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1508,218 +1508,218 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.30.0",
-			"Rev": "f6359ffcbdec3c228bf312e6939ea6edf556ce52"
+			"Comment": "v0.30.1",
+			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go",

--- a/vendor/github.com/google/cadvisor/container/common/BUILD
+++ b/vendor/github.com/google/cadvisor/container/common/BUILD
@@ -5,18 +5,18 @@ go_library(
     srcs = [
         "container_hints.go",
         "fsHandler.go",
-        "fsnotify_watcher.go",
         "helpers.go",
+        "inotify_watcher.go",
     ],
     importpath = "github.com/google/cadvisor/container/common",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/cadvisor/container:go_default_library",
         "//vendor/github.com/google/cadvisor/fs:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/utils:go_default_library",
+        "//vendor/golang.org/x/exp/inotify:go_default_library",
     ],
 )
 

--- a/vendor/github.com/google/cadvisor/container/common/helpers.go
+++ b/vendor/github.com/google/cadvisor/container/common/helpers.go
@@ -40,7 +40,7 @@ func DebugInfo(watches map[string][]string) map[string][]string {
 			lines = append(lines, fmt.Sprintf("\t%s", cg))
 		}
 	}
-	out["Fsnotify watches"] = lines
+	out["Inotify watches"] = lines
 
 	return out
 }

--- a/vendor/github.com/google/cadvisor/container/raw/factory.go
+++ b/vendor/github.com/google/cadvisor/container/raw/factory.go
@@ -40,8 +40,8 @@ type rawFactory struct {
 	// Information about mounted filesystems.
 	fsInfo fs.FsInfo
 
-	// Watcher for fsnotify events.
-	watcher *common.FsnotifyWatcher
+	// Watcher for inotify events.
+	watcher *common.InotifyWatcher
 
 	// List of metrics to be ignored.
 	ignoreMetrics map[container.MetricKind]struct{}
@@ -78,7 +78,7 @@ func Register(machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, igno
 		return fmt.Errorf("failed to find supported cgroup mounts for the raw factory")
 	}
 
-	watcher, err := common.NewFsnotifyWatcher()
+	watcher, err := common.NewInotifyWatcher()
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/google/cadvisor/container/raw/handler.go
+++ b/vendor/github.com/google/cadvisor/container/raw/handler.go
@@ -49,7 +49,7 @@ func isRootCgroup(name string) bool {
 	return name == "/"
 }
 
-func newRawContainerHandler(name string, cgroupSubsystems *libcontainer.CgroupSubsystems, machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, watcher *common.FsnotifyWatcher, rootFs string, ignoreMetrics container.MetricSet) (container.ContainerHandler, error) {
+func newRawContainerHandler(name string, cgroupSubsystems *libcontainer.CgroupSubsystems, machineInfoFactory info.MachineInfoFactory, fsInfo fs.FsInfo, watcher *common.InotifyWatcher, rootFs string, ignoreMetrics container.MetricSet) (container.ContainerHandler, error) {
 	cgroupPaths := common.MakeCgroupPaths(cgroupSubsystems.MountPoints, name)
 
 	cHints, err := common.GetContainerHintsFromFile(*common.ArgContainerHints)

--- a/vendor/github.com/google/cadvisor/manager/watcher/raw/BUILD
+++ b/vendor/github.com/google/cadvisor/manager/watcher/raw/BUILD
@@ -6,11 +6,11 @@ go_library(
     importpath = "github.com/google/cadvisor/manager/watcher/raw",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/cadvisor/container/common:go_default_library",
         "//vendor/github.com/google/cadvisor/container/libcontainer:go_default_library",
         "//vendor/github.com/google/cadvisor/manager/watcher:go_default_library",
+        "//vendor/golang.org/x/exp/inotify:go_default_library",
     ],
 )
 

--- a/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
+++ b/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
@@ -27,8 +27,8 @@ import (
 	"github.com/google/cadvisor/container/libcontainer"
 	"github.com/google/cadvisor/manager/watcher"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
+	"golang.org/x/exp/inotify"
 )
 
 type rawContainerWatcher struct {
@@ -37,8 +37,8 @@ type rawContainerWatcher struct {
 
 	cgroupSubsystems *libcontainer.CgroupSubsystems
 
-	// Fsnotify event watcher.
-	watcher *common.FsnotifyWatcher
+	// Inotify event watcher.
+	watcher *common.InotifyWatcher
 
 	// Signal for watcher thread to stop.
 	stopWatcher chan error
@@ -53,7 +53,7 @@ func NewRawContainerWatcher() (watcher.ContainerWatcher, error) {
 		return nil, fmt.Errorf("failed to find supported cgroup mounts for the raw factory")
 	}
 
-	watcher, err := common.NewFsnotifyWatcher()
+	watcher, err := common.NewInotifyWatcher()
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (self *rawContainerWatcher) watchDirectory(events chan watcher.ContainerEve
 		if cleanup {
 			_, err := self.watcher.RemoveWatch(containerName, dir)
 			if err != nil {
-				glog.Warningf("Failed to remove fsnotify watch for %q: %v", dir, err)
+				glog.Warningf("Failed to remove inotify watch for %q: %v", dir, err)
 			}
 		}
 	}()
@@ -163,16 +163,18 @@ func (self *rawContainerWatcher) watchDirectory(events chan watcher.ContainerEve
 	return alreadyWatching, nil
 }
 
-func (self *rawContainerWatcher) processEvent(event fsnotify.Event, events chan watcher.ContainerEvent) error {
-	// Convert the fsnotify event type to a container create or delete.
+func (self *rawContainerWatcher) processEvent(event *inotify.Event, events chan watcher.ContainerEvent) error {
+	// Convert the inotify event type to a container create or delete.
 	var eventType watcher.ContainerEventType
 	switch {
-	case event.Op == fsnotify.Create:
+	case (event.Mask & inotify.IN_CREATE) > 0:
 		eventType = watcher.ContainerAdd
-	case event.Op == fsnotify.Remove:
+	case (event.Mask & inotify.IN_DELETE) > 0:
 		eventType = watcher.ContainerDelete
-	case event.Op == fsnotify.Rename:
+	case (event.Mask & inotify.IN_MOVED_FROM) > 0:
 		eventType = watcher.ContainerDelete
+	case (event.Mask & inotify.IN_MOVED_TO) > 0:
+		eventType = watcher.ContainerAdd
 	default:
 		// Ignore other events.
 		return nil


### PR DESCRIPTION
/sig node
/priority critical-urgent
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64933

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubernetes depends on v0.30.1 of cAdvisor
```
