### PR TITLE
fix ipset creation fails on centos. issue 65461

### DIFF
--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -289,7 +289,7 @@ func (runner *runner) CreateSet(set *IPSet, ignoreExistErr bool) error {
 // If ignoreExistErr is set to true, then the -exist option of ipset will be specified, ipset ignores the error
 // otherwise raised when the same set (setname and create parameters are identical) already exists.
 func (runner *runner) createSet(set *IPSet, ignoreExistErr bool) error {
-	args := []string{"create", set.Name, string(set.SetType), "comment"}
+	args := []string{"create", set.Name, string(set.SetType)}
 	if set.SetType == HashIPPortIP || set.SetType == HashIPPort {
 		args = append(args,
 			"family", set.HashFamily,
@@ -313,7 +313,7 @@ func (runner *runner) createSet(set *IPSet, ignoreExistErr bool) error {
 // If the -exist option is specified, ipset ignores the error otherwise raised when
 // the same set (setname and create parameters are identical) already exists.
 func (runner *runner) AddEntry(entry string, set *IPSet, ignoreExistErr bool) error {
-	args := []string{"add", set.Name, entry, "comment", set.Comment}
+	args := []string{"add", set.Name, entry}
 	if ignoreExistErr {
 		args = append(args, "-exist")
 	}
@@ -325,7 +325,6 @@ func (runner *runner) AddEntry(entry string, set *IPSet, ignoreExistErr bool) er
 
 // DelEntry is used to delete the specified entry from the set.
 func (runner *runner) DelEntry(entry string, set string) error {
-	entry = strings.Split(entry, " comment")[0]
 	if _, err := runner.exec.Command(IPSetCmd, "del", set, entry).CombinedOutput(); err != nil {
 		return fmt.Errorf("error deleting entry %s: from set: %s, error: %v", entry, set, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
remove usage of ipset comment extension because ipset versions on centos 7.x don't support comment yet.
See the issue #65461

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65461

**Special notes for your reviewer**:
The comments for corresponding iptable rules are left untouched.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
