### PR TITLE
update codegenerator to generate fake list subresources correctly

### DIFF
--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -91,6 +91,33 @@ func NewListAction(resource schema.GroupVersionResource, kind schema.GroupVersio
 	return action
 }
 
+func NewRootListSubresourceAction(resource schema.GroupVersionResource, kind schema.GroupVersionKind, name, subresource string, opts interface{}) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Kind = kind
+	action.Name = name
+	action.Subresource = subresource
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewListSubresourceAction(resource schema.GroupVersionResource, kind schema.GroupVersionKind, name, subresource, namespace string, opts interface{}) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Kind = kind
+	action.Namespace = namespace
+	action.Name = name
+	action.Subresource = subresource
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
 func NewRootCreateAction(resource schema.GroupVersionResource, object runtime.Object) CreateActionImpl {
 	action := CreateActionImpl{}
 	action.Verb = "create"


### PR DESCRIPTION
The fake generator doesn't handle lists for subresources with custom types.  This updates it to work

@k8s-mirror-api-machinery-bugs 
@sttts @mfojtik 