### PR TITLE
Handle empty cluster UID in instance group name

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_naming.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_naming.go
@@ -31,7 +31,12 @@ import (
 
 // Instance groups remain legacy named to stay consistent with ingress
 func makeInstanceGroupName(clusterID string) string {
-	return fmt.Sprintf("k8s-ig--%s", clusterID)
+	prefix := "k8s-ig"
+	// clusterID might be empty for legacy clusters
+	if clusterID == "" {
+		return prefix
+	}
+	return fmt.Sprintf("%s--%s", prefix, clusterID)
 }
 
 func makeBackendServiceName(loadBalancerName, clusterID string, shared bool, scheme cloud.LbScheme, protocol v1.Protocol, svcAffinity v1.ServiceAffinity) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR handles an empty cluster UID when generating InstanceGroupName. The current implementation will create a name ending in "--" which is invalid.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
