### PR TITLE
Fix cleanup of volume metadata json file.

### DIFF
--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -523,10 +523,6 @@ func TestAttacherMountDevice(t *testing.T) {
 			deviceMountPath: "path2",
 			stageUnstageSet: false,
 		},
-		{
-			testName:        "stage_unstage not set no vars should not fail",
-			stageUnstageSet: false,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Create the json file with metadata as the last item, when everything else is ready, so we don't need to clean up the file in all error cases in this function.

Fixes #65322

**Release note**:
```release-note
Fixed cleanup of CSI metadata files.
```

/assign @saad-ali @vladimirvivien 
