### PR TITLE
use lowercase hostnames for node names

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -173,7 +173,7 @@ def shutdown():
     '''
     try:
         if os.path.isfile(kubeconfig_path):
-            kubectl('delete', 'node', gethostname().lower())
+            kubectl('delete', 'node', get_node_name())
     except CalledProcessError:
         hookenv.log('Failed to unregister node.')
     service_stop('snap.kubelet.daemon')
@@ -314,7 +314,7 @@ def send_data(tls, kube_control):
     sans = [
         hookenv.unit_public_ip(),
         ingress_ip,
-        gethostname()
+        get_node_name()
     ]
 
     # Create a path safe name by removing path characters from the unit name.
@@ -1058,9 +1058,9 @@ def get_node_name():
     elif is_state('endpoint.openstack.ready'):
         cloud_provider = 'openstack'
     if cloud_provider == 'aws':
-        return getfqdn()
+        return getfqdn().lower()
     else:
-        return gethostname()
+        return gethostname().lower()
 
 
 class ApplyNodeLabelFailed(Exception):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Uppercase hostnames used in charms result in (lowercase) node name lookup errors. This happens when /etc/hostname contains uppercase characters and gethostname or getfqdn return those characters.

**Special notes for your reviewer**:

Discovered in a field deployment where hostnames are all uppercase.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hostnames are now converted to lowercase before being used for node lookups in the kubernetes-worker charm.
```