### PR TITLE
Automated cherry pick of #65731: Remove scheduler config deprecated warning as the new

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -144,9 +144,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 // ApplyTo applies the scheduler options to the given scheduler app configuration.
 func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
-	if len(o.ConfigFile) == 0 && len(o.WriteConfigTo) == 0 {
-		glog.Warning("WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.")
-	}
 	if len(o.ConfigFile) == 0 {
 		c.ComponentConfig = o.ComponentConfig
 


### PR DESCRIPTION
Cherry pick of #65731 on release-1.11.

#65731: Remove scheduler config deprecated warning as the new

Release note:

```release-note
NONE
```