### PR TITLE
Add sysctls to the ouput of `describe` on PSPs

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -3530,6 +3530,12 @@ func describePodSecurityPolicy(psp *policy.PodSecurityPolicy) (string, error) {
 		if len(psp.Spec.AllowedFlexVolumes) > 0 {
 			w.Write(LEVEL_1, "Allowed FlexVolume Types:\t%s\n", flexVolumesToString(psp.Spec.AllowedFlexVolumes))
 		}
+		if len(psp.Spec.AllowedUnsafeSysctls) > 0 {
+			w.Write(LEVEL_1, "Allowed Unsafe Sysctls:\t%s\n", sysctlsToString(psp.Spec.AllowedUnsafeSysctls))
+		}
+		if len(psp.Spec.ForbiddenSysctls) > 0 {
+			w.Write(LEVEL_1, "Forbidden Sysctls:\t%s\n", sysctlsToString(psp.Spec.ForbiddenSysctls))
+		}
 		w.Write(LEVEL_1, "Allow Host Network:\t%t\n", psp.Spec.HostNetwork)
 		w.Write(LEVEL_1, "Allow Host Ports:\t%s\n", hostPortRangeToString(psp.Spec.HostPorts))
 		w.Write(LEVEL_1, "Allow Host PID:\t%t\n", psp.Spec.HostPID)
@@ -3587,6 +3593,10 @@ func flexVolumesToString(flexVolumes []policy.AllowedFlexVolume) string {
 		volumes = append(volumes, "driver="+flexVolume.Driver)
 	}
 	return stringOrDefaultValue(strings.Join(volumes, ","), "<all>")
+}
+
+func sysctlsToString(sysctls []string) string {
+	return stringOrNone(strings.Join(sysctls, ","))
 }
 
 func hostPortRangeToString(ranges []policy.HostPortRange) string {

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -2228,6 +2228,8 @@ func TestDescribePodSecurityPolicy(t *testing.T) {
 		"Required Drop Capabilities:\\s*<none>",
 		"Allowed Capabilities:\\s*<none>",
 		"Allowed Volume Types:\\s*<none>",
+		"Allowed Unsafe Sysctls:\\s*kernel\\.\\*,net\\.ipv4.ip_local_port_range",
+		"Forbidden Sysctls:\\s*net\\.ipv4\\.ip_default_ttl",
 		"Allow Host Network:\\s*false",
 		"Allow Host Ports:\\s*<none>",
 		"Allow Host PID:\\s*false",
@@ -2248,6 +2250,8 @@ func TestDescribePodSecurityPolicy(t *testing.T) {
 			Name: "mypsp",
 		},
 		Spec: policy.PodSecurityPolicySpec{
+			AllowedUnsafeSysctls: []string{"kernel.*", "net.ipv4.ip_local_port_range"},
+			ForbiddenSysctls:     []string{"net.ipv4.ip_default_ttl"},
 			SELinux: policy.SELinuxStrategyOptions{
 				Rule: policy.SELinuxStrategyRunAsAny,
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When promoting the sysctls feature for PSPs, the output of the
`kubectl describe` command was forgotten about. This commit
adds the `AllowedUnsafeSysctls` and `ForbiddenSysctls` fields
to the output of that command.

**Which issue(s) this PR fixes** :
Fixes #65181 

**Release notes**:
```release-note
NONE
```