### PR TITLE
When splitting `snake_case` words, omit the underscore

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -275,19 +275,22 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 func smartLabelFor(field string) string {
 	commonAcronyms := []string{"API", "URL", "UID", "OSB", "GUID"}
 
-	splitted := camelcase.Split(field)
-	for i := 0; i < len(splitted); i++ {
-		part := splitted[i]
+	parts := camelcase.Split(field)
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "_" {
+			continue
+		}
 
 		if slice.ContainsString(commonAcronyms, strings.ToUpper(part), nil) {
 			part = strings.ToUpper(part)
 		} else {
 			part = strings.Title(part)
 		}
-		splitted[i] = part
+		result = append(result, part)
 	}
 
-	return strings.Join(splitted, " ")
+	return strings.Join(result, " ")
 }
 
 // DefaultObjectDescriber can describe the default Kubernetes objects.


### PR DESCRIPTION
While we require camelCase by convention for official APIs, CRDs may use
`snake_case`, and the generic describer prints this as `Snake _ Case`.  We should print `Snake Case`

Prow is impacted by this for the ProwJob CRD:

```
  Decoration _ Config:
    Gcs _ Configuration:
      Bucket:                    origin-ci-test
      Default _ Org:             openshift
      Default _ Repo:            origin
      Path _ Strategy:           single
    Gcs _ Credentials _ Secret:  gcs-publisher-credentials
```

@kubernetes/sig-cli-pr-reviews

```release-note
Using `kubectl describe` on CRDs that use underscores will be prettier.
```