### PR TITLE
azure: Add validation of resourceGroup option.

### DIFF
--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure_dd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -143,6 +144,10 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	diskController, err := getDiskController(p.plugin.host)
 	if err != nil {
 		return nil, err
+	}
+
+	if resourceGroup != "" && kind != v1.AzureManagedDisk {
+		return nil, errors.New("StorageClass option 'resourceGroup' can be used only for managed disks")
 	}
 
 	// create disk


### PR DESCRIPTION
ResourceGroup can be set only on `kind: Managed` disks.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @andyzhangx 