### PR TITLE
Add CSI volume attributes for kubectl describe pv

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -1161,6 +1161,80 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			},
 			expectedElements: []string{"Terminating (lasts 10y)"},
 		},
+		{
+			name:   "test16",
+			plugin: "local",
+			pv: &api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:                       "bar",
+					GenerateName:               "test-GenerateName",
+					UID:                        "test-UID",
+					CreationTimestamp:          metav1.Time{Time: time.Now()},
+					DeletionTimestamp:          &metav1.Time{Time: time.Now()},
+					DeletionGracePeriodSeconds: new(int64),
+					Labels:      map[string]string{"label1": "label1", "label2": "label2", "label3": "label3"},
+					Annotations: map[string]string{"annotation1": "annotation1", "annotation2": "annotation2", "annotation3": "annotation3"},
+				},
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						Local: &api.LocalVolumeSource{},
+					},
+					NodeAffinity: &api.VolumeNodeAffinity{
+						Required: &api.NodeSelector{
+							NodeSelectorTerms: []api.NodeSelectorTerm{
+								{
+									MatchExpressions: []api.NodeSelectorRequirement{
+										{
+											Key:      "foo",
+											Operator: "In",
+											Values:   []string{"val1", "val2"},
+										},
+										{
+											Key:      "foo",
+											Operator: "Exists",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedElements: []string{"Node Affinity", "Required Terms", "Term 0",
+				"foo in [val1, val2]",
+				"foo exists"},
+		},
+		{
+			name:   "test17",
+			plugin: "local",
+			pv: &api.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:                       "bar",
+					GenerateName:               "test-GenerateName",
+					UID:                        "test-UID",
+					CreationTimestamp:          metav1.Time{Time: time.Now()},
+					DeletionTimestamp:          &metav1.Time{Time: time.Now()},
+					DeletionGracePeriodSeconds: new(int64),
+					Labels:      map[string]string{"label1": "label1", "label2": "label2", "label3": "label3"},
+					Annotations: map[string]string{"annotation1": "annotation1", "annotation2": "annotation2", "annotation3": "annotation3"},
+				},
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						CSI: &api.CSIPersistentVolumeSource{
+							Driver:       "drive",
+							VolumeHandle: "handler",
+							ReadOnly:     true,
+							VolumeAttributes: map[string]string{
+								"Attribute1": "Value1",
+								"Attribute2": "Value2",
+								"Attribute3": "Value3",
+							},
+						},
+					},
+				},
+			},
+			expectedElements: []string{"Driver", "VolumeHandle", "ReadOnly", "VolumeAttributes"},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
/king feature

kubectl describe pv doesn't show the volume attributes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65021

**Special notes for your reviewer**:
/cc @saad-ali 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add CSI volume attributes for kubectl describe pv.
```
