### PR TITLE
Automated cherry pick of #65443: azure: Move configuration of resource group in storage class.

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_managedDiskController.go
@@ -80,7 +80,7 @@ func (c *ManagedDiskController) CreateManagedDisk(diskName string, storageAccoun
 	diskID := ""
 
 	err = kwait.ExponentialBackoff(defaultBackOff, func() (bool, error) {
-		provisonState, id, err := c.getDisk(diskName)
+		provisonState, id, err := c.getDisk(resourceGroup, diskName)
 		diskID = id
 		// We are waiting for provisioningState==Succeeded
 		// We don't want to hand-off managed disks to k8s while they are
@@ -127,8 +127,8 @@ func (c *ManagedDiskController) DeleteManagedDisk(diskURI string) error {
 }
 
 // return: disk provisionState, diskID, error
-func (c *ManagedDiskController) getDisk(diskName string) (string, string, error) {
-	result, err := c.common.cloud.DisksClient.Get(c.common.resourceGroup, diskName)
+func (c *ManagedDiskController) getDisk(resourceGroup, diskName string) (string, string, error) {
+	result, err := c.common.cloud.DisksClient.Get(resourceGroup, diskName)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure_dd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -141,6 +142,10 @@ func (p *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	diskController, err := getDiskController(p.plugin.host)
 	if err != nil {
 		return nil, err
+	}
+
+	if resourceGroup != "" && kind != v1.AzureManagedDisk {
+		return nil, errors.New("StorageClass option 'resourceGroup' can be used only for managed disks")
 	}
 
 	// create disk


### PR DESCRIPTION
Cherry pick of #65443 on release-1.8.

#65443: azure: Move configuration of resource group in storage class.

```release-note
NONE
```