### PR TITLE
Store the latest cloud provider node addresses

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "active_deadline.go",
+        "cloud_request_manager.go",
         "doc.go",
         "kubelet.go",
         "kubelet_getters.go",
@@ -147,6 +148,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "active_deadline_test.go",
+        "cloud_request_manager_test.go",
         "kubelet_getters_test.go",
         "kubelet_network_test.go",
         "kubelet_node_status_test.go",

--- a/pkg/kubelet/cloud_request_manager.go
+++ b/pkg/kubelet/cloud_request_manager.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	"github.com/golang/glog"
+)
+
+var nodeAddressesRetryPeriod = 5 * time.Second
+
+type cloudResourceSyncManager struct {
+	// Cloud provider interface.
+	cloud cloudprovider.Interface
+	// Sync period
+	syncPeriod time.Duration
+
+	nodeAddressesMux sync.Mutex
+	nodeAddressesErr error
+	nodeAddresses    []v1.NodeAddress
+
+	nodeName types.NodeName
+}
+
+// NewCloudResourceSyncManager creates a manager responsible for collecting resources
+// from a cloud provider through requests that are sensitive to timeouts and hanging
+func NewCloudResourceSyncManager(cloud cloudprovider.Interface, nodeName types.NodeName, syncPeriod time.Duration) *cloudResourceSyncManager {
+	return &cloudResourceSyncManager{
+		cloud:      cloud,
+		syncPeriod: syncPeriod,
+		nodeName:   nodeName,
+	}
+}
+
+func (manager *cloudResourceSyncManager) getNodeAddressSafe() ([]v1.NodeAddress, error) {
+	manager.nodeAddressesMux.Lock()
+	defer manager.nodeAddressesMux.Unlock()
+
+	return manager.nodeAddresses, manager.nodeAddressesErr
+}
+
+func (manager *cloudResourceSyncManager) setNodeAddressSafe(nodeAddresses []v1.NodeAddress, err error) {
+	manager.nodeAddressesMux.Lock()
+	defer manager.nodeAddressesMux.Unlock()
+
+	manager.nodeAddresses = nodeAddresses
+	manager.nodeAddressesErr = err
+}
+
+// NodeAddresses does not wait for cloud provider to return a node addresses.
+// It always returns node addresses or an error.
+func (manager *cloudResourceSyncManager) NodeAddresses() ([]v1.NodeAddress, error) {
+	// wait until there is something
+	for {
+		nodeAddresses, err := manager.getNodeAddressSafe()
+		if len(nodeAddresses) == 0 && err == nil {
+			glog.V(5).Infof("Waiting for %v for cloud provider to provide node addresses", nodeAddressesRetryPeriod)
+			time.Sleep(nodeAddressesRetryPeriod)
+			continue
+		}
+		return nodeAddresses, err
+	}
+}
+
+func (manager *cloudResourceSyncManager) collectNodeAddresses(ctx context.Context, nodeName types.NodeName) {
+	glog.V(2).Infof("Requesting node addresses from cloud provider for node %q", nodeName)
+
+	instances, ok := manager.cloud.Instances()
+	if !ok {
+		manager.setNodeAddressSafe(nil, fmt.Errorf("failed to get instances from cloud provider"))
+		return
+	}
+
+	// TODO(roberthbailey): Can we do this without having credentials to talk
+	// to the cloud provider?
+	// TODO(justinsb): We can if CurrentNodeName() was actually CurrentNode() and returned an interface
+	// TODO: If IP addresses couldn't be fetched from the cloud provider, should kubelet fallback on the other methods for getting the IP below?
+
+	nodeAddresses, err := instances.NodeAddresses(ctx, nodeName)
+	if err != nil {
+		manager.setNodeAddressSafe(nil, fmt.Errorf("failed to get node address from cloud provider: %v", err))
+		glog.V(2).Infof("Node addresses from cloud provider for node %q not collected", nodeName)
+	} else {
+		manager.setNodeAddressSafe(nodeAddresses, nil)
+		glog.V(2).Infof("Node addresses from cloud provider for node %q collected", nodeName)
+	}
+}
+
+func (manager *cloudResourceSyncManager) Run(stopCh <-chan struct{}) {
+	wait.Until(func() {
+		manager.collectNodeAddresses(context.TODO(), manager.nodeName)
+	}, manager.syncPeriod, stopCh)
+}

