### PR TITLE
Remove resources from system addon manifests

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
@@ -35,6 +35,7 @@ spec:
           timeoutSeconds: 5
         ports:
         - containerPort: 8080
+        # BEGIN_RESOURCES
         resources:
           limits:
             cpu: 10m
@@ -42,3 +43,4 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        # END_RESOURCES

--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -81,6 +81,7 @@ spec:
             - --sink=gcl
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: heapster-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -88,6 +89,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           volumeMounts:
           - name: heapster-config-volume
             mountPath: /etc/config
@@ -114,6 +116,7 @@ spec:
             - --estimator=exponential
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: eventer-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -121,6 +124,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           env:
             - name: MY_POD_NAME
               valueFrom:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -82,6 +82,7 @@ spec:
             - --sink=gcl
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: heapster-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -89,6 +90,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           volumeMounts:
           - name: heapster-config-volume
             mountPath: /etc/config
@@ -115,6 +117,7 @@ spec:
             - --estimator=exponential
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: eventer-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -122,6 +125,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           volumeMounts:
           - name: eventer-config-volume
             mountPath: /etc/config

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -81,6 +81,7 @@ spec:
             - --sink=influxdb:http://monitoring-influxdb:8086
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: heapster-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -88,6 +89,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -114,6 +116,7 @@ spec:
             - --estimator=exponential
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: eventer-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -121,6 +124,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           env:
             - name: MY_POD_NAME
               valueFrom:

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -82,6 +82,7 @@ spec:
         # END_PROMETHEUS_TO_SD
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: heapster-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -89,6 +90,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           volumeMounts:
           - name: heapster-config-volume
             mountPath: /etc/config

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -61,6 +61,7 @@ spec:
             - --source=kubernetes.summary_api:''
         - image: k8s.gcr.io/addon-resizer:1.8.1
           name: heapster-nanny
+          # BEGIN_RESOURCES
           resources:
             limits:
               cpu: 50m
@@ -68,6 +69,7 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          # END_RESOURCES
           env:
             - name: MY_POD_NAME
               valueFrom:

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -83,10 +83,12 @@ spec:
       containers:
       - name: autoscaler
         image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        # BEGIN_RESOURCES
         resources:
             requests:
                 cpu: "20m"
                 memory: "10Mi"
+        # END_RESOURCES
         command:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2036,6 +2036,16 @@ function setup-addon-manifests {
       copy-manifests "${psp_dir}" "${dst_dir}"
     fi
   fi
+
+  # If system addon vertical scaling is enabled, remove resource fields from the
+  # manifest.
+  if [[ "${ENABLE_SYSTEM_ADDON_VERTICAL_SCALING:-false}" == "true" ]]; then
+    # TODO: Check if there are any intermediate yaml files that need to be
+    # updated and are not caught by the regex passed to find.
+    if [[ $(find ${dst_dir} -name '*.yaml') ]]; then
+      find ${dst_dir} -name '*.yaml' | xargs sed -i -e '/^\s*# BEGIN_RESOURCES/,/^\s*# END_RESOURCES/d'
+    fi
+  fi
 }
 
 # A function that downloads extra addons from a URL and puts them in the GCI


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update the setup-addon-manifests function to remove all fields contained
within and including the BEGIN_RESOURCES and END_RESOURCES markers, which have
been embedded as comments. The BEGIN_RESOURCE and END_RESOURCE markers were
chosen to be consistent with existing markers, such as, BEGIN_PROMETHEUS_TO_SD
and END_PROMETHEUS_TO_SD.

This logic is guarded by the ENABLE_SYSTEM_ADDON_VERTICAL_SCALING
environment variable, which is set to false by default rendering this change
benign. The removal of resource-related fields is necessary to enable
vertical scaling of system pods. Otherwise, the addon manager will undo
any changes specified by a scaler whenever it reconciles an addon's
definition.

Note that not all system manifests have been updated. Additional
follow-up changes may be needed pending further testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
