### PR TITLE
Make kubernetes json serializer case sensitive

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2029,8 +2029,8 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Comment": "1.1.3-16-g2ddf6d7",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Comment": "1.1.3-22-gf2b4162",
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/jteeuwen/go-bindata",

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -58,7 +58,6 @@ go_library(
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
         "//pkg/util/pointer:go_default_library",
-        "//vendor/github.com/json-iterator/go:go_default_library",
         "//vendor/github.com/ugorji/go/codec:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/upgrade.go
@@ -23,15 +23,12 @@ import (
 	"strconv"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/ugorji/go/codec"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
-
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 type configMutationFunc func(map[string]interface{}) error
 

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -64,7 +64,7 @@ KubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1.yaml
@@ -53,7 +53,7 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1_without_TypeMeta.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha1_without_TypeMeta.yaml
@@ -50,7 +50,7 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
@@ -54,7 +54,7 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -49,7 +49,7 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/after.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/v1alpha1_upgrade/after.yaml
@@ -49,7 +49,7 @@ kubeProxy:
       minSyncPeriod: 0s
       syncPeriod: 30s
     ipvs:
-      ExcludeCIDRs: null
+      excludeCIDRs: null
       minSyncPeriod: 0s
       scheduler: ""
       syncPeriod: 30s

--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -96,6 +96,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/protobuf:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/api/testing/serialization_test.go
+++ b/pkg/api/testing/serialization_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8s_json "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -560,9 +561,10 @@ func BenchmarkDecodeIntoJSONCodecGenConfigFast(b *testing.B) {
 	b.StopTimer()
 }
 
-// BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary
-//  provides a baseline for JSON decode performance
-// with jsoniter.ConfigCompatibleWithStandardLibrary
+// BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary provides a
+// baseline for JSON decode performance with
+// jsoniter.ConfigCompatibleWithStandardLibrary, but with case sensitivity set
+// to true
 func BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary(b *testing.B) {
 	kcodec := testapi.Default.Codec()
 	items := benchmarkItems(b)
@@ -577,9 +579,10 @@ func BenchmarkDecodeIntoJSONCodecGenConfigCompatibleWithStandardLibrary(b *testi
 	}
 
 	b.ResetTimer()
+	iter := k8s_json.CaseSensitiveJsonIterator()
 	for i := 0; i < b.N; i++ {
 		obj := v1.Pod{}
-		if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(encoded[i%width], &obj); err != nil {
+		if err := iter.Unmarshal(encoded[i%width], &obj); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
@@ -65,7 +65,7 @@ type KubeProxyIPVSConfiguration struct {
 	Scheduler string `json:"scheduler"`
 	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
-	ExcludeCIDRs []string
+	ExcludeCIDRs []string `json:"excludeCIDRs"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/staging/src/k8s.io/api/Godeps/Godeps.json
+++ b/staging/src/k8s.io/api/Godeps/Godeps.json
@@ -36,7 +36,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -532,7 +532,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -92,7 +92,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -21,9 +21,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
-        "//vendor/github.com/json-iterator/go:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	k8s_json "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 type GroupVersionHolder struct {
@@ -47,7 +47,8 @@ func TestGroupVersionUnmarshalJSON(t *testing.T) {
 			t.Errorf("JSON codec failed to unmarshal input '%s': expected %+v, got %+v", c.input, c.expect, result.GV)
 		}
 		// test the json-iterator codec
-		if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(c.input, &result); err != nil {
+		iter := k8s_json.CaseSensitiveJsonIterator()
+		if err := iter.Unmarshal(c.input, &result); err != nil {
 			t.Errorf("json-iterator codec failed to unmarshal input '%v': %v", c.input, err)
 		}
 		if !reflect.DeepEqual(result.GV, c.expect) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
+	k8s_json "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 func TestVerbsUgorjiMarshalJSON(t *testing.T) {
@@ -45,7 +45,7 @@ func TestVerbsUgorjiMarshalJSON(t *testing.T) {
 	}
 }
 
-func TestVerbsUgorjiUnmarshalJSON(t *testing.T) {
+func TestVerbsUJsonIterUnmarshalJSON(t *testing.T) {
 	cases := []struct {
 		input  string
 		result APIResource
@@ -56,9 +56,10 @@ func TestVerbsUgorjiUnmarshalJSON(t *testing.T) {
 		{`{"verbs":["delete"]}`, APIResource{Verbs: Verbs([]string{"delete"})}},
 	}
 
+	iter := k8s_json.CaseSensitiveJsonIterator()
 	for i, c := range cases {
 		var result APIResource
-		if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(c.input), &result); err != nil {
+		if err := iter.Unmarshal([]byte(c.input), &result); err != nil {
 			t.Errorf("[%d] Failed to unmarshal input '%v': %v", i, c.input, err)
 		}
 		if !reflect.DeepEqual(result, c.result) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -93,6 +93,20 @@ func init() {
 	jsoniter.RegisterTypeDecoderFunc("interface {}", decodeNumberAsInt64IfPossible)
 }
 
+// CaseSensitiveJsonIterator returns a jsoniterator API that's configured to be
+// case-sensitive when unmarshalling, and otherwise compatible with
+// the encoding/json standard library.
+func CaseSensitiveJsonIterator() jsoniter.API {
+	return jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+	}.Froze()
+}
+
+var caseSensitiveJsonIterator = CaseSensitiveJsonIterator()
+
 // gvkWithDefaults returns group kind and version defaulting from provided default
 func gvkWithDefaults(actual, defaultGVK schema.GroupVersionKind) schema.GroupVersionKind {
 	if len(actual.Kind) == 0 {
@@ -157,7 +171,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		types, _, err := s.typer.ObjectKinds(into)
 		switch {
 		case runtime.IsNotRegisteredError(err), isUnstructured:
-			if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, into); err != nil {
+			if err := caseSensitiveJsonIterator.Unmarshal(data, into); err != nil {
 				return nil, actual, err
 			}
 			return into, actual, nil
@@ -181,7 +195,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		return nil, actual, err
 	}
 
-	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, obj); err != nil {
+	if err := caseSensitiveJsonIterator.Unmarshal(data, obj); err != nil {
 		return nil, actual, err
 	}
 	return obj, actual, nil
@@ -190,7 +204,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 // Encode serializes the provided object to the given writer.
 func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	if s.yaml {
-		json, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(obj)
+		json, err := caseSensitiveJsonIterator.Marshal(obj)
 		if err != nil {
 			return err
 		}
@@ -203,7 +217,7 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	}
 
 	if s.pretty {
-		data, err := jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(obj, "", "  ")
+		data, err := caseSensitiveJsonIterator.MarshalIndent(obj, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -504,7 +504,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -156,7 +156,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -216,7 +216,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",

--- a/staging/src/k8s.io/metrics/Godeps/Godeps.json
+++ b/staging/src/k8s.io/metrics/Godeps/Godeps.json
@@ -76,7 +76,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -208,7 +208,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/mailru/easyjson/buffer",

--- a/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -92,7 +92,7 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Rev": "2ddf6d758266fcb080a4f9e054b9f292c85e6798"
+			"Rev": "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 		},
 		{
 			"ImportPath": "github.com/modern-go/concurrent",

--- a/vendor/github.com/json-iterator/go/Gopkg.lock
+++ b/vendor/github.com/json-iterator/go/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
+  version = "1.1.3"
+
+[[projects]]
   name = "github.com/modern-go/concurrent"
   packages = ["."]
   revision = "e0a39a4cb4216ea8db28e22a69f4ec25610d513a"
@@ -16,6 +22,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ac7003b5a981716353a43055ab7d4c5357403cb30a60de2dbdeb446c1544beaa"
+  inputs-digest = "56a0b9e9e61d2bc8af5e1b68537401b7f4d60805eda3d107058f3171aa5cf793"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/json-iterator/go/config.go
+++ b/vendor/github.com/json-iterator/go/config.go
@@ -2,12 +2,13 @@ package jsoniter
 
 import (
 	"encoding/json"
-	"github.com/modern-go/concurrent"
-	"github.com/modern-go/reflect2"
 	"io"
 	"reflect"
 	"sync"
 	"unsafe"
+
+	"github.com/modern-go/concurrent"
+	"github.com/modern-go/reflect2"
 )
 
 // Config customize how the API should behave.
@@ -23,6 +24,7 @@ type Config struct {
 	OnlyTaggedField               bool
 	ValidateJsonRawMessage        bool
 	ObjectFieldMustBeSimpleString bool
+	CaseSensitive                 bool
 }
 
 // API the public interface of this package.
@@ -75,6 +77,7 @@ type frozenConfig struct {
 	extensions                    []Extension
 	streamPool                    *sync.Pool
 	iteratorPool                  *sync.Pool
+	caseSensitive                 bool
 }
 
 func (cfg *frozenConfig) initCache() {
@@ -128,6 +131,7 @@ func (cfg Config) Froze() API {
 		objectFieldMustBeSimpleString: cfg.ObjectFieldMustBeSimpleString,
 		onlyTaggedField:               cfg.OnlyTaggedField,
 		disallowUnknownFields:         cfg.DisallowUnknownFields,
+		caseSensitive:                 cfg.CaseSensitive,
 	}
 	api.streamPool = &sync.Pool{
 		New: func() interface{} {

--- a/vendor/github.com/json-iterator/go/iter_object.go
+++ b/vendor/github.com/json-iterator/go/iter_object.go
@@ -60,7 +60,7 @@ func (iter *Iterator) readFieldHash() int64 {
 			if b == '\\' {
 				iter.head = i
 				for _, b := range iter.readStringSlowPath() {
-					if 'A' <= b && b <= 'Z' {
+					if 'A' <= b && b <= 'Z' && !iter.cfg.caseSensitive {
 						b += 'a' - 'A'
 					}
 					hash ^= int64(b)
@@ -82,7 +82,7 @@ func (iter *Iterator) readFieldHash() int64 {
 				}
 				return hash
 			}
-			if 'A' <= b && b <= 'Z' {
+			if 'A' <= b && b <= 'Z' && !iter.cfg.caseSensitive {
 				b += 'a' - 'A'
 			}
 			hash ^= int64(b)
@@ -95,10 +95,14 @@ func (iter *Iterator) readFieldHash() int64 {
 	}
 }
 
-func calcHash(str string) int64 {
+func calcHash(str string, caseSensitive bool) int64 {
 	hash := int64(0x811c9dc5)
 	for _, b := range str {
-		hash ^= int64(unicode.ToLower(b))
+		if caseSensitive {
+			hash ^= int64(b)
+		} else {
+			hash ^= int64(unicode.ToLower(b))
+		}
 		hash *= 0x1000193
 	}
 	return int64(hash)

--- a/vendor/github.com/json-iterator/go/reflect.go
+++ b/vendor/github.com/json-iterator/go/reflect.go
@@ -2,9 +2,10 @@ package jsoniter
 
 import (
 	"fmt"
-	"github.com/modern-go/reflect2"
 	"reflect"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 // ValDecoder is an internal type registered to cache as needed.
@@ -38,6 +39,14 @@ type ctx struct {
 	prefix   string
 	encoders map[reflect2.Type]ValEncoder
 	decoders map[reflect2.Type]ValDecoder
+}
+
+func (b *ctx) caseSensitive() bool {
+	if b.frozenConfig == nil {
+		// default is case-insensitive
+		return false
+	}
+	return b.frozenConfig.caseSensitive
 }
 
 func (b *ctx) append(prefix string) *ctx {

--- a/vendor/github.com/json-iterator/go/reflect_native.go
+++ b/vendor/github.com/json-iterator/go/reflect_native.go
@@ -1,7 +1,6 @@
 package jsoniter
 
 import (
-	"bytes"
 	"encoding/base64"
 	"reflect"
 	"strconv"
@@ -418,20 +417,11 @@ func (codec *base64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	}
 	switch iter.WhatIsNext() {
 	case StringValue:
-		encoding := base64.StdEncoding
-		src := iter.SkipAndReturnBytes()
-		// New line characters (\r and \n) are ignored.
-		// Refer to https://golang.org/pkg/encoding/base64/#Encoding.Decode
-		src = bytes.Replace(src, []byte(`\r`), []byte{}, -1)
-		src = bytes.Replace(src, []byte(`\n`), []byte{}, -1)
-		src = src[1 : len(src)-1]
-		decodedLen := encoding.DecodedLen(len(src))
-		dst := make([]byte, decodedLen)
-		len, err := encoding.Decode(dst, src)
+		src := iter.ReadString()
+		dst, err := base64.StdEncoding.DecodeString(src)
 		if err != nil {
 			iter.ReportError("decode base64", err.Error())
 		} else {
-			dst = dst[:len]
 			codec.sliceType.UnsafeSet(ptr, unsafe.Pointer(&dst))
 		}
 	case ArrayValue:


### PR DESCRIPTION
This PR imported the latest jsoniterator library so that case sensitivity during unmarhsaling is optional. The PR also set Kubernetes json serializer to be case sensitive.

Kubernetes json serializer had been case sensitive for 1.1-1.7 as we were using ugorji. This PR restores the behavior.

Fix #64612.

```release-notes
Kubernetes json deserializer is now case-sensitive to restore compatibility with pre-1.8 servers.
If your config files contain fields with wrong case, the config files will be now invalid.

Action required: 
Fix your JSON config files that contain fields of wrong case, otherwise they will be invalid.
If the fields in the golang schema doesn't have json tags, e.g., missing `json:"podSpec,omitempty"`, then the field in the JSON config file should match the case of the golang field, e.g., CamelCase.

Known non camelCase fields:

v1.10.5, scheduler/v1#ExtenderConfig.BindVerb, in the JSON config file, it needs to be "BindVerb".
```