### PR TITLE
[kubeadm] Make kube-proxy optional in kubeadm init

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -59,6 +59,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.UnifiedControlPlaneImage = "foo"
 			obj.FeatureGates = map[string]bool{"foo": true}
 			obj.ClusterName = "foo"
+			obj.SkipKubeProxyInstall = false
 			obj.APIServerExtraArgs = map[string]string{"foo": "foo"}
 			obj.APIServerExtraVolumes = []kubeadm.HostPathMount{{
 				Name:      "foo",

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -111,8 +111,8 @@ type MasterConfiguration struct {
 	// The cluster name
 	ClusterName string
 
-	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
-	NotInstallKubeProxy bool
+	// SkipKubeProxyInstall indicates if the kube-proxy will be installed.
+	SkipKubeProxyInstall bool
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -110,6 +110,9 @@ type MasterConfiguration struct {
 
 	// The cluster name
 	ClusterName string
+
+	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
+	NotInstallKubeProxy bool
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -119,6 +119,9 @@ type MasterConfiguration struct {
 
 	// The cluster name
 	ClusterName string `json:"clusterName,omitempty"`
+
+	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
+	NotInstallKubeProxy bool `json:"notInstallKubeProxy,omitempty"`
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -119,9 +119,6 @@ type MasterConfiguration struct {
 
 	// The cluster name
 	ClusterName string `json:"clusterName,omitempty"`
-
-	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
-	NotInstallKubeProxy bool `json:"notInstallKubeProxy,omitempty"`
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -240,7 +240,6 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
-	out.NotInstallKubeProxy = in.NotInstallKubeProxy
 	return nil
 }
 
@@ -279,7 +278,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
-	out.NotInstallKubeProxy = in.NotInstallKubeProxy
+	// WARNING: in.SkipKubeProxyInstall requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -240,6 +240,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
+	out.NotInstallKubeProxy = in.NotInstallKubeProxy
 	return nil
 }
 
@@ -278,6 +279,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
+	out.NotInstallKubeProxy = in.NotInstallKubeProxy
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
@@ -102,6 +102,9 @@ type MasterConfiguration struct {
 
 	// The cluster name
 	ClusterName string `json:"clusterName,omitempty"`
+
+	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
+	NotInstallKubeProxy bool `json:"notInstallKubeProxy,omitempty"`
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
@@ -103,8 +103,8 @@ type MasterConfiguration struct {
 	// The cluster name
 	ClusterName string `json:"clusterName,omitempty"`
 
-	// NotInstallKubeProxy indicates if the kube-proxy will be installed.
-	NotInstallKubeProxy bool `json:"notInstallKubeProxy,omitempty"`
+	// SkipKubeProxyInstall indicates if the kube-proxy will be installed.
+	SkipKubeProxyInstall bool `json:"skipKubeProxyInstall,omitempty"`
 }
 
 // API struct contains elements of API server address.

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.conversion.go
@@ -351,7 +351,7 @@ func autoConvert_v1alpha2_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
-	out.NotInstallKubeProxy = in.NotInstallKubeProxy
+	out.SkipKubeProxyInstall = in.SkipKubeProxyInstall
 	return nil
 }
 
@@ -397,7 +397,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha2_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
-	out.NotInstallKubeProxy = in.NotInstallKubeProxy
+	out.SkipKubeProxyInstall = in.SkipKubeProxyInstall
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/zz_generated.conversion.go
@@ -351,6 +351,7 @@ func autoConvert_v1alpha2_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
+	out.NotInstallKubeProxy = in.NotInstallKubeProxy
 	return nil
 }
 
@@ -396,6 +397,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha2_MasterConfiguration(in 
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.ClusterName = in.ClusterName
+	out.NotInstallKubeProxy = in.NotInstallKubeProxy
 	return nil
 }
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -502,9 +502,11 @@ func (i *Init) Run(out io.Writer) error {
 		return fmt.Errorf("error ensuring dns addon: %v", err)
 	}
 
-	glog.V(1).Infof("[init] ensuring proxy addon")
-	if err := proxyaddonphase.EnsureProxyAddon(i.cfg, client); err != nil {
-		return fmt.Errorf("error ensuring proxy addon: %v", err)
+	if !i.cfg.NotInstallKubeProxy {
+		glog.V(1).Infof("[init] ensuring proxy addon")
+		if err := proxyaddonphase.EnsureProxyAddon(i.cfg, client); err != nil {
+			return fmt.Errorf("error ensuring proxy addon: %v", err)
+		}
 	}
 
 	// PHASE 7: Make the control plane self-hosted if feature gate is enabled

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -502,7 +502,7 @@ func (i *Init) Run(out io.Writer) error {
 		return fmt.Errorf("error ensuring dns addon: %v", err)
 	}
 
-	if !i.cfg.NotInstallKubeProxy {
+	if !i.cfg.SkipKubeProxyInstall {
 		glog.V(1).Infof("[init] ensuring proxy addon")
 		if err := proxyaddonphase.EnsureProxyAddon(i.cfg, client); err != nil {
 			return fmt.Errorf("error ensuring proxy addon: %v", err)

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -158,4 +158,5 @@ NodeRegistration:
     key: node-role.kubernetes.io/master
 SchedulerExtraArgs: null
 SchedulerExtraVolumes: null
+SkipKubeProxyInstall: false
 UnifiedControlPlaneImage: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Make kube-proxy optional in kubeadm init

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
close [#kubernetes/kubeadm/776](https://github.com/kubernetes/kubeadm/issues/776)

**Special notes for your reviewer**:
ref #60428
So I use `NotInstallKubeProxy` instead of `InstallKubeProxy` to avoid complicated default value logic and keep the current default behavior.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: make kube-proxy optional
```
