### PR TITLE
Update output format so that it matches actual accepted values

### DIFF
--- a/pkg/kubectl/genericclioptions/print_flags.go
+++ b/pkg/kubectl/genericclioptions/print_flags.go
@@ -97,7 +97,7 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.NamePrintFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf("Output format. One of: %s.", strings.Join(f.AllowedFormats(), "|")))
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of #65700 on 1.11 branch.

/assign @juanvallejo @foxish 


**Release note**:
```release-note
NONE
```
