### PR TITLE
kubeadm - set peer urls for default etcd instance

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	upgradeManifestTimeout = 1 * time.Minute
+	upgradeManifestTimeout = 5 * time.Minute
 )
 
 // applyFlags holds the information about the flags that can be passed to apply

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -80,8 +80,6 @@ const (
 	EtcdServerCertName = "etcd/server.crt"
 	// EtcdServerKeyName defines etcd's server key name
 	EtcdServerKeyName = "etcd/server.key"
-	// EtcdServerCertCommonName defines etcd's server certificate common name (CN)
-	EtcdServerCertCommonName = "kube-etcd"
 
 	// EtcdPeerCertAndKeyBaseName defines etcd's peer certificate and key base name
 	EtcdPeerCertAndKeyBaseName = "etcd/peer"
@@ -89,8 +87,6 @@ const (
 	EtcdPeerCertName = "etcd/peer.crt"
 	// EtcdPeerKeyName defines etcd's peer key name
 	EtcdPeerKeyName = "etcd/peer.key"
-	// EtcdPeerCertCommonName defines etcd's peer certificate common name (CN)
-	EtcdPeerCertCommonName = "kube-etcd-peer"
 
 	// EtcdHealthcheckClientCertAndKeyBaseName defines etcd's healthcheck client certificate and key base name
 	EtcdHealthcheckClientCertAndKeyBaseName = "etcd/healthcheck-client"

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -375,7 +375,7 @@ func NewEtcdServerCertAndKey(cfg *kubeadmapi.MasterConfiguration, caCert *x509.C
 	}
 
 	config := certutil.Config{
-		CommonName: kubeadmconstants.EtcdServerCertCommonName,
+		CommonName: cfg.NodeRegistration.Name,
 		AltNames:   *altNames,
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
@@ -396,7 +396,7 @@ func NewEtcdPeerCertAndKey(cfg *kubeadmapi.MasterConfiguration, caCert *x509.Cer
 	}
 
 	config := certutil.Config{
-		CommonName: kubeadmconstants.EtcdPeerCertCommonName,
+		CommonName: cfg.NodeRegistration.Name,
 		AltNames:   *altNames,
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -324,6 +324,9 @@ func TestNewEtcdServerCertAndKey(t *testing.T) {
 	proxyIP := "10.10.10.100"
 
 	cfg := &kubeadmapi.MasterConfiguration{
+		NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+			Name: "etcd-server-cert",
+		},
 		Etcd: kubeadmapi.Etcd{
 			Local: &kubeadmapi.LocalEtcd{
 				ServerCertSANs: []string{

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -312,7 +312,7 @@ func GetAPIServerAltNames(cfg *kubeadmapi.MasterConfiguration) (*certutil.AltNam
 func GetEtcdAltNames(cfg *kubeadmapi.MasterConfiguration) (*certutil.AltNames, error) {
 	// create AltNames with defaults DNSNames/IPs
 	altNames := &certutil.AltNames{
-		DNSNames: []string{"localhost"},
+		DNSNames: []string{cfg.NodeRegistration.Name, "localhost"},
 		IPs:      []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 
@@ -336,8 +336,8 @@ func GetEtcdPeerAltNames(cfg *kubeadmapi.MasterConfiguration) (*certutil.AltName
 
 	// create AltNames with defaults DNSNames/IPs
 	altNames := &certutil.AltNames{
-		DNSNames: []string{cfg.NodeRegistration.Name},
-		IPs:      []net.IP{advertiseAddress},
+		DNSNames: []string{cfg.NodeRegistration.Name, "localhost"},
+		IPs:      []net.IP{advertiseAddress, net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 
 	if cfg.Etcd.Local != nil {

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -77,18 +77,22 @@ func GetEtcdPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.Pod {
 // getEtcdCommand builds the right etcd command from the given config object
 func getEtcdCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 	defaultArguments := map[string]string{
-		"listen-client-urls":    "https://127.0.0.1:2379",
-		"advertise-client-urls": "https://127.0.0.1:2379",
-		"data-dir":              cfg.Etcd.Local.DataDir,
-		"cert-file":             filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerCertName),
-		"key-file":              filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerKeyName),
-		"trusted-ca-file":       filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
-		"client-cert-auth":      "true",
-		"peer-cert-file":        filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerCertName),
-		"peer-key-file":         filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerKeyName),
-		"peer-trusted-ca-file":  filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
-		"peer-client-cert-auth": "true",
-		"snapshot-count":        "10000",
+		"name":                        cfg.GetNodeName(),
+		"listen-client-urls":          "https://127.0.0.1:2379",
+		"advertise-client-urls":       "https://127.0.0.1:2379",
+		"listen-peer-urls":            "https://127.0.0.1:2380",
+		"initial-advertise-peer-urls": "https://127.0.0.1:2380",
+		"data-dir":                    cfg.Etcd.Local.DataDir,
+		"cert-file":                   filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerCertName),
+		"key-file":                    filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerKeyName),
+		"trusted-ca-file":             filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
+		"client-cert-auth":            "true",
+		"peer-cert-file":              filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerCertName),
+		"peer-key-file":               filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerKeyName),
+		"peer-trusted-ca-file":        filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
+		"peer-client-cert-auth":       "true",
+		"snapshot-count":              "10000",
+		"initial-cluster":             fmt.Sprintf("%s=https://127.0.0.1:2380", cfg.GetNodeName()),
 	}
 
 	command := []string{"etcd"}

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -87,12 +87,22 @@ func TestGetEtcdCommand(t *testing.T) {
 	}{
 		{
 			cfg: &kubeadmapi.MasterConfiguration{
-				Etcd: kubeadmapi.Etcd{Local: &kubeadmapi.LocalEtcd{DataDir: "/var/lib/etcd"}},
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					Name: "foo",
+				},
+				Etcd: kubeadmapi.Etcd{
+					Local: &kubeadmapi.LocalEtcd{
+						DataDir: "/var/lib/etcd",
+					},
+				},
 			},
 			expected: []string{
 				"etcd",
+				"--name=foo",
 				"--listen-client-urls=https://127.0.0.1:2379",
 				"--advertise-client-urls=https://127.0.0.1:2379",
+				"--listen-peer-urls=https://127.0.0.1:2380",
+				"--initial-advertise-peer-urls=https://127.0.0.1:2380",
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + kubeadmconstants.EtcdServerCertName,
 				"--key-file=" + kubeadmconstants.EtcdServerKeyName,
@@ -103,10 +113,14 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--peer-trusted-ca-file=" + kubeadmconstants.EtcdCACertName,
 				"--snapshot-count=10000",
 				"--peer-client-cert-auth=true",
+				"--initial-cluster=foo=https://127.0.0.1:2380",
 			},
 		},
 		{
 			cfg: &kubeadmapi.MasterConfiguration{
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					Name: "bar",
+				},
 				Etcd: kubeadmapi.Etcd{
 					Local: &kubeadmapi.LocalEtcd{
 						DataDir: "/var/lib/etcd",
@@ -119,8 +133,11 @@ func TestGetEtcdCommand(t *testing.T) {
 			},
 			expected: []string{
 				"etcd",
+				"--name=bar",
 				"--listen-client-urls=https://10.0.1.10:2379",
 				"--advertise-client-urls=https://10.0.1.10:2379",
+				"--listen-peer-urls=https://127.0.0.1:2380",
+				"--initial-advertise-peer-urls=https://127.0.0.1:2380",
 				"--data-dir=/var/lib/etcd",
 				"--cert-file=" + kubeadmconstants.EtcdServerCertName,
 				"--key-file=" + kubeadmconstants.EtcdServerKeyName,
@@ -131,16 +148,27 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--peer-trusted-ca-file=" + kubeadmconstants.EtcdCACertName,
 				"--snapshot-count=10000",
 				"--peer-client-cert-auth=true",
+				"--initial-cluster=bar=https://127.0.0.1:2380",
 			},
 		},
 		{
 			cfg: &kubeadmapi.MasterConfiguration{
-				Etcd: kubeadmapi.Etcd{Local: &kubeadmapi.LocalEtcd{DataDir: "/etc/foo"}},
+				NodeRegistration: kubeadmapi.NodeRegistrationOptions{
+					Name: "wombat",
+				},
+				Etcd: kubeadmapi.Etcd{
+					Local: &kubeadmapi.LocalEtcd{
+						DataDir: "/etc/foo",
+					},
+				},
 			},
 			expected: []string{
 				"etcd",
+				"--name=wombat",
 				"--listen-client-urls=https://127.0.0.1:2379",
 				"--advertise-client-urls=https://127.0.0.1:2379",
+				"--listen-peer-urls=https://127.0.0.1:2380",
+				"--initial-advertise-peer-urls=https://127.0.0.1:2380",
 				"--data-dir=/etc/foo",
 				"--cert-file=" + kubeadmconstants.EtcdServerCertName,
 				"--key-file=" + kubeadmconstants.EtcdServerKeyName,
@@ -151,6 +179,7 @@ func TestGetEtcdCommand(t *testing.T) {
 				"--peer-trusted-ca-file=" + kubeadmconstants.EtcdCACertName,
 				"--snapshot-count=10000",
 				"--peer-client-cert-auth=true",
+				"--initial-cluster=wombat=https://127.0.0.1:2380",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Override the default peer URLs for the default etcd instance. Previously we left the defaults, which meant the peer URL was unsecured previously.

**Release note**:
```release-note
kubeadm - Ensure the peer port is secured by explicitly setting the peer URLs for the default etcd instance.
kubeadm - Ensure that the etcd certificates are generated using a proper CN
kubeadm - Update generated etcd peer certificate to include localhost addresses for the default configuration.
kubeadm - Increase the manifest update timeout to make upgrades a bit more reliable.
```
