### PR TITLE
kubeadm: Fix an upgrading issue wrt the dynamic kubelet dropin

### DIFF
--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,13 @@ func NewFileToPrint(realPath, printPath string) FileToPrint {
 		RealPath:  realPath,
 		PrintPath: printPath,
 	}
+}
+
+// PrintDryRunFile is a helper method around PrintDryRunFiles
+func PrintDryRunFile(fileName, realDir, printDir string, w io.Writer) error {
+	return PrintDryRunFiles([]FileToPrint{
+		NewFileToPrint(filepath.Join(realDir, fileName), filepath.Join(printDir, fileName)),
+	}, w)
 }
 
 // PrintDryRunFiles prints the contents of the FileToPrints given to it to the writer w


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
At the moment (will change), this PR does two things:
 - Makes `kubeletphase.WriteKubeletDynamicEnvFile` run at upgrade time if needed for making v1.10 -> v1.11 upgrades work end to end
 - Fixes so that `--dry-run` works smoothly on `init/upgrade` ==> separate PR

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 
/kind bug
/priority critical-urgent
/status approved-for-milestone
/assign @timothysc 