### PR TITLE
kubectl convert should not double wrap output in nested lists

### DIFF
--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -181,7 +181,11 @@ func (o *ConvertOptions) RunConvert() error {
 	}
 
 	if meta.IsListType(objects) {
-		obj, err := objectListToVersionedObject([]runtime.Object{objects}, o.specifiedOutputVersion)
+		listContent, err := meta.ExtractList(objects)
+		if err != nil {
+			return err
+		}
+		obj, err := objectListToVersionedObject(listContent, o.specifiedOutputVersion)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
@kubernetes/sig-cli-maintainers 
@soltysh 

```release-note
kubectl convert previous created a list inside of a list.  Now it is only wrapped once.
```