### PR TITLE
Change prometheus versions from latest to tag

### DIFF
--- a/cluster/addons/istio/auth/istio-auth.yaml
+++ b/cluster/addons/istio/auth/istio-auth.yaml
@@ -2595,7 +2595,7 @@ spec:
           name: istio-statsd-prom-bridge
       containers:
       - name: statsd-prom-bridge
-        image: "gcr.io/istio-release/prom/statsd-exporter:latest"
+        image: "gcr.io/istio-release/prom/statsd-exporter:v0.6.0"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9102
@@ -3477,7 +3477,7 @@ spec:
 
       containers:
         - name: prometheus
-          image: "gcr.io/istio-release/prom/prometheus:latest"
+          image: "gcr.io/istio-release/prom/prometheus:v2.3.1"
           imagePullPolicy: IfNotPresent
           args:
             - '--storage.tsdb.retention=6h'

--- a/cluster/addons/istio/noauth/istio.yaml
+++ b/cluster/addons/istio/noauth/istio.yaml
@@ -2582,7 +2582,7 @@ spec:
           name: istio-statsd-prom-bridge
       containers:
       - name: statsd-prom-bridge
-        image: "gcr.io/istio-release/prom/statsd-exporter:latest"
+        image: "gcr.io/istio-release/prom/statsd-exporter:v0.6.0"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9102
@@ -3464,7 +3464,7 @@ spec:
 
       containers:
         - name: prometheus
-          image: "gcr.io/istio-release/prom/prometheus:latest"
+          image: "gcr.io/istio-release/prom/prometheus:v2.3.1"
           imagePullPolicy: IfNotPresent
           args:
             - '--storage.tsdb.retention=6h'


### PR DESCRIPTION
**What this PR does / why we need it:**
Istio 0.8.0 yaml references Prometheus components at :latest tag. This affects reproducability and means some versions may not be security scanned.  
https://github.com/kubernetes/kubernetes/issues/65160