### PR TITLE
Automated cherry pick of #65548: Bug fix: Should allow alias range size equals to max number

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -99,13 +99,13 @@ function get-cluster-ip-range {
 }
 
 # Calculate ip alias range based on max number of pods.
-# Let pow be the smallest integer which is bigger than log2($1 * 2).
+# Let pow be the smallest integer which is bigger or equal to log2($1 * 2).
 # (32 - pow) will be returned.
 #
 # $1: The number of max pods limitation.
 function get-alias-range-size() {
   for pow in {0..31}; do
-    if (( 1 << $pow > $1 * 2 )); then
+    if (( 1 << $pow >= $1 * 2 )); then
       echo $((32 - pow))
       return 0
     fi


### PR DESCRIPTION
Cherry pick of #65548 on release-1.9.

#65548: Bug fix: Should allow alias range size equals to max number