### PR TITLE
Automated cherry pick of #65584: apiserver: do not print feature gates for glog v=0

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -191,7 +191,7 @@ func (f *featureGate) Set(value string) error {
 	f.known.Store(known)
 	f.enabled.Store(enabled)
 
-	glog.Infof("feature gates: %v", enabled)
+	glog.V(1).Infof("feature gates: %v", enabled)
 	return nil
 }
 
@@ -227,7 +227,7 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 	f.known.Store(known)
 	f.enabled.Store(enabled)
 
-	glog.Infof("feature gates: %v", f.enabled)
+	glog.V(1).Infof("feature gates: %v", f.enabled)
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #65584 on release-1.11.

#65584: apiserver: do not print feature gates for glog v=0