### PR TITLE
fail on rbac resources of non-v1 versions in reconcile

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -5341,6 +5341,9 @@ runTests() {
     kube::test::get_object_assert 'clusterrolebindings -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-CRB:'
     kube::test::get_object_assert 'clusterroles -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-CR:'
 
+    failure_message=$(! kubectl auth reconcile "${kube_flags[@]}" -f test/fixtures/pkg/kubectl/cmd/auth/rbac-v1beta1.yaml 2>&1 )
+    kube::test::if_has_string "${failure_message}" 'only rbac.authorization.k8s.io/v1 is supported'
+
     kubectl delete "${kube_flags[@]}" rolebindings,role,clusterroles,clusterrolebindings -n some-other-random -l test-cmd=auth
   fi
 

--- a/pkg/kubectl/cmd/auth/BUILD
+++ b/pkg/kubectl/cmd/auth/BUILD
@@ -26,6 +26,8 @@ go_library(
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/registry/rbac/reconciliation:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
+        "//staging/src/k8s.io/api/rbac/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -18,11 +18,14 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -236,6 +239,16 @@ func (o *ReconcileOptions) RunReconcile() error {
 				return err
 			}
 			o.PrintObject(result.RoleBinding.GetObject(), o.Out)
+
+		case *rbacv1beta1.Role,
+			*rbacv1beta1.RoleBinding,
+			*rbacv1beta1.ClusterRole,
+			*rbacv1beta1.ClusterRoleBinding,
+			*rbacv1alpha1.Role,
+			*rbacv1alpha1.RoleBinding,
+			*rbacv1alpha1.ClusterRole,
+			*rbacv1alpha1.ClusterRoleBinding:
+			return fmt.Errorf("only rbac.authorization.k8s.io/v1 is supported: not %T", t)
 
 		default:
 			glog.V(1).Infof("skipping %#v", info.Object.GetObjectKind())

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-v1beta1.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-v1beta1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    labels:
+      test-cmd: auth
+    name: testing-CR
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+
+kind: List
+metadata: {}


### PR DESCRIPTION
Reconcile only supports rbac/v1 and other resources are skipped.  This is good, except that only RBAC resources should really fail.  This makes it fail.

@kubernetes/sig-cli-maintainers 

```release-note
NONE
```