### PR TITLE
Add Ubuntu 18.04 (Bionic) series to Juju charms

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/metadata.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/metadata.yaml
@@ -14,6 +14,7 @@ tags:
 subordinate: false
 series:
   - xenial
+  - bionic
 requires:
   apiserver:
     interface: http

--- a/cluster/juju/layers/kubernetes-e2e/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/metadata.yaml
@@ -15,6 +15,7 @@ tags:
   - conformance
 series:
   - xenial
+  - bionic
 requires:
   kubernetes-master:
     interface: http

--- a/cluster/juju/layers/kubernetes-master/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-master/metadata.yaml
@@ -20,6 +20,7 @@ tags:
 subordinate: false
 series:
   - xenial
+  - bionic
 provides:
   kube-api-endpoint:
     interface: http

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -18,6 +18,7 @@ tags:
   - misc
 series:
   - xenial
+  - bionic
 subordinate: false
 requires:
   kube-api-endpoint:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Ubuntu 18.04 (Bionic) series to Juju charms. 16.04 (Xenial) is still the default series, but with this change the charms can be easily deployed on Bionic if desired.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Add Ubuntu 18.04 (Bionic) series to Juju charms
```
