### PR TITLE
errcheck linter return values

### DIFF
--- a/pkg/util/goroutinemap/goroutinemap.go
+++ b/pkg/util/goroutinemap/goroutinemap.go
@@ -105,14 +105,15 @@ func (grm *goRoutineMap) Run(
 		operationPending: true,
 		expBackoff:       existingOp.expBackoff,
 	}
-	go func() (err error) {
+	go func() {
+		var err error
 		// Handle unhandled panics (very unlikely)
 		defer k8sRuntime.HandleCrash()
-		// Handle completion of and error, if any, from operationFunc()
+		// Handle completion of and error (including from panic), if any, from operationFunc()
 		defer grm.operationComplete(operationName, &err)
 		// Handle panic, if any, from operationFunc()
 		defer k8sRuntime.RecoverFromPanic(&err)
-		return operationFunc()
+		err = operationFunc()
 	}()
 
 	return nil


### PR DESCRIPTION
Make error handling easier to understand.

Don't claim to return from the go func.
From the go lang spec:

If the function has any return values, they are discarded when the function completes.


**Release note**:
```release-note
NONE
```
