### PR TITLE
Remove cloud-controller-manager deb from releases

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -13,7 +13,6 @@ load("//build:workspace.bzl", "CRI_TOOLS_VERSION")
 release_filegroup(
     name = "debs",
     srcs = [
-        ":cloud-controller-manager.deb",
         ":cri-tools.deb",
         ":kubeadm.deb",
         ":kubectl.deb",


### PR DESCRIPTION
**What this PR does / why we need it**:
Stop including cloud controller manager deb from Kubernetes releases. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubernetes/issues/65337 

```release-note
NONE
```
