### PR TITLE
 Make kubectl exec support "pod/" prefix in the pod name (closes #65670)

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	exec_example = templates.Examples(i18n.T(`
+	execExample = templates.Examples(i18n.T(`
 		# Get output from running 'date' from pod 123456-7890, using the first container by default
 		kubectl exec 123456-7890 date
 
@@ -76,7 +76,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		DisableFlagsInUseLine: true,
 		Short:   i18n.T("Execute a command in a container"),
 		Long:    "Execute a command in a container.",
-		Example: exec_example,
+		Example: execExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			cmdutil.CheckErr(options.Complete(f, cmd, args, argsLenAtDash))

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 
 	dockerterm "github.com/docker/docker/pkg/term"
 	"github.com/spf13/cobra"
@@ -159,7 +160,8 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 		}
 		p.Command = argsIn
 	} else {
-		p.PodName = argsIn[0]
+		// Extract "pod/" from pod name.
+		p.PodName = strings.TrimPrefix(argsIn[0], "pod/")
 		p.Command = argsIn[1:]
 		if len(p.Command) < 1 {
 			return cmdutil.UsageErrorf(cmd, execUsageStr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #65670

**Release note**:
```release-note
Add support of "pod/" prefix in the pod name to kubectl exec command.
```
