### PR TITLE
apiextensions: enable CoreAPI options needed for admission

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -51,9 +51,6 @@ func NewCustomResourceDefinitionsServerOptions(out, errOut io.Writer) *CustomRes
 		StdErr: errOut,
 	}
 
-	// the shared informer is not needed for apiextentions apiserver. Disable the kubeconfig flag and the client creation.
-	o.RecommendedOptions.CoreAPI = nil
-
 	return o
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/start.go
@@ -47,6 +47,7 @@ func DefaultServerConfig() (*extensionsapiserver.Config, error) {
 	options.RecommendedOptions.Authentication = nil // disable
 	options.RecommendedOptions.Authorization = nil  // disable
 	options.RecommendedOptions.Admission = nil      // disable
+	options.RecommendedOptions.CoreAPI = nil        // disable
 	options.RecommendedOptions.SecureServing.BindAddress = net.ParseIP("127.0.0.1")
 	options.RecommendedOptions.SecureServing.Listener = listener
 	etcdURL, ok := os.LookupEnv("KUBE_INTEGRATION_ETCD_URL")


### PR DESCRIPTION
Admission webhooks need the client and the shared informers for kube resources. The comment is invalid and we have to enable the CoreAPI options.

This PR is important to run apiextensions-apiserver in a standalone integration test setup.