### PR TITLE
kubeadm - increase upgrade manifest timeout

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	upgradeManifestTimeout = 1 * time.Minute
+	upgradeManifestTimeout = 5 * time.Minute
 )
 
 // applyFlags holds the information about the flags that can be passed to apply


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports the manifest upgrade timeout from https://github.com/kubernetes/kubernetes/pull/64988 to v1.10

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/850

**Release note**:
```release-note
kubeadm - Increase the manifest upgrade timeout to make upgrades more reliable.
```
