### PR TITLE
Automated cherry pick of #65189: fix paths w shortcuts when copying from pods

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -299,6 +299,7 @@ func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
 // stripPathShortcuts removes any leading or trailing "../" from a given path
 func stripPathShortcuts(p string) string {
 	newPath := path.Clean(p)
+	newPath = strings.TrimLeft(p, "../")
 	if len(newPath) > 0 && string(newPath[0]) == "/" {
 		return newPath[1:]
 	}
@@ -453,8 +454,24 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 }
 
 func getPrefix(file string) string {
+	segs := strings.Split(file, "/")
+	prefix := file
+
+	lastIdx := -1
+	for i := len(segs) - 1; i > 0; i-- {
+		if len(segs[i]) == 0 {
+			continue
+		}
+		lastIdx = i
+		break
+	}
+
+	if lastIdx >= 0 {
+		prefix = strings.Join(segs[:lastIdx], "/")
+	}
+
 	// tar strips the leading '/' if it's there, so we will too
-	return strings.TrimLeft(file, "/")
+	return strings.TrimLeft(prefix, "/")
 }
 
 func (o *CopyOptions) execute(options *ExecOptions) error {

--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -113,15 +113,49 @@ func TestGetPrefix(t *testing.T) {
 	}{
 		{
 			input:    "/foo/bar",
-			expected: "foo/bar",
+			expected: "foo",
 		},
 		{
 			input:    "foo/bar",
+			expected: "foo",
+		},
+		{
+			input:    "foo/bar/baz/",
 			expected: "foo/bar",
 		},
 	}
 	for _, test := range tests {
 		out := getPrefix(test.input)
+		if out != test.expected {
+			t.Errorf("expected: %s, saw: %s", test.expected, out)
+		}
+	}
+}
+
+func TestStripPathShortcuts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "test single path shortcut prefix",
+			input:    "../foo/bar",
+			expected: "foo/bar",
+		},
+		{
+			name:     "test multiple path shortcuts",
+			input:    "../../foo/bar",
+			expected: "foo/bar",
+		},
+		{
+			name:     "test path shortcuts in middle of path are preserved",
+			input:    "../foo/../foo/bar/baz/",
+			expected: "foo/../foo/bar/baz/",
+		},
+	}
+	for _, test := range tests {
+		out := stripPathShortcuts(test.input)
 		if out != test.expected {
 			t.Errorf("expected: %s, saw: %s", test.expected, out)
 		}
@@ -339,10 +373,7 @@ func TestCopyToLocalFileOrDir(t *testing.T) {
 				t.FailNow()
 			}
 
-			actualDestFilePath := destPath
-			if file.destDirExists {
-				actualDestFilePath = filepath.Join(destPath, filepath.Base(srcFilePath))
-			}
+			actualDestFilePath := filepath.Join(destPath, filepath.Base(srcFilePath))
 			_, err = os.Stat(actualDestFilePath)
 			if err != nil && os.IsNotExist(err) {
 				t.Errorf("expecting %s exists, but actually it's missing", actualDestFilePath)


### PR DESCRIPTION
Cherry pick of #65189 on release-1.11.

#65189: fix paths w shortcuts when copying from pods