### PR TITLE
[GCE] update GCE Neg naming scheme in e2e test

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -940,7 +940,7 @@ func (cont *GCEIngressController) backendMode(svcPorts map[string]v1.ServicePort
 		bsMatch := &compute.BackendService{}
 		// Non-NEG BackendServices are named with the Nodeport in the name.
 		// NEG BackendServices' names contain the a sha256 hash of a string.
-		negString := strings.Join([]string{uid, cont.Ns, svcName, sp.TargetPort.String()}, ";")
+		negString := strings.Join([]string{uid, cont.Ns, svcName, fmt.Sprintf("%v", sp.Port)}, ";")
 		negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))[:8]
 		for _, bs := range beList {
 			if strings.Contains(bs.Name, strconv.Itoa(int(sp.NodePort))) ||


### PR DESCRIPTION
**What this PR does / why we need it**:
As of https://github.com/kubernetes/ingress-gce/pull/284 , NEGs will now be named with `Port` instead of `ServicePort`.

**Release note**:
```release-note
NONE
```