--- a/pkg/kubelet/cloud_request_manager_test.go
+++ b/pkg/kubelet/cloud_request_manager_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
+)
+
+func collectNodeAddresses(manager *cloudResourceSyncManager) ([]v1.NodeAddress, error) {
+	var nodeAddresses []v1.NodeAddress
+	var err error
+
+	collected := make(chan struct{}, 1)
+	go func() {
+		nodeAddresses, err = manager.NodeAddresses()
+		close(collected)
+	}()
+
+	select {
+	case <-collected:
+		return nodeAddresses, err
+	case <-time.Tick(2 * nodeAddressesRetryPeriod):
+		return nil, fmt.Errorf("Timeout after %v waiting for address to appear", 2*nodeAddressesRetryPeriod)
+	}
+}
+
+func createNodeInternalIPAddress(address string) []v1.NodeAddress {
+	return []v1.NodeAddress{
+		{
+			Type:    v1.NodeInternalIP,
+			Address: address,
+		},
+	}
+}
+
+func TestNodeAddressesRequest(t *testing.T) {
+	syncPeriod := 300 * time.Millisecond
+	maxRetry := 5
+	cloud := &fake.FakeCloud{
+		Addresses: createNodeInternalIPAddress("10.0.1.12"),
+		// Set the request delay so the manager timeouts and collects the node addresses later
+		RequestDelay: 400 * time.Millisecond,
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	manager := NewCloudResourceSyncManager(cloud, "defaultNode", syncPeriod)
+	go manager.Run(stopCh)
+
+	nodeAddresses, err := collectNodeAddresses(manager)
+	if err != nil {
+		t.Errorf("Unexpected err: %q\n", err)
+	}
+	if !reflect.DeepEqual(nodeAddresses, cloud.Addresses) {
+		t.Errorf("Unexpected list of node addresses %#v, expected %#v: %v", nodeAddresses, cloud.Addresses, err)
+	}
+
+	// Change the IP address
+	cloud.SetNodeAddresses(createNodeInternalIPAddress("10.0.1.13"))
+
+	// Wait until the IP address changes
+	for i := 0; i < maxRetry; i++ {
+		nodeAddresses, err := collectNodeAddresses(manager)
+		t.Logf("nodeAddresses: %#v, err: %v", nodeAddresses, err)
+		if err != nil {
+			t.Errorf("Unexpected err: %q\n", err)
+		}
+		// It is safe to read cloud.Addresses since no routine is changing the value at the same time
+		if err == nil && nodeAddresses[0].Address != cloud.Addresses[0].Address {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if err != nil {
+			t.Errorf("Unexpected err: %q\n", err)
+		}
+		return
+	}
+	t.Errorf("Timeout waiting for %q address to appear", cloud.Addresses[0].Address)
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -545,10 +545,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 
 	if klet.cloud != nil {
-		klet.cloudproviderRequestParallelism = make(chan int, 1)
-		klet.cloudproviderRequestSync = make(chan int)
-		// TODO(jchaloup): Make it configurable via --cloud-provider-request-timeout
-		klet.cloudproviderRequestTimeout = 10 * time.Second
+		klet.cloudResourceSyncManager = NewCloudResourceSyncManager(klet.cloud, nodeName, klet.nodeStatusUpdateFrequency)
 	}
 
 	var secretManager secret.Manager
@@ -1007,14 +1004,8 @@ type Kubelet struct {
 
 	// Cloud provider interface.
 	cloud cloudprovider.Interface
-	// To keep exclusive access to the cloudproviderRequestParallelism
-	cloudproviderRequestMux sync.Mutex
-	// Keep the count of requests processed in parallel (expected to be 1 at most at a given time)
-	cloudproviderRequestParallelism chan int
-	// Sync with finished requests
-	cloudproviderRequestSync chan int
-	// Request timeout
-	cloudproviderRequestTimeout time.Duration
+	// Handles requests to cloud provider with timeout
+	cloudResourceSyncManager *cloudResourceSyncManager
 
 	// Indicates that the node initialization happens in an external cloud controller
 	externalCloudProvider bool
@@ -1400,6 +1391,11 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 	// Start a goroutine responsible for killing pods (that are not properly
 	// handled by pod workers).
 	go wait.Until(kl.podKiller, 1*time.Second, wait.NeverStop)
+
+	// Start the cloud provider sync manager
+	if kl.cloudResourceSyncManager != nil {
+		go kl.cloudResourceSyncManager.Run(wait.NeverStop)
+	}
 
 	// Start component sync loops.
 	kl.statusManager.Start()

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -463,47 +463,11 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		return nil
 	}
 	if kl.cloud != nil {
-		instances, ok := kl.cloud.Instances()
-		if !ok {
-			return fmt.Errorf("failed to get instances from cloud provider")
-		}
-		// TODO(roberthbailey): Can we do this without having credentials to talk
-		// to the cloud provider?
-		// TODO(justinsb): We can if CurrentNodeName() was actually CurrentNode() and returned an interface
-		// TODO: If IP addresses couldn't be fetched from the cloud provider, should kubelet fallback on the other methods for getting the IP below?
-		var nodeAddresses []v1.NodeAddress
-		var err error
-
-		// Make sure the instances.NodeAddresses returns even if the cloud provider API hangs for a long time
-		func() {
-			kl.cloudproviderRequestMux.Lock()
-			if len(kl.cloudproviderRequestParallelism) > 0 {
-				kl.cloudproviderRequestMux.Unlock()
-				return
-			}
-			kl.cloudproviderRequestParallelism <- 0
-			kl.cloudproviderRequestMux.Unlock()
-
-			go func() {
-				nodeAddresses, err = instances.NodeAddresses(context.TODO(), kl.nodeName)
-
-				kl.cloudproviderRequestMux.Lock()
-				<-kl.cloudproviderRequestParallelism
-				kl.cloudproviderRequestMux.Unlock()
-
-				kl.cloudproviderRequestSync <- 0
-			}()
-		}()
-
-		select {
-		case <-kl.cloudproviderRequestSync:
-		case <-time.After(kl.cloudproviderRequestTimeout):
-			err = fmt.Errorf("Timeout after %v", kl.cloudproviderRequestTimeout)
-		}
-
+		nodeAddresses, err := kl.cloudResourceSyncManager.NodeAddresses()
 		if err != nil {
-			return fmt.Errorf("failed to get node address from cloud provider: %v", err)
+			return err
 		}
+
 		if kl.nodeIP != nil {
 			enforcedNodeAddresses := []v1.NodeAddress{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Buffer the recently retrieved node address so they can be used as soon as the next node status update is run.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65814

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
