### PR TITLE
Fix local volume directory can't be deleted issue

### DIFF
--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -169,6 +169,7 @@ func (plugin *localVolumePlugin) NewBlockVolumeUnmapper(volName string,
 
 // TODO: check if no path and no topology constraints are ok
 func (plugin *localVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
+	fs := v1.PersistentVolumeFilesystem
 	localVolume := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: volumeName,
@@ -179,6 +180,7 @@ func (plugin *localVolumePlugin) ConstructVolumeSpec(volumeName, mountPath strin
 					Path: "",
 				},
 			},
+			VolumeMode: &fs,
 		},
 	}
 	return volume.NewSpecFromPersistentVolume(localVolume, false), nil

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -336,6 +336,14 @@ func TestConstructVolumeSpec(t *testing.T) {
 		t.Fatalf("PersistentVolume object nil")
 	}
 
+	if spec.PersistentVolume.Spec.VolumeMode == nil {
+		t.Fatalf("Volume mode has not been set.")
+	}
+
+	if *spec.PersistentVolume.Spec.VolumeMode != v1.PersistentVolumeFilesystem {
+		t.Errorf("Unexpected volume mode %q", *spec.PersistentVolume.Spec.VolumeMode)
+	}
+
 	ls := pv.Spec.PersistentVolumeSource.Local
 	if ls == nil {
 		t.Fatalf("LocalVolumeSource object nil")


### PR DESCRIPTION

**What this PR does / why we need it**:
Need to add volume mode field to constructed pv spec.

**Special notes for your reviewer**:
I  get an issue:
1) kubelet has lots of logs with errors  related with volume mode
```
Jun 21 10:31:18  kubelet[19333]: E0621 10:31:18.422321   19333 reconciler.go:179] operationExecutor.NewVolumeHandler for UnmountVolume failed for volume "lv-e57cf589-4658-4881-b125-7b9f35c2c8eb" (UniqueName: "kubernetes.io/local-volume/4103e613-656c-11e8-8c20-74dbd180ddb4-lv-e57cf589-4658-4881-b125-7b9f35c2c8eb") pod "4103e613-656c-11e8-8c20-74dbd180ddb4" (UID: "4103e613-656c-11e8-8c20-74dbd180ddb4") : cannot get volumeMode for volume: lv-e57cf589-4658-4881-b125-7b9f35c2c8eb
Jun 21 10:31:18  kubelet[19333]: E0621 10:31:18.422351   19333 reconciler.go:179] operationExecutor.NewVolumeHandler for UnmountVolume failed for volume "lv-b1e788ac-78eb-4d26-819a-263cef5337ea" (UniqueName: "kubernetes.io/local-volume/4082c1da-656c-11e8-8c20-74dbd180ddb4-lv-b1e788ac-78eb-4d26-819a-263cef5337ea") pod "4082c1da-656c-11e8-8c20-74dbd180ddb4" (UID: "4082c1da-656c-11e8-8c20-74dbd180ddb4") : cannot get volumeMode for volume: lv-b1e788ac-78eb-4d26-819a-263cef5337ea
```
2) The pod is an orphan pod and have the volume directory left at the node

3) Because of the errors, the volume directory will never be deleted

**Release note**:
```release-note
Fix local volume directory can't be deleted because of volumeMode error
```
