### PR TITLE
Remove unneeded sleep from test.

### DIFF
--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -74,9 +74,6 @@ func testStackdriverAcceleratorMonitoring(f *framework.Framework) {
 
 	scheduling.SetupNVIDIAGPUNode(f, false)
 
-	// TODO: remove this after cAdvisor race is fixed.
-	time.Sleep(time.Minute)
-
 	f.PodClient().Create(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: rcName,


### PR DESCRIPTION
The race condition that required this sleep was fixed in google/cadvisor#1969.
That was vendored in #65334.

```release-note
NONE
```

/assign @jiayingz @vishh 