### PR TITLE
Add /home/kubernetes/bin into sudoers path, so that `sudo crictl` works.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2578,6 +2578,16 @@ EOF
 function override-kubectl {
     echo "overriding kubectl"
     echo "export PATH=${KUBE_HOME}/bin:\$PATH" > /etc/profile.d/kube_env.sh
+    # Add ${KUBE_HOME}/bin into sudoer secure path.
+    local sudo_path
+    sudo_path=$(sudo env | grep "^PATH=")
+    if [[ -n "${sudo_path}" ]]; then
+      sudo_path=${sudo_path#PATH=}
+      (
+        umask 027
+        echo "Defaults secure_path=\"${KUBE_HOME}/bin:${sudo_path}\"" > /etc/sudoers.d/kube_secure_path
+      )
+    fi
 }
 
 function override-pv-recycler {


### PR DESCRIPTION
Add `/home/kubernetes/bin` to sudoers path, so that user can call `sudo crictl` directly.

Without this fix, user has to either use the full path `sudo /home/kubernetes/bin/crictl` or switch to root, which is not a good user experience.

/cc @yujuhong @feiskyer @filbranden @kubernetes/sig-node-pr-reviews @kubernetes/sig-gcp-pr-reviews 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
User can now use `sudo crictl` on GCE cluster.
```
