### PR TITLE
update describe annotations to be more readable

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -4012,7 +4012,7 @@ func printAnnotationsMultilineWithIndent(w PrefixWriter, initialIndent, title, i
 			w.Write(LEVEL_0, initialIndent)
 			w.Write(LEVEL_0, innerIndent)
 		}
-		line := fmt.Sprintf("%s=%s", key, annotations[key])
+		line := fmt.Sprintf("%s: %s", key, annotations[key])
 		if len(line) > maxAnnotationLen {
 			w.Write(LEVEL_0, "%s...\n", line[:maxAnnotationLen])
 		} else {


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Updates the describe output of objects (pods, namespaces, etc.) to display annotations in a more human-readable way.

```
# before
$ kubectl describe pod foo
Name:         foo
Labels:       <none>
Annotations:  labelName=key=value

# After
$ kubectl describe pod foo
Name:         foo
Labels:       <none>
Annotations:  labelName: key=value
```
cc @soltysh 