### PR TITLE
Automated cherry pick of #64427: add external resource group support for azure disk

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -77,7 +78,7 @@ func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccoun
 	diskID := ""
 
 	err = kwait.ExponentialBackoff(defaultBackOff, func() (bool, error) {
-		provisonState, id, err := c.getDisk(diskName)
+		provisonState, id, err := c.getDisk(resourceGroup, diskName)
 		diskID = id
 		// We are waiting for provisioningState==Succeeded
 		// We don't want to hand-off managed disks to k8s while they are
@@ -123,8 +124,8 @@ func (c *ManagedDiskController) DeleteManagedDisk(diskURI string) error {
 }
 
 // return: disk provisionState, diskID, error
-func (c *ManagedDiskController) getDisk(diskName string) (string, string, error) {
-	result, err := c.common.cloud.DisksClient.Get(c.common.resourceGroup, diskName)
+func (c *ManagedDiskController) getDisk(resourceGroup, diskName string) (string, string, error) {
+	result, err := c.common.cloud.DisksClient.Get(resourceGroup, diskName)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
@@ -36,7 +36,8 @@ func newManagedDiskController(common *controllerCommon) (*ManagedDiskController,
 }
 
 //CreateManagedDisk : create managed disk
-func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccountType storage.SkuName, sizeGB int, tags map[string]string) (string, error) {
+func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccountType storage.SkuName, resourceGroup string,
+	sizeGB int, tags map[string]string) (string, error) {
 	glog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", diskName, storageAccountType, sizeGB)
 
 	newTags := make(map[string]*string)
@@ -62,8 +63,11 @@ func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccoun
 			DiskSizeGB:   &diskSizeGB,
 			CreationData: &disk.CreationData{CreateOption: disk.Empty},
 		}}
+	if resourceGroup == "" {
+		resourceGroup = c.common.resourceGroup
+	}
 	cancel := make(chan struct{})
-	respChan, errChan := c.common.cloud.DisksClient.CreateOrUpdate(c.common.resourceGroup, diskName, model, cancel)
+	respChan, errChan := c.common.cloud.DisksClient.CreateOrUpdate(resourceGroup, diskName, model, cancel)
 	<-respChan
 	err := <-errChan
 	if err != nil {
@@ -99,10 +103,14 @@ func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccoun
 //DeleteManagedDisk : delete managed disk
 func (c *ManagedDiskController) DeleteManagedDisk(diskURI string) error {
 	diskName := path.Base(diskURI)
+	resourceGroup, err := getResourceGroupFromDiskURI(diskURI)
+	if err != nil {
+		return err
+	}
 	cancel := make(chan struct{})
-	respChan, errChan := c.common.cloud.DisksClient.Delete(c.common.resourceGroup, diskName, cancel)
+	respChan, errChan := c.common.cloud.DisksClient.Delete(resourceGroup, diskName, cancel)
 	<-respChan
-	err := <-errChan
+	err = <-errChan
 	if err != nil {
 		return err
 	}
@@ -126,4 +134,14 @@ func (c *ManagedDiskController) getDisk(diskName string) (string, string, error)
 	}
 
 	return "", "", err
+}
+
+// get resource group name from a managed disk URI, e.g. return {group-name} according to
+// /subscriptions/{sub-id}/resourcegroups/{group-name}/providers/microsoft.compute/disks/{disk-id}
+func getResourceGroupFromDiskURI(diskURI string) (string, error) {
+	fields := strings.Split(diskURI, "/")
+	if len(fields) != 9 {
+		return "", fmt.Errorf("disk URI(%s) is not expected", diskURI)
+	}
+	return fields[4], nil
 }

--- a/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
@@ -138,10 +138,11 @@ func (c *ManagedDiskController) getDisk(diskName string) (string, string, error)
 
 // get resource group name from a managed disk URI, e.g. return {group-name} according to
 // /subscriptions/{sub-id}/resourcegroups/{group-name}/providers/microsoft.compute/disks/{disk-id}
+// according to https://docs.microsoft.com/en-us/rest/api/compute/disks/get
 func getResourceGroupFromDiskURI(diskURI string) (string, error) {
 	fields := strings.Split(diskURI, "/")
-	if len(fields) != 9 {
-		return "", fmt.Errorf("disk URI(%s) is not expected", diskURI)
+	if len(fields) != 9 || fields[3] != "resourceGroups" {
+		return "", fmt.Errorf("invalid disk URI: %s", diskURI)
 	}
 	return fields[4], nil
 }

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
 )
 
 var testClusterName = "testCluster"

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -2603,3 +2603,39 @@ func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 // func TestIfServiceIsEditedFromSharedRuleToOwnRuleThenItIsRemovedFromSharedRuleAndOwnRuleIsCreated(t *testing.T) {
 // 	t.Error()
 // }
+
+func TestGetResourceGroupFromDiskURI(t *testing.T) {
+	tests := []struct {
+		diskURL        string
+		expectedResult string
+		expectError    bool
+	}{
+		{
+			diskURL:        "/subscriptions/4be8920b-2978-43d7-axyz-04d8549c1d05/resourceGroups/azure-k8s1102/providers/Microsoft.Compute/disks/andy-mghyb1102-dynamic-pvc-f7f014c9-49f4-11e8-ab5c-000d3af7b38e",
+			expectedResult: "azure-k8s1102",
+			expectError:    false,
+		},
+		{
+			diskURL:        "/4be8920b-2978-43d7-axyz-04d8549c1d05/resourceGroups/azure-k8s1102/providers/Microsoft.Compute/disks/andy-mghyb1102-dynamic-pvc-f7f014c9-49f4-11e8-ab5c-000d3af7b38e",
+			expectedResult: "",
+			expectError:    true,
+		},
+		{
+			diskURL:        "",
+			expectedResult: "",
+			expectError:    true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := getResourceGroupFromDiskURI(test.diskURL)
+		assert.Equal(t, result, test.expectedResult, "Expect result not equal with getResourceGroupFromDiskURI(%s) return: %q, expected: %q",
+			test.diskURL, result, test.expectedResult)
+
+		if test.expectError {
+			assert.NotNil(t, err, "Expect error during getResourceGroupFromDiskURI(%s)", test.diskURL)
+		} else {
+			assert.Nil(t, err, "Expect error is nil during getResourceGroupFromDiskURI(%s)", test.diskURL)
+		}
+	}
+}

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -31,7 +31,7 @@ type DiskController interface {
 	CreateBlobDisk(dataDiskName string, storageAccountType storage.SkuName, sizeGB int) (string, error)
 	DeleteBlobDisk(diskUri string) error
 
-	CreateManagedDisk(diskName string, storageAccountType storage.SkuName, sizeGB int, tags map[string]string) (string, error)
+	CreateManagedDisk(diskName string, storageAccountType storage.SkuName, resourceGroup string, sizeGB int, tags map[string]string) (string, error)
 	DeleteManagedDisk(diskURI string) error
 
 	// Attaches the disk to the host machine.

--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure_dd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -140,6 +141,10 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	diskController, err := getDiskController(p.plugin.host)
 	if err != nil {
 		return nil, err
+	}
+
+	if resourceGroup != "" && kind != v1.AzureManagedDisk {
+		return nil, errors.New("StorageClass option 'resourceGroup' can be used only for managed disks")
 	}
 
 	// create disk

--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -40,6 +40,10 @@ type azureDiskDeleter struct {
 var _ volume.Provisioner = &azureDiskProvisioner{}
 var _ volume.Deleter = &azureDiskDeleter{}
 
+// PVCAnnotationResourceGroup is the annotation used on the PVC
+// to specify the resource group of azure managed disk that are not in the same resource group as the cluster.
+const PVCAnnotationResourceGroup = "volume.beta.kubernetes.io/resource-group"
+
 func (d *azureDiskDeleter) GetPath() string {
 	return getPath(d.podUID, d.dataDisk.diskName, d.plugin.host)
 }
@@ -142,7 +146,15 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	// create disk
 	diskURI := ""
 	if kind == v1.AzureManagedDisk {
-		diskURI, err = diskController.CreateManagedDisk(name, skuName, requestGB, *(p.options.CloudTags))
+		resourceGroup := ""
+		if rg, found := p.options.PVC.Annotations[PVCAnnotationResourceGroup]; found {
+			resourceGroup = rg
+		}
+		tags := make(map[string]string)
+		if p.options.CloudTags != nil {
+			tags = *(p.options.CloudTags)
+		}
+		diskURI, err = diskController.CreateManagedDisk(name, skuName, resourceGroup, requestGB, tags)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -40,10 +40,6 @@ type azureDiskDeleter struct {
 var _ volume.Provisioner = &azureDiskProvisioner{}
 var _ volume.Deleter = &azureDiskDeleter{}
 
-// PVCAnnotationResourceGroup is the annotation used on the PVC
-// to specify the resource group of azure managed disk that are not in the same resource group as the cluster.
-const PVCAnnotationResourceGroup = "volume.beta.kubernetes.io/resource-group"
-
 func (d *azureDiskDeleter) GetPath() string {
 	return getPath(d.podUID, d.dataDisk.diskName, d.plugin.host)
 }
@@ -95,6 +91,7 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 		cachingMode                v1.AzureDataDiskCachingMode
 		strKind                    string
 		err                        error
+		resourceGroup              string
 	)
 	// maxLength = 79 - (4 for ".vhd") = 75
 	name := volume.GenerateVolumeName(p.options.ClusterName, p.options.PVName, 75)
@@ -118,6 +115,8 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 			cachingMode = v1.AzureDataDiskCachingMode(v)
 		case volume.VolumeParameterFSType:
 			fsType = strings.ToLower(v)
+		case "resourcegroup":
+			resourceGroup = v
 		default:
 			return nil, fmt.Errorf("AzureDisk - invalid option %s in storage class", k)
 		}
@@ -146,10 +145,6 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	// create disk
 	diskURI := ""
 	if kind == v1.AzureManagedDisk {
-		resourceGroup := ""
-		if rg, found := p.options.PVC.Annotations[PVCAnnotationResourceGroup]; found {
-			resourceGroup = rg
-		}
 		tags := make(map[string]string)
 		if p.options.CloudTags != nil {
 			tags = *(p.options.CloudTags)


### PR DESCRIPTION
Cherry pick of #64427 on release-1.9.

#64427: add external resource group support for azure disk