### PR TITLE
Always create kubeClusterIPSet in ipvs proxier

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -789,14 +789,11 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 		// add service Cluster IP:Port to kubeServiceAccess ip set for the purpose of solving hairpin.
 		// proxier.kubeServiceAccessSet.activeEntries.Insert(entry.String())
-		// Install masquerade rules if 'masqueradeAll' or 'clusterCIDR' is specified.
-		if proxier.masqueradeAll || len(proxier.clusterCIDR) > 0 {
-			if valid := proxier.ipsetList[kubeClusterIPSet].validateEntry(entry); !valid {
-				glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeClusterIPSet].Name))
-				continue
-			}
-			proxier.ipsetList[kubeClusterIPSet].activeEntries.Insert(entry.String())
+		if valid := proxier.ipsetList[kubeClusterIPSet].validateEntry(entry); !valid {
+			glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeClusterIPSet].Name))
+			continue
 		}
+		proxier.ipsetList[kubeClusterIPSet].activeEntries.Insert(entry.String())
 		// ipvs call
 		serv := &utilipvs.VirtualServer{
 			Address:   svcInfo.ClusterIP,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates the kubeClusterIPSet ipset even if kube-proxy is started without masqueradeAll and clusterCIDR.
This is necessary to masquerade traffic sent to a clusterIP from the host network namespace. The code to do so is actually already present here: https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/proxier.go#L1220-L1244

However the second else (neither masqueradeAll nor clusterCIDR are set) cannot be used because, before this PR, the initial test `if !proxier.ipsetList[kubeClusterIPSet].isEmpty()` can never return true when masqueradeAll and clusterCIDR are not set because kubeClusterIPSet is empty.

**Which issue(s) this PR fixes** 
Fixes #65158

```release-note
Allow access to ClusterIP from the host network namespace when kube-proxy is started in IPVS mode without either masqueradeAll or clusterCIDR flags
```

**Additional comment**
Issue #65158 is closed because ClusterIP access from the host has already fixed in master, except for the case described here (no masquerade flag). More detail in the issue.