### PR TITLE
Promote "[sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator" e2e test for Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -1,3 +1,4 @@
+test/e2e/apimachinery/aggregator.go: "Should be able to support the 1.7 Sample API Server using the current Aggregator"
 test/e2e/apimachinery/custom_resource_definition.go: "creating/deleting custom resource definition objects works"
 test/e2e/apimachinery/garbage_collector.go: "should delete pods created by rc when not orphaning"
 test/e2e/apimachinery/garbage_collector.go: "should orphan pods created by rc if delete options say so"

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -73,7 +73,11 @@ var _ = SIGDescribe("Aggregator", func() {
 		aggrclient = f.AggregatorClient
 	})
 
-	It("Should be able to support the 1.7 Sample API Server using the current Aggregator", func() {
+	/*
+		Testname: aggregator-supports-apiserver-v1.7
+		Description: Ensure that current Aggregator supports apiserver 1.7.
+	*/
+	framework.ConformanceIt("Should be able to support the 1.7 Sample API Server using the current Aggregator", func() {
 		// Make sure the relevant provider supports Agggregator
 		framework.SkipUnlessServerVersionGTE(serverAggregatorVersion, f.ClientSet.Discovery())
 		framework.SkipUnlessProviderIs("gce", "gke")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR promotes following e2e test for Conformance.
1. [sig-api-machinery] Aggregator Should be able to support the 1.7 Sample API Server using the current Aggregator

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- No flakes found.
- https://github.com/cncf/k8s-conformance/issues/221#issuecomment-397375358
- GCE and GKE cloud agnostic
- GKE Cluster info while testing flakyness:
```
Jun 19 13:14:45.026: INFO: e2e test version: v1.12.0-alpha.0.1068+69f44f421737b8
Jun 19 13:14:45.677: INFO: kube-apiserver version: v1.10.4-gke.0
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
cc @fedebongio, @AishSundar 