### PR TITLE
Print error when APIServer fails to start

### DIFF
--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -58,7 +58,7 @@ ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 API_PORT=${API_PORT:-8050}
 API_HOST=${API_HOST:-127.0.0.1}
-API_LOGFILE=/tmp/swagger-api-server.log
+API_LOGFILE=${API_LOGFILE:-/tmp/swagger-api-server.log}
 
 kube::etcd::start
 


### PR DESCRIPTION
**What this PR does / why we need it**: Print apiserver logs when it fails to start.
This is copied from `update-swagger-spec.sh`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
