### PR TITLE
Cleanup cri-tools bazel build

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -82,16 +82,21 @@ deb_data(
     ],
 )
 
+deb_data(
+    name = "cri-tools",
+    data = [
+        {
+            "files": ["@cri_tools//:crictl"],
+            "mode": "0755",
+            "dir": "/usr/bin",
+        },
+    ],
+)
+
 pkg_tar(
     name = "kubernetes-cni-data",
     package_dir = "/opt/cni/bin",
     deps = ["@kubernetes_cni//file"],
-)
-
-pkg_tar(
-    name = "cri-tools-data",
-    package_dir = "/usr/bin",
-    deps = ["@cri_tools//file"],
 )
 
 k8s_deb(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -59,8 +59,9 @@ http_file(
     urls = mirror("https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz"),
 )
 
-http_file(
+new_http_archive(
     name = "cri_tools",
+    build_file = "third_party/cri-tools.BUILD",
     sha256 = "672cdc7670003949bb247fb2e3e0dccab74de0075fc283d6579e88a6c1ab3256",
     urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-amd64.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION)),
 )

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -71,7 +71,7 @@ pkg_rpm(
     name = "cri-tools",
     architecture = "x86_64",
     data = [
-        "@cri_tools//file",
+        "@cri_tools//:crictl",
     ],
     spec_file = "cri-tools.spec",
     tags = ["manual"],

--- a/build/rpms/cri-tools.spec
+++ b/build/rpms/cri-tools.spec
@@ -7,15 +7,13 @@ Summary: Container Runtime Interface tools
 URL: https://kubernetes.io
 
 %description
-Binaries to interface with the container runtime.
+Binary to interface with the container runtime.
 
 %prep
-# This has to be hard coded because bazel does a path substitution before rpm's %{version} is substituted.
-tar -xzf {crictl-v1.11.0-linux-amd64.tar.gz}
 
 %install
 install -m 755 -d %{buildroot}%{_bindir}
-install -p -m 755 -t %{buildroot}%{_bindir} crictl
+install -p -m 755 -t %{buildroot}%{_bindir} {crictl}
 
 %files
 %{_bindir}/crictl

--- a/third_party/cri-tools.BUILD
+++ b/third_party/cri-tools.BUILD
@@ -1,0 +1,1 @@
+exports_files(["crictl"])


### PR DESCRIPTION
Fixes kubernetes/kubeadm#940

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>

**What this PR does / why we need it**:
We had a lingering hard coded version for crictl. This cleans up that lingering version and generally simplifies the cri-tools deb/rpm build.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#940

**Special notes for your reviewer**:
Both built and installed. To install rpm I used alien to convert to a deb then install since I was testing under ubuntu.

**Release note**:
```release-note
NONE
```

/assign @luxas 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 