### PR TITLE
Fix unit tests that fails when ran inside the cluster as they incorrectly read in-cluster config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/authentication.go
@@ -57,6 +57,11 @@ func (a *AuthenticationInfoResolverDelegator) ClientConfigForService(serviceName
 
 type defaultAuthenticationInfoResolver struct {
 	kubeconfig clientcmdapi.Config
+
+	// skipInCluster causes the defaultAuthenticationInfoResolver skip the in-cluster config check.
+	// This is useful only for unit testing when it is done inside the actual cluster where the existing in-cluster config will cause
+	// the unit tests to give incorrect results.
+	skipInCluster bool
 }
 
 // NewDefaultAuthenticationInfoResolver generates an AuthenticationInfoResolver
@@ -102,7 +107,7 @@ func (c *defaultAuthenticationInfoResolver) clientConfig(target string) (*rest.C
 	}
 
 	// if we're trying to hit the kube-apiserver and there wasn't an explicit config, use the in-cluster config
-	if target == "kubernetes.default.svc" {
+	if target == "kubernetes.default.svc" && !c.skipInCluster {
 		// if we can find an in-cluster-config use that.  If we can't, fall through.
 		inClusterConfig, err := rest.InClusterConfig()
 		if err == nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/authentication_test.go
@@ -113,7 +113,7 @@ func TestAuthenticationDetection(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			resolver := defaultAuthenticationInfoResolver{kubeconfig: tc.kubeconfig}
+			resolver := defaultAuthenticationInfoResolver{kubeconfig: tc.kubeconfig, skipInCluster: true}
 			actual, err := resolver.ClientConfigFor(tc.serverName)
 			if err != nil {
 				t.Fatal(err)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -118,7 +118,7 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 	}
 
 	// check for in-cluster configuration and use it
-	if config.icc.Possible() {
+	if !config.loader.IsExplicitFile() && config.icc.Possible() {
 		glog.V(4).Infof("Using in-cluster configuration")
 		return config.icc.ClientConfig()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When you run some unit tests[1] inside a Pod in cluster, they might incorrectly read the in-cluster configuration (because they use `os.Getenv()`... 
This PR will prevent this from happening by shiming the `defaultAuthenticationInfoResolver` for unit tests and fixing the `DeferredLoadingClientConfig` to skip in-cluster config detection when the kubeconfig file is explicitly provided.

[1] https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/19827/pull-ci-origin-unit/1002401727812472832/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` 

Fixes: https://github.com/openshift/origin/issues/19902

**Release note**:
```release-note
NONE
```