### PR TITLE
Added attach/mount/check steps to CSI Driver E2E tests

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -135,7 +135,7 @@ func (c *csiAttacher) waitForVolumeAttachmentInternal(volumeHandle, attachID str
 	attach, err := c.k8s.StorageV1beta1().VolumeAttachments().Get(attachID, meta.GetOptions{})
 	if err != nil {
 		glog.Error(log("attacher.WaitForAttach failed for volume [%s] (will continue to try): %v", volumeHandle, err))
-		return "", err
+		return "", fmt.Errorf("volume %v has GET error for volume attachment %v: %v", volumeHandle, attachID, err)
 	}
 	// if being deleted, fail fast
 	if attach.GetDeletionTimestamp() != nil {

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -132,6 +132,7 @@ func (h *hostpathCSIDriver) createStorageClassTest(node v1.Node) storageClassTes
 		claimSize:    "1Gi",
 		expectedSize: "1Gi",
 		nodeName:     node.Name,
+		attach:       true,
 	}
 }
 
@@ -197,6 +198,7 @@ func (g *gcePDCSIDriver) createStorageClassTest(node v1.Node) storageClassTest {
 		claimSize:    "5Gi",
 		expectedSize: "5Gi",
 		nodeName:     node.Name,
+		attach:       true,
 	}
 }
 


### PR DESCRIPTION
This PR makes the CSI Volume E2E tests actually go through the entire dynamic provisioning pipeline and test attach/mount/check file etc.

Fixes #64927

```release-note
None
```
