### PR TITLE
Mark DisruptedPods in PodDisruptionBudgetStatus as optional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -83134,7 +83134,6 @@
    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus": {
     "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
     "required": [
-     "disruptedPods",
      "disruptionsAllowed",
      "currentHealthy",
      "desiredHealthy",

--- a/pkg/apis/policy/types.go
+++ b/pkg/apis/policy/types.go
@@ -63,6 +63,7 @@ type PodDisruptionBudgetStatus struct {
 	// the list automatically by PodDisruptionBudget controller after some time.
 	// If everything goes smooth this map should be empty for the most of the time.
 	// Large number of entries in the map may indicate problems with pod deletions.
+	// +optional
 	DisruptedPods map[string]metav1.Time
 
 	// Number of pod disruptions that are currently allowed.

--- a/staging/src/k8s.io/api/policy/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1beta1/generated.proto
@@ -151,6 +151,7 @@ message PodDisruptionBudgetStatus {
   // the list automatically by PodDisruptionBudget controller after some time.
   // If everything goes smooth this map should be empty for the most of the time.
   // Large number of entries in the map may indicate problems with pod deletions.
+  // +optional
   map<string, k8s.io.apimachinery.pkg.apis.meta.v1.Time> disruptedPods = 2;
 
   // Number of pod disruptions that are currently allowed.

--- a/staging/src/k8s.io/api/policy/v1beta1/types.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/types.go
@@ -60,6 +60,7 @@ type PodDisruptionBudgetStatus struct {
 	// the list automatically by PodDisruptionBudget controller after some time.
 	// If everything goes smooth this map should be empty for the most of the time.
 	// Large number of entries in the map may indicate problems with pod deletions.
+	// +optional
 	DisruptedPods map[string]metav1.Time `json:"disruptedPods" protobuf:"bytes,2,rep,name=disruptedPods"`
 
 	// Number of pod disruptions that are currently allowed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
API server may return `null` for required field `DisruptedPods` in `policy.v1beta1.PodDisruptionBudgetStatus` ([documented behavior](https://kubernetes.io/docs/tasks/run-application/configure-pdb#check-the-status-of-the-pdb)), which fails client-side validation https://github.com/kubernetes-client/python/issues/466. The property should be optional if it's not required by API server. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Property `DisruptedPods` in `policy.v1beta1.PodDisruptionBudgetStatus` becomes optional instead of required
```

@kubernetes/sig-apps-api-reviews