### PR TITLE
Fix KubeletCommand() works in k8s environments which have no external IP

### DIFF
--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -34,11 +34,10 @@ var _ = utils.SIGDescribe("GenericPersistentVolume[Disruptive]", func() {
 	)
 
 	BeforeEach(func() {
-		// Skip tests unless number of nodes is 2
-		framework.SkipUnlessNodeCountIsAtLeast(2)
-		framework.SkipIfProviderIs("local")
 		c = f.ClientSet
 		ns = f.Namespace.Name
+		// Skip tests unless number of actual nodes is 2
+		framework.SkipUnlessActualNodeCountIsAtLeast(c, 2)
 	})
 	disruptiveTestTable := []disruptiveTest{
 		{

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -56,6 +56,10 @@ func KubeletCommand(kOp KubeletOpt, c clientset.Interface, pod *v1.Pod) {
 	kubeletPid := ""
 
 	nodeIP, err := framework.GetHostExternalAddress(c, pod)
+	if err != nil {
+		// Fallback to internal address.
+		nodeIP, err = framework.GetHostInternalAddress(c, pod)
+	}
 	Expect(err).NotTo(HaveOccurred())
 	nodeIP = nodeIP + ":22"
 
@@ -158,6 +162,10 @@ func TestKubeletRestartsAndRestoresMount(c clientset.Interface, f *framework.Fra
 // forceDelete is true indicating whether the pod is forcefully deleted.
 func TestVolumeUnmountsFromDeletedPodWithForceOption(c clientset.Interface, f *framework.Framework, clientPod *v1.Pod, forceDelete bool, checkSubpath bool) {
 	nodeIP, err := framework.GetHostExternalAddress(c, clientPod)
+	if err != nil {
+		// Fallback to internal address.
+		nodeIP, err = framework.GetHostInternalAddress(c, clientPod)
+	}
 	Expect(err).NotTo(HaveOccurred())
 	nodeIP = nodeIP + ":22"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix KubeletCommand() to work in k8s environments which have no external IP.
With this fix, k8s without cloud provider will also be able to run test which
uses KubeletCommand().

This PR also change TestKubeletRestartsAndRestoresMount() to run in such environments.
This test was previously skipped, if TestContext.CloudConfig.NumNodes is not set or
cloud provider is local, even when there are more than or equal to two nodes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65232

**Special notes for your reviewer**:
/sig storage
This is split from PR #65117 @jsafrane 
This PR is aim to make disruptive tests work in k8s without cloud provider.  I hope that you agree to change this way. @gnufied 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
