### PR TITLE
Automated cherry pick of #65702: Reload systemd config files before starting kubelet.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1277,6 +1277,7 @@ ExecStart=${kubelet_bin} \$KUBELET_OPTS
 WantedBy=multi-user.target
 EOF
 
+  systemctl daemon-reload
   systemctl start kubelet.service
 }
 


### PR DESCRIPTION
Cherry pick of #65702 on release-1.9.

#65702: Reload systemd config files before starting kubelet.

```release-note
Reload systemd config files before starting kubelet.
```