### PR TITLE
client-go/examples/fake-client: add doc.go to fix go build warnings

### DIFF
--- a/staging/src/k8s.io/client-go/examples/fake-client/BUILD
+++ b/staging/src/k8s.io/client-go/examples/fake-client/BUILD
@@ -1,8 +1,9 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -23,5 +24,13 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/examples/fake-client",
+    importpath = "k8s.io/client-go/examples/fake-client",
     visibility = ["//visibility:public"],
 )

--- a/staging/src/k8s.io/client-go/examples/fake-client/doc.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fakeclient contains examples on how to use fakeclient in tests.
+// Note: This file is here to avoid warnings on go build since there are no
+// non-test files in this package.
+package fakeclient


### PR DESCRIPTION
The publishing bot is currently broken (https://github.com/kubernetes/kubernetes/issues/56876#issuecomment-399763681). This is due to the following error:

```
[24 Jun 18 15:08 UTC]: Running smoke tests for branch master
[24 Jun 18 15:08 UTC]: /bin/bash -xec "godep restore\ngo build ./...\ngo test $(go list ./... | grep -v /vendor/)\n"
	+ godep restore
	+ go build ./...
	go build k8s.io/client-go/examples/fake-client: no non-test Go files in /go-workspace/src/k8s.io/client-go/examples/fake-client
[24 Jun 18 15:09 UTC]: exit status 1
    	+ godep restore
    	+ go build ./...
    	go build k8s.io/client-go/examples/fake-client: no non-test Go files in /go-workspace/src/k8s.io/client-go/examples/fake-client

[24 Jun 18 15:09 UTC]: exit status 1```
```

The fakeclient package does not have any non-test go files. The test file was added in https://github.com/kubernetes/kubernetes/pull/65291 2 days ago.

This causes `go build` to give a warning: `no non-test Go files in /go-workspace/src/k8s.io/client-go/examples/fake-client`, which breaks the publishing bot. This PR adds a dummy doc.go file in the package to avoid this warning and fix the publishing bot.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
