### PR TITLE
Add DynamicProvisioningScheduling support for EBS

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -413,14 +413,10 @@ const (
 
 // VolumeOptions specifies capacity and tags for a volume.
 type VolumeOptions struct {
-	CapacityGB        int
-	Tags              map[string]string
-	PVCName           string
-	VolumeType        string
-	ZonePresent       bool
-	ZonesPresent      bool
-	AvailabilityZone  string
-	AvailabilityZones string
+	CapacityGB       int
+	Tags             map[string]string
+	VolumeType       string
+	AvailabilityZone string
 	// IOPSPerGB x CapacityGB will give total IOPS of the volume to create.
 	// Calculated total IOPS will be capped at MaxTotalIOPS.
 	IOPSPerGB int
@@ -1431,9 +1427,9 @@ func (c *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (stri
 	return aws.StringValue(inst.InstanceType), nil
 }
 
-// getCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
+// GetCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
 // It currently involves querying all instances
-func (c *Cloud) getCandidateZonesForDynamicVolume() (sets.String, error) {
+func (c *Cloud) GetCandidateZonesForDynamicVolume() (sets.String, error) {
 	// We don't currently cache this; it is currently used only in volume
 	// creation which is expected to be a comparatively rare occurrence.
 
@@ -2157,29 +2153,6 @@ func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 
 // CreateDisk implements Volumes.CreateDisk
 func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, error) {
-	var createAZ string
-	if !volumeOptions.ZonePresent && !volumeOptions.ZonesPresent {
-		// querry for candidate zones only if zone parameters absent
-		allZones, err := c.getCandidateZonesForDynamicVolume()
-		if err != nil {
-			return "", fmt.Errorf("error querying for all zones: %v", err)
-		}
-		createAZ = volumeutil.ChooseZoneForVolume(allZones, volumeOptions.PVCName)
-	}
-	if !volumeOptions.ZonePresent && volumeOptions.ZonesPresent {
-		if adminSetOfZones, err := volumeutil.ZonesToSet(volumeOptions.AvailabilityZones); err != nil {
-			return "", err
-		} else {
-			createAZ = volumeutil.ChooseZoneForVolume(adminSetOfZones, volumeOptions.PVCName)
-		}
-	}
-	if volumeOptions.ZonePresent && !volumeOptions.ZonesPresent {
-		if err := volumeutil.ValidateZone(volumeOptions.AvailabilityZone); err != nil {
-			return "", err
-		}
-		createAZ = volumeOptions.AvailabilityZone
-	}
-
 	var createType string
 	var iops int64
 	switch volumeOptions.VolumeType {
@@ -2211,7 +2184,7 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, er
 
 	// TODO: Should we tag this with the cluster id (so it gets deleted when the cluster does?)
 	request := &ec2.CreateVolumeInput{}
-	request.AvailabilityZone = aws.String(createAZ)
+	request.AvailabilityZone = aws.String(volumeOptions.AvailabilityZone)
 	request.Size = aws.Int64(int64(volumeOptions.CapacityGB))
 	request.VolumeType = aws.String(createType)
 	request.Encrypted = aws.Bool(volumeOptions.Encrypted)

--- a/pkg/volume/aws_ebs/BUILD
+++ b/pkg/volume/aws_ebs/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -56,6 +56,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//pkg/volume:go_default_library",
@@ -64,6 +65,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
     ],
 )

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -37,6 +37,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 
 	"k8s.io/kubernetes/pkg/util/slice"
 	"k8s.io/kubernetes/pkg/volume"
@@ -1017,6 +1019,443 @@ func TestValidateZone(t *testing.T) {
 	for _, succCase := range succCases {
 		if got := ValidateZone(succCase); got != nil {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, succCase, got, nil)
+		}
+	}
+}
+
+func TestSelectZoneForVolume(t *testing.T) {
+
+	nodeWithZoneLabels := &v1.Node{}
+	nodeWithZoneLabels.Labels = map[string]string{kubeletapis.LabelZoneFailureDomain: "zoneX"}
+
+	nodeWithNoLabels := &v1.Node{}
+
+	tests := []struct {
+		// Parameters passed by test to SelectZoneForVolume
+		Name                          string
+		ZonePresent                   bool
+		Zone                          string
+		ZonesPresent                  bool
+		Zones                         string
+		ZonesWithNodes                string
+		Node                          *v1.Node
+		AllowedTopologies             []v1.TopologySelectorTerm
+		DynamicProvisioningScheduling bool
+		// Expectations around returned zone from SelectZoneForVolume
+		Reject             bool   // expect error due to validation failing
+		ExpectSpecificZone bool   // expect returned zone to specifically match a single zone (rather than one from a set)
+		ExpectedZone       string // single zone that should perfectly match returned zone (requires ExpectSpecificZone to be true)
+		ExpectedZones      string // set of zones one of whose members should match returned zone (requires ExpectSpecificZone to be false)
+	}{
+		// NEGATIVE TESTS
+
+		// Zone and Zones are both specified [Fail]
+		// [1] Node irrelevant
+		// [2] Zone and Zones parameters presents
+		// [3] AllowedTopologies irrelevant
+		// [4] DynamicProvisioningScheduling  irrelevant
+		{
+			Name:         "Nil_Node_with_Zone_Zones_parameters_present",
+			ZonePresent:  true,
+			Zone:         "zoneX",
+			ZonesPresent: true,
+			Zones:        "zoneX,zoneY",
+			Reject:       true,
+		},
+
+		// Node has no zone labels [Fail]
+		// [1] Node with no zone labels
+		// [2] Zone/Zones parameter irrelevant
+		// [3] AllowedTopologies irrelevant
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Node_with_no_Zone_labels",
+			Node: nodeWithNoLabels,
+			DynamicProvisioningScheduling: true,
+			Reject: true,
+		},
+
+		// Node with Zone labels as well as Zone parameter specified [Fail]
+		// [1] Node with zone labels
+		// [2] Zone parameter specified
+		// [3] AllowedTopologies irrelevant
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name:        "Node_with_Zone_labels_and_Zone_parameter_present",
+			Node:        nodeWithZoneLabels,
+			ZonePresent: true,
+			Zone:        "zoneX",
+			DynamicProvisioningScheduling: true,
+			Reject: true,
+		},
+
+		// Node with Zone labels as well as Zones parameter specified [Fail]
+		// [1] Node with zone labels
+		// [2] Zones parameter specified
+		// [3] AllowedTopologies irrelevant
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name:         "Node_with_Zone_labels_and_Zones_parameter_present",
+			Node:         nodeWithZoneLabels,
+			ZonesPresent: true,
+			Zones:        "zoneX,zoneY",
+			DynamicProvisioningScheduling: true,
+			Reject: true,
+		},
+
+		// Zone parameter as well as AllowedTopologies specified [Fail]
+		// [1] nil Node
+		// [2] Zone parameter specified
+		// [3] AllowedTopologies specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name:        "Nil_Node_and_Zone_parameter_and_Allowed_Topology_term",
+			Node:        nil,
+			ZonePresent: true,
+			Zone:        "zoneX",
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneX"},
+						},
+					},
+				},
+			},
+			Reject: true,
+		},
+
+		// Zones parameter as well as AllowedTopologies specified [Fail]
+		// [1] nil Node
+		// [2] Zones parameter specified
+		// [3] AllowedTopologies specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name:         "Nil_Node_and_Zones_parameter_and_Allowed_Topology_term",
+			Node:         nil,
+			ZonesPresent: true,
+			Zones:        "zoneX,zoneY",
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneX"},
+						},
+					},
+				},
+			},
+			Reject: true,
+		},
+
+		// Key specified in AllowedTopologies is not LabelZoneFailureDomain [Fail]
+		// [1] nil Node
+		// [2] no Zone/Zones parameter
+		// [3] AllowedTopologies with invalid key specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Nil_Node_and_Invalid_Allowed_Topology_Key",
+			Node: nil,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    "invalid_key",
+							Values: []string{"zoneX"},
+						},
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneY"},
+						},
+					},
+				},
+			},
+			Reject: true,
+		},
+
+		// AllowedTopologies without keys specifying LabelZoneFailureDomain [Fail]
+		// [1] nil Node
+		// [2] no Zone/Zones parameter
+		// [3] Invalid AllowedTopologies
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Nil_Node_and_Invalid_AllowedTopologies",
+			Node: nil,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{},
+				},
+			},
+			Reject: true,
+		},
+
+		// POSITIVE TESTS WITH DynamicProvisioningScheduling DISABLED
+
+		// Select zone from active zones [Pass]
+		// [1] nil Node (Node irrelevant)
+		// [2] no Zone parameter
+		// [3] no AllowedTopologies
+		// [4] DynamicProvisioningScheduling disabled
+		{
+			Name:                          "No_Zone_Zones_parameter_and_DynamicProvisioningScheduling_disabled",
+			ZonesWithNodes:                "zoneX,zoneY",
+			DynamicProvisioningScheduling: false,
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select zone from single zone parameter [Pass]
+		// [1] nil Node (Node irrelevant)
+		// [2] Zone parameter specified
+		// [3] no AllowedTopologies
+		// [4] DynamicProvisioningScheduling disabled
+		{
+			Name:        "Zone_parameter_present_and_DynamicProvisioningScheduling_disabled",
+			ZonePresent: true,
+			Zone:        "zoneX",
+			DynamicProvisioningScheduling: false,
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneX",
+		},
+
+		// Select zone from zones parameter [Pass]
+		// [1] nil Node (Node irrelevant)
+		// [2] Zones parameter specified
+		// [3] no AllowedTopologies
+		// [4] DynamicProvisioningScheduling disabled
+		{
+			Name:         "Zones_parameter_present_and_DynamicProvisioningScheduling_disabled",
+			ZonesPresent: true,
+			Zones:        "zoneX,zoneY",
+			DynamicProvisioningScheduling: false,
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// POSITIVE TESTS WITH DynamicProvisioningScheduling ENABLED
+
+		// Select zone from active zones [Pass]
+		// [1] nil Node
+		// [2] no Zone parameter specified
+		// [3] no AllowedTopologies
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name:                          "Nil_Node_and_No_Zone_Zones_parameter_and_no_Allowed_topologies_and_DynamicProvisioningScheduling_enabled",
+			Node:                          nil,
+			ZonesWithNodes:                "zoneX,zoneY",
+			DynamicProvisioningScheduling: true,
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select zone from single zone parameter [Pass]
+		// [1] nil Node
+		// [2] Zone parameter specified
+		// [3] no AllowedTopology specified
+		// [4] DynamicSchedulingEnabled enabled
+		{
+			Name:        "Nil_Node_and_Zone_parameter_present_and_DynamicProvisioningScheduling_enabled",
+			ZonePresent: true,
+			Zone:        "zoneX",
+			Node:        nil,
+			DynamicProvisioningScheduling: true,
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneX",
+		},
+
+		// Select zone from zones parameter [Pass]
+		// [1] nil Node
+		// [2] Zones parameter specified
+		// [3] no AllowedTopology
+		// [4] DynamicSchedulingEnabled enabled
+		{
+			Name:         "Nil_Node_and_Zones_parameter_present_and_DynamicProvisioningScheduling_enabled",
+			ZonesPresent: true,
+			Zones:        "zoneX,zoneY",
+			Node:         nil,
+			DynamicProvisioningScheduling: true,
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select zone from node label [Pass]
+		// [1] Node with zone labels
+		// [2] no zone/zones parameters
+		// [3] no AllowedTopology
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Node_with_Zone_labels_and_DynamicProvisioningScheduling_enabled",
+			Node: nodeWithZoneLabels,
+			DynamicProvisioningScheduling: true,
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneX",
+		},
+
+		// Select zone from node label [Pass]
+		// [1] Node with zone labels
+		// [2] no Zone/Zones parameters
+		// [3] AllowedTopology with single term with multiple values specified (ignored)
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Node_with_Zone_labels_and_Multiple_Allowed_Topology_values_and_DynamicProvisioningScheduling_enabled",
+			Node: nodeWithZoneLabels,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneZ", "zoneY"},
+						},
+					},
+				},
+			},
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneX",
+		},
+
+		// Select Zone from AllowedTopologies [Pass]
+		// [1] nil Node
+		// [2] no Zone/Zones parametes specified
+		// [3] AllowedTopologies with single term with multiple values specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Nil_Node_with_Multiple_Allowed_Topology_values_and_DynamicProvisioningScheduling_enabled",
+			Node: nil,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneX", "zoneY"},
+						},
+					},
+				},
+			},
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select zone from AllowedTopologies [Pass]
+		// [1] nil Node
+		// [2] no Zone/Zones parametes specified
+		// [3] AllowedTopologies with multiple terms specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Nil_Node_and_Multiple_Allowed_Topology_terms_and_DynamicProvisioningScheduling_enabled",
+			Node: nil,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneX"},
+						},
+					},
+				},
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneY"},
+						},
+					},
+				},
+			},
+			Reject:        false,
+			ExpectedZones: "zoneX,zoneY",
+		},
+
+		// Select Zone from AllowedTopologies [Pass]
+		// Note: Dual replica with same AllowedTopologies will fail: Nil_Node_and_Single_Allowed_Topology_term_value_and_Dual_replicas
+		// [1] nil Node
+		// [2] no Zone/Zones parametes specified
+		// [3] AllowedTopologies with single term and value specified
+		// [4] DynamicProvisioningScheduling enabled
+		{
+			Name: "Nil_Node_and_Single_Allowed_Topology_term_value_and_DynamicProvisioningScheduling_enabled",
+			Node: nil,
+			DynamicProvisioningScheduling: true,
+			AllowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    kubeletapis.LabelZoneFailureDomain,
+							Values: []string{"zoneX"},
+						},
+					},
+				},
+			},
+			Reject:             false,
+			ExpectSpecificZone: true,
+			ExpectedZone:       "zoneX",
+		},
+	}
+
+	for _, test := range tests {
+		utilfeature.DefaultFeatureGate.Set("DynamicProvisioningScheduling=false")
+		if test.DynamicProvisioningScheduling {
+			utilfeature.DefaultFeatureGate.Set("DynamicProvisioningScheduling=true")
+		}
+
+		var zonesParameter, zonesWithNodes sets.String
+		var err error
+
+		if test.Zones != "" {
+			zonesParameter, err = ZonesToSet(test.Zones)
+			if err != nil {
+				t.Errorf("Could not convert Zones to a set: %s. This is a test error %s", test.Zones, test.Name)
+				continue
+			}
+		}
+
+		if test.ZonesWithNodes != "" {
+			zonesWithNodes, err = ZonesToSet(test.ZonesWithNodes)
+			if err != nil {
+				t.Errorf("Could not convert specified ZonesWithNodes to a set: %s. This is a test error %s", test.ZonesWithNodes, test.Name)
+				continue
+			}
+		}
+
+		zone, err := SelectZoneForVolume(test.ZonePresent, test.ZonesPresent, test.Zone, zonesParameter, zonesWithNodes, test.Node, test.AllowedTopologies, test.Name)
+
+		if test.Reject && err == nil {
+			t.Errorf("Unexpected zone from SelectZoneForVolume for %s", zone)
+			continue
+		}
+
+		if !test.Reject {
+			if err != nil {
+				t.Errorf("Unexpected error from SelectZoneForVolume for %s; Error: %v", test.Name, err)
+				continue
+			}
+
+			if test.ExpectSpecificZone == true {
+				if zone != test.ExpectedZone {
+					t.Errorf("Expected zone %v does not match obtained zone %v for %s", test.ExpectedZone, zone, test.Name)
+				}
+				continue
+			}
+
+			expectedZones, err := ZonesToSet(test.ExpectedZones)
+			if err != nil {
+				t.Errorf("Could not convert ExpectedZones to a set: %s. This is a test error", test.ExpectedZones)
+				continue
+			}
+			if !expectedZones.Has(zone) {
+				t.Errorf("Obtained zone %s not member of expectedZones %s", zone, expectedZones)
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for the DynamicProvisioningScheduling feature in EBS. With this in place, if VolumeBindingMode: WaitForFirstConsumer is specified in a EBS storageclass and DynamicProvisioningScheduling is enabled, EBS provisioner will use the selected node's LabelZoneFailureDomain as the zone to provision the EBS volume in.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Related to #63232

Sample `describe pv` output with NodeAffinity populated:

```
~$ kubectl describe pv pvc-f9d2138b-7e3e-11e8-a4ea-064124617820
Name:              pvc-f9d2138b-7e3e-11e8-a4ea-064124617820
Labels:            failure-domain.beta.kubernetes.io/region=us-west-2
                   failure-domain.beta.kubernetes.io/zone=us-west-2a
Annotations:       kubernetes.io/createdby=aws-ebs-dynamic-provisioner
                   pv.kubernetes.io/bound-by-controller=yes
                   pv.kubernetes.io/provisioned-by=kubernetes.io/aws-ebs
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      slow3
Status:            Bound
Claim:             default/pvc3
Reclaim Policy:    Delete
Access Modes:      RWO
Capacity:          6Gi
Node Affinity:     
  Required Terms:  
    Term 0:        failure-domain.beta.kubernetes.io/zone in [us-west-2a]
                   failure-domain.beta.kubernetes.io/region in [us-west-2]
Message:           
Source:
    Type:       AWSElasticBlockStore (a Persistent Disk resource in AWS)
    VolumeID:   aws://us-west-2a/vol-0fc1cdae7d10860f6
    FSType:     ext4
    Partition:  0
    ReadOnly:   false
Events:         <none>
```

**Release note**:
```release-note
none
```

/sig storage
/assign @msau42 @jsafrane 