### PR TITLE
Update cAdvisor godeps to v0.28.5

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1382,218 +1382,218 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.28.4",
-			"Rev": "0b8d4a2d514fcbfffac2601478e0b1d62d9e94f6"
+			"Comment": "v0.28.5",
+			"Rev": "7ae91cb14ebf50a974438e21334f64a441c8db62"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",
@@ -1915,6 +1915,7 @@
 		},
 		{
 			"ImportPath": "github.com/juju/ratelimit",
+			"Comment": "1.0",
 			"Rev": "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 		},
 		{

--- a/vendor/github.com/google/cadvisor/container/crio/handler.go
+++ b/vendor/github.com/google/cadvisor/container/crio/handler.go
@@ -81,9 +81,6 @@ type crioContainerHandler struct {
 	ipAddress string
 
 	ignoreMetrics container.MetricSet
-
-	// container restart count
-	restartCount int
 }
 
 var _ container.ContainerHandler = &crioContainerHandler{}
@@ -175,7 +172,10 @@ func newCrioContainerHandler(
 	// ignore err and get zero as default, this happens with sandboxes, not sure why...
 	// kube isn't sending restart count in labels for sandboxes.
 	restartCount, _ := strconv.Atoi(cInfo.Annotations["io.kubernetes.container.restartCount"])
-	handler.restartCount = restartCount
+	// Only adds restartcount label if it's greater than 0
+	if restartCount > 0 {
+		handler.labels["restartcount"] = strconv.Itoa(restartCount)
+	}
 
 	handler.ipAddress = cInfo.IP
 
@@ -225,10 +225,6 @@ func (self *crioContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
 
 	spec.Labels = self.labels
-	// Only adds restartcount label if it's greater than 0
-	if self.restartCount > 0 {
-		spec.Labels["restartcount"] = strconv.Itoa(self.restartCount)
-	}
 	spec.Envs = self.envs
 	spec.Image = self.image
 

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -114,9 +114,6 @@ type dockerContainerHandler struct {
 
 	// zfs watcher
 	zfsWatcher *zfs.ZfsWatcher
-
-	// container restart count
-	restartCount int
 }
 
 var _ container.ContainerHandler = &dockerContainerHandler{}
@@ -249,7 +246,10 @@ func newDockerContainerHandler(
 	handler.image = ctnr.Config.Image
 	handler.networkMode = ctnr.HostConfig.NetworkMode
 	handler.deviceID = ctnr.GraphDriver.Data["DeviceId"]
-	handler.restartCount = ctnr.RestartCount
+	// Only adds restartcount label if it's greater than 0
+	if ctnr.RestartCount > 0 {
+		handler.labels["restartcount"] = strconv.Itoa(ctnr.RestartCount)
+	}
 
 	// Obtain the IP address for the contianer.
 	// If the NetworkMode starts with 'container:' then we need to use the IP address of the container specified.
@@ -385,10 +385,6 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
 
 	spec.Labels = self.labels
-	// Only adds restartcount label if it's greater than 0
-	if self.restartCount > 0 {
-		spec.Labels["restartcount"] = strconv.Itoa(self.restartCount)
-	}
 	spec.Envs = self.envs
 	spec.Image = self.image
 	spec.CreationTime = self.creationTime

--- a/vendor/github.com/google/cadvisor/fs/fs.go
+++ b/vendor/github.com/google/cadvisor/fs/fs.go
@@ -526,6 +526,21 @@ func (self *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
 	}
 
 	mount, found := self.mounts[dir]
+	// try the parent dir if not found until we reach the root dir
+	// this is an issue on btrfs systems where the directory is not
+	// the subvolume
+	for !found {
+		pathdir, _ := filepath.Split(dir)
+		// break when we reach root
+		if pathdir == "/" {
+			break
+		}
+		// trim "/" from the new parent path otherwise the next possible
+		// filepath.Split in the loop will not split the string any further
+		dir = strings.TrimSuffix(pathdir, "/")
+		mount, found = self.mounts[dir]
+	}
+
 	if found && mount.Fstype == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
 		major, minor, err := getBtrfsMajorMinorIds(mount)
 		if err != nil {

--- a/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
+++ b/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
@@ -110,6 +110,11 @@ func (self *rawContainerWatcher) Stop() error {
 // Watches the specified directory and all subdirectories. Returns whether the path was
 // already being watched and an error (if any).
 func (self *rawContainerWatcher) watchDirectory(dir string, containerName string) (bool, error) {
+	// Don't watch .mount cgroups because they never have containers as sub-cgroups.  A single container
+	// can have many .mount cgroups associated with it which can quickly exhaust the inotify watches on a node.
+	if strings.HasSuffix(containerName, ".mount") {
+		return false, nil
+	}
 	alreadyWatching, err := self.watcher.AddWatch(containerName, dir)
 	if err != nil {
 		return alreadyWatching, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the cAdvisor godeps from v0.28.4 to v0.28.5 to incorporate a number of important bug-fixes.

**Release note**:
```release-note
Fix concurrent map access panic
Don't watch .mount cgroups to reduce number of inotify watches
Fix NVML initialization race condition
Fix brtfs disk metrics when using a subdirectory of a subvolume
```
/assign @dchen1107
for lgtm
/assign @mbohlool 
for milestone, milestone approval, and cherrypick-approval