### PR TITLE
[FEATURE-SERVERSIDE-APPLY]  Allow patch to override AllowCreateOnUpdate with new argument to Update

### DIFF
--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -96,6 +96,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/apps/daemonset/storage/storage.go
+++ b/pkg/registry/apps/daemonset/storage/storage.go
@@ -96,6 +96,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/apps/deployment/registry.go
+++ b/pkg/registry/apps/deployment/registry.go
@@ -73,7 +73,7 @@ func (s *storage) CreateDeployment(ctx context.Context, deployment *extensions.D
 }
 
 func (s *storage) UpdateDeployment(ctx context.Context, deployment *extensions.Deployment, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*extensions.Deployment, error) {
-	obj, _, err := s.Update(ctx, deployment.Name, rest.DefaultUpdatedObjectInfo(deployment), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, deployment.Name, rest.DefaultUpdatedObjectInfo(deployment), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/deployment/registry.go
+++ b/pkg/registry/apps/deployment/registry.go
@@ -73,7 +73,7 @@ func (s *storage) CreateDeployment(ctx context.Context, deployment *extensions.D
 }
 
 func (s *storage) UpdateDeployment(ctx context.Context, deployment *extensions.Deployment, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*extensions.Deployment, error) {
-	obj, _, err := s.Update(ctx, deployment.Name, rest.DefaultUpdatedObjectInfo(deployment), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, deployment.Name, rest.DefaultUpdatedObjectInfo(deployment), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -128,8 +128,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 // RollbackREST implements the REST endpoint for initiating the rollback of a deployment
@@ -240,7 +240,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	deployment, err := r.registry.GetDeployment(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("deployments/scale"), name)
@@ -269,7 +269,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	deployment.Spec.Replicas = scale.Spec.Replicas
 	deployment.ResourceVersion = scale.ResourceVersion
-	deployment, err = r.registry.UpdateDeployment(ctx, deployment, createValidation, updateValidation)
+	deployment, err = r.registry.UpdateDeployment(ctx, deployment, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -128,8 +128,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 // RollbackREST implements the REST endpoint for initiating the rollback of a deployment
@@ -240,7 +240,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	deployment, err := r.registry.GetDeployment(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("deployments/scale"), name)
@@ -269,7 +269,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	deployment.Spec.Replicas = scale.Spec.Replicas
 	deployment.ResourceVersion = scale.ResourceVersion
-	deployment, err = r.registry.UpdateDeployment(ctx, deployment, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	deployment, err = r.registry.UpdateDeployment(ctx, deployment, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/deployment/storage/storage_test.go
+++ b/pkg/registry/apps/deployment/storage/storage_test.go
@@ -257,7 +257,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 	obj, err := storage.Scale.Get(ctx, name, &metav1.GetOptions{})
@@ -272,7 +272,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = deployment.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -296,7 +296,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.Deployment.Get(ctx, name, &metav1.GetOptions{})

--- a/pkg/registry/apps/deployment/storage/storage_test.go
+++ b/pkg/registry/apps/deployment/storage/storage_test.go
@@ -257,7 +257,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 	obj, err := storage.Scale.Get(ctx, name, &metav1.GetOptions{})
@@ -272,7 +272,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = deployment.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -296,7 +296,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.Deployment.Get(ctx, name, &metav1.GetOptions{})

--- a/pkg/registry/apps/replicaset/registry.go
+++ b/pkg/registry/apps/replicaset/registry.go
@@ -82,7 +82,7 @@ func (s *storage) CreateReplicaSet(ctx context.Context, replicaSet *extensions.R
 }
 
 func (s *storage) UpdateReplicaSet(ctx context.Context, replicaSet *extensions.ReplicaSet, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*extensions.ReplicaSet, error) {
-	obj, _, err := s.Update(ctx, replicaSet.Name, rest.DefaultUpdatedObjectInfo(replicaSet), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, replicaSet.Name, rest.DefaultUpdatedObjectInfo(replicaSet), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/replicaset/registry.go
+++ b/pkg/registry/apps/replicaset/registry.go
@@ -82,7 +82,7 @@ func (s *storage) CreateReplicaSet(ctx context.Context, replicaSet *extensions.R
 }
 
 func (s *storage) UpdateReplicaSet(ctx context.Context, replicaSet *extensions.ReplicaSet, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*extensions.ReplicaSet, error) {
-	obj, _, err := s.Update(ctx, replicaSet.Name, rest.DefaultUpdatedObjectInfo(replicaSet), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, replicaSet.Name, rest.DefaultUpdatedObjectInfo(replicaSet), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -126,8 +126,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 type ScaleREST struct {
@@ -168,7 +168,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	rs, err := r.registry.GetReplicaSet(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("replicasets/scale"), name)
@@ -198,7 +198,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rs.Spec.Replicas = scale.Spec.Replicas
 	rs.ResourceVersion = scale.ResourceVersion
-	rs, err = r.registry.UpdateReplicaSet(ctx, rs, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	rs, err = r.registry.UpdateReplicaSet(ctx, rs, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -126,8 +126,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 type ScaleREST struct {
@@ -168,7 +168,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	rs, err := r.registry.GetReplicaSet(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("replicasets/scale"), name)
@@ -198,7 +198,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rs.Spec.Replicas = scale.Spec.Replicas
 	rs.ResourceVersion = scale.ResourceVersion
-	rs, err = r.registry.UpdateReplicaSet(ctx, rs, createValidation, updateValidation)
+	rs, err = r.registry.UpdateReplicaSet(ctx, rs, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/replicaset/storage/storage_test.go
+++ b/pkg/registry/apps/replicaset/storage/storage_test.go
@@ -174,7 +174,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	storedRS.Spec.Replicas += 1
-	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdRS, err = storage.ReplicaSet.Get(ctx, rs.Name, &metav1.GetOptions{})
@@ -188,7 +188,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment either spec or status generation numbers
 	storedRS.Status.Replicas += 1
-	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdRS, err = storage.ReplicaSet.Get(ctx, rs.Name, &metav1.GetOptions{})
@@ -319,7 +319,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -335,7 +335,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = rs.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -360,7 +360,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.ReplicaSet.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/apps/replicaset/storage/storage_test.go
+++ b/pkg/registry/apps/replicaset/storage/storage_test.go
@@ -174,7 +174,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	storedRS.Spec.Replicas += 1
-	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdRS, err = storage.ReplicaSet.Get(ctx, rs.Name, &metav1.GetOptions{})
@@ -188,7 +188,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment either spec or status generation numbers
 	storedRS.Status.Replicas += 1
-	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.ReplicaSet.Update(ctx, storedRS.Name, rest.DefaultUpdatedObjectInfo(storedRS), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdRS, err = storage.ReplicaSet.Get(ctx, rs.Name, &metav1.GetOptions{})
@@ -319,7 +319,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -335,7 +335,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = rs.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -360,7 +360,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.ReplicaSet.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/apps/statefulset/registry.go
+++ b/pkg/registry/apps/statefulset/registry.go
@@ -81,7 +81,7 @@ func (s *storage) CreateStatefulSet(ctx context.Context, statefulSet *apps.State
 }
 
 func (s *storage) UpdateStatefulSet(ctx context.Context, statefulSet *apps.StatefulSet, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*apps.StatefulSet, error) {
-	obj, _, err := s.Update(ctx, statefulSet.Name, rest.DefaultUpdatedObjectInfo(statefulSet), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, statefulSet.Name, rest.DefaultUpdatedObjectInfo(statefulSet), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/statefulset/registry.go
+++ b/pkg/registry/apps/statefulset/registry.go
@@ -81,7 +81,7 @@ func (s *storage) CreateStatefulSet(ctx context.Context, statefulSet *apps.State
 }
 
 func (s *storage) UpdateStatefulSet(ctx context.Context, statefulSet *apps.StatefulSet, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*apps.StatefulSet, error) {
-	obj, _, err := s.Update(ctx, statefulSet.Name, rest.DefaultUpdatedObjectInfo(statefulSet), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, statefulSet.Name, rest.DefaultUpdatedObjectInfo(statefulSet), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -109,8 +109,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 // Implement ShortNamesProvider
@@ -157,7 +157,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	ss, err := r.registry.GetStatefulSet(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -186,7 +186,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	ss.Spec.Replicas = scale.Spec.Replicas
 	ss.ResourceVersion = scale.ResourceVersion
-	ss, err = r.registry.UpdateStatefulSet(ctx, ss, createValidation, updateValidation)
+	ss, err = r.registry.UpdateStatefulSet(ctx, ss, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -109,8 +109,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 // Implement ShortNamesProvider
@@ -157,7 +157,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	ss, err := r.registry.GetStatefulSet(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -186,7 +186,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	ss.Spec.Replicas = scale.Spec.Replicas
 	ss.ResourceVersion = scale.ResourceVersion
-	ss, err = r.registry.UpdateStatefulSet(ctx, ss, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	ss, err = r.registry.UpdateStatefulSet(ctx, ss, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/apps/statefulset/storage/storage_test.go
+++ b/pkg/registry/apps/statefulset/storage/storage_test.go
@@ -115,7 +115,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.StatefulSet.Get(ctx, "foo", &metav1.GetOptions{})
@@ -268,7 +268,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -284,7 +284,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = sts.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/apps/statefulset/storage/storage_test.go
+++ b/pkg/registry/apps/statefulset/storage/storage_test.go
@@ -115,7 +115,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.StatefulSet.Get(ctx, "foo", &metav1.GetOptions{})
@@ -268,7 +268,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -284,7 +284,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = sts.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -89,6 +89,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -89,6 +89,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -194,7 +194,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = statusStorage.Update(ctx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -194,7 +194,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = statusStorage.Update(ctx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -88,6 +88,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -88,6 +88,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -99,6 +99,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -99,6 +99,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/certificates/certificates/registry.go
+++ b/pkg/registry/certificates/certificates/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateCSR(ctx context.Context, csr *certificates.CertificateSi
 }
 
 func (s *storage) UpdateCSR(ctx context.Context, csr *certificates.CertificateSigningRequest, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, csr.Name, rest.DefaultUpdatedObjectInfo(csr), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, csr.Name, rest.DefaultUpdatedObjectInfo(csr), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/certificates/certificates/registry.go
+++ b/pkg/registry/certificates/certificates/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateCSR(ctx context.Context, csr *certificates.CertificateSi
 }
 
 func (s *storage) UpdateCSR(ctx context.Context, csr *certificates.CertificateSigningRequest, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, csr.Name, rest.DefaultUpdatedObjectInfo(csr), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, csr.Name, rest.DefaultUpdatedObjectInfo(csr), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -90,8 +90,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 var _ = rest.Patcher(&StatusREST{})
@@ -106,6 +106,6 @@ func (r *ApprovalREST) New() runtime.Object {
 }
 
 // Update alters the approval subset of an object.
-func (r *ApprovalREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *ApprovalREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -90,8 +90,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 var _ = rest.Patcher(&StatusREST{})
@@ -106,6 +106,6 @@ func (r *ApprovalREST) New() runtime.Object {
 }
 
 // Update alters the approval subset of an object.
-func (r *ApprovalREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *ApprovalREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/configmap/registry.go
+++ b/pkg/registry/core/configmap/registry.go
@@ -79,7 +79,7 @@ func (s *storage) CreateConfigMap(ctx context.Context, cfg *api.ConfigMap, creat
 }
 
 func (s *storage) UpdateConfigMap(ctx context.Context, cfg *api.ConfigMap, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.ConfigMap, error) {
-	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/configmap/registry.go
+++ b/pkg/registry/core/configmap/registry.go
@@ -79,7 +79,7 @@ func (s *storage) CreateConfigMap(ctx context.Context, cfg *api.ConfigMap, creat
 }
 
 func (s *storage) UpdateConfigMap(ctx context.Context, cfg *api.ConfigMap, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.ConfigMap, error) {
-	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/endpoint/registry.go
+++ b/pkg/registry/core/endpoint/registry.go
@@ -67,7 +67,7 @@ func (s *storage) GetEndpoints(ctx context.Context, name string, options *metav1
 }
 
 func (s *storage) UpdateEndpoints(ctx context.Context, endpoints *api.Endpoints, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, endpoints.Name, rest.DefaultUpdatedObjectInfo(endpoints), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, endpoints.Name, rest.DefaultUpdatedObjectInfo(endpoints), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/endpoint/registry.go
+++ b/pkg/registry/core/endpoint/registry.go
@@ -67,7 +67,7 @@ func (s *storage) GetEndpoints(ctx context.Context, name string, options *metav1
 }
 
 func (s *storage) UpdateEndpoints(ctx context.Context, endpoints *api.Endpoints, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, endpoints.Name, rest.DefaultUpdatedObjectInfo(endpoints), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, endpoints.Name, rest.DefaultUpdatedObjectInfo(endpoints), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/namespace/registry.go
+++ b/pkg/registry/core/namespace/registry.go
@@ -73,7 +73,7 @@ func (s *storage) CreateNamespace(ctx context.Context, namespace *api.Namespace,
 }
 
 func (s *storage) UpdateNamespace(ctx context.Context, namespace *api.Namespace, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, namespace.Name, rest.DefaultUpdatedObjectInfo(namespace), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, namespace.Name, rest.DefaultUpdatedObjectInfo(namespace), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/namespace/registry.go
+++ b/pkg/registry/core/namespace/registry.go
@@ -73,7 +73,7 @@ func (s *storage) CreateNamespace(ctx context.Context, namespace *api.Namespace,
 }
 
 func (s *storage) UpdateNamespace(ctx context.Context, namespace *api.Namespace, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, namespace.Name, rest.DefaultUpdatedObjectInfo(namespace), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, namespace.Name, rest.DefaultUpdatedObjectInfo(namespace), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -104,8 +104,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	return r.store.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -234,8 +234,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 func (r *FinalizeREST) New() runtime.Object {
@@ -243,6 +243,6 @@ func (r *FinalizeREST) New() runtime.Object {
 }
 
 // Update alters the status finalizers subset of an object.
-func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -104,8 +104,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	return r.store.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -234,8 +234,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 func (r *FinalizeREST) New() runtime.Object {
@@ -243,6 +243,6 @@ func (r *FinalizeREST) New() runtime.Object {
 }
 
 // Update alters the status finalizers subset of an object.
-func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *FinalizeREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/node/registry.go
+++ b/pkg/registry/core/node/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateNode(ctx context.Context, node *api.Node, createValidati
 }
 
 func (s *storage) UpdateNode(ctx context.Context, node *api.Node, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/node/registry.go
+++ b/pkg/registry/core/node/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateNode(ctx context.Context, node *api.Node, createValidati
 }
 
 func (s *storage) UpdateNode(ctx context.Context, node *api.Node, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -69,8 +69,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 // NewStorage returns a NodeStorage object that will work against nodes.

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -69,8 +69,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 // NewStorage returns a NodeStorage object that will work against nodes.

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -84,6 +84,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -84,6 +84,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -183,7 +183,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, pvIn.Name, rest.DefaultUpdatedObjectInfo(pvIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = statusStorage.Update(ctx, pvIn.Name, rest.DefaultUpdatedObjectInfo(pvIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -183,7 +183,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, pvIn.Name, rest.DefaultUpdatedObjectInfo(pvIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = statusStorage.Update(ctx, pvIn.Name, rest.DefaultUpdatedObjectInfo(pvIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -84,6 +84,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -84,6 +84,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
@@ -179,7 +179,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, pvc.Name, rest.DefaultUpdatedObjectInfo(pvc), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = statusStorage.Update(ctx, pvc.Name, rest.DefaultUpdatedObjectInfo(pvc), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
@@ -179,7 +179,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, pvc.Name, rest.DefaultUpdatedObjectInfo(pvc), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = statusStorage.Update(ctx, pvc.Name, rest.DefaultUpdatedObjectInfo(pvc), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -217,6 +217,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -217,6 +217,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -728,7 +728,7 @@ func TestEtcdUpdateUninitialized(t *testing.T) {
 	})
 	podIn.ObjectMeta.Initializers = nil
 
-	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestEtcdStatusUpdateUninitialized(t *testing.T) {
 	podIn.Status.Phase = api.PodRunning
 	podIn.ObjectMeta.Initializers = nil
 
-	_, _, err := statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	expected := "Forbidden: must not update status when the object is uninitialized"
 	if err == nil {
 		t.Fatalf("Unexpected no err, expected %q", expected)
@@ -784,7 +784,7 @@ func TestEtcdUpdateNotScheduled(t *testing.T) {
 	}
 
 	podIn := validChangedPod()
-	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(podIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
-	_, _, err = storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -938,7 +938,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 	expected.Labels = podIn.Labels
 	expected.Status = podIn.Status
 
-	_, _, err = statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -728,7 +728,7 @@ func TestEtcdUpdateUninitialized(t *testing.T) {
 	})
 	podIn.ObjectMeta.Initializers = nil
 
-	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestEtcdStatusUpdateUninitialized(t *testing.T) {
 	podIn.Status.Phase = api.PodRunning
 	podIn.ObjectMeta.Initializers = nil
 
-	_, _, err := statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	expected := "Forbidden: must not update status when the object is uninitialized"
 	if err == nil {
 		t.Fatalf("Unexpected no err, expected %q", expected)
@@ -784,7 +784,7 @@ func TestEtcdUpdateNotScheduled(t *testing.T) {
 	}
 
 	podIn := validChangedPod()
-	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(podIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 			SchedulerName:                 api.DefaultSchedulerName,
 		},
 	}
-	_, _, err = storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = storage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -938,7 +938,7 @@ func TestEtcdUpdateStatus(t *testing.T) {
 	expected.Labels = podIn.Labels
 	expected.Status = podIn.Status
 
-	_, _, err = statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = statusStorage.Update(ctx, podIn.Name, rest.DefaultUpdatedObjectInfo(&podIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/replicationcontroller/registry.go
+++ b/pkg/registry/core/replicationcontroller/registry.go
@@ -82,7 +82,7 @@ func (s *storage) CreateController(ctx context.Context, controller *api.Replicat
 }
 
 func (s *storage) UpdateController(ctx context.Context, controller *api.ReplicationController, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.ReplicationController, error) {
-	obj, _, err := s.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/replicationcontroller/registry.go
+++ b/pkg/registry/core/replicationcontroller/registry.go
@@ -82,7 +82,7 @@ func (s *storage) CreateController(ctx context.Context, controller *api.Replicat
 }
 
 func (s *storage) UpdateController(ctx context.Context, controller *api.ReplicationController, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.ReplicationController, error) {
-	obj, _, err := s.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -119,8 +119,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 type ScaleREST struct {
@@ -153,7 +153,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleFromRC(rc), nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	rc, err := r.registry.GetController(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(autoscaling.Resource("replicationcontrollers/scale"), name)
@@ -180,7 +180,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rc.Spec.Replicas = scale.Spec.Replicas
 	rc.ResourceVersion = scale.ResourceVersion
-	rc, err = r.registry.UpdateController(ctx, rc, createValidation, updateValidation)
+	rc, err = r.registry.UpdateController(ctx, rc, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -119,8 +119,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 type ScaleREST struct {
@@ -153,7 +153,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleFromRC(rc), nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	rc, err := r.registry.GetController(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(autoscaling.Resource("replicationcontrollers/scale"), name)
@@ -180,7 +180,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rc.Spec.Replicas = scale.Spec.Replicas
 	rc.ResourceVersion = scale.ResourceVersion
-	rc, err = r.registry.UpdateController(ctx, rc, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	rc, err = r.registry.UpdateController(ctx, rc, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/registry/core/replicationcontroller/storage/storage_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage_test.go
@@ -177,7 +177,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	controller.Spec.Replicas += 1
-	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	ctrl, err = storage.Controller.Get(ctx, rc.Name, &metav1.GetOptions{})
@@ -191,7 +191,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment either spec or status generation numbers
 	controller.Status.Replicas += 1
-	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	ctrl, err = storage.Controller.Get(ctx, rc.Name, &metav1.GetOptions{})
@@ -310,7 +310,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 	obj, err := storage.Scale.Get(ctx, name, &metav1.GetOptions{})
@@ -325,7 +325,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = rc.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/core/replicationcontroller/storage/storage_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage_test.go
@@ -177,7 +177,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	controller.Spec.Replicas += 1
-	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	ctrl, err = storage.Controller.Get(ctx, rc.Name, &metav1.GetOptions{})
@@ -191,7 +191,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment either spec or status generation numbers
 	controller.Status.Replicas += 1
-	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Controller.Update(ctx, controller.Name, rest.DefaultUpdatedObjectInfo(controller), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	ctrl, err = storage.Controller.Get(ctx, rc.Name, &metav1.GetOptions{})
@@ -310,7 +310,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 	obj, err := storage.Scale.Get(ctx, name, &metav1.GetOptions{})
@@ -325,7 +325,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = rc.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -78,6 +78,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -78,6 +78,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/resourcequota/storage/storage_test.go
+++ b/pkg/registry/core/resourcequota/storage/storage_test.go
@@ -192,7 +192,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = status.Update(ctx, resourcequotaIn.Name, rest.DefaultUpdatedObjectInfo(resourcequotaIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = status.Update(ctx, resourcequotaIn.Name, rest.DefaultUpdatedObjectInfo(resourcequotaIn), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/resourcequota/storage/storage_test.go
+++ b/pkg/registry/core/resourcequota/storage/storage_test.go
@@ -192,7 +192,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = status.Update(ctx, resourcequotaIn.Name, rest.DefaultUpdatedObjectInfo(resourcequotaIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = status.Update(ctx, resourcequotaIn.Name, rest.DefaultUpdatedObjectInfo(resourcequotaIn), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/service/registry.go
+++ b/pkg/registry/core/service/registry.go
@@ -79,7 +79,7 @@ func (s *storage) DeleteService(ctx context.Context, name string) error {
 }
 
 func (s *storage) UpdateService(ctx context.Context, svc *api.Service, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.Service, error) {
-	obj, _, err := s.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(svc), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(svc), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/service/registry.go
+++ b/pkg/registry/core/service/registry.go
@@ -79,7 +79,7 @@ func (s *storage) DeleteService(ctx context.Context, name string) error {
 }
 
 func (s *storage) UpdateService(ctx context.Context, svc *api.Service, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*api.Service, error) {
-	obj, _, err := s.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(svc), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, svc.Name, rest.DefaultUpdatedObjectInfo(svc), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -326,7 +326,7 @@ func (rs *REST) healthCheckNodePortUpdate(oldService, service *api.Service, node
 	return true, nil
 }
 
-func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	oldObj, err := rs.services.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -400,7 +400,7 @@ func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		return nil, false, errors.NewInvalid(api.Kind("Service"), service.Name, errs)
 	}
 
-	out, created, err := rs.services.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), createValidation, updateValidation)
+	out, created, err := rs.services.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), pLACEHOLDERVARNAME)
 	if err == nil {
 		el := nodePortOp.Commit()
 		if el != nil {

--- a/pkg/registry/core/service/storage/rest.go
+++ b/pkg/registry/core/service/storage/rest.go
@@ -326,7 +326,7 @@ func (rs *REST) healthCheckNodePortUpdate(oldService, service *api.Service, node
 	return true, nil
 }
 
-func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	oldObj, err := rs.services.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -400,7 +400,7 @@ func (rs *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		return nil, false, errors.NewInvalid(api.Kind("Service"), service.Name, errs)
 	}
 
-	out, created, err := rs.services.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), pLACEHOLDERVARNAME)
+	out, created, err := rs.services.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), config)
 	if err == nil {
 		el := nodePortOp.Commit()
 		if el != nil {

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -120,7 +120,7 @@ func (s *serviceStorage) Create(ctx context.Context, obj runtime.Object, createV
 	return svc, s.Err
 }
 
-func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	s.UpdatedID = name
 	obj, err := objInfo.UpdatedObject(ctx, s.OldService)
 	if err != nil {
@@ -496,7 +496,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 				TargetPort: intstr.FromInt(6502),
 			}},
 		},
-	}), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	}), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Expected no error: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, created, err := storage.Update(ctx, failureCase.Name, rest.DefaultUpdatedObjectInfo(&failureCase), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		c, created, err := storage.Update(ctx, failureCase.Name, rest.DefaultUpdatedObjectInfo(&failureCase), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if c != nil || created {
 			t.Errorf("Expected nil object or created false")
 		}
@@ -679,7 +679,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	// Modify load balancer to be external.
 	svc2 := svc1.DeepCopy()
 	svc2.Spec.Type = api.ServiceTypeLoadBalancer
-	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer releaseServiceNodePorts(t, ctx, svc2.Name, storage, registry)
@@ -687,7 +687,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	// Change port.
 	svc3 := svc2.DeepCopy()
 	svc3.Spec.Ports[0].Port = 6504
-	if _, _, err := storage.Update(ctx, svc3.Name, rest.DefaultUpdatedObjectInfo(svc3), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Update(ctx, svc3.Name, rest.DefaultUpdatedObjectInfo(svc3), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
@@ -725,7 +725,7 @@ func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
 	// Modify ports
 	svc2 := svc1.DeepCopy()
 	svc2.Spec.Ports[1].Port = 8088
-	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
@@ -1108,7 +1108,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	update := created_service.DeepCopy()
 	update.Spec.Ports[0].Port = 6503
 
-	updated_svc, _, _ := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	updated_svc, _, _ := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	updated_service := updated_svc.(*api.Service)
 	if updated_service.Spec.Ports[0].Port != 6503 {
 		t.Errorf("Expected port 6503, but got %v", updated_service.Spec.Ports[0].Port)
@@ -1127,7 +1127,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	update.Spec.Ports[0].Port = 6503
 	update.Spec.ClusterIP = testIP // Error: Cluster IP is immutable
 
-	_, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil || !errors.IsInvalid(err) {
 		t.Errorf("Unexpected error type: %v", err)
 	}
@@ -1167,7 +1167,7 @@ func TestServiceRegistryIPLoadBalancer(t *testing.T) {
 
 	update := created_service.DeepCopy()
 
-	_, _, err = storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -1181,7 +1181,7 @@ func TestUpdateServiceWithConflictingNamespace(t *testing.T) {
 	}
 
 	ctx := genericapirequest.NewDefaultContext()
-	obj, created, err := storage.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	obj, created, err := storage.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if obj != nil || created {
 		t.Error("Expected a nil object, but we got a value or created was true")
 	}

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -120,7 +120,7 @@ func (s *serviceStorage) Create(ctx context.Context, obj runtime.Object, createV
 	return svc, s.Err
 }
 
-func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (s *serviceStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	s.UpdatedID = name
 	obj, err := objInfo.UpdatedObject(ctx, s.OldService)
 	if err != nil {
@@ -496,7 +496,7 @@ func TestServiceRegistryUpdate(t *testing.T) {
 				TargetPort: intstr.FromInt(6502),
 			}},
 		},
-	}), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	}), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Expected no error: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestServiceStorageValidatesUpdate(t *testing.T) {
 		},
 	}
 	for _, failureCase := range failureCases {
-		c, created, err := storage.Update(ctx, failureCase.Name, rest.DefaultUpdatedObjectInfo(&failureCase), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		c, created, err := storage.Update(ctx, failureCase.Name, rest.DefaultUpdatedObjectInfo(&failureCase), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if c != nil || created {
 			t.Errorf("Expected nil object or created false")
 		}
@@ -679,7 +679,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	// Modify load balancer to be external.
 	svc2 := svc1.DeepCopy()
 	svc2.Spec.Type = api.ServiceTypeLoadBalancer
-	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	defer releaseServiceNodePorts(t, ctx, svc2.Name, storage, registry)
@@ -687,7 +687,7 @@ func TestServiceRegistryUpdateExternalService(t *testing.T) {
 	// Change port.
 	svc3 := svc2.DeepCopy()
 	svc3.Spec.Ports[0].Port = 6504
-	if _, _, err := storage.Update(ctx, svc3.Name, rest.DefaultUpdatedObjectInfo(svc3), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Update(ctx, svc3.Name, rest.DefaultUpdatedObjectInfo(svc3), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
@@ -725,7 +725,7 @@ func TestServiceRegistryUpdateMultiPortExternalService(t *testing.T) {
 	// Modify ports
 	svc2 := svc1.DeepCopy()
 	svc2.Spec.Ports[1].Port = 8088
-	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Update(ctx, svc2.Name, rest.DefaultUpdatedObjectInfo(svc2), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
@@ -1108,7 +1108,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	update := created_service.DeepCopy()
 	update.Spec.Ports[0].Port = 6503
 
-	updated_svc, _, _ := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	updated_svc, _, _ := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	updated_service := updated_svc.(*api.Service)
 	if updated_service.Spec.Ports[0].Port != 6503 {
 		t.Errorf("Expected port 6503, but got %v", updated_service.Spec.Ports[0].Port)
@@ -1127,7 +1127,7 @@ func TestServiceRegistryIPUpdate(t *testing.T) {
 	update.Spec.Ports[0].Port = 6503
 	update.Spec.ClusterIP = testIP // Error: Cluster IP is immutable
 
-	_, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil || !errors.IsInvalid(err) {
 		t.Errorf("Unexpected error type: %v", err)
 	}
@@ -1167,7 +1167,7 @@ func TestServiceRegistryIPLoadBalancer(t *testing.T) {
 
 	update := created_service.DeepCopy()
 
-	_, _, err = storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -1181,7 +1181,7 @@ func TestUpdateServiceWithConflictingNamespace(t *testing.T) {
 	}
 
 	ctx := genericapirequest.NewDefaultContext()
-	obj, created, err := storage.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	obj, created, err := storage.Update(ctx, service.Name, rest.DefaultUpdatedObjectInfo(service), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if obj != nil || created {
 		t.Error("Expected a nil object, but we got a value or created was true")
 	}

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -90,6 +90,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -90,6 +90,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/extensions/controller/storage/storage.go
+++ b/pkg/registry/extensions/controller/storage/storage.go
@@ -71,7 +71,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleFromRC(rc), nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	rc, err := (*r.registry).GetController(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("replicationcontrollers/scale"), name)
@@ -94,7 +94,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rc.Spec.Replicas = scale.Spec.Replicas
 	rc.ResourceVersion = scale.ResourceVersion
-	rc, err = (*r.registry).UpdateController(ctx, rc, createValidation, updateValidation)
+	rc, err = (*r.registry).UpdateController(ctx, rc, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, errors.NewConflict(extensions.Resource("replicationcontrollers/scale"), scale.Name, err)
 	}

--- a/pkg/registry/extensions/controller/storage/storage.go
+++ b/pkg/registry/extensions/controller/storage/storage.go
@@ -71,7 +71,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleFromRC(rc), nil
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	rc, err := (*r.registry).GetController(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errors.NewNotFound(extensions.Resource("replicationcontrollers/scale"), name)
@@ -94,7 +94,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 
 	rc.Spec.Replicas = scale.Spec.Replicas
 	rc.ResourceVersion = scale.ResourceVersion
-	rc, err = (*r.registry).UpdateController(ctx, rc, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	rc, err = (*r.registry).UpdateController(ctx, rc, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, errors.NewConflict(extensions.Resource("replicationcontrollers/scale"), scale.Name, err)
 	}

--- a/pkg/registry/extensions/controller/storage/storage_test.go
+++ b/pkg/registry/extensions/controller/storage/storage_test.go
@@ -110,7 +110,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/extensions/controller/storage/storage_test.go
+++ b/pkg/registry/extensions/controller/storage/storage_test.go
@@ -110,7 +110,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -82,6 +82,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -82,6 +82,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/networking/networkpolicy/registry.go
+++ b/pkg/registry/networking/networkpolicy/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateNetworkPolicy(ctx context.Context, np *networking.Networ
 }
 
 func (s *storage) UpdateNetworkPolicy(ctx context.Context, np *networking.NetworkPolicy, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, np.Name, rest.DefaultUpdatedObjectInfo(np), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, np.Name, rest.DefaultUpdatedObjectInfo(np), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/networking/networkpolicy/registry.go
+++ b/pkg/registry/networking/networkpolicy/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreateNetworkPolicy(ctx context.Context, np *networking.Networ
 }
 
 func (s *storage) UpdateNetworkPolicy(ctx context.Context, np *networking.NetworkPolicy, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, np.Name, rest.DefaultUpdatedObjectInfo(np), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, np.Name, rest.DefaultUpdatedObjectInfo(np), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -79,6 +79,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -79,6 +79,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
@@ -99,7 +99,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := statusStorage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := statusStorage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err = storage.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
@@ -99,7 +99,7 @@ func TestStatusUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := statusStorage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := statusStorage.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	obj, err = storage.Get(ctx, "foo", &metav1.GetOptions{})

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -71,9 +71,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidatingAdmission, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
+		return s.StandardStorage.Update(ctx, name, obj, config)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -99,7 +99,7 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, config)
 }
 
 func hasAggregationRule(clusterRole *rbac.ClusterRole) bool {

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -71,9 +71,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidatingAdmission, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, createValidation, updateValidation)
+		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -99,7 +99,7 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, createValidation, updateValidation)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
 }
 
 func hasAggregationRule(clusterRole *rbac.ClusterRole) bool {

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -76,9 +76,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
+		return s.StandardStorage.Update(ctx, name, obj, config)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -110,5 +110,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, config)
 }

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -76,9 +76,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, createValidation, updateValidation)
+		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -110,5 +110,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, createValidation, updateValidation)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -58,9 +58,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
+		return s.StandardStorage.Update(ctx, name, obj, config)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -78,5 +78,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, config)
 }

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -58,9 +58,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, createValidation, updateValidation)
+		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -78,5 +78,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, createValidation, updateValidation)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -83,9 +83,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, createValidation, updateValidation)
+		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -124,5 +124,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, createValidation, updateValidation)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
 }

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -83,9 +83,9 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	return s.StandardStorage.Create(ctx, obj, createValidation, includeUninitialized)
 }
 
-func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
-		return s.StandardStorage.Update(ctx, name, obj, pLACEHOLDERVARNAME)
+		return s.StandardStorage.Update(ctx, name, obj, config)
 	}
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
@@ -124,5 +124,5 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		return obj, nil
 	})
 
-	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, pLACEHOLDERVARNAME)
+	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo, config)
 }

--- a/pkg/registry/scheduling/priorityclass/registry.go
+++ b/pkg/registry/scheduling/priorityclass/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreatePriorityClass(ctx context.Context, pc *scheduling.Priori
 }
 
 func (s *storage) UpdatePriorityClass(ctx context.Context, pc *scheduling.PriorityClass, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, pc.Name, rest.DefaultUpdatedObjectInfo(pc), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, pc.Name, rest.DefaultUpdatedObjectInfo(pc), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/scheduling/priorityclass/registry.go
+++ b/pkg/registry/scheduling/priorityclass/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreatePriorityClass(ctx context.Context, pc *scheduling.Priori
 }
 
 func (s *storage) UpdatePriorityClass(ctx context.Context, pc *scheduling.PriorityClass, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, pc.Name, rest.DefaultUpdatedObjectInfo(pc), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, pc.Name, rest.DefaultUpdatedObjectInfo(pc), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/settings/podpreset/registry.go
+++ b/pkg/registry/settings/podpreset/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreatePodPreset(ctx context.Context, pp *settings.PodPreset, c
 }
 
 func (s *storage) UpdatePodPreset(ctx context.Context, pp *settings.PodPreset, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, pp.Name, rest.DefaultUpdatedObjectInfo(pp), createValidation, updateValidation)
+	_, _, err := s.Update(ctx, pp.Name, rest.DefaultUpdatedObjectInfo(pp), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	return err
 }
 

--- a/pkg/registry/settings/podpreset/registry.go
+++ b/pkg/registry/settings/podpreset/registry.go
@@ -62,7 +62,7 @@ func (s *storage) CreatePodPreset(ctx context.Context, pp *settings.PodPreset, c
 }
 
 func (s *storage) UpdatePodPreset(ctx context.Context, pp *settings.PodPreset, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) error {
-	_, _, err := s.Update(ctx, pp.Name, rest.DefaultUpdatedObjectInfo(pp), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	_, _, err := s.Update(ctx, pp.Name, rest.DefaultUpdatedObjectInfo(pp), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	return err
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -128,8 +128,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }
 
 type ScaleREST struct {
@@ -168,7 +168,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleObject, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	cr, err := r.registry.GetCustomResource(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -206,7 +206,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 	}
 	cr.SetResourceVersion(scale.ResourceVersion)
 
-	cr, err = r.registry.UpdateCustomResource(ctx, cr, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
+	cr, err = r.registry.UpdateCustomResource(ctx, cr, config.CreateValidation, config.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -128,8 +128,8 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }
 
 type ScaleREST struct {
@@ -168,7 +168,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scaleObject, err
 }
 
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	cr, err := r.registry.GetCustomResource(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
@@ -206,7 +206,7 @@ func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.Update
 	}
 	cr.SetResourceVersion(scale.ResourceVersion)
 
-	cr, err = r.registry.UpdateCustomResource(ctx, cr, createValidation, updateValidation)
+	cr, err = r.registry.UpdateCustomResource(ctx, cr, pLACEHOLDERVARNAME.CreateValidation, pLACEHOLDERVARNAME.UpdateValidation)
 	if err != nil {
 		return nil, false, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -205,7 +205,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	setSpecReplicas(storedCR, getSpecReplicas(storedCR)+1)
-	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdCR, err = storage.CustomResource.Get(ctx, cr.GetName(), &metav1.GetOptions{})
@@ -219,7 +219,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment the generation number
 	setStatusReplicas(storedCR, getStatusReplicas(storedCR)+1)
-	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdCR, err = storage.CustomResource.Get(ctx, cr.GetName(), &metav1.GetOptions{})
@@ -339,7 +339,7 @@ func TestStatusUpdate(t *testing.T) {
 		"replicas": int64(7),
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.GetName(), rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.GetName(), rest.DefaultUpdatedObjectInfo(update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -459,7 +459,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -475,7 +475,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = scale.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -507,7 +507,7 @@ func TestScaleUpdateWithoutSpecReplicas(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -205,7 +205,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to spec should increment the generation number
 	setSpecReplicas(storedCR, getSpecReplicas(storedCR)+1)
-	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdCR, err = storage.CustomResource.Get(ctx, cr.GetName(), &metav1.GetOptions{})
@@ -219,7 +219,7 @@ func TestGenerationNumber(t *testing.T) {
 
 	// Updates to status should not increment the generation number
 	setStatusReplicas(storedCR, getStatusReplicas(storedCR)+1)
-	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.CustomResource.Update(ctx, storedCR.GetName(), rest.DefaultUpdatedObjectInfo(storedCR), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	etcdCR, err = storage.CustomResource.Get(ctx, cr.GetName(), &metav1.GetOptions{})
@@ -339,7 +339,7 @@ func TestStatusUpdate(t *testing.T) {
 		"replicas": int64(7),
 	}
 
-	if _, _, err := storage.Status.Update(ctx, update.GetName(), rest.DefaultUpdatedObjectInfo(update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Status.Update(ctx, update.GetName(), rest.DefaultUpdatedObjectInfo(update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -459,7 +459,7 @@ func TestScaleUpdate(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 
@@ -475,7 +475,7 @@ func TestScaleUpdate(t *testing.T) {
 	update.ResourceVersion = scale.ResourceVersion
 	update.Spec.Replicas = 15
 
-	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil && !errors.IsConflict(err) {
+	if _, _, err = storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil && !errors.IsConflict(err) {
 		t.Fatalf("unexpected error, expecting an update conflict but got %v", err)
 	}
 }
@@ -507,7 +507,7 @@ func TestScaleUpdateWithoutSpecReplicas(t *testing.T) {
 		},
 	}
 
-	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if _, _, err := storage.Scale.Update(ctx, update.Name, rest.DefaultUpdatedObjectInfo(&update), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("error updating scale %v: %v", update, err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/registry.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/registry.go
@@ -91,7 +91,7 @@ func (s *storage) CreateCustomResource(ctx context.Context, customResource *unst
 }
 
 func (s *storage) UpdateCustomResource(ctx context.Context, customResource *unstructured.Unstructured, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*unstructured.Unstructured, error) {
-	obj, _, err := s.Update(ctx, customResource.GetName(), rest.DefaultUpdatedObjectInfo(customResource), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
+	obj, _, err := s.Update(ctx, customResource.GetName(), rest.DefaultUpdatedObjectInfo(customResource), rest.DefaultUpdateConfig(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/registry.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/registry.go
@@ -91,7 +91,7 @@ func (s *storage) CreateCustomResource(ctx context.Context, customResource *unst
 }
 
 func (s *storage) UpdateCustomResource(ctx context.Context, customResource *unstructured.Unstructured, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (*unstructured.Unstructured, error) {
-	obj, _, err := s.Update(ctx, customResource.GetName(), rest.DefaultUpdatedObjectInfo(customResource), createValidation, updateValidation)
+	obj, _, err := s.Update(ctx, customResource.GetName(), rest.DefaultUpdatedObjectInfo(customResource), rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false))
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -172,6 +172,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -172,6 +172,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -476,7 +476,7 @@ func (storage *SimpleRESTStorage) Create(ctx context.Context, obj runtime.Object
 	return obj, err
 }
 
-func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	storage.checkContext(ctx)
 	obj, err := objInfo.UpdatedObject(ctx, &storage.item)
 	if err != nil {
@@ -489,7 +489,7 @@ func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objIn
 	if storage.injectedFunction != nil {
 		obj, err = storage.injectedFunction(obj)
 	}
-	if err := updateValidation(&storage.item, obj); err != nil {
+	if err := pLACEHOLDERVARNAME.UpdateValidation(&storage.item, obj); err != nil {
 		return nil, false, err
 	}
 	return obj, false, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -476,7 +476,7 @@ func (storage *SimpleRESTStorage) Create(ctx context.Context, obj runtime.Object
 	return obj, err
 }
 
-func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	storage.checkContext(ctx)
 	obj, err := objInfo.UpdatedObject(ctx, &storage.item)
 	if err != nil {
@@ -489,7 +489,7 @@ func (storage *SimpleRESTStorage) Update(ctx context.Context, name string, objIn
 	if storage.injectedFunction != nil {
 		obj, err = storage.injectedFunction(obj)
 	}
-	if err := pLACEHOLDERVARNAME.UpdateValidation(&storage.item, obj); err != nil {
+	if err := config.UpdateValidation(&storage.item, obj); err != nil {
 		return nil, false, err
 	}
 	return obj, false, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -204,6 +204,7 @@ type patcher struct {
 	// Set at invocation-time (by applyPatch) and immutable thereafter
 	namespace         string
 	updatedObjectInfo rest.UpdatedObjectInfo
+	pLACEHOLDERINTERFACENAME rest.PLACEHOLDERINTERFACENAME
 	mechanism         patchMechanism
 }
 
@@ -399,9 +400,10 @@ func (p *patcher) patchResource(ctx context.Context, scope RequestScope) (runtim
 
 	wasCreated := false
 	p.updatedObjectInfo = rest.DefaultUpdatedObjectInfo(nil, p.applyPatch, p.applyAdmission)
+	p.pLACEHOLDERINTERFACENAME = rest.DefaultPLACEHOLDERINTERFACENAME(p.createValidation, p.updateValidation, true)
 	result, err := finishRequest(p.timeout, func() (runtime.Object, error) {
 		// TODO: Pass in UpdateOptions to override UpdateStrategy.AllowUpdateOnCreate
-		updateObject, created, updateErr := p.restPatcher.Update(ctx, p.name, p.updatedObjectInfo, p.createValidation, p.updateValidation)
+		updateObject, created, updateErr := p.restPatcher.Update(ctx, p.name, p.updatedObjectInfo, p.pLACEHOLDERINTERFACENAME)
 		wasCreated = created
 		return updateObject, updateErr
 	})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -202,10 +202,10 @@ type patcher struct {
 	trace *utiltrace.Trace
 
 	// Set at invocation-time (by applyPatch) and immutable thereafter
-	namespace         string
-	updatedObjectInfo rest.UpdatedObjectInfo
+	namespace                string
+	updatedObjectInfo        rest.UpdatedObjectInfo
 	pLACEHOLDERINTERFACENAME rest.PLACEHOLDERINTERFACENAME
-	mechanism         patchMechanism
+	mechanism                patchMechanism
 }
 
 func (p *patcher) toUnversioned(versionedObj runtime.Object) (runtime.Object, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -202,10 +202,10 @@ type patcher struct {
 	trace *utiltrace.Trace
 
 	// Set at invocation-time (by applyPatch) and immutable thereafter
-	namespace                string
-	updatedObjectInfo        rest.UpdatedObjectInfo
-	pLACEHOLDERINTERFACENAME rest.PLACEHOLDERINTERFACENAME
-	mechanism                patchMechanism
+	namespace         string
+	updatedObjectInfo rest.UpdatedObjectInfo
+	updateConfig      rest.UpdateConfig
+	mechanism         patchMechanism
 }
 
 func (p *patcher) toUnversioned(versionedObj runtime.Object) (runtime.Object, error) {
@@ -400,10 +400,10 @@ func (p *patcher) patchResource(ctx context.Context, scope RequestScope) (runtim
 
 	wasCreated := false
 	p.updatedObjectInfo = rest.DefaultUpdatedObjectInfo(nil, p.applyPatch, p.applyAdmission)
-	p.pLACEHOLDERINTERFACENAME = rest.DefaultPLACEHOLDERINTERFACENAME(p.createValidation, p.updateValidation, true)
+	p.updateConfig = rest.DefaultUpdateConfig(p.createValidation, p.updateValidation, true)
 	result, err := finishRequest(p.timeout, func() (runtime.Object, error) {
 		// TODO: Pass in UpdateOptions to override UpdateStrategy.AllowUpdateOnCreate
-		updateObject, created, updateErr := p.restPatcher.Update(ctx, p.name, p.updatedObjectInfo, p.pLACEHOLDERINTERFACENAME)
+		updateObject, created, updateErr := p.restPatcher.Update(ctx, p.name, p.updatedObjectInfo, p.updateConfig)
 		wasCreated = created
 		return updateObject, updateErr
 	})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -173,7 +173,7 @@ func (p *testPatcher) New() runtime.Object {
 	return &example.Pod{}
 }
 
-func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	// Simulate GuaranteedUpdate behavior (retries internally on etcd changes if the incoming resource doesn't pin resourceVersion)
 	for {
 		currentPod := p.startingPod
@@ -203,11 +203,11 @@ func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.Upda
 		}
 
 		if currentPod == nil {
-			if err := pLACEHOLDERVARNAME.CreateValidation(currentPod); err != nil {
+			if err := config.CreateValidation(currentPod); err != nil {
 				return nil, false, err
 			}
 		} else {
-			if err := pLACEHOLDERVARNAME.UpdateValidation(currentPod, inPod); err != nil {
+			if err := config.UpdateValidation(currentPod, inPod); err != nil {
 				return nil, false, err
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -173,7 +173,7 @@ func (p *testPatcher) New() runtime.Object {
 	return &example.Pod{}
 }
 
-func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	// Simulate GuaranteedUpdate behavior (retries internally on etcd changes if the incoming resource doesn't pin resourceVersion)
 	for {
 		currentPod := p.startingPod
@@ -203,11 +203,11 @@ func (p *testPatcher) Update(ctx context.Context, name string, objInfo rest.Upda
 		}
 
 		if currentPod == nil {
-			if err := createValidation(currentPod); err != nil {
+			if err := pLACEHOLDERVARNAME.CreateValidation(currentPod); err != nil {
 				return nil, false, err
 			}
 		} else {
-			if err := updateValidation(currentPod, inPod); err != nil {
+			if err := pLACEHOLDERVARNAME.UpdateValidation(currentPod, inPod); err != nil {
 				return nil, false, err
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -101,6 +101,8 @@ func UpdateResource(r rest.Updater, scope RequestScope, admit admission.Interfac
 				return newObj, mutatingAdmission.Admit(admission.NewAttributesRecord(newObj, oldObj, scope.Kind, namespace, name, scope.Resource, scope.Subresource, admission.Update, userInfo))
 			})
 		}
+		createValidation := rest.AdmissionToValidateObjectFunc(admit, staticAdmissionAttributes)
+		updateValidation := rest.AdmissionToValidateObjectUpdateFunc(admit, staticAdmissionAttributes)
 
 		trace.Step("About to store object in database")
 		wasCreated := false
@@ -109,8 +111,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, admit admission.Interfac
 				ctx,
 				name,
 				rest.DefaultUpdatedObjectInfo(obj, transformers...),
-				rest.AdmissionToValidateObjectFunc(admit, staticAdmissionAttributes),
-				rest.AdmissionToValidateObjectUpdateFunc(admit, staticAdmissionAttributes),
+				rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false),
 			)
 			wasCreated = created
 			return obj, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -111,7 +111,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, admit admission.Interfac
 				ctx,
 				name,
 				rest.DefaultUpdatedObjectInfo(obj, transformers...),
-				rest.DefaultPLACEHOLDERINTERFACENAME(createValidation, updateValidation, false),
+				rest.DefaultUpdateConfig(createValidation, updateValidation, false),
 			)
 			wasCreated = created
 			return obj, err

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -522,7 +522,7 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 // Update performs an atomic update and set of the object. Returns the result of the update
 // or an error. If the registry allows create-on-update, the create flow will be executed.
 // A bool is returned along with the object and any errors, to indicate object creation.
-func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
 	key, err := e.KeyFunc(ctx, name)
 	if err != nil {
 		return nil, false, err
@@ -564,7 +564,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 			return nil, nil, err
 		}
 		if version == 0 {
-			if !e.UpdateStrategy.AllowCreateOnUpdate() && !pLACEHOLDERVARNAME.ForceAllowCreateOnUpdate() {
+			if !e.UpdateStrategy.AllowCreateOnUpdate() && !config.ForceAllowCreateOnUpdate() {
 				return nil, nil, kubeerr.NewNotFound(qualifiedResource, name)
 			}
 			creating = true
@@ -574,7 +574,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 			}
 			// at this point we have a fully formed object.  It is time to call the validators that the apiserver
 			// handling chain wants to enforce.
-			if err := pLACEHOLDERVARNAME.CreateValidation(obj.DeepCopyObject()); err != nil {
+			if err := config.CreateValidation(obj.DeepCopyObject()); err != nil {
 				return nil, nil, err
 			}
 			ttl, err := e.calculateTTL(obj, 0, false)
@@ -614,7 +614,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		}
 		// at this point we have a fully formed object.  It is time to call the validators that the apiserver
 		// handling chain wants to enforce.
-		if err := pLACEHOLDERVARNAME.UpdateValidation(obj.DeepCopyObject(), existing.DeepCopyObject()); err != nil {
+		if err := config.UpdateValidation(obj.DeepCopyObject(), existing.DeepCopyObject()); err != nil {
 			return nil, nil, err
 		}
 		if e.shouldDeleteDuringUpdate(ctx, key, obj, existing) {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -522,7 +522,7 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 // Update performs an atomic update and set of the object. Returns the result of the update
 // or an error. If the registry allows create-on-update, the create flow will be executed.
 // A bool is returned along with the object and any errors, to indicate object creation.
-func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
+func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
 	key, err := e.KeyFunc(ctx, name)
 	if err != nil {
 		return nil, false, err
@@ -564,7 +564,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 			return nil, nil, err
 		}
 		if version == 0 {
-			if !e.UpdateStrategy.AllowCreateOnUpdate() {
+			if !e.UpdateStrategy.AllowCreateOnUpdate() && !pLACEHOLDERVARNAME.ForceAllowCreateOnUpdate() {
 				return nil, nil, kubeerr.NewNotFound(qualifiedResource, name)
 			}
 			creating = true
@@ -574,10 +574,8 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 			}
 			// at this point we have a fully formed object.  It is time to call the validators that the apiserver
 			// handling chain wants to enforce.
-			if createValidation != nil {
-				if err := createValidation(obj.DeepCopyObject()); err != nil {
-					return nil, nil, err
-				}
+			if err := pLACEHOLDERVARNAME.CreateValidation(obj.DeepCopyObject()); err != nil {
+				return nil, nil, err
 			}
 			ttl, err := e.calculateTTL(obj, 0, false)
 			if err != nil {
@@ -616,10 +614,8 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		}
 		// at this point we have a fully formed object.  It is time to call the validators that the apiserver
 		// handling chain wants to enforce.
-		if updateValidation != nil {
-			if err := updateValidation(obj.DeepCopyObject(), existing.DeepCopyObject()); err != nil {
-				return nil, nil, err
-			}
+		if err := pLACEHOLDERVARNAME.UpdateValidation(obj.DeepCopyObject(), existing.DeepCopyObject()); err != nil {
+			return nil, nil, err
 		}
 		if e.shouldDeleteDuringUpdate(ctx, key, obj, existing) {
 			deleteObj = obj

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -457,7 +457,7 @@ func TestStoreCreateInitialized(t *testing.T) {
 		}
 
 		pod.Initializers = nil
-		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -550,7 +550,7 @@ func TestStoreCreateInitializedFailed(t *testing.T) {
 		}
 		pod.Initializers.Pending = nil
 		pod.Initializers.Result = &metav1.Status{Status: metav1.StatusFailure, Code: 403, Reason: metav1.StatusReasonForbidden, Message: "induced failure"}
-		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -591,7 +591,7 @@ func TestStoreCreateInitializedFailed(t *testing.T) {
 }
 
 func updateAndVerify(t *testing.T, ctx context.Context, registry *Store, pod *example.Pod) bool {
-	obj, _, err := registry.Update(ctx, pod.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	obj, _, err := registry.Update(ctx, pod.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return false
@@ -627,13 +627,13 @@ func TestStoreUpdate(t *testing.T) {
 	defer destroyFunc()
 
 	// try to update a non-existing node with denying admission, should still return NotFound
-	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(denyCreateValidation, denyUpdateValidation, false))
+	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultUpdateConfig(denyCreateValidation, denyUpdateValidation, false))
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	// try to update a non-existing node
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -642,7 +642,7 @@ func TestStoreUpdate(t *testing.T) {
 	registry.UpdateStrategy.(*testRESTStrategy).allowCreateOnUpdate = true
 
 	// createIfNotFound with denying create admission
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(denyCreateValidation, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultUpdateConfig(denyCreateValidation, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil {
 		t.Errorf("expected admission error on create")
 	}
@@ -656,13 +656,13 @@ func TestStoreUpdate(t *testing.T) {
 	registry.UpdateStrategy.(*testRESTStrategy).allowCreateOnUpdate = false
 
 	// outofDate
-	_, _, err = registry.Update(testContext, podAWithResourceVersion.Name, rest.DefaultUpdatedObjectInfo(podAWithResourceVersion), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = registry.Update(testContext, podAWithResourceVersion.Name, rest.DefaultUpdatedObjectInfo(podAWithResourceVersion), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsConflict(err) {
 		t.Errorf("Unexpected error updating podAWithResourceVersion: %v", err)
 	}
 
 	// try to update with denying admission
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, denyUpdateValidation, false))
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, denyUpdateValidation, false))
 	if err == nil {
 		t.Errorf("expected admission error on update")
 	}
@@ -710,7 +710,7 @@ func TestNoOpUpdates(t *testing.T) {
 
 	var updateResult runtime.Object
 	p := newPod()
-	if updateResult, _, err = registry.Update(genericapirequest.NewDefaultContext(), p.Name, rest.DefaultUpdatedObjectInfo(p), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
+	if updateResult, _, err = registry.Update(genericapirequest.NewDefaultContext(), p.Name, rest.DefaultUpdatedObjectInfo(p), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -1011,7 +1011,7 @@ func TestGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Finalizers: []string{"foo.com/x"}, ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "machine"},
 		}
-		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1026,7 +1026,7 @@ func TestGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "anothermachine"},
 		}
-		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1063,7 +1063,7 @@ func TestFailedInitializationStoreUpdate(t *testing.T) {
 
 	// update the pod with initialization failure, the pod should be deleted
 	pod.Initializers.Result = &metav1.Status{Status: metav1.StatusFailure}
-	result, _, err := registry.Update(testContext, podInitializing.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	result, _, err := registry.Update(testContext, podInitializing.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestNonGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Finalizers: []string{"foo.com/x"}, ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "machine"},
 		}
-		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1150,7 +1150,7 @@ func TestNonGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "anothermachine"},
 		}
-		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1961,7 +1961,7 @@ func TestQualifiedResource(t *testing.T) {
 	defer destroyFunc()
 
 	// update a non-exist object
-	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsNotFound(err) {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -457,7 +457,7 @@ func TestStoreCreateInitialized(t *testing.T) {
 		}
 
 		pod.Initializers = nil
-		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -550,7 +550,7 @@ func TestStoreCreateInitializedFailed(t *testing.T) {
 		}
 		pod.Initializers.Pending = nil
 		pod.Initializers.Result = &metav1.Status{Status: metav1.StatusFailure, Code: 403, Reason: metav1.StatusReasonForbidden, Message: "induced failure"}
-		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		updated, _, err := registry.Update(ctx, podA.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -591,7 +591,7 @@ func TestStoreCreateInitializedFailed(t *testing.T) {
 }
 
 func updateAndVerify(t *testing.T, ctx context.Context, registry *Store, pod *example.Pod) bool {
-	obj, _, err := registry.Update(ctx, pod.Name, rest.DefaultUpdatedObjectInfo(pod), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	obj, _, err := registry.Update(ctx, pod.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return false
@@ -627,13 +627,13 @@ func TestStoreUpdate(t *testing.T) {
 	defer destroyFunc()
 
 	// try to update a non-existing node with denying admission, should still return NotFound
-	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), denyCreateValidation, denyUpdateValidation)
+	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(denyCreateValidation, denyUpdateValidation, false))
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
 	// try to update a non-existing node
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -642,7 +642,7 @@ func TestStoreUpdate(t *testing.T) {
 	registry.UpdateStrategy.(*testRESTStrategy).allowCreateOnUpdate = true
 
 	// createIfNotFound with denying create admission
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), denyCreateValidation, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(denyCreateValidation, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil {
 		t.Errorf("expected admission error on create")
 	}
@@ -656,13 +656,13 @@ func TestStoreUpdate(t *testing.T) {
 	registry.UpdateStrategy.(*testRESTStrategy).allowCreateOnUpdate = false
 
 	// outofDate
-	_, _, err = registry.Update(testContext, podAWithResourceVersion.Name, rest.DefaultUpdatedObjectInfo(podAWithResourceVersion), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = registry.Update(testContext, podAWithResourceVersion.Name, rest.DefaultUpdatedObjectInfo(podAWithResourceVersion), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsConflict(err) {
 		t.Errorf("Unexpected error updating podAWithResourceVersion: %v", err)
 	}
 
 	// try to update with denying admission
-	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.ValidateAllObjectFunc, denyUpdateValidation)
+	_, _, err = registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, denyUpdateValidation, false))
 	if err == nil {
 		t.Errorf("expected admission error on update")
 	}
@@ -710,7 +710,7 @@ func TestNoOpUpdates(t *testing.T) {
 
 	var updateResult runtime.Object
 	p := newPod()
-	if updateResult, _, err = registry.Update(genericapirequest.NewDefaultContext(), p.Name, rest.DefaultUpdatedObjectInfo(p), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc); err != nil {
+	if updateResult, _, err = registry.Update(genericapirequest.NewDefaultContext(), p.Name, rest.DefaultUpdatedObjectInfo(p), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false)); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -1011,7 +1011,7 @@ func TestGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Finalizers: []string{"foo.com/x"}, ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "machine"},
 		}
-		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1026,7 +1026,7 @@ func TestGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "anothermachine"},
 		}
-		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1063,7 +1063,7 @@ func TestFailedInitializationStoreUpdate(t *testing.T) {
 
 	// update the pod with initialization failure, the pod should be deleted
 	pod.Initializers.Result = &metav1.Status{Status: metav1.StatusFailure}
-	result, _, err := registry.Update(testContext, podInitializing.Name, rest.DefaultUpdatedObjectInfo(pod), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	result, _, err := registry.Update(testContext, podInitializing.Name, rest.DefaultUpdatedObjectInfo(pod), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestNonGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Finalizers: []string{"foo.com/x"}, ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "machine"},
 		}
-		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		_, _, err = registry.Update(testContext, updatedPodWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(updatedPodWithFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1150,7 +1150,7 @@ func TestNonGracefulStoreHandleFinalizers(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: podWithFinalizer.ObjectMeta.ResourceVersion},
 			Spec:       example.PodSpec{NodeName: "anothermachine"},
 		}
-		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		_, _, err = registry.Update(testContext, podWithFinalizer.ObjectMeta.Name, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1961,7 +1961,7 @@ func TestQualifiedResource(t *testing.T) {
 	defer destroyFunc()
 
 	// update a non-exist object
-	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := registry.Update(testContext, podA.Name, rest.DefaultUpdatedObjectInfo(podA), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if !errors.IsNotFound(err) {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -207,6 +207,24 @@ type UpdatedObjectInfo interface {
 	UpdatedObject(ctx context.Context, oldObj runtime.Object) (newObj runtime.Object, err error)
 }
 
+// PLACEHOLDERINTERFACENAME provides information about the validation functions that
+// the Updater should use, and allows for overriding certain UpdateStrategy behavior.
+type PLACEHOLDERINTERFACENAME interface {
+	// CreateValidation is a function to act on a given object. An error may be returned
+	// if the hook cannot be completed. An ObjectFunc may NOT transform the provided
+	// object.
+	CreateValidation(obj runtime.Object) error
+
+	// UpdateValidation is a function to act on a given object and its predecessor.
+	// An error may be returned if the hook cannot be completed. An UpdateObjectFunc
+	// may NOT transform the provided object.
+	UpdateValidation(obj, old runtime.Object) error
+
+	// ForceAllowCreateOnUpdate returns true if the object should be created on
+	// update if it doesn't exist yet, no matter what the UpdateStrategy specifies for AllowCreateOnUpdate.
+	ForceAllowCreateOnUpdate() bool
+}
+
 // ValidateObjectFunc is a function to act on a given object. An error may be returned
 // if the hook cannot be completed. An ObjectFunc may NOT transform the provided
 // object.
@@ -236,14 +254,14 @@ type Updater interface {
 	// Update finds a resource in the storage and updates it. Some implementations
 	// may allow updates creates the object - they should set the created boolean
 	// to true.
-	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, createValidation ValidateObjectFunc, updateValidation ValidateObjectUpdateFunc) (runtime.Object, bool, error)
+	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, pLACEHOLDERVARNAME PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error)
 }
 
 // CreaterUpdater is a storage object that must support both create and update.
 // Go prevents embedded interfaces that implement the same method.
 type CreaterUpdater interface {
 	Creater
-	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, createValidation ValidateObjectFunc, updateValidation ValidateObjectUpdateFunc) (runtime.Object, bool, error)
+	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, pLACEHOLDERVARNAME PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error)
 }
 
 // CreaterUpdater must satisfy the Updater interface.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -207,9 +207,9 @@ type UpdatedObjectInfo interface {
 	UpdatedObject(ctx context.Context, oldObj runtime.Object) (newObj runtime.Object, err error)
 }
 
-// PLACEHOLDERINTERFACENAME provides information about the validation functions that
+// UpdateConfig provides information about the validation functions that
 // the Updater should use, and allows for overriding certain UpdateStrategy behavior.
-type PLACEHOLDERINTERFACENAME interface {
+type UpdateConfig interface {
 	// CreateValidation is a function to act on a given object. An error may be returned
 	// if the hook cannot be completed. An ObjectFunc may NOT transform the provided
 	// object.
@@ -254,14 +254,14 @@ type Updater interface {
 	// Update finds a resource in the storage and updates it. Some implementations
 	// may allow updates creates the object - they should set the created boolean
 	// to true.
-	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, pLACEHOLDERVARNAME PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error)
+	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, config UpdateConfig) (runtime.Object, bool, error)
 }
 
 // CreaterUpdater is a storage object that must support both create and update.
 // Go prevents embedded interfaces that implement the same method.
 type CreaterUpdater interface {
 	Creater
-	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, pLACEHOLDERVARNAME PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error)
+	Update(ctx context.Context, name string, objInfo UpdatedObjectInfo, config UpdateConfig) (runtime.Object, bool, error)
 }
 
 // CreaterUpdater must satisfy the Updater interface.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -463,7 +463,7 @@ func (t *Tester) testUpdateEquals(obj runtime.Object, createFn CreateFunc, getFn
 	}
 	toUpdate = updateFn(toUpdate)
 	toUpdateMeta := t.getObjectMetaOrFail(toUpdate)
-	updated, created, err := t.storage.(rest.Updater).Update(ctx, toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	updated, created, err := t.storage.(rest.Updater).Update(ctx, toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -503,7 +503,7 @@ func (t *Tester) testUpdateFailsOnVersionTooOld(obj runtime.Object, createFn Cre
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetResourceVersion("1")
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil {
 		t.Errorf("Expected an error, but we didn't get one")
 	} else if !errors.IsConflict(err) {
@@ -523,7 +523,7 @@ func (t *Tester) testUpdateInvokesValidation(obj runtime.Object, createFn Create
 	for _, update := range invalidUpdateFn {
 		toUpdate := update(foo.DeepCopyObject())
 		toUpdateMeta := t.getObjectMetaOrFail(toUpdate)
-		got, created, err := t.storage.(rest.Updater).Update(t.TestContext(), toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+		got, created, err := t.storage.(rest.Updater).Update(t.TestContext(), toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if got != nil || created {
 			t.Errorf("expected nil object and no creation for object: %v", toUpdate)
 		}
@@ -544,7 +544,7 @@ func (t *Tester) testUpdateWithWrongUID(obj runtime.Object, createFn CreateFunc,
 	}
 	objectMeta.SetUID(types.UID("UID1111"))
 
-	obj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(foo), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	obj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(foo), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if created || obj != nil {
 		t.Errorf("expected nil object and no creation for object: %v", foo)
 	}
@@ -588,7 +588,7 @@ func (t *Tester) testUpdateRetrievesOldObject(obj runtime.Object, createFn Creat
 		return updatedObject, nil
 	}
 
-	updatedObj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(storedFooWithUpdates, noopTransform), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	updatedObj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(storedFooWithUpdates, noopTransform), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return
@@ -623,7 +623,7 @@ func (t *Tester) testUpdatePropagatesUpdatedObjectError(obj runtime.Object, crea
 		return nil, propagateErr
 	}
 
-	_, _, err := t.storage.(rest.Updater).Update(ctx, name, rest.DefaultUpdatedObjectInfo(foo, noopTransform), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err := t.storage.(rest.Updater).Update(ctx, name, rest.DefaultUpdatedObjectInfo(foo, noopTransform), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != propagateErr {
 		t.Errorf("expected propagated error, got %#v", err)
 	}
@@ -649,7 +649,7 @@ func (t *Tester) testUpdateIgnoreGenerationUpdates(obj runtime.Object, createFn 
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetGeneration(2)
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -665,7 +665,7 @@ func (t *Tester) testUpdateIgnoreGenerationUpdates(obj runtime.Object, createFn 
 
 func (t *Tester) testUpdateOnNotFound(obj runtime.Object) {
 	t.setObjectMeta(obj, t.namer(0))
-	_, created, err := t.storage.(rest.Updater).Update(t.TestContext(), t.namer(0), rest.DefaultUpdatedObjectInfo(obj), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, created, err := t.storage.(rest.Updater).Update(t.TestContext(), t.namer(0), rest.DefaultUpdatedObjectInfo(obj), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if t.createOnUpdate {
 		if err != nil {
 			t.Errorf("creation allowed on updated, but got an error: %v", err)
@@ -700,7 +700,7 @@ func (t *Tester) testUpdateRejectsMismatchedNamespace(obj runtime.Object, create
 	objectMeta.SetName(t.namer(1))
 	objectMeta.SetNamespace("not-default")
 
-	obj, updated, err := t.storage.(rest.Updater).Update(t.TestContext(), "foo1", rest.DefaultUpdatedObjectInfo(storedFoo), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	obj, updated, err := t.storage.(rest.Updater).Update(t.TestContext(), "foo1", rest.DefaultUpdatedObjectInfo(storedFoo), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if obj != nil || updated {
 		t.Errorf("expected nil object and not updated")
 	}
@@ -731,7 +731,7 @@ func (t *Tester) testUpdateIgnoreClusterName(obj runtime.Object, createFn Create
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetClusterName("clustername-to-ignore")
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -463,7 +463,7 @@ func (t *Tester) testUpdateEquals(obj runtime.Object, createFn CreateFunc, getFn
 	}
 	toUpdate = updateFn(toUpdate)
 	toUpdateMeta := t.getObjectMetaOrFail(toUpdate)
-	updated, created, err := t.storage.(rest.Updater).Update(ctx, toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	updated, created, err := t.storage.(rest.Updater).Update(ctx, toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -503,7 +503,7 @@ func (t *Tester) testUpdateFailsOnVersionTooOld(obj runtime.Object, createFn Cre
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetResourceVersion("1")
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err == nil {
 		t.Errorf("Expected an error, but we didn't get one")
 	} else if !errors.IsConflict(err) {
@@ -523,7 +523,7 @@ func (t *Tester) testUpdateInvokesValidation(obj runtime.Object, createFn Create
 	for _, update := range invalidUpdateFn {
 		toUpdate := update(foo.DeepCopyObject())
 		toUpdateMeta := t.getObjectMetaOrFail(toUpdate)
-		got, created, err := t.storage.(rest.Updater).Update(t.TestContext(), toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+		got, created, err := t.storage.(rest.Updater).Update(t.TestContext(), toUpdateMeta.GetName(), rest.DefaultUpdatedObjectInfo(toUpdate), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 		if got != nil || created {
 			t.Errorf("expected nil object and no creation for object: %v", toUpdate)
 		}
@@ -544,7 +544,7 @@ func (t *Tester) testUpdateWithWrongUID(obj runtime.Object, createFn CreateFunc,
 	}
 	objectMeta.SetUID(types.UID("UID1111"))
 
-	obj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(foo), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	obj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(foo), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if created || obj != nil {
 		t.Errorf("expected nil object and no creation for object: %v", foo)
 	}
@@ -588,7 +588,7 @@ func (t *Tester) testUpdateRetrievesOldObject(obj runtime.Object, createFn Creat
 		return updatedObject, nil
 	}
 
-	updatedObj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(storedFooWithUpdates, noopTransform), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	updatedObj, created, err := t.storage.(rest.Updater).Update(ctx, objectMeta.GetName(), rest.DefaultUpdatedObjectInfo(storedFooWithUpdates, noopTransform), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 		return
@@ -623,7 +623,7 @@ func (t *Tester) testUpdatePropagatesUpdatedObjectError(obj runtime.Object, crea
 		return nil, propagateErr
 	}
 
-	_, _, err := t.storage.(rest.Updater).Update(ctx, name, rest.DefaultUpdatedObjectInfo(foo, noopTransform), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err := t.storage.(rest.Updater).Update(ctx, name, rest.DefaultUpdatedObjectInfo(foo, noopTransform), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != propagateErr {
 		t.Errorf("expected propagated error, got %#v", err)
 	}
@@ -649,7 +649,7 @@ func (t *Tester) testUpdateIgnoreGenerationUpdates(obj runtime.Object, createFn 
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetGeneration(2)
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -665,7 +665,7 @@ func (t *Tester) testUpdateIgnoreGenerationUpdates(obj runtime.Object, createFn 
 
 func (t *Tester) testUpdateOnNotFound(obj runtime.Object) {
 	t.setObjectMeta(obj, t.namer(0))
-	_, created, err := t.storage.(rest.Updater).Update(t.TestContext(), t.namer(0), rest.DefaultUpdatedObjectInfo(obj), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, created, err := t.storage.(rest.Updater).Update(t.TestContext(), t.namer(0), rest.DefaultUpdatedObjectInfo(obj), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if t.createOnUpdate {
 		if err != nil {
 			t.Errorf("creation allowed on updated, but got an error: %v", err)
@@ -700,7 +700,7 @@ func (t *Tester) testUpdateRejectsMismatchedNamespace(obj runtime.Object, create
 	objectMeta.SetName(t.namer(1))
 	objectMeta.SetNamespace("not-default")
 
-	obj, updated, err := t.storage.(rest.Updater).Update(t.TestContext(), "foo1", rest.DefaultUpdatedObjectInfo(storedFoo), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	obj, updated, err := t.storage.(rest.Updater).Update(t.TestContext(), "foo1", rest.DefaultUpdatedObjectInfo(storedFoo), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if obj != nil || updated {
 		t.Errorf("expected nil object and not updated")
 	}
@@ -731,7 +731,7 @@ func (t *Tester) testUpdateIgnoreClusterName(obj runtime.Object, createFn Create
 	olderMeta := t.getObjectMetaOrFail(older)
 	olderMeta.SetClusterName("clustername-to-ignore")
 
-	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultPLACEHOLDERINTERFACENAME(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
+	_, _, err = t.storage.(rest.Updater).Update(t.TestContext(), olderMeta.GetName(), rest.DefaultUpdatedObjectInfo(older), rest.DefaultUpdateConfig(rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -277,3 +277,35 @@ func AdmissionToValidateObjectUpdateFunc(admit admission.Interface, staticAttrib
 		return validatingAdmission.Validate(finalAttributes)
 	}
 }
+
+type defaultPLACEHOLDERINTERFACENAME struct {
+	createValidation         ValidateObjectFunc
+	updateValidation         ValidateObjectUpdateFunc
+	forceAllowCreateOnUpdate bool
+}
+
+// DefaultPLACEHOLDERINTERFACENAME returns an PLACEHOLDERINTERFACENAME implementation.
+func DefaultPLACEHOLDERINTERFACENAME(createValidation ValidateObjectFunc, updateValidation ValidateObjectUpdateFunc, forceAllowCreateOnUpdate bool) PLACEHOLDERINTERFACENAME {
+	return &defaultPLACEHOLDERINTERFACENAME{createValidation, updateValidation, forceAllowCreateOnUpdate}
+}
+
+// CreateValidation implements PLACEHOLDERINTERFACENAME.
+func (i *defaultPLACEHOLDERINTERFACENAME) CreateValidation(obj runtime.Object) error {
+	if i.createValidation == nil {
+		return nil
+	}
+	return i.createValidation(obj)
+}
+
+// UpdateValidation implements PLACEHOLDERINTERFACENAME.
+func (i *defaultPLACEHOLDERINTERFACENAME) UpdateValidation(obj, old runtime.Object) error {
+	if i.updateValidation == nil {
+		return nil
+	}
+	return i.updateValidation(obj, old)
+}
+
+// ForceAllowCreateOnUpdate implements PLACEHOLDERINTERFACENAME.
+func (i *defaultPLACEHOLDERINTERFACENAME) ForceAllowCreateOnUpdate() bool {
+	return i.forceAllowCreateOnUpdate
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -278,34 +278,34 @@ func AdmissionToValidateObjectUpdateFunc(admit admission.Interface, staticAttrib
 	}
 }
 
-type defaultPLACEHOLDERINTERFACENAME struct {
+type defaultUpdateConfig struct {
 	createValidation         ValidateObjectFunc
 	updateValidation         ValidateObjectUpdateFunc
 	forceAllowCreateOnUpdate bool
 }
 
-// DefaultPLACEHOLDERINTERFACENAME returns an PLACEHOLDERINTERFACENAME implementation.
-func DefaultPLACEHOLDERINTERFACENAME(createValidation ValidateObjectFunc, updateValidation ValidateObjectUpdateFunc, forceAllowCreateOnUpdate bool) PLACEHOLDERINTERFACENAME {
-	return &defaultPLACEHOLDERINTERFACENAME{createValidation, updateValidation, forceAllowCreateOnUpdate}
+// DefaultUpdateConfig returns an UpdateConfig implementation.
+func DefaultUpdateConfig(createValidation ValidateObjectFunc, updateValidation ValidateObjectUpdateFunc, forceAllowCreateOnUpdate bool) UpdateConfig {
+	return &defaultUpdateConfig{createValidation, updateValidation, forceAllowCreateOnUpdate}
 }
 
-// CreateValidation implements PLACEHOLDERINTERFACENAME.
-func (i *defaultPLACEHOLDERINTERFACENAME) CreateValidation(obj runtime.Object) error {
+// CreateValidation implements UpdateConfig.
+func (i *defaultUpdateConfig) CreateValidation(obj runtime.Object) error {
 	if i.createValidation == nil {
 		return nil
 	}
 	return i.createValidation(obj)
 }
 
-// UpdateValidation implements PLACEHOLDERINTERFACENAME.
-func (i *defaultPLACEHOLDERINTERFACENAME) UpdateValidation(obj, old runtime.Object) error {
+// UpdateValidation implements UpdateConfig.
+func (i *defaultUpdateConfig) UpdateValidation(obj, old runtime.Object) error {
 	if i.updateValidation == nil {
 		return nil
 	}
 	return i.updateValidation(obj, old)
 }
 
-// ForceAllowCreateOnUpdate implements PLACEHOLDERINTERFACENAME.
-func (i *defaultPLACEHOLDERINTERFACENAME) ForceAllowCreateOnUpdate() bool {
+// ForceAllowCreateOnUpdate implements UpdateConfig.
+func (i *defaultUpdateConfig) ForceAllowCreateOnUpdate() bool {
 	return i.forceAllowCreateOnUpdate
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -79,6 +79,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, config rest.UpdateConfig) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, config)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -79,6 +79,6 @@ func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, pLACEHOLDERVARNAME rest.PLACEHOLDERINTERFACENAME) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, pLACEHOLDERVARNAME)
 }

--- a/test/integration/apiserver/apply_test.go
+++ b/test/integration/apiserver/apply_test.go
@@ -35,16 +35,21 @@ func TestApplyAlsoCreates(t *testing.T) {
 	_, client, closeFn := setup(t)
 	defer closeFn()
 
-	// Using limitrange here because it allows create on update
 	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
 		Namespace("default").
-		Resource("limitranges").
-		Name("test-limitrange").
+		Resource("pods").
+		Name("test-pod").
 		Body([]byte(`{
 			"apiVersion": "v1",
-			"kind": "LimitRange",
+			"kind": "Pod",
 			"metadata": {
-				"name": "test-limitrange"
+				"name": "test-pod"
+			},
+			"spec": {
+				"containers": [{
+					"name":  "test-container",
+					"image": "test-image"
+				}]
 			}
 		}`)).
 		Do().
@@ -53,7 +58,7 @@ func TestApplyAlsoCreates(t *testing.T) {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
 
-	_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource("limitranges").Name("test-limitrange").Do().Get()
+	_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource("pods").Name("test-pod").Do().Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the Update function signature to include a new interface which combines createValidation, updateValidation, and a new flag to allow the caller of Update to override what the UpdateStrategy returns for AllowCreateOnUpdate. This is not exposed to the user, the patch handler is the one that sets this override value, in order to provide more consistent apply behavior. Also, having this new interface, instead of just adding a flag to the Update signature directly, will make it much easier to wire dry-run run from a query parameter to the storage layer.

The name of the new interface is still being decided so I have left a placeholder name in this PR. It will probably be called UpdateConfig. Something like:
```
s/PLACEHOLDERINTERFACENAME/UpdateConfig/
s/pLACEHOLDERINTERFACENAME/updateConfig/
s/pLACEHOLDERVARNAME/config/
```

**Special notes for your reviewer**:
This is not a generated change.

/sig api-machinery
/kind feature

**Release note**:
```release-note
NONE
```
