### PR TITLE
WIP: client-go per API call stack-trace via user-agent for #APIsnoop

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	maxUserAgentLength      = 1024
+	maxUserAgentLength      = 16384
 	userAgentTruncateSuffix = "...TRUNCATED"
 )
 

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -629,11 +629,12 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 	}
 }
 
-// assembles a User-Agent header that contains the br.client.transport().agent acktrace of function calls
-func appendDebugBacktrace(currUserAgent string) string {
+// appends sacktrace of source and function calls via goruntime.CallersFrames
+func appendWhakapapa(currUserAgent string) string {
 	var lines []string
 	var callers []uintptr
-	const SKIP_CALLERS = 3 // TODO: is this the right hard-coded value?
+	const SKIP_CALLERS = 3 // This is always NewRESTClient,Verb, and Do
+	// https://github.com/cncf/apisnoop/issues/23#issuecomment-397106705
 
 	callers = make([]uintptr, 64)
 	num_callers := goruntime.Callers(SKIP_CALLERS, callers)
@@ -697,10 +698,10 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		client = http.DefaultClient
 	}
 
-	// Add debug information to the User-Agent
-	if true { // TODO: feed an option through to turn this on
+	// Add Whakapapa to the User-Agent
+	if true { // TODO: Enable only when a VAR is set
 		userAgent := DefaultKubernetesUserAgent()
-		r.SetHeader("User-Agent", appendDebugBacktrace(userAgent))
+		r.SetHeader("User-Agent", appendWhakapapa(userAgent))
 	}
 
 	// Right now we make about ten retry attempts if we get a Retry-After response.

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -26,8 +26,11 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -626,6 +629,45 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 	}
 }
 
+// assembles a User-Agent header that contains the br.client.transport().agent acktrace of function calls
+func appendDebugBacktrace(currUserAgent string) string {
+	var lines []string
+	var callers []uintptr
+	const SKIP_CALLERS = 3 // TODO: is this the right hard-coded value?
+
+	callers = make([]uintptr, 64)
+	num_callers := goruntime.Callers(SKIP_CALLERS, callers)
+
+	cwdir, err := os.Getwd()
+	if err != nil {
+		return fmt.Sprintf("%v",err)
+	}
+
+	if num_callers > 0 {
+		frames := goruntime.CallersFrames(callers)
+
+		for {
+			frame, more := frames.Next()
+			// TODO: maybe differentiate between $GOPATH and current directory
+			relpath, err := filepath.Rel(cwdir, frame.File)
+			var line string
+			if err != nil {
+				line = fmt.Sprintf("%s():NOCWD-%s:%d:ERR-%v", frame.Function, frame.File, frame.Line, err)
+			} else {
+				line = fmt.Sprintf("%s():%s:%d", frame.Function, relpath, frame.Line)
+			}
+			lines = append(lines, line)
+
+			// Exclude functions in backtrace that are higher than "main.main"
+			if more == false || frame.Function == "main.main" {
+				break
+			}
+		}
+	}
+
+	return fmt.Sprintf("%s stacktrace=[%s]", currUserAgent, strings.Join(lines, ";"))
+}
+
 // request connects to the server and invokes the provided function when a server response is
 // received. It handles retry behavior and up front validation of requests. It will invoke
 // fn at most once. It will return an error if a problem occurred prior to connecting to the
@@ -653,6 +695,12 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 	client := r.client
 	if client == nil {
 		client = http.DefaultClient
+	}
+
+	// Add debug information to the User-Agent
+	if true { // TODO: feed an option through to turn this on
+		userAgent := DefaultKubernetesUserAgent()
+		r.SetHeader("User-Agent", appendDebugBacktrace(userAgent))
 	}
 
 	// Right now we make about ten retry attempts if we get a Retry-After response.


### PR DESCRIPTION
In our search for meaningful API usage information, we need to identify the source code location of client side requests (specifically e2e tests) as they make K8s API calls.

