### PR TITLE
document /watch prefix deprecation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12770,7 +12770,7 @@
    },
    "/api/v1/watch/configmaps": {
     "get": {
-     "description": "watch individual changes to a list of ConfigMap",
+     "description": "watch individual changes to a list of ConfigMap. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -12874,7 +12874,7 @@
    },
    "/api/v1/watch/endpoints": {
     "get": {
-     "description": "watch individual changes to a list of Endpoints",
+     "description": "watch individual changes to a list of Endpoints. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -12978,7 +12978,7 @@
    },
    "/api/v1/watch/events": {
     "get": {
-     "description": "watch individual changes to a list of Event",
+     "description": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13082,7 +13082,7 @@
    },
    "/api/v1/watch/limitranges": {
     "get": {
-     "description": "watch individual changes to a list of LimitRange",
+     "description": "watch individual changes to a list of LimitRange. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13186,7 +13186,7 @@
    },
    "/api/v1/watch/namespaces": {
     "get": {
-     "description": "watch individual changes to a list of Namespace",
+     "description": "watch individual changes to a list of Namespace. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13290,7 +13290,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/configmaps": {
     "get": {
-     "description": "watch individual changes to a list of ConfigMap",
+     "description": "watch individual changes to a list of ConfigMap. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13402,7 +13402,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/configmaps/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ConfigMap",
+     "description": "watch changes to an object of kind ConfigMap. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -13522,7 +13522,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/endpoints": {
     "get": {
-     "description": "watch individual changes to a list of Endpoints",
+     "description": "watch individual changes to a list of Endpoints. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13634,7 +13634,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/endpoints/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Endpoints",
+     "description": "watch changes to an object of kind Endpoints. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -13754,7 +13754,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/events": {
     "get": {
-     "description": "watch individual changes to a list of Event",
+     "description": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -13866,7 +13866,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/events/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Event",
+     "description": "watch changes to an object of kind Event. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -13986,7 +13986,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/limitranges": {
     "get": {
-     "description": "watch individual changes to a list of LimitRange",
+     "description": "watch individual changes to a list of LimitRange. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -14098,7 +14098,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/limitranges/{name}": {
     "get": {
-     "description": "watch changes to an object of kind LimitRange",
+     "description": "watch changes to an object of kind LimitRange. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -14218,7 +14218,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims": {
     "get": {
-     "description": "watch individual changes to a list of PersistentVolumeClaim",
+     "description": "watch individual changes to a list of PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -14330,7 +14330,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/persistentvolumeclaims/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PersistentVolumeClaim",
+     "description": "watch changes to an object of kind PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -14450,7 +14450,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/pods": {
     "get": {
-     "description": "watch individual changes to a list of Pod",
+     "description": "watch individual changes to a list of Pod. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -14562,7 +14562,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/pods/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Pod",
+     "description": "watch changes to an object of kind Pod. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -14682,7 +14682,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/podtemplates": {
     "get": {
-     "description": "watch individual changes to a list of PodTemplate",
+     "description": "watch individual changes to a list of PodTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -14794,7 +14794,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/podtemplates/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PodTemplate",
+     "description": "watch changes to an object of kind PodTemplate. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -14914,7 +14914,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/replicationcontrollers": {
     "get": {
-     "description": "watch individual changes to a list of ReplicationController",
+     "description": "watch individual changes to a list of ReplicationController. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -15026,7 +15026,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/replicationcontrollers/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ReplicationController",
+     "description": "watch changes to an object of kind ReplicationController. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -15146,7 +15146,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/resourcequotas": {
     "get": {
-     "description": "watch individual changes to a list of ResourceQuota",
+     "description": "watch individual changes to a list of ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -15258,7 +15258,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/resourcequotas/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ResourceQuota",
+     "description": "watch changes to an object of kind ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -15378,7 +15378,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/secrets": {
     "get": {
-     "description": "watch individual changes to a list of Secret",
+     "description": "watch individual changes to a list of Secret. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -15490,7 +15490,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/secrets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Secret",
+     "description": "watch changes to an object of kind Secret. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -15610,7 +15610,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/serviceaccounts": {
     "get": {
-     "description": "watch individual changes to a list of ServiceAccount",
+     "description": "watch individual changes to a list of ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -15722,7 +15722,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/serviceaccounts/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ServiceAccount",
+     "description": "watch changes to an object of kind ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -15842,7 +15842,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/services": {
     "get": {
-     "description": "watch individual changes to a list of Service",
+     "description": "watch individual changes to a list of Service. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -15954,7 +15954,7 @@
    },
    "/api/v1/watch/namespaces/{namespace}/services/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Service",
+     "description": "watch changes to an object of kind Service. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -16074,7 +16074,7 @@
    },
    "/api/v1/watch/namespaces/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Namespace",
+     "description": "watch changes to an object of kind Namespace. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -16186,7 +16186,7 @@
    },
    "/api/v1/watch/nodes": {
     "get": {
-     "description": "watch individual changes to a list of Node",
+     "description": "watch individual changes to a list of Node. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -16290,7 +16290,7 @@
    },
    "/api/v1/watch/nodes/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Node",
+     "description": "watch changes to an object of kind Node. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -16402,7 +16402,7 @@
    },
    "/api/v1/watch/persistentvolumeclaims": {
     "get": {
-     "description": "watch individual changes to a list of PersistentVolumeClaim",
+     "description": "watch individual changes to a list of PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -16506,7 +16506,7 @@
    },
    "/api/v1/watch/persistentvolumes": {
     "get": {
-     "description": "watch individual changes to a list of PersistentVolume",
+     "description": "watch individual changes to a list of PersistentVolume. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -16610,7 +16610,7 @@
    },
    "/api/v1/watch/persistentvolumes/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PersistentVolume",
+     "description": "watch changes to an object of kind PersistentVolume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -16722,7 +16722,7 @@
    },
    "/api/v1/watch/pods": {
     "get": {
-     "description": "watch individual changes to a list of Pod",
+     "description": "watch individual changes to a list of Pod. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -16826,7 +16826,7 @@
    },
    "/api/v1/watch/podtemplates": {
     "get": {
-     "description": "watch individual changes to a list of PodTemplate",
+     "description": "watch individual changes to a list of PodTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -16930,7 +16930,7 @@
    },
    "/api/v1/watch/replicationcontrollers": {
     "get": {
-     "description": "watch individual changes to a list of ReplicationController",
+     "description": "watch individual changes to a list of ReplicationController. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -17034,7 +17034,7 @@
    },
    "/api/v1/watch/resourcequotas": {
     "get": {
-     "description": "watch individual changes to a list of ResourceQuota",
+     "description": "watch individual changes to a list of ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -17138,7 +17138,7 @@
    },
    "/api/v1/watch/secrets": {
     "get": {
-     "description": "watch individual changes to a list of Secret",
+     "description": "watch individual changes to a list of Secret. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -17242,7 +17242,7 @@
    },
    "/api/v1/watch/serviceaccounts": {
     "get": {
-     "description": "watch individual changes to a list of ServiceAccount",
+     "description": "watch individual changes to a list of ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -17346,7 +17346,7 @@
    },
    "/api/v1/watch/services": {
     "get": {
-     "description": "watch individual changes to a list of Service",
+     "description": "watch individual changes to a list of Service. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -18052,7 +18052,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1alpha1/watch/initializerconfigurations": {
     "get": {
-     "description": "watch individual changes to a list of InitializerConfiguration",
+     "description": "watch individual changes to a list of InitializerConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -18156,7 +18156,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1alpha1/watch/initializerconfigurations/{name}": {
     "get": {
-     "description": "watch changes to an object of kind InitializerConfiguration",
+     "description": "watch changes to an object of kind InitializerConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -19307,7 +19307,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1beta1/watch/mutatingwebhookconfigurations": {
     "get": {
-     "description": "watch individual changes to a list of MutatingWebhookConfiguration",
+     "description": "watch individual changes to a list of MutatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -19411,7 +19411,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1beta1/watch/mutatingwebhookconfigurations/{name}": {
     "get": {
-     "description": "watch changes to an object of kind MutatingWebhookConfiguration",
+     "description": "watch changes to an object of kind MutatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -19523,7 +19523,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1beta1/watch/validatingwebhookconfigurations": {
     "get": {
-     "description": "watch individual changes to a list of ValidatingWebhookConfiguration",
+     "description": "watch individual changes to a list of ValidatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -19627,7 +19627,7 @@
    },
    "/apis/admissionregistration.k8s.io/v1beta1/watch/validatingwebhookconfigurations/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ValidatingWebhookConfiguration",
+     "description": "watch changes to an object of kind ValidatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -20460,7 +20460,7 @@
    },
    "/apis/apiextensions.k8s.io/v1beta1/watch/customresourcedefinitions": {
     "get": {
-     "description": "watch individual changes to a list of CustomResourceDefinition",
+     "description": "watch individual changes to a list of CustomResourceDefinition. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -20564,7 +20564,7 @@
    },
    "/apis/apiextensions.k8s.io/v1beta1/watch/customresourcedefinitions/{name}": {
     "get": {
-     "description": "watch changes to an object of kind CustomResourceDefinition",
+     "description": "watch changes to an object of kind CustomResourceDefinition. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -21397,7 +21397,7 @@
    },
    "/apis/apiregistration.k8s.io/v1/watch/apiservices": {
     "get": {
-     "description": "watch individual changes to a list of APIService",
+     "description": "watch individual changes to a list of APIService. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -21501,7 +21501,7 @@
    },
    "/apis/apiregistration.k8s.io/v1/watch/apiservices/{name}": {
     "get": {
-     "description": "watch changes to an object of kind APIService",
+     "description": "watch changes to an object of kind APIService. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -22301,7 +22301,7 @@
    },
    "/apis/apiregistration.k8s.io/v1beta1/watch/apiservices": {
     "get": {
-     "description": "watch individual changes to a list of APIService",
+     "description": "watch individual changes to a list of APIService. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -22405,7 +22405,7 @@
    },
    "/apis/apiregistration.k8s.io/v1beta1/watch/apiservices/{name}": {
     "get": {
-     "description": "watch changes to an object of kind APIService",
+     "description": "watch changes to an object of kind APIService. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -26818,7 +26818,7 @@
    },
    "/apis/apps/v1/watch/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -26922,7 +26922,7 @@
    },
    "/apis/apps/v1/watch/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27026,7 +27026,7 @@
    },
    "/apis/apps/v1/watch/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27130,7 +27130,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27242,7 +27242,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ControllerRevision",
+     "description": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -27362,7 +27362,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27474,7 +27474,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/daemonsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind DaemonSet",
+     "description": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -27594,7 +27594,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27706,7 +27706,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/deployments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Deployment",
+     "description": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -27826,7 +27826,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -27938,7 +27938,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/replicasets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ReplicaSet",
+     "description": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -28058,7 +28058,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -28170,7 +28170,7 @@
    },
    "/apis/apps/v1/watch/namespaces/{namespace}/statefulsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind StatefulSet",
+     "description": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -28290,7 +28290,7 @@
    },
    "/apis/apps/v1/watch/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -28394,7 +28394,7 @@
    },
    "/apis/apps/v1/watch/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31124,7 +31124,7 @@
    },
    "/apis/apps/v1beta1/watch/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31228,7 +31228,7 @@
    },
    "/apis/apps/v1beta1/watch/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31332,7 +31332,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31444,7 +31444,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/controllerrevisions/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ControllerRevision",
+     "description": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -31564,7 +31564,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31676,7 +31676,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/deployments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Deployment",
+     "description": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -31796,7 +31796,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -31908,7 +31908,7 @@
    },
    "/apis/apps/v1beta1/watch/namespaces/{namespace}/statefulsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind StatefulSet",
+     "description": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -32028,7 +32028,7 @@
    },
    "/apis/apps/v1beta1/watch/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -36400,7 +36400,7 @@
    },
    "/apis/apps/v1beta2/watch/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -36504,7 +36504,7 @@
    },
    "/apis/apps/v1beta2/watch/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -36608,7 +36608,7 @@
    },
    "/apis/apps/v1beta2/watch/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -36712,7 +36712,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/controllerrevisions": {
     "get": {
-     "description": "watch individual changes to a list of ControllerRevision",
+     "description": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -36824,7 +36824,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/controllerrevisions/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ControllerRevision",
+     "description": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -36944,7 +36944,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -37056,7 +37056,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/daemonsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind DaemonSet",
+     "description": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -37176,7 +37176,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -37288,7 +37288,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/deployments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Deployment",
+     "description": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -37408,7 +37408,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -37520,7 +37520,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/replicasets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ReplicaSet",
+     "description": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -37640,7 +37640,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -37752,7 +37752,7 @@
    },
    "/apis/apps/v1beta2/watch/namespaces/{namespace}/statefulsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind StatefulSet",
+     "description": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -37872,7 +37872,7 @@
    },
    "/apis/apps/v1beta2/watch/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -37976,7 +37976,7 @@
    },
    "/apis/apps/v1beta2/watch/statefulsets": {
     "get": {
-     "description": "watch individual changes to a list of StatefulSet",
+     "description": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -39823,7 +39823,7 @@
    },
    "/apis/autoscaling/v1/watch/horizontalpodautoscalers": {
     "get": {
-     "description": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "description": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -39927,7 +39927,7 @@
    },
    "/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers": {
     "get": {
-     "description": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "description": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -40039,7 +40039,7 @@
    },
    "/apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}": {
     "get": {
-     "description": "watch changes to an object of kind HorizontalPodAutoscaler",
+     "description": "watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -40975,7 +40975,7 @@
    },
    "/apis/autoscaling/v2beta1/watch/horizontalpodautoscalers": {
     "get": {
-     "description": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "description": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -41079,7 +41079,7 @@
    },
    "/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers": {
     "get": {
-     "description": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "description": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -41191,7 +41191,7 @@
    },
    "/apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}": {
     "get": {
-     "description": "watch changes to an object of kind HorizontalPodAutoscaler",
+     "description": "watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -42160,7 +42160,7 @@
    },
    "/apis/batch/v1/watch/jobs": {
     "get": {
-     "description": "watch individual changes to a list of Job",
+     "description": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -42264,7 +42264,7 @@
    },
    "/apis/batch/v1/watch/namespaces/{namespace}/jobs": {
     "get": {
-     "description": "watch individual changes to a list of Job",
+     "description": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -42376,7 +42376,7 @@
    },
    "/apis/batch/v1/watch/namespaces/{namespace}/jobs/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Job",
+     "description": "watch changes to an object of kind Job. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -43312,7 +43312,7 @@
    },
    "/apis/batch/v1beta1/watch/cronjobs": {
     "get": {
-     "description": "watch individual changes to a list of CronJob",
+     "description": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -43416,7 +43416,7 @@
    },
    "/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs": {
     "get": {
-     "description": "watch individual changes to a list of CronJob",
+     "description": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -43528,7 +43528,7 @@
    },
    "/apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs/{name}": {
     "get": {
-     "description": "watch changes to an object of kind CronJob",
+     "description": "watch changes to an object of kind CronJob. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -44464,7 +44464,7 @@
    },
    "/apis/batch/v2alpha1/watch/cronjobs": {
     "get": {
-     "description": "watch individual changes to a list of CronJob",
+     "description": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -44568,7 +44568,7 @@
    },
    "/apis/batch/v2alpha1/watch/namespaces/{namespace}/cronjobs": {
     "get": {
-     "description": "watch individual changes to a list of CronJob",
+     "description": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -44680,7 +44680,7 @@
    },
    "/apis/batch/v2alpha1/watch/namespaces/{namespace}/cronjobs/{name}": {
     "get": {
-     "description": "watch changes to an object of kind CronJob",
+     "description": "watch changes to an object of kind CronJob. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -45591,7 +45591,7 @@
    },
    "/apis/certificates.k8s.io/v1beta1/watch/certificatesigningrequests": {
     "get": {
-     "description": "watch individual changes to a list of CertificateSigningRequest",
+     "description": "watch individual changes to a list of CertificateSigningRequest. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -45695,7 +45695,7 @@
    },
    "/apis/certificates.k8s.io/v1beta1/watch/certificatesigningrequests/{name}": {
     "get": {
-     "description": "watch changes to an object of kind CertificateSigningRequest",
+     "description": "watch changes to an object of kind CertificateSigningRequest. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -46496,7 +46496,7 @@
    },
    "/apis/coordination.k8s.io/v1beta1/watch/leases": {
     "get": {
-     "description": "watch individual changes to a list of Lease",
+     "description": "watch individual changes to a list of Lease. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -46600,7 +46600,7 @@
    },
    "/apis/coordination.k8s.io/v1beta1/watch/namespaces/{namespace}/leases": {
     "get": {
-     "description": "watch individual changes to a list of Lease",
+     "description": "watch individual changes to a list of Lease. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -46712,7 +46712,7 @@
    },
    "/apis/coordination.k8s.io/v1beta1/watch/namespaces/{namespace}/leases/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Lease",
+     "description": "watch changes to an object of kind Lease. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -47521,7 +47521,7 @@
    },
    "/apis/events.k8s.io/v1beta1/watch/events": {
     "get": {
-     "description": "watch individual changes to a list of Event",
+     "description": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -47625,7 +47625,7 @@
    },
    "/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events": {
     "get": {
-     "description": "watch individual changes to a list of Event",
+     "description": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -47737,7 +47737,7 @@
    },
    "/apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Event",
+     "description": "watch changes to an object of kind Event. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -52745,7 +52745,7 @@
    },
    "/apis/extensions/v1beta1/watch/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -52849,7 +52849,7 @@
    },
    "/apis/extensions/v1beta1/watch/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -52953,7 +52953,7 @@
    },
    "/apis/extensions/v1beta1/watch/ingresses": {
     "get": {
-     "description": "watch individual changes to a list of Ingress",
+     "description": "watch individual changes to a list of Ingress. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -53057,7 +53057,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets": {
     "get": {
-     "description": "watch individual changes to a list of DaemonSet",
+     "description": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -53169,7 +53169,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind DaemonSet",
+     "description": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -53289,7 +53289,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments": {
     "get": {
-     "description": "watch individual changes to a list of Deployment",
+     "description": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -53401,7 +53401,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Deployment",
+     "description": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -53521,7 +53521,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses": {
     "get": {
-     "description": "watch individual changes to a list of Ingress",
+     "description": "watch individual changes to a list of Ingress. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -53633,7 +53633,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Ingress",
+     "description": "watch changes to an object of kind Ingress. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -53753,7 +53753,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies": {
     "get": {
-     "description": "watch individual changes to a list of NetworkPolicy",
+     "description": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -53865,7 +53865,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies/{name}": {
     "get": {
-     "description": "watch changes to an object of kind NetworkPolicy",
+     "description": "watch changes to an object of kind NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -53985,7 +53985,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -54097,7 +54097,7 @@
    },
    "/apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ReplicaSet",
+     "description": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -54217,7 +54217,7 @@
    },
    "/apis/extensions/v1beta1/watch/networkpolicies": {
     "get": {
-     "description": "watch individual changes to a list of NetworkPolicy",
+     "description": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -54321,7 +54321,7 @@
    },
    "/apis/extensions/v1beta1/watch/podsecuritypolicies": {
     "get": {
-     "description": "watch individual changes to a list of PodSecurityPolicy",
+     "description": "watch individual changes to a list of PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -54425,7 +54425,7 @@
    },
    "/apis/extensions/v1beta1/watch/podsecuritypolicies/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PodSecurityPolicy",
+     "description": "watch changes to an object of kind PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -54537,7 +54537,7 @@
    },
    "/apis/extensions/v1beta1/watch/replicasets": {
     "get": {
-     "description": "watch individual changes to a list of ReplicaSet",
+     "description": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -55330,7 +55330,7 @@
    },
    "/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies": {
     "get": {
-     "description": "watch individual changes to a list of NetworkPolicy",
+     "description": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -55442,7 +55442,7 @@
    },
    "/apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies/{name}": {
     "get": {
-     "description": "watch changes to an object of kind NetworkPolicy",
+     "description": "watch changes to an object of kind NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -55562,7 +55562,7 @@
    },
    "/apis/networking.k8s.io/v1/watch/networkpolicies": {
     "get": {
-     "description": "watch individual changes to a list of NetworkPolicy",
+     "description": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -57018,7 +57018,7 @@
    },
    "/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets": {
     "get": {
-     "description": "watch individual changes to a list of PodDisruptionBudget",
+     "description": "watch individual changes to a list of PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -57130,7 +57130,7 @@
    },
    "/apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PodDisruptionBudget",
+     "description": "watch changes to an object of kind PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -57250,7 +57250,7 @@
    },
    "/apis/policy/v1beta1/watch/poddisruptionbudgets": {
     "get": {
-     "description": "watch individual changes to a list of PodDisruptionBudget",
+     "description": "watch individual changes to a list of PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -57354,7 +57354,7 @@
    },
    "/apis/policy/v1beta1/watch/podsecuritypolicies": {
     "get": {
-     "description": "watch individual changes to a list of PodSecurityPolicy",
+     "description": "watch individual changes to a list of PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -57458,7 +57458,7 @@
    },
    "/apis/policy/v1beta1/watch/podsecuritypolicies/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PodSecurityPolicy",
+     "description": "watch changes to an object of kind PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -59824,7 +59824,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRoleBinding",
+     "description": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -59928,7 +59928,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRoleBinding",
+     "description": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -60040,7 +60040,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/clusterroles": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRole",
+     "description": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -60144,7 +60144,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/clusterroles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRole",
+     "description": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -60256,7 +60256,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -60368,7 +60368,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind RoleBinding",
+     "description": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -60488,7 +60488,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -60600,7 +60600,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Role",
+     "description": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -60720,7 +60720,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -60824,7 +60824,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1/watch/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -63149,7 +63149,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterrolebindings": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRoleBinding",
+     "description": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -63253,7 +63253,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterrolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRoleBinding",
+     "description": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -63365,7 +63365,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterroles": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRole",
+     "description": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -63469,7 +63469,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterroles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRole",
+     "description": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -63581,7 +63581,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -63693,7 +63693,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/rolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind RoleBinding",
+     "description": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -63813,7 +63813,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -63925,7 +63925,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/roles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Role",
+     "description": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -64045,7 +64045,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -64149,7 +64149,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1alpha1/watch/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -66474,7 +66474,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/clusterrolebindings": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRoleBinding",
+     "description": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -66578,7 +66578,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/clusterrolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRoleBinding",
+     "description": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -66690,7 +66690,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/clusterroles": {
     "get": {
-     "description": "watch individual changes to a list of ClusterRole",
+     "description": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -66794,7 +66794,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/clusterroles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind ClusterRole",
+     "description": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -66906,7 +66906,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -67018,7 +67018,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/rolebindings/{name}": {
     "get": {
-     "description": "watch changes to an object of kind RoleBinding",
+     "description": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -67138,7 +67138,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -67250,7 +67250,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/roles/{name}": {
     "get": {
-     "description": "watch changes to an object of kind Role",
+     "description": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -67370,7 +67370,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/rolebindings": {
     "get": {
-     "description": "watch individual changes to a list of RoleBinding",
+     "description": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -67474,7 +67474,7 @@
    },
    "/apis/rbac.authorization.k8s.io/v1beta1/watch/roles": {
     "get": {
-     "description": "watch individual changes to a list of Role",
+     "description": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -68147,7 +68147,7 @@
    },
    "/apis/scheduling.k8s.io/v1alpha1/watch/priorityclasses": {
     "get": {
-     "description": "watch individual changes to a list of PriorityClass",
+     "description": "watch individual changes to a list of PriorityClass. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -68251,7 +68251,7 @@
    },
    "/apis/scheduling.k8s.io/v1alpha1/watch/priorityclasses/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PriorityClass",
+     "description": "watch changes to an object of kind PriorityClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -68899,7 +68899,7 @@
    },
    "/apis/scheduling.k8s.io/v1beta1/watch/priorityclasses": {
     "get": {
-     "description": "watch individual changes to a list of PriorityClass",
+     "description": "watch individual changes to a list of PriorityClass. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -69003,7 +69003,7 @@
    },
    "/apis/scheduling.k8s.io/v1beta1/watch/priorityclasses/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PriorityClass",
+     "description": "watch changes to an object of kind PriorityClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -69804,7 +69804,7 @@
    },
    "/apis/settings.k8s.io/v1alpha1/watch/namespaces/{namespace}/podpresets": {
     "get": {
-     "description": "watch individual changes to a list of PodPreset",
+     "description": "watch individual changes to a list of PodPreset. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -69916,7 +69916,7 @@
    },
    "/apis/settings.k8s.io/v1alpha1/watch/namespaces/{namespace}/podpresets/{name}": {
     "get": {
-     "description": "watch changes to an object of kind PodPreset",
+     "description": "watch changes to an object of kind PodPreset. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -70036,7 +70036,7 @@
    },
    "/apis/settings.k8s.io/v1alpha1/watch/podpresets": {
     "get": {
-     "description": "watch individual changes to a list of PodPreset",
+     "description": "watch individual changes to a list of PodPreset. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -70709,7 +70709,7 @@
    },
    "/apis/storage.k8s.io/v1/watch/storageclasses": {
     "get": {
-     "description": "watch individual changes to a list of StorageClass",
+     "description": "watch individual changes to a list of StorageClass. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -70813,7 +70813,7 @@
    },
    "/apis/storage.k8s.io/v1/watch/storageclasses/{name}": {
     "get": {
-     "description": "watch changes to an object of kind StorageClass",
+     "description": "watch changes to an object of kind StorageClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -71461,7 +71461,7 @@
    },
    "/apis/storage.k8s.io/v1alpha1/watch/volumeattachments": {
     "get": {
-     "description": "watch individual changes to a list of VolumeAttachment",
+     "description": "watch individual changes to a list of VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -71565,7 +71565,7 @@
    },
    "/apis/storage.k8s.io/v1alpha1/watch/volumeattachments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind VolumeAttachment",
+     "description": "watch changes to an object of kind VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -72716,7 +72716,7 @@
    },
    "/apis/storage.k8s.io/v1beta1/watch/storageclasses": {
     "get": {
-     "description": "watch individual changes to a list of StorageClass",
+     "description": "watch individual changes to a list of StorageClass. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -72820,7 +72820,7 @@
    },
    "/apis/storage.k8s.io/v1beta1/watch/storageclasses/{name}": {
     "get": {
-     "description": "watch changes to an object of kind StorageClass",
+     "description": "watch changes to an object of kind StorageClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],
@@ -72932,7 +72932,7 @@
    },
    "/apis/storage.k8s.io/v1beta1/watch/volumeattachments": {
     "get": {
-     "description": "watch individual changes to a list of VolumeAttachment",
+     "description": "watch individual changes to a list of VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead.",
      "consumes": [
       "*/*"
      ],
@@ -73036,7 +73036,7 @@
    },
    "/apis/storage.k8s.io/v1beta1/watch/volumeattachments/{name}": {
     "get": {
-     "description": "watch changes to an object of kind VolumeAttachment",
+     "description": "watch changes to an object of kind VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
      "consumes": [
       "*/*"
      ],

--- a/api/swagger-spec/admissionregistration.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/admissionregistration.k8s.io_v1alpha1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of InitializerConfiguration",
+      "summary": "watch individual changes to a list of InitializerConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchInitializerConfigurationList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind InitializerConfiguration",
+      "summary": "watch changes to an object of kind InitializerConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchInitializerConfiguration",
       "parameters": [
        {

--- a/api/swagger-spec/admissionregistration.k8s.io_v1beta1.json
+++ b/api/swagger-spec/admissionregistration.k8s.io_v1beta1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of MutatingWebhookConfiguration",
+      "summary": "watch individual changes to a list of MutatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchMutatingWebhookConfigurationList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind MutatingWebhookConfiguration",
+      "summary": "watch changes to an object of kind MutatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchMutatingWebhookConfiguration",
       "parameters": [
        {
@@ -969,7 +969,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ValidatingWebhookConfiguration",
+      "summary": "watch individual changes to a list of ValidatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchValidatingWebhookConfigurationList",
       "parameters": [
        {
@@ -1318,7 +1318,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ValidatingWebhookConfiguration",
+      "summary": "watch changes to an object of kind ValidatingWebhookConfiguration. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchValidatingWebhookConfiguration",
       "parameters": [
        {

--- a/api/swagger-spec/apps_v1.json
+++ b/api/swagger-spec/apps_v1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedControllerRevisionList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ControllerRevision",
+      "summary": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedControllerRevision",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchControllerRevisionListForAllNamespaces",
       "parameters": [
        {
@@ -1271,7 +1271,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDaemonSetList",
       "parameters": [
        {
@@ -1660,7 +1660,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind DaemonSet",
+      "summary": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDaemonSet",
       "parameters": [
        {
@@ -1882,7 +1882,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDaemonSetListForAllNamespaces",
       "parameters": [
        {
@@ -2426,7 +2426,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDeploymentList",
       "parameters": [
        {
@@ -2815,7 +2815,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Deployment",
+      "summary": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDeployment",
       "parameters": [
        {
@@ -3037,7 +3037,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDeploymentListForAllNamespaces",
       "parameters": [
        {
@@ -3751,7 +3751,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedReplicaSetList",
       "parameters": [
        {
@@ -4140,7 +4140,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ReplicaSet",
+      "summary": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedReplicaSet",
       "parameters": [
        {
@@ -4362,7 +4362,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchReplicaSetListForAllNamespaces",
       "parameters": [
        {
@@ -5076,7 +5076,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedStatefulSetList",
       "parameters": [
        {
@@ -5465,7 +5465,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind StatefulSet",
+      "summary": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedStatefulSet",
       "parameters": [
        {
@@ -5687,7 +5687,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchStatefulSetListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedControllerRevisionList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ControllerRevision",
+      "summary": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedControllerRevision",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchControllerRevisionListForAllNamespaces",
       "parameters": [
        {
@@ -1271,7 +1271,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDeploymentList",
       "parameters": [
        {
@@ -1660,7 +1660,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Deployment",
+      "summary": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDeployment",
       "parameters": [
        {
@@ -1882,7 +1882,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDeploymentListForAllNamespaces",
       "parameters": [
        {
@@ -2667,7 +2667,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedStatefulSetList",
       "parameters": [
        {
@@ -3056,7 +3056,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind StatefulSet",
+      "summary": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedStatefulSet",
       "parameters": [
        {
@@ -3278,7 +3278,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchStatefulSetListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedControllerRevisionList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ControllerRevision",
+      "summary": "watch changes to an object of kind ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedControllerRevision",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ControllerRevision",
+      "summary": "watch individual changes to a list of ControllerRevision. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchControllerRevisionListForAllNamespaces",
       "parameters": [
        {
@@ -1271,7 +1271,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDaemonSetList",
       "parameters": [
        {
@@ -1660,7 +1660,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind DaemonSet",
+      "summary": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDaemonSet",
       "parameters": [
        {
@@ -1882,7 +1882,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDaemonSetListForAllNamespaces",
       "parameters": [
        {
@@ -2426,7 +2426,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDeploymentList",
       "parameters": [
        {
@@ -2815,7 +2815,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Deployment",
+      "summary": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDeployment",
       "parameters": [
        {
@@ -3037,7 +3037,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDeploymentListForAllNamespaces",
       "parameters": [
        {
@@ -3751,7 +3751,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedReplicaSetList",
       "parameters": [
        {
@@ -4140,7 +4140,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ReplicaSet",
+      "summary": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedReplicaSet",
       "parameters": [
        {
@@ -4362,7 +4362,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchReplicaSetListForAllNamespaces",
       "parameters": [
        {
@@ -5076,7 +5076,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedStatefulSetList",
       "parameters": [
        {
@@ -5465,7 +5465,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind StatefulSet",
+      "summary": "watch changes to an object of kind StatefulSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedStatefulSet",
       "parameters": [
        {
@@ -5687,7 +5687,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StatefulSet",
+      "summary": "watch individual changes to a list of StatefulSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchStatefulSetListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+      "summary": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedHorizontalPodAutoscalerList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind HorizontalPodAutoscaler",
+      "summary": "watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedHorizontalPodAutoscaler",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+      "summary": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchHorizontalPodAutoscalerListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/autoscaling_v2beta1.json
+++ b/api/swagger-spec/autoscaling_v2beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+      "summary": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedHorizontalPodAutoscalerList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind HorizontalPodAutoscaler",
+      "summary": "watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedHorizontalPodAutoscaler",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+      "summary": "watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchHorizontalPodAutoscalerListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Job",
+      "summary": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedJobList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Job",
+      "summary": "watch changes to an object of kind Job. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedJob",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Job",
+      "summary": "watch individual changes to a list of Job. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchJobListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/batch_v1beta1.json
+++ b/api/swagger-spec/batch_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of CronJob",
+      "summary": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedCronJobList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind CronJob",
+      "summary": "watch changes to an object of kind CronJob. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedCronJob",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of CronJob",
+      "summary": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchCronJobListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of CronJob",
+      "summary": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedCronJobList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind CronJob",
+      "summary": "watch changes to an object of kind CronJob. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedCronJob",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of CronJob",
+      "summary": "watch individual changes to a list of CronJob. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchCronJobListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/certificates.k8s.io_v1beta1.json
+++ b/api/swagger-spec/certificates.k8s.io_v1beta1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of CertificateSigningRequest",
+      "summary": "watch individual changes to a list of CertificateSigningRequest. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchCertificateSigningRequestList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind CertificateSigningRequest",
+      "summary": "watch changes to an object of kind CertificateSigningRequest. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchCertificateSigningRequest",
       "parameters": [
        {

--- a/api/swagger-spec/coordination.k8s.io_v1beta1.json
+++ b/api/swagger-spec/coordination.k8s.io_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Lease",
+      "summary": "watch individual changes to a list of Lease. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedLeaseList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Lease",
+      "summary": "watch changes to an object of kind Lease. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedLease",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Lease",
+      "summary": "watch individual changes to a list of Lease. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchLeaseListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/events.k8s.io_v1beta1.json
+++ b/api/swagger-spec/events.k8s.io_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Event",
+      "summary": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedEventList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Event",
+      "summary": "watch changes to an object of kind Event. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedEvent",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Event",
+      "summary": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchEventListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDaemonSetList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind DaemonSet",
+      "summary": "watch changes to an object of kind DaemonSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDaemonSet",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of DaemonSet",
+      "summary": "watch individual changes to a list of DaemonSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDaemonSetListForAllNamespaces",
       "parameters": [
        {
@@ -1441,7 +1441,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedDeploymentList",
       "parameters": [
        {
@@ -1830,7 +1830,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Deployment",
+      "summary": "watch changes to an object of kind Deployment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedDeployment",
       "parameters": [
        {
@@ -2052,7 +2052,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Deployment",
+      "summary": "watch individual changes to a list of Deployment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchDeploymentListForAllNamespaces",
       "parameters": [
        {
@@ -2837,7 +2837,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Ingress",
+      "summary": "watch individual changes to a list of Ingress. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedIngressList",
       "parameters": [
        {
@@ -3226,7 +3226,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Ingress",
+      "summary": "watch changes to an object of kind Ingress. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedIngress",
       "parameters": [
        {
@@ -3448,7 +3448,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Ingress",
+      "summary": "watch individual changes to a list of Ingress. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchIngressListForAllNamespaces",
       "parameters": [
        {
@@ -3992,7 +3992,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of NetworkPolicy",
+      "summary": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedNetworkPolicyList",
       "parameters": [
        {
@@ -4381,7 +4381,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind NetworkPolicy",
+      "summary": "watch changes to an object of kind NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedNetworkPolicy",
       "parameters": [
        {
@@ -4603,7 +4603,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of NetworkPolicy",
+      "summary": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNetworkPolicyListForAllNamespaces",
       "parameters": [
        {
@@ -4953,7 +4953,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodSecurityPolicy",
+      "summary": "watch individual changes to a list of PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodSecurityPolicyList",
       "parameters": [
        {
@@ -5302,7 +5302,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PodSecurityPolicy",
+      "summary": "watch changes to an object of kind PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchPodSecurityPolicy",
       "parameters": [
        {
@@ -5684,7 +5684,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedReplicaSetList",
       "parameters": [
        {
@@ -6073,7 +6073,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ReplicaSet",
+      "summary": "watch changes to an object of kind ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedReplicaSet",
       "parameters": [
        {
@@ -6295,7 +6295,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicaSet",
+      "summary": "watch individual changes to a list of ReplicaSet. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchReplicaSetListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/networking.k8s.io_v1.json
+++ b/api/swagger-spec/networking.k8s.io_v1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of NetworkPolicy",
+      "summary": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedNetworkPolicyList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind NetworkPolicy",
+      "summary": "watch changes to an object of kind NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedNetworkPolicy",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of NetworkPolicy",
+      "summary": "watch individual changes to a list of NetworkPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNetworkPolicyListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/policy_v1beta1.json
+++ b/api/swagger-spec/policy_v1beta1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodDisruptionBudget",
+      "summary": "watch individual changes to a list of PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedPodDisruptionBudgetList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PodDisruptionBudget",
+      "summary": "watch changes to an object of kind PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedPodDisruptionBudget",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodDisruptionBudget",
+      "summary": "watch individual changes to a list of PodDisruptionBudget. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodDisruptionBudgetListForAllNamespaces",
       "parameters": [
        {
@@ -1417,7 +1417,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodSecurityPolicy",
+      "summary": "watch individual changes to a list of PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodSecurityPolicyList",
       "parameters": [
        {
@@ -1766,7 +1766,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PodSecurityPolicy",
+      "summary": "watch changes to an object of kind PodSecurityPolicy. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchPodSecurityPolicy",
       "parameters": [
        {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRoleBinding",
+      "summary": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleBindingList",
       "parameters": [
        {
@@ -595,7 +595,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRoleBinding",
+      "summary": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRoleBinding",
       "parameters": [
        {
@@ -953,7 +953,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRole",
+      "summary": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleList",
       "parameters": [
        {
@@ -1286,7 +1286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRole",
+      "summary": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRole",
       "parameters": [
        {
@@ -1668,7 +1668,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleBindingList",
       "parameters": [
        {
@@ -2041,7 +2041,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind RoleBinding",
+      "summary": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRoleBinding",
       "parameters": [
        {
@@ -2263,7 +2263,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleBindingListForAllNamespaces",
       "parameters": [
        {
@@ -2637,7 +2637,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleList",
       "parameters": [
        {
@@ -3010,7 +3010,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Role",
+      "summary": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRole",
       "parameters": [
        {
@@ -3232,7 +3232,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRoleBinding",
+      "summary": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleBindingList",
       "parameters": [
        {
@@ -595,7 +595,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRoleBinding",
+      "summary": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRoleBinding",
       "parameters": [
        {
@@ -953,7 +953,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRole",
+      "summary": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleList",
       "parameters": [
        {
@@ -1286,7 +1286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRole",
+      "summary": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRole",
       "parameters": [
        {
@@ -1668,7 +1668,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleBindingList",
       "parameters": [
        {
@@ -2041,7 +2041,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind RoleBinding",
+      "summary": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRoleBinding",
       "parameters": [
        {
@@ -2263,7 +2263,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleBindingListForAllNamespaces",
       "parameters": [
        {
@@ -2637,7 +2637,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleList",
       "parameters": [
        {
@@ -3010,7 +3010,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Role",
+      "summary": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRole",
       "parameters": [
        {
@@ -3232,7 +3232,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1beta1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRoleBinding",
+      "summary": "watch individual changes to a list of ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleBindingList",
       "parameters": [
        {
@@ -595,7 +595,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRoleBinding",
+      "summary": "watch changes to an object of kind ClusterRoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRoleBinding",
       "parameters": [
        {
@@ -953,7 +953,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ClusterRole",
+      "summary": "watch individual changes to a list of ClusterRole. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchClusterRoleList",
       "parameters": [
        {
@@ -1286,7 +1286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ClusterRole",
+      "summary": "watch changes to an object of kind ClusterRole. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchClusterRole",
       "parameters": [
        {
@@ -1668,7 +1668,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleBindingList",
       "parameters": [
        {
@@ -2041,7 +2041,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind RoleBinding",
+      "summary": "watch changes to an object of kind RoleBinding. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRoleBinding",
       "parameters": [
        {
@@ -2263,7 +2263,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of RoleBinding",
+      "summary": "watch individual changes to a list of RoleBinding. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleBindingListForAllNamespaces",
       "parameters": [
        {
@@ -2637,7 +2637,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedRoleList",
       "parameters": [
        {
@@ -3010,7 +3010,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Role",
+      "summary": "watch changes to an object of kind Role. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedRole",
       "parameters": [
        {
@@ -3232,7 +3232,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Role",
+      "summary": "watch individual changes to a list of Role. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchRoleListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/scheduling.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/scheduling.k8s.io_v1alpha1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PriorityClass",
+      "summary": "watch individual changes to a list of PriorityClass. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPriorityClassList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PriorityClass",
+      "summary": "watch changes to an object of kind PriorityClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchPriorityClass",
       "parameters": [
        {

--- a/api/swagger-spec/scheduling.k8s.io_v1beta1.json
+++ b/api/swagger-spec/scheduling.k8s.io_v1beta1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PriorityClass",
+      "summary": "watch individual changes to a list of PriorityClass. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPriorityClassList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PriorityClass",
+      "summary": "watch changes to an object of kind PriorityClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchPriorityClass",
       "parameters": [
        {

--- a/api/swagger-spec/settings.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/settings.k8s.io_v1alpha1.json
@@ -286,7 +286,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodPreset",
+      "summary": "watch individual changes to a list of PodPreset. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedPodPresetList",
       "parameters": [
        {
@@ -675,7 +675,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PodPreset",
+      "summary": "watch changes to an object of kind PodPreset. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedPodPreset",
       "parameters": [
        {
@@ -897,7 +897,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodPreset",
+      "summary": "watch individual changes to a list of PodPreset. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodPresetListForAllNamespaces",
       "parameters": [
        {

--- a/api/swagger-spec/storage.k8s.io_v1.json
+++ b/api/swagger-spec/storage.k8s.io_v1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StorageClass",
+      "summary": "watch individual changes to a list of StorageClass. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchStorageClassList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind StorageClass",
+      "summary": "watch changes to an object of kind StorageClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchStorageClass",
       "parameters": [
        {

--- a/api/swagger-spec/storage.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/storage.k8s.io_v1alpha1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of VolumeAttachment",
+      "summary": "watch individual changes to a list of VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchVolumeAttachmentList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind VolumeAttachment",
+      "summary": "watch changes to an object of kind VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchVolumeAttachment",
       "parameters": [
        {

--- a/api/swagger-spec/storage.k8s.io_v1beta1.json
+++ b/api/swagger-spec/storage.k8s.io_v1beta1.json
@@ -262,7 +262,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of StorageClass",
+      "summary": "watch individual changes to a list of StorageClass. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchStorageClassList",
       "parameters": [
        {
@@ -611,7 +611,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind StorageClass",
+      "summary": "watch changes to an object of kind StorageClass. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchStorageClass",
       "parameters": [
        {
@@ -969,7 +969,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of VolumeAttachment",
+      "summary": "watch individual changes to a list of VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchVolumeAttachmentList",
       "parameters": [
        {
@@ -1318,7 +1318,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind VolumeAttachment",
+      "summary": "watch changes to an object of kind VolumeAttachment. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchVolumeAttachment",
       "parameters": [
        {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -497,7 +497,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ConfigMap",
+      "summary": "watch individual changes to a list of ConfigMap. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedConfigMapList",
       "parameters": [
        {
@@ -886,7 +886,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ConfigMap",
+      "summary": "watch changes to an object of kind ConfigMap. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedConfigMap",
       "parameters": [
        {
@@ -1108,7 +1108,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ConfigMap",
+      "summary": "watch individual changes to a list of ConfigMap. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchConfigMapListForAllNamespaces",
       "parameters": [
        {
@@ -1482,7 +1482,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Endpoints",
+      "summary": "watch individual changes to a list of Endpoints. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedEndpointsList",
       "parameters": [
        {
@@ -1871,7 +1871,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Endpoints",
+      "summary": "watch changes to an object of kind Endpoints. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedEndpoints",
       "parameters": [
        {
@@ -2093,7 +2093,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Endpoints",
+      "summary": "watch individual changes to a list of Endpoints. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchEndpointsListForAllNamespaces",
       "parameters": [
        {
@@ -2467,7 +2467,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Event",
+      "summary": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedEventList",
       "parameters": [
        {
@@ -2856,7 +2856,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Event",
+      "summary": "watch changes to an object of kind Event. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedEvent",
       "parameters": [
        {
@@ -3078,7 +3078,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Event",
+      "summary": "watch individual changes to a list of Event. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchEventListForAllNamespaces",
       "parameters": [
        {
@@ -3452,7 +3452,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of LimitRange",
+      "summary": "watch individual changes to a list of LimitRange. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedLimitRangeList",
       "parameters": [
        {
@@ -3841,7 +3841,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind LimitRange",
+      "summary": "watch changes to an object of kind LimitRange. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedLimitRange",
       "parameters": [
        {
@@ -4063,7 +4063,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of LimitRange",
+      "summary": "watch individual changes to a list of LimitRange. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchLimitRangeListForAllNamespaces",
       "parameters": [
        {
@@ -4318,7 +4318,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Namespace",
+      "summary": "watch individual changes to a list of Namespace. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespaceList",
       "parameters": [
        {
@@ -4667,7 +4667,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Namespace",
+      "summary": "watch changes to an object of kind Namespace. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespace",
       "parameters": [
        {
@@ -5229,7 +5229,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Node",
+      "summary": "watch individual changes to a list of Node. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNodeList",
       "parameters": [
        {
@@ -5578,7 +5578,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Node",
+      "summary": "watch changes to an object of kind Node. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNode",
       "parameters": [
        {
@@ -6594,7 +6594,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PersistentVolumeClaim",
+      "summary": "watch individual changes to a list of PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedPersistentVolumeClaimList",
       "parameters": [
        {
@@ -6983,7 +6983,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PersistentVolumeClaim",
+      "summary": "watch changes to an object of kind PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedPersistentVolumeClaim",
       "parameters": [
        {
@@ -7205,7 +7205,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PersistentVolumeClaim",
+      "summary": "watch individual changes to a list of PersistentVolumeClaim. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPersistentVolumeClaimListForAllNamespaces",
       "parameters": [
        {
@@ -7725,7 +7725,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PersistentVolume",
+      "summary": "watch individual changes to a list of PersistentVolume. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPersistentVolumeList",
       "parameters": [
        {
@@ -8074,7 +8074,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PersistentVolume",
+      "summary": "watch changes to an object of kind PersistentVolume. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchPersistentVolume",
       "parameters": [
        {
@@ -8602,7 +8602,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Pod",
+      "summary": "watch individual changes to a list of Pod. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedPodList",
       "parameters": [
        {
@@ -8991,7 +8991,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Pod",
+      "summary": "watch changes to an object of kind Pod. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedPod",
       "parameters": [
        {
@@ -9213,7 +9213,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Pod",
+      "summary": "watch individual changes to a list of Pod. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodListForAllNamespaces",
       "parameters": [
        {
@@ -10999,7 +10999,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodTemplate",
+      "summary": "watch individual changes to a list of PodTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedPodTemplateList",
       "parameters": [
        {
@@ -11388,7 +11388,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind PodTemplate",
+      "summary": "watch changes to an object of kind PodTemplate. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedPodTemplate",
       "parameters": [
        {
@@ -11610,7 +11610,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of PodTemplate",
+      "summary": "watch individual changes to a list of PodTemplate. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchPodTemplateListForAllNamespaces",
       "parameters": [
        {
@@ -11984,7 +11984,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicationController",
+      "summary": "watch individual changes to a list of ReplicationController. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedReplicationControllerList",
       "parameters": [
        {
@@ -12373,7 +12373,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ReplicationController",
+      "summary": "watch changes to an object of kind ReplicationController. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedReplicationController",
       "parameters": [
        {
@@ -12595,7 +12595,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ReplicationController",
+      "summary": "watch individual changes to a list of ReplicationController. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchReplicationControllerListForAllNamespaces",
       "parameters": [
        {
@@ -13309,7 +13309,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ResourceQuota",
+      "summary": "watch individual changes to a list of ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedResourceQuotaList",
       "parameters": [
        {
@@ -13698,7 +13698,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ResourceQuota",
+      "summary": "watch changes to an object of kind ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedResourceQuota",
       "parameters": [
        {
@@ -13920,7 +13920,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ResourceQuota",
+      "summary": "watch individual changes to a list of ResourceQuota. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchResourceQuotaListForAllNamespaces",
       "parameters": [
        {
@@ -14464,7 +14464,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Secret",
+      "summary": "watch individual changes to a list of Secret. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedSecretList",
       "parameters": [
        {
@@ -14853,7 +14853,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Secret",
+      "summary": "watch changes to an object of kind Secret. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedSecret",
       "parameters": [
        {
@@ -15075,7 +15075,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Secret",
+      "summary": "watch individual changes to a list of Secret. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchSecretListForAllNamespaces",
       "parameters": [
        {
@@ -15449,7 +15449,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ServiceAccount",
+      "summary": "watch individual changes to a list of ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedServiceAccountList",
       "parameters": [
        {
@@ -15838,7 +15838,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind ServiceAccount",
+      "summary": "watch changes to an object of kind ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedServiceAccount",
       "parameters": [
        {
@@ -16060,7 +16060,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of ServiceAccount",
+      "summary": "watch individual changes to a list of ServiceAccount. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchServiceAccountListForAllNamespaces",
       "parameters": [
        {
@@ -16331,7 +16331,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Service",
+      "summary": "watch individual changes to a list of Service. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchNamespacedServiceList",
       "parameters": [
        {
@@ -16720,7 +16720,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch changes to an object of kind Service",
+      "summary": "watch changes to an object of kind Service. deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter.",
       "nickname": "watchNamespacedService",
       "parameters": [
        {
@@ -16942,7 +16942,7 @@
      {
       "type": "v1.WatchEvent",
       "method": "GET",
-      "summary": "watch individual changes to a list of Service",
+      "summary": "watch individual changes to a list of Service. deprecated: use the 'watch' parameter with a list operation instead.",
       "nickname": "watchServiceListForAllNamespaces",
       "parameters": [
        {

--- a/docs/api-reference/admissionregistration.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/admissionregistration.k8s.io/v1alpha1/operations.html
@@ -1438,7 +1438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_initializerconfiguration">watch individual changes to a list of InitializerConfiguration</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_initializerconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of InitializerConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1alpha1/watch/initializerconfigurations</pre>
@@ -1612,7 +1612,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_initializerconfiguration">watch changes to an object of kind InitializerConfiguration</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_initializerconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind InitializerConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1alpha1/watch/initializerconfigurations/{name}</pre>

--- a/docs/api-reference/admissionregistration.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/admissionregistration.k8s.io/v1beta1/operations.html
@@ -2433,7 +2433,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_mutatingwebhookconfiguration">watch individual changes to a list of MutatingWebhookConfiguration</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_mutatingwebhookconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of MutatingWebhookConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1beta1/watch/mutatingwebhookconfigurations</pre>
@@ -2607,7 +2607,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_mutatingwebhookconfiguration">watch changes to an object of kind MutatingWebhookConfiguration</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_mutatingwebhookconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind MutatingWebhookConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1beta1/watch/mutatingwebhookconfigurations/{name}</pre>
@@ -2789,7 +2789,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_validatingwebhookconfiguration">watch individual changes to a list of ValidatingWebhookConfiguration</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_validatingwebhookconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ValidatingWebhookConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1beta1/watch/validatingwebhookconfigurations</pre>
@@ -2963,7 +2963,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_validatingwebhookconfiguration">watch changes to an object of kind ValidatingWebhookConfiguration</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_validatingwebhookconfiguration_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ValidatingWebhookConfiguration. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/admissionregistration.k8s.io/v1beta1/watch/validatingwebhookconfigurations/{name}</pre>

--- a/docs/api-reference/apps/v1/operations.html
+++ b/docs/api-reference/apps/v1/operations.html
@@ -9256,7 +9256,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/controllerrevisions</pre>
@@ -9430,7 +9430,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/daemonsets</pre>
@@ -9604,7 +9604,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/deployments</pre>
@@ -9778,7 +9778,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_2">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions</pre>
@@ -9960,7 +9960,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision">watch changes to an object of kind ControllerRevision</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/controllerrevisions/{name}</pre>
@@ -10150,7 +10150,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset_2">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/daemonsets</pre>
@@ -10332,7 +10332,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_daemonset">watch changes to an object of kind DaemonSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/daemonsets/{name}</pre>
@@ -10522,7 +10522,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment_2">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/deployments</pre>
@@ -10704,7 +10704,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_deployment">watch changes to an object of kind Deployment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/deployments/{name}</pre>
@@ -10894,7 +10894,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/replicasets</pre>
@@ -11076,7 +11076,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_replicaset">watch changes to an object of kind ReplicaSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/replicasets/{name}</pre>
@@ -11266,7 +11266,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/statefulsets</pre>
@@ -11448,7 +11448,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_statefulset">watch changes to an object of kind StatefulSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/namespaces/{namespace}/statefulsets/{name}</pre>
@@ -11638,7 +11638,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset_2">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/replicasets</pre>
@@ -11812,7 +11812,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset_2">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1/watch/statefulsets</pre>

--- a/docs/api-reference/apps/v1beta1/operations.html
+++ b/docs/api-reference/apps/v1beta1/operations.html
@@ -5791,7 +5791,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/controllerrevisions</pre>
@@ -5965,7 +5965,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/deployments</pre>
@@ -6139,7 +6139,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_2">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/controllerrevisions</pre>
@@ -6321,7 +6321,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision">watch changes to an object of kind ControllerRevision</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/controllerrevisions/{name}</pre>
@@ -6511,7 +6511,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment_2">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/deployments</pre>
@@ -6693,7 +6693,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_deployment">watch changes to an object of kind Deployment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/deployments/{name}</pre>
@@ -6883,7 +6883,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/statefulsets</pre>
@@ -7065,7 +7065,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_statefulset">watch changes to an object of kind StatefulSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/namespaces/{namespace}/statefulsets/{name}</pre>
@@ -7255,7 +7255,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset_2">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/watch/statefulsets</pre>

--- a/docs/api-reference/apps/v1beta2/operations.html
+++ b/docs/api-reference/apps/v1beta2/operations.html
@@ -9256,7 +9256,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/controllerrevisions</pre>
@@ -9430,7 +9430,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/daemonsets</pre>
@@ -9604,7 +9604,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/deployments</pre>
@@ -9778,7 +9778,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_2">watch individual changes to a list of ControllerRevision</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/controllerrevisions</pre>
@@ -9960,7 +9960,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision">watch changes to an object of kind ControllerRevision</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_controllerrevision_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ControllerRevision. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/controllerrevisions/{name}</pre>
@@ -10150,7 +10150,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset_2">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/daemonsets</pre>
@@ -10332,7 +10332,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_daemonset">watch changes to an object of kind DaemonSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/daemonsets/{name}</pre>
@@ -10522,7 +10522,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment_2">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/deployments</pre>
@@ -10704,7 +10704,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_deployment">watch changes to an object of kind Deployment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/deployments/{name}</pre>
@@ -10894,7 +10894,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/replicasets</pre>
@@ -11076,7 +11076,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_replicaset">watch changes to an object of kind ReplicaSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/replicasets/{name}</pre>
@@ -11266,7 +11266,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/statefulsets</pre>
@@ -11448,7 +11448,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_statefulset">watch changes to an object of kind StatefulSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/namespaces/{namespace}/statefulsets/{name}</pre>
@@ -11638,7 +11638,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset_2">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/replicasets</pre>
@@ -11812,7 +11812,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_statefulset_2">watch individual changes to a list of StatefulSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_statefulset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of StatefulSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/watch/statefulsets</pre>

--- a/docs/api-reference/autoscaling/v1/operations.html
+++ b/docs/api-reference/autoscaling/v1/operations.html
@@ -2052,7 +2052,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler">watch individual changes to a list of HorizontalPodAutoscaler</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v1/watch/horizontalpodautoscalers</pre>
@@ -2226,7 +2226,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_2">watch individual changes to a list of HorizontalPodAutoscaler</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers</pre>
@@ -2408,7 +2408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_horizontalpodautoscaler">watch changes to an object of kind HorizontalPodAutoscaler</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}</pre>

--- a/docs/api-reference/autoscaling/v2beta1/operations.html
+++ b/docs/api-reference/autoscaling/v2beta1/operations.html
@@ -2052,7 +2052,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler">watch individual changes to a list of HorizontalPodAutoscaler</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v2beta1/watch/horizontalpodautoscalers</pre>
@@ -2226,7 +2226,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_2">watch individual changes to a list of HorizontalPodAutoscaler</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers</pre>
@@ -2408,7 +2408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_horizontalpodautoscaler">watch changes to an object of kind HorizontalPodAutoscaler</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_horizontalpodautoscaler_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind HorizontalPodAutoscaler. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/autoscaling/v2beta1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}</pre>

--- a/docs/api-reference/batch/v1/operations.html
+++ b/docs/api-reference/batch/v1/operations.html
@@ -2052,7 +2052,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_job">watch individual changes to a list of Job</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_job_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Job. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1/watch/jobs</pre>
@@ -2226,7 +2226,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_job_2">watch individual changes to a list of Job</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_job_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Job. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1/watch/namespaces/{namespace}/jobs</pre>
@@ -2408,7 +2408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_job">watch changes to an object of kind Job</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_job_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Job. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1/watch/namespaces/{namespace}/jobs/{name}</pre>

--- a/docs/api-reference/batch/v1beta1/operations.html
+++ b/docs/api-reference/batch/v1beta1/operations.html
@@ -2052,7 +2052,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_cronjob">watch individual changes to a list of CronJob</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1beta1/watch/cronjobs</pre>
@@ -2226,7 +2226,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_cronjob_2">watch individual changes to a list of CronJob</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs</pre>
@@ -2408,7 +2408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_cronjob">watch changes to an object of kind CronJob</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v1beta1/watch/namespaces/{namespace}/cronjobs/{name}</pre>

--- a/docs/api-reference/batch/v2alpha1/operations.html
+++ b/docs/api-reference/batch/v2alpha1/operations.html
@@ -2052,7 +2052,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_cronjob">watch individual changes to a list of CronJob</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v2alpha1/watch/cronjobs</pre>
@@ -2226,7 +2226,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_cronjob_2">watch individual changes to a list of CronJob</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v2alpha1/watch/namespaces/{namespace}/cronjobs</pre>
@@ -2408,7 +2408,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_cronjob">watch changes to an object of kind CronJob</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_cronjob_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind CronJob. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/batch/v2alpha1/watch/namespaces/{namespace}/cronjobs/{name}</pre>

--- a/docs/api-reference/certificates.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/certificates.k8s.io/v1beta1/operations.html
@@ -1922,7 +1922,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_certificatesigningrequest">watch individual changes to a list of CertificateSigningRequest</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_certificatesigningrequest_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of CertificateSigningRequest. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/certificates.k8s.io/v1beta1/watch/certificatesigningrequests</pre>
@@ -2096,7 +2096,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_certificatesigningrequest">watch changes to an object of kind CertificateSigningRequest</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_certificatesigningrequest_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind CertificateSigningRequest. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/certificates.k8s.io/v1beta1/watch/certificatesigningrequests/{name}</pre>

--- a/docs/api-reference/coordination.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/coordination.k8s.io/v1beta1/operations.html
@@ -1668,7 +1668,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_lease">watch individual changes to a list of Lease</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_lease_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Lease. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/coordination.k8s.io/v1beta1/watch/leases</pre>
@@ -1842,7 +1842,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_lease_2">watch individual changes to a list of Lease</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_lease_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Lease. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/coordination.k8s.io/v1beta1/watch/namespaces/{namespace}/leases</pre>
@@ -2024,7 +2024,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_lease">watch changes to an object of kind Lease</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_lease_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Lease. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/coordination.k8s.io/v1beta1/watch/namespaces/{namespace}/leases/{name}</pre>

--- a/docs/api-reference/events.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/events.k8s.io/v1beta1/operations.html
@@ -1668,7 +1668,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_event">watch individual changes to a list of Event</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Event. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/events.k8s.io/v1beta1/watch/events</pre>
@@ -1842,7 +1842,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_event_2">watch individual changes to a list of Event</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Event. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events</pre>
@@ -2024,7 +2024,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_event">watch changes to an object of kind Event</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Event. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/events.k8s.io/v1beta1/watch/namespaces/{namespace}/events/{name}</pre>

--- a/docs/api-reference/extensions/v1beta1/operations.html
+++ b/docs/api-reference/extensions/v1beta1/operations.html
@@ -10388,7 +10388,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/daemonsets</pre>
@@ -10562,7 +10562,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/deployments</pre>
@@ -10736,7 +10736,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_ingress">watch individual changes to a list of Ingress</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_ingress_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Ingress. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/ingresses</pre>
@@ -10910,7 +10910,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_daemonset_2">watch individual changes to a list of DaemonSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets</pre>
@@ -11092,7 +11092,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_daemonset">watch changes to an object of kind DaemonSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_daemonset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind DaemonSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets/{name}</pre>
@@ -11282,7 +11282,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_deployment_2">watch individual changes to a list of Deployment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments</pre>
@@ -11464,7 +11464,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_deployment">watch changes to an object of kind Deployment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_deployment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Deployment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments/{name}</pre>
@@ -11654,7 +11654,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_ingress_2">watch individual changes to a list of Ingress</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_ingress_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Ingress. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses</pre>
@@ -11836,7 +11836,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_ingress">watch changes to an object of kind Ingress</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_ingress_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Ingress. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses/{name}</pre>
@@ -12026,7 +12026,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy">watch individual changes to a list of NetworkPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies</pre>
@@ -12208,7 +12208,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_networkpolicy">watch changes to an object of kind NetworkPolicy</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies/{name}</pre>
@@ -12398,7 +12398,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets</pre>
@@ -12580,7 +12580,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_replicaset">watch changes to an object of kind ReplicaSet</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets/{name}</pre>
@@ -12770,7 +12770,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_2">watch individual changes to a list of NetworkPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/networkpolicies</pre>
@@ -12944,7 +12944,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podsecuritypolicy">watch individual changes to a list of PodSecurityPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podsecuritypolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PodSecurityPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/podsecuritypolicies</pre>
@@ -13118,7 +13118,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_podsecuritypolicy">watch changes to an object of kind PodSecurityPolicy</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_podsecuritypolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PodSecurityPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/podsecuritypolicies/{name}</pre>
@@ -13300,7 +13300,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicaset_2">watch individual changes to a list of ReplicaSet</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicaset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ReplicaSet. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/watch/replicasets</pre>

--- a/docs/api-reference/networking.k8s.io/v1/operations.html
+++ b/docs/api-reference/networking.k8s.io/v1/operations.html
@@ -1668,7 +1668,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy">watch individual changes to a list of NetworkPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies</pre>
@@ -1850,7 +1850,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_networkpolicy">watch changes to an object of kind NetworkPolicy</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/networking.k8s.io/v1/watch/namespaces/{namespace}/networkpolicies/{name}</pre>
@@ -2040,7 +2040,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_2">watch individual changes to a list of NetworkPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_networkpolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of NetworkPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/networking.k8s.io/v1/watch/networkpolicies</pre>

--- a/docs/api-reference/policy/v1beta1/operations.html
+++ b/docs/api-reference/policy/v1beta1/operations.html
@@ -3047,7 +3047,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_poddisruptionbudget">watch individual changes to a list of PodDisruptionBudget</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_poddisruptionbudget_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PodDisruptionBudget. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets</pre>
@@ -3229,7 +3229,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_poddisruptionbudget">watch changes to an object of kind PodDisruptionBudget</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_poddisruptionbudget_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PodDisruptionBudget. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/policy/v1beta1/watch/namespaces/{namespace}/poddisruptionbudgets/{name}</pre>
@@ -3419,7 +3419,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_poddisruptionbudget_2">watch individual changes to a list of PodDisruptionBudget</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_poddisruptionbudget_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of PodDisruptionBudget. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/policy/v1beta1/watch/poddisruptionbudgets</pre>
@@ -3593,7 +3593,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podsecuritypolicy">watch individual changes to a list of PodSecurityPolicy</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podsecuritypolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PodSecurityPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/policy/v1beta1/watch/podsecuritypolicies</pre>
@@ -3767,7 +3767,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_podsecuritypolicy">watch changes to an object of kind PodSecurityPolicy</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_podsecuritypolicy_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PodSecurityPolicy. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/policy/v1beta1/watch/podsecuritypolicies/{name}</pre>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1/operations.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1/operations.html
@@ -4819,7 +4819,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding">watch individual changes to a list of ClusterRoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings</pre>
@@ -4993,7 +4993,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding">watch changes to an object of kind ClusterRoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/clusterrolebindings/{name}</pre>
@@ -5175,7 +5175,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrole">watch individual changes to a list of ClusterRole</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/clusterroles</pre>
@@ -5349,7 +5349,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrole">watch changes to an object of kind ClusterRole</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/clusterroles/{name}</pre>
@@ -5531,7 +5531,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings</pre>
@@ -5713,7 +5713,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_rolebinding">watch changes to an object of kind RoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/rolebindings/{name}</pre>
@@ -5903,7 +5903,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles</pre>
@@ -6085,7 +6085,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_role">watch changes to an object of kind Role</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Role. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/namespaces/{namespace}/roles/{name}</pre>
@@ -6275,7 +6275,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_2">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/rolebindings</pre>
@@ -6449,7 +6449,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role_2">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1/watch/roles</pre>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/operations.html
@@ -4819,7 +4819,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding">watch individual changes to a list of ClusterRoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterrolebindings</pre>
@@ -4993,7 +4993,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding">watch changes to an object of kind ClusterRoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterrolebindings/{name}</pre>
@@ -5175,7 +5175,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrole">watch individual changes to a list of ClusterRole</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterroles</pre>
@@ -5349,7 +5349,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrole">watch changes to an object of kind ClusterRole</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/clusterroles/{name}</pre>
@@ -5531,7 +5531,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/rolebindings</pre>
@@ -5713,7 +5713,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_rolebinding">watch changes to an object of kind RoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/rolebindings/{name}</pre>
@@ -5903,7 +5903,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/roles</pre>
@@ -6085,7 +6085,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_role">watch changes to an object of kind Role</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Role. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/namespaces/{namespace}/roles/{name}</pre>
@@ -6275,7 +6275,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_2">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/rolebindings</pre>
@@ -6449,7 +6449,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role_2">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1alpha1/watch/roles</pre>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1beta1/operations.html
@@ -4819,7 +4819,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding">watch individual changes to a list of ClusterRoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/clusterrolebindings</pre>
@@ -4993,7 +4993,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding">watch changes to an object of kind ClusterRoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/clusterrolebindings/{name}</pre>
@@ -5175,7 +5175,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_clusterrole">watch individual changes to a list of ClusterRole</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/clusterroles</pre>
@@ -5349,7 +5349,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_clusterrole">watch changes to an object of kind ClusterRole</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_clusterrole_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ClusterRole. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/clusterroles/{name}</pre>
@@ -5531,7 +5531,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/rolebindings</pre>
@@ -5713,7 +5713,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_rolebinding">watch changes to an object of kind RoleBinding</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/rolebindings/{name}</pre>
@@ -5903,7 +5903,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/roles</pre>
@@ -6085,7 +6085,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_role">watch changes to an object of kind Role</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Role. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/namespaces/{namespace}/roles/{name}</pre>
@@ -6275,7 +6275,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_2">watch individual changes to a list of RoleBinding</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_rolebinding_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of RoleBinding. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/rolebindings</pre>
@@ -6449,7 +6449,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_role_2">watch individual changes to a list of Role</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_role_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Role. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/rbac.authorization.k8s.io/v1beta1/watch/roles</pre>

--- a/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
@@ -1438,7 +1438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_priorityclass">watch individual changes to a list of PriorityClass</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_priorityclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PriorityClass. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/scheduling.k8s.io/v1alpha1/watch/priorityclasses</pre>
@@ -1612,7 +1612,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_priorityclass">watch changes to an object of kind PriorityClass</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_priorityclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PriorityClass. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/scheduling.k8s.io/v1alpha1/watch/priorityclasses/{name}</pre>

--- a/docs/api-reference/scheduling.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/scheduling.k8s.io/v1beta1/operations.html
@@ -1438,7 +1438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_priorityclass">watch individual changes to a list of PriorityClass</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_priorityclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PriorityClass. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/scheduling.k8s.io/v1beta1/watch/priorityclasses</pre>
@@ -1612,7 +1612,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_priorityclass">watch changes to an object of kind PriorityClass</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_priorityclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PriorityClass. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/scheduling.k8s.io/v1beta1/watch/priorityclasses/{name}</pre>

--- a/docs/api-reference/settings.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/operations.html
@@ -1668,7 +1668,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podpreset">watch individual changes to a list of PodPreset</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podpreset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PodPreset. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/settings.k8s.io/v1alpha1/watch/namespaces/{namespace}/podpresets</pre>
@@ -1850,7 +1850,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_podpreset">watch changes to an object of kind PodPreset</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_podpreset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PodPreset. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/settings.k8s.io/v1alpha1/watch/namespaces/{namespace}/podpresets/{name}</pre>
@@ -2040,7 +2040,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podpreset_2">watch individual changes to a list of PodPreset</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podpreset_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of PodPreset. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/settings.k8s.io/v1alpha1/watch/podpresets</pre>

--- a/docs/api-reference/storage.k8s.io/v1/operations.html
+++ b/docs/api-reference/storage.k8s.io/v1/operations.html
@@ -1438,7 +1438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_storageclass">watch individual changes to a list of StorageClass</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_storageclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of StorageClass. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1/watch/storageclasses</pre>
@@ -1612,7 +1612,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_storageclass">watch changes to an object of kind StorageClass</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_storageclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind StorageClass. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1/watch/storageclasses/{name}</pre>

--- a/docs/api-reference/storage.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/storage.k8s.io/v1alpha1/operations.html
@@ -1438,7 +1438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_volumeattachment">watch individual changes to a list of VolumeAttachment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_volumeattachment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of VolumeAttachment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1alpha1/watch/volumeattachments</pre>
@@ -1612,7 +1612,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_volumeattachment">watch changes to an object of kind VolumeAttachment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_volumeattachment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind VolumeAttachment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1alpha1/watch/volumeattachments/{name}</pre>

--- a/docs/api-reference/storage.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/storage.k8s.io/v1beta1/operations.html
@@ -2433,7 +2433,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_storageclass">watch individual changes to a list of StorageClass</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_storageclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of StorageClass. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1beta1/watch/storageclasses</pre>
@@ -2607,7 +2607,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_storageclass">watch changes to an object of kind StorageClass</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_storageclass_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind StorageClass. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1beta1/watch/storageclasses/{name}</pre>
@@ -2789,7 +2789,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_volumeattachment">watch individual changes to a list of VolumeAttachment</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_volumeattachment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of VolumeAttachment. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1beta1/watch/volumeattachments</pre>
@@ -2963,7 +2963,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_volumeattachment">watch changes to an object of kind VolumeAttachment</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_volumeattachment_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind VolumeAttachment. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/storage.k8s.io/v1beta1/watch/volumeattachments/{name}</pre>

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -26410,7 +26410,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_configmap">watch individual changes to a list of ConfigMap</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_configmap_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ConfigMap. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/configmaps</pre>
@@ -26584,7 +26584,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_endpoints">watch individual changes to a list of Endpoints</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_endpoints_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Endpoints. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/endpoints</pre>
@@ -26758,7 +26758,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_event">watch individual changes to a list of Event</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Event. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/events</pre>
@@ -26932,7 +26932,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_limitrange">watch individual changes to a list of LimitRange</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_limitrange_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of LimitRange. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/limitranges</pre>
@@ -27106,7 +27106,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_namespace">watch individual changes to a list of Namespace</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_namespace_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Namespace. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces</pre>
@@ -27280,7 +27280,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_configmap_2">watch individual changes to a list of ConfigMap</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_configmap_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ConfigMap. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/configmaps</pre>
@@ -27462,7 +27462,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_configmap">watch changes to an object of kind ConfigMap</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_configmap_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ConfigMap. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/configmaps/{name}</pre>
@@ -27652,7 +27652,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_endpoints_2">watch individual changes to a list of Endpoints</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_endpoints_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Endpoints. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/endpoints</pre>
@@ -27834,7 +27834,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_endpoints">watch changes to an object of kind Endpoints</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_endpoints_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Endpoints. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/endpoints/{name}</pre>
@@ -28024,7 +28024,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_event_2">watch individual changes to a list of Event</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Event. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/events</pre>
@@ -28206,7 +28206,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_event">watch changes to an object of kind Event</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_event_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Event. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/events/{name}</pre>
@@ -28396,7 +28396,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_limitrange_2">watch individual changes to a list of LimitRange</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_limitrange_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of LimitRange. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/limitranges</pre>
@@ -28578,7 +28578,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_limitrange">watch changes to an object of kind LimitRange</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_limitrange_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind LimitRange. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/limitranges/{name}</pre>
@@ -28768,7 +28768,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_persistentvolumeclaim">watch individual changes to a list of PersistentVolumeClaim</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_persistentvolumeclaim_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PersistentVolumeClaim. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/persistentvolumeclaims</pre>
@@ -28950,7 +28950,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_persistentvolumeclaim">watch changes to an object of kind PersistentVolumeClaim</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_persistentvolumeclaim_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PersistentVolumeClaim. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/persistentvolumeclaims/{name}</pre>
@@ -29140,7 +29140,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_pod">watch individual changes to a list of Pod</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_pod_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Pod. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/pods</pre>
@@ -29322,7 +29322,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_pod">watch changes to an object of kind Pod</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_pod_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Pod. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/pods/{name}</pre>
@@ -29512,7 +29512,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podtemplate">watch individual changes to a list of PodTemplate</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podtemplate_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PodTemplate. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/podtemplates</pre>
@@ -29694,7 +29694,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_podtemplate">watch changes to an object of kind PodTemplate</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_podtemplate_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PodTemplate. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/podtemplates/{name}</pre>
@@ -29884,7 +29884,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicationcontroller">watch individual changes to a list of ReplicationController</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicationcontroller_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ReplicationController. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/replicationcontrollers</pre>
@@ -30066,7 +30066,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_replicationcontroller">watch changes to an object of kind ReplicationController</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_replicationcontroller_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ReplicationController. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/replicationcontrollers/{name}</pre>
@@ -30256,7 +30256,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_resourcequota">watch individual changes to a list of ResourceQuota</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_resourcequota_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ResourceQuota. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/resourcequotas</pre>
@@ -30438,7 +30438,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_resourcequota">watch changes to an object of kind ResourceQuota</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_resourcequota_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ResourceQuota. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/resourcequotas/{name}</pre>
@@ -30628,7 +30628,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_secret">watch individual changes to a list of Secret</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_secret_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Secret. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/secrets</pre>
@@ -30810,7 +30810,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_secret">watch changes to an object of kind Secret</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_secret_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Secret. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/secrets/{name}</pre>
@@ -31000,7 +31000,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_serviceaccount">watch individual changes to a list of ServiceAccount</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_serviceaccount_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of ServiceAccount. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/serviceaccounts</pre>
@@ -31182,7 +31182,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_serviceaccount">watch changes to an object of kind ServiceAccount</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_serviceaccount_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind ServiceAccount. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/serviceaccounts/{name}</pre>
@@ -31372,7 +31372,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_service">watch individual changes to a list of Service</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_service_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Service. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/services</pre>
@@ -31554,7 +31554,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_service">watch changes to an object of kind Service</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_service_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Service. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{namespace}/services/{name}</pre>
@@ -31744,7 +31744,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_namespace">watch changes to an object of kind Namespace</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_namespace_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Namespace. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/namespaces/{name}</pre>
@@ -31926,7 +31926,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_node">watch individual changes to a list of Node</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_node_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of Node. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/nodes</pre>
@@ -32100,7 +32100,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_node">watch changes to an object of kind Node</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_node_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind Node. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/nodes/{name}</pre>
@@ -32282,7 +32282,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_persistentvolumeclaim_2">watch individual changes to a list of PersistentVolumeClaim</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_persistentvolumeclaim_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of PersistentVolumeClaim. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/persistentvolumeclaims</pre>
@@ -32456,7 +32456,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_persistentvolume">watch individual changes to a list of PersistentVolume</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_persistentvolume_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead">watch individual changes to a list of PersistentVolume. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/persistentvolumes</pre>
@@ -32630,7 +32630,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_changes_to_an_object_of_kind_persistentvolume">watch changes to an object of kind PersistentVolume</h3>
+<h3 id="_watch_changes_to_an_object_of_kind_persistentvolume_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_filtered_to_a_single_item_with_the_em_fieldselector_em_parameter">watch changes to an object of kind PersistentVolume. deprecated: use the <em>watch</em> parameter with a list operation instead, filtered to a single item with the <em>fieldSelector</em> parameter.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/persistentvolumes/{name}</pre>
@@ -32812,7 +32812,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_pod_2">watch individual changes to a list of Pod</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_pod_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Pod. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/pods</pre>
@@ -32986,7 +32986,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_podtemplate_2">watch individual changes to a list of PodTemplate</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_podtemplate_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of PodTemplate. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/podtemplates</pre>
@@ -33160,7 +33160,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_replicationcontroller_2">watch individual changes to a list of ReplicationController</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_replicationcontroller_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ReplicationController. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/replicationcontrollers</pre>
@@ -33334,7 +33334,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_resourcequota_2">watch individual changes to a list of ResourceQuota</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_resourcequota_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ResourceQuota. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/resourcequotas</pre>
@@ -33508,7 +33508,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_secret_2">watch individual changes to a list of Secret</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_secret_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Secret. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/secrets</pre>
@@ -33682,7 +33682,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_serviceaccount_2">watch individual changes to a list of ServiceAccount</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_serviceaccount_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of ServiceAccount. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/serviceaccounts</pre>
@@ -33856,7 +33856,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_watch_individual_changes_to_a_list_of_service_2">watch individual changes to a list of Service</h3>
+<h3 id="_watch_individual_changes_to_a_list_of_service_deprecated_use_the_em_watch_em_parameter_with_a_list_operation_instead_2">watch individual changes to a list of Service. deprecated: use the <em>watch</em> parameter with a list operation instead.</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/watch/services</pre>

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -382,7 +382,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
 		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
 		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
-		// DEPRECATED
+		// DEPRECATED in 1.11
 		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
 
 		// Add actions at the item path: /api/apiVersion/resource/{name}
@@ -393,6 +393,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
 		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
 		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isGracefulDeleter)
+		// DEPRECATED in 1.11
 		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
 		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
 		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
@@ -429,7 +430,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions = appendIf(actions, action{"LIST", resourcePath, resourceParams, namer, false}, isLister)
 		actions = appendIf(actions, action{"POST", resourcePath, resourceParams, namer, false}, isCreater)
 		actions = appendIf(actions, action{"DELETECOLLECTION", resourcePath, resourceParams, namer, false}, isCollectionDeleter)
-		// DEPRECATED
+		// DEPRECATED in 1.11
 		actions = appendIf(actions, action{"WATCHLIST", "watch/" + resourcePath, resourceParams, namer, false}, allowWatchList)
 
 		actions = appendIf(actions, action{"GET", itemPath, nameParams, namer, false}, isGetter)
@@ -439,6 +440,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		actions = appendIf(actions, action{"PUT", itemPath, nameParams, namer, false}, isUpdater)
 		actions = appendIf(actions, action{"PATCH", itemPath, nameParams, namer, false}, isPatcher)
 		actions = appendIf(actions, action{"DELETE", itemPath, nameParams, namer, false}, isGracefulDeleter)
+		// DEPRECATED in 1.11
 		actions = appendIf(actions, action{"WATCH", "watch/" + itemPath, nameParams, namer, false}, isWatcher)
 		actions = appendIf(actions, action{"CONNECT", itemPath, nameParams, namer, false}, isConnecter)
 		actions = appendIf(actions, action{"CONNECT", itemPath + "/{path:*}", proxyParams, namer, false}, isConnecter && connectSubpath)
@@ -448,6 +450,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		// TODO: more strongly type whether a resource allows these actions on "all namespaces" (bulk delete)
 		if !isSubresource {
 			actions = appendIf(actions, action{"LIST", resource, params, namer, true}, isLister)
+			// DEPRECATED in 1.11
 			actions = appendIf(actions, action{"WATCHLIST", "watch/" + resource, params, namer, true}, allowWatchList)
 		}
 		break
@@ -744,12 +747,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			}
 			addParams(route, action.Params)
 			routes = append(routes, route)
-		// TODO: deprecated
+		// deprecated in 1.11
 		case "WATCH": // Watch a resource.
 			doc := "watch changes to an object of kind " + kind
 			if isSubresource {
 				doc = "watch changes to " + subresource + " of an object of kind " + kind
 			}
+			doc += ". deprecated: use the 'watch' parameter with a list operation instead, filtered to a single item with the 'fieldSelector' parameter."
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
@@ -763,12 +767,13 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			}
 			addParams(route, action.Params)
 			routes = append(routes, route)
-		// TODO: deprecated
+		// deprecated in 1.11
 		case "WATCHLIST": // Watch all resources of a kind.
 			doc := "watch individual changes to a list of " + kind
 			if isSubresource {
 				doc = "watch individual changes to a list of " + subresource + " of " + kind
 			}
+			doc += ". deprecated: use the 'watch' parameter with a list operation instead."
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, requestScope, restfulListResource(lister, watcher, reqScope, true, a.minRequestTimeout))
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).


### PR DESCRIPTION
closes #65133

these have been marked as deprecated in code for many releases, and all client accesses have switched to using the ?watch=true access method, but documentation was never updated

@kubernetes/sig-api-machinery-api-reviews @kubernetes/api-reviewers

```release-note
The watch API endpoints prefixed with `/watch` are deprecated and will be removed in a future release. These standard method for watching resources (supported since v1.0) is to use the list API endpoints with a `?watch=true` parameter. All client-go clients have used the parameter method since v1.6.0.
```