### PR TITLE
Fix apiserver crash for invalid regex in CRD validation schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -875,3 +875,41 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCustomResourceDefinitionValidationPattern(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     apiextensions.CustomResourceValidation
+		wantError bool
+	}{
+		{
+			name: "invalid regex",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Pattern: `+`,
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "valid regex",
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Pattern: `^k[0-8]s$`,
+				},
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateCustomResourceDefinitionValidation(&tt.input, false, field.NewPath("spec", "validation"))
+			if !tt.wantError && len(got) > 0 {
+				t.Errorf("Expected no error, but got: %v", got)
+			} else if tt.wantError && len(got) == 0 {
+				t.Error("Expected error, but got none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #65470

The go-openapi library used for CR validation panics when the regex is invalid in the schema.

This PR validates the regex during CRD validation, so that the invalid regex is caught earlier and the panic does not occur.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The API server crash, which occurred when the CRD validation schema contained an invalid regular expression is fixed. Now, the invalid regular expression is reported as an error during CRD validation, instead of CustomResource validation.
```

/cc sttts liggitt mbohlool 
