### PR TITLE
Check to see if we already created the resource by comparing the bytes

### DIFF
--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -253,6 +253,11 @@ func (rh *realHistory) CreateControllerRevision(parent metav1.Object, revision *
 		clone.Name = ControllerRevisionName(parent.GetName(), hash)
 		created, err := rh.client.AppsV1().ControllerRevisions(parent.GetNamespace()).Create(clone)
 		if errors.IsAlreadyExists(err) {
+			existed, err := rh.client.AppsV1().ControllerRevisions(parent.GetNamespace()).Get(parent.GetName(), metav1.GetOptions{})
+			// Check if we already created it
+			if (err == nil) && bytes.Equal(existed.Data.Raw, clone.Data.Raw) {
+				return existed, err
+			}
 			*collisionCount++
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When a statefulset object is created, a lot of controllerrevisions are created at the same time with the same raw data. Rather than create duplicates, only create if the raw data is different.

**Which issue(s) this PR fixes**
Fixes #55159

**Special notes for your reviewer**:
First PR. I tried to follow along with the guidance suggested on the bug. Vetted by running the unit tests though would more than welcome other suggestions for testing.

**Release note**:
