### PR TITLE
Cleanup verbose cAdvisor mocking in Kubelet unit tests

### DIFF
--- a/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
@@ -28,6 +28,14 @@ type Fake struct {
 	NodeName string
 }
 
+const (
+	FakeNumCores           = 1
+	FakeMemoryCapacity     = 4026531840
+	FakeKernelVersion      = "3.16.0-0.bpo.4-amd64"
+	FakeContainerOsVersion = "Debian GNU/Linux 7 (wheezy)"
+	FakeDockerVersion      = "1.5.0"
+)
+
 var _ cadvisor.Interface = new(Fake)
 
 func (c *Fake) Start() error {
@@ -54,14 +62,18 @@ func (c *Fake) MachineInfo() (*cadvisorapi.MachineInfo, error) {
 	// Simulate a machine with 1 core and 3.75GB of memory.
 	// We set it to non-zero values to make non-zero-capacity machines in Kubemark.
 	return &cadvisorapi.MachineInfo{
-		NumCores:       1,
+		NumCores:       FakeNumCores,
 		InstanceID:     cadvisorapi.InstanceID(c.NodeName),
-		MemoryCapacity: 4026531840,
+		MemoryCapacity: FakeMemoryCapacity,
 	}, nil
 }
 
 func (c *Fake) VersionInfo() (*cadvisorapi.VersionInfo, error) {
-	return new(cadvisorapi.VersionInfo), nil
+	return &cadvisorapi.VersionInfo{
+		KernelVersion:      FakeKernelVersion,
+		ContainerOsVersion: FakeContainerOsVersion,
+		DockerVersion:      FakeDockerVersion,
+	}, nil
 }
 
 func (c *Fake) ImagesFsInfo() (cadvisorapiv2.FsInfo, error) {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
-	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +48,7 @@ import (
 	core "k8s.io/client-go/testing"
 	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
@@ -359,27 +359,6 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 				NumCores:       2,
 				MemoryCapacity: 10E9, // 10G
 			}
-			mockCadvisor := testKubelet.fakeCadvisor
-			mockCadvisor.On("Start").Return(nil)
-			mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
-			versionInfo := &cadvisorapi.VersionInfo{
-				KernelVersion:      "3.16.0-0.bpo.4-amd64",
-				ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
-			}
-			mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-				Usage:     400,
-				Capacity:  5000,
-				Available: 600,
-			}, nil)
-			mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
-				Usage:     400,
-				Capacity:  5000,
-				Available: 600,
-			}, nil)
-			mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
-			maxAge := 0 * time.Second
-			options := cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false, MaxAge: &maxAge}
-			mockCadvisor.On("ContainerInfoV2", "/", options).Return(map[string]cadvisorapiv2.ContainerInfo{}, nil)
 			kubelet.machineInfo = machineInfo
 
 			expectedNode := &v1.Node{
@@ -432,8 +411,8 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 						MachineID:               "123",
 						SystemUUID:              "abc",
 						BootID:                  "1b3",
-						KernelVersion:           "3.16.0-0.bpo.4-amd64",
-						OSImage:                 "Debian GNU/Linux 7 (wheezy)",
+						KernelVersion:           cadvisortest.FakeKernelVersion,
+						OSImage:                 cadvisortest.FakeContainerOsVersion,
 						OperatingSystem:         goruntime.GOOS,
 						Architecture:            goruntime.GOARCH,
 						ContainerRuntimeVersion: "test://1.5.0",
@@ -564,8 +543,6 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		},
 	}
 	kubeClient.ReactionChain = fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{existingNode}}).ReactionChain
-	mockCadvisor := testKubelet.fakeCadvisor
-	mockCadvisor.On("Start").Return(nil)
 	machineInfo := &cadvisorapi.MachineInfo{
 		MachineID:      "123",
 		SystemUUID:     "abc",
@@ -573,25 +550,6 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		NumCores:       2,
 		MemoryCapacity: 20E9,
 	}
-	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
-	versionInfo := &cadvisorapi.VersionInfo{
-		KernelVersion:      "3.16.0-0.bpo.4-amd64",
-		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
-	}
-	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:     400,
-		Capacity:  5000,
-		Available: 600,
-	}, nil)
-	mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:     400,
-		Capacity:  5000,
-		Available: 600,
-	}, nil)
-	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
-	maxAge := 0 * time.Second
-	options := cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false, MaxAge: &maxAge}
-	mockCadvisor.On("ContainerInfoV2", "/", options).Return(map[string]cadvisorapiv2.ContainerInfo{}, nil)
 	kubelet.machineInfo = machineInfo
 
 	expectedNode := &v1.Node{
@@ -644,8 +602,8 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 				MachineID:               "123",
 				SystemUUID:              "abc",
 				BootID:                  "1b3",
-				KernelVersion:           "3.16.0-0.bpo.4-amd64",
-				OSImage:                 "Debian GNU/Linux 7 (wheezy)",
+				KernelVersion:           cadvisortest.FakeKernelVersion,
+				OSImage:                 cadvisortest.FakeContainerOsVersion,
 				OperatingSystem:         goruntime.GOOS,
 				Architecture:            goruntime.GOARCH,
 				ContainerRuntimeVersion: "test://1.5.0",
@@ -795,8 +753,6 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 	kubeClient := testKubelet.fakeKubeClient
 	existingNode := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname}}
 	kubeClient.ReactionChain = fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{existingNode}}).ReactionChain
