### PR TITLE
kubelet: Fix ResolverConfig defaulting and documentation

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -528,7 +528,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.StringVar(&c.PodCIDR, "pod-cidr", c.PodCIDR, "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master. For IPv6, the maximum number of IP's allocated is 65536")
 	fs.Int64Var(&c.PodPidsLimit, "pod-max-pids", c.PodPidsLimit, "<Warning: Alpha feature> Set the maximum number of processes per pod.")
 
-	fs.StringVar(&c.ResolverConfig, "resolv-conf", c.ResolverConfig, "Resolver configuration file used as the basis for the container DNS resolution configuration.")
+	fs.StringVar(&c.ResolverConfig, "resolv-conf", c.ResolverConfig, `Resolver configuration file used as the basis for the container DNS resolution configuration, set it to "" to prevent Pods from inheriting DNS configuration from node.`)
 	fs.BoolVar(&c.CPUCFSQuota, "cpu-cfs-quota", c.CPUCFSQuota, "Enable CPU CFS quota enforcement for containers that specify CPU limits")
 	fs.BoolVar(&c.EnableControllerAttachDetach, "enable-controller-attach-detach", c.EnableControllerAttachDetach, "Enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations")
 	fs.BoolVar(&c.MakeIPTablesUtilChains, "make-iptables-util-chains", c.MakeIPTablesUtilChains, "If true, kubelet will ensure iptables utility rules are present on host.")

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -215,7 +215,8 @@ type KubeletConfiguration struct {
 	// PodPidsLimit is the maximum number of pids in any pod.
 	PodPidsLimit int64
 	// ResolverConfig is the resolver configuration file used as the basis
-	// for the container DNS resolution configuration.
+	// for the container DNS resolution configuration, set it to "" to prevent
+	// Pods from inheriting DNS configuration from node.
 	ResolverConfig string
 	// cpuCFSQuota enables CPU CFS quota enforcement for containers that
 	// specify CPU limits

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -148,8 +148,9 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		temp := int64(-1)
 		obj.PodPidsLimit = &temp
 	}
-	if obj.ResolverConfig == "" {
-		obj.ResolverConfig = kubetypes.ResolvConfDefault
+	if obj.ResolverConfig == nil {
+		temp := kubetypes.ResolvConfDefault
+		obj.ResolverConfig = &temp
 	}
 	if obj.CPUCFSQuota == nil {
 		obj.CPUCFSQuota = utilpointer.BoolPtr(true)

--- a/pkg/kubelet/apis/config/v1beta1/types.go
+++ b/pkg/kubelet/apis/config/v1beta1/types.go
@@ -452,13 +452,14 @@ type KubeletConfiguration struct {
 	// +optional
 	PodPidsLimit *int64 `json:"podPidsLimit,omitempty"`
 	// ResolverConfig is the resolver configuration file used as the basis
-	// for the container DNS resolution configuration.
+	// for the container DNS resolution configuration, set it to "" to prevent
+	// Pods from inheriting DNS configuration from node.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
 	// changes will only take effect on Pods created after the update. Draining
 	// the node is recommended before changing this field.
 	// Default: "/etc/resolv.conf"
 	// +optional
-	ResolverConfig string `json:"resolvConf,omitempty"`
+	ResolverConfig *string `json:"resolvConf,omitempty"`
 	// cpuCFSQuota enables CPU CFS quota enforcement for containers that
 	// specify CPU limits.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -276,7 +276,9 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := v1.Convert_Pointer_int64_To_int64(&in.PodPidsLimit, &out.PodPidsLimit, s); err != nil {
 		return err
 	}
-	out.ResolverConfig = in.ResolverConfig
+	if err := v1.Convert_Pointer_string_To_string(&in.ResolverConfig, &out.ResolverConfig, s); err != nil {
+		return err
+	}
 	if err := v1.Convert_Pointer_bool_To_bool(&in.CPUCFSQuota, &out.CPUCFSQuota, s); err != nil {
 		return err
 	}
@@ -402,7 +404,9 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	if err := v1.Convert_int64_To_Pointer_int64(&in.PodPidsLimit, &out.PodPidsLimit, s); err != nil {
 		return err
 	}
-	out.ResolverConfig = in.ResolverConfig
+	if err := v1.Convert_string_To_Pointer_string(&in.ResolverConfig, &out.ResolverConfig, s); err != nil {
+		return err
+	}
 	if err := v1.Convert_bool_To_Pointer_bool(&in.CPUCFSQuota, &out.CPUCFSQuota, s); err != nil {
 		return err
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ResolverConfig != nil {
+		in, out := &in.ResolverConfig, &out.ResolverConfig
+		*out = new(string)
+		**out = **in
+	}
 	if in.CPUCFSQuota != nil {
 		in, out := &in.CPUCFSQuota, &out.CPUCFSQuota
 		*out = new(bool)


### PR DESCRIPTION
Allow setting ResolverConfig to empty string via config file to prevent
Pods from inheriting DNS configuration from node. Also, we could keep
the ResolverConfig's behavior (in config file) in line with
--resolv-conf's behavior (in the command-line).

Refer: https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#inheriting-dns-from-the-node

Signed-off-by: Jingwen Peng <pengsrc@outlook.com>

**What this PR does / why we need it**:

Currently, we can set the kubelet’s --resolv-conf flag to "" to prevent Pods from inheriting DNS configuration from node, but can not do the same thing via ResolverConfig option in config file. This PR fixs this problem by allowing setting ResolverConfig to "".

**Release note**:

```release-note
Support setting ResolverConfig to "" in kubelet's config file.
```
