### PR TITLE
Add ravi to sig scheduling approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,6 +6,7 @@ aliases:
     - timothysc
     - wojtek-t
     - aveshagarwal
+    - ravisantoshgudimetla
   sig-scheduling:
     - bsalamat
     - davidopp


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
According to the requirement of Approver at community-membership.md, I meet the following requirements so I'd like to add myself as an approver of scheduler.

I have :

- Authored more than ~40 commits to k/k repository and 22 commits in kube-incubator/descheduler.
- Been co-maintainer on descheduler.
- Been a reviewer for more than 3 months.
- Reviewed/helped in reviewing more than 70 PRs.
- Been helping new contributors in getting upto speed and guide them on performance aspects of the kube-scheduler.

As an approver,

-   I agree to only approve familiar PRs
-   I agree to be responsive to review/approve requests as per community expectations
-   I agree to continue my reviewer work as per community expectations
-   I agree to continue my contribution, e.g. PRs, mentor contributors


```release-note
NONE
```

/cc @bsalamat @k82cn @aveshagarwal 