### PR TITLE
Have the /rootfs rw for containerized node e2e

### DIFF
--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -205,7 +205,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 				"-v", "/etc/localtime:/etc/localtime:ro",
 				"-v", "/etc/machine-id:/etc/machine-id:ro",
 				"-v", filepath.Dir(kubeconfigPath)+":/etc/kubernetes",
-				"-v", "/:/rootfs:ro,rslave",
+				"-v", "/:/rootfs:rw,rslave",
 				"-v", "/run:/run",
 				"-v", "/sys/fs/cgroup:/sys/fs/cgroup:rw",
 				"-v", "/sys:/sys:rw",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The ``[sig-storage] HostPath [It] should support subPath [NodeConformance]`` test needs it otherwise the kubelet complains with:

```
  Jun 19 20:05:27 ip-172-18-11-17.ec2.internal docker[26836]: E0619 20:05:27.495132   26860 kubelet_pods.go:198] failed to create subPath directory for volumeMount "test-volume" of container "test-container-1": cannot create directory /rootfs/tmp/sub-path: read-only file system
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: The tests are run inside RH infrastructure so no CI tests are needed to run

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
