### PR TITLE
Resolve potential devicePath symlink when MapVolume in containerized kubelet

### DIFF
--- a/pkg/util/mount/exec_mount.go
+++ b/pkg/util/mount/exec_mount.go
@@ -140,6 +140,10 @@ func (m *execMounter) ExistsPath(pathname string) (bool, error) {
 	return m.wrappedMounter.ExistsPath(pathname)
 }
 
+func (m *execMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return m.wrappedMounter.EvalHostSymlinks(pathname)
+}
+
 func (m *execMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return m.wrappedMounter.PrepareSafeSubpath(subPath)
 }

--- a/pkg/util/mount/exec_mount_unsupported.go
+++ b/pkg/util/mount/exec_mount_unsupported.go
@@ -87,6 +87,10 @@ func (mounter *execMounter) ExistsPath(pathname string) (bool, error) {
 	return true, errors.New("not implemented")
 }
 
+func (m *execMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (mounter *execMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, nil
 }

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -212,6 +212,10 @@ func (f *FakeMounter) ExistsPath(pathname string) (bool, error) {
 	return false, nil
 }
 
+func (f *FakeMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return pathname, nil
+}
+
 func (f *FakeMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, nil
 }

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -96,6 +96,9 @@ type Interface interface {
 	// Will operate in the host mount namespace if kubelet is running in a container.
 	// Error is returned on any other error than "file not found".
 	ExistsPath(pathname string) (bool, error)
+	// EvalHostSymlinks returns the path name after evaluating symlinks.
+	// Will operate in the host mount namespace if kubelet is running in a container.
+	EvalHostSymlinks(pathname string) (string, error)
 	// CleanSubPaths removes any bind-mounts created by PrepareSafeSubpath in given
 	// pod volume directory.
 	CleanSubPaths(podDir string, volumeName string) error

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -419,6 +419,10 @@ func (mounter *Mounter) ExistsPath(pathname string) (bool, error) {
 	return utilfile.FileExists(pathname)
 }
 
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}
+
 // formatAndMount uses unix utils to format and mount the given disk
 func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, fstype string, options []string) error {
 	readOnly := false

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -106,6 +106,10 @@ func (mounter *Mounter) ExistsPath(pathname string) (bool, error) {
 	return true, errors.New("not implemented")
 }
 
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", unsupportedErr
+}
+
 func (mounter *Mounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, unsupportedErr
 }

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -232,6 +232,11 @@ func (mounter *Mounter) ExistsPath(pathname string) (bool, error) {
 	return utilfile.FileExists(pathname)
 }
 
+// EvalHostSymlinks returns the path name after evaluating symlinks
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}
+
 // check whether hostPath is within volume path
 // this func will lock all intermediate subpath directories, need to close handle outside of this func after container started
 func lockAndCheckSubPath(volumePath, hostPath string) ([]uintptr, error) {

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -287,6 +287,10 @@ func (mounter *NsenterMounter) ExistsPath(pathname string) (bool, error) {
 	return utilfile.FileExists(kubeletpath)
 }
 
+func (mounter *NsenterMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return mounter.ne.EvalSymlinks(pathname, true)
+}
+
 func (mounter *NsenterMounter) CleanSubPaths(podDir string, volumeName string) error {
 	return doCleanSubPaths(mounter, podDir, volumeName)
 }

--- a/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/pkg/util/mount/nsenter_mount_unsupported.go
@@ -89,6 +89,10 @@ func (*NsenterMounter) ExistsPath(pathname string) (bool, error) {
 	return true, errors.New("not implemented")
 }
 
+func (*NsenterMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (*NsenterMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Ensures local block volumes will work in case kubelet is running in a container

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65445

**Special notes for your reviewer**: Code is mostly plumbing. If there is a better way to do it, let me know :)

I assume there will be e2e tests for the non-containerized case. I will need to test the containerized case myself, which may take a while.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
