### PR TITLE
Fix DeletionTimestamp printing

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -643,7 +643,7 @@ func describePod(pod *api.Pod, events *api.EventList) (string, error) {
 		printLabelsMultiline(w, "Labels", pod.Labels)
 		printAnnotationsMultiline(w, "Annotations", pod.Annotations)
 		if pod.DeletionTimestamp != nil {
-			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestamp(*pod.DeletionTimestamp))
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampUntil(*pod.DeletionTimestamp))
 			w.Write(LEVEL_0, "Termination Grace Period:\t%ds\n", *pod.DeletionGracePeriodSeconds)
 		} else {
 			w.Write(LEVEL_0, "Status:\t%s\n", string(pod.Status.Phase))
@@ -1202,7 +1202,7 @@ func describePersistentVolume(pv *api.PersistentVolume, events *api.EventList) (
 		w.Write(LEVEL_0, "Finalizers:\t%v\n", pv.ObjectMeta.Finalizers)
 		w.Write(LEVEL_0, "StorageClass:\t%s\n", helper.GetPersistentVolumeClass(pv))
 		if pv.ObjectMeta.DeletionTimestamp != nil {
-			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestamp(*pv.ObjectMeta.DeletionTimestamp))
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampUntil(*pv.ObjectMeta.DeletionTimestamp))
 		} else {
 			w.Write(LEVEL_0, "Status:\t%v\n", pv.Status.Phase)
 		}
@@ -1303,7 +1303,7 @@ func describePersistentVolumeClaim(pvc *api.PersistentVolumeClaim, events *api.E
 		w.Write(LEVEL_0, "Namespace:\t%s\n", pvc.Namespace)
 		w.Write(LEVEL_0, "StorageClass:\t%s\n", helper.GetPersistentVolumeClaimClass(pvc))
 		if pvc.ObjectMeta.DeletionTimestamp != nil {
-			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestamp(*pvc.ObjectMeta.DeletionTimestamp))
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampUntil(*pvc.ObjectMeta.DeletionTimestamp))
 		} else {
 			w.Write(LEVEL_0, "Status:\t%v\n", pvc.Status.Phase)
 		}
@@ -3083,9 +3083,9 @@ func DescribeEvents(el *api.EventList, w PrefixWriter) {
 	for _, e := range el.Items {
 		var interval string
 		if e.Count > 1 {
-			interval = fmt.Sprintf("%s (x%d over %s)", translateTimestamp(e.LastTimestamp), e.Count, translateTimestamp(e.FirstTimestamp))
+			interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, translateTimestampSince(e.FirstTimestamp))
 		} else {
-			interval = translateTimestamp(e.FirstTimestamp)
+			interval = translateTimestampSince(e.FirstTimestamp)
 		}
 		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,


### PR DESCRIPTION
**What this PR does / why we need it**:

I found a bug that `ObjectMeta.DeletionTimestamp` is not displayed correctly because it's a future time but it uses the time difference until now. So I fixed it by calculating the time difference from now instead of until now.

Before this fix:
```
Name:                      test-pod-7bd594bd96-hf5kk
Namespace:                 default
Node:                      kube-node-2/10.192.0.4
Start Time:                Fri, 22 Jun 2018 14:57:09 +0900
Labels:                    pod-template-hash=3681506852
                           run=test-pod
Annotations:               <none>
Status:                    Terminating (lasts <invalid>)
Termination Grace Period:  30s
IP:                        10.244.3.5
Controlled By:             ReplicaSet/test-pod-7bd594bd96
Containers:
...
```

After this fix:
```
Name:                      test-pod-7bd594bd96-85cdd
Namespace:                 default
Node:                      kube-node-2/10.192.0.4
Start Time:                Fri, 22 Jun 2018 14:56:44 +0900
Labels:                    pod-template-hash=3681506852
                           run=test-pod
Annotations:               <none>
Status:                    Terminating (lasts 2m)
Termination Grace Period:  123s
IP:                        10.244.3.4
Controlled By:             ReplicaSet/test-pod-7bd594bd96
...
```

Could you consider merging it?
We heavily use preemptible jobs in my company and knowing deletion time and grace periods is really important when jobs trap `SIGTERM` and decide if it should continue to run until the deletion time or just stop immediately.

**Which issue(s) this PR fixes**
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
```release-note
NONE
```
