### PR TITLE
Fix bug printing openapi columns

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1392,6 +1392,12 @@ run_kubectl_old_print_tests() {
   actual_output=$(kubectl get pod --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
+  # Test printing objects with --use-openapi-print-columns
+  actual_output=$(kubectl get namespaces --use-openapi-print-columns --v=7 "${kube_flags[@]}" 2>&1)
+  # it should request full objects (not server-side printing)
+  kube::test::if_has_not_string "${actual_output}" 'application/json;as=Table'
+  kube::test::if_has_string "${actual_output}"     'application/json'
+
   ### Test retrieval of daemonsets against server-side printing
   kubectl apply -f hack/testdata/rollingupdate-daemonset.yaml "${kube_flags[@]}"
   # Post-condition: daemonset is created

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -318,6 +318,10 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		Latest().
 		Flatten().
 		TransformRequests(func(req *rest.Request) {
+			// We need full objects if printing with openapi columns
+			if o.PrintWithOpenAPICols {
+				return
+			}
 			if o.ServerPrint && o.IsHumanReadablePrinter && !o.Sort {
 				group := metav1beta1.GroupName
 				version := metav1beta1.SchemeGroupVersion.Version


### PR DESCRIPTION
Fixes #65579 

```release-note
kubectl: fixes a regression with --use-openapi-print-columns that would not print object contents
```