### PR TITLE
[FEATURE BRANCH] Force allow create on patch if content type is apply

### DIFF
--- a/test/integration/apiserver/BUILD
+++ b/test/integration/apiserver/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",

--- a/test/integration/apiserver/apply_test.go
+++ b/test/integration/apiserver/apply_test.go
@@ -19,32 +19,37 @@ package apiserver
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
 )
 
 // TestApplyAlsoCreates makes sure that PATCH requests with the apply content type
 // will create the object if it doesn't already exist
 // TODO: make a set of test cases in an easy-to-consume place (separate package?) so it's easy to test in both integration and e2e.
 func TestApplyAlsoCreates(t *testing.T) {
-	// TODO: make setup do this optionally, and make it temporary rather than affecting global state.
-	if err := utilfeature.DefaultFeatureGate.Set(string(genericfeatures.ServerSideApply) + "=true"); err != nil {
-		t.Fatal(err)
-	}
+	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
 	_, client, closeFn := setup(t)
 	defer closeFn()
 
-	// Using limitrange here because it allows create on update
 	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
 		Namespace("default").
-		Resource("limitranges").
-		Name("test-limitrange").
+		Resource("pods").
+		Name("test-pod").
 		Body([]byte(`{
 			"apiVersion": "v1",
-			"kind": "LimitRange",
+			"kind": "Pod",
 			"metadata": {
-				"name": "test-limitrange"
+				"name": "test-pod"
+			},
+			"spec": {
+				"containers": [{
+					"name":  "test-container",
+					"image": "test-image"
+				}]
 			}
 		}`)).
 		Do().
@@ -53,8 +58,41 @@ func TestApplyAlsoCreates(t *testing.T) {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
 
-	_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource("limitranges").Name("test-limitrange").Do().Get()
+	_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource("pods").Name("test-pod").Do().Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
+	}
+}
+
+// TestCreateOnApplyFailsWithUID makes sure that PATCH requests with the apply content type
+// will not create the object if it doesn't already exist and it specifies a UID
+func TestCreateOnApplyFailsWithUID(t *testing.T) {
+	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.ServerSideApply, true)()
+
+	_, client, closeFn := setup(t)
+	defer closeFn()
+
+	_, err := client.CoreV1().RESTClient().Patch(types.ApplyPatchType).
+		Namespace("default").
+		Resource("pods").
+		Name("test-pod-uid").
+		Body([]byte(`{
+			"apiVersion": "v1",
+			"kind": "Pod",
+			"metadata": {
+				"name": "test-pod-uid",
+				"uid":  "88e00824-7f0e-11e8-94a1-c8d3ffb15800"
+			},
+			"spec": {
+				"containers": [{
+					"name":  "test-container",
+					"image": "test-image"
+				}]
+			}
+		}`)).
+		Do().
+		Get()
+	if !errors.IsConflict(err) {
+		t.Fatalf("Expected conflict error but got: %v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Force allow create on patch if content type is apply and change the apply test to use a resource which doesn't have create-on-update enabled.

**Special notes for your reviewer**:
Based on top of https://github.com/kubernetes/kubernetes/pull/65720 because it relies on #65154 from master.
Only https://github.com/kubernetes/kubernetes/pull/65723/commits/083a596367c3adf64ca3cd97ba6b99b7a24124d0 is part of this PR.

**Release note**:
```release-note
NONE
```

/sig api-machinery
/kind feature
/cc @seans3 @liggitt @apelisse 