### PR TITLE
Automated cherry pick of #65482: fix 'kubectl cp' with no arguments causes a panic

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -164,6 +164,9 @@ func (o *CopyOptions) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (o *CopyOptions) Run(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("source and destination are required")
+	}
 	srcSpec, err := extractFileSpec(args[0])
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #65482 on release-1.11.

#65482: Fix 'kubectl cp' with no arguments causes a panic.