### PR TITLE
kubeadm - fix local etcd grpc gateway

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -377,7 +377,7 @@ func NewEtcdServerCertAndKey(cfg *kubeadmapi.MasterConfiguration, caCert *x509.C
 	config := certutil.Config{
 		CommonName: cfg.NodeRegistration.Name,
 		AltNames:   *altNames,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
 	etcdServerCert, etcdServerKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
etcd 3.2 uses the server certificate as the client cert for the grpc
gateway, this updates the generation of the etcd server certificate to
add client usage to resolve the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/910

**Release note**:
```release-note
NONE
```
