### PR TITLE
deprecate --use-openapi-print-columns in favor of --server-print

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1392,6 +1392,12 @@ run_kubectl_old_print_tests() {
   actual_output=$(kubectl get pod --server-print=false "${kube_flags[@]}" | awk 'NF{NF--};1')
   kube::test::if_has_string "${actual_output}" "${expected_output}"
 
+  # Test printing objects with --use-openapi-print-columns
+  actual_output=$(kubectl get namespaces --use-openapi-print-columns --v=7 "${kube_flags[@]}" 2>&1)
+  # it should request full objects (not server-side printing)
+  kube::test::if_has_not_string "${actual_output}" 'application/json;as=Table'
+  kube::test::if_has_string "${actual_output}"     'application/json'
+
   ### Test retrieval of daemonsets against server-side printing
   kubectl apply -f hack/testdata/rollingupdate-daemonset.yaml "${kube_flags[@]}"
   # Post-condition: daemonset is created

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -318,6 +318,10 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		Latest().
 		Flatten().
 		TransformRequests(func(req *rest.Request) {
+			// We need full objects if printing with openapi columns
+			if o.PrintWithOpenAPICols {
+				return
+			}
 			if o.ServerPrint && o.IsHumanReadablePrinter && !o.Sort {
 				group := metav1beta1.GroupName
 				version := metav1beta1.SchemeGroupVersion.Version

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -304,6 +304,11 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		return o.watch(f, cmd, args)
 	}
 
+	// openapi printing is mutually exclusive with server side printing
+	if o.PrintWithOpenAPICols && o.ServerPrint {
+		fmt.Fprintf(o.IOStreams.ErrOut, "warning: --%s requested, --%s will be ignored\n", useOpenAPIPrintColumnFlagLabel, useServerPrintColumns)
+	}
+
 	r := f.NewBuilder().
 		Unstructured().
 		NamespaceParam(o.Namespace).DefaultNamespace().AllNamespaces(o.AllNamespaces).
@@ -716,6 +721,7 @@ func (o *GetOptions) printGeneric(r *resource.Result) error {
 
 func addOpenAPIPrintColumnFlags(cmd *cobra.Command, opt *GetOptions) {
 	cmd.Flags().BoolVar(&opt.PrintWithOpenAPICols, useOpenAPIPrintColumnFlagLabel, opt.PrintWithOpenAPICols, "If true, use x-kubernetes-print-column metadata (if present) from the OpenAPI schema for displaying a resource.")
+	cmd.Flags().MarkDeprecated(useOpenAPIPrintColumnFlagLabel, "deprecated in favor of server-side printing")
 }
 
 func addServerPrintColumnFlags(cmd *cobra.Command, opt *GetOptions) {


### PR DESCRIPTION
server-side printing has been supported since 1.10 with identical output for core kubernetes types, support is available for extension API servers since 1.10, and for CRDs since 1.11.

openapi printing is mutually exclusive with server-side printing (you have to fetch full objects to do openapi printing, and table row output to do server side printing)

openapi printing has many downsides:
* it requires fetching/parsing a very large schema on every get request
* it requires complex object extraction logic be built into every client
* it is limited to literal values that appear in the objects

see discussion of long-term direction between these two approaches in https://github.com/kubernetes/kubernetes/pull/53483

/sig cli

@kubernetes/sig-cli-pr-reviews 
/assign @pwittrock @soltysh

```release-note
kubectl: --use-openapi-print-columns is deprecated in favor of --server-print
```