### PR TITLE
Fix test failure of truncated time

### DIFF
--- a/pkg/kubelet/kubeletconfig/checkpoint/store/fsstore_test.go
+++ b/pkg/kubelet/kubeletconfig/checkpoint/store/fsstore_test.go
@@ -299,15 +299,14 @@ func TestFsStoreAssignedModified(t *testing.T) {
 	// create an empty assigned file, this is good enough for testing
 	saveTestSourceFile(t, store, assignedFile, nil)
 
+	// round the current time to the nearest second because some file systems do not support sub-second precision.
+	now := time.Now().Round(time.Second)
 	// set the timestamps to the current time, so we can compare to result of store.AssignedModified
-	now := time.Now()
 	err = store.fs.Chtimes(store.metaPath(assignedFile), now, now)
 	if err != nil {
 		t.Fatalf("could not change timestamps, error: %v", err)
 	}
 
-	// for now we hope that the system won't truncate the time to a less precise unit,
-	// if this test fails on certain systems that may be the reason.
 	modTime, err := store.AssignedModified()
 	if err != nil {
 		t.Fatalf("unable to determine modification time of assigned config source, error: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The test of `TestFsStoreAssignedModified` in `pkg/kubelet/kubeletconfig/checkpoint/store` fails in my environment like below.

```
$ make test WHAT=./pkg/kubelet/kubeletconfig/checkpoint/store/
Running tests for APIVersion: v1,admissionregistration.k8s.io/v1alpha1,admissionregistration.k8s.io/v1beta1,admission.k8s.io/v1beta1,apps/v1beta1,apps/v1beta2,apps/v1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2beta1,batch/v1,batch/v1beta1,batch/v2alpha1,certificates.k8s.io/v1beta1,coordination.k8s.io/v1beta1,extensions/v1beta1,events.k8s.io/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,scheduling.k8s.io/v1alpha1,scheduling.k8s.io/v1beta1,settings.k8s.io/v1alpha1,storage.k8s.io/v1beta1,storage.k8s.io/v1,storage.k8s.io/v1alpha1,
+++ [0628 22:53:39] Running tests without code coverage
--- FAIL: TestFsStoreAssignedModified (0.00s)
        fsstore_test.go:316: expect "2018-06-28T22:53:43+09:00" but got "2018-06-28T22:53:43+09:00"
FAIL
FAIL    k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint/store    0.236s
make: *** [test] Error 1
```

My environment is
OS: macOS Sierra Version 10.12.6
File System: Journaled HFS+

The error message confused me because the comparing times looked the same in the error log. If we know certain systems truncate times, I think we can just compare less precise times to avoid confusions in tests.

**Special notes for your reviewer**:
N/A

**Release note**:

```release-note
NONE
```
