### PR TITLE
Fix exception detection in new version of fluentd-gcp addon

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -108,7 +108,7 @@ data:
       @type detect_exceptions
 
       remove_tag_prefix raw
-      message log
+      message message
       stream stream
       multiline_flush_interval 5
       max_bytes 500000


### PR DESCRIPTION
**What this PR does / why we need it**:
The `detect_exceptions` plugin is used to group log entries that belong to a common exception together into one log message. A [recent change](https://github.com/kubernetes/kubernetes/blob/1ca851baec6a245bbb2bd3aea284e6cb4f364348/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml#L100) to the configuration modified which field is used for the log message, but this change was not applied to the configuration of the `detect_exceptions` plugin, so currently no collation of exception lines is happening.

This change fixes the issue by changing the field the `detect_exceptions` plugin is using.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed exception detection in fluentd-gcp plugin.
```
