### PR TITLE
cri-tools deb: Rename cri_tools to the correct cri-tools

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -14,7 +14,7 @@ release_filegroup(
     name = "debs",
     srcs = [
         ":cloud-controller-manager.deb",
-        ":cri_tools.deb",
+        ":cri-tools.deb",
         ":kubeadm.deb",
         ":kubectl.deb",
         ":kubelet.deb",
@@ -89,7 +89,7 @@ pkg_tar(
 )
 
 pkg_tar(
-    name = "cri_tools-data",
+    name = "cri-tools-data",
     package_dir = "/usr/bin",
     deps = ["@cri_tools//file"],
 )
@@ -176,7 +176,7 @@ The Container Networking Interface tools for provisioning container networks.
 )
 
 k8s_deb(
-    name = "cri_tools",
+    name = "cri-tools",
     description = """Container Runtime Interface tools (crictl)""",
     version = CRI_TOOLS_VERSION,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This deb was incorrectly named `cri_tools` in CI testing.
We should make this match what we ship in official releases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @dims @ixdy 