### PR TITLE
Update COC link

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 # Kubernetes Community Code of Conduct
 
-Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)
+Kubernetes follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
The k/k COC today points to the kubernetes/community repo, which says that Kubernetes uses the CNCF COC.
This PR updates the k/k COC to point directly to the CNCF COC with the same text.

```release-note
NONE
```