### PR TITLE
Remove scheduler config deprecated warning as the new component config is still in alpha

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -144,9 +144,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 // ApplyTo applies the scheduler options to the given scheduler app configuration.
 func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
-	if len(o.ConfigFile) == 0 && len(o.WriteConfigTo) == 0 {
-		glog.Warning("WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.")
-	}
 	if len(o.ConfigFile) == 0 {
 		c.ComponentConfig = o.ComponentConfig
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new scheduler's component config file (API) is still in alpha. We shouldn't push users to use the alpha feature as it may change in the future and the changes may not be backward compatible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig scheduling