### PR TITLE
Fix kubeadm init/upgrade --dry-run mode

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -260,11 +260,15 @@ func NewInit(cfgPath string, externalcfg *kubeadmapiv1alpha2.MasterConfiguration
 		return nil, err
 	}
 
-	fmt.Println("[preflight/images] Pulling images required for setting up a Kubernetes cluster")
-	fmt.Println("[preflight/images] This might take a minute or two, depending on the speed of your internet connection")
-	fmt.Println("[preflight/images] You can also perform this action in beforehand using 'kubeadm config images pull'")
-	if err := preflight.RunPullImagesCheck(utilsexec.New(), cfg, ignorePreflightErrors); err != nil {
-		return nil, err
+	if !dryRun {
+		fmt.Println("[preflight/images] Pulling images required for setting up a Kubernetes cluster")
+		fmt.Println("[preflight/images] This might take a minute or two, depending on the speed of your internet connection")
+		fmt.Println("[preflight/images] You can also perform this action in beforehand using 'kubeadm config images pull'")
+		if err := preflight.RunPullImagesCheck(utilsexec.New(), cfg, ignorePreflightErrors); err != nil {
+			return nil, err
+		}
+	} else {
+		fmt.Println("[preflight/images] Would pull the required images (like 'kubeadm config images pull')")
 	}
 
 	return &Init{cfg: cfg, skipTokenPrint: skipTokenPrint, dryRun: dryRun, ignorePreflightErrors: ignorePreflightErrors}, nil

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -292,6 +292,10 @@ func createDNSService(dnsService *v1.Service, serviceBytes []byte, client client
 // translateStubDomainOfKubeDNSToProxyCoreDNS translates StubDomain Data in kube-dns ConfigMap
 // in the form of Proxy for the CoreDNS Corefile.
 func translateStubDomainOfKubeDNSToProxyCoreDNS(dataField string, kubeDNSConfigMap *v1.ConfigMap) (string, error) {
+	if kubeDNSConfigMap == nil {
+		return "", nil
+	}
+
 	if proxy, ok := kubeDNSConfigMap.Data[dataField]; ok {
 		stubDomainData := make(map[string][]string)
 		err := json.Unmarshal([]byte(proxy), &stubDomainData)
@@ -328,6 +332,10 @@ func translateStubDomainOfKubeDNSToProxyCoreDNS(dataField string, kubeDNSConfigM
 // translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS translates UpstreamNameServer Data in kube-dns ConfigMap
 // in the form of Proxy for the CoreDNS Corefile.
 func translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS(dataField string, kubeDNSConfigMap *v1.ConfigMap) (string, error) {
+	if kubeDNSConfigMap == nil {
+		return "", nil
+	}
+
 	if upstreamValues, ok := kubeDNSConfigMap.Data[dataField]; ok {
 		var upstreamProxyIP []string
 
@@ -345,6 +353,10 @@ func translateUpstreamNameServerOfKubeDNSToUpstreamProxyCoreDNS(dataField string
 // translateFederationsofKubeDNSToCoreDNS translates Federations Data in kube-dns ConfigMap
 // to Federation for CoreDNS Corefile.
 func translateFederationsofKubeDNSToCoreDNS(dataField, coreDNSDomain string, kubeDNSConfigMap *v1.ConfigMap) (string, error) {
+	if kubeDNSConfigMap == nil {
+		return "", nil
+	}
+
 	if federation, ok := kubeDNSConfigMap.Data[dataField]; ok {
 		var (
 			federationStanza []interface{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Split out from https://github.com/kubernetes/kubernetes/pull/65104.
Fixes `kubeadm init --dry-run` and `kubeadm upgrade apply [version] --dry-run`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 