### PR TITLE
add sjenning to sig-node-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -66,6 +66,7 @@ aliases:
     - ncdc
     - pmorie
     - resouer
+    - sjenning
     - sjpotter
     - tallclair
     - tmrts


### PR DESCRIPTION
Request to be added to sig-node-reviewers

Sponsor @derekwaynecarr 

PR activity (~75 merged PRs):
https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Asjenning

QoS-level memory limits:
https://github.com/kubernetes/kubernetes/pull/41149

QoS pod status field:
https://github.com/kubernetes/kubernetes/pull/37968
https://github.com/kubernetes/kubernetes/pull/38989

Memcg threshold notification for eviction:
https://github.com/kubernetes/kubernetes/pull/38989

Areas of focus:
Kubelet sync loop and pod lifecycle
QoS/Pod level cgroup manager
systemd cgroup driver
CRI
dockershim
Volume manager
SELinux
cAdvisor

Member since: Feb 2016
