### PR TITLE
fix printer check to tolerate vendoring

### DIFF
--- a/pkg/kubectl/cmd/cmd_printing_test.go
+++ b/pkg/kubectl/cmd/cmd_printing_test.go
@@ -83,39 +83,41 @@ func TestIllegalPackageSourceCheckerThroughPrintFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		printFlags := genericclioptions.NewPrintFlags("succeeded").WithTypeSetter(scheme.Scheme)
-		printFlags.OutputFormat = &tc.output
+		t.Run(tc.name, func(t *testing.T) {
+			printFlags := genericclioptions.NewPrintFlags("succeeded").WithTypeSetter(scheme.Scheme)
+			printFlags.OutputFormat = &tc.output
 
-		printer, err := printFlags.ToPrinter()
-		if err != nil {
-			t.Fatalf("unexpected error %v", err)
-		}
-
-		output := bytes.NewBuffer([]byte{})
-
-		err = printer.PrintObj(tc.obj, output)
-		if err != nil {
-			if !tc.expectInternalObjErr {
+			printer, err := printFlags.ToPrinter()
+			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
 
-			if !genericprinters.IsInternalObjectError(err) {
-				t.Fatalf("unexpected error - expecting internal object printer error, got %q", err)
+			output := bytes.NewBuffer([]byte{})
+
+			err = printer.PrintObj(tc.obj, output)
+			if err != nil {
+				if !tc.expectInternalObjErr {
+					t.Fatalf("unexpected error %v", err)
+				}
+
+				if !genericprinters.IsInternalObjectError(err) {
+					t.Fatalf("unexpected error - expecting internal object printer error, got %q", err)
+				}
+				return
 			}
-			continue
-		}
 
-		if tc.expectInternalObjErr {
-			t.Fatalf("expected internal object printer error, but got no error")
-		}
+			if tc.expectInternalObjErr {
+				t.Fatalf("expected internal object printer error, but got no error")
+			}
 
-		if len(tc.expectedOutput) == 0 {
-			continue
-		}
+			if len(tc.expectedOutput) == 0 {
+				return
+			}
 
-		if tc.expectedOutput != output.String() {
-			t.Fatalf("unexpected output: expecting %q, got %q", tc.expectedOutput, output.String())
-		}
+			if tc.expectedOutput != output.String() {
+				t.Fatalf("unexpected output: expecting %q, got %q", tc.expectedOutput, output.String())
+			}
+		})
 	}
 }
 
@@ -181,31 +183,33 @@ func TestIllegalPackageSourceCheckerDirectlyThroughPrinters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		output := bytes.NewBuffer([]byte{})
+		t.Run(tc.name, func(t *testing.T) {
+			output := bytes.NewBuffer([]byte{})
 
-		err := tc.printer.PrintObj(tc.obj, output)
-		if err != nil {
-			if !tc.expectInternalObjErr {
-				t.Fatalf("unexpected error %v", err)
+			err := tc.printer.PrintObj(tc.obj, output)
+			if err != nil {
+				if !tc.expectInternalObjErr {
+					t.Fatalf("unexpected error %v", err)
+				}
+
+				if !genericprinters.IsInternalObjectError(err) {
+					t.Fatalf("unexpected error - expecting internal object printer error, got %q", err)
+				}
+				return
 			}
 
-			if !genericprinters.IsInternalObjectError(err) {
-				t.Fatalf("unexpected error - expecting internal object printer error, got %q", err)
+			if tc.expectInternalObjErr {
+				t.Fatalf("expected internal object printer error, but got no error")
 			}
-			continue
-		}
 
-		if tc.expectInternalObjErr {
-			t.Fatalf("expected internal object printer error, but got no error")
-		}
+			if len(tc.expectedOutput) == 0 {
+				return
+			}
 
-		if len(tc.expectedOutput) == 0 {
-			continue
-		}
-
-		if tc.expectedOutput != output.String() {
-			t.Fatalf("unexpected output: expecting %q, got %q", tc.expectedOutput, output.String())
-		}
+			if tc.expectedOutput != output.String() {
+				t.Fatalf("unexpected output: expecting %q, got %q", tc.expectedOutput, output.String())
+			}
+		})
 	}
 }
 

--- a/pkg/kubectl/genericclioptions/printers/sourcechecker.go
+++ b/pkg/kubectl/genericclioptions/printers/sourcechecker.go
@@ -51,7 +51,7 @@ type illegalPackageSourceChecker struct {
 
 func (c *illegalPackageSourceChecker) IsForbidden(pkgPath string) bool {
 	for _, forbiddenPrefix := range c.disallowedPrefixes {
-		if strings.HasPrefix(pkgPath, forbiddenPrefix) {
+		if strings.HasPrefix(pkgPath, forbiddenPrefix) || strings.Contains(pkgPath, "/vendor/"+forbiddenPrefix) {
 			return true
 		}
 	}


### PR DESCRIPTION
After you've vendored code, the package includes a vendor dir.  This updates the code to tolerate that.

/assign @soltysh @juanvallejo 


```release-note
NONE
```