### PR TITLE
[WIP] Introducing RestartPolicy "AlwaysPod"

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -378,7 +378,8 @@ type podActions struct {
 	ContainersToKill map[kubecontainer.ContainerID]containerToKillInfo
 }
 
-// podSandboxChanged checks whether the spec of the pod is changed and returns
+// podSandboxChanged checks whether the spec of the pod is changed
+// or needs restart because of RestartPolicyAlwaysPod and returns
 // (changed, new attempt, original sandboxID if exist).
 func (m *kubeGenericRuntimeManager) podSandboxChanged(pod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, uint32, string) {
 	if len(podStatus.SandboxStatuses) == 0 {
@@ -414,6 +415,16 @@ func (m *kubeGenericRuntimeManager) podSandboxChanged(pod *v1.Pod, podStatus *ku
 	if !kubecontainer.IsHostNetworkPod(pod) && sandboxStatus.Network.Ip == "" {
 		glog.V(2).Infof("Sandbox for pod %q has no IP address.  Need to start a new one", format.Pod(pod))
 		return true, sandboxStatus.Metadata.Attempt + 1, sandboxStatus.Id
+	}
+
+	// For RestartPolicyAlwaysPod, check if we still need to create pod sandbox because of some failed non-init-container(s).
+	if pod.Spec.RestartPolicy == v1.RestartPolicyAlwaysPod {
+		for _, container := range pod.Spec.Containers {
+			status := podStatus.FindContainerStatusByName(container.Name)
+			if status != nil && status.State != kubecontainer.ContainerStateRunning {
+				return true, sandboxStatus.Metadata.Attempt + 1, sandboxStatus.Id
+			}
+		}
 	}
 
 	return false, sandboxStatus.Metadata.Attempt, sandboxStatus.Id

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2350,6 +2350,7 @@ type PodCondition struct {
 type RestartPolicy string
 
 const (
+	RestartPolicyAlwaysPod RestartPolicy = "AlwaysPod"
 	RestartPolicyAlways    RestartPolicy = "Always"
 	RestartPolicyOnFailure RestartPolicy = "OnFailure"
 	RestartPolicyNever     RestartPolicy = "Never"


### PR DESCRIPTION
Addresses #52345.

With RestartPolicyAlwaysPod, if any non-init container requires a restart (similar to the RestartPolicyAlways policy) then the Pod is restarted (not just the container).

I.e. the init-containers are also re-executed.

The current implementation re-creates the pod sandbox. Optimisation might be possible if pod sandbox can be re-used. TODO evaluate the possibility for the optimization.

It would be great to get review comments and suggestions on this from SIG-Node community.

This topic might be at the intersection of sig-node and sig-apps.
