### PR TITLE
apiserver: fix typo introduced in #57366

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -771,7 +771,7 @@ func (c *errWatcher) Stop() {
 	// no-op
 }
 
-// cachWatcher implements watch.Interface
+// cacheWatcher implements watch.Interface
 type cacheWatcher struct {
 	sync.Mutex
 	input     chan *watchCacheEvent


### PR DESCRIPTION
fix typo introduced in #57366

```release-note
NONE
```
