### PR TITLE
test/e2e_node/system/types_unix: support ZFS

### DIFF
--- a/test/e2e_node/system/types_unix.go
+++ b/test/e2e_node/system/types_unix.go
@@ -63,7 +63,7 @@ var DefaultSysSpec = SysSpec{
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.03\..*`}, // Requires [1.11, 17.03]
-			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper"},
+			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker validation tests in the case of ZFS used as the graph driver
fail due to "zfs" not being present in the default Docker specification.

Add "zfs" in the GraphDriver slice.

kubeadm relies on the `DockerValidator` and pre-flight checks would fail if the user is using ZFS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Updates kubernetes/kubeadm#930

**Special notes for your reviewer**:
NONE

/cc @kubernetes/sig-node-pr-reviews 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/cc @kvaps (reported by)
/area node-e2e
/area kubeadm

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unix: support ZFS as a valid graph driver for Docker
```
