### PR TITLE
kubeadm: Fix a small config upgrading issue with .CloudProvider

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
@@ -113,6 +113,9 @@ func UpgradeCloudProvider(in *MasterConfiguration, out *kubeadm.MasterConfigurat
 		if out.ControllerManagerExtraArgs == nil {
 			out.ControllerManagerExtraArgs = map[string]string{}
 		}
+		if out.NodeRegistration.KubeletExtraArgs == nil {
+			out.NodeRegistration.KubeletExtraArgs = map[string]string{}
+		}
 
 		out.APIServerExtraArgs["cloud-provider"] = in.CloudProvider
 		out.ControllerManagerExtraArgs["cloud-provider"] = in.CloudProvider


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes a panic in the conversion code where `.NodeRegistration.KubeletExtraArgs` could be nil :/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews
/kind bug
/priority critical-urgent
/milestone v1.11
/status approved-for-milestone