### PR TITLE
Use kubernetes image repo for coredns

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -64,7 +64,7 @@ func GetAllImages(cfg *kubeadmapi.MasterConfiguration) []string {
 
 	dnsImage := fmt.Sprintf("%v/k8s-dns-kube-dns-%v:%v", cfg.ImageRepository, runtime.GOARCH, constants.KubeDNSVersion)
 	if features.Enabled(cfg.FeatureGates, features.CoreDNS) {
-		dnsImage = fmt.Sprintf("coredns/coredns:%v", constants.CoreDNSVersion)
+		dnsImage = fmt.Sprintf("%v/coredns:%v", cfg.ImageRepository, constants.CoreDNSVersion)
 	}
 	imgs = append(imgs, dnsImage)
 	return imgs


### PR DESCRIPTION
Fixes #927

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>
**What this PR does / why we need it**:
use the coredns image from the k8s image repository when building a cluster with kubeadm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#927

```release-note
NONE
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @luxas 