### PR TITLE
fix cluster server address path in proxy calls

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -225,7 +225,7 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		newReq.URL = &loc
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
+	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host, Path: h.Location.Path})
 	proxy.Transport = h.Transport
 	proxy.FlushInterval = h.FlushInterval
 	proxy.ServeHTTP(w, newReq)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if the kube config cluster address is set to a url with a path, for example `https://api.cluster.com/myclusterproxy` the path is stripped when making the requests from the proxy server when running `kubectl proxy`.

With the example above, if I was to run `kubectl proxy` and hit `http://localhost:8001/api/v1/namespaces` - the forwarded request currently goes to `https://api.cluster.com/api/v1/namespaces` when it should be going to `https://api.cluster.com/myclusterproxy/api/v1/namespaces`.

```release-note
None
```