### PR TITLE
Re-use private key after failed CSR

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/io.go
+++ b/staging/src/k8s.io/client-go/util/cert/io.go
@@ -88,7 +88,8 @@ func WriteKey(keyPath string, data []byte) error {
 // can't find one, it will generate a new key and store it there.
 func LoadOrGenerateKeyFile(keyPath string) (data []byte, wasGenerated bool, err error) {
 	loadedData, err := ioutil.ReadFile(keyPath)
-	if err == nil {
+	// Call verifyKeyData to ensure the file wasn't empty/corrupt.
+	if err == nil && verifyKeyData(loadedData) {
 		return loadedData, false, err
 	}
 	if !os.IsNotExist(err) {
@@ -180,4 +181,13 @@ func PublicKeysFromFile(file string) ([]interface{}, error) {
 		return nil, fmt.Errorf("error reading public key file %s: %v", file, err)
 	}
 	return keys, nil
+}
+
+// verifyKeyData returns true if the provided data appears to be a valid private key.
+func verifyKeyData(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	_, err := ParsePrivateKeyPEM(data)
+	return err == nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a regression introduced in 1.11.

If we create a new key on each CSR, if CSR fails the next attempt will
create a new one instead of reusing previous CSR.

If approver/signer don't handle CSRs as quickly as new nodes come up,
they can pile up and approver would keep handling old abandoned CSRs and
Nodes would keep timing out on startup.

**Release note**:
```release-note
NONE
```
