### PR TITLE
Promote [sig-api-machinery] Namespaces [Serial] e2e test for Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -6,6 +6,8 @@ test/e2e/apimachinery/garbage_collector.go: "should orphan RS created by deploym
 test/e2e/apimachinery/garbage_collector.go: "should keep the rc around until all its pods are deleted if the deleteOptions says so"
 test/e2e/apimachinery/garbage_collector.go: "should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted"
 test/e2e/apimachinery/garbage_collector.go: "should not be blocked by dependency circle"
+test/e2e/apimachinery/namespace.go: "should ensure that all pods are removed when a namespace is deleted"
+test/e2e/apimachinery/namespace.go: "should ensure that all services are removed when a namespace is deleted"
 test/e2e/apimachinery/watch.go: "should observe add, update, and delete watch notifications on configmaps"
 test/e2e/apimachinery/watch.go: "should be able to start watching from a specific resource version"
 test/e2e/apimachinery/watch.go: "should be able to restart watching from the last resource version observed by the previous watch"

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -262,10 +262,18 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 
 	f := framework.NewDefaultFramework("namespaces")
 
-	It("should ensure that all pods are removed when a namespace is deleted.",
+	/*
+		Testname: namespace-deletion-removes-pods
+		Description: Ensure that if a namespace is deleted then all pods are removed from that namespace.
+	*/
+	framework.ConformanceIt("should ensure that all pods are removed when a namespace is deleted",
 		func() { ensurePodsAreRemovedWhenNamespaceIsDeleted(f) })
 
-	It("should ensure that all services are removed when a namespace is deleted.",
+	/*
+		Testname: namespace-deletion-removes-services
+		Description: Ensure that if a namespace is deleted then all services are removed from that namespace.
+	*/
+	framework.ConformanceIt("should ensure that all services are removed when a namespace is deleted",
 		func() { ensureServicesAreRemovedWhenNamespaceIsDeleted(f) })
 
 	It("should delete fast enough (90 percent of 100 namespaces in 150 seconds)",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR promotes two e2e tests cases for Conformance.
1. [sig-api-machinery] Namespaces [Serial] should ensure that all pods are removed when a namespace is deleted.
2. [sig-api-machinery] Namespaces [Serial] should ensure that all services are removed when a namespace is deleted.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- No flakes found.
- https://github.com/cncf/k8s-conformance/issues/221#issuecomment-397375358

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
cc @fedebongio, @AishSundar 