### PR TITLE
Automated cherry pick of #65238: fix scheduler port boundary to match detection

### DIFF
--- a/cmd/kube-scheduler/app/options/insecure_serving.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving.go
@@ -152,7 +152,7 @@ func (o *CombinedInsecureServingOptions) Validate() []error {
 
 	errors := []error{}
 
-	if o.BindPort <= 0 || o.BindPort > 32767 {
+	if o.BindPort < 0 || o.BindPort > 32767 {
 		errors = append(errors, fmt.Errorf("--port %v must be between 0 and 32767, inclusive. 0 for turning off insecure (HTTP) port", o.BindPort))
 	}
 


### PR DESCRIPTION
Cherry pick of #65238 on release-1.11.

#65238: fix scheduler port boundary to match detection

```release-note
NONE
```