### PR TITLE
Allow custom manifests in GCP master setup

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -391,7 +391,14 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${src_dir}/rescheduler.manifest" "${dst_dir}/"
   cp "${src_dir}/e2e-image-puller.manifest" "${dst_dir}/"
   cp "${src_dir}/etcd-empty-dir-cleanup.yaml" "${dst_dir}/"
+  local internal_manifest
+  for internal_manifest in $(ls "${src_dir}" | grep "^internal-*"); do
+    cp "${src_dir}/${internal_manifest}" "${dst_dir}"
+  done
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
+  if [[ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]]; then
+    cp "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" "${dst_dir}/"
+  fi
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
   local objects
   objects=$(cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)

--- a/cluster/gce/gci/BUILD
+++ b/cluster/gce/gci/BUILD
@@ -35,6 +35,7 @@ release_filegroup(
 
 pkg_tar(
     name = "gci-trusty-manifests",
+    srcs = glob(["gke-internal-configure-helper.sh"]),
     files = {
         "//cluster/gce/gci/mounter": "gci-mounter",
         "configure-helper.sh": "gci-configure-helper.sh",

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2518,6 +2518,15 @@ function setup-kubelet-dir {
     mount -B -o remount,exec,suid,dev /var/lib/kubelet
 }
 
+# Override for GKE custom master setup scripts (no-op outside of GKE).
+function gke-master-start {
+  if [[ -e "${KUBE_HOME}/bin/gke-internal-configure-helper.sh" ]]; then
+    echo "Running GKE internal configuration script"
+    . "${KUBE_HOME}/bin/gke-internal-configure-helper.sh"
+    gke-internal-master-start
+  fi
+}
+
 function reset-motd {
   # kubelet is installed both on the master and nodes, and the version is easy to parse (unlike kubectl)
   local -r version="$("${KUBE_HOME}"/bin/kubelet --version=true | cut -f2 -d " ")"
@@ -2644,6 +2653,7 @@ function main() {
     create-master-kubelet-auth
     create-master-etcd-auth
     override-pv-recycler
+    gke-master-start
   else
     create-node-pki
     create-kubelet-kubeconfig ${KUBERNETES_MASTER_NAME}

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -306,6 +306,10 @@ function install-kube-manifests {
       xargs sed -ri "s@(image\":\s+\")k8s.gcr.io@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/gci-configure-helper.sh" "${KUBE_BIN}/configure-helper.sh"
+  if [[ -e "${dst_dir}/kubernetes/gci-trusty/gke-internal-configure-helper.sh" ]]; then
+    cp "${dst_dir}/kubernetes/gci-trusty/gke-internal-configure-helper.sh" "${KUBE_BIN}/"
+  fi
+
   cp "${dst_dir}/kubernetes/gci-trusty/health-monitor.sh" "${KUBE_BIN}/health-monitor.sh"
 
   rm -f "${KUBE_HOME}/${manifests_tar}"

--- a/cluster/gce/manifests/BUILD
+++ b/cluster/gce/manifests/BUILD
@@ -26,7 +26,7 @@ filegroup(
         "kube-proxy.manifest",
         "kube-scheduler.manifest",
         "rescheduler.manifest",
-    ],
+    ] + glob(["internal-*"]),
 )
 
 filegroup(


### PR DESCRIPTION
Add a hook in GCE setup script to allow using custom manifests on master, so we can decouple some GKE changes from k8s. Note that this PR just adds a hook there is no change in default behavior.

```release-note
```
