### PR TITLE
fix usage string for the kubectl logs command

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -38,6 +38,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
+const (
+	logsUsageStr = "logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]"
+)
+
 var (
 	logsExample = templates.Examples(i18n.T(`
 		# Return snapshot logs from pod nginx with only one container
@@ -67,11 +71,8 @@ var (
 		# Return snapshot logs from container nginx-1 of a deployment named nginx
 		kubectl logs deployment/nginx -c nginx-1`))
 
-	selectorTail int64 = 10
-)
-
-const (
-	logsUsageStr = "expected 'logs (POD | TYPE/NAME) [CONTAINER_NAME]'.\nPOD or TYPE/NAME is a required argument for the logs command"
+	selectorTail    int64 = 10
+	logsUsageErrStr       = fmt.Sprintf("expected '%s'.\nPOD or TYPE/NAME is a required argument for the logs command", logsUsageStr)
 )
 
 type LogsOptions struct {
@@ -119,7 +120,7 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	o := NewLogsOptions(streams, false)
 
 	cmd := &cobra.Command{
-		Use: "logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]",
+		Use: logsUsageStr,
 		DisableFlagsInUseLine: true,
 		Short:   i18n.T("Print the logs for a container in a pod"),
 		Long:    "Print the logs for a container in a pod or specified resource. If the pod has only one container, the container name is optional.",
@@ -195,7 +196,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 	switch len(args) {
 	case 0:
 		if len(o.Selector) == 0 {
-			return cmdutil.UsageErrorf(cmd, "%s", logsUsageStr)
+			return cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
 		}
 	case 1:
 		o.ResourceArg = args[0]
@@ -206,7 +207,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 		o.ResourceArg = args[0]
 		o.Container = args[1]
 	default:
-		return cmdutil.UsageErrorf(cmd, "%s", logsUsageStr)
+		return cmdutil.UsageErrorf(cmd, "%s", logsUsageErrStr)
 	}
 	var err error
 	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -246,13 +246,6 @@ func TestLogComplete(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "No args case",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				return NewLogsOptions(streams, false)
-			},
-			expected: "'logs (POD | TYPE/NAME) [CONTAINER_NAME]'.\nPOD or TYPE/NAME is a required argument for the logs command",
-		},
-		{
 			name: "One args case",
 			args: []string{"foo"},
 			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
@@ -261,16 +254,6 @@ func TestLogComplete(t *testing.T) {
 				return o
 			},
 			expected: "only a selector (-l) or a POD name is allowed",
-		},
-		{
-			name: "More than two args case",
-			args: []string{"foo", "foo1", "foo2"},
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
-				o := NewLogsOptions(streams, false)
-				o.Tail = 1
-				return o
-			},
-			expected: "'logs (POD | TYPE/NAME) [CONTAINER_NAME]'.\nPOD or TYPE/NAME is a required argument for the logs command",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Even though the use of an inline [CONTAINER] name is still accepted for,
legacy purpose the error message does not match what the documentation
or man page says. This commit aligns the usage string that is displayed
when the `kubectl logs` command is called with more than one container
name (with the use of the -c flag or not).

```release-note
NONE
```
