### PR TITLE
Bumps cri-tools version to GA in bazel build

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -61,7 +61,7 @@ http_file(
 
 http_file(
     name = "cri_tools",
-    sha256 = "bdc838174778223a1af4bdeaaed4bd266120c0e152588f78750fb86221677fb4",
+    sha256 = "672cdc7670003949bb247fb2e3e0dccab74de0075fc283d6579e88a6c1ab3256",
     urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-amd64.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION)),
 )
 

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -75,8 +75,7 @@ pkg_rpm(
     ],
     spec_file = "cri-tools.spec",
     tags = ["manual"],
-    # dashes are not allowed in rpm versions
-    version = CRI_TOOLS_VERSION.replace("-", "_"),
+    version = CRI_TOOLS_VERSION,
 )
 
 filegroup(

--- a/build/rpms/cri-tools.spec
+++ b/build/rpms/cri-tools.spec
@@ -10,8 +10,8 @@ URL: https://kubernetes.io
 Binaries to interface with the container runtime.
 
 %prep
-# TODO(chuckha): update this to use %{version} when the dash is removed from the release
-tar -xzf {crictl-v1.0.0-beta.1-linux-amd64.tar.gz}
+# This has to be hard coded because bazel does a path substitution before rpm's %{version} is substituted.
+tar -xzf {crictl-v1.11.0-linux-amd64.tar.gz}
 
 %install
 install -m 755 -d %{buildroot}%{_bindir}

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CRI_TOOLS_VERSION = "1.0.0-beta.1"
+CRI_TOOLS_VERSION = "1.11.0"


### PR DESCRIPTION
Fixes kubernetes/kubeadm#903

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
This PR bumps cri-tools version to appropriate version for k8s 1.11

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#903

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
