### PR TITLE
dry-run: Create feature-gate flag

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -409,6 +409,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	genericfeatures.APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
 	genericfeatures.Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
 	genericfeatures.APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.DryRun:                  {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -63,6 +63,14 @@ const (
 	// Allow API clients to retrieve resource lists in chunks rather than
 	// all at once.
 	APIListChunking utilfeature.Feature = "APIListChunking"
+
+	// owner: @apelisse
+	// alpha: v1.12
+	//
+	// Allow requests to be processed but not stored, so that
+	// validation, merging, mutation can be tested without
+	// committing.
+	DryRun utilfeature.Feature = "DryRun"
 )
 
 func init() {
@@ -78,4 +86,5 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
 	Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
 	APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	DryRun:                  {Default: false, PreRelease: utilfeature.Alpha},
 }


### PR DESCRIPTION
Creates a feature gate flag for dry-run. Currently, dry-run query parameter is completely blocking all requests, once the feature is implemented, the flag will allow the parameter to pass if enabled.

cc @jennybuckley @deads2k @liggitt @lavalamp 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