-	mockCadvisor := testKubelet.fakeCadvisor
-	mockCadvisor.On("Start").Return(nil)
 	machineInfo := &cadvisorapi.MachineInfo{
 		MachineID:      "123",
 		SystemUUID:     "abc",
@@ -804,25 +760,6 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 		NumCores:       2,
 		MemoryCapacity: 10E9,
 	}
-	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
-	versionInfo := &cadvisorapi.VersionInfo{
-		KernelVersion:      "3.16.0-0.bpo.4-amd64",
-		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
-	}
-
-	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
-	maxAge := 0 * time.Second
-	options := cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false, MaxAge: &maxAge}
-	mockCadvisor.On("ContainerInfoV2", "/", options).Return(map[string]cadvisorapiv2.ContainerInfo{}, nil)
-	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    400,
-		Capacity: 10E9,
-	}, nil)
-	mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    400,
-		Capacity: 20E9,
-	}, nil)
-
 	kubelet.machineInfo = machineInfo
 
 	expectedNode := &v1.Node{
@@ -868,8 +805,8 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 				MachineID:               "123",
 				SystemUUID:              "abc",
 				BootID:                  "1b3",
-				KernelVersion:           "3.16.0-0.bpo.4-amd64",
-				OSImage:                 "Debian GNU/Linux 7 (wheezy)",
+				KernelVersion:           cadvisortest.FakeKernelVersion,
+				OSImage:                 cadvisortest.FakeContainerOsVersion,
 				OperatingSystem:         goruntime.GOOS,
 				Architecture:            goruntime.GOARCH,
 				ContainerRuntimeVersion: "test://1.5.0",
@@ -1051,23 +988,6 @@ func TestRegisterWithApiServer(t *testing.T) {
 		NumCores:       2,
 		MemoryCapacity: 1024,
 	}
-	mockCadvisor := testKubelet.fakeCadvisor
-	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
-	versionInfo := &cadvisorapi.VersionInfo{
-		KernelVersion:      "3.16.0-0.bpo.4-amd64",
-		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
-		DockerVersion:      "1.5.0",
-	}
-	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
-	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:     400,
-		Capacity:  1000,
-		Available: 600,
-	}, nil)
-	mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:    9,
-		Capacity: 10,
-	}, nil)
 	kubelet.machineInfo = machineInfo
 
 	done := make(chan struct{})
@@ -1279,27 +1199,6 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 		NumCores:       2,
 		MemoryCapacity: 10E9, // 10G
 	}
-	mockCadvisor := testKubelet.fakeCadvisor
-	mockCadvisor.On("Start").Return(nil)
-	mockCadvisor.On("MachineInfo").Return(machineInfo, nil)
-	versionInfo := &cadvisorapi.VersionInfo{
-		KernelVersion:      "3.16.0-0.bpo.4-amd64",
-		ContainerOsVersion: "Debian GNU/Linux 7 (wheezy)",
-	}
-	mockCadvisor.On("VersionInfo").Return(versionInfo, nil)
-	maxAge := 0 * time.Second
-	options := cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false, MaxAge: &maxAge}
-	mockCadvisor.On("ContainerInfoV2", "/", options).Return(map[string]cadvisorapiv2.ContainerInfo{}, nil)
-	mockCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:     400,
-		Capacity:  3000,
-		Available: 600,
-	}, nil)
-	mockCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{
-		Usage:     400,
-		Capacity:  3000,
-		Available: 600,
-	}, nil)
 	kubelet.machineInfo = machineInfo
 
 	expectedNode := &v1.Node{

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	cadvisorapi "github.com/google/cadvisor/info/v1"
-	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,17 +28,8 @@ import (
 )
 
 func TestPodResourceLimitsDefaulting(t *testing.T) {
-	cpuCores := resource.MustParse("10")
-	memoryCapacity := resource.MustParse("10Gi")
 	tk := newTestKubelet(t, true)
 	defer tk.Cleanup()
-	tk.fakeCadvisor.On("VersionInfo").Return(&cadvisorapi.VersionInfo{}, nil)
-	tk.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{
-		NumCores:       int(cpuCores.Value()),
-		MemoryCapacity: uint64(memoryCapacity.Value()),
-	}, nil)
-	tk.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	tk.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	tk.kubelet.nodeInfo = &testNodeInfo{
 		nodes: []*v1.Node{
 			{


### PR DESCRIPTION
These tests had a lot of duplicate code to set up the cAdvisor mock, but weren't really depending on the mock functionality. By moving the tests to use the fake cAdvisor, most of the setup can be cleaned up.

/kind cleanup
/sig node

```release-note
NONE
```