### PR TITLE
Remove unused srv_kube_path variable

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1326,7 +1326,6 @@ function prepare-etcd-manifest {
   sed -i -e "s@{{ *cpulimit *}}@\"$4\"@g" "${temp_file}"
   sed -i -e "s@{{ *hostname *}}@$host_name@g" "${temp_file}"
   sed -i -e "s@{{ *host_ip *}}@$host_ip@g" "${temp_file}"
-  sed -i -e "s@{{ *srv_kube_path *}}@/etc/srv/kubernetes@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_cluster *}}@$etcd_cluster@g" "${temp_file}"
   sed -i -e "s@{{ *liveness_probe_initial_delay *}}@${ETCD_LIVENESS_PROBE_INITIAL_DELAY_SEC:-15}@g" "${temp_file}"
   # Get default storage backend from manifest file.
@@ -1773,7 +1772,6 @@ EOM
   local -r kube_apiserver_docker_tag="${KUBE_API_SERVER_DOCKER_TAG:-$(cat /home/kubernetes/kube-docker-files/kube-apiserver.docker_tag)}"
   sed -i -e "s@{{params}}@${params}@g" "${src_file}"
   sed -i -e "s@{{container_env}}@${container_env}@g" ${src_file}
-  sed -i -e "s@{{srv_kube_path}}@/etc/srv/kubernetes@g" "${src_file}"
   sed -i -e "s@{{srv_sshproxy_path}}@/etc/srv/sshproxy@g" "${src_file}"
   sed -i -e "s@{{cloud_config_mount}}@${CLOUD_CONFIG_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{cloud_config_volume}}@${CLOUD_CONFIG_VOLUME}@g" "${src_file}"
@@ -1943,7 +1941,6 @@ function start-kube-controller-manager {
 
   local -r src_file="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/kube-controller-manager.manifest"
   # Evaluate variables.
-  sed -i -e "s@{{srv_kube_path}}@/etc/srv/kubernetes@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${DOCKER_REGISTRY}@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube-controller-manager_docker_tag'\]}}@${kube_rc_docker_tag}@g" "${src_file}"
   sed -i -e "s@{{params}}@${params}@g" "${src_file}"
@@ -1990,7 +1987,6 @@ function start-kube-scheduler {
   # Remove salt comments and replace variables with values.
   local -r src_file="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty/kube-scheduler.manifest"
 
-  sed -i -e "s@{{srv_kube_path}}@/etc/srv/kubernetes@g" "${src_file}"
   sed -i -e "s@{{params}}@${params}@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${DOCKER_REGISTRY}@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube-scheduler_docker_tag'\]}}@${kube_scheduler_docker_tag}@g" "${src_file}"

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -80,7 +80,7 @@
         "readOnly": false
       },
       { "name": "etc",
-        "mountPath": "{{ srv_kube_path }}",
+        "mountPath": "/etc/srv/kubernetes",
         "readOnly": false
       }
     ]
@@ -98,7 +98,7 @@
   },
   { "name": "etc",
     "hostPath": {
-        "path": "{{ srv_kube_path }}"}
+        "path": "/etc/srv/kubernetes"}
   }
 ]
 }}

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -60,7 +60,7 @@
         {{admission_controller_config_mount}}
         {{image_policy_webhook_config_mount}}
         { "name": "srvkube",
-        "mountPath": "{{srv_kube_path}}",
+        "mountPath": "/etc/srv/kubernetes",
         "readOnly": true},
         { "name": "logfile",
         "mountPath": "/var/log/kube-apiserver.log",
@@ -102,7 +102,7 @@
   {{image_policy_webhook_config_volume}}
   { "name": "srvkube",
     "hostPath": {
-        "path": "{{srv_kube_path}}"}
+        "path": "/etc/srv/kubernetes"}
   },
   { "name": "logfile",
     "hostPath": {

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -44,7 +44,7 @@
         {{additional_cloud_config_mount}}
         {{pv_recycler_mount}}
         { "name": "srvkube",
-        "mountPath": "{{srv_kube_path}}",
+        "mountPath": "/etc/srv/kubernetes",
         "readOnly": true},
         {{flexvolume_hostpath_mount}}
         { "name": "logfile",
@@ -74,7 +74,7 @@
   {{pv_recycler_volume}}
   { "name": "srvkube",
     "hostPath": {
-        "path": "{{srv_kube_path}}"}
+        "path": "/etc/srv/kubernetes"}
   },
   {{flexvolume_hostpath}}
   { "name": "logfile",

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -46,7 +46,7 @@
         },
         {
           "name": "srvkube",
-          "mountPath": "{{srv_kube_path}}",
+          "mountPath": "/etc/srv/kubernetes",
           "readOnly": true
         }
       ]
@@ -55,7 +55,7 @@
 "volumes":[
   {
     "name": "srvkube",
-    "hostPath": {"path": "{{srv_kube_path}}"}
+    "hostPath": {"path": "/etc/srv/kubernetes"}
   },
   {
     "name": "logfile",


### PR DESCRIPTION
**What this PR does / why we need it**:

Clean-up of an unused script variable, as discussed with @mikedanese after [a comment in PR 64503](https://github.com/kubernetes/kubernetes/pull/64503#discussion_r194505831).

**Release note**:

```release-note
NONE
```
