### PR TITLE
kubeadm: Use the release-1.11 branch by default

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -39,7 +39,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.10"
+	DefaultKubernetesVersion = "stable-1.11"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultAuthorizationModes defines default authorization modes

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -38,7 +38,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.10"
+	DefaultKubernetesVersion = "stable-1.11"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultCertificatesDir defines default certificate directory

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -358,7 +358,7 @@ func NewCmdConfigImages(out io.Writer) *cobra.Command {
 		Short: "Interact with container images used by kubeadm.",
 		RunE:  cmdutil.SubCmdRunE("images"),
 	}
-	cmd.AddCommand(NewCmdConfigImagesList(out))
+	cmd.AddCommand(NewCmdConfigImagesList(out, nil))
 	cmd.AddCommand(NewCmdConfigImagesPull())
 	return cmd
 }
@@ -416,11 +416,17 @@ func (ip *ImagesPull) PullAll() error {
 }
 
 // NewCmdConfigImagesList returns the "kubeadm config images list" command
-func NewCmdConfigImagesList(out io.Writer) *cobra.Command {
+func NewCmdConfigImagesList(out io.Writer, mockK8sVersion *string) *cobra.Command {
 	cfg := &kubeadmapiv1alpha2.MasterConfiguration{}
 	kubeadmscheme.Scheme.Default(cfg)
 	var cfgPath, featureGatesString string
 	var err error
+
+	// This just sets the kubernetes version for unit testing so kubeadm won't try to
+	// lookup the latest release from the internet.
+	if mockK8sVersion != nil {
+		cfg.KubernetesVersion = *mockK8sVersion
+	}
 
 	cmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -55,11 +55,6 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 		configContents          []byte
 	}{
 		{
-			name:               "empty config contents",
-			expectedImageCount: defaultNumberOfImages,
-			configContents:     []byte{},
-		},
-		{
 			name:               "set k8s version",
 			expectedImageCount: defaultNumberOfImages,
 			expectedImageSubstrings: []string{
@@ -80,6 +75,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			configContents: []byte(dedent.Dedent(`
 				apiVersion: kubeadm.k8s.io/v1alpha2
 				kind: MasterConfiguration
+				kubernetesVersion: 1.11.0
 				featureGates:
 				    CoreDNS: True
 			`)),

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -34,11 +34,15 @@ import (
 
 const (
 	defaultNumberOfImages = 8
+	// dummyKubernetesVersion is just used for unit testing, in order to not make
+	// kubeadm lookup dl.k8s.io to resolve what the latest stable release is
+	dummyKubernetesVersion = "v1.10.0"
 )
 
 func TestNewCmdConfigImagesList(t *testing.T) {
 	var output bytes.Buffer
-	images := cmd.NewCmdConfigImagesList(&output)
+	mockK8sVersion := dummyKubernetesVersion
+	images := cmd.NewCmdConfigImagesList(&output, &mockK8sVersion)
 	images.Run(nil, nil)
 	actual := strings.Split(output.String(), "\n")
 	if len(actual) != defaultNumberOfImages {
@@ -63,7 +67,7 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			configContents: []byte(dedent.Dedent(`
 				apiVersion: kubeadm.k8s.io/v1alpha2
 				kind: MasterConfiguration
-				kubernetesVersion: 1.10.1
+				kubernetesVersion: v1.10.1
 			`)),
 		},
 		{
@@ -75,9 +79,9 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 			configContents: []byte(dedent.Dedent(`
 				apiVersion: kubeadm.k8s.io/v1alpha2
 				kind: MasterConfiguration
-				kubernetesVersion: 1.11.0
+				kubernetesVersion: v1.11.0
 				featureGates:
-				    CoreDNS: True
+				  CoreDNS: True
 			`)),
 		},
 	}
@@ -96,7 +100,9 @@ func TestImagesListRunWithCustomConfigPath(t *testing.T) {
 				t.Fatalf("Failed writing a config file: %v", err)
 			}
 
-			i, err := cmd.NewImagesList(configFilePath, &kubeadmapiv1alpha2.MasterConfiguration{})
+			i, err := cmd.NewImagesList(configFilePath, &kubeadmapiv1alpha2.MasterConfiguration{
+				KubernetesVersion: dummyKubernetesVersion,
+			})
 			if err != nil {
 				t.Fatalf("Failed getting the kubeadm images command: %v", err)
 			}
@@ -127,6 +133,9 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 		{
 			name:           "empty config",
 			expectedImages: defaultNumberOfImages,
+			cfg: kubeadmapiv1alpha2.MasterConfiguration{
+				KubernetesVersion: dummyKubernetesVersion,
+			},
 		},
 		{
 			name: "external etcd configuration",
@@ -136,6 +145,7 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 						Endpoints: []string{"https://some.etcd.com:2379"},
 					},
 				},
+				KubernetesVersion: dummyKubernetesVersion,
 			},
 			expectedImages: defaultNumberOfImages - 1,
 		},
@@ -145,6 +155,7 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 				FeatureGates: map[string]bool{
 					features.CoreDNS: true,
 				},
+				KubernetesVersion: dummyKubernetesVersion,
 			},
 			expectedImages: defaultNumberOfImages,
 		},
@@ -198,6 +209,7 @@ func TestMigrate(t *testing.T) {
 	cfg := []byte(dedent.Dedent(`
 		apiVersion: kubeadm.k8s.io/v1alpha2
 		kind: MasterConfiguration
+		kubernetesVersion: v1.10.0
 	`))
 	configFile, cleanup := tempConfig(t, cfg)
 	defer cleanup()

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -61,6 +61,7 @@ func SetupMasterConfigurationFile(t *testing.T, tmpdir string, cfg *kubeadmapi.M
 		  bindPort: {{.API.BindPort}}
 		nodeRegistration:
 		  name: {{.NodeRegistration.Name}}
+		kubernetesVersion: v1.10.0
 		`)))
 
 	f, err := os.Create(cfgPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Carries https://github.com/kubernetes/kubernetes/pull/63919

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/820

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: Use the release-1.11 branch by default
```
cc @kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/kubernetes-release-managers 
/kind cleanup
/priority critical-urgent
/milestone v1.11
/status approved-for-milestone
/assign @timothysc 