### PR TITLE
fix wrong requested CPU count when node has finished jobs

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -156,6 +156,8 @@ func cleanupFinishedJobs(sj *batchv1beta1.CronJob, js []batchv1.Job, jc jobContr
 			pc,
 			*sj.Spec.SuccessfulJobsHistoryLimit,
 			recorder)
+		sj.Spec.SuccessfulJobsHistoryLimit = new(int32)
+		*sj.Spec.SuccessfulJobsHistoryLimit = 0
 	}
 
 	if sj.Spec.FailedJobsHistoryLimit != nil {
@@ -165,6 +167,8 @@ func cleanupFinishedJobs(sj *batchv1beta1.CronJob, js []batchv1.Job, jc jobContr
 			pc,
 			*sj.Spec.FailedJobsHistoryLimit,
 			recorder)
+		sj.Spec.FailedJobsHistoryLimit = new(int32)
+		*sj.Spec.FailedJobsHistoryLimit = 0
 	}
 
 	// Update the CronJob, in case jobs were removed from the list.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
/kind bug

Set the CronJob spec.SuccessfulJobsHistoryLimit to 0, so successful jobs are not kept.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65207

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
