### PR TITLE
apiserver: add context to authn/authz kubeconfig errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -266,7 +266,7 @@ func (s *DelegatingAuthenticationOptions) getRequestHeader() (*RequestHeaderAuth
 func (s *DelegatingAuthenticationOptions) lookupInClusterClientCA() (*ClientCertAuthenticationOptions, error) {
 	clientConfig, err := s.getClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get delegated authentication kubeconfig: %v", err)
 	}
 	client, err := coreclient.NewForConfig(clientConfig)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -125,7 +126,7 @@ func (s *DelegatingAuthorizationOptions) newSubjectAccessReview() (authorization
 		clientConfig, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get delegated authorization kubeconfig: %v", err)
 	}
 
 	// set high qps/burst limits since this will effectively limit API server responsiveness


### PR DESCRIPTION
Before this the user only saw messages about in-cluster config, but didn't know which.