### PR TITLE
Allow more fields at root of CRD schema if status is enabled

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -832,32 +832,71 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			name: "root type without status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					Type: "object",
+					Type: "string",
 				},
 			},
 			statusEnabled: false,
 			wantError:     false,
 		},
 		{
-			name: "root type with status",
+			name: "root type having invalid value, with status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-					Type: "object",
+					Type: "string",
 				},
 			},
 			statusEnabled: true,
 			wantError:     true,
 		},
 		{
-			name: "properties, required and description with status",
+			name: "non-allowed root field with status",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					AnyOf: []apiextensions.JSONSchemaProps{
+						{
+							Description: "First schema",
+						},
+						{
+							Description: "Second schema",
+						},
+					},
+				},
+			},
+			statusEnabled: true,
+			wantError:     true,
+		},
+		{
+			name: "all allowed fields at the root of the schema with status",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Description:      "This is a description",
+					Type:             "object",
+					Format:           "date-time",
+					Title:            "This is a title",
+					Maximum:          float64Ptr(10),
+					ExclusiveMaximum: true,
+					Minimum:          float64Ptr(5),
+					ExclusiveMinimum: true,
+					MaxLength:        int64Ptr(10),
+					MinLength:        int64Ptr(5),
+					Pattern:          "^[a-z]$",
+					MaxItems:         int64Ptr(10),
+					MinItems:         int64Ptr(5),
+					MultipleOf:       float64Ptr(3),
+					Required:         []string{"spec", "status"},
+					Items: &apiextensions.JSONSchemaPropsOrArray{
+						Schema: &apiextensions.JSONSchemaProps{
+							Description: "This is a schema nested under Items",
+						},
+					},
 					Properties: map[string]apiextensions.JSONSchemaProps{
 						"spec":   {},
 						"status": {},
 					},
-					Required:    []string{"spec", "status"},
-					Description: "This is a description",
+					ExternalDocs: &apiextensions.ExternalDocumentation{
+						Description: "This is an external documentation description",
+					},
+					Example: &example,
 				},
 			},
 			statusEnabled: true,
@@ -874,4 +913,14 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+var example = apiextensions.JSON(`"This is an example"`)
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func int64Ptr(f int64) *int64 {
+	return &f
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -321,7 +321,7 @@ func TestScaleSubresource(t *testing.T) {
 	}
 }
 
-func TestValidationSchema(t *testing.T) {
+func TestValidationSchemaWithStatus(t *testing.T) {
 	stopCh, config, err := testserver.StartDefaultServer()
 	if err != nil {
 		t.Fatal(err)
@@ -344,7 +344,7 @@ func TestValidationSchema(t *testing.T) {
 	}
 	_, err = testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err == nil {
-		t.Fatalf(`unexpected non-error, expected: must only have "properties" or "required" at the root if the status subresource is enabled`)
+		t.Fatalf(`unexpected non-error, expected: must not have "additionalProperties" at the root of the schema if the status subresource is enabled`)
 	}
 
 	// make sure we are not restricting fields to properties even in subschemas


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/65293

Currently, we allow only `properties`, `required` and `description` at the root of the CRD schema when the status subresource is enabled.

We can also include some other fields, even though sometimes they might not make sense (but they don't harm).

The main idea is that when validation schema for status is extracted as `properties["status"]`, validation for status is not lost.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
More fields are allowed at the root of the CRD validation schema when the status subresource is enabled.
```