### PR TITLE
delete should tolerate a failed wait because of missing verbs

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -282,7 +282,7 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		IOStreams:   o.IOStreams,
 	}
 	err = waitOptions.RunWait()
-	if errors.IsForbidden(err) {
+	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {
 		// if we're forbidden from waiting, we shouldn't fail.
 		glog.V(1).Info(err)
 		return nil


### PR DESCRIPTION
The power and ability to delete does not imply the power and ability to watch.  We correctly handled missing power (authz), but failed to account for ability (method not supported)

@kubernetes/sig-cli-maintainers 
@soltysh 

```release-note
Tolerate missing watch permission when deleting a resource
```