### PR TITLE
Fix run-in-gopath issue with symlink'd gopath

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -178,4 +178,3 @@ kube::realpath() {
   fi
   kube::readlinkdashf "$1"
 }
-

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -435,7 +435,7 @@ kube::util::ensure_godep_version() {
   fi
 
   kube::log::status "Installing godep version ${GODEP_VERSION}"
-  go install ./vendor/github.com/tools/godep/
+  go install k8s.io/kubernetes/vendor/github.com/tools/godep/
   if ! which godep >/dev/null 2>&1; then
     kube::log::error "Can't find godep - is your GOPATH 'bin' in your PATH?"
     kube::log::error "  GOPATH: ${GOPATH}"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -20,8 +20,6 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-kube::util::ensure-gnu-sed
-
 # Remove generated files prior to running kazel.
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
@@ -31,9 +29,8 @@ export GOBIN="${KUBE_OUTPUT_BINPATH}"
 PATH="${GOBIN}:${PATH}"
 
 # Install tools we need, but only from vendor/...
-go install ./vendor/github.com/bazelbuild/bazel-gazelle/cmd/gazelle
-
-go install ./vendor/github.com/kubernetes/repo-infra/kazel
+go install k8s.io/kubernetes/vendor/github.com/bazelbuild/bazel-gazelle/cmd/gazelle
+go install k8s.io/kubernetes/vendor/github.com/kubernetes/repo-infra/kazel
 
 touch "${KUBE_ROOT}/vendor/BUILD"
 # Ensure that we use the correct importmap for all vendored dependencies.
@@ -46,6 +43,8 @@ fi
 gazelle fix \
     -build_file_name=BUILD,BUILD.bazel \
     -external=vendored \
-    -mode=fix
+    -mode=fix \
+    -repo_root "${KUBE_ROOT}" \
+    "${KUBE_ROOT}"
 
 kazel

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -25,7 +25,7 @@ export GOBIN="${KUBE_OUTPUT_BINPATH}"
 PATH="${GOBIN}:${PATH}"
 
 # Install tools we need, but only from vendor/...
-go install ./vendor/github.com/client9/misspell/cmd/misspell
+go install k8s.io/kubernetes/vendor/github.com/client9/misspell/cmd/misspell
 
 # Spell checking
 # All the skipping files are defined in hack/.spelling_failures


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes `hack/update-bazel.sh` so that it can be run in a symlink'd GOPATH, (such as using `hack/run-in-gopath.sh`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65403.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```