### PR TITLE
Query candidate zones for EBS when zone/zones not passed

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2127,13 +2127,13 @@ func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 
 // CreateDisk implements Volumes.CreateDisk
 func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, error) {
-	allZones, err := c.getCandidateZonesForDynamicVolume()
-	if err != nil {
-		return "", fmt.Errorf("error querying for all zones: %v", err)
-	}
-
 	var createAZ string
 	if !volumeOptions.ZonePresent && !volumeOptions.ZonesPresent {
+		// querry for candidate zones only if zone parameters absent
+		allZones, err := c.getCandidateZonesForDynamicVolume()
+		if err != nil {
+			return "", fmt.Errorf("error querying for all zones: %v", err)
+		}
 		createAZ = volumeutil.ChooseZoneForVolume(allZones, volumeOptions.PVCName)
 	}
 	if !volumeOptions.ZonePresent && volumeOptions.ZonesPresent {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips invoking `getCandidateZonesForDynamicVolume` to query EC2 zones of instances when zone/zones is present.

/sig storage

**Release note**:
```
none
```
