### PR TITLE
Minimize writes to the client CA ConfigMap during API server start up

### DIFF
--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -19,6 +19,7 @@ package master
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,7 +132,9 @@ func writeConfigMap(client coreclient.ConfigMapsGetter, name string, data map[st
 		return err
 	}
 
-	existing.Data = data
-	_, err = client.ConfigMaps(metav1.NamespaceSystem).Update(existing)
+	if !reflect.DeepEqual(existing.Data, data) {
+		existing.Data = data
+		_, err = client.ConfigMaps(metav1.NamespaceSystem).Update(existing)
+	}
 	return err
 }

--- a/pkg/master/client_ca_hook_test.go
+++ b/pkg/master/client_ca_hook_test.go
@@ -186,6 +186,30 @@ func TestWriteClientCAs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip on no change",
+			hook: ClientCARegistrationHook{
+				RequestHeaderUsernameHeaders:     []string{},
+				RequestHeaderGroupHeaders:        []string{},
+				RequestHeaderExtraHeaderPrefixes: []string{},
+				RequestHeaderCA:                  []byte("bar"),
+				RequestHeaderAllowedNames:        []string{},
+			},
+			preexistingObjs: []runtime.Object{
+				&api.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "extension-apiserver-authentication"},
+					Data: map[string]string{
+						"requestheader-username-headers":     `[]`,
+						"requestheader-group-headers":        `[]`,
+						"requestheader-extra-headers-prefix": `[]`,
+						"requestheader-client-ca-file":       "bar",
+						"requestheader-allowed-names":        `[]`,
+					},
+				},
+			},
+			expectedConfigMaps: map[string]*api.ConfigMap{},
+			expectUpdate:       false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Continues from #56761

In our set up, we found that a failing Webhook that admits ConfigMaps within the `kube-system` namespace continues to cause API server reboot loops.

This fix attempts to reduce this failure scenario by minimising attempts to update the Client CA configmap.

I've added a check which determines whether the Data within the ConfigMap has changed, and only attempts to update the ConfigMap if it would actually update the Data field.

Therefore, if you have a failing webhook, but the configuration of the API server has not changed, the failing webhook will not block the API server from starting

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
