### PR TITLE
Treat cloud provider addresses as authoritative

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -529,20 +529,10 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 			return fmt.Errorf("failed to get node address from cloud provider that matches ip: %v", kl.nodeIP)
 		}
 
-		// Only add a NodeHostName address if the cloudprovider did not specify one
-		// (we assume the cloudprovider knows best)
-		var addressNodeHostName *v1.NodeAddress
-		for i := range nodeAddresses {
-			if nodeAddresses[i].Type == v1.NodeHostName {
-				addressNodeHostName = &nodeAddresses[i]
-				break
-			}
-		}
-		if addressNodeHostName == nil {
-			hostnameAddress := v1.NodeAddress{Type: v1.NodeHostName, Address: kl.GetHostname()}
-			nodeAddresses = append(nodeAddresses, hostnameAddress)
-		} else {
-			glog.V(2).Infof("Using Node Hostname from cloudprovider: %q", addressNodeHostName.Address)
+		// Only use a locally detected/overridden address if the cloudprovider did not specify any.
+		// This ensures cloud-provider-reported addresses are completely authoritative, and matches the way the kubelet requests serving certificates.
+		if len(nodeAddresses) == 0 {
+			nodeAddresses = []v1.NodeAddress{{Type: v1.NodeHostName, Address: kl.GetHostname()}}
 		}
 		node.Status.Addresses = nodeAddresses
 	} else {


### PR DESCRIPTION
Addresses reported by a node using a cloud provider should be able to be verified via the cloud provider. That means we should not append locally detected addresses.

This matches the change made to cert requests that treats cloud provider addresses as authoritative: https://github.com/kubernetes/kubernetes/pull/61869

/cc @mikedanese