### PR TITLE
add cleanLegacyBindAddr

### DIFF
--- a/pkg/proxy/ipvs/netlink.go
+++ b/pkg/proxy/ipvs/netlink.go
@@ -30,6 +30,8 @@ type NetLinkHandle interface {
 	EnsureDummyDevice(devName string) (exist bool, err error)
 	// DeleteDummyDevice deletes the given dummy device by name.
 	DeleteDummyDevice(devName string) error
+	// ListBindAddress will list all IP addresses which are bound in a given interface
+	ListBindAddress(devName string) ([]string, error)
 	// GetLocalAddresses returns all unique local type IP addresses based on filter device interface.  If filter device is not given,
 	// it will list all unique local type addresses.
 	GetLocalAddresses(filterDev string) (sets.String, error)

--- a/pkg/proxy/ipvs/netlink_linux.go
+++ b/pkg/proxy/ipvs/netlink_linux.go
@@ -105,6 +105,23 @@ func (h *netlinkHandle) DeleteDummyDevice(devName string) error {
 	return h.LinkDel(dummy)
 }
 
+// ListBindAddress will list all IP addresses which are bound in a given interface
+func (h *netlinkHandle) ListBindAddress(devName string) ([]string, error) {
+	dev, err := h.LinkByName(devName)
+	if err != nil {
+		return nil, fmt.Errorf("error get interface: %s, err: %v", devName, err)
+	}
+	addrs, err := h.AddrList(dev, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error list bound address of interface: %s, err: %v", devName, err)
+	}
+	ips := make([]string, 0)
+	for _, addr := range addrs {
+		ips = append(ips, addr.IP.String())
+	}
+	return ips, nil
+}
+
 // GetLocalAddresses lists all LOCAL type IP addresses from host based on filter device.
 // If filter device is not specified, it's equivalent to exec:
 // $ ip route show table local type local proto kernel

--- a/pkg/proxy/ipvs/netlink_unsupported.go
+++ b/pkg/proxy/ipvs/netlink_unsupported.go
@@ -52,6 +52,11 @@ func (h *emptyHandle) DeleteDummyDevice(devName string) error {
 	return fmt.Errorf("netlink is not supported in this platform")
 }
 
+// ListBindAddress is part of interface.
+func (h *emptyHandle) ListBindAddress(devName string) ([]string, error) {
+	return nil, fmt.Errorf("netlink is not supported in this platform")
+}
+
 // GetLocalAddresses is part of interface.
 func (h *emptyHandle) GetLocalAddresses(filterDev string) (sets.String, error) {
 	return nil, fmt.Errorf("netlink is not supported in this platform")

--- a/pkg/proxy/ipvs/testing/fake.go
+++ b/pkg/proxy/ipvs/testing/fake.go
@@ -57,6 +57,11 @@ func (h *FakeNetlinkHandle) DeleteDummyDevice(devName string) error {
 	return nil
 }
 
+// ListBindAddress is a mock implementation
+func (h *FakeNetlinkHandle) ListBindAddress(devName string) ([]string, error) {
+	return nil, nil
+}
+
 // GetLocalAddresses is a mock implementation
 func (h *FakeNetlinkHandle) GetLocalAddresses(filterDev string) (sets.String, error) {
 	res := sets.NewString()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65263

**Special notes for your reviewer**:
To fix the issue,   
use `activeBindAddrs` map which represents ip address successfully bind to DefaultDummyDevice in the round of sync  
use `currentBindAddrs` map which represents ip addresses bind to DefaultDummyDevice from the system  
create a function `cleanLegacyBindAddr` to unbind address which is in `currentBindAddrs` map but not in `activeBindAddrs` map

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig network
/area kube-proxy