### PR TITLE
Updated GlusterFS client to 4.0 in Hypercube

### DIFF
--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:gluster/glusterfs-4.0
+RUN add-apt-repository -y ppa:gluster/glusterfs-4.1
 RUN apt-get update
 Run apt-get install -y netbase nfs-common glusterfs-client
 

--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
+RUN apt-get update
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:gluster/glusterfs-4.0
+RUN apt-get update
+Run apt-get install -y netbase nfs-common glusterfs-client
 
 ENTRYPOINT ["/bin/mount"]


### PR DESCRIPTION
Updated Dockerfile to install the latest stable release of GlusterFS, 4.0. This fixes a problem when mounting Gluster volumes created on a GlusterFS 4.0 server. See https://github.com/kubernetes/kubernetes/issues/65093


**What this PR does / why we need it**:

The current image uses Cluster 3.7.6, 5 minor versions behind, and 1 one major release behind (and countless patch versions). If someone tries to mount a Gluster volume from a server that is using GlusterFS 3.9+, the volume will fail to mount with the following error:

`Server is operating at an op-version which is not supported`

Sysadmins are using Gluster 4.0 because of the many performance improvements over 3.7.6, and added integrity features such as bitrot scrubbing. Not to mention, Gluster 4.0 includes a REST API that is meant to assist with dynamic provisioning for platforms like Kubernetes.

**Which issue(s) this PR fixes** :
Fixes #65093

**Special notes for your reviewer**:
We've tested these changes and are running it in production currently.

**Release note**:
```release-note
hypercube: updated GlusterFS client to version 4.0.
```
