### PR TITLE
CSI block map file path fix

### DIFF
--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -123,7 +123,7 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
 
-	if devicePath != globalMapPath {
+	if devicePath != filepath.Join(globalMapPath, "file") {
 		t.Fatalf("mapper.SetupDevice returned unexpected path %s instead of %v", devicePath, globalMapPath)
 	}
 
@@ -186,16 +186,17 @@ func TestBlockMapperMapDevice(t *testing.T) {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(volumeMapPath, volName)); err != nil {
+	podVolumeBlockFilePath := filepath.Join(volumeMapPath, "file")
+	if _, err := os.Stat(podVolumeBlockFilePath); err != nil {
 		if os.IsNotExist(err) {
-			t.Errorf("mapper.MapDevice failed, volume path not created: %s", volumeMapPath)
+			t.Errorf("mapper.MapDevice failed, volume path not created: %v", err)
 		} else {
 			t.Errorf("mapper.MapDevice failed: %v", err)
 		}
 	}
 
 	pubs := csiMapper.csiClient.(*fakeCsiDriverClient).nodeClient.GetNodePublishedVolumes()
-	if pubs[csiMapper.volumeID] != volumeMapPath {
+	if pubs[csiMapper.volumeID] != podVolumeBlockFilePath {
 		t.Error("csi server may not have received NodePublishVolume call")
 	}
 }

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -346,6 +346,7 @@ func (p *csiPlugin) NewBlockVolumeMapper(spec *volume.Spec, podRef *api.Pod, opt
 		driverName: pvSource.Driver,
 		readOnly:   readOnly,
 		spec:       spec,
+		specName:   spec.Name(),
 		podUID:     podRef.UID,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a bug fix that addresses the way CSI communicates block volume path.  Instead of sending a directory to the external CSI driver, this PR fixes it to send path to a pre-existing file used for block mapping.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64854 

**Special notes for your reviewer**:
/kind bug

**Release note**:
```release-note
NONE
```
