### PR TITLE
show type differences in reflect diff

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -108,6 +108,14 @@ func limit(aObj, bObj interface{}, max int) (string, string) {
 	elidedASuffix := ""
 	elidedBSuffix := ""
 	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
 	for {
 		switch {
 		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:

--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
@@ -75,6 +75,11 @@ object.A:
   a: []int(nil)
   b: []int{}`,
 		},
+		"display type differences": {a: []interface{}{int64(1)}, b: []interface{}{uint64(1)}, out: `
+object[0]:
+  a: 1 (int64)
+  b: 0x1 (uint64)`,
+		},
 	}
 	for name, test := range testCases {
 		expect := test.out


### PR DESCRIPTION
helps debugging type coercion round-tripping issues

/assign @smarterclayton

```release-note
NONE
```