### PR TITLE
Configurable x509 user conversion mode for server-side

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -169,6 +169,12 @@ func (s *BuiltInAuthenticationOptions) Validate() []error {
 			allErrors = append(allErrors, fmt.Errorf("service-account-issuer contained a ':' but was not a valid URL: %v", err))
 		}
 	}
+	if len(s.ClientCert.ClientCA) == 0 && len(s.ClientCert.UserConversionMode) > 0 {
+		allErrors = append(allErrors, fmt.Errorf("client-ca-file must not be empty when x509-user-conversion-mode is specified"))
+	}
+	if len(s.ClientCert.UserConversionMode) > 0 && !sets.NewString(authenticator.UserConversionModes...).Has(s.ClientCert.UserConversionMode) {
+		allErrors = append(allErrors, fmt.Errorf("unsupported x509-user-conversion-mode: %s, must be one of %v", s.ClientCert.UserConversionMode, authenticator.UserConversionModes))
+	}
 
 	return allErrors
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -86,14 +86,17 @@ func (s *RequestHeaderAuthenticationOptions) ToAuthenticationRequestHeaderConfig
 
 type ClientCertAuthenticationOptions struct {
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
-	ClientCA string
+	ClientCA           string
+	UserConversionMode string
 }
 
 func (s *ClientCertAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ClientCA, "client-ca-file", s.ClientCA, ""+
 		"If set, any request presenting a client certificate signed by one of "+
-		"the authorities in the client-ca-file is authenticated with an identity "+
-		"corresponding to the CommonName of the client certificate.")
+		"the authorities in the client-ca-file is authenticated with a user identity ")
+	fs.StringVar(&s.UserConversionMode, "x509-user-conversion-mode", s.UserConversionMode, ""+
+		"Requesting client's user identity information will be extracted in the provided mode. "+
+		"Currently CommonName|DNSName|EmailAddr modes are supported. [default=CommonName]")
 }
 
 // DelegatingAuthenticationOptions provides an easy way for composing API servers to delegate their authentication to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add new flag `x509-user-conversion-mode` for kube-apiserver command. For configurable ways of extracting `UserInfo` from request certificate.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
