### PR TITLE
Add a timeout when fetching latest version

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -22,8 +22,13 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
+)
+
+const (
+	getReleaseVersionTimeout = time.Duration(10 * time.Second)
 )
 
 var (
@@ -69,7 +74,7 @@ func KubernetesReleaseVersion(version string) (string, error) {
 
 	if kubeReleaseLabelRegex.MatchString(versionLabel) {
 		url := fmt.Sprintf("%s/%s.txt", bucketURL, versionLabel)
-		body, err := fetchFromURL(url)
+		body, err := fetchFromURL(url, getReleaseVersionTimeout)
 		if err != nil {
 			return "", err
 		}
@@ -132,8 +137,8 @@ func splitVersion(version string) (string, string, error) {
 }
 
 // Internal helper: return content of URL
-func fetchFromURL(url string) (string, error) {
-	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+func fetchFromURL(url string, timeout time.Duration) (string, error) {
+	client := &http.Client{Timeout: timeout, Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 	resp, err := client.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("unable to get URL %q: %s", url, err.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When there is no internet on the node and `--kubernetes-versio`n is not specified running `kubeadm init` hangs forever with no text output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/986

**Special notes for your reviewer**:
Using the same duration as the existing timeout `externalEtcdRequestTimeout`

Sample output:
```
kubeadm init
unable to get URL "https://dl.k8s.io/release/stable-1.11.txt": Get https://dl.k8s.io/release/stable-1.11.txt: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: use an HTTP request timeout when fetching the latest version of Kubernetes from dl.k8s.io
```
