### PR TITLE
Added PV GET api rule to external-provisioner

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -466,7 +466,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			// a role for the csi external provisioner
 			ObjectMeta: metav1.ObjectMeta{Name: "system:csi-external-provisioner"},
 			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("create", "delete", "list", "watch").Groups(legacyGroup).Resources("persistentvolumes").RuleOrDie(),
+				rbacv1helpers.NewRule("create", "delete", "get", "list", "watch").Groups(legacyGroup).Resources("persistentvolumes").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch", "update", "patch").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch", "create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -688,6 +688,7 @@ items:
     verbs:
     - create
     - delete
+    - get
     - list
     - watch
   - apiGroups:


### PR DESCRIPTION
Adds the PV GET API rule to the system:external-provisioner cluster role. It is required because the provisioner does a GET here:
https://github.com/kubernetes-incubator/external-storage/blob/master/lib/controller/controller.go#L1121

Fixes #65058

/sig storage
/kind bug
/priority critical-urgent
/cc @msau42 @sbezverk 

```release-note
NONE
```