### PR TITLE
daemon: add counter for pod failures per node

### DIFF
--- a/pkg/controller/daemon/BUILD
+++ b/pkg/controller/daemon/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "daemon_controller.go",
         "doc.go",
+        "metrics.go",
         "update.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/controller/daemon",
@@ -27,6 +28,7 @@ go_library(
         "//pkg/util/labels:go_default_library",
         "//pkg/util/metrics:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -869,6 +869,9 @@ func (dsc *DaemonSetsController) podsShouldBeOnNode(
 				glog.V(2).Infof(msg)
 				// Emit an event so that it's discoverable to users.
 				dsc.eventRecorder.Eventf(ds, v1.EventTypeWarning, FailedDaemonPodReason, msg)
+				// Increment the metric counter if this happens as it might suggests that the node is in a bad state and the controller
+				// is fighting with kubelet for pod creation.
+				podFailedPerNodeNumber.WithLabelValues(dsKey, node.Name).Inc()
 				podsToDelete = append(podsToDelete, pod.Name)
 				failedPodsObserved++
 			} else {

--- a/pkg/controller/daemon/metrics.go
+++ b/pkg/controller/daemon/metrics.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemon
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	daemonControllerSubsystem = "daemon_controller"
+	podFailedPerNodeNumberKey = "pods_failed_per_node_number"
+)
+
+var (
+	podFailedPerNodeNumber = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: daemonControllerSubsystem,
+			Name:      podFailedPerNodeNumberKey,
+			Help:      "Number of pods observed as failed for particular daemon set per node.",
+		},
+		[]string{"daemon", "node_name"},
+	)
+)
+
+var registerMetrics sync.Once
+
+func Register() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(podFailedPerNodeNumber)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

On large clusters (100+ nodes) with many daemon sets deployed a single broken node might cause the daemon set controller fight with the kubelet running on that node (evicting/recreating pods).

This PR is adding one simple prometheus counter that will track a number of observed pod failures on particular node for a daemon set. Administrators can spot a problem on node when the counter starts
increasing and they can setup alerts when that starts to happen.

**Release note**:
```release-note
Add `daemon_controller_pods_failed_per_node_number` counter that tracks number of pods created by daemon set on particular node.
```