### PR TITLE
if loadbalancer section is not defined in cloudconfig, do not init support

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"reflect"
 	"strings"
 	"time"
 
@@ -572,6 +573,11 @@ func (os *OpenStack) HasClusterID() bool {
 // LoadBalancer initializes a LbaasV2 object
 func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	glog.V(4).Info("openstack.LoadBalancer() called")
+
+	if reflect.DeepEqual(os.lbOpts, LoadBalancerOpts{}) {
+		glog.V(4).Info("LoadBalancer section is empty/not defined in cloud-config")
+		return nil, false
+	}
 
 	network, err := os.NewNetworkV2()
 	if err != nil {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -26,8 +26,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 


### PR DESCRIPTION
**What this PR does / why we need it**: if LoadBalancer section is not defined in cloudconfig, we should not initialize loadbalancer support for openstack cloudprovider.

**Which issue(s) this PR fixes**:
Fixes #65775

**Special notes for your reviewer**:

**Release note**:
```release-note
If Openstack LoadBalancer is not defined in cloud config, the loadbalancer is not initialized any more in openstack. All setups must have some setting under that section
```
