### PR TITLE
GCE PD: Resolving disk name collisions

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -188,7 +188,6 @@ type Routes interface {
 
 var (
 	InstanceNotFound = errors.New("instance not found")
-	DiskNotFound     = errors.New("disk is not found")
 	NotImplemented   = errors.New("unimplemented")
 )
 

--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -116,12 +116,16 @@ go_test(
         "//pkg/cloudprovider/providers/gce/cloud/mock:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/net/sets:go_default_library",
+<<<<<<< HEAD
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+=======
+        "//pkg/volume/util:go_default_library",
+>>>>>>> GCE PD: Resolving disk name collisions
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",

--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -116,16 +116,13 @@ go_test(
         "//pkg/cloudprovider/providers/gce/cloud/mock:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/net/sets:go_default_library",
-<<<<<<< HEAD
+        "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
-=======
-        "//pkg/volume/util:go_default_library",
->>>>>>> GCE PD: Resolving disk name collisions
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce_disks_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks_test.go
@@ -305,7 +305,7 @@ func TestDeleteDisk_NotFound(t *testing.T) {
 	}
 }
 
-func TestDeleteDisk_NotFoundNoZone(t *testing.T) {
+func TestDeleteDisk_NoZone(t *testing.T) {
 	/* Arrange */
 	gce, _, test := initTest()
 
@@ -313,8 +313,8 @@ func TestDeleteDisk_NotFoundNoZone(t *testing.T) {
 	err := gce.DeleteDisk(test.diskName, "")
 
 	/* Assert */
-	if err != nil {
-		t.Errorf("Expected successful operation when disk is not found, but an error is returned: %v", err)
+	if err == nil {
+		t.Errorf("Expected error when zone is unspecified, but none returned")
 	}
 }
 
@@ -367,7 +367,7 @@ func TestDeleteDisk_DiffDiskMultiZone(t *testing.T) {
 	var err error
 	for _, zone := range gce.managedZones {
 		diskName := zone + "_disk"
-		err = gce.DeleteDisk(diskName, "")
+		err = gce.DeleteDisk(diskName, zone)
 		if err != nil {
 			t.Errorf("Error deleting disk in zone '%v'; error: \"%v\"", zone, err)
 		}

--- a/pkg/volume/gce_pd/BUILD
+++ b/pkg/volume/gce_pd/BUILD
@@ -48,6 +48,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/cloudprovider/providers/gce:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
@@ -61,6 +62,17 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+<<<<<<< HEAD
+=======
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/util/testing:go_default_library",
+>>>>>>> GCE PD: Resolving disk name collisions
     ],
 )
 

--- a/pkg/volume/gce_pd/BUILD
+++ b/pkg/volume/gce_pd/BUILD
@@ -59,20 +59,10 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-<<<<<<< HEAD
-=======
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//vendor/k8s.io/client-go/util/testing:go_default_library",
->>>>>>> GCE PD: Resolving disk name collisions
     ],
 )
 

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -99,7 +99,12 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName ty
 		// Volume is already attached to node.
 		glog.Infof("Attach operation is successful. PD %q is already attached to node %q.", pdName, nodeName)
 	} else {
-		if err := attacher.gceDisks.AttachDisk(pdName, nodeName, deviceName, readOnly, isRegionalPD(spec)); err != nil {
+		if isRegionalPD(spec) {
+			err = attacher.gceDisks.AttachRegionalDisk(pdName, nodeName, deviceName, readOnly)
+		} else {
+			err = attacher.gceDisks.AttachDisk(pdName, nodeName, deviceName, readOnly)
+		}
+		if err != nil {
 			glog.Errorf("Error attaching PD %q to node %q: %+v", pdName, nodeName, err)
 			return "", err
 		}

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -82,7 +82,7 @@ func (attacher *gcePersistentDiskAttacher) Attach(spec *volume.Spec, nodeName ty
 
 	pdName := volumeSource.PDName
 
-	deviceName, err := getDeviceName(spec)
+	deviceName, err := getDeviceName(spec, attacher.host)
 	if err != nil {
 		return "", err
 	}
@@ -118,7 +118,7 @@ func (attacher *gcePersistentDiskAttacher) VolumesAreAttached(specs []*volume.Sp
 	volumePdNameMap := make(map[string]*volume.Spec)
 	deviceNameList := []string{}
 	for _, spec := range specs {
-		deviceName, err := getDeviceName(spec)
+		deviceName, err := getDeviceName(spec, attacher.host)
 		// If error is occurred, skip this volume and move to the next one
 		if err != nil {
 			glog.Errorf("Error computing device name for volume (specName: %q) source : %v", spec.Name(), err)
@@ -158,7 +158,7 @@ func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devi
 		return "", err
 	}
 
-	deviceName, err := getDeviceName(spec)
+	deviceName, err := getDeviceName(spec, attacher.host)
 	if err != nil {
 		return "", err
 	}
@@ -197,7 +197,7 @@ func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devi
 
 func (attacher *gcePersistentDiskAttacher) GetDeviceMountPath(
 	spec *volume.Spec) (string, error) {
-	deviceName, err := getDeviceName(spec)
+	deviceName, err := getDeviceName(spec, attacher.host)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -175,7 +175,7 @@ func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devi
 		select {
 		case <-ticker.C:
 			glog.V(5).Infof("Checking GCE PD %q is attached.", pdName)
-			path, err := verifyDevicePath(devicePaths, sdBeforeSet, pdName)
+			path, err := verifyDevicePath(devicePaths, sdBeforeSet, deviceName)
 			if err != nil {
 				// Log error, if any, and continue checking periodically. See issue #11321
 				glog.Errorf("Error verifying GCE PD (%q) is attached: %v", pdName, err)

--- a/pkg/volume/gce_pd/attacher_test.go
+++ b/pkg/volume/gce_pd/attacher_test.go
@@ -440,7 +440,7 @@ type diskIsAttachedCall struct {
 
 var _ gce.Disks = &testcase{}
 
-func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, deviceName string, readOnly bool, regional bool) error {
+func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, deviceName string, readOnly bool) error {
 	expected := &testcase.attach
 
 	if expected.diskName == "" && expected.nodeName == "" {
@@ -470,12 +470,52 @@ func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName, d
 		return errors.New("Unexpected AttachDisk call: wrong readOnly")
 	}
 
-	if expected.regional != regional {
-		testcase.t.Errorf("Unexpected AttachDisk call: expected regional %v, got %v", expected.regional, regional)
-		return errors.New("Unexpected AttachDisk call: wrong regional")
+	if expected.regional {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected AttachRegionalDisk call")
+		return errors.New("Unexpected AttachDisk call: expected AttachRegionalDisk call")
 	}
 
 	glog.V(4).Infof("AttachDisk call: %s, %s, %v, returning %v", diskName, nodeName, readOnly, expected.ret)
+
+	return expected.ret
+}
+
+func (testcase *testcase) AttachRegionalDisk(diskName string, nodeName types.NodeName, deviceName string, readOnly bool) error {
+	expected := &testcase.attach
+
+	if expected.diskName == "" && expected.nodeName == "" {
+		// testcase.attach looks uninitialized, test did not expect to call
+		// AttachRegionalDisk
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call!")
+		return errors.New("Unexpected AttachRegionalDisk call!")
+	}
+
+	if expected.diskName != diskName {
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call: expected diskName %s, got %s", expected.diskName, diskName)
+		return errors.New("Unexpected AttachRegionalDisk call: wrong diskName")
+	}
+
+	if expected.nodeName != nodeName {
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+		return errors.New("Unexpected AttachRegionalDisk call: wrong nodeName")
+	}
+
+	if expected.deviceName != deviceName {
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call: expected deviceName %s, got %s", expected.deviceName, deviceName)
+		return errors.New("Unexpected AttachRegionalDisk call: wrong deviceName")
+	}
+
+	if expected.readOnly != readOnly {
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call: expected readOnly %v, got %v", expected.readOnly, readOnly)
+		return errors.New("Unexpected AttachRegionalDisk call: wrong readOnly")
+	}
+
+	if !expected.regional {
+		testcase.t.Errorf("Unexpected AttachRegionalDisk call: expected AttachDisk call")
+		return errors.New("Unexpected AttachRegionalDisk call: expected AttachDisk call")
+	}
+
+	glog.V(4).Infof("AttachRegionalDisk call: %s, %s, %v, returning %v", diskName, nodeName, readOnly, expected.ret)
 
 	return expected.ret
 }
@@ -556,7 +596,14 @@ func (testcase *testcase) GetAutoLabelsForPD(name string, zone string) (map[stri
 
 func (testcase *testcase) ResizeDisk(
 	diskName string,
-	zoneSet sets.String,
+	zone string,
+	oldSize resource.Quantity,
+	newSize resource.Quantity) (resource.Quantity, error) {
+	return oldSize, errors.New("Not implemented")
+}
+
+func (testcase *testcase) ResizeRegionalDisk(
+	diskName string,
 	oldSize resource.Quantity,
 	newSize resource.Quantity) (resource.Quantity, error) {
 	return oldSize, errors.New("Not implemented")

--- a/pkg/volume/gce_pd/attacher_test.go
+++ b/pkg/volume/gce_pd/attacher_test.go
@@ -75,7 +75,7 @@ func TestGetDeviceName_PersistentVolumeRegional(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetDeviceName error: %v", err)
 	}
-	if deviceName != name+volNameRegionalSuffix {
+	if deviceName != name+deviceNameRegionalSuffix {
 		t.Errorf("GetDeviceName error: expected %s, got %s", name, deviceName)
 	}
 }
@@ -98,7 +98,7 @@ type testcase struct {
 func TestAttachDetachRegional(t *testing.T) {
 	diskName := "disk"
 	nodeName := types.NodeName("instance")
-	deviceName := diskName + volNameRegionalSuffix
+	deviceName := diskName + deviceNameRegionalSuffix
 	readOnly := false
 	regional := true
 	spec := createPVSpec(diskName, readOnly, []string{"zone1", "zone2"})

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -86,7 +86,7 @@ func (plugin *gcePersistentDiskPlugin) GetPluginName() string {
 }
 
 func (plugin *gcePersistentDiskPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
-	return getDeviceName(spec)
+	return getDeviceName(spec, plugin.host)
 }
 
 func (plugin *gcePersistentDiskPlugin) CanSupport(spec *volume.Spec) bool {
@@ -190,7 +190,7 @@ func (plugin *gcePersistentDiskPlugin) newMounterInternal(spec *volume.Spec, pod
 		return nil, err
 	}
 
-	deviceName, err := getDeviceName(spec)
+	deviceName, err := getDeviceName(spec, plugin.host)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -273,7 +273,7 @@ func TestPlugin(t *testing.T) {
 
 	fakePDManager := &fakePDManager{
 		labels: map[string]string{
-			"fakepdmanager":             "yes",
+			"fakepdmanager":                    "yes",
 			kubeletapis.LabelZoneFailureDomain: "zone1__zone2",
 		},
 		expectedZones: sets.NewString("zone1", "zone2"),

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -111,6 +111,7 @@ func getNodeSelectorRequirementWithKey(key string, term v1.NodeSelectorTerm) (*v
 }
 
 type deviceNameTestCase struct {
+	testName           string
 	spec               *volume.Spec
 	expectedDeviceName string
 }
@@ -121,6 +122,7 @@ func TestDeviceName(t *testing.T) {
 
 	tests := []deviceNameTestCase{
 		{
+			testName: "inline volume",
 			spec: &volume.Spec{
 				Volume: &v1.Volume{
 					Name: "vol1",
@@ -135,6 +137,7 @@ func TestDeviceName(t *testing.T) {
 			expectedDeviceName: "pd",
 		},
 		{
+			testName: "PV with zonal disk",
 			spec: &volume.Spec{
 				PersistentVolume: &v1.PersistentVolume{
 					ObjectMeta: metav1.ObjectMeta{
@@ -154,6 +157,7 @@ func TestDeviceName(t *testing.T) {
 			expectedDeviceName: "pd",
 		},
 		{
+			testName: "PV with regional disk",
 			spec: &volume.Spec{
 				PersistentVolume: &v1.PersistentVolume{
 					ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -30,7 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
@@ -76,6 +78,10 @@ var _ = utils.SIGDescribe("Regional PD", func() {
 
 		It("should provision storage in the allowedTopologies with delayed binding [Slow]", func() {
 			testRegionalAllowedTopologiesWithDelayedBinding(c, ns)
+		})
+
+		It("should create and delete pods successfully in the presence of PD name collisions [Slow]", func() {
+			testDiskNameCollision(f, c, ns)
 		})
 
 		It("should failover to a different zone when all nodes in one zone become unreachable [Slow] [Disruptive]", func() {
@@ -139,6 +145,69 @@ func testVolumeProvisioning(c clientset.Interface, ns string) {
 		claim.Spec.StorageClassName = &class.Name
 		testDynamicProvisioning(test, c, claim, class)
 	}
+}
+
+// Verifies PD attach and detach succeed when there is a disk name collision between
+// a zonal PD and a regional PD.
+func testDiskNameCollision(f *framework.Framework, c clientset.Interface, ns string) {
+	diskName := fmt.Sprintf("%s-%s", framework.TestContext.Prefix, string(uuid.NewUUID()))
+
+	zones, err := framework.GetClusterZones(c)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(zones.Len()).To(BeNumerically(">", 1))
+
+	By("creating zonal and regional disks")
+	zonePrimary, _ := zones.PopAny()
+	zoneSecondary, _ := zones.PopAny()
+	replicaZones := make(sets.String)
+	replicaZones.Insert(zonePrimary, zoneSecondary)
+
+	_, err = framework.CreatePDWithRetryAndZone(diskName, zonePrimary)
+	framework.ExpectNoError(err)
+	defer framework.DeletePDWithRetry(diskName)
+
+	_, err = framework.CreateRegionalPDWithRetry(diskName, replicaZones)
+	framework.ExpectNoError(err)
+	defer framework.DeleteRegionalPDWithRetry(diskName)
+
+	By("creating PV, PVC, and pod for zonal disk")
+	pvConfig, pvcConfig := createBasePVPVCConfig(diskName, ns)
+
+	pvConfig.Labels[apis.LabelZoneFailureDomain] = zonePrimary
+	pv, pvc, err := framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, false)
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		if errs := framework.PVPVCCleanup(c, ns, pv, pvc); len(errs) > 0 {
+			framework.Failf("Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
+		}
+	}()
+	framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
+
+	pod := framework.MakeWritePod(ns, pvc)
+	pod, err = c.CoreV1().Pods(ns).Create(pod)
+
+	By("creating PV, PVC, and pod for regional disk")
+	pvConfig.Labels[apis.LabelZoneFailureDomain] = util.ZonesSetToLabelValue(replicaZones)
+	pvRegional, pvcRegional, err := framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, false)
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		if errs := framework.PVPVCCleanup(c, ns, pv, pvc); len(errs) > 0 {
+			framework.Failf("Failed to delete PVC and/or PV. Errors: %v", utilerrors.NewAggregate(errs))
+		}
+	}()
+	framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pvRegional, pvcRegional))
+
+	podRegional, err := framework.CreatePod(c, ns, nil, []*v1.PersistentVolumeClaim{pvcRegional}, true,
+		"if [ -f /mnt/volume1/SUCCESS ]; then echo FileExists; fi")
+
+	By("verify pod with regional disk cannot access data written previously")
+	logs, err := framework.GetPodLogs(c, ns, podRegional.Name, "")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(logs)).To(Equal(0), fmt.Sprintf("expected no log messages from container but got: %s", logs))
+
+	By("delete pods")
+	framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod))
+	framework.ExpectNoError(framework.DeletePodWithWait(f, c, podRegional))
 }
 
 func testZonalFailover(c clientset.Interface, ns string) {
@@ -561,4 +630,32 @@ func verifyZonesInPV(volume *v1.PersistentVolume, zones sets.String, match bool)
 
 	return fmt.Errorf("Zones in StorageClass are %v, but zones in PV are %v", zones, pvZones)
 
+}
+
+func createBasePVPVCConfig(diskName string, ns string) (framework.PersistentVolumeConfig, framework.PersistentVolumeClaimConfig) {
+	volLabel := labels.Set{
+		framework.VolumeSelectorKey: ns,
+	}
+	selector := metav1.SetAsLabelSelector(volLabel)
+
+	pvConfig := framework.PersistentVolumeConfig{
+		NamePrefix: "gce-",
+		Labels:     volLabel,
+		PVSource: v1.PersistentVolumeSource{
+			GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+				PDName:   diskName,
+				FSType:   "ext3",
+				ReadOnly: false,
+			},
+		},
+		Prebind:       nil,
+		ReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+	}
+	emptyStorageClass := ""
+	pvcConfig := framework.PersistentVolumeClaimConfig{
+		Selector:         selector,
+		StorageClassName: &emptyStorageClass,
+	}
+
+	return pvConfig, pvcConfig
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Eliminates problems with disk name collisions across zones and between zonal and regional PD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65126

**Special notes for your reviewer**:
These are the categories of the largest changes:
* Updating the Deleter to support disk identification by both name and zone
* Updating the device name format to differentiate between zonal and regional disks. This change affects most of the volume functions like Attach, MountDevice, DisksAreAttached, etc.
* Zone & region label generation logic

There's a major component missing: supporting upgrade and downgrade scenarios. This will be done in a separate PR.

A noteworthy refactor I did is consolidating the different kinds of DiskNotFound errors into one, in order to fix a bug I discovered along the way.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Action Required] This impacts clusters running on GCE VMs only. Device names for GCE Regional PDs now have a different format. Upon node upgrade, VM instances with GCE PD volumes attached through Kubernetes must be restarted.
```
