### PR TITLE
[FEATURE-SERVERSIDE-APPLY] apply: Save lastApplied on apply-create path

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/apply.go
@@ -147,7 +147,6 @@ func (p *applyPatcher) applyPatchToCurrentObject(currentObject runtime.Object) (
 		return nil, fmt.Errorf("failed to save last intent: %v", err)
 	}
 
-	// TODO(apelisse): Also update last-applied on the create path
 	// TODO(apelisse): Check for conflicts with other lastApplied
 	// and report actionable errors to users.
 
@@ -163,5 +162,15 @@ func (p *applyPatcher) createNewObject() (runtime.Object, error) {
 	if gvk.GroupVersion() != p.kind.GroupVersion() {
 		return nil, errors.NewBadRequest(fmt.Sprintf("the API version in the data (%s) does not match the expected API version (%v)", gvk.GroupVersion().String(), p.kind.GroupVersion().String()))
 	}
-	return objToCreate, err
+
+	newIntent, err := p.getNewIntent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get new intent: %v", err)
+	}
+
+	if err := p.saveNewIntent(newIntent, workflowId, objToCreate); err != nil {
+		return nil, fmt.Errorf("failed to save last intent: %v", err)
+	}
+
+	return objToCreate, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/patchhandler_test.go
@@ -186,3 +186,38 @@ func TestApplyAddsGVK(t *testing.T) {
 		)
 	}
 }
+
+func TestApplyCreatesWithLastApplied(t *testing.T) {
+	if err := utilfeature.DefaultFeatureGate.Set(string(genericfeatures.ServerSideApply) + "=true"); err != nil {
+		t.Fatal(err)
+	}
+	storage := map[string]rest.Storage{}
+	simpleStorage := SimpleRESTStorage{}
+	storage["simple"] = &simpleStorage
+	handler := handle(storage)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client := http.Client{}
+	request, err := http.NewRequest(
+		"PATCH",
+		server.URL+"/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/namespaces/default/simple/id",
+		bytes.NewReader([]byte(`{"metadata":{"name":"id"}, "labels": {"test": "yes"}}`)),
+	)
+	request.Header.Set("Content-Type", "application/apply-patch+yaml")
+	response, err := client.Do(request)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("Unexpected response %#v", response)
+	}
+	expected := `{"apiVersion":"test.group/version","kind":"Simple","labels":{"test":"yes"},"metadata":{"name":"id"}}`
+	if simpleStorage.updated.ObjectMeta.LastApplied["default"] != expected {
+		t.Errorf(
+			`Expected lastApplied field to be %q, got %q`,
+			expected,
+			simpleStorage.updated.ObjectMeta.LastApplied["default"],
+		)
+	}
+}


### PR DESCRIPTION
Save last applied field when apply is used to create an object.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
