### PR TITLE
skip nic that are in failing state

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_standard.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard.go
@@ -52,7 +52,8 @@ const (
 	InternalLoadBalancerNameSuffix = "-internal"
 
 	// nodeLabelRole specifies the role of a node
-	nodeLabelRole = "kubernetes.io/role"
+	nodeLabelRole  = "kubernetes.io/role"
+	nicFailedState = "Failed"
 
 	storageAccountNameMaxLength = 24
 )
@@ -617,6 +618,11 @@ func (as *availabilitySet) ensureHostInPool(serviceName string, nodeName types.N
 
 		glog.Errorf("error: az.ensureHostInPool(%s), az.vmSet.GetPrimaryInterface.Get(%s, %s), err=%v", nodeName, vmName, vmSetName, err)
 		return err
+	}
+
+	if nic.ProvisioningState != nil && *nic.ProvisioningState == nicFailedState {
+		glog.V(3).Infof("ensureHostInPool skips node %s because its primdary nic %s is in Failed state", nodeName, nic.Name)
+		return nil
 	}
 
 	var primaryIPConfig *network.InterfaceIPConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**: this fixes partially #65025. Currently when getting primary NIC for VMSS the provisioning state isn't returned.

**Which issue(s) this PR fixes** : Fixes partially (for VMAS) #65025

**Special notes for your reviewer**:

/assign @feiskyer 

**Release note**:

```release-note
skip nodes that have a primary NIC in a 'Failed' provisioningState
```
