### PR TITLE
Read manifest directory in Kubelet immediately to speed up cluster startup in GCE

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -93,6 +93,10 @@ func (s *sourceFile) run() {
 	listTicker := time.NewTicker(s.period)
 
 	go func() {
+		// Read path immediately to speed up startup.
+		if err := s.listConfig(); err != nil {
+			glog.Errorf("Unable to read config path %q: %v", s.path, err)
+		}
 		for {
 			select {
 			case <-listTicker.C:


### PR DESCRIPTION
This eliminated unnecessary 20s on cluster startup.