### PR TITLE
[kubeadm]fix DynamicKubeletConfig feature to beta

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -39,7 +39,7 @@ const (
 	// StoreCertsInSecrets is alpha in v1.8 and v1.9
 	StoreCertsInSecrets = "StoreCertsInSecrets"
 
-	// DynamicKubeletConfig is alpha in v1.9
+	// DynamicKubeletConfig is beta in v1.11
 	DynamicKubeletConfig = "DynamicKubeletConfig"
 
 	// Auditing is beta in 1.8
@@ -53,7 +53,7 @@ var InitFeatureGates = FeatureList{
 	// We don't want to advertise this feature gate exists in v1.9 to avoid confusion as it is not yet working
 	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, HiddenInHelpText: true},
 	CoreDNS:              {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.GA}},
-	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
+	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
 	Auditing:             {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 }
 

--- a/cmd/kubeadm/app/phases/kubelet/dynamic.go
+++ b/cmd/kubeadm/app/phases/kubelet/dynamic.go
@@ -36,7 +36,7 @@ func EnableDynamicConfigForNode(client clientset.Interface, nodeName string, kub
 	configMapName := configMapName(kubeletVersion)
 	fmt.Printf("[kubelet] Enabling Dynamic Kubelet Config for Node %q; config sourced from ConfigMap %q in namespace %s\n",
 		nodeName, configMapName, metav1.NamespaceSystem)
-	fmt.Println("[kubelet] WARNING: The Dynamic Kubelet Config feature is alpha and off by default. It hasn't been well-tested yet at this stage, use with caution.")
+	fmt.Println("[kubelet] WARNING: The Dynamic Kubelet Config feature is beta, but off by default. It hasn't been well-tested yet at this stage, use with caution.")
 
 	kubeletConfigMap, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(configMapName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
As [PR](https://github.com/kubernetes/kubernetes/pull/64275) get merged,  DynamicKubeletConfig feature convert to  `beta` in v1.11, and set to `true` in default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[https://github.com/kubernetes/kubeadm/issues/957](https://github.com/kubernetes/kubeadm/issues/957)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
