### PR TITLE
Add client-go example using fake client in test.

### DIFF
--- a/staging/BUILD
+++ b/staging/BUILD
@@ -104,6 +104,7 @@ filegroup(
         "//staging/src/k8s.io/client-go/discovery:all-srcs",
         "//staging/src/k8s.io/client-go/dynamic:all-srcs",
         "//staging/src/k8s.io/client-go/examples/create-update-delete-deployment:all-srcs",
+        "//staging/src/k8s.io/client-go/examples/fake-client:all-srcs",
         "//staging/src/k8s.io/client-go/examples/in-cluster-client-configuration:all-srcs",
         "//staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration:all-srcs",
         "//staging/src/k8s.io/client-go/examples/workqueue:all-srcs",

--- a/staging/src/k8s.io/client-go/examples/README.md
+++ b/staging/src/k8s.io/client-go/examples/README.md
@@ -25,3 +25,7 @@ for client-go.
   the custom resources.
 
 [informer]: https://godoc.org/k8s.io/client-go/tools/cache#NewInformer
+
+### Testing
+
+- [**Fake Client**](./fake-client): Use a fake client in tests.

--- a/staging/src/k8s.io/client-go/examples/fake-client/BUILD
+++ b/staging/src/k8s.io/client-go/examples/fake-client/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/informers:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/client-go/examples/fake-client/README.md
+++ b/staging/src/k8s.io/client-go/examples/fake-client/README.md
@@ -1,0 +1,14 @@
+# Fake Client Example
+
+This example demonstrates how to use a fake client with SharedInformerFactory in tests.
+
+It covers:
+ * Creating the fake client
+ * Setting up real informers
+ * Injecting events into those informers
+
+## Running
+
+```
+go test -v k8s.io/client-go/examples/fake-client
+```

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakeclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+// TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
+func TestFakeClient(t *testing.T) {
+	// Use a timeout to keep the test from hanging.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	// Create the fake client.
+	client := fake.NewSimpleClientset()
+
+	// We will create an informer that writes added pods to a channel.
+	pods := make(chan *v1.Pod, 1)
+	informers := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informers.Core().V1().Pods().Informer()
+	podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*v1.Pod)
+			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
+			pods <- pod
+			cancel()
+		},
+	})
+
+	// Make sure informers are running.
+	informers.Start(ctx.Done())
+
+	// This is not required in tests, but it serves as a proof-of-concept by
+	// ensuring that the informer goroutine have warmed up and called List before
+	// we send any events to it.
+	for !podInformer.HasSynced() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Inject an event into the fake client.
+	p := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
+	_, err := client.Core().Pods("test-ns").Create(p)
+	if err != nil {
+		t.Errorf("error injecting pod add: %v", err)
+	}
+
+	// Wait and check result.
+	<-ctx.Done()
+	select {
+	case pod := <-pods:
+		t.Logf("Got pod from channel: %s/%s", pod.Namespace, pod.Name)
+	default:
+		t.Error("Informer did not get the added pod")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an example showing the steps needed to get a working
SharedInformerFactory with a fake client for testing.


**Special notes for your reviewer**:
I had a really hard time figuring out how to use this utility correctly. I don't think this example is sufficient documentation, but it's a good start.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/sig api-machinery
/kind documentation