### PR TITLE
sample-apiserver: Add RBAC roles and ClusterRoleBindings for Admission Webhooks

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/rbac-bind.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/rbac-bind.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sample-apiserver-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-apiserver-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: apiserver
+  namespace: wardle

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/rbac.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/rbac.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregated-apiserver-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "watch", "list"]

--- a/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
+++ b/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
@@ -78,6 +78,10 @@ kubectl create -f artifacts/example/sa.yaml -n wardle
 kubectl create -f artifacts/example/auth-delegator.yaml -n kube-system
 kubectl create -f artifacts/example/auth-reader.yaml -n kube-system
 
+# create rbac roles and clusterrolebinding that allow the service account user to use admission webhooks
+kubectl create -f artifacts/example/rbac.yaml
+kubectl create -f artifacts/example/rbac-bind.yaml
+
 # create the service and replication controller
 kubectl create -f artifacts/example/rc.yaml -n wardle
 kubectl create -f artifacts/example/service.yaml -n wardle


### PR DESCRIPTION
**What this PR does / why we need it**:

When you run the `sample-apiserver` using the [manifests provided in the artifacts directory](https://github.com/kubernetes/sample-apiserver/tree/master/artifacts/example), you will get the following errors, related to insufficient permissions to list Namespaces and Admission Webhooks:
```
E0619 07:43:06.422862       1 reflector.go:205] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:130: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:wardle:apiserver" cannot list namespaces at the cluster scope
E0619 07:43:06.423981       1 reflector.go:205] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:130: Failed to list *v1beta1.MutatingWebhookConfiguration: mutatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User "system:serviceaccount:wardle:apiserver" cannot list mutatingwebhookconfigurations.admissionregistration.k8s.io at the cluster scope
E0619 07:43:07.424130       1 reflector.go:205] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:130: Failed to list *v1beta1.ValidatingWebhookConfiguration: validatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User "system:serviceaccount:wardle:apiserver" cannot list validatingwebhookconfigurations.admissionregistration.k8s.io at the cluster scope
```

This PR adds two manifests, `rbac.yaml` containing the RBAC rules, and `rbac-bind.yaml` used to bind roles to the `wardle` service account.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: None

**Release note**:
```release-note
NONE
```

/assign @sttts @deads2k 
/sig api-machinery