### PR TITLE
Cleanup apiserver errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
@@ -32,14 +32,6 @@ import (
 // Avoid emitting errors that look like valid HTML. Quotes are okay.
 var sanitizer = strings.NewReplacer(`&`, "&amp;", `<`, "&lt;", `>`, "&gt;")
 
-// BadGatewayError renders a simple bad gateway error.
-func BadGatewayError(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(http.StatusBadGateway)
-	fmt.Fprintf(w, "Bad Gateway: %q", sanitizer.Replace(req.RequestURI))
-}
-
 // Forbidden renders a simple forbidden error
 func Forbidden(ctx context.Context, attributes authorizer.Attributes, w http.ResponseWriter, req *http.Request, reason string, s runtime.NegotiatedSerializer) {
 	msg := sanitizer.Replace(forbiddenMessage(attributes))
@@ -83,15 +75,7 @@ func forbiddenMessage(attributes authorizer.Attributes) string {
 
 // InternalError renders a simple internal error
 func InternalError(w http.ResponseWriter, req *http.Request, err error) {
-	w.Header().Set("Content-Type", "text/plain")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(http.StatusInternalServerError)
-	fmt.Fprintf(w, "Internal Server Error: %q: %v", sanitizer.Replace(req.RequestURI), err)
+	http.Error(w, sanitizer.Replace(fmt.Sprintf("Internal Server Error: %q: %v", req.RequestURI, err)),
+		http.StatusInternalServerError)
 	utilruntime.HandleError(err)
-}
-
-// NotFound renders a simple not found error.
-func NotFound(w http.ResponseWriter, req *http.Request) {
-	w.WriteHeader(http.StatusNotFound)
-	fmt.Fprintf(w, "Not Found: %q", sanitizer.Replace(req.RequestURI))
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors_test.go
@@ -32,8 +32,6 @@ import (
 func TestErrors(t *testing.T) {
 	internalError := errors.New("ARGH")
 	fns := map[string]func(http.ResponseWriter, *http.Request){
-		"BadGatewayError": BadGatewayError,
-		"NotFound":        NotFound,
 		"InternalError": func(w http.ResponseWriter, req *http.Request) {
 			InternalError(w, req, internalError)
 		},
@@ -43,12 +41,8 @@ func TestErrors(t *testing.T) {
 		uri      string
 		expected string
 	}{
-		{"BadGatewayError", "/get", `Bad Gateway: "/get"`},
-		{"BadGatewayError", "/<script>", `Bad Gateway: "/&lt;script&gt;"`},
-		{"NotFound", "/get", `Not Found: "/get"`},
-		{"NotFound", "/<script&>", `Not Found: "/&lt;script&amp;&gt;"`},
-		{"InternalError", "/get", `Internal Server Error: "/get": ARGH`},
-		{"InternalError", "/<script>", `Internal Server Error: "/&lt;script&gt;": ARGH`},
+		{"InternalError", "/get", "Internal Server Error: \"/get\": ARGH\n"},
+		{"InternalError", "/<script>", "Internal Server Error: \"/&lt;script&gt;\": ARGH\n"},
 	}
 	for _, test := range cases {
 		observer := httptest.NewRecorder()


### PR DESCRIPTION
- delete unused methods (is this safe, or might they be used in another project outside kubernetes/kubernetes?)
- use the standard library `http.Error` function (functional change adds a newline)

```release-note
NONE
```

/sig api-machinery
/kind cleanup