### PR TITLE
Fix kubeadm taints to not override existing node taints

### DIFF
--- a/cmd/kubeadm/app/phases/markmaster/markmaster.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster.go
@@ -43,8 +43,24 @@ func MarkMaster(client clientset.Interface, masterName string, taints []v1.Taint
 	})
 }
 
+func taintExists(taint v1.Taint, taints []v1.Taint) bool {
+	for _, t := range taints {
+		if t == taint {
+			return true
+		}
+	}
+
+	return false
+}
+
 func markMasterNode(n *v1.Node, taints []v1.Taint) {
 	n.ObjectMeta.Labels[constants.LabelNodeRoleMaster] = ""
-	// TODO: Append taints, don't override?
+
+	for _, nt := range n.Spec.Taints {
+		if !taintExists(nt, taints) {
+			taints = append(taints, nt)
+		}
+	}
+
 	n.Spec.Taints = taints
 }

--- a/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
@@ -82,11 +82,28 @@ func TestMarkMaster(t *testing.T) {
 			"{}",
 		},
 		{
-			"nothing missing but taint unwanted",
+			"has taint and no new taints wanted",
 			kubeadmconstants.LabelNodeRoleMaster,
-			[]v1.Taint{kubeadmconstants.MasterTaint},
+			[]v1.Taint{
+				{
+					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
 			nil,
-			"{\"spec\":{\"taints\":null}}",
+			"{}",
+		},
+		{
+			"has taint and should merge with wanted taint",
+			kubeadmconstants.LabelNodeRoleMaster,
+			[]v1.Taint{
+				{
+					Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+			[]v1.Taint{kubeadmconstants.MasterTaint},
+			"{\"spec\":{\"taints\":[{\"effect\":\"NoSchedule\",\"key\":\"node-role.kubernetes.io/master\"},{\"effect\":\"NoSchedule\",\"key\":\"node.cloudprovider.kubernetes.io/uninitialized\"}]}}",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If a node has existing taints they are being replaced with taints from the kubeadm config. 

An example of this is that the `uninitialized` taint that kubelet sets for external cloud provider is being removed, and replaces with the master taint if set, or removed leaving the nodes taints empty if `noTaintMaster=true` . 

```release-note
None
```
