### PR TITLE
apiextensions: add AddToGroupVersion call to CRD example register.go

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -47,5 +48,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Example{},
 		&ExampleList{},
 	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
Avoid `v1.ListOptions is not suitable for converting to ...` message in CRD client on List.

https://github.com/kubernetes/kubernetes/pull/57243 did the same for the sample-controller.