### PR TITLE
Automated cherry pick of #58685: Openstack: Fill size attribute for the V3 API volumes

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -222,6 +222,7 @@ func (volumes *VolumesV3) getVolume(volumeID string) (Volume, error) {
 		ID:     volumeV3.ID,
 		Name:   volumeV3.Name,
 		Status: volumeV3.Status,
+		Size:   volumeV3.Size,
 	}
 
 	if len(volumeV3.Attachments) > 0 {


### PR DESCRIPTION
Cherry pick of #58685 on release-1.9.

#58685: Openstack: Fill size attribute for the V3 API volumes

```release-note
Fix volume resize with OpenStack cinder
```

This resolves a problem with resizing PVCs with the OpenStack cloud provider. There is currently no workaround and users are blocked with the following message: `Warning  VolumeResizeFailed     18m   volume_expand                Invalid request due to incorrect syntax or missing required parameters.`

Therefore I think this would fit under the [patch release policy](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#patch-releases):
> problems affecting a large number of users, severe problems with no workaround, and blockers for products based on Kubernetes.
