### PR TITLE
Fixed the wrong elasticsearch node counter

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -104,7 +105,7 @@ func main() {
 	var endpoints *api.Endpoints
 	addrs := []string{}
 	// Wait for some endpoints.
-	count := 0
+	count, _ := strconv.Atoi(os.Getenv("MINIMUM_MASTER_NODES"))
 	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
 		endpoints, err = client.Core().Endpoints(namespace).Get(serviceName, metav1.GetOptions{})
 		if err != nil {
@@ -115,7 +116,6 @@ func main() {
 		if len(addrs) > 0 && len(addrs) == count {
 			break
 		}
-		count = len(addrs)
 	}
 	// If there was an error finding endpoints then log a warning and quit.
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I am experiencing the nasty bug during the deployment of the elasticsearch-logging statefulset on my custom Kubernetes in Azure (AzureDisk persistant storage). Let's imaging that we want two master nodes which our elasticsearch will try to find during the discovery procedure. Because of the delay between creation of two nodes (azure disk creation) there will be a situation when only one node exists in the service endpoint list and it will be enough to pass the elasticsearch logging discovery step. Only one node will be written to the elasticsearch.yml, but it expects two. Elasticsearch will not be able to find required two nodes. Then Kubernetes will terminate the first pod while the second pod is almost ready (remove that endpoint from service). Then it adds the ip of the second pod to the endpoint and discovery fails as well. This is the endless procedure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes the wrong elasticsearch node counter

```
