### PR TITLE
Automated cherry pick of #65035 upstream release 1.10

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -382,6 +382,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${src_dir}/cluster-autoscaler.manifest" "${dst_dir}/"
   cp "${src_dir}/etcd.manifest" "${dst_dir}"
   cp "${src_dir}/kube-scheduler.manifest" "${dst_dir}"
+  cp "${src_dir}/kms-plugin-container.manifest" "${dst_dir}"
   cp "${src_dir}/kube-apiserver.manifest" "${dst_dir}"
   cp "${src_dir}/abac-authz-policy.jsonl" "${dst_dir}"
   cp "${src_dir}/kube-controller-manager.manifest" "${dst_dir}"

--- a/cluster/gce/manifests/BUILD
+++ b/cluster/gce/manifests/BUILD
@@ -9,6 +9,7 @@ pkg_tar(
     mode = "0644",
 )
 
+# if you update this, also update function kube::release::package_kube_manifests_tarball() in build/lib/release.sh
 filegroup(
     name = "manifests",
     srcs = [


### PR DESCRIPTION
Add kms-plugin-container.sh to release.sh.

```release-note
Due to the mismatch between quick release and bazel release need to manually update release.sh to include kms-plugin-container.manifest in release.sh. Otherwise, when KMS integration is requested kube-apiserver fails to come-up.
```
REF #65035

