### PR TITLE
Remove item from taint manager workqueue on completion

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -224,9 +224,11 @@ func (tc *NoExecuteTaintManager) Run(stopCh <-chan struct{}) {
 			hash := hash(nodeUpdate.name())
 			select {
 			case <-stopCh:
+				tc.nodeUpdateQueue.Done(item)
 				break
 			case tc.nodeUpdateChannels[hash%workers] <- nodeUpdate:
 			}
+			tc.nodeUpdateQueue.Done(item)
 		}
 	}(stopCh)
 
@@ -240,9 +242,11 @@ func (tc *NoExecuteTaintManager) Run(stopCh <-chan struct{}) {
 			hash := hash(podUpdate.nodeName())
 			select {
 			case <-stopCh:
+				tc.podUpdateQueue.Done(item)
 				break
 			case tc.podUpdateChannels[hash%workers] <- podUpdate:
 			}
+			tc.podUpdateQueue.Done(item)
 		}
 	}(stopCh)
 


### PR DESCRIPTION
fixes a memory leak observed in the controller manager when creating/deleting pods containing tolerations

xref #65325

```release-note
fixes a memory leak in the kube-controller-manager observed when large numbers of pods with tolerations are created/deleted
```