### PR TITLE
Mark Conditions in CustomResourceDefinitionStatus as optional

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -221,6 +221,7 @@ message CustomResourceDefinitionSpec {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 message CustomResourceDefinitionStatus {
   // Conditions indicate state for particular aspects of a CustomResourceDefinition
+  // +optional
   repeated CustomResourceDefinitionCondition conditions = 1;
 
   // AcceptedNames are the names that are actually being used to serve discovery

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
@@ -295,6 +295,7 @@ type CustomResourceDefinitionCondition struct {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatus struct {
 	// Conditions indicate state for particular aspects of a CustomResourceDefinition
+	// +optional
 	Conditions []CustomResourceDefinitionCondition `json:"conditions" protobuf:"bytes,1,opt,name=conditions"`
 
 	// AcceptedNames are the names that are actually being used to serve discovery

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -260,6 +260,7 @@ message CustomResourceDefinitionSpec {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 message CustomResourceDefinitionStatus {
   // Conditions indicate state for particular aspects of a CustomResourceDefinition
+  // +optional
   repeated CustomResourceDefinitionCondition conditions = 1;
 
   // AcceptedNames are the names that are actually being used to serve discovery

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -337,6 +337,7 @@ type CustomResourceDefinitionCondition struct {
 // CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 type CustomResourceDefinitionStatus struct {
 	// Conditions indicate state for particular aspects of a CustomResourceDefinition
+	// +optional
 	Conditions []CustomResourceDefinitionCondition `json:"conditions" protobuf:"bytes,1,opt,name=conditions"`
 
 	// AcceptedNames are the names that are actually being used to serve discovery


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Apiserver may respond `null` for required property `Conditions` in `metav1.CustomResourceDefinitionStatus` (e.g. create a [crd](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/sample-controller/artifacts/examples/crd.yaml) with `kubectl --v=9` and check the response), which fails the validation in generated python client https://github.com/kubernetes-client/python/issues/415. This PR marks the field as optional. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Property `conditions` in `apiextensions.v1beta1.CustomResourceDefinitionStatus` and `apiextensions.v1.CustomResourceDefinitionStatus` is now optional instead of required.
```

/sig api-machinery
/area custom-resources