### PR TITLE
Automated cherry pick of #65377: special-case template printing in get.go

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1620,6 +1620,10 @@ run_kubectl_get_tests() {
   ## check --allow-missing-template-keys defaults to true for go templates
   kubectl get "${kube_flags[@]}" pod valid-pod -o go-template='{{.missing}}'
 
+  ## check --template flag causes go-template to be printed, even when no --output value is provided
+  output_message=$(kubectl get "${kube_flags[@]}" pod valid-pod --template="{{$id_field}}:")
+  kube::test::if_has_string "${output_message}" 'valid-pod:'
+
   ## check --allow-missing-template-keys=false results in an error for a missing key with jsonpath
   output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o jsonpath='{.missing}' "${kube_flags[@]}")
   kube::test::if_has_string "${output_message}" 'missing is not found'

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -212,8 +212,13 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		o.ServerPrint = false
 	}
 
+	templateArg := ""
+	if o.PrintFlags.TemplateFlags != nil && o.PrintFlags.TemplateFlags.TemplateArgument != nil {
+		templateArg = *o.PrintFlags.TemplateFlags.TemplateArgument
+	}
+
 	// human readable printers have special conversion rules, so we determine if we're using one.
-	if len(*o.PrintFlags.OutputFormat) == 0 || *o.PrintFlags.OutputFormat == "wide" {
+	if (len(*o.PrintFlags.OutputFormat) == 0 && len(templateArg) == 0) || *o.PrintFlags.OutputFormat == "wide" {
 		o.IsHumanReadablePrinter = true
 	}
 


### PR DESCRIPTION
Cherry pick of #65377 on release-1.11.

#65377: special-case template printing in get.go