### PR TITLE
ipvs: remove duplicated masq rules

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1283,13 +1283,6 @@ func (proxier *Proxier) writeIptablesRules() {
 			)
 			writeLine(proxier.natRules, append(args, "-j", "ACCEPT")...)
 		}
-		// mark masq for others
-		args = append(args[:0],
-			"-A", string(KubeNodePortChain),
-			"-m", "comment", "--comment",
-			fmt.Sprintf(`"mark MASQ for externaltrafficpolicy=cluster"`),
-		)
-		writeLine(proxier.natRules, append(args, "-j", string(KubeMarkMasqChain))...)
 	}
 
 	// mark masq for KUBE-NODE-PORT


### PR DESCRIPTION
Duplicated masq rules are created by current implementation:
```
-A KUBE-NODE-PORT -m comment --comment "mark MASQ for
externaltrafficpolicy=cluster" -j KUBE-MARK-MASQ
-A KUBE-NODE-PORT -j KUBE-MARK-MASQ
```
The last one is always there. So the one inside if statement could
just be removed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
