### PR TITLE
[FEATURE SERVERSIDE APPLY] Pass dry-run flag to serverside apply when appropriate

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -340,15 +340,13 @@ func (o *ApplyOptions) Run() error {
 			if err != nil {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}
-			// TODO: Pass in dry-run flag if it exists.
 			// TODO: If we get a 415 (unsupported media type), then the server doesn't understand
 			// serverside apply; continue flow after this block.
-			obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(
-				info.Namespace,
-				info.Name,
-				types.ApplyPatchType,
-				data,
-			)
+			h := resource.NewHelper(info.Client, info.Mapping)
+			if o.DryRun {
+				h.DryRun()
+			}
+			obj, err := h.Patch(info.Namespace, info.Name, types.ApplyPatchType, data)
 			if err != nil {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -342,11 +342,9 @@ func (o *ApplyOptions) Run() error {
 			}
 			// TODO: If we get a 415 (unsupported media type), then the server doesn't understand
 			// serverside apply; continue flow after this block.
-			h := resource.NewHelper(info.Client, info.Mapping)
-			if o.DryRun {
-				h.DryRun()
-			}
-			obj, err := h.Patch(info.Namespace, info.Name, types.ApplyPatchType, data)
+			obj, err := resource.NewHelper(info.Client, info.Mapping).
+				DryRun(o.DryRun).
+				Patch(info.Namespace, info.Name, types.ApplyPatchType, data)
 			if err != nil {
 				return cmdutil.AddSourceToErr("serverside-apply", info.Source, err)
 			}

--- a/pkg/kubectl/genericclioptions/resource/helper.go
+++ b/pkg/kubectl/genericclioptions/resource/helper.go
@@ -52,8 +52,8 @@ func NewHelper(client RESTClient, mapping *meta.RESTMapping) *Helper {
 	}
 }
 
-func (m *Helper) DryRun() *Helper {
-	m.dryRun = true
+func (m *Helper) DryRun(dryRun bool) *Helper {
+	m.dryRun = dryRun
 	return m
 }
 


### PR DESCRIPTION
Plumbs the `dry-run` flag to the apiserver for server-side apply.
```release-note
NONE
```