### PR TITLE
Use encrypted kubelet port for summary api

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -71,7 +71,7 @@ spec:
             timeoutSeconds: 5
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes.summary_api:?kubeletPort=10250&kubeletHttps=true&insecure=true
             - --sink=gcm
         - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: eventer

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -71,7 +71,7 @@ spec:
             timeoutSeconds: 5
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes.summary_api:?kubeletPort=10250&kubeletHttps=true&insecure=true
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
         - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -71,7 +71,7 @@ spec:
             timeoutSeconds: 5
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes.summary_api:?kubeletPort=10250&kubeletHttps=true&insecure=true
             - --sink=influxdb:http://monitoring-influxdb:8086
         - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: eventer

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -59,7 +59,7 @@ spec:
           command:
             # On GCP, container.googleapis.com/instance_id node annotation is used to provide instance_id label for Stackdriver
             - /heapster
-            - --source=kubernetes.summary_api:?host_id_annotation=container.googleapis.com/instance_id
+            - --source=kubernetes.summary_api:?host_id_annotation=container.googleapis.com/instance_id&kubeletPort=10250&kubeletHttps=true&insecure=true
             - --sink=stackdriver:?cluster_name={{ cluster_name }}&use_old_resources={{ use_old_resources }}&use_new_resources={{ use_new_resources }}&min_interval_sec=100&batch_export_timeout_sec=110&cluster_location={{ cluster_location }}
         # BEGIN_PROMETHEUS_TO_SD
         - name: prom-to-sd

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -58,7 +58,7 @@ spec:
             timeoutSeconds: 5
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes.summary_api:?kubeletPort=10250&kubeletHttps=true&insecure=true
         - image: k8s.gcr.io/addon-resizer:1.8.3
           name: heapster-nanny
           resources:

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         image: k8s.gcr.io/metrics-server-amd64:v0.2.1
         command:
         - /metrics-server
-        - --source=kubernetes.summary_api:''
+        - --source=kubernetes.summary_api:?kubeletPort=10250&kubeletHttps=true&insecure=true
         ports:
         - containerPort: 443
           name: https

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -11,6 +11,7 @@ rules:
   resources:
   - pods
   - nodes
+  - nodes/stats
   - namespaces
   verbs:
   - get

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -309,7 +309,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			// a role to use for heapster's connections back to the API server
 			ObjectMeta: metav1.ObjectMeta{Name: "system:heapster"},
 			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("events", "pods", "nodes", "namespaces").RuleOrDie(),
+				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("events", "pods", "nodes", "nodes/stats", "namespaces").RuleOrDie(),
 				rbacv1helpers.NewRule(Read...).Groups(extensionsGroup).Resources("deployments").RuleOrDie(),
 			},
 		},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -565,6 +565,7 @@ items:
     - events
     - namespaces
     - nodes
+    - nodes/stats
     - pods
     verbs:
     - get


### PR DESCRIPTION
This PR changes kubelet port used to secure one. This requires access to `nodes/stats` resource.
Flag `insecure` is passed to disable verification of kubelet certificate. 

```release-note
[heapster & metrics server addon] Use secure port when communicating to summary api
```
/cc @kawych @DirectXMan12 @timstclair