### PR TITLE
Add Reconcile label to kube namespaces

### DIFF
--- a/cluster/addons/istio/auth/istio-auth.yaml
+++ b/cluster/addons/istio/auth/istio-auth.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: kube-public
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     istio-injection: disabled
 ---
 apiVersion: v1
@@ -10,6 +11,7 @@ kind: Namespace
 metadata:
   name: kube-system
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     istio-injection: disabled
 ---
 ################################

--- a/cluster/addons/istio/noauth/istio.yaml
+++ b/cluster/addons/istio/noauth/istio.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: kube-public
   labels:
+    addonmanager.kubernetes.io/mode: Reconcile
     istio-injection: disabled
 ---
 apiVersion: v1
@@ -10,7 +11,8 @@ kind: Namespace
 metadata:
   name: kube-system
   labels:
-    istio-injection: disabled
+   addonmanager.kubernetes.io/mode: Reconcile
+   istio-injection: disabled
 ---
 ################################
 # Istio system namespace


### PR DESCRIPTION
**What this PR does / why we need it:**
During testing of Istio on GKE it was discovered that sidecar was injected into kube namespaces. This was due to the fact that unless a resource has an addon label, addon manager skips applying it, so istio-injection: disabled was not applied.