### PR TITLE
Update cadvisor godeps (master) to v0.30.2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1508,249 +1508,257 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/accelerators",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/containerd",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.30.1",
-			"Rev": "49c4fae21f151168b09758b7da1968fed8cd56a0"
+			"Comment": "v0.30.2",
+			"Rev": "de723a090f4dd5390dc7c2acee37ba9c62f0cc09"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/asn1",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/client",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/client/configpb",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/jsonclient",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/tls",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/x509",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency-go/x509/pkix",
+			"Comment": "v1.0.10",
 			"Rev": "1bec4527572c443752ad4f2830bef88be0533236"
 		},
 		{
@@ -1992,6 +2000,7 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
@@ -2861,6 +2870,7 @@
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",
+			"Comment": "0.0.1",
 			"Rev": "07dd2e8dfe18522e9c447ba95f2fe95262f63bb2"
 		},
 		{

--- a/vendor/github.com/google/cadvisor/container/crio/handler.go
+++ b/vendor/github.com/google/cadvisor/container/crio/handler.go
@@ -65,9 +65,6 @@ type crioContainerHandler struct {
 
 	ignoreMetrics container.MetricSet
 
-	// container restart count
-	restartCount int
-
 	reference info.ContainerReference
 
 	libcontainerHandler *containerlibcontainer.Handler
@@ -166,7 +163,10 @@ func newCrioContainerHandler(
 	// ignore err and get zero as default, this happens with sandboxes, not sure why...
 	// kube isn't sending restart count in labels for sandboxes.
 	restartCount, _ := strconv.Atoi(cInfo.Annotations["io.kubernetes.container.restartCount"])
-	handler.restartCount = restartCount
+	// Only adds restartcount label if it's greater than 0
+	if restartCount > 0 {
+		handler.labels["restartcount"] = strconv.Itoa(restartCount)
+	}
 
 	handler.ipAddress = cInfo.IP
 
@@ -210,10 +210,6 @@ func (self *crioContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec, err := common.GetSpec(self.cgroupPaths, self.machineInfoFactory, self.needNet(), hasFilesystem)
 
 	spec.Labels = self.labels
-	// Only adds restartcount label if it's greater than 0
-	if self.restartCount > 0 {
-		spec.Labels["restartcount"] = strconv.Itoa(self.restartCount)
-	}
 	spec.Envs = self.envs
 	spec.Image = self.image
 

--- a/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
+++ b/vendor/github.com/google/cadvisor/manager/watcher/raw/raw.go
@@ -110,6 +110,11 @@ func (self *rawContainerWatcher) Stop() error {
 // Watches the specified directory and all subdirectories. Returns whether the path was
 // already being watched and an error (if any).
 func (self *rawContainerWatcher) watchDirectory(events chan watcher.ContainerEvent, dir string, containerName string) (bool, error) {
+	// Don't watch .mount cgroups because they never have containers as sub-cgroups.  A single container
+	// can have many .mount cgroups associated with it which can quickly exhaust the inotify watches on a node.
+	if strings.HasSuffix(containerName, ".mount") {
+		return false, nil
+	}
 	alreadyWatching, err := self.watcher.AddWatch(containerName, dir)
 	if err != nil {
 		return alreadyWatching, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cadvisor godeps to v0.30.2.  This is needed to fix a number of bugs.
Normally, we wait to do this until the quarterly cAdvisor release, but we want to get some soak time on these bug fixes so that we know it is safe to cherry-pick them to previous releases:
https://github.com/kubernetes/kubernetes/pull/65331
https://github.com/kubernetes/kubernetes/pull/65328
https://github.com/kubernetes/kubernetes/pull/65327

**Release note**:
```release-note
Fix concurrent map access panic
Don't watch .mount cgroups to reduce number of inotify watches
Fix NVML initialization race condition
Fix brtfs disk metrics when using a subdirectory of a subvolume
```
/kind bug
/sig node
/priority important-soon
/assign @dchen1107 

cc @yujuhong @mindprince 