### PR TITLE
add test for convert CloudControllerManagerConfiguration api

### DIFF
--- a/pkg/apis/componentconfig/v1alpha1/defaults_test.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults_test.go
@@ -52,10 +52,28 @@ func TestControllerDefaultsRoundTrip(t *testing.T) {
 
 	ks2 := &KubeControllerManagerConfiguration{}
 	if err = json.Unmarshal([]byte(cm.Data["KubeControllerManagerConfiguration"]), ks2); err != nil {
-		t.Errorf("unexpected error unserializing controller manager config %v", err)
+		t.Errorf("unexpected error unserializing kube-controller manager config %v", err)
 	}
 
 	if !reflect.DeepEqual(ks2, ks1) {
 		t.Errorf("Expected:\n%#v\n\nGot:\n%#v", ks1, ks2)
+	}
+}
+
+func TestCloudControllerManagerConfigurationDefaults(t *testing.T) {
+	cs1 := &CloudControllerManagerConfiguration{}
+	SetDefaults_CloudControllerManagerConfiguration(cs1)
+	cm, err := componentconfig.ConvertObjToConfigMap("CloudControllerManagerConfiguration", cs1)
+	if err != nil {
+		t.Errorf("unexpected ConvertObjToConfigMap error %v", err)
+	}
+
+	cs2 := &CloudControllerManagerConfiguration{}
+	if err = json.Unmarshal([]byte(cm.Data["CloudControllerManagerConfiguration"]), cs2); err != nil {
+		t.Errorf("unexpected error unserializing cloud-controller manager config %v", err)
+	}
+
+	if !reflect.DeepEqual(cs2, cs1) {
+		t.Errorf("Expected:\n%#v\n\nGot:\n%#v", cs1, cs2)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
add `CloudControllerManagerConfiguration ` api before, but missing `test case` about it's convert.
should same as `KubeControllerManagerConfiguration` api.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
