### PR TITLE
Correct several mistakes in the comments/doc for PollImmediate.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -230,13 +230,13 @@ func pollInternal(wait WaitFunc, condition ConditionFunc) error {
 // PollImmediate tries a condition func until it returns true, an error, or the timeout
 // is reached.
 //
-// Poll always checks 'condition' before waiting for the interval. 'condition'
+// PollImmediate always checks 'condition' before waiting for the interval. 'condition'
 // will always be invoked at least once.
 //
 // Some intervals may be missed if the condition takes too long or the time
 // window is too short.
 //
-// If you want to Poll something forever, see PollInfinite.
+// If you want to immediately Poll something forever, see PollImmediateInfinite.
 func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
 	return pollImmediateInternal(poller(interval, timeout), condition)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The wait.PollImmediate(...) docs refer to the Poll(...) function by mistake which is confusing. This PR fixes that issue.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Corrected a mistake in the documentation for wait.PollImmediate(...)
```
