### PR TITLE
use case-sensitive json-iter to decode custom resource ObjectMeta

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	encodingjson "encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -821,6 +820,8 @@ func (v *unstructuredSchemaCoercer) apply(u *unstructured.Unstructured) error {
 	return nil
 }
 
+var encodingjson = json.CaseSensitiveJsonIterator()
+
 func getObjectMeta(u *unstructured.Unstructured, dropMalformedFields bool) (*metav1.ObjectMeta, bool, error) {
 	metadata, found := u.UnstructuredContent()["metadata"]
 	if !found {
@@ -862,6 +863,7 @@ func getObjectMeta(u *unstructured.Unstructured, dropMalformedFields bool) (*met
 			}
 		}
 	}
+
 	return accumulatedObjectMeta, true, nil
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -62,8 +62,8 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 		t.Fatalf("expected APIStatus error, but got: %#v", err)
 	} else if !errors.IsBadRequest(err) {
 		t.Fatalf("expected BadRequst error, but got: %v", errors.ReasonForError(err))
-	} else if !strings.Contains(status.Status().Message, "json: cannot unmarshal") {
-		t.Fatalf("expected 'json: cannot unmarshal' error message, got: %v", status.Status().Message)
+	} else if !strings.Contains(status.Status().Message, "cannot be handled") {
+		t.Fatalf("expected 'cannot be handled' error message, got: %v", status.Status().Message)
 	}
 
 	unstructured.SetNestedField(obj.UnstructuredContent(), map[string]interface{}{"bar": "abc"}, "metadata", "labels")


### PR DESCRIPTION
found one additional spot where case-insensitivity could bite us. uses the case-sensitive decode added in https://github.com/kubernetes/kubernetes/pull/65034


/assign @sttts
/cc @caesarxuchao 

```release-note
NONE
```