### PR TITLE
Bump gengo to include uniform pointer deepcopy

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1723,42 +1723,34 @@
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/asn1",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/client",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/client/configpb",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/jsonclient",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/tls",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/x509",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/x509/pkix",
-			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
@@ -2000,7 +1992,6 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
-			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
@@ -2870,7 +2861,6 @@
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",
-			"Comment": "0.0.1",
 			"Rev": "07dd2e8dfe18522e9c447ba95f2fe95262f63bb2"
 		},
 		{
@@ -3312,43 +3302,43 @@
 		},
 		{
 			"ImportPath": "k8s.io/gengo/args",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/deepcopy-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/defaulter-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/import-boss/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/sets",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/generator",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/namer",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/parser",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/types",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/heapster/metrics/api/v1/types",

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
@@ -48,12 +48,8 @@ func (in *AuditPolicyConfiguration) DeepCopyInto(out *AuditPolicyConfiguration) 
 	*out = *in
 	if in.LogMaxAge != nil {
 		in, out := &in.LogMaxAge, &out.LogMaxAge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -85,12 +81,8 @@ func (in *Etcd) DeepCopyInto(out *Etcd) {
 	}
 	if in.SelfHosted != nil {
 		in, out := &in.SelfHosted, &out.SelfHosted
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SelfHostedEtcd)
-			**out = **in
-		}
+		*out = new(SelfHostedEtcd)
+		**out = **in
 	}
 	if in.ServerCertSANs != nil {
 		in, out := &in.ServerCertSANs, &out.ServerCertSANs
@@ -136,12 +128,8 @@ func (in *KubeProxy) DeepCopyInto(out *KubeProxy) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(kubeproxyconfig_v1alpha1.KubeProxyConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(kubeproxyconfig_v1alpha1.KubeProxyConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -161,12 +149,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	*out = *in
 	if in.BaseConfig != nil {
 		in, out := &in.BaseConfig, &out.BaseConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1beta1.KubeletConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1beta1.KubeletConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -197,12 +181,8 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 	}
 	if in.TokenTTL != nil {
 		in, out := &in.TokenTTL, &out.TokenTTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.TokenUsages != nil {
 		in, out := &in.TokenUsages, &out.TokenUsages
@@ -311,12 +291,8 @@ func (in *NodeConfiguration) DeepCopyInto(out *NodeConfiguration) {
 	}
 	if in.DiscoveryTimeout != nil {
 		in, out := &in.DiscoveryTimeout, &out.DiscoveryTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.DiscoveryTokenCACertHashes != nil {
 		in, out := &in.DiscoveryTokenCACertHashes, &out.DiscoveryTokenCACertHashes

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.deepcopy.go
@@ -49,12 +49,8 @@ func (in *AuditPolicyConfiguration) DeepCopyInto(out *AuditPolicyConfiguration) 
 	*out = *in
 	if in.LogMaxAge != nil {
 		in, out := &in.LogMaxAge, &out.LogMaxAge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -74,29 +70,17 @@ func (in *BootstrapToken) DeepCopyInto(out *BootstrapToken) {
 	*out = *in
 	if in.Token != nil {
 		in, out := &in.Token, &out.Token
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(BootstrapTokenString)
-			**out = **in
-		}
+		*out = new(BootstrapTokenString)
+		**out = **in
 	}
 	if in.TTL != nil {
 		in, out := &in.TTL, &out.TTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.Expires != nil {
 		in, out := &in.Expires, &out.Expires
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
@@ -142,21 +126,13 @@ func (in *Etcd) DeepCopyInto(out *Etcd) {
 	*out = *in
 	if in.Local != nil {
 		in, out := &in.Local, &out.Local
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalEtcd)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(LocalEtcd)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalEtcd)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalEtcd)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -213,12 +189,8 @@ func (in *KubeProxy) DeepCopyInto(out *KubeProxy) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1alpha1.KubeProxyConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1alpha1.KubeProxyConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -238,12 +210,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	*out = *in
 	if in.BaseConfig != nil {
 		in, out := &in.BaseConfig, &out.BaseConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1beta1.KubeletConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1beta1.KubeletConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -406,12 +374,8 @@ func (in *NodeConfiguration) DeepCopyInto(out *NodeConfiguration) {
 	}
 	if in.DiscoveryTimeout != nil {
 		in, out := &in.DiscoveryTimeout, &out.DiscoveryTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.DiscoveryTokenCACertHashes != nil {
 		in, out := &in.DiscoveryTokenCACertHashes, &out.DiscoveryTokenCACertHashes

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -49,12 +49,8 @@ func (in *AuditPolicyConfiguration) DeepCopyInto(out *AuditPolicyConfiguration) 
 	*out = *in
 	if in.LogMaxAge != nil {
 		in, out := &in.LogMaxAge, &out.LogMaxAge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -74,29 +70,17 @@ func (in *BootstrapToken) DeepCopyInto(out *BootstrapToken) {
 	*out = *in
 	if in.Token != nil {
 		in, out := &in.Token, &out.Token
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(BootstrapTokenString)
-			**out = **in
-		}
+		*out = new(BootstrapTokenString)
+		**out = **in
 	}
 	if in.TTL != nil {
 		in, out := &in.TTL, &out.TTL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.Expires != nil {
 		in, out := &in.Expires, &out.Expires
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
@@ -142,21 +126,13 @@ func (in *Etcd) DeepCopyInto(out *Etcd) {
 	*out = *in
 	if in.Local != nil {
 		in, out := &in.Local, &out.Local
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalEtcd)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(LocalEtcd)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalEtcd)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalEtcd)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -213,12 +189,8 @@ func (in *KubeProxy) DeepCopyInto(out *KubeProxy) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1alpha1.KubeProxyConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1alpha1.KubeProxyConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -238,12 +210,8 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	*out = *in
 	if in.BaseConfig != nil {
 		in, out := &in.BaseConfig, &out.BaseConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1beta1.KubeletConfiguration)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1beta1.KubeletConfiguration)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -406,12 +374,8 @@ func (in *NodeConfiguration) DeepCopyInto(out *NodeConfiguration) {
 	}
 	if in.DiscoveryTimeout != nil {
 		in, out := &in.DiscoveryTimeout, &out.DiscoveryTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.DiscoveryTokenCACertHashes != nil {
 		in, out := &in.DiscoveryTokenCACertHashes, &out.DiscoveryTokenCACertHashes

--- a/pkg/apis/admission/zz_generated.deepcopy.go
+++ b/pkg/apis/admission/zz_generated.deepcopy.go
@@ -59,12 +59,8 @@ func (in *AdmissionResponse) DeepCopyInto(out *AdmissionResponse) {
 	*out = *in
 	if in.Result != nil {
 		in, out := &in.Result, &out.Result
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Status)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Patch != nil {
 		in, out := &in.Patch, &out.Patch
@@ -73,12 +69,8 @@ func (in *AdmissionResponse) DeepCopyInto(out *AdmissionResponse) {
 	}
 	if in.PatchType != nil {
 		in, out := &in.PatchType, &out.PatchType
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PatchType)
-			**out = **in
-		}
+		*out = new(PatchType)
+		**out = **in
 	}
 	return
 }
@@ -99,21 +91,13 @@ func (in *AdmissionReview) DeepCopyInto(out *AdmissionReview) {
 	out.TypeMeta = in.TypeMeta
 	if in.Request != nil {
 		in, out := &in.Request, &out.Request
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AdmissionRequest)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AdmissionRequest)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Response != nil {
 		in, out := &in.Response, &out.Response
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AdmissionResponse)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AdmissionResponse)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/admissionregistration/zz_generated.deepcopy.go
+++ b/pkg/apis/admissionregistration/zz_generated.deepcopy.go
@@ -238,12 +238,8 @@ func (in *ServiceReference) DeepCopyInto(out *ServiceReference) {
 	*out = *in
 	if in.Path != nil {
 		in, out := &in.Path, &out.Path
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -337,21 +333,13 @@ func (in *Webhook) DeepCopyInto(out *Webhook) {
 	}
 	if in.FailurePolicy != nil {
 		in, out := &in.FailurePolicy, &out.FailurePolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FailurePolicyType)
-			**out = **in
-		}
+		*out = new(FailurePolicyType)
+		**out = **in
 	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -371,21 +359,13 @@ func (in *WebhookClientConfig) DeepCopyInto(out *WebhookClientConfig) {
 	*out = *in
 	if in.URL != nil {
 		in, out := &in.URL, &out.URL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceReference)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ServiceReference)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CABundle != nil {
 		in, out := &in.CABundle, &out.CABundle

--- a/pkg/apis/apps/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/zz_generated.deepcopy.go
@@ -189,12 +189,8 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	if in.VolumeClaimTemplates != nil {
@@ -207,12 +203,8 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -232,21 +224,13 @@ func (in *StatefulSetStatus) DeepCopyInto(out *StatefulSetStatus) {
 	*out = *in
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -273,12 +257,8 @@ func (in *StatefulSetUpdateStrategy) DeepCopyInto(out *StatefulSetUpdateStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateStatefulSetStrategy)
-			**out = **in
-		}
+		*out = new(RollingUpdateStatefulSetStrategy)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/authentication/zz_generated.deepcopy.go
+++ b/pkg/apis/authentication/zz_generated.deepcopy.go
@@ -98,12 +98,8 @@ func (in *TokenRequestSpec) DeepCopyInto(out *TokenRequestSpec) {
 	}
 	if in.BoundObjectRef != nil {
 		in, out := &in.BoundObjectRef, &out.BoundObjectRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(BoundObjectReference)
-			**out = **in
-		}
+		*out = new(BoundObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -208,12 +204,15 @@ func (in *UserInfo) DeepCopyInto(out *UserInfo) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/apis/authorization/zz_generated.deepcopy.go
+++ b/pkg/apis/authorization/zz_generated.deepcopy.go
@@ -199,21 +199,13 @@ func (in *SelfSubjectAccessReviewSpec) DeepCopyInto(out *SelfSubjectAccessReview
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	return
 }
@@ -305,21 +297,13 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	if in.Groups != nil {
 		in, out := &in.Groups, &out.Groups
@@ -330,12 +314,15 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/apis/autoscaling/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/zz_generated.deepcopy.go
@@ -46,30 +46,18 @@ func (in *ExternalMetricSource) DeepCopyInto(out *ExternalMetricSource) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TargetValue != nil {
 		in, out := &in.TargetValue, &out.TargetValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -89,22 +77,14 @@ func (in *ExternalMetricStatus) DeepCopyInto(out *ExternalMetricStatus) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	out.CurrentValue = in.CurrentValue.DeepCopy()
 	if in.CurrentAverageValue != nil {
 		in, out := &in.CurrentAverageValue, &out.CurrentAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -203,12 +183,8 @@ func (in *HorizontalPodAutoscalerSpec) DeepCopyInto(out *HorizontalPodAutoscaler
 	out.ScaleTargetRef = in.ScaleTargetRef
 	if in.MinReplicas != nil {
 		in, out := &in.MinReplicas, &out.MinReplicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
@@ -235,20 +211,12 @@ func (in *HorizontalPodAutoscalerStatus) DeepCopyInto(out *HorizontalPodAutoscal
 	*out = *in
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.LastScaleTime != nil {
 		in, out := &in.LastScaleTime, &out.LastScaleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.CurrentMetrics != nil {
 		in, out := &in.CurrentMetrics, &out.CurrentMetrics
@@ -282,39 +250,23 @@ func (in *MetricSpec) DeepCopyInto(out *MetricSpec) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -334,39 +286,23 @@ func (in *MetricStatus) DeepCopyInto(out *MetricStatus) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -456,21 +392,13 @@ func (in *ResourceMetricSource) DeepCopyInto(out *ResourceMetricSource) {
 	*out = *in
 	if in.TargetAverageUtilization != nil {
 		in, out := &in.TargetAverageUtilization, &out.TargetAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -490,12 +418,8 @@ func (in *ResourceMetricStatus) DeepCopyInto(out *ResourceMetricStatus) {
 	*out = *in
 	if in.CurrentAverageUtilization != nil {
 		in, out := &in.CurrentAverageUtilization, &out.CurrentAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.CurrentAverageValue = in.CurrentAverageValue.DeepCopy()
 	return

--- a/pkg/apis/batch/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/zz_generated.deepcopy.go
@@ -92,40 +92,24 @@ func (in *CronJobSpec) DeepCopyInto(out *CronJobSpec) {
 	*out = *in
 	if in.StartingDeadlineSeconds != nil {
 		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Suspend != nil {
 		in, out := &in.Suspend, &out.Suspend
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	in.JobTemplate.DeepCopyInto(&out.JobTemplate)
 	if in.SuccessfulJobsHistoryLimit != nil {
 		in, out := &in.SuccessfulJobsHistoryLimit, &out.SuccessfulJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FailedJobsHistoryLimit != nil {
 		in, out := &in.FailedJobsHistoryLimit, &out.FailedJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -150,11 +134,7 @@ func (in *CronJobStatus) DeepCopyInto(out *CronJobStatus) {
 	}
 	if in.LastScheduleTime != nil {
 		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -253,57 +233,33 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 	*out = *in
 	if in.Parallelism != nil {
 		in, out := &in.Parallelism, &out.Parallelism
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Completions != nil {
 		in, out := &in.Completions, &out.Completions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ManualSelector != nil {
 		in, out := &in.ManualSelector, &out.ManualSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
@@ -331,19 +287,11 @@ func (in *JobStatus) DeepCopyInto(out *JobStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.CompletionTime != nil {
 		in, out := &in.CompletionTime, &out.CompletionTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/pkg/apis/certificates/zz_generated.deepcopy.go
+++ b/pkg/apis/certificates/zz_generated.deepcopy.go
@@ -124,12 +124,15 @@ func (in *CertificateSigningRequestSpec) DeepCopyInto(out *CertificateSigningReq
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -207,12 +207,8 @@ func (in *GarbageCollectorControllerConfiguration) DeepCopyInto(out *GarbageColl
 	*out = *in
 	if in.EnableGarbageCollector != nil {
 		in, out := &in.EnableGarbageCollector, &out.EnableGarbageCollector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.GCIgnoredResources != nil {
 		in, out := &in.GCIgnoredResources, &out.GCIgnoredResources
@@ -275,12 +271,8 @@ func (in *HPAControllerConfiguration) DeepCopyInto(out *HPAControllerConfigurati
 	out.HorizontalPodAutoscalerDownscaleForbiddenWindow = in.HorizontalPodAutoscalerDownscaleForbiddenWindow
 	if in.HorizontalPodAutoscalerUseRESTClients != nil {
 		in, out := &in.HorizontalPodAutoscalerUseRESTClients, &out.HorizontalPodAutoscalerUseRESTClients
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -318,12 +310,8 @@ func (in *KubeCloudSharedConfiguration) DeepCopyInto(out *KubeCloudSharedConfigu
 	out.NodeMonitorPeriod = in.NodeMonitorPeriod
 	if in.ConfigureCloudRoutes != nil {
 		in, out := &in.ConfigureCloudRoutes, &out.ConfigureCloudRoutes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.NodeSyncPeriod = in.NodeSyncPeriod
 	return
@@ -442,12 +430,8 @@ func (in *LeaderElectionConfiguration) DeepCopyInto(out *LeaderElectionConfigura
 	*out = *in
 	if in.LeaderElect != nil {
 		in, out := &in.LeaderElect, &out.LeaderElect
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.LeaseDuration = in.LeaseDuration
 	out.RenewDeadline = in.RenewDeadline
@@ -503,12 +487,8 @@ func (in *NodeLifecycleControllerConfiguration) DeepCopyInto(out *NodeLifecycleC
 	*out = *in
 	if in.EnableTaintManager != nil {
 		in, out := &in.EnableTaintManager, &out.EnableTaintManager
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.NodeStartupGracePeriod = in.NodeStartupGracePeriod
 	out.NodeMonitorGracePeriod = in.NodeMonitorGracePeriod
@@ -646,21 +626,13 @@ func (in *SchedulerAlgorithmSource) DeepCopyInto(out *SchedulerAlgorithmSource) 
 	*out = *in
 	if in.Policy != nil {
 		in, out := &in.Policy, &out.Policy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicySource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SchedulerPolicySource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Provider != nil {
 		in, out := &in.Provider, &out.Provider
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -712,21 +684,13 @@ func (in *SchedulerPolicySource) DeepCopyInto(out *SchedulerPolicySource) {
 	*out = *in
 	if in.File != nil {
 		in, out := &in.File, &out.File
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicyFileSource)
-			**out = **in
-		}
+		*out = new(SchedulerPolicyFileSource)
+		**out = **in
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicyConfigMapSource)
-			**out = **in
-		}
+		*out = new(SchedulerPolicyConfigMapSource)
+		**out = **in
 	}
 	return
 }
@@ -762,21 +726,13 @@ func (in *VolumeConfiguration) DeepCopyInto(out *VolumeConfiguration) {
 	*out = *in
 	if in.EnableHostPathProvisioning != nil {
 		in, out := &in.EnableHostPathProvisioning, &out.EnableHostPathProvisioning
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.EnableDynamicProvisioning != nil {
 		in, out := &in.EnableDynamicProvisioning, &out.EnableDynamicProvisioning
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.PersistentVolumeRecyclerConfiguration = in.PersistentVolumeRecyclerConfiguration
 	return

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -282,12 +282,8 @@ func (in *IPPortVar) DeepCopyInto(out *IPPortVar) {
 	*out = *in
 	if in.Val != nil {
 		in, out := &in.Val, &out.Val
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -307,12 +303,8 @@ func (in *IPVar) DeepCopyInto(out *IPVar) {
 	*out = *in
 	if in.Val != nil {
 		in, out := &in.Val, &out.Val
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -586,12 +578,8 @@ func (in *PortRangeVar) DeepCopyInto(out *PortRangeVar) {
 	*out = *in
 	if in.Val != nil {
 		in, out := &in.Val, &out.Val
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -676,21 +664,13 @@ func (in *SchedulerAlgorithmSource) DeepCopyInto(out *SchedulerAlgorithmSource) 
 	*out = *in
 	if in.Policy != nil {
 		in, out := &in.Policy, &out.Policy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicySource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SchedulerPolicySource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Provider != nil {
 		in, out := &in.Provider, &out.Provider
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -742,21 +722,13 @@ func (in *SchedulerPolicySource) DeepCopyInto(out *SchedulerPolicySource) {
 	*out = *in
 	if in.File != nil {
 		in, out := &in.File, &out.File
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicyFileSource)
-			**out = **in
-		}
+		*out = new(SchedulerPolicyFileSource)
+		**out = **in
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SchedulerPolicyConfigMapSource)
-			**out = **in
-		}
+		*out = new(SchedulerPolicyConfigMapSource)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -47,30 +47,18 @@ func (in *Affinity) DeepCopyInto(out *Affinity) {
 	*out = *in
 	if in.NodeAffinity != nil {
 		in, out := &in.NodeAffinity, &out.NodeAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PodAffinity != nil {
 		in, out := &in.PodAffinity, &out.PodAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PodAntiAffinity != nil {
 		in, out := &in.PodAntiAffinity, &out.PodAntiAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodAntiAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodAntiAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -129,39 +117,23 @@ func (in *AzureDiskVolumeSource) DeepCopyInto(out *AzureDiskVolumeSource) {
 	*out = *in
 	if in.CachingMode != nil {
 		in, out := &in.CachingMode, &out.CachingMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDataDiskCachingMode)
-			**out = **in
-		}
+		*out = new(AzureDataDiskCachingMode)
+		**out = **in
 	}
 	if in.FSType != nil {
 		in, out := &in.FSType, &out.FSType
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.ReadOnly != nil {
 		in, out := &in.ReadOnly, &out.ReadOnly
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDataDiskKind)
-			**out = **in
-		}
+		*out = new(AzureDataDiskKind)
+		**out = **in
 	}
 	return
 }
@@ -181,12 +153,8 @@ func (in *AzureFilePersistentVolumeSource) DeepCopyInto(out *AzureFilePersistent
 	*out = *in
 	if in.SecretNamespace != nil {
 		in, out := &in.SecretNamespace, &out.SecretNamespace
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -256,30 +224,18 @@ func (in *CSIPersistentVolumeSource) DeepCopyInto(out *CSIPersistentVolumeSource
 	}
 	if in.ControllerPublishSecretRef != nil {
 		in, out := &in.ControllerPublishSecretRef, &out.ControllerPublishSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.NodeStageSecretRef != nil {
 		in, out := &in.NodeStageSecretRef, &out.NodeStageSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.NodePublishSecretRef != nil {
 		in, out := &in.NodePublishSecretRef, &out.NodePublishSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -330,12 +286,8 @@ func (in *CephFSPersistentVolumeSource) DeepCopyInto(out *CephFSPersistentVolume
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -360,12 +312,8 @@ func (in *CephFSVolumeSource) DeepCopyInto(out *CephFSVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -385,12 +333,8 @@ func (in *CinderPersistentVolumeSource) DeepCopyInto(out *CinderPersistentVolume
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -410,12 +354,8 @@ func (in *CinderVolumeSource) DeepCopyInto(out *CinderVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -435,12 +375,8 @@ func (in *ClientIPConfig) DeepCopyInto(out *ClientIPConfig) {
 	*out = *in
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -551,12 +487,15 @@ func (in *ConfigMap) DeepCopyInto(out *ConfigMap) {
 		in, out := &in.BinaryData, &out.BinaryData
 		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
+			var outVal []byte
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]byte, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -586,12 +525,8 @@ func (in *ConfigMapEnvSource) DeepCopyInto(out *ConfigMapEnvSource) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -612,12 +547,8 @@ func (in *ConfigMapKeySelector) DeepCopyInto(out *ConfigMapKeySelector) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -694,12 +625,8 @@ func (in *ConfigMapProjection) DeepCopyInto(out *ConfigMapProjection) {
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -727,21 +654,13 @@ func (in *ConfigMapVolumeSource) DeepCopyInto(out *ConfigMapVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -803,39 +722,23 @@ func (in *Container) DeepCopyInto(out *Container) {
 	}
 	if in.LivenessProbe != nil {
 		in, out := &in.LivenessProbe, &out.LivenessProbe
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Probe)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Probe)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ReadinessProbe != nil {
 		in, out := &in.ReadinessProbe, &out.ReadinessProbe
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Probe)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Probe)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Lifecycle)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Lifecycle)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecurityContext)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -892,30 +795,18 @@ func (in *ContainerState) DeepCopyInto(out *ContainerState) {
 	*out = *in
 	if in.Waiting != nil {
 		in, out := &in.Waiting, &out.Waiting
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateWaiting)
-			**out = **in
-		}
+		*out = new(ContainerStateWaiting)
+		**out = **in
 	}
 	if in.Running != nil {
 		in, out := &in.Running, &out.Running
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateRunning)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ContainerStateRunning)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Terminated != nil {
 		in, out := &in.Terminated, &out.Terminated
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateTerminated)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ContainerStateTerminated)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1043,30 +934,18 @@ func (in *DownwardAPIVolumeFile) DeepCopyInto(out *DownwardAPIVolumeFile) {
 	*out = *in
 	if in.FieldRef != nil {
 		in, out := &in.FieldRef, &out.FieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectFieldSelector)
-			**out = **in
-		}
+		*out = new(ObjectFieldSelector)
+		**out = **in
 	}
 	if in.ResourceFieldRef != nil {
 		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceFieldSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceFieldSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1093,12 +972,8 @@ func (in *DownwardAPIVolumeSource) DeepCopyInto(out *DownwardAPIVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1118,12 +993,8 @@ func (in *EmptyDirVolumeSource) DeepCopyInto(out *EmptyDirVolumeSource) {
 	*out = *in
 	if in.SizeLimit != nil {
 		in, out := &in.SizeLimit, &out.SizeLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -1143,21 +1014,13 @@ func (in *EndpointAddress) DeepCopyInto(out *EndpointAddress) {
 	*out = *in
 	if in.NodeName != nil {
 		in, out := &in.NodeName, &out.NodeName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.TargetRef != nil {
 		in, out := &in.TargetRef, &out.TargetRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -1294,21 +1157,13 @@ func (in *EnvFromSource) DeepCopyInto(out *EnvFromSource) {
 	*out = *in
 	if in.ConfigMapRef != nil {
 		in, out := &in.ConfigMapRef, &out.ConfigMapRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapEnvSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapEnvSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretEnvSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretEnvSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1328,12 +1183,8 @@ func (in *EnvVar) DeepCopyInto(out *EnvVar) {
 	*out = *in
 	if in.ValueFrom != nil {
 		in, out := &in.ValueFrom, &out.ValueFrom
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EnvVarSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EnvVarSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1353,39 +1204,23 @@ func (in *EnvVarSource) DeepCopyInto(out *EnvVarSource) {
 	*out = *in
 	if in.FieldRef != nil {
 		in, out := &in.FieldRef, &out.FieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectFieldSelector)
-			**out = **in
-		}
+		*out = new(ObjectFieldSelector)
+		**out = **in
 	}
 	if in.ResourceFieldRef != nil {
 		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceFieldSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceFieldSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ConfigMapKeyRef != nil {
 		in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapKeySelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecretKeyRef != nil {
 		in, out := &in.SecretKeyRef, &out.SecretKeyRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretKeySelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1412,21 +1247,13 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.EventTime.DeepCopyInto(&out.EventTime)
 	if in.Series != nil {
 		in, out := &in.Series, &out.Series
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EventSeries)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EventSeries)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Related != nil {
 		in, out := &in.Related, &out.Related
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -1546,12 +1373,8 @@ func (in *FCVolumeSource) DeepCopyInto(out *FCVolumeSource) {
 	}
 	if in.Lun != nil {
 		in, out := &in.Lun, &out.Lun
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.WWIDs != nil {
 		in, out := &in.WWIDs, &out.WWIDs
@@ -1576,12 +1399,8 @@ func (in *FlexPersistentVolumeSource) DeepCopyInto(out *FlexPersistentVolumeSour
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
@@ -1608,12 +1427,8 @@ func (in *FlexVolumeSource) DeepCopyInto(out *FlexVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
@@ -1742,30 +1557,18 @@ func (in *Handler) DeepCopyInto(out *Handler) {
 	*out = *in
 	if in.Exec != nil {
 		in, out := &in.Exec, &out.Exec
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecAction)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecAction)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.HTTPGet != nil {
 		in, out := &in.HTTPGet, &out.HTTPGet
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HTTPGetAction)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HTTPGetAction)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TCPSocket != nil {
 		in, out := &in.TCPSocket, &out.TCPSocket
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(TCPSocketAction)
-			**out = **in
-		}
+		*out = new(TCPSocketAction)
+		**out = **in
 	}
 	return
 }
@@ -1806,12 +1609,8 @@ func (in *HostPathVolumeSource) DeepCopyInto(out *HostPathVolumeSource) {
 	*out = *in
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathType)
-			**out = **in
-		}
+		*out = new(HostPathType)
+		**out = **in
 	}
 	return
 }
@@ -1836,21 +1635,13 @@ func (in *ISCSIPersistentVolumeSource) DeepCopyInto(out *ISCSIPersistentVolumeSo
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.InitiatorName != nil {
 		in, out := &in.InitiatorName, &out.InitiatorName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1875,21 +1666,13 @@ func (in *ISCSIVolumeSource) DeepCopyInto(out *ISCSIVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	if in.InitiatorName != nil {
 		in, out := &in.InitiatorName, &out.InitiatorName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1909,12 +1692,8 @@ func (in *KeyToPath) DeepCopyInto(out *KeyToPath) {
 	*out = *in
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1934,21 +1713,13 @@ func (in *Lifecycle) DeepCopyInto(out *Lifecycle) {
 	*out = *in
 	if in.PostStart != nil {
 		in, out := &in.PostStart, &out.PostStart
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Handler)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Handler)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PreStop != nil {
 		in, out := &in.PreStop, &out.PreStop
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Handler)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Handler)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2366,12 +2137,8 @@ func (in *NodeAffinity) DeepCopyInto(out *NodeAffinity) {
 	*out = *in
 	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -2416,12 +2183,8 @@ func (in *NodeConfigSource) DeepCopyInto(out *NodeConfigSource) {
 	*out = *in
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapNodeConfigSource)
-			**out = **in
-		}
+		*out = new(ConfigMapNodeConfigSource)
+		**out = **in
 	}
 	return
 }
@@ -2441,30 +2204,18 @@ func (in *NodeConfigStatus) DeepCopyInto(out *NodeConfigStatus) {
 	*out = *in
 	if in.Assigned != nil {
 		in, out := &in.Assigned, &out.Assigned
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Active != nil {
 		in, out := &in.Active, &out.Active
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LastKnownGood != nil {
 		in, out := &in.LastKnownGood, &out.LastKnownGood
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2663,12 +2414,8 @@ func (in *NodeSpec) DeepCopyInto(out *NodeSpec) {
 	}
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2733,12 +2480,8 @@ func (in *NodeStatus) DeepCopyInto(out *NodeStatus) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2926,31 +2669,19 @@ func (in *PersistentVolumeClaimSpec) DeepCopyInto(out *PersistentVolumeClaimSpec
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.StorageClassName != nil {
 		in, out := &in.StorageClassName, &out.StorageClassName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.VolumeMode != nil {
 		in, out := &in.VolumeMode, &out.VolumeMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeMode)
-			**out = **in
-		}
+		*out = new(PersistentVolumeMode)
+		**out = **in
 	}
 	return
 }
@@ -3054,201 +2785,113 @@ func (in *PersistentVolumeSource) DeepCopyInto(out *PersistentVolumeSource) {
 	*out = *in
 	if in.GCEPersistentDisk != nil {
 		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GCEPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(GCEPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.AWSElasticBlockStore != nil {
 		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AWSElasticBlockStoreVolumeSource)
-			**out = **in
-		}
+		*out = new(AWSElasticBlockStoreVolumeSource)
+		**out = **in
 	}
 	if in.HostPath != nil {
 		in, out := &in.HostPath, &out.HostPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HostPathVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Glusterfs != nil {
 		in, out := &in.Glusterfs, &out.Glusterfs
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GlusterfsVolumeSource)
-			**out = **in
-		}
+		*out = new(GlusterfsVolumeSource)
+		**out = **in
 	}
 	if in.NFS != nil {
 		in, out := &in.NFS, &out.NFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NFSVolumeSource)
-			**out = **in
-		}
+		*out = new(NFSVolumeSource)
+		**out = **in
 	}
 	if in.RBD != nil {
 		in, out := &in.RBD, &out.RBD
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RBDPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RBDPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Quobyte != nil {
 		in, out := &in.Quobyte, &out.Quobyte
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(QuobyteVolumeSource)
-			**out = **in
-		}
+		*out = new(QuobyteVolumeSource)
+		**out = **in
 	}
 	if in.ISCSI != nil {
 		in, out := &in.ISCSI, &out.ISCSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ISCSIPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ISCSIPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FlexVolume != nil {
 		in, out := &in.FlexVolume, &out.FlexVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlexPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FlexPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Cinder != nil {
 		in, out := &in.Cinder, &out.Cinder
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CinderPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CinderPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CephFS != nil {
 		in, out := &in.CephFS, &out.CephFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CephFSPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CephFSPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FC != nil {
 		in, out := &in.FC, &out.FC
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FCVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FCVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Flocker != nil {
 		in, out := &in.Flocker, &out.Flocker
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlockerVolumeSource)
-			**out = **in
-		}
+		*out = new(FlockerVolumeSource)
+		**out = **in
 	}
 	if in.AzureFile != nil {
 		in, out := &in.AzureFile, &out.AzureFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureFilePersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureFilePersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.VsphereVolume != nil {
 		in, out := &in.VsphereVolume, &out.VsphereVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VsphereVirtualDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(VsphereVirtualDiskVolumeSource)
+		**out = **in
 	}
 	if in.AzureDisk != nil {
 		in, out := &in.AzureDisk, &out.AzureDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDiskVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureDiskVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PhotonPersistentDisk != nil {
 		in, out := &in.PhotonPersistentDisk, &out.PhotonPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PhotonPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(PhotonPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.PortworxVolume != nil {
 		in, out := &in.PortworxVolume, &out.PortworxVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PortworxVolumeSource)
-			**out = **in
-		}
+		*out = new(PortworxVolumeSource)
+		**out = **in
 	}
 	if in.ScaleIO != nil {
 		in, out := &in.ScaleIO, &out.ScaleIO
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScaleIOPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScaleIOPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Local != nil {
 		in, out := &in.Local, &out.Local
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalVolumeSource)
-			**out = **in
-		}
+		*out = new(LocalVolumeSource)
+		**out = **in
 	}
 	if in.StorageOS != nil {
 		in, out := &in.StorageOS, &out.StorageOS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(StorageOSPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(StorageOSPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CSI != nil {
 		in, out := &in.CSI, &out.CSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CSIPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CSIPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3281,12 +2924,8 @@ func (in *PersistentVolumeSpec) DeepCopyInto(out *PersistentVolumeSpec) {
 	}
 	if in.ClaimRef != nil {
 		in, out := &in.ClaimRef, &out.ClaimRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	if in.MountOptions != nil {
 		in, out := &in.MountOptions, &out.MountOptions
@@ -3295,21 +2934,13 @@ func (in *PersistentVolumeSpec) DeepCopyInto(out *PersistentVolumeSpec) {
 	}
 	if in.VolumeMode != nil {
 		in, out := &in.VolumeMode, &out.VolumeMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeMode)
-			**out = **in
-		}
+		*out = new(PersistentVolumeMode)
+		**out = **in
 	}
 	if in.NodeAffinity != nil {
 		in, out := &in.NodeAffinity, &out.NodeAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeNodeAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeNodeAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3419,12 +3050,8 @@ func (in *PodAffinityTerm) DeepCopyInto(out *PodAffinityTerm) {
 	*out = *in
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Namespaces != nil {
 		in, out := &in.Namespaces, &out.Namespaces
@@ -3555,12 +3182,8 @@ func (in *PodDNSConfigOption) DeepCopyInto(out *PodDNSConfigOption) {
 	*out = *in
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -3644,38 +3267,22 @@ func (in *PodLogOptions) DeepCopyInto(out *PodLogOptions) {
 	out.TypeMeta = in.TypeMeta
 	if in.SinceSeconds != nil {
 		in, out := &in.SinceSeconds, &out.SinceSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.SinceTime != nil {
 		in, out := &in.SinceTime, &out.SinceTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.TailLines != nil {
 		in, out := &in.TailLines, &out.TailLines
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.LimitBytes != nil {
 		in, out := &in.LimitBytes, &out.LimitBytes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -3774,48 +3381,28 @@ func (in *PodSecurityContext) DeepCopyInto(out *PodSecurityContext) {
 	*out = *in
 	if in.ShareProcessNamespace != nil {
 		in, out := &in.ShareProcessNamespace, &out.ShareProcessNamespace
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SELinuxOptions)
-			**out = **in
-		}
+		*out = new(SELinuxOptions)
+		**out = **in
 	}
 	if in.RunAsUser != nil {
 		in, out := &in.RunAsUser, &out.RunAsUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsGroup != nil {
 		in, out := &in.RunAsGroup, &out.RunAsGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsNonRoot != nil {
 		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SupplementalGroups != nil {
 		in, out := &in.SupplementalGroups, &out.SupplementalGroups
@@ -3824,12 +3411,8 @@ func (in *PodSecurityContext) DeepCopyInto(out *PodSecurityContext) {
 	}
 	if in.FSGroup != nil {
 		in, out := &in.FSGroup, &out.FSGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Sysctls != nil {
 		in, out := &in.Sysctls, &out.Sysctls
@@ -3854,12 +3437,8 @@ func (in *PodSignature) DeepCopyInto(out *PodSignature) {
 	*out = *in
 	if in.PodController != nil {
 		in, out := &in.PodController, &out.PodController
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.OwnerReference)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.OwnerReference)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3900,21 +3479,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -3925,21 +3496,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.AutomountServiceAccountToken != nil {
 		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodSecurityContext)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodSecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
@@ -3948,12 +3511,8 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Affinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Affinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
@@ -3971,21 +3530,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.DNSConfig != nil {
 		in, out := &in.DNSConfig, &out.DNSConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodDNSConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodDNSConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ReadinessGates != nil {
 		in, out := &in.ReadinessGates, &out.ReadinessGates
@@ -4017,11 +3568,7 @@ func (in *PodStatus) DeepCopyInto(out *PodStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
@@ -4176,12 +3723,8 @@ func (in *Preconditions) DeepCopyInto(out *Preconditions) {
 	*out = *in
 	if in.UID != nil {
 		in, out := &in.UID, &out.UID
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(types.UID)
-			**out = **in
-		}
+		*out = new(types.UID)
+		**out = **in
 	}
 	return
 }
@@ -4260,12 +3803,8 @@ func (in *ProjectedVolumeSource) DeepCopyInto(out *ProjectedVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -4306,12 +3845,8 @@ func (in *RBDPersistentVolumeSource) DeepCopyInto(out *RBDPersistentVolumeSource
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -4336,12 +3871,8 @@ func (in *RBDVolumeSource) DeepCopyInto(out *RBDVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -4477,12 +4008,8 @@ func (in *ReplicationControllerSpec) DeepCopyInto(out *ReplicationControllerSpec
 	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodTemplateSpec)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -4637,12 +4164,8 @@ func (in *ResourceQuotaSpec) DeepCopyInto(out *ResourceQuotaSpec) {
 	}
 	if in.ScopeSelector != nil {
 		in, out := &in.ScopeSelector, &out.ScopeSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScopeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScopeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -4738,12 +4261,8 @@ func (in *ScaleIOPersistentVolumeSource) DeepCopyInto(out *ScaleIOPersistentVolu
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -4763,12 +4282,8 @@ func (in *ScaleIOVolumeSource) DeepCopyInto(out *ScaleIOVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -4836,12 +4351,15 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 		in, out := &in.Data, &out.Data
 		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
+			var outVal []byte
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]byte, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -4871,12 +4389,8 @@ func (in *SecretEnvSource) DeepCopyInto(out *SecretEnvSource) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -4897,12 +4411,8 @@ func (in *SecretKeySelector) DeepCopyInto(out *SecretKeySelector) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -4963,12 +4473,8 @@ func (in *SecretProjection) DeepCopyInto(out *SecretProjection) {
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5011,21 +4517,13 @@ func (in *SecretVolumeSource) DeepCopyInto(out *SecretVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5045,75 +4543,43 @@ func (in *SecurityContext) DeepCopyInto(out *SecurityContext) {
 	*out = *in
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Capabilities)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Capabilities)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Privileged != nil {
 		in, out := &in.Privileged, &out.Privileged
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SELinuxOptions)
-			**out = **in
-		}
+		*out = new(SELinuxOptions)
+		**out = **in
 	}
 	if in.RunAsUser != nil {
 		in, out := &in.RunAsUser, &out.RunAsUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsGroup != nil {
 		in, out := &in.RunAsGroup, &out.RunAsGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsNonRoot != nil {
 		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.ReadOnlyRootFilesystem != nil {
 		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowPrivilegeEscalation != nil {
 		in, out := &in.AllowPrivilegeEscalation, &out.AllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5199,12 +4665,8 @@ func (in *ServiceAccount) DeepCopyInto(out *ServiceAccount) {
 	}
 	if in.AutomountServiceAccountToken != nil {
 		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5373,12 +4835,8 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 	}
 	if in.SessionAffinityConfig != nil {
 		in, out := &in.SessionAffinityConfig, &out.SessionAffinityConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SessionAffinityConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SessionAffinityConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LoadBalancerSourceRanges != nil {
 		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
@@ -5420,12 +4878,8 @@ func (in *SessionAffinityConfig) DeepCopyInto(out *SessionAffinityConfig) {
 	*out = *in
 	if in.ClientIP != nil {
 		in, out := &in.ClientIP, &out.ClientIP
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClientIPConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ClientIPConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5445,12 +4899,8 @@ func (in *StorageOSPersistentVolumeSource) DeepCopyInto(out *StorageOSPersistent
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -5470,12 +4920,8 @@ func (in *StorageOSVolumeSource) DeepCopyInto(out *StorageOSVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -5528,11 +4974,7 @@ func (in *Taint) DeepCopyInto(out *Taint) {
 	*out = *in
 	if in.TimeAdded != nil {
 		in, out := &in.TimeAdded, &out.TimeAdded
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -5552,12 +4994,8 @@ func (in *Toleration) DeepCopyInto(out *Toleration) {
 	*out = *in
 	if in.TolerationSeconds != nil {
 		in, out := &in.TolerationSeconds, &out.TolerationSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -5654,12 +5092,8 @@ func (in *VolumeMount) DeepCopyInto(out *VolumeMount) {
 	*out = *in
 	if in.MountPropagation != nil {
 		in, out := &in.MountPropagation, &out.MountPropagation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(MountPropagationMode)
-			**out = **in
-		}
+		*out = new(MountPropagationMode)
+		**out = **in
 	}
 	return
 }
@@ -5679,12 +5113,8 @@ func (in *VolumeNodeAffinity) DeepCopyInto(out *VolumeNodeAffinity) {
 	*out = *in
 	if in.Required != nil {
 		in, out := &in.Required, &out.Required
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5704,39 +5134,23 @@ func (in *VolumeProjection) DeepCopyInto(out *VolumeProjection) {
 	*out = *in
 	if in.Secret != nil {
 		in, out := &in.Secret, &out.Secret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DownwardAPI != nil {
 		in, out := &in.DownwardAPI, &out.DownwardAPI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(DownwardAPIProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(DownwardAPIProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ServiceAccountToken != nil {
 		in, out := &in.ServiceAccountToken, &out.ServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAccountTokenProjection)
-			**out = **in
-		}
+		*out = new(ServiceAccountTokenProjection)
+		**out = **in
 	}
 	return
 }
@@ -5756,246 +5170,138 @@ func (in *VolumeSource) DeepCopyInto(out *VolumeSource) {
 	*out = *in
 	if in.HostPath != nil {
 		in, out := &in.HostPath, &out.HostPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HostPathVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EmptyDir != nil {
 		in, out := &in.EmptyDir, &out.EmptyDir
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EmptyDirVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EmptyDirVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.GCEPersistentDisk != nil {
 		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GCEPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(GCEPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.AWSElasticBlockStore != nil {
 		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AWSElasticBlockStoreVolumeSource)
-			**out = **in
-		}
+		*out = new(AWSElasticBlockStoreVolumeSource)
+		**out = **in
 	}
 	if in.GitRepo != nil {
 		in, out := &in.GitRepo, &out.GitRepo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GitRepoVolumeSource)
-			**out = **in
-		}
+		*out = new(GitRepoVolumeSource)
+		**out = **in
 	}
 	if in.Secret != nil {
 		in, out := &in.Secret, &out.Secret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NFS != nil {
 		in, out := &in.NFS, &out.NFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NFSVolumeSource)
-			**out = **in
-		}
+		*out = new(NFSVolumeSource)
+		**out = **in
 	}
 	if in.ISCSI != nil {
 		in, out := &in.ISCSI, &out.ISCSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ISCSIVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ISCSIVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Glusterfs != nil {
 		in, out := &in.Glusterfs, &out.Glusterfs
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GlusterfsVolumeSource)
-			**out = **in
-		}
+		*out = new(GlusterfsVolumeSource)
+		**out = **in
 	}
 	if in.PersistentVolumeClaim != nil {
 		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeClaimVolumeSource)
-			**out = **in
-		}
+		*out = new(PersistentVolumeClaimVolumeSource)
+		**out = **in
 	}
 	if in.RBD != nil {
 		in, out := &in.RBD, &out.RBD
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RBDVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RBDVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Quobyte != nil {
 		in, out := &in.Quobyte, &out.Quobyte
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(QuobyteVolumeSource)
-			**out = **in
-		}
+		*out = new(QuobyteVolumeSource)
+		**out = **in
 	}
 	if in.FlexVolume != nil {
 		in, out := &in.FlexVolume, &out.FlexVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlexVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FlexVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Cinder != nil {
 		in, out := &in.Cinder, &out.Cinder
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CinderVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CinderVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CephFS != nil {
 		in, out := &in.CephFS, &out.CephFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CephFSVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CephFSVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Flocker != nil {
 		in, out := &in.Flocker, &out.Flocker
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlockerVolumeSource)
-			**out = **in
-		}
+		*out = new(FlockerVolumeSource)
+		**out = **in
 	}
 	if in.DownwardAPI != nil {
 		in, out := &in.DownwardAPI, &out.DownwardAPI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(DownwardAPIVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(DownwardAPIVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FC != nil {
 		in, out := &in.FC, &out.FC
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FCVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FCVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AzureFile != nil {
 		in, out := &in.AzureFile, &out.AzureFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureFileVolumeSource)
-			**out = **in
-		}
+		*out = new(AzureFileVolumeSource)
+		**out = **in
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.VsphereVolume != nil {
 		in, out := &in.VsphereVolume, &out.VsphereVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VsphereVirtualDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(VsphereVirtualDiskVolumeSource)
+		**out = **in
 	}
 	if in.AzureDisk != nil {
 		in, out := &in.AzureDisk, &out.AzureDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDiskVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureDiskVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PhotonPersistentDisk != nil {
 		in, out := &in.PhotonPersistentDisk, &out.PhotonPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PhotonPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(PhotonPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.Projected != nil {
 		in, out := &in.Projected, &out.Projected
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ProjectedVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ProjectedVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PortworxVolume != nil {
 		in, out := &in.PortworxVolume, &out.PortworxVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PortworxVolumeSource)
-			**out = **in
-		}
+		*out = new(PortworxVolumeSource)
+		**out = **in
 	}
 	if in.ScaleIO != nil {
 		in, out := &in.ScaleIO, &out.ScaleIO
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScaleIOVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScaleIOVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StorageOS != nil {
 		in, out := &in.StorageOS, &out.StorageOS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(StorageOSVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(StorageOSVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/extensions/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/zz_generated.deepcopy.go
@@ -188,23 +188,15 @@ func (in *DaemonSetSpec) DeepCopyInto(out *DaemonSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -224,12 +216,8 @@ func (in *DaemonSetStatus) DeepCopyInto(out *DaemonSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -256,12 +244,8 @@ func (in *DaemonSetUpdateStrategy) DeepCopyInto(out *DaemonSetUpdateStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDaemonSet)
-			**out = **in
-		}
+		*out = new(RollingUpdateDaemonSet)
+		**out = **in
 	}
 	return
 }
@@ -393,41 +377,25 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.RollbackTo != nil {
 		in, out := &in.RollbackTo, &out.RollbackTo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollbackConfig)
-			**out = **in
-		}
+		*out = new(RollbackConfig)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -454,12 +422,8 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -479,12 +443,8 @@ func (in *DeploymentStrategy) DeepCopyInto(out *DeploymentStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDeployment)
-			**out = **in
-		}
+		*out = new(RollingUpdateDeployment)
+		**out = **in
 	}
 	return
 }
@@ -637,12 +597,8 @@ func (in *IngressRuleValue) DeepCopyInto(out *IngressRuleValue) {
 	*out = *in
 	if in.HTTP != nil {
 		in, out := &in.HTTP, &out.HTTP
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HTTPIngressRuleValue)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HTTPIngressRuleValue)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -662,12 +618,8 @@ func (in *IngressSpec) DeepCopyInto(out *IngressSpec) {
 	*out = *in
 	if in.Backend != nil {
 		in, out := &in.Backend, &out.Backend
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(IngressBackend)
-			**out = **in
-		}
+		*out = new(IngressBackend)
+		**out = **in
 	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
@@ -817,12 +769,8 @@ func (in *ReplicaSetSpec) DeepCopyInto(out *ReplicaSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return

--- a/pkg/apis/networking/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/zz_generated.deepcopy.go
@@ -173,30 +173,18 @@ func (in *NetworkPolicyPeer) DeepCopyInto(out *NetworkPolicyPeer) {
 	*out = *in
 	if in.PodSelector != nil {
 		in, out := &in.PodSelector, &out.PodSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.IPBlock != nil {
 		in, out := &in.IPBlock, &out.IPBlock
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(IPBlock)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(IPBlock)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -216,21 +204,13 @@ func (in *NetworkPolicyPort) DeepCopyInto(out *NetworkPolicyPort) {
 	*out = *in
 	if in.Protocol != nil {
 		in, out := &in.Protocol, &out.Protocol
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core.Protocol)
-			**out = **in
-		}
+		*out = new(core.Protocol)
+		**out = **in
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/policy/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/zz_generated.deepcopy.go
@@ -66,12 +66,8 @@ func (in *Eviction) DeepCopyInto(out *Eviction) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	if in.DeleteOptions != nil {
 		in, out := &in.DeleteOptions, &out.DeleteOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.DeleteOptions)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.DeleteOptions)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -213,30 +209,18 @@ func (in *PodDisruptionBudgetSpec) DeepCopyInto(out *PodDisruptionBudgetSpec) {
 	*out = *in
 	if in.MinAvailable != nil {
 		in, out := &in.MinAvailable, &out.MinAvailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -368,12 +352,8 @@ func (in *PodSecurityPolicySpec) DeepCopyInto(out *PodSecurityPolicySpec) {
 	in.FSGroup.DeepCopyInto(&out.FSGroup)
 	if in.DefaultAllowPrivilegeEscalation != nil {
 		in, out := &in.DefaultAllowPrivilegeEscalation, &out.DefaultAllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowedHostPaths != nil {
 		in, out := &in.AllowedHostPaths, &out.AllowedHostPaths
@@ -434,12 +414,8 @@ func (in *SELinuxStrategyOptions) DeepCopyInto(out *SELinuxStrategyOptions) {
 	*out = *in
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core.SELinuxOptions)
-			**out = **in
-		}
+		*out = new(core.SELinuxOptions)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/rbac/zz_generated.deepcopy.go
+++ b/pkg/apis/rbac/zz_generated.deepcopy.go
@@ -62,12 +62,8 @@ func (in *ClusterRole) DeepCopyInto(out *ClusterRole) {
 	}
 	if in.AggregationRule != nil {
 		in, out := &in.AggregationRule, &out.AggregationRule
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AggregationRule)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AggregationRule)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/storage/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/zz_generated.deepcopy.go
@@ -39,12 +39,8 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.ReclaimPolicy != nil {
 		in, out := &in.ReclaimPolicy, &out.ReclaimPolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core.PersistentVolumeReclaimPolicy)
-			**out = **in
-		}
+		*out = new(core.PersistentVolumeReclaimPolicy)
+		**out = **in
 	}
 	if in.MountOptions != nil {
 		in, out := &in.MountOptions, &out.MountOptions
@@ -53,21 +49,13 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.AllowVolumeExpansion != nil {
 		in, out := &in.AllowVolumeExpansion, &out.AllowVolumeExpansion
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.VolumeBindingMode != nil {
 		in, out := &in.VolumeBindingMode, &out.VolumeBindingMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeBindingMode)
-			**out = **in
-		}
+		*out = new(VolumeBindingMode)
+		**out = **in
 	}
 	if in.AllowedTopologies != nil {
 		in, out := &in.AllowedTopologies, &out.AllowedTopologies
@@ -196,12 +184,8 @@ func (in *VolumeAttachmentSource) DeepCopyInto(out *VolumeAttachmentSource) {
 	*out = *in
 	if in.PersistentVolumeName != nil {
 		in, out := &in.PersistentVolumeName, &out.PersistentVolumeName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -245,21 +229,13 @@ func (in *VolumeAttachmentStatus) DeepCopyInto(out *VolumeAttachmentStatus) {
 	}
 	if in.AttachError != nil {
 		in, out := &in.AttachError, &out.AttachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DetachError != nil {
 		in, out := &in.DetachError, &out.DetachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/zz_generated.deepcopy.go
@@ -29,12 +29,8 @@ func (in *KubeletAnonymousAuthentication) DeepCopyInto(out *KubeletAnonymousAuth
 	*out = *in
 	if in.Enabled != nil {
 		in, out := &in.Enabled, &out.Enabled
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -96,12 +92,15 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		in, out := &in.StaticPodURLHeader, &out.StaticPodURLHeader
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.TLSCipherSuites != nil {
@@ -113,48 +112,28 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.Authorization = in.Authorization
 	if in.RegistryPullQPS != nil {
 		in, out := &in.RegistryPullQPS, &out.RegistryPullQPS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.EventRecordQPS != nil {
 		in, out := &in.EventRecordQPS, &out.EventRecordQPS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.EnableDebuggingHandlers != nil {
 		in, out := &in.EnableDebuggingHandlers, &out.EnableDebuggingHandlers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.HealthzPort != nil {
 		in, out := &in.HealthzPort, &out.HealthzPort
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.OOMScoreAdj != nil {
 		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ClusterDNS != nil {
 		in, out := &in.ClusterDNS, &out.ClusterDNS
@@ -166,31 +145,19 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.ImageMinimumGCAge = in.ImageMinimumGCAge
 	if in.ImageGCHighThresholdPercent != nil {
 		in, out := &in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ImageGCLowThresholdPercent != nil {
 		in, out := &in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
 	if in.CgroupsPerQOS != nil {
 		in, out := &in.CgroupsPerQOS, &out.CgroupsPerQOS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.CPUManagerReconcilePeriod = in.CPUManagerReconcilePeriod
 	if in.QOSReserved != nil {
@@ -203,39 +170,23 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
 	if in.PodPidsLimit != nil {
 		in, out := &in.PodPidsLimit, &out.PodPidsLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.CPUCFSQuota != nil {
 		in, out := &in.CPUCFSQuota, &out.CPUCFSQuota
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.KubeAPIQPS != nil {
 		in, out := &in.KubeAPIQPS, &out.KubeAPIQPS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.SerializeImagePulls != nil {
 		in, out := &in.SerializeImagePulls, &out.SerializeImagePulls
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.EvictionHard != nil {
 		in, out := &in.EvictionHard, &out.EvictionHard
@@ -268,39 +219,23 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	}
 	if in.EnableControllerAttachDetach != nil {
 		in, out := &in.EnableControllerAttachDetach, &out.EnableControllerAttachDetach
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.MakeIPTablesUtilChains != nil {
 		in, out := &in.MakeIPTablesUtilChains, &out.MakeIPTablesUtilChains
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.IPTablesMasqueradeBit != nil {
 		in, out := &in.IPTablesMasqueradeBit, &out.IPTablesMasqueradeBit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.IPTablesDropBit != nil {
 		in, out := &in.IPTablesDropBit, &out.IPTablesDropBit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
@@ -311,21 +246,13 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 	}
 	if in.FailSwapOn != nil {
 		in, out := &in.FailSwapOn, &out.FailSwapOn
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.ContainerLogMaxFiles != nil {
 		in, out := &in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.SystemReserved != nil {
 		in, out := &in.SystemReserved, &out.SystemReserved
@@ -372,12 +299,8 @@ func (in *KubeletWebhookAuthentication) DeepCopyInto(out *KubeletWebhookAuthenti
 	*out = *in
 	if in.Enabled != nil {
 		in, out := &in.Enabled, &out.Enabled
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	out.CacheTTL = in.CacheTTL
 	return

--- a/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/zz_generated.deepcopy.go
@@ -87,12 +87,15 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		in, out := &in.StaticPodURLHeader, &out.StaticPodURLHeader
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.TLSCipherSuites != nil {

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.deepcopy.go
@@ -57,12 +57,8 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	in.IPVS.DeepCopyInto(&out.IPVS)
 	if in.OOMScoreAdj != nil {
 		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.UDPIdleTimeout = in.UDPIdleTimeout
 	in.Conntrack.DeepCopyInto(&out.Conntrack)
@@ -98,48 +94,28 @@ func (in *KubeProxyConntrackConfiguration) DeepCopyInto(out *KubeProxyConntrackC
 	*out = *in
 	if in.Max != nil {
 		in, out := &in.Max, &out.Max
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.MaxPerCore != nil {
 		in, out := &in.MaxPerCore, &out.MaxPerCore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Min != nil {
 		in, out := &in.Min, &out.Min
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TCPEstablishedTimeout != nil {
 		in, out := &in.TCPEstablishedTimeout, &out.TCPEstablishedTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.TCPCloseWaitTimeout != nil {
 		in, out := &in.TCPCloseWaitTimeout, &out.TCPCloseWaitTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	return
 }
@@ -159,12 +135,8 @@ func (in *KubeProxyIPTablesConfiguration) DeepCopyInto(out *KubeProxyIPTablesCon
 	*out = *in
 	if in.MasqueradeBit != nil {
 		in, out := &in.MasqueradeBit, &out.MasqueradeBit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod

--- a/pkg/proxy/apis/kubeproxyconfig/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/kubeproxyconfig/zz_generated.deepcopy.go
@@ -79,12 +79,8 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	in.IPVS.DeepCopyInto(&out.IPVS)
 	if in.OOMScoreAdj != nil {
 		in, out := &in.OOMScoreAdj, &out.OOMScoreAdj
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.UDPIdleTimeout = in.UDPIdleTimeout
 	in.Conntrack.DeepCopyInto(&out.Conntrack)
@@ -120,48 +116,28 @@ func (in *KubeProxyConntrackConfiguration) DeepCopyInto(out *KubeProxyConntrackC
 	*out = *in
 	if in.Max != nil {
 		in, out := &in.Max, &out.Max
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.MaxPerCore != nil {
 		in, out := &in.MaxPerCore, &out.MaxPerCore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Min != nil {
 		in, out := &in.Min, &out.Min
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TCPEstablishedTimeout != nil {
 		in, out := &in.TCPEstablishedTimeout, &out.TCPEstablishedTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	if in.TCPCloseWaitTimeout != nil {
 		in, out := &in.TCPCloseWaitTimeout, &out.TCPCloseWaitTimeout
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Duration)
-			**out = **in
-		}
+		*out = new(v1.Duration)
+		**out = **in
 	}
 	return
 }
@@ -181,12 +157,8 @@ func (in *KubeProxyIPTablesConfiguration) DeepCopyInto(out *KubeProxyIPTablesCon
 	*out = *in
 	if in.MasqueradeBit != nil {
 		in, out := &in.MasqueradeBit, &out.MasqueradeBit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -134,7 +134,7 @@ var ipsetInfo = []struct {
 // ipsetWithIptablesChain is the ipsets list with iptables source chain and the chain jump to
 // `iptables -t nat -A <from> -m set --match-set <name> <matchType> -j <to>`
 // example: iptables -t nat -A KUBE-SERVICES -m set --match-set KUBE-NODE-PORT-TCP dst -j KUBE-NODE-PORT
-// ipsets with ohter match rules will be create Individually.
+// ipsets with other match rules will be created Individually.
 var ipsetWithIptablesChain = []struct {
 	name      string
 	from      string
@@ -366,6 +366,7 @@ func NewProxier(ipt utiliptables.Interface,
 		endpointsChanges:  proxy.NewEndpointChangeTracker(hostname, nil, &isIPv6, recorder),
 		syncPeriod:        syncPeriod,
 		minSyncPeriod:     minSyncPeriod,
+		excludeCIDRs:      excludeCIDRs,
 		iptables:          ipt,
 		masqueradeAll:     masqueradeAll,
 		masqueradeMark:    masqueradeMark,

--- a/pkg/registry/rbac/reconciliation/zz_generated.deepcopy.go
+++ b/pkg/registry/rbac/reconciliation/zz_generated.deepcopy.go
@@ -29,12 +29,8 @@ func (in *ClusterRoleBindingAdapter) DeepCopyInto(out *ClusterRoleBindingAdapter
 	*out = *in
 	if in.ClusterRoleBinding != nil {
 		in, out := &in.ClusterRoleBinding, &out.ClusterRoleBinding
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.ClusterRoleBinding)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.ClusterRoleBinding)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -59,12 +55,8 @@ func (in *ClusterRoleRuleOwner) DeepCopyInto(out *ClusterRoleRuleOwner) {
 	*out = *in
 	if in.ClusterRole != nil {
 		in, out := &in.ClusterRole, &out.ClusterRole
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.ClusterRole)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.ClusterRole)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -89,12 +81,8 @@ func (in *RoleBindingAdapter) DeepCopyInto(out *RoleBindingAdapter) {
 	*out = *in
 	if in.RoleBinding != nil {
 		in, out := &in.RoleBinding, &out.RoleBinding
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.RoleBinding)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.RoleBinding)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -119,12 +107,8 @@ func (in *RoleRuleOwner) DeepCopyInto(out *RoleRuleOwner) {
 	*out = *in
 	if in.Role != nil {
 		in, out := &in.Role, &out.Role
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Role)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Role)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/scheduler/api/v1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/v1/zz_generated.deepcopy.go
@@ -31,33 +31,21 @@ func (in *ExtenderArgs) DeepCopyInto(out *ExtenderArgs) {
 	*out = *in
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.Pod)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(core_v1.Pod)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.NodeList)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(core_v1.NodeList)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNames != nil {
 		in, out := &in.NodeNames, &out.NodeNames
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
 		}
 	}
 	return
@@ -110,12 +98,8 @@ func (in *ExtenderConfig) DeepCopyInto(out *ExtenderConfig) {
 	*out = *in
 	if in.TLSConfig != nil {
 		in, out := &in.TLSConfig, &out.TLSConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(rest.TLSClientConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(rest.TLSClientConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ManagedResources != nil {
 		in, out := &in.ManagedResources, &out.ManagedResources
@@ -140,24 +124,16 @@ func (in *ExtenderFilterResult) DeepCopyInto(out *ExtenderFilterResult) {
 	*out = *in
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.NodeList)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(core_v1.NodeList)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNames != nil {
 		in, out := &in.NodeNames, &out.NodeNames
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
 		}
 	}
 	if in.FailedNodes != nil {
@@ -201,35 +177,37 @@ func (in *ExtenderPreemptionArgs) DeepCopyInto(out *ExtenderPreemptionArgs) {
 	*out = *in
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.Pod)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(core_v1.Pod)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNameToVictims != nil {
 		in, out := &in.NodeNameToVictims, &out.NodeNameToVictims
 		*out = make(map[string]*Victims, len(*in))
 		for key, val := range *in {
+			var outVal *Victims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(Victims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(Victims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.NodeNameToMetaVictims != nil {
 		in, out := &in.NodeNameToMetaVictims, &out.NodeNameToMetaVictims
 		*out = make(map[string]*MetaVictims, len(*in))
 		for key, val := range *in {
+			var outVal *MetaVictims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(MetaVictims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(MetaVictims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -252,12 +230,15 @@ func (in *ExtenderPreemptionResult) DeepCopyInto(out *ExtenderPreemptionResult) 
 		in, out := &in.NodeNameToMetaVictims, &out.NodeNameToMetaVictims
 		*out = make(map[string]*MetaVictims, len(*in))
 		for key, val := range *in {
+			var outVal *MetaVictims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(MetaVictims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(MetaVictims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -394,8 +375,9 @@ func (in *MetaVictims) DeepCopyInto(out *MetaVictims) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(MetaPod)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(MetaPod)
+				**out = **in
 			}
 		}
 	}
@@ -463,21 +445,13 @@ func (in *PredicateArgument) DeepCopyInto(out *PredicateArgument) {
 	*out = *in
 	if in.ServiceAffinity != nil {
 		in, out := &in.ServiceAffinity, &out.ServiceAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ServiceAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LabelsPresence != nil {
 		in, out := &in.LabelsPresence, &out.LabelsPresence
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LabelsPresence)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(LabelsPresence)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -497,12 +471,8 @@ func (in *PredicatePolicy) DeepCopyInto(out *PredicatePolicy) {
 	*out = *in
 	if in.Argument != nil {
 		in, out := &in.Argument, &out.Argument
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PredicateArgument)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PredicateArgument)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -522,30 +492,18 @@ func (in *PriorityArgument) DeepCopyInto(out *PriorityArgument) {
 	*out = *in
 	if in.ServiceAntiAffinity != nil {
 		in, out := &in.ServiceAntiAffinity, &out.ServiceAntiAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAntiAffinity)
-			**out = **in
-		}
+		*out = new(ServiceAntiAffinity)
+		**out = **in
 	}
 	if in.LabelPreference != nil {
 		in, out := &in.LabelPreference, &out.LabelPreference
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LabelPreference)
-			**out = **in
-		}
+		*out = new(LabelPreference)
+		**out = **in
 	}
 	if in.RequestedToCapacityRatioArguments != nil {
 		in, out := &in.RequestedToCapacityRatioArguments, &out.RequestedToCapacityRatioArguments
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RequestedToCapacityRatioArguments)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RequestedToCapacityRatioArguments)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -565,12 +523,8 @@ func (in *PriorityPolicy) DeepCopyInto(out *PriorityPolicy) {
 	*out = *in
 	if in.Argument != nil {
 		in, out := &in.Argument, &out.Argument
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PriorityArgument)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PriorityArgument)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -669,8 +623,9 @@ func (in *Victims) DeepCopyInto(out *Victims) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(core_v1.Pod)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(core_v1.Pod)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}

--- a/pkg/scheduler/api/zz_generated.deepcopy.go
+++ b/pkg/scheduler/api/zz_generated.deepcopy.go
@@ -31,33 +31,21 @@ func (in *ExtenderArgs) DeepCopyInto(out *ExtenderArgs) {
 	*out = *in
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Pod)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Pod)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.NodeList)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.NodeList)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNames != nil {
 		in, out := &in.NodeNames, &out.NodeNames
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
 		}
 	}
 	return
@@ -110,12 +98,8 @@ func (in *ExtenderConfig) DeepCopyInto(out *ExtenderConfig) {
 	*out = *in
 	if in.TLSConfig != nil {
 		in, out := &in.TLSConfig, &out.TLSConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(rest.TLSClientConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(rest.TLSClientConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ManagedResources != nil {
 		in, out := &in.ManagedResources, &out.ManagedResources
@@ -140,24 +124,16 @@ func (in *ExtenderFilterResult) DeepCopyInto(out *ExtenderFilterResult) {
 	*out = *in
 	if in.Nodes != nil {
 		in, out := &in.Nodes, &out.Nodes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.NodeList)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.NodeList)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNames != nil {
 		in, out := &in.NodeNames, &out.NodeNames
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]string)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]string, len(*in))
-				copy(*out, *in)
-			}
+		*out = new([]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]string, len(*in))
+			copy(*out, *in)
 		}
 	}
 	if in.FailedNodes != nil {
@@ -201,35 +177,37 @@ func (in *ExtenderPreemptionArgs) DeepCopyInto(out *ExtenderPreemptionArgs) {
 	*out = *in
 	if in.Pod != nil {
 		in, out := &in.Pod, &out.Pod
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Pod)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Pod)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NodeNameToVictims != nil {
 		in, out := &in.NodeNameToVictims, &out.NodeNameToVictims
 		*out = make(map[string]*Victims, len(*in))
 		for key, val := range *in {
+			var outVal *Victims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(Victims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(Victims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.NodeNameToMetaVictims != nil {
 		in, out := &in.NodeNameToMetaVictims, &out.NodeNameToMetaVictims
 		*out = make(map[string]*MetaVictims, len(*in))
 		for key, val := range *in {
+			var outVal *MetaVictims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(MetaVictims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(MetaVictims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -252,12 +230,15 @@ func (in *ExtenderPreemptionResult) DeepCopyInto(out *ExtenderPreemptionResult) 
 		in, out := &in.NodeNameToMetaVictims, &out.NodeNameToMetaVictims
 		*out = make(map[string]*MetaVictims, len(*in))
 		for key, val := range *in {
+			var outVal *MetaVictims
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(MetaVictims)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(MetaVictims)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -394,8 +375,9 @@ func (in *MetaVictims) DeepCopyInto(out *MetaVictims) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(MetaPod)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(MetaPod)
+				**out = **in
 			}
 		}
 	}
@@ -463,21 +445,13 @@ func (in *PredicateArgument) DeepCopyInto(out *PredicateArgument) {
 	*out = *in
 	if in.ServiceAffinity != nil {
 		in, out := &in.ServiceAffinity, &out.ServiceAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ServiceAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LabelsPresence != nil {
 		in, out := &in.LabelsPresence, &out.LabelsPresence
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LabelsPresence)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(LabelsPresence)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -497,12 +471,8 @@ func (in *PredicatePolicy) DeepCopyInto(out *PredicatePolicy) {
 	*out = *in
 	if in.Argument != nil {
 		in, out := &in.Argument, &out.Argument
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PredicateArgument)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PredicateArgument)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -522,30 +492,18 @@ func (in *PriorityArgument) DeepCopyInto(out *PriorityArgument) {
 	*out = *in
 	if in.ServiceAntiAffinity != nil {
 		in, out := &in.ServiceAntiAffinity, &out.ServiceAntiAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAntiAffinity)
-			**out = **in
-		}
+		*out = new(ServiceAntiAffinity)
+		**out = **in
 	}
 	if in.LabelPreference != nil {
 		in, out := &in.LabelPreference, &out.LabelPreference
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LabelPreference)
-			**out = **in
-		}
+		*out = new(LabelPreference)
+		**out = **in
 	}
 	if in.RequestedToCapacityRatioArguments != nil {
 		in, out := &in.RequestedToCapacityRatioArguments, &out.RequestedToCapacityRatioArguments
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RequestedToCapacityRatioArguments)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RequestedToCapacityRatioArguments)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -565,12 +523,8 @@ func (in *PriorityPolicy) DeepCopyInto(out *PriorityPolicy) {
 	*out = *in
 	if in.Argument != nil {
 		in, out := &in.Argument, &out.Argument
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PriorityArgument)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PriorityArgument)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -669,8 +623,9 @@ func (in *Victims) DeepCopyInto(out *Victims) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(v1.Pod)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(v1.Pod)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}

--- a/staging/src/k8s.io/api/admission/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/admission/v1beta1/zz_generated.deepcopy.go
@@ -51,12 +51,8 @@ func (in *AdmissionResponse) DeepCopyInto(out *AdmissionResponse) {
 	*out = *in
 	if in.Result != nil {
 		in, out := &in.Result, &out.Result
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Status)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Patch != nil {
 		in, out := &in.Patch, &out.Patch
@@ -65,12 +61,8 @@ func (in *AdmissionResponse) DeepCopyInto(out *AdmissionResponse) {
 	}
 	if in.PatchType != nil {
 		in, out := &in.PatchType, &out.PatchType
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PatchType)
-			**out = **in
-		}
+		*out = new(PatchType)
+		**out = **in
 	}
 	return
 }
@@ -91,21 +83,13 @@ func (in *AdmissionReview) DeepCopyInto(out *AdmissionReview) {
 	out.TypeMeta = in.TypeMeta
 	if in.Request != nil {
 		in, out := &in.Request, &out.Request
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AdmissionRequest)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AdmissionRequest)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Response != nil {
 		in, out := &in.Response, &out.Response
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AdmissionResponse)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AdmissionResponse)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/zz_generated.deepcopy.go
@@ -149,12 +149,8 @@ func (in *ServiceReference) DeepCopyInto(out *ServiceReference) {
 	*out = *in
 	if in.Path != nil {
 		in, out := &in.Path, &out.Path
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -248,21 +244,13 @@ func (in *Webhook) DeepCopyInto(out *Webhook) {
 	}
 	if in.FailurePolicy != nil {
 		in, out := &in.FailurePolicy, &out.FailurePolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FailurePolicyType)
-			**out = **in
-		}
+		*out = new(FailurePolicyType)
+		**out = **in
 	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -282,21 +270,13 @@ func (in *WebhookClientConfig) DeepCopyInto(out *WebhookClientConfig) {
 	*out = *in
 	if in.URL != nil {
 		in, out := &in.URL, &out.URL
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceReference)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ServiceReference)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CABundle != nil {
 		in, out := &in.CABundle, &out.CABundle

--- a/staging/src/k8s.io/api/apps/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/apps/v1/zz_generated.deepcopy.go
@@ -170,23 +170,15 @@ func (in *DaemonSetSpec) DeepCopyInto(out *DaemonSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -206,12 +198,8 @@ func (in *DaemonSetStatus) DeepCopyInto(out *DaemonSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -238,12 +226,8 @@ func (in *DaemonSetUpdateStrategy) DeepCopyInto(out *DaemonSetUpdateStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDaemonSet)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDaemonSet)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -342,41 +326,25 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -403,12 +371,8 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -428,12 +392,8 @@ func (in *DeploymentStrategy) DeepCopyInto(out *DeploymentStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -531,21 +491,13 @@ func (in *ReplicaSetSpec) DeepCopyInto(out *ReplicaSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
@@ -589,12 +541,8 @@ func (in *RollingUpdateDaemonSet) DeepCopyInto(out *RollingUpdateDaemonSet) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -614,21 +562,13 @@ func (in *RollingUpdateDeployment) DeepCopyInto(out *RollingUpdateDeployment) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -648,12 +588,8 @@ func (in *RollingUpdateStatefulSetStrategy) DeepCopyInto(out *RollingUpdateState
 	*out = *in
 	if in.Partition != nil {
 		in, out := &in.Partition, &out.Partition
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -751,21 +687,13 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	if in.VolumeClaimTemplates != nil {
@@ -778,12 +706,8 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -803,12 +727,8 @@ func (in *StatefulSetStatus) DeepCopyInto(out *StatefulSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -835,12 +755,8 @@ func (in *StatefulSetUpdateStrategy) DeepCopyInto(out *StatefulSetUpdateStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateStatefulSetStrategy)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateStatefulSetStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/apps/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/zz_generated.deepcopy.go
@@ -204,50 +204,30 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.RollbackTo != nil {
 		in, out := &in.RollbackTo, &out.RollbackTo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollbackConfig)
-			**out = **in
-		}
+		*out = new(RollbackConfig)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -274,12 +254,8 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -299,12 +275,8 @@ func (in *DeploymentStrategy) DeepCopyInto(out *DeploymentStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -340,21 +312,13 @@ func (in *RollingUpdateDeployment) DeepCopyInto(out *RollingUpdateDeployment) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -374,12 +338,8 @@ func (in *RollingUpdateStatefulSetStrategy) DeepCopyInto(out *RollingUpdateState
 	*out = *in
 	if in.Partition != nil {
 		in, out := &in.Partition, &out.Partition
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -544,21 +504,13 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	if in.VolumeClaimTemplates != nil {
@@ -571,12 +523,8 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -596,21 +544,13 @@ func (in *StatefulSetStatus) DeepCopyInto(out *StatefulSetStatus) {
 	*out = *in
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -637,12 +577,8 @@ func (in *StatefulSetUpdateStrategy) DeepCopyInto(out *StatefulSetUpdateStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateStatefulSetStrategy)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateStatefulSetStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/apps/v1beta2/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/zz_generated.deepcopy.go
@@ -170,23 +170,15 @@ func (in *DaemonSetSpec) DeepCopyInto(out *DaemonSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -206,12 +198,8 @@ func (in *DaemonSetStatus) DeepCopyInto(out *DaemonSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -238,12 +226,8 @@ func (in *DaemonSetUpdateStrategy) DeepCopyInto(out *DaemonSetUpdateStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDaemonSet)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDaemonSet)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -342,41 +326,25 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -403,12 +371,8 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -428,12 +392,8 @@ func (in *DeploymentStrategy) DeepCopyInto(out *DeploymentStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -531,21 +491,13 @@ func (in *ReplicaSetSpec) DeepCopyInto(out *ReplicaSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
@@ -589,12 +541,8 @@ func (in *RollingUpdateDaemonSet) DeepCopyInto(out *RollingUpdateDaemonSet) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -614,21 +562,13 @@ func (in *RollingUpdateDeployment) DeepCopyInto(out *RollingUpdateDeployment) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -648,12 +588,8 @@ func (in *RollingUpdateStatefulSetStrategy) DeepCopyInto(out *RollingUpdateState
 	*out = *in
 	if in.Partition != nil {
 		in, out := &in.Partition, &out.Partition
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -818,21 +754,13 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	if in.VolumeClaimTemplates != nil {
@@ -845,12 +773,8 @@ func (in *StatefulSetSpec) DeepCopyInto(out *StatefulSetSpec) {
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -870,12 +794,8 @@ func (in *StatefulSetStatus) DeepCopyInto(out *StatefulSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -902,12 +822,8 @@ func (in *StatefulSetUpdateStrategy) DeepCopyInto(out *StatefulSetUpdateStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateStatefulSetStrategy)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateStatefulSetStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/authentication/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authentication/v1/zz_generated.deepcopy.go
@@ -98,21 +98,13 @@ func (in *TokenRequestSpec) DeepCopyInto(out *TokenRequestSpec) {
 	}
 	if in.ExpirationSeconds != nil {
 		in, out := &in.ExpirationSeconds, &out.ExpirationSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.BoundObjectRef != nil {
 		in, out := &in.BoundObjectRef, &out.BoundObjectRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(BoundObjectReference)
-			**out = **in
-		}
+		*out = new(BoundObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -217,12 +209,15 @@ func (in *UserInfo) DeepCopyInto(out *UserInfo) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/api/authentication/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/zz_generated.deepcopy.go
@@ -117,12 +117,15 @@ func (in *UserInfo) DeepCopyInto(out *UserInfo) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/api/authorization/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authorization/v1/zz_generated.deepcopy.go
@@ -199,21 +199,13 @@ func (in *SelfSubjectAccessReviewSpec) DeepCopyInto(out *SelfSubjectAccessReview
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	return
 }
@@ -305,21 +297,13 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	if in.Groups != nil {
 		in, out := &in.Groups, &out.Groups
@@ -330,12 +314,15 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/api/authorization/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/zz_generated.deepcopy.go
@@ -199,21 +199,13 @@ func (in *SelfSubjectAccessReviewSpec) DeepCopyInto(out *SelfSubjectAccessReview
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	return
 }
@@ -305,21 +297,13 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 	*out = *in
 	if in.ResourceAttributes != nil {
 		in, out := &in.ResourceAttributes, &out.ResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceAttributes)
-			**out = **in
-		}
+		*out = new(ResourceAttributes)
+		**out = **in
 	}
 	if in.NonResourceAttributes != nil {
 		in, out := &in.NonResourceAttributes, &out.NonResourceAttributes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NonResourceAttributes)
-			**out = **in
-		}
+		*out = new(NonResourceAttributes)
+		**out = **in
 	}
 	if in.Groups != nil {
 		in, out := &in.Groups, &out.Groups
@@ -330,12 +314,15 @@ func (in *SubjectAccessReviewSpec) DeepCopyInto(out *SubjectAccessReviewSpec) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/api/autoscaling/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/zz_generated.deepcopy.go
@@ -46,30 +46,18 @@ func (in *ExternalMetricSource) DeepCopyInto(out *ExternalMetricSource) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TargetValue != nil {
 		in, out := &in.TargetValue, &out.TargetValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -89,22 +77,14 @@ func (in *ExternalMetricStatus) DeepCopyInto(out *ExternalMetricStatus) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	out.CurrentValue = in.CurrentValue.DeepCopy()
 	if in.CurrentAverageValue != nil {
 		in, out := &in.CurrentAverageValue, &out.CurrentAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -203,21 +183,13 @@ func (in *HorizontalPodAutoscalerSpec) DeepCopyInto(out *HorizontalPodAutoscaler
 	out.ScaleTargetRef = in.ScaleTargetRef
 	if in.MinReplicas != nil {
 		in, out := &in.MinReplicas, &out.MinReplicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TargetCPUUtilizationPercentage != nil {
 		in, out := &in.TargetCPUUtilizationPercentage, &out.TargetCPUUtilizationPercentage
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -237,29 +209,17 @@ func (in *HorizontalPodAutoscalerStatus) DeepCopyInto(out *HorizontalPodAutoscal
 	*out = *in
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.LastScaleTime != nil {
 		in, out := &in.LastScaleTime, &out.LastScaleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.CurrentCPUUtilizationPercentage != nil {
 		in, out := &in.CurrentCPUUtilizationPercentage, &out.CurrentCPUUtilizationPercentage
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -279,39 +239,23 @@ func (in *MetricSpec) DeepCopyInto(out *MetricSpec) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -331,39 +275,23 @@ func (in *MetricStatus) DeepCopyInto(out *MetricStatus) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -453,21 +381,13 @@ func (in *ResourceMetricSource) DeepCopyInto(out *ResourceMetricSource) {
 	*out = *in
 	if in.TargetAverageUtilization != nil {
 		in, out := &in.TargetAverageUtilization, &out.TargetAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -487,12 +407,8 @@ func (in *ResourceMetricStatus) DeepCopyInto(out *ResourceMetricStatus) {
 	*out = *in
 	if in.CurrentAverageUtilization != nil {
 		in, out := &in.CurrentAverageUtilization, &out.CurrentAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.CurrentAverageValue = in.CurrentAverageValue.DeepCopy()
 	return

--- a/staging/src/k8s.io/api/autoscaling/v2beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta1/zz_generated.deepcopy.go
@@ -46,30 +46,18 @@ func (in *ExternalMetricSource) DeepCopyInto(out *ExternalMetricSource) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TargetValue != nil {
 		in, out := &in.TargetValue, &out.TargetValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -89,22 +77,14 @@ func (in *ExternalMetricStatus) DeepCopyInto(out *ExternalMetricStatus) {
 	*out = *in
 	if in.MetricSelector != nil {
 		in, out := &in.MetricSelector, &out.MetricSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	out.CurrentValue = in.CurrentValue.DeepCopy()
 	if in.CurrentAverageValue != nil {
 		in, out := &in.CurrentAverageValue, &out.CurrentAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -203,12 +183,8 @@ func (in *HorizontalPodAutoscalerSpec) DeepCopyInto(out *HorizontalPodAutoscaler
 	out.ScaleTargetRef = in.ScaleTargetRef
 	if in.MinReplicas != nil {
 		in, out := &in.MinReplicas, &out.MinReplicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
@@ -235,20 +211,12 @@ func (in *HorizontalPodAutoscalerStatus) DeepCopyInto(out *HorizontalPodAutoscal
 	*out = *in
 	if in.ObservedGeneration != nil {
 		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.LastScaleTime != nil {
 		in, out := &in.LastScaleTime, &out.LastScaleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.CurrentMetrics != nil {
 		in, out := &in.CurrentMetrics, &out.CurrentMetrics
@@ -282,39 +250,23 @@ func (in *MetricSpec) DeepCopyInto(out *MetricSpec) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -334,39 +286,23 @@ func (in *MetricStatus) DeepCopyInto(out *MetricStatus) {
 	*out = *in
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ObjectMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Pods != nil {
 		in, out := &in.Pods, &out.Pods
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodsMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodsMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Resource != nil {
 		in, out := &in.Resource, &out.Resource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.External != nil {
 		in, out := &in.External, &out.External
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalMetricStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExternalMetricStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -456,21 +392,13 @@ func (in *ResourceMetricSource) DeepCopyInto(out *ResourceMetricSource) {
 	*out = *in
 	if in.TargetAverageUtilization != nil {
 		in, out := &in.TargetAverageUtilization, &out.TargetAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.TargetAverageValue != nil {
 		in, out := &in.TargetAverageValue, &out.TargetAverageValue
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -490,12 +418,8 @@ func (in *ResourceMetricStatus) DeepCopyInto(out *ResourceMetricStatus) {
 	*out = *in
 	if in.CurrentAverageUtilization != nil {
 		in, out := &in.CurrentAverageUtilization, &out.CurrentAverageUtilization
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	out.CurrentAverageValue = in.CurrentAverageValue.DeepCopy()
 	return

--- a/staging/src/k8s.io/api/batch/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/batch/v1/zz_generated.deepcopy.go
@@ -109,57 +109,33 @@ func (in *JobSpec) DeepCopyInto(out *JobSpec) {
 	*out = *in
 	if in.Parallelism != nil {
 		in, out := &in.Parallelism, &out.Parallelism
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Completions != nil {
 		in, out := &in.Completions, &out.Completions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.BackoffLimit != nil {
 		in, out := &in.BackoffLimit, &out.BackoffLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ManualSelector != nil {
 		in, out := &in.ManualSelector, &out.ManualSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
@@ -187,19 +163,11 @@ func (in *JobStatus) DeepCopyInto(out *JobStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.CompletionTime != nil {
 		in, out := &in.CompletionTime, &out.CompletionTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/api/batch/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/zz_generated.deepcopy.go
@@ -91,40 +91,24 @@ func (in *CronJobSpec) DeepCopyInto(out *CronJobSpec) {
 	*out = *in
 	if in.StartingDeadlineSeconds != nil {
 		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Suspend != nil {
 		in, out := &in.Suspend, &out.Suspend
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	in.JobTemplate.DeepCopyInto(&out.JobTemplate)
 	if in.SuccessfulJobsHistoryLimit != nil {
 		in, out := &in.SuccessfulJobsHistoryLimit, &out.SuccessfulJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FailedJobsHistoryLimit != nil {
 		in, out := &in.FailedJobsHistoryLimit, &out.FailedJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -149,11 +133,7 @@ func (in *CronJobStatus) DeepCopyInto(out *CronJobStatus) {
 	}
 	if in.LastScheduleTime != nil {
 		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/api/batch/v2alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/batch/v2alpha1/zz_generated.deepcopy.go
@@ -91,40 +91,24 @@ func (in *CronJobSpec) DeepCopyInto(out *CronJobSpec) {
 	*out = *in
 	if in.StartingDeadlineSeconds != nil {
 		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Suspend != nil {
 		in, out := &in.Suspend, &out.Suspend
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	in.JobTemplate.DeepCopyInto(&out.JobTemplate)
 	if in.SuccessfulJobsHistoryLimit != nil {
 		in, out := &in.SuccessfulJobsHistoryLimit, &out.SuccessfulJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FailedJobsHistoryLimit != nil {
 		in, out := &in.FailedJobsHistoryLimit, &out.FailedJobsHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -149,11 +133,7 @@ func (in *CronJobStatus) DeepCopyInto(out *CronJobStatus) {
 	}
 	if in.LastScheduleTime != nil {
 		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/api/certificates/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/zz_generated.deepcopy.go
@@ -124,12 +124,15 @@ func (in *CertificateSigningRequestSpec) DeepCopyInto(out *CertificateSigningReq
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
@@ -47,30 +47,18 @@ func (in *Affinity) DeepCopyInto(out *Affinity) {
 	*out = *in
 	if in.NodeAffinity != nil {
 		in, out := &in.NodeAffinity, &out.NodeAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PodAffinity != nil {
 		in, out := &in.PodAffinity, &out.PodAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PodAntiAffinity != nil {
 		in, out := &in.PodAntiAffinity, &out.PodAntiAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodAntiAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodAntiAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -129,39 +117,23 @@ func (in *AzureDiskVolumeSource) DeepCopyInto(out *AzureDiskVolumeSource) {
 	*out = *in
 	if in.CachingMode != nil {
 		in, out := &in.CachingMode, &out.CachingMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDataDiskCachingMode)
-			**out = **in
-		}
+		*out = new(AzureDataDiskCachingMode)
+		**out = **in
 	}
 	if in.FSType != nil {
 		in, out := &in.FSType, &out.FSType
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.ReadOnly != nil {
 		in, out := &in.ReadOnly, &out.ReadOnly
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.Kind != nil {
 		in, out := &in.Kind, &out.Kind
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDataDiskKind)
-			**out = **in
-		}
+		*out = new(AzureDataDiskKind)
+		**out = **in
 	}
 	return
 }
@@ -181,12 +153,8 @@ func (in *AzureFilePersistentVolumeSource) DeepCopyInto(out *AzureFilePersistent
 	*out = *in
 	if in.SecretNamespace != nil {
 		in, out := &in.SecretNamespace, &out.SecretNamespace
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -256,30 +224,18 @@ func (in *CSIPersistentVolumeSource) DeepCopyInto(out *CSIPersistentVolumeSource
 	}
 	if in.ControllerPublishSecretRef != nil {
 		in, out := &in.ControllerPublishSecretRef, &out.ControllerPublishSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.NodeStageSecretRef != nil {
 		in, out := &in.NodeStageSecretRef, &out.NodeStageSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.NodePublishSecretRef != nil {
 		in, out := &in.NodePublishSecretRef, &out.NodePublishSecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -330,12 +286,8 @@ func (in *CephFSPersistentVolumeSource) DeepCopyInto(out *CephFSPersistentVolume
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -360,12 +312,8 @@ func (in *CephFSVolumeSource) DeepCopyInto(out *CephFSVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -385,12 +333,8 @@ func (in *CinderPersistentVolumeSource) DeepCopyInto(out *CinderPersistentVolume
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -410,12 +354,8 @@ func (in *CinderVolumeSource) DeepCopyInto(out *CinderVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -435,12 +375,8 @@ func (in *ClientIPConfig) DeepCopyInto(out *ClientIPConfig) {
 	*out = *in
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -551,12 +487,15 @@ func (in *ConfigMap) DeepCopyInto(out *ConfigMap) {
 		in, out := &in.BinaryData, &out.BinaryData
 		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
+			var outVal []byte
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]byte, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return
@@ -586,12 +525,8 @@ func (in *ConfigMapEnvSource) DeepCopyInto(out *ConfigMapEnvSource) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -612,12 +547,8 @@ func (in *ConfigMapKeySelector) DeepCopyInto(out *ConfigMapKeySelector) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -694,12 +625,8 @@ func (in *ConfigMapProjection) DeepCopyInto(out *ConfigMapProjection) {
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -727,21 +654,13 @@ func (in *ConfigMapVolumeSource) DeepCopyInto(out *ConfigMapVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -803,39 +722,23 @@ func (in *Container) DeepCopyInto(out *Container) {
 	}
 	if in.LivenessProbe != nil {
 		in, out := &in.LivenessProbe, &out.LivenessProbe
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Probe)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Probe)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ReadinessProbe != nil {
 		in, out := &in.ReadinessProbe, &out.ReadinessProbe
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Probe)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Probe)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Lifecycle)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Lifecycle)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecurityContext)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -892,30 +795,18 @@ func (in *ContainerState) DeepCopyInto(out *ContainerState) {
 	*out = *in
 	if in.Waiting != nil {
 		in, out := &in.Waiting, &out.Waiting
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateWaiting)
-			**out = **in
-		}
+		*out = new(ContainerStateWaiting)
+		**out = **in
 	}
 	if in.Running != nil {
 		in, out := &in.Running, &out.Running
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateRunning)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ContainerStateRunning)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Terminated != nil {
 		in, out := &in.Terminated, &out.Terminated
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ContainerStateTerminated)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ContainerStateTerminated)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1043,30 +934,18 @@ func (in *DownwardAPIVolumeFile) DeepCopyInto(out *DownwardAPIVolumeFile) {
 	*out = *in
 	if in.FieldRef != nil {
 		in, out := &in.FieldRef, &out.FieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectFieldSelector)
-			**out = **in
-		}
+		*out = new(ObjectFieldSelector)
+		**out = **in
 	}
 	if in.ResourceFieldRef != nil {
 		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceFieldSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceFieldSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1093,12 +972,8 @@ func (in *DownwardAPIVolumeSource) DeepCopyInto(out *DownwardAPIVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1118,12 +993,8 @@ func (in *EmptyDirVolumeSource) DeepCopyInto(out *EmptyDirVolumeSource) {
 	*out = *in
 	if in.SizeLimit != nil {
 		in, out := &in.SizeLimit, &out.SizeLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			x := (*in).DeepCopy()
-			*out = &x
-		}
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	return
 }
@@ -1143,21 +1014,13 @@ func (in *EndpointAddress) DeepCopyInto(out *EndpointAddress) {
 	*out = *in
 	if in.NodeName != nil {
 		in, out := &in.NodeName, &out.NodeName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.TargetRef != nil {
 		in, out := &in.TargetRef, &out.TargetRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -1294,21 +1157,13 @@ func (in *EnvFromSource) DeepCopyInto(out *EnvFromSource) {
 	*out = *in
 	if in.ConfigMapRef != nil {
 		in, out := &in.ConfigMapRef, &out.ConfigMapRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapEnvSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapEnvSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretEnvSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretEnvSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1328,12 +1183,8 @@ func (in *EnvVar) DeepCopyInto(out *EnvVar) {
 	*out = *in
 	if in.ValueFrom != nil {
 		in, out := &in.ValueFrom, &out.ValueFrom
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EnvVarSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EnvVarSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1353,39 +1204,23 @@ func (in *EnvVarSource) DeepCopyInto(out *EnvVarSource) {
 	*out = *in
 	if in.FieldRef != nil {
 		in, out := &in.FieldRef, &out.FieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectFieldSelector)
-			**out = **in
-		}
+		*out = new(ObjectFieldSelector)
+		**out = **in
 	}
 	if in.ResourceFieldRef != nil {
 		in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ResourceFieldSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ResourceFieldSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ConfigMapKeyRef != nil {
 		in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapKeySelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SecretKeyRef != nil {
 		in, out := &in.SecretKeyRef, &out.SecretKeyRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretKeySelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretKeySelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1412,21 +1247,13 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.EventTime.DeepCopyInto(&out.EventTime)
 	if in.Series != nil {
 		in, out := &in.Series, &out.Series
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EventSeries)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EventSeries)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Related != nil {
 		in, out := &in.Related, &out.Related
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -1546,12 +1373,8 @@ func (in *FCVolumeSource) DeepCopyInto(out *FCVolumeSource) {
 	}
 	if in.Lun != nil {
 		in, out := &in.Lun, &out.Lun
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.WWIDs != nil {
 		in, out := &in.WWIDs, &out.WWIDs
@@ -1576,12 +1399,8 @@ func (in *FlexPersistentVolumeSource) DeepCopyInto(out *FlexPersistentVolumeSour
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
@@ -1608,12 +1427,8 @@ func (in *FlexVolumeSource) DeepCopyInto(out *FlexVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	if in.Options != nil {
 		in, out := &in.Options, &out.Options
@@ -1742,30 +1557,18 @@ func (in *Handler) DeepCopyInto(out *Handler) {
 	*out = *in
 	if in.Exec != nil {
 		in, out := &in.Exec, &out.Exec
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecAction)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecAction)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.HTTPGet != nil {
 		in, out := &in.HTTPGet, &out.HTTPGet
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HTTPGetAction)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HTTPGetAction)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.TCPSocket != nil {
 		in, out := &in.TCPSocket, &out.TCPSocket
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(TCPSocketAction)
-			**out = **in
-		}
+		*out = new(TCPSocketAction)
+		**out = **in
 	}
 	return
 }
@@ -1806,12 +1609,8 @@ func (in *HostPathVolumeSource) DeepCopyInto(out *HostPathVolumeSource) {
 	*out = *in
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathType)
-			**out = **in
-		}
+		*out = new(HostPathType)
+		**out = **in
 	}
 	return
 }
@@ -1836,21 +1635,13 @@ func (in *ISCSIPersistentVolumeSource) DeepCopyInto(out *ISCSIPersistentVolumeSo
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	if in.InitiatorName != nil {
 		in, out := &in.InitiatorName, &out.InitiatorName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1875,21 +1666,13 @@ func (in *ISCSIVolumeSource) DeepCopyInto(out *ISCSIVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	if in.InitiatorName != nil {
 		in, out := &in.InitiatorName, &out.InitiatorName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1909,12 +1692,8 @@ func (in *KeyToPath) DeepCopyInto(out *KeyToPath) {
 	*out = *in
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1934,21 +1713,13 @@ func (in *Lifecycle) DeepCopyInto(out *Lifecycle) {
 	*out = *in
 	if in.PostStart != nil {
 		in, out := &in.PostStart, &out.PostStart
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Handler)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Handler)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PreStop != nil {
 		in, out := &in.PreStop, &out.PreStop
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Handler)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Handler)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2362,12 +2133,8 @@ func (in *NodeAffinity) DeepCopyInto(out *NodeAffinity) {
 	*out = *in
 	if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PreferredDuringSchedulingIgnoredDuringExecution != nil {
 		in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
@@ -2412,12 +2179,8 @@ func (in *NodeConfigSource) DeepCopyInto(out *NodeConfigSource) {
 	*out = *in
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapNodeConfigSource)
-			**out = **in
-		}
+		*out = new(ConfigMapNodeConfigSource)
+		**out = **in
 	}
 	return
 }
@@ -2437,30 +2200,18 @@ func (in *NodeConfigStatus) DeepCopyInto(out *NodeConfigStatus) {
 	*out = *in
 	if in.Assigned != nil {
 		in, out := &in.Assigned, &out.Assigned
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Active != nil {
 		in, out := &in.Active, &out.Active
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LastKnownGood != nil {
 		in, out := &in.LastKnownGood, &out.LastKnownGood
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2659,12 +2410,8 @@ func (in *NodeSpec) DeepCopyInto(out *NodeSpec) {
 	}
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2729,12 +2476,8 @@ func (in *NodeStatus) DeepCopyInto(out *NodeStatus) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeConfigStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeConfigStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -2922,31 +2665,19 @@ func (in *PersistentVolumeClaimSpec) DeepCopyInto(out *PersistentVolumeClaimSpec
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.StorageClassName != nil {
 		in, out := &in.StorageClassName, &out.StorageClassName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.VolumeMode != nil {
 		in, out := &in.VolumeMode, &out.VolumeMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeMode)
-			**out = **in
-		}
+		*out = new(PersistentVolumeMode)
+		**out = **in
 	}
 	return
 }
@@ -3050,201 +2781,113 @@ func (in *PersistentVolumeSource) DeepCopyInto(out *PersistentVolumeSource) {
 	*out = *in
 	if in.GCEPersistentDisk != nil {
 		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GCEPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(GCEPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.AWSElasticBlockStore != nil {
 		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AWSElasticBlockStoreVolumeSource)
-			**out = **in
-		}
+		*out = new(AWSElasticBlockStoreVolumeSource)
+		**out = **in
 	}
 	if in.HostPath != nil {
 		in, out := &in.HostPath, &out.HostPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HostPathVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Glusterfs != nil {
 		in, out := &in.Glusterfs, &out.Glusterfs
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GlusterfsVolumeSource)
-			**out = **in
-		}
+		*out = new(GlusterfsVolumeSource)
+		**out = **in
 	}
 	if in.NFS != nil {
 		in, out := &in.NFS, &out.NFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NFSVolumeSource)
-			**out = **in
-		}
+		*out = new(NFSVolumeSource)
+		**out = **in
 	}
 	if in.RBD != nil {
 		in, out := &in.RBD, &out.RBD
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RBDPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RBDPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ISCSI != nil {
 		in, out := &in.ISCSI, &out.ISCSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ISCSIPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ISCSIPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Cinder != nil {
 		in, out := &in.Cinder, &out.Cinder
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CinderPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CinderPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CephFS != nil {
 		in, out := &in.CephFS, &out.CephFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CephFSPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CephFSPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FC != nil {
 		in, out := &in.FC, &out.FC
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FCVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FCVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Flocker != nil {
 		in, out := &in.Flocker, &out.Flocker
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlockerVolumeSource)
-			**out = **in
-		}
+		*out = new(FlockerVolumeSource)
+		**out = **in
 	}
 	if in.FlexVolume != nil {
 		in, out := &in.FlexVolume, &out.FlexVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlexPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FlexPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AzureFile != nil {
 		in, out := &in.AzureFile, &out.AzureFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureFilePersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureFilePersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.VsphereVolume != nil {
 		in, out := &in.VsphereVolume, &out.VsphereVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VsphereVirtualDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(VsphereVirtualDiskVolumeSource)
+		**out = **in
 	}
 	if in.Quobyte != nil {
 		in, out := &in.Quobyte, &out.Quobyte
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(QuobyteVolumeSource)
-			**out = **in
-		}
+		*out = new(QuobyteVolumeSource)
+		**out = **in
 	}
 	if in.AzureDisk != nil {
 		in, out := &in.AzureDisk, &out.AzureDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDiskVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureDiskVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PhotonPersistentDisk != nil {
 		in, out := &in.PhotonPersistentDisk, &out.PhotonPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PhotonPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(PhotonPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.PortworxVolume != nil {
 		in, out := &in.PortworxVolume, &out.PortworxVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PortworxVolumeSource)
-			**out = **in
-		}
+		*out = new(PortworxVolumeSource)
+		**out = **in
 	}
 	if in.ScaleIO != nil {
 		in, out := &in.ScaleIO, &out.ScaleIO
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScaleIOPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScaleIOPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Local != nil {
 		in, out := &in.Local, &out.Local
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalVolumeSource)
-			**out = **in
-		}
+		*out = new(LocalVolumeSource)
+		**out = **in
 	}
 	if in.StorageOS != nil {
 		in, out := &in.StorageOS, &out.StorageOS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(StorageOSPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(StorageOSPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CSI != nil {
 		in, out := &in.CSI, &out.CSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CSIPersistentVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CSIPersistentVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3277,12 +2920,8 @@ func (in *PersistentVolumeSpec) DeepCopyInto(out *PersistentVolumeSpec) {
 	}
 	if in.ClaimRef != nil {
 		in, out := &in.ClaimRef, &out.ClaimRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	if in.MountOptions != nil {
 		in, out := &in.MountOptions, &out.MountOptions
@@ -3291,21 +2930,13 @@ func (in *PersistentVolumeSpec) DeepCopyInto(out *PersistentVolumeSpec) {
 	}
 	if in.VolumeMode != nil {
 		in, out := &in.VolumeMode, &out.VolumeMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeMode)
-			**out = **in
-		}
+		*out = new(PersistentVolumeMode)
+		**out = **in
 	}
 	if in.NodeAffinity != nil {
 		in, out := &in.NodeAffinity, &out.NodeAffinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeNodeAffinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeNodeAffinity)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3415,12 +3046,8 @@ func (in *PodAffinityTerm) DeepCopyInto(out *PodAffinityTerm) {
 	*out = *in
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Namespaces != nil {
 		in, out := &in.Namespaces, &out.Namespaces
@@ -3551,12 +3178,8 @@ func (in *PodDNSConfigOption) DeepCopyInto(out *PodDNSConfigOption) {
 	*out = *in
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -3640,38 +3263,22 @@ func (in *PodLogOptions) DeepCopyInto(out *PodLogOptions) {
 	out.TypeMeta = in.TypeMeta
 	if in.SinceSeconds != nil {
 		in, out := &in.SinceSeconds, &out.SinceSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.SinceTime != nil {
 		in, out := &in.SinceTime, &out.SinceTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.TailLines != nil {
 		in, out := &in.TailLines, &out.TailLines
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.LimitBytes != nil {
 		in, out := &in.LimitBytes, &out.LimitBytes
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -3770,39 +3377,23 @@ func (in *PodSecurityContext) DeepCopyInto(out *PodSecurityContext) {
 	*out = *in
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SELinuxOptions)
-			**out = **in
-		}
+		*out = new(SELinuxOptions)
+		**out = **in
 	}
 	if in.RunAsUser != nil {
 		in, out := &in.RunAsUser, &out.RunAsUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsGroup != nil {
 		in, out := &in.RunAsGroup, &out.RunAsGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsNonRoot != nil {
 		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SupplementalGroups != nil {
 		in, out := &in.SupplementalGroups, &out.SupplementalGroups
@@ -3811,12 +3402,8 @@ func (in *PodSecurityContext) DeepCopyInto(out *PodSecurityContext) {
 	}
 	if in.FSGroup != nil {
 		in, out := &in.FSGroup, &out.FSGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Sysctls != nil {
 		in, out := &in.Sysctls, &out.Sysctls
@@ -3841,12 +3428,8 @@ func (in *PodSignature) DeepCopyInto(out *PodSignature) {
 	*out = *in
 	if in.PodController != nil {
 		in, out := &in.PodController, &out.PodController
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.OwnerReference)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.OwnerReference)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -3887,21 +3470,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -3912,30 +3487,18 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.AutomountServiceAccountToken != nil {
 		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.ShareProcessNamespace != nil {
 		in, out := &in.ShareProcessNamespace, &out.ShareProcessNamespace
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodSecurityContext)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodSecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
@@ -3944,12 +3507,8 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Affinity)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Affinity)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
@@ -3967,21 +3526,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.DNSConfig != nil {
 		in, out := &in.DNSConfig, &out.DNSConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodDNSConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodDNSConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ReadinessGates != nil {
 		in, out := &in.ReadinessGates, &out.ReadinessGates
@@ -4013,11 +3564,7 @@ func (in *PodStatus) DeepCopyInto(out *PodStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.InitContainerStatuses != nil {
 		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
@@ -4172,12 +3719,8 @@ func (in *Preconditions) DeepCopyInto(out *Preconditions) {
 	*out = *in
 	if in.UID != nil {
 		in, out := &in.UID, &out.UID
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(types.UID)
-			**out = **in
-		}
+		*out = new(types.UID)
+		**out = **in
 	}
 	return
 }
@@ -4256,12 +3799,8 @@ func (in *ProjectedVolumeSource) DeepCopyInto(out *ProjectedVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -4302,12 +3841,8 @@ func (in *RBDPersistentVolumeSource) DeepCopyInto(out *RBDPersistentVolumeSource
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -4332,12 +3867,8 @@ func (in *RBDVolumeSource) DeepCopyInto(out *RBDVolumeSource) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -4466,12 +3997,8 @@ func (in *ReplicationControllerSpec) DeepCopyInto(out *ReplicationControllerSpec
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
@@ -4482,12 +4009,8 @@ func (in *ReplicationControllerSpec) DeepCopyInto(out *ReplicationControllerSpec
 	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PodTemplateSpec)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(PodTemplateSpec)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -4642,12 +4165,8 @@ func (in *ResourceQuotaSpec) DeepCopyInto(out *ResourceQuotaSpec) {
 	}
 	if in.ScopeSelector != nil {
 		in, out := &in.ScopeSelector, &out.ScopeSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScopeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScopeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -4743,12 +4262,8 @@ func (in *ScaleIOPersistentVolumeSource) DeepCopyInto(out *ScaleIOPersistentVolu
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretReference)
-			**out = **in
-		}
+		*out = new(SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -4768,12 +4283,8 @@ func (in *ScaleIOVolumeSource) DeepCopyInto(out *ScaleIOVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -4841,12 +4352,15 @@ func (in *Secret) DeepCopyInto(out *Secret) {
 		in, out := &in.Data, &out.Data
 		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
+			var outVal []byte
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]byte, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.StringData != nil {
@@ -4883,12 +4397,8 @@ func (in *SecretEnvSource) DeepCopyInto(out *SecretEnvSource) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -4909,12 +4419,8 @@ func (in *SecretKeySelector) DeepCopyInto(out *SecretKeySelector) {
 	out.LocalObjectReference = in.LocalObjectReference
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -4975,12 +4481,8 @@ func (in *SecretProjection) DeepCopyInto(out *SecretProjection) {
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5023,21 +4525,13 @@ func (in *SecretVolumeSource) DeepCopyInto(out *SecretVolumeSource) {
 	}
 	if in.DefaultMode != nil {
 		in, out := &in.DefaultMode, &out.DefaultMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Optional != nil {
 		in, out := &in.Optional, &out.Optional
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5057,75 +4551,43 @@ func (in *SecurityContext) DeepCopyInto(out *SecurityContext) {
 	*out = *in
 	if in.Capabilities != nil {
 		in, out := &in.Capabilities, &out.Capabilities
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Capabilities)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Capabilities)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Privileged != nil {
 		in, out := &in.Privileged, &out.Privileged
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SELinuxOptions)
-			**out = **in
-		}
+		*out = new(SELinuxOptions)
+		**out = **in
 	}
 	if in.RunAsUser != nil {
 		in, out := &in.RunAsUser, &out.RunAsUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsGroup != nil {
 		in, out := &in.RunAsGroup, &out.RunAsGroup
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.RunAsNonRoot != nil {
 		in, out := &in.RunAsNonRoot, &out.RunAsNonRoot
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.ReadOnlyRootFilesystem != nil {
 		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowPrivilegeEscalation != nil {
 		in, out := &in.AllowPrivilegeEscalation, &out.AllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5211,12 +4673,8 @@ func (in *ServiceAccount) DeepCopyInto(out *ServiceAccount) {
 	}
 	if in.AutomountServiceAccountToken != nil {
 		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -5277,12 +4735,8 @@ func (in *ServiceAccountTokenProjection) DeepCopyInto(out *ServiceAccountTokenPr
 	*out = *in
 	if in.ExpirationSeconds != nil {
 		in, out := &in.ExpirationSeconds, &out.ExpirationSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -5399,12 +4853,8 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 	}
 	if in.SessionAffinityConfig != nil {
 		in, out := &in.SessionAffinityConfig, &out.SessionAffinityConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SessionAffinityConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SessionAffinityConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5441,12 +4891,8 @@ func (in *SessionAffinityConfig) DeepCopyInto(out *SessionAffinityConfig) {
 	*out = *in
 	if in.ClientIP != nil {
 		in, out := &in.ClientIP, &out.ClientIP
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClientIPConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ClientIPConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5466,12 +4912,8 @@ func (in *StorageOSPersistentVolumeSource) DeepCopyInto(out *StorageOSPersistent
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -5491,12 +4933,8 @@ func (in *StorageOSVolumeSource) DeepCopyInto(out *StorageOSVolumeSource) {
 	*out = *in
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(LocalObjectReference)
-			**out = **in
-		}
+		*out = new(LocalObjectReference)
+		**out = **in
 	}
 	return
 }
@@ -5549,11 +4987,7 @@ func (in *Taint) DeepCopyInto(out *Taint) {
 	*out = *in
 	if in.TimeAdded != nil {
 		in, out := &in.TimeAdded, &out.TimeAdded
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -5573,12 +5007,8 @@ func (in *Toleration) DeepCopyInto(out *Toleration) {
 	*out = *in
 	if in.TolerationSeconds != nil {
 		in, out := &in.TolerationSeconds, &out.TolerationSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -5675,12 +5105,8 @@ func (in *VolumeMount) DeepCopyInto(out *VolumeMount) {
 	*out = *in
 	if in.MountPropagation != nil {
 		in, out := &in.MountPropagation, &out.MountPropagation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(MountPropagationMode)
-			**out = **in
-		}
+		*out = new(MountPropagationMode)
+		**out = **in
 	}
 	return
 }
@@ -5700,12 +5126,8 @@ func (in *VolumeNodeAffinity) DeepCopyInto(out *VolumeNodeAffinity) {
 	*out = *in
 	if in.Required != nil {
 		in, out := &in.Required, &out.Required
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NodeSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(NodeSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5725,39 +5147,23 @@ func (in *VolumeProjection) DeepCopyInto(out *VolumeProjection) {
 	*out = *in
 	if in.Secret != nil {
 		in, out := &in.Secret, &out.Secret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DownwardAPI != nil {
 		in, out := &in.DownwardAPI, &out.DownwardAPI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(DownwardAPIProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(DownwardAPIProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ServiceAccountToken != nil {
 		in, out := &in.ServiceAccountToken, &out.ServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceAccountTokenProjection)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ServiceAccountTokenProjection)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -5777,246 +5183,138 @@ func (in *VolumeSource) DeepCopyInto(out *VolumeSource) {
 	*out = *in
 	if in.HostPath != nil {
 		in, out := &in.HostPath, &out.HostPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HostPathVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HostPathVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EmptyDir != nil {
 		in, out := &in.EmptyDir, &out.EmptyDir
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EmptyDirVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EmptyDirVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.GCEPersistentDisk != nil {
 		in, out := &in.GCEPersistentDisk, &out.GCEPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GCEPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(GCEPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.AWSElasticBlockStore != nil {
 		in, out := &in.AWSElasticBlockStore, &out.AWSElasticBlockStore
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AWSElasticBlockStoreVolumeSource)
-			**out = **in
-		}
+		*out = new(AWSElasticBlockStoreVolumeSource)
+		**out = **in
 	}
 	if in.GitRepo != nil {
 		in, out := &in.GitRepo, &out.GitRepo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GitRepoVolumeSource)
-			**out = **in
-		}
+		*out = new(GitRepoVolumeSource)
+		**out = **in
 	}
 	if in.Secret != nil {
 		in, out := &in.Secret, &out.Secret
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(SecretVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(SecretVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NFS != nil {
 		in, out := &in.NFS, &out.NFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(NFSVolumeSource)
-			**out = **in
-		}
+		*out = new(NFSVolumeSource)
+		**out = **in
 	}
 	if in.ISCSI != nil {
 		in, out := &in.ISCSI, &out.ISCSI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ISCSIVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ISCSIVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Glusterfs != nil {
 		in, out := &in.Glusterfs, &out.Glusterfs
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(GlusterfsVolumeSource)
-			**out = **in
-		}
+		*out = new(GlusterfsVolumeSource)
+		**out = **in
 	}
 	if in.PersistentVolumeClaim != nil {
 		in, out := &in.PersistentVolumeClaim, &out.PersistentVolumeClaim
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PersistentVolumeClaimVolumeSource)
-			**out = **in
-		}
+		*out = new(PersistentVolumeClaimVolumeSource)
+		**out = **in
 	}
 	if in.RBD != nil {
 		in, out := &in.RBD, &out.RBD
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RBDVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RBDVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FlexVolume != nil {
 		in, out := &in.FlexVolume, &out.FlexVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlexVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FlexVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Cinder != nil {
 		in, out := &in.Cinder, &out.Cinder
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CinderVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CinderVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CephFS != nil {
 		in, out := &in.CephFS, &out.CephFS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CephFSVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CephFSVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Flocker != nil {
 		in, out := &in.Flocker, &out.Flocker
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FlockerVolumeSource)
-			**out = **in
-		}
+		*out = new(FlockerVolumeSource)
+		**out = **in
 	}
 	if in.DownwardAPI != nil {
 		in, out := &in.DownwardAPI, &out.DownwardAPI
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(DownwardAPIVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(DownwardAPIVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FC != nil {
 		in, out := &in.FC, &out.FC
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(FCVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(FCVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AzureFile != nil {
 		in, out := &in.AzureFile, &out.AzureFile
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureFileVolumeSource)
-			**out = **in
-		}
+		*out = new(AzureFileVolumeSource)
+		**out = **in
 	}
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ConfigMapVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ConfigMapVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.VsphereVolume != nil {
 		in, out := &in.VsphereVolume, &out.VsphereVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VsphereVirtualDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(VsphereVirtualDiskVolumeSource)
+		**out = **in
 	}
 	if in.Quobyte != nil {
 		in, out := &in.Quobyte, &out.Quobyte
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(QuobyteVolumeSource)
-			**out = **in
-		}
+		*out = new(QuobyteVolumeSource)
+		**out = **in
 	}
 	if in.AzureDisk != nil {
 		in, out := &in.AzureDisk, &out.AzureDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureDiskVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AzureDiskVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PhotonPersistentDisk != nil {
 		in, out := &in.PhotonPersistentDisk, &out.PhotonPersistentDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PhotonPersistentDiskVolumeSource)
-			**out = **in
-		}
+		*out = new(PhotonPersistentDiskVolumeSource)
+		**out = **in
 	}
 	if in.Projected != nil {
 		in, out := &in.Projected, &out.Projected
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ProjectedVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ProjectedVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PortworxVolume != nil {
 		in, out := &in.PortworxVolume, &out.PortworxVolume
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(PortworxVolumeSource)
-			**out = **in
-		}
+		*out = new(PortworxVolumeSource)
+		**out = **in
 	}
 	if in.ScaleIO != nil {
 		in, out := &in.ScaleIO, &out.ScaleIO
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ScaleIOVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ScaleIOVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StorageOS != nil {
 		in, out := &in.StorageOS, &out.StorageOS
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(StorageOSVolumeSource)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(StorageOSVolumeSource)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/events/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/events/v1beta1/zz_generated.deepcopy.go
@@ -33,22 +33,14 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.EventTime.DeepCopyInto(&out.EventTime)
 	if in.Series != nil {
 		in, out := &in.Series, &out.Series
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(EventSeries)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(EventSeries)
+		(*in).DeepCopyInto(*out)
 	}
 	out.Regarding = in.Regarding
 	if in.Related != nil {
 		in, out := &in.Related, &out.Related
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.ObjectReference)
-			**out = **in
-		}
+		*out = new(v1.ObjectReference)
+		**out = **in
 	}
 	out.DeprecatedSource = in.DeprecatedSource
 	in.DeprecatedFirstTimestamp.DeepCopyInto(&out.DeprecatedFirstTimestamp)

--- a/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.deepcopy.go
@@ -222,23 +222,15 @@ func (in *DaemonSetSpec) DeepCopyInto(out *DaemonSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.UpdateStrategy.DeepCopyInto(&out.UpdateStrategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -258,12 +250,8 @@ func (in *DaemonSetStatus) DeepCopyInto(out *DaemonSetStatus) {
 	*out = *in
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
@@ -290,12 +278,8 @@ func (in *DaemonSetUpdateStrategy) DeepCopyInto(out *DaemonSetUpdateStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDaemonSet)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDaemonSet)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -427,50 +411,30 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.RollbackTo != nil {
 		in, out := &in.RollbackTo, &out.RollbackTo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollbackConfig)
-			**out = **in
-		}
+		*out = new(RollbackConfig)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -497,12 +461,8 @@ func (in *DeploymentStatus) DeepCopyInto(out *DeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -522,12 +482,8 @@ func (in *DeploymentStrategy) DeepCopyInto(out *DeploymentStrategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -754,12 +710,8 @@ func (in *IngressRuleValue) DeepCopyInto(out *IngressRuleValue) {
 	*out = *in
 	if in.HTTP != nil {
 		in, out := &in.HTTP, &out.HTTP
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(HTTPIngressRuleValue)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(HTTPIngressRuleValue)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -779,12 +731,8 @@ func (in *IngressSpec) DeepCopyInto(out *IngressSpec) {
 	*out = *in
 	if in.Backend != nil {
 		in, out := &in.Backend, &out.Backend
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(IngressBackend)
-			**out = **in
-		}
+		*out = new(IngressBackend)
+		**out = **in
 	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
@@ -976,30 +924,18 @@ func (in *NetworkPolicyPeer) DeepCopyInto(out *NetworkPolicyPeer) {
 	*out = *in
 	if in.PodSelector != nil {
 		in, out := &in.PodSelector, &out.PodSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.IPBlock != nil {
 		in, out := &in.IPBlock, &out.IPBlock
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(IPBlock)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(IPBlock)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1019,21 +955,13 @@ func (in *NetworkPolicyPort) DeepCopyInto(out *NetworkPolicyPort) {
 	*out = *in
 	if in.Protocol != nil {
 		in, out := &in.Protocol, &out.Protocol
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.Protocol)
-			**out = **in
-		}
+		*out = new(core_v1.Protocol)
+		**out = **in
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -1178,21 +1106,13 @@ func (in *PodSecurityPolicySpec) DeepCopyInto(out *PodSecurityPolicySpec) {
 	in.FSGroup.DeepCopyInto(&out.FSGroup)
 	if in.DefaultAllowPrivilegeEscalation != nil {
 		in, out := &in.DefaultAllowPrivilegeEscalation, &out.DefaultAllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowPrivilegeEscalation != nil {
 		in, out := &in.AllowPrivilegeEscalation, &out.AllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowedHostPaths != nil {
 		in, out := &in.AllowedHostPaths, &out.AllowedHostPaths
@@ -1310,21 +1230,13 @@ func (in *ReplicaSetSpec) DeepCopyInto(out *ReplicaSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	return
@@ -1409,12 +1321,8 @@ func (in *RollingUpdateDaemonSet) DeepCopyInto(out *RollingUpdateDaemonSet) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -1434,21 +1342,13 @@ func (in *RollingUpdateDeployment) DeepCopyInto(out *RollingUpdateDeployment) {
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -1489,12 +1389,8 @@ func (in *SELinuxStrategyOptions) DeepCopyInto(out *SELinuxStrategyOptions) {
 	*out = *in
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.SELinuxOptions)
-			**out = **in
-		}
+		*out = new(core_v1.SELinuxOptions)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/api/networking/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/networking/v1/zz_generated.deepcopy.go
@@ -173,30 +173,18 @@ func (in *NetworkPolicyPeer) DeepCopyInto(out *NetworkPolicyPeer) {
 	*out = *in
 	if in.PodSelector != nil {
 		in, out := &in.PodSelector, &out.PodSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.IPBlock != nil {
 		in, out := &in.IPBlock, &out.IPBlock
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(IPBlock)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(IPBlock)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -216,21 +204,13 @@ func (in *NetworkPolicyPort) DeepCopyInto(out *NetworkPolicyPort) {
 	*out = *in
 	if in.Protocol != nil {
 		in, out := &in.Protocol, &out.Protocol
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.Protocol)
-			**out = **in
-		}
+		*out = new(core_v1.Protocol)
+		**out = **in
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/api/policy/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/zz_generated.deepcopy.go
@@ -66,12 +66,8 @@ func (in *Eviction) DeepCopyInto(out *Eviction) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	if in.DeleteOptions != nil {
 		in, out := &in.DeleteOptions, &out.DeleteOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.DeleteOptions)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.DeleteOptions)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -213,30 +209,18 @@ func (in *PodDisruptionBudgetSpec) DeepCopyInto(out *PodDisruptionBudgetSpec) {
 	*out = *in
 	if in.MinAvailable != nil {
 		in, out := &in.MinAvailable, &out.MinAvailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -368,21 +352,13 @@ func (in *PodSecurityPolicySpec) DeepCopyInto(out *PodSecurityPolicySpec) {
 	in.FSGroup.DeepCopyInto(&out.FSGroup)
 	if in.DefaultAllowPrivilegeEscalation != nil {
 		in, out := &in.DefaultAllowPrivilegeEscalation, &out.DefaultAllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowPrivilegeEscalation != nil {
 		in, out := &in.AllowPrivilegeEscalation, &out.AllowPrivilegeEscalation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.AllowedHostPaths != nil {
 		in, out := &in.AllowedHostPaths, &out.AllowedHostPaths
@@ -443,12 +419,8 @@ func (in *SELinuxStrategyOptions) DeepCopyInto(out *SELinuxStrategyOptions) {
 	*out = *in
 	if in.SELinuxOptions != nil {
 		in, out := &in.SELinuxOptions, &out.SELinuxOptions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.SELinuxOptions)
-			**out = **in
-		}
+		*out = new(core_v1.SELinuxOptions)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/api/rbac/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/rbac/v1/zz_generated.deepcopy.go
@@ -62,12 +62,8 @@ func (in *ClusterRole) DeepCopyInto(out *ClusterRole) {
 	}
 	if in.AggregationRule != nil {
 		in, out := &in.AggregationRule, &out.AggregationRule
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AggregationRule)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AggregationRule)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/rbac/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/zz_generated.deepcopy.go
@@ -62,12 +62,8 @@ func (in *ClusterRole) DeepCopyInto(out *ClusterRole) {
 	}
 	if in.AggregationRule != nil {
 		in, out := &in.AggregationRule, &out.AggregationRule
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AggregationRule)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AggregationRule)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/rbac/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/zz_generated.deepcopy.go
@@ -62,12 +62,8 @@ func (in *ClusterRole) DeepCopyInto(out *ClusterRole) {
 	}
 	if in.AggregationRule != nil {
 		in, out := &in.AggregationRule, &out.AggregationRule
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AggregationRule)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AggregationRule)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/storage/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/storage/v1/zz_generated.deepcopy.go
@@ -39,12 +39,8 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.ReclaimPolicy != nil {
 		in, out := &in.ReclaimPolicy, &out.ReclaimPolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(core_v1.PersistentVolumeReclaimPolicy)
-			**out = **in
-		}
+		*out = new(core_v1.PersistentVolumeReclaimPolicy)
+		**out = **in
 	}
 	if in.MountOptions != nil {
 		in, out := &in.MountOptions, &out.MountOptions
@@ -53,21 +49,13 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.AllowVolumeExpansion != nil {
 		in, out := &in.AllowVolumeExpansion, &out.AllowVolumeExpansion
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.VolumeBindingMode != nil {
 		in, out := &in.VolumeBindingMode, &out.VolumeBindingMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeBindingMode)
-			**out = **in
-		}
+		*out = new(VolumeBindingMode)
+		**out = **in
 	}
 	if in.AllowedTopologies != nil {
 		in, out := &in.AllowedTopologies, &out.AllowedTopologies

--- a/staging/src/k8s.io/api/storage/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/zz_generated.deepcopy.go
@@ -90,12 +90,8 @@ func (in *VolumeAttachmentSource) DeepCopyInto(out *VolumeAttachmentSource) {
 	*out = *in
 	if in.PersistentVolumeName != nil {
 		in, out := &in.PersistentVolumeName, &out.PersistentVolumeName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -139,21 +135,13 @@ func (in *VolumeAttachmentStatus) DeepCopyInto(out *VolumeAttachmentStatus) {
 	}
 	if in.AttachError != nil {
 		in, out := &in.AttachError, &out.AttachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DetachError != nil {
 		in, out := &in.DetachError, &out.DetachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/api/storage/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/zz_generated.deepcopy.go
@@ -39,12 +39,8 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.ReclaimPolicy != nil {
 		in, out := &in.ReclaimPolicy, &out.ReclaimPolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.PersistentVolumeReclaimPolicy)
-			**out = **in
-		}
+		*out = new(v1.PersistentVolumeReclaimPolicy)
+		**out = **in
 	}
 	if in.MountOptions != nil {
 		in, out := &in.MountOptions, &out.MountOptions
@@ -53,21 +49,13 @@ func (in *StorageClass) DeepCopyInto(out *StorageClass) {
 	}
 	if in.AllowVolumeExpansion != nil {
 		in, out := &in.AllowVolumeExpansion, &out.AllowVolumeExpansion
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.VolumeBindingMode != nil {
 		in, out := &in.VolumeBindingMode, &out.VolumeBindingMode
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeBindingMode)
-			**out = **in
-		}
+		*out = new(VolumeBindingMode)
+		**out = **in
 	}
 	if in.AllowedTopologies != nil {
 		in, out := &in.AllowedTopologies, &out.AllowedTopologies
@@ -196,12 +184,8 @@ func (in *VolumeAttachmentSource) DeepCopyInto(out *VolumeAttachmentSource) {
 	*out = *in
 	if in.PersistentVolumeName != nil {
 		in, out := &in.PersistentVolumeName, &out.PersistentVolumeName
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -245,21 +229,13 @@ func (in *VolumeAttachmentStatus) DeepCopyInto(out *VolumeAttachmentStatus) {
 	}
 	if in.AttachError != nil {
 		in, out := &in.AttachError, &out.AttachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DetachError != nil {
 		in, out := &in.DetachError, &out.DetachError
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(VolumeError)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(VolumeError)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.deepcopy.go
@@ -150,21 +150,13 @@ func (in *CustomResourceDefinitionSpec) DeepCopyInto(out *CustomResourceDefiniti
 	in.Names.DeepCopyInto(&out.Names)
 	if in.Validation != nil {
 		in, out := &in.Validation, &out.Validation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceValidation)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceValidation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Subresources != nil {
 		in, out := &in.Subresources, &out.Subresources
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresources)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceSubresources)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Versions != nil {
 		in, out := &in.Versions, &out.Versions
@@ -239,12 +231,8 @@ func (in *CustomResourceSubresourceScale) DeepCopyInto(out *CustomResourceSubres
 	*out = *in
 	if in.LabelSelectorPath != nil {
 		in, out := &in.LabelSelectorPath, &out.LabelSelectorPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -280,21 +268,13 @@ func (in *CustomResourceSubresources) DeepCopyInto(out *CustomResourceSubresourc
 	*out = *in
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresourceStatus)
-			**out = **in
-		}
+		*out = new(CustomResourceSubresourceStatus)
+		**out = **in
 	}
 	if in.Scale != nil {
 		in, out := &in.Scale, &out.Scale
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresourceScale)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceSubresourceScale)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -314,11 +294,7 @@ func (in *CustomResourceValidation) DeepCopyInto(out *CustomResourceValidation) 
 	*out = *in
 	if in.OpenAPIV3Schema != nil {
 		in, out := &in.OpenAPIV3Schema, &out.OpenAPIV3Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -426,11 +402,7 @@ func (in *JSONSchemaPropsOrArray) DeepCopyInto(out *JSONSchemaPropsOrArray) {
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.JSONSchemas != nil {
 		in, out := &in.JSONSchemas, &out.JSONSchemas
@@ -457,11 +429,7 @@ func (in *JSONSchemaPropsOrBool) DeepCopyInto(out *JSONSchemaPropsOrBool) {
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -481,11 +449,7 @@ func (in *JSONSchemaPropsOrStringArray) DeepCopyInto(out *JSONSchemaPropsOrStrin
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.Property != nil {
 		in, out := &in.Property, &out.Property

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/zz_generated.deepcopy.go
@@ -150,21 +150,13 @@ func (in *CustomResourceDefinitionSpec) DeepCopyInto(out *CustomResourceDefiniti
 	in.Names.DeepCopyInto(&out.Names)
 	if in.Validation != nil {
 		in, out := &in.Validation, &out.Validation
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceValidation)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceValidation)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Subresources != nil {
 		in, out := &in.Subresources, &out.Subresources
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresources)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceSubresources)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Versions != nil {
 		in, out := &in.Versions, &out.Versions
@@ -239,12 +231,8 @@ func (in *CustomResourceSubresourceScale) DeepCopyInto(out *CustomResourceSubres
 	*out = *in
 	if in.LabelSelectorPath != nil {
 		in, out := &in.LabelSelectorPath, &out.LabelSelectorPath
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -280,21 +268,13 @@ func (in *CustomResourceSubresources) DeepCopyInto(out *CustomResourceSubresourc
 	*out = *in
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresourceStatus)
-			**out = **in
-		}
+		*out = new(CustomResourceSubresourceStatus)
+		**out = **in
 	}
 	if in.Scale != nil {
 		in, out := &in.Scale, &out.Scale
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(CustomResourceSubresourceScale)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(CustomResourceSubresourceScale)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -314,11 +294,7 @@ func (in *CustomResourceValidation) DeepCopyInto(out *CustomResourceValidation) 
 	*out = *in
 	if in.OpenAPIV3Schema != nil {
 		in, out := &in.OpenAPIV3Schema, &out.OpenAPIV3Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -405,11 +381,7 @@ func (in *JSONSchemaPropsOrArray) DeepCopyInto(out *JSONSchemaPropsOrArray) {
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.JSONSchemas != nil {
 		in, out := &in.JSONSchemas, &out.JSONSchemas
@@ -436,11 +408,7 @@ func (in *JSONSchemaPropsOrBool) DeepCopyInto(out *JSONSchemaPropsOrBool) {
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -460,11 +428,7 @@ func (in *JSONSchemaPropsOrStringArray) DeepCopyInto(out *JSONSchemaPropsOrStrin
 	*out = *in
 	if in.Schema != nil {
 		in, out := &in.Schema, &out.Schema
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.Property != nil {
 		in, out := &in.Property, &out.Property

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.deepcopy.go
@@ -77,12 +77,8 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
@@ -197,39 +197,23 @@ func (in *DeleteOptions) DeepCopyInto(out *DeleteOptions) {
 	out.TypeMeta = in.TypeMeta
 	if in.GracePeriodSeconds != nil {
 		in, out := &in.GracePeriodSeconds, &out.GracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Preconditions != nil {
 		in, out := &in.Preconditions, &out.Preconditions
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Preconditions)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Preconditions)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.OrphanDependents != nil {
 		in, out := &in.OrphanDependents, &out.OrphanDependents
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.PropagationPolicy != nil {
 		in, out := &in.PropagationPolicy, &out.PropagationPolicy
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(DeletionPropagation)
-			**out = **in
-		}
+		*out = new(DeletionPropagation)
+		**out = **in
 	}
 	return
 }
@@ -440,12 +424,8 @@ func (in *Initializers) DeepCopyInto(out *Initializers) {
 	}
 	if in.Result != nil {
 		in, out := &in.Result, &out.Result
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Status)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -587,12 +567,8 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 	out.TypeMeta = in.TypeMeta
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }
@@ -631,20 +607,12 @@ func (in *ObjectMeta) DeepCopyInto(out *ObjectMeta) {
 	in.CreationTimestamp.DeepCopyInto(&out.CreationTimestamp)
 	if in.DeletionTimestamp != nil {
 		in, out := &in.DeletionTimestamp, &out.DeletionTimestamp
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	if in.DeletionGracePeriodSeconds != nil {
 		in, out := &in.DeletionGracePeriodSeconds, &out.DeletionGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
@@ -669,12 +637,8 @@ func (in *ObjectMeta) DeepCopyInto(out *ObjectMeta) {
 	}
 	if in.Initializers != nil {
 		in, out := &in.Initializers, &out.Initializers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Initializers)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Initializers)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Finalizers != nil {
 		in, out := &in.Finalizers, &out.Finalizers
@@ -699,21 +663,13 @@ func (in *OwnerReference) DeepCopyInto(out *OwnerReference) {
 	*out = *in
 	if in.Controller != nil {
 		in, out := &in.Controller, &out.Controller
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	if in.BlockOwnerDeletion != nil {
 		in, out := &in.BlockOwnerDeletion, &out.BlockOwnerDeletion
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }
@@ -749,12 +705,8 @@ func (in *Preconditions) DeepCopyInto(out *Preconditions) {
 	*out = *in
 	if in.UID != nil {
 		in, out := &in.UID, &out.UID
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(types.UID)
-			**out = **in
-		}
+		*out = new(types.UID)
+		**out = **in
 	}
 	return
 }
@@ -813,12 +765,8 @@ func (in *Status) DeepCopyInto(out *Status) {
 	out.ListMeta = in.ListMeta
 	if in.Details != nil {
 		in, out := &in.Details, &out.Details
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(StatusDetails)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(StatusDetails)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/zz_generated.deepcopy.go
@@ -61,8 +61,9 @@ func (in *PartialObjectMetadataList) DeepCopyInto(out *PartialObjectMetadataList
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(PartialObjectMetadata)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(PartialObjectMetadata)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.deepcopy.go
@@ -108,21 +108,13 @@ func (in *CarpSpec) DeepCopyInto(out *CarpSpec) {
 	*out = *in
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -156,11 +148,7 @@ func (in *CarpStatus) DeepCopyInto(out *CarpStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/zz_generated.deepcopy.go
@@ -108,21 +108,13 @@ func (in *CarpSpec) DeepCopyInto(out *CarpSpec) {
 	*out = *in
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -156,11 +148,7 @@ func (in *CarpStatus) DeepCopyInto(out *CarpStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/testing/zz_generated.deepcopy.go
@@ -70,12 +70,8 @@ func (in *ExternalTestType1) DeepCopyInto(out *ExternalTestType1) {
 	}
 	if in.O != nil {
 		in, out := &in.O, &out.O
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalTestType2)
-			**out = **in
-		}
+		*out = new(ExternalTestType2)
+		**out = **in
 	}
 	if in.P != nil {
 		in, out := &in.P, &out.P
@@ -147,12 +143,8 @@ func (in *TestType1) DeepCopyInto(out *TestType1) {
 	}
 	if in.O != nil {
 		in, out := &in.O, &out.O
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(TestType2)
-			**out = **in
-		}
+		*out = new(TestType2)
+		**out = **in
 	}
 	if in.P != nil {
 		in, out := &in.P, &out.P

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/zz_generated.deepcopy.go
@@ -284,12 +284,8 @@ func (in *ExternalTestType1) DeepCopyInto(out *ExternalTestType1) {
 	}
 	if in.O != nil {
 		in, out := &in.O, &out.O
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExternalTestType2)
-			**out = **in
-		}
+		*out = new(ExternalTestType2)
+		**out = **in
 	}
 	if in.P != nil {
 		in, out := &in.P, &out.P
@@ -539,12 +535,8 @@ func (in *TestType1) DeepCopyInto(out *TestType1) {
 	}
 	if in.O != nil {
 		in, out := &in.O, &out.O
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(TestType2)
-			**out = **in
-		}
+		*out = new(TestType2)
+		**out = **in
 	}
 	if in.P != nil {
 		in, out := &in.P, &out.P

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
@@ -61,12 +61,8 @@ func (in *AdmissionPluginConfiguration) DeepCopyInto(out *AdmissionPluginConfigu
 	*out = *in
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
@@ -61,12 +61,8 @@ func (in *AdmissionPluginConfiguration) DeepCopyInto(out *AdmissionPluginConfigu
 	*out = *in
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.deepcopy.go
@@ -35,12 +35,8 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.User.DeepCopyInto(&out.User)
 	if in.ImpersonatedUser != nil {
 		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.UserInfo)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.UserInfo)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SourceIPs != nil {
 		in, out := &in.SourceIPs, &out.SourceIPs
@@ -49,39 +45,23 @@ func (in *Event) DeepCopyInto(out *Event) {
 	}
 	if in.ObjectRef != nil {
 		in, out := &in.ObjectRef, &out.ObjectRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	if in.ResponseStatus != nil {
 		in, out := &in.ResponseStatus, &out.ResponseStatus
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.Status)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RequestObject != nil {
 		in, out := &in.RequestObject, &out.RequestObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ResponseObject != nil {
 		in, out := &in.ResponseObject, &out.ResponseObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	in.RequestReceivedTimestamp.DeepCopyInto(&out.RequestReceivedTimestamp)
 	in.StageTimestamp.DeepCopyInto(&out.StageTimestamp)

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.deepcopy.go
@@ -35,12 +35,8 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.User.DeepCopyInto(&out.User)
 	if in.ImpersonatedUser != nil {
 		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.UserInfo)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.UserInfo)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SourceIPs != nil {
 		in, out := &in.SourceIPs, &out.SourceIPs
@@ -49,39 +45,23 @@ func (in *Event) DeepCopyInto(out *Event) {
 	}
 	if in.ObjectRef != nil {
 		in, out := &in.ObjectRef, &out.ObjectRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	if in.ResponseStatus != nil {
 		in, out := &in.ResponseStatus, &out.ResponseStatus
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(meta_v1.Status)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RequestObject != nil {
 		in, out := &in.RequestObject, &out.RequestObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ResponseObject != nil {
 		in, out := &in.ResponseObject, &out.ResponseObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	in.RequestReceivedTimestamp.DeepCopyInto(&out.RequestReceivedTimestamp)
 	in.StageTimestamp.DeepCopyInto(&out.StageTimestamp)

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/zz_generated.deepcopy.go
@@ -32,12 +32,8 @@ func (in *Event) DeepCopyInto(out *Event) {
 	in.User.DeepCopyInto(&out.User)
 	if in.ImpersonatedUser != nil {
 		in, out := &in.ImpersonatedUser, &out.ImpersonatedUser
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(UserInfo)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(UserInfo)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SourceIPs != nil {
 		in, out := &in.SourceIPs, &out.SourceIPs
@@ -46,39 +42,23 @@ func (in *Event) DeepCopyInto(out *Event) {
 	}
 	if in.ObjectRef != nil {
 		in, out := &in.ObjectRef, &out.ObjectRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ObjectReference)
-			**out = **in
-		}
+		*out = new(ObjectReference)
+		**out = **in
 	}
 	if in.ResponseStatus != nil {
 		in, out := &in.ResponseStatus, &out.ResponseStatus
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.Status)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.Status)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RequestObject != nil {
 		in, out := &in.RequestObject, &out.RequestObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ResponseObject != nil {
 		in, out := &in.ResponseObject, &out.ResponseObject
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(runtime.Unknown)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(runtime.Unknown)
+		(*in).DeepCopyInto(*out)
 	}
 	in.RequestReceivedTimestamp.DeepCopyInto(&out.RequestReceivedTimestamp)
 	in.StageTimestamp.DeepCopyInto(&out.StageTimestamp)
@@ -341,12 +321,15 @@ func (in *UserInfo) DeepCopyInto(out *UserInfo) {
 		in, out := &in.Extra, &out.Extra
 		*out = make(map[string]ExtraValue, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make(ExtraValue, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
@@ -108,21 +108,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	*out = *in
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -156,11 +148,7 @@ func (in *PodStatus) DeepCopyInto(out *PodStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
@@ -108,21 +108,13 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 	*out = *in
 	if in.TerminationGracePeriodSeconds != nil {
 		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
@@ -156,11 +148,7 @@ func (in *PodStatus) DeepCopyInto(out *PodStatus) {
 	}
 	if in.StartTime != nil {
 		in, out := &in.StartTime, &out.StartTime
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/zz_generated.deepcopy.go
@@ -57,12 +57,8 @@ func (in *ReplicaSetSpec) DeepCopyInto(out *ReplicaSetSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/zz_generated.deepcopy.go
@@ -31,12 +31,8 @@ func (in *ExecCredential) DeepCopyInto(out *ExecCredential) {
 	in.Spec.DeepCopyInto(&out.Spec)
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecCredentialStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecCredentialStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -64,12 +60,8 @@ func (in *ExecCredentialSpec) DeepCopyInto(out *ExecCredentialSpec) {
 	*out = *in
 	if in.Response != nil {
 		in, out := &in.Response, &out.Response
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Response)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Response)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -89,11 +81,7 @@ func (in *ExecCredentialStatus) DeepCopyInto(out *ExecCredentialStatus) {
 	*out = *in
 	if in.ExpirationTimestamp != nil {
 		in, out := &in.ExpirationTimestamp, &out.ExpirationTimestamp
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -115,12 +103,15 @@ func (in *Response) DeepCopyInto(out *Response) {
 		in, out := &in.Header, &out.Header
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/zz_generated.deepcopy.go
@@ -31,12 +31,8 @@ func (in *ExecCredential) DeepCopyInto(out *ExecCredential) {
 	out.Spec = in.Spec
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecCredentialStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecCredentialStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -80,11 +76,7 @@ func (in *ExecCredentialStatus) DeepCopyInto(out *ExecCredentialStatus) {
 	*out = *in
 	if in.ExpirationTimestamp != nil {
 		in, out := &in.ExpirationTimestamp, &out.ExpirationTimestamp
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/zz_generated.deepcopy.go
@@ -31,12 +31,8 @@ func (in *ExecCredential) DeepCopyInto(out *ExecCredential) {
 	in.Spec.DeepCopyInto(&out.Spec)
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecCredentialStatus)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecCredentialStatus)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -64,12 +60,8 @@ func (in *ExecCredentialSpec) DeepCopyInto(out *ExecCredentialSpec) {
 	*out = *in
 	if in.Response != nil {
 		in, out := &in.Response, &out.Response
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Response)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(Response)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -89,11 +81,7 @@ func (in *ExecCredentialStatus) DeepCopyInto(out *ExecCredentialStatus) {
 	*out = *in
 	if in.ExpirationTimestamp != nil {
 		in, out := &in.ExpirationTimestamp, &out.ExpirationTimestamp
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = (*in).DeepCopy()
-		}
+		*out = (*in).DeepCopy()
 	}
 	return
 }
@@ -115,12 +103,15 @@ func (in *Response) DeepCopyInto(out *Response) {
 		in, out := &in.Header, &out.Header
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/staging/src/k8s.io/client-go/scale/scheme/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/zz_generated.deepcopy.go
@@ -74,12 +74,8 @@ func (in *ScaleStatus) DeepCopyInto(out *ScaleStatus) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/zz_generated.deepcopy.go
@@ -46,31 +46,26 @@ func (in *AuthInfo) DeepCopyInto(out *AuthInfo) {
 		in, out := &in.ImpersonateUserExtra, &out.ImpersonateUserExtra
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.AuthProvider != nil {
 		in, out := &in.AuthProvider, &out.AuthProvider
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AuthProviderConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AuthProviderConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Exec != nil {
 		in, out := &in.Exec, &out.Exec
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Extensions != nil {
 		in, out := &in.Extensions, &out.Extensions

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/zz_generated.deepcopy.go
@@ -46,31 +46,26 @@ func (in *AuthInfo) DeepCopyInto(out *AuthInfo) {
 		in, out := &in.ImpersonateUserExtra, &out.ImpersonateUserExtra
 		*out = make(map[string][]string, len(*in))
 		for key, val := range *in {
+			var outVal []string
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = make([]string, len(val))
-				copy((*out)[key], val)
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.AuthProvider != nil {
 		in, out := &in.AuthProvider, &out.AuthProvider
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AuthProviderConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(AuthProviderConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Exec != nil {
 		in, out := &in.Exec, &out.Exec
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ExecConfig)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(ExecConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Extensions != nil {
 		in, out := &in.Extensions, &out.Extensions
@@ -159,36 +154,45 @@ func (in *Config) DeepCopyInto(out *Config) {
 		in, out := &in.Clusters, &out.Clusters
 		*out = make(map[string]*Cluster, len(*in))
 		for key, val := range *in {
+			var outVal *Cluster
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(Cluster)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(Cluster)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.AuthInfos != nil {
 		in, out := &in.AuthInfos, &out.AuthInfos
 		*out = make(map[string]*AuthInfo, len(*in))
 		for key, val := range *in {
+			var outVal *AuthInfo
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(AuthInfo)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(AuthInfo)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.Contexts != nil {
 		in, out := &in.Contexts, &out.Contexts
 		*out = make(map[string]*Context, len(*in))
 		for key, val := range *in {
+			var outVal *Context
 			if val == nil {
 				(*out)[key] = nil
 			} else {
-				(*out)[key] = new(Context)
-				val.DeepCopyInto((*out)[key])
+				in, out := &val, &outVal
+				*out = new(Context)
+				(*in).DeepCopyInto(*out)
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.Extensions != nil {

--- a/staging/src/k8s.io/code-generator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/code-generator/Godeps/Godeps.json
@@ -220,43 +220,43 @@
 		},
 		{
 			"ImportPath": "k8s.io/gengo/args",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/deepcopy-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/defaulter-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/import-boss/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/generators",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/sets",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/generator",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/namer",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/parser",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/types",
-			"Rev": "01a732e01d00cb9a81bb0ca050d3e6d2b947927b"
+			"Rev": "dcbe4570f0cf6efbc583a5321c8f9390f71a544d"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/common",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/zz_generated.deepcopy.go
@@ -107,12 +107,8 @@ func (in *APIServiceSpec) DeepCopyInto(out *APIServiceSpec) {
 	*out = *in
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceReference)
-			**out = **in
-		}
+		*out = new(ServiceReference)
+		**out = **in
 	}
 	if in.CABundle != nil {
 		in, out := &in.CABundle, &out.CABundle

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.deepcopy.go
@@ -107,12 +107,8 @@ func (in *APIServiceSpec) DeepCopyInto(out *APIServiceSpec) {
 	*out = *in
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceReference)
-			**out = **in
-		}
+		*out = new(ServiceReference)
+		**out = **in
 	}
 	if in.CABundle != nil {
 		in, out := &in.CABundle, &out.CABundle

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
@@ -107,12 +107,8 @@ func (in *APIServiceSpec) DeepCopyInto(out *APIServiceSpec) {
 	*out = *in
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ServiceReference)
-			**out = **in
-		}
+		*out = new(ServiceReference)
+		**out = **in
 	}
 	if in.CABundle != nil {
 		in, out := &in.CABundle, &out.CABundle
@@ -164,8 +160,9 @@ func (in ByGroupPriorityMinimum) DeepCopyInto(out *ByGroupPriorityMinimum) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(APIService)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(APIService)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 		return
@@ -191,8 +188,9 @@ func (in ByVersionPriority) DeepCopyInto(out *ByVersionPriority) {
 			if (*in)[i] == nil {
 				(*out)[i] = nil
 			} else {
-				(*out)[i] = new(APIService)
-				(*in)[i].DeepCopyInto((*out)[i])
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(APIService)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 		return

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/zz_generated.deepcopy.go
@@ -32,12 +32,8 @@ func (in *MetricValue) DeepCopyInto(out *MetricValue) {
 	in.Timestamp.DeepCopyInto(&out.Timestamp)
 	if in.WindowSeconds != nil {
 		in, out := &in.WindowSeconds, &out.WindowSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	out.Value = in.Value.DeepCopy()
 	return

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/zz_generated.deepcopy.go
@@ -32,12 +32,8 @@ func (in *MetricValue) DeepCopyInto(out *MetricValue) {
 	in.Timestamp.DeepCopyInto(&out.Timestamp)
 	if in.WindowSeconds != nil {
 		in, out := &in.WindowSeconds, &out.WindowSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	out.Value = in.Value.DeepCopy()
 	return

--- a/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1/zz_generated.deepcopy.go
@@ -38,12 +38,8 @@ func (in *ExternalMetricValue) DeepCopyInto(out *ExternalMetricValue) {
 	in.Timestamp.DeepCopyInto(&out.Timestamp)
 	if in.WindowSeconds != nil {
 		in, out := &in.WindowSeconds, &out.WindowSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	out.Value = in.Value.DeepCopy()
 	return

--- a/staging/src/k8s.io/metrics/pkg/apis/external_metrics/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/external_metrics/zz_generated.deepcopy.go
@@ -38,12 +38,8 @@ func (in *ExternalMetricValue) DeepCopyInto(out *ExternalMetricValue) {
 	in.Timestamp.DeepCopyInto(&out.Timestamp)
 	if in.WindowSeconds != nil {
 		in, out := &in.WindowSeconds, &out.WindowSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int64)
-			**out = **in
-		}
+		*out = new(int64)
+		**out = **in
 	}
 	out.Value = in.Value.DeepCopy()
 	return

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.deepcopy.go
@@ -154,12 +154,8 @@ func (in *FlunderSpec) DeepCopyInto(out *FlunderSpec) {
 	*out = *in
 	if in.ReferenceType != nil {
 		in, out := &in.ReferenceType, &out.ReferenceType
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ReferenceType)
-			**out = **in
-		}
+		*out = new(ReferenceType)
+		**out = **in
 	}
 	return
 }

--- a/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/zz_generated.deepcopy.go
@@ -90,12 +90,8 @@ func (in *FooSpec) DeepCopyInto(out *FooSpec) {
 	*out = *in
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }

--- a/vendor/k8s.io/gengo/generator/import_tracker.go
+++ b/vendor/k8s.io/gengo/generator/import_tracker.go
@@ -17,8 +17,9 @@ limitations under the License.
 package generator
 
 import (
-	"path/filepath"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
@@ -37,7 +38,14 @@ func NewImportTracker(typesToAdd ...*types.Type) namer.ImportTracker {
 
 func golangTrackerLocalName(tracker namer.ImportTracker, t types.Name) string {
 	path := t.Package
-	dirs := strings.Split(path, string(filepath.Separator))
+
+	// Using backslashes in package names causes gengo to produce Go code which
+	// will not compile with the gc compiler. See the comment on GoSeperator.
+	if strings.ContainsRune(path, '\\') {
+		glog.Warningf("Warning: backslash used in import path '%v', this is unsupported.\n", path)
+	}
+
+	dirs := strings.Split(path, namer.GoSeperator)
 	for n := len(dirs) - 1; n >= 0; n-- {
 		// TODO: bikeshed about whether it's more readable to have an
 		// _, something else, or nothing between directory names.

--- a/vendor/k8s.io/gengo/namer/namer.go
+++ b/vendor/k8s.io/gengo/namer/namer.go
@@ -23,6 +23,17 @@ import (
 	"k8s.io/gengo/types"
 )
 
+const (
+	// GoSeperator is used to split go import paths.
+	// Forward slash is used instead of filepath.Seperator because it is the
+	// only universally-accepted path delimiter and the only delimiter not
+	// potentially forbidden by Go compilers. (In particular gc does not allow
+	// the use of backslashes in import paths.)
+	// See https://golang.org/ref/spec#Import_declarations.
+	// See also https://github.com/kubernetes/gengo/issues/83#issuecomment-367040772.
+	GoSeperator = "/"
+)
+
 // Returns whether a name is a private Go name.
 func IsPrivateGoName(name string) bool {
 	return len(name) == 0 || strings.ToLower(name[:1]) == name[:1]
@@ -187,7 +198,7 @@ var (
 
 // filters out unwanted directory names and sanitizes remaining names.
 func (ns *NameStrategy) filterDirs(path string) []string {
-	allDirs := strings.Split(path, string(filepath.Separator))
+	allDirs := strings.Split(path, GoSeperator)
 	dirs := make([]string, 0, len(allDirs))
 	for _, p := range allDirs {
 		if ns.IgnoreWords == nil || !ns.IgnoreWords[p] {

--- a/vendor/k8s.io/gengo/parser/parse.go
+++ b/vendor/k8s.io/gengo/parser/parse.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -226,12 +227,12 @@ func (b *Builder) AddDirRecursive(dir string) error {
 	// filepath.Walk includes the root dir, but we already did that, so we'll
 	// remove that prefix and rebuild a package import path.
 	prefix := b.buildPackages[dir].Dir
-	fn := func(path string, info os.FileInfo, err error) error {
+	fn := func(filePath string, info os.FileInfo, err error) error {
 		if info != nil && info.IsDir() {
-			rel := strings.TrimPrefix(path, prefix)
+			rel := filepath.ToSlash(strings.TrimPrefix(filePath, prefix))
 			if rel != "" {
 				// Make a pkg path.
-				pkg := filepath.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
+				pkg := path.Join(string(canonicalizeImportPath(b.buildPackages[dir].ImportPath)), rel)
 
 				// Add it.
 				if _, err := b.importPackage(pkg, true); err != nil {
@@ -488,7 +489,7 @@ func (b *Builder) findTypesIn(pkgPath importPathString, u *types.Universe) error
 	u.Package(string(pkgPath)).SourcePath = b.absPaths[pkgPath]
 
 	for _, f := range b.parsed[pkgPath] {
-		if strings.HasSuffix(f.name, "/doc.go") {
+		if _, fileName := filepath.Split(f.name); fileName == "doc.go" {
 			tp := u.Package(string(pkgPath))
 			// findTypesIn might be called multiple times. Clean up tp.Comments
 			// to avoid repeatedly fill same comments to it.


### PR DESCRIPTION
This bumps k8s.io/gengo with uniform pointer support in deepcopy-gen.

Fixes https://github.com/kubernetes/code-generator/issues/45.