### PR TITLE
also use rules on aggrageting cluster role

### DIFF
--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -103,10 +103,6 @@ func (c *ClusterRoleAggregationController) syncClusterRole(key string) error {
 		sort.Sort(byName(clusterRoles))
 
 		for i := range clusterRoles {
-			if clusterRoles[i].Name == sharedClusterRole.Name {
-				continue
-			}
-
 			for j := range clusterRoles[i].Rules {
 				currRule := clusterRoles[i].Rules[j]
 				if !ruleExists(newPolicyRules, currRule) {


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
for example, we cannot get "pods" rule at sample-aggregated-role.

```
---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: sub-clusterrole1
  labels:
    app: sample-rbac
rules:
- apiGroups: [""]
  resources: ["deployments"]
  verbs: ["get"]

---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: sub-clusterrole2
  labels:
    app: sample-rbac
rules:
- apiGroups: [""]
  resources: ["services"]
  verbs: ["get"]

---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: sample-aggregated-role
aggregationRule:
  clusterRoleSelectors:
  - matchLabels:
      app: sample-rbac
rules:
- apiGroups: [""]
  resources: ["pods"]
  verbs: ["get"]
```

after that,
```
$ kubectl get clusterrole sample-aggregated-role -o yaml
...
rules:
- apiGroups:
  - ""
  resources:
  - deployments
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - get
```

I think we need pods rules.

$ kubectl get clusterrole sample-aggregated-role -o yaml
...
rules:
- apiGroups:
  - ""
  resources:
  - deployments
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - get
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65171

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: ClusterRole aggragation ignore own rule
```