[APISnoop's](http://github.com/cncf/apisnoop) current method requires this information to be available via the audit-logging mechanism.

User-agent will be available in 1.13 via audit-logging -> https://github.com/kubernetes/kubernetes/pull/64812

This is related to Add user-agent to audit-logging -> #64791 but delves a bit deeper in providing a stacktrace for any program that uses k8s.io/client-go when env `KUBE_USERAGENT_STACKTRACE=true`

Release Note:
```release-note
Support KUBE_USERAGENT_STACKTRACE
```

This may be an extremely verbose user-agent, but the information it provides will enable accurate correlation between API requests and their precise origin (down to a function within a commit).

A simple example from kubectl after being parsed from user-agent in audit-logs:

```
get /api?timeout=32s
    k8s.io/kubernetes/vendor/k8s.io/client-go/rest.(*Request).Do()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/rest/request.go:805
    k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*DiscoveryClient).ServerGroups()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/discovery_client.go:138
    k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*CachedDiscoveryClient).ServerGroups()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached_discovery.go:109
    k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.ServerResources()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/discovery_client.go:230
    k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*CachedDiscoveryClient).ServerResources()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached_discovery.go:94
    k8s.io/kubernetes/vendor/k8s.io/client-go/restmapper.discoveryCategoryExpander.Expand()
        _output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/restmapper/category_expansion.go:61
    k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource.(*Builder).ReplaceAliases()
        _output/local/go/src/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go:563
    k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource.(*Builder).ResourceTypeOrNameArgs()
        _output/local/go/src/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go:533
    k8s.io/kubernetes/pkg/kubectl/cmd/get.(*GetOptions).Run()
        _output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:311
    k8s.io/kubernetes/pkg/kubectl/cmd/get.NewCmdGet.func1()
        _output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:159
    k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute()
        _output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760
    k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
        _output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846
    k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute()
        _output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794
    main.main()
        _output/local/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:50
```

The raw audit-event with user-agent set via this patch:

```json
{
   "kind":"Event",
   "apiVersion":"audit.k8s.io/v1beta1",
   "metadata":{
      "creationTimestamp":"2018-06-19T03:15:27Z"
   },
   "level":"Metadata",
   "timestamp":"2018-06-19T03:15:27Z",
   "auditID":"1ee40a9b-3afa-42b2-80d2-e980d17e580e",
   "stage":"ResponseComplete",
   "requestURI":"/api?timeout=32s",
   "verb":"get",
   "user":{
      "username":"kubecfg",
      "groups":[
         "system:masters",
         "system:authenticated"
      ]
   },
   "sourceIPs":[
      "147.75.76.213"
   ],
   "userAgent":"kubectl/v1.12.0 (linux/amd64) kubernetes/b143093 stacktrace=[k8s.io/kubernetes/vendor/k8s.io/client-go/rest.(*Request).Do():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/rest/request.go:805;k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*DiscoveryClient).ServerGroups():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/discovery_client.go:138;k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*CachedDiscoveryClient).ServerGroups():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached_discovery.go:109;k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.ServerResources():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/discovery_client.go:230;k8s.io/kubernetes/vendor/k8s.io/client-go/discovery.(*CachedDiscoveryClient).ServerResources():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached_discovery.go:94;k8s.io/kubernetes/vendor/k8s.io/client-go/restmapper.discoveryCategoryExpander.Expand():_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/restmapper/category_expansion.go:61;k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource.(*Builder).ReplaceAliases():_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go:563;k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource.(*Builder).ResourceTypeOrNameArgs():_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go:533;k8s.io/kubernetes/pkg/kubectl/cmd/get.(*GetOptions).Run():_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:311;k8s.io/kubernetes/pkg/kubectl/cmd/get.NewCmdGet.func1():_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go:159;k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute():_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760;k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC():_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846;k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute():_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794;main.main():_output/local/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:50]",
   "responseStatus":{
      "metadata":{

      },
      "code":200
   },
   "requestReceivedTimestamp":"2018-06-19T03:15:27.250302Z",
   "stageTimestamp":"2018-06-19T03:15:27.250544Z",
   "annotations":{
      "authorization.k8s.io/decision":"allow",
      "authorization.k8s.io/reason":""
   }
}
```

/cc @AishSundar @lavalamp @kubernetes/client-go-reviewers @kubernetes/sig-api-machinery-feature-requests @kubernetes/sig-architecture-feature-requests
