### PR TITLE
Remove DefaultingSerializer as it is not being used

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
@@ -76,24 +76,6 @@ func EncodeOrDie(e Encoder, obj Object) string {
 	return string(bytes)
 }
 
-// DefaultingSerializer invokes defaulting after decoding.
-type DefaultingSerializer struct {
-	Defaulter ObjectDefaulter
-	Decoder   Decoder
-	// Encoder is optional to allow this type to be used as both a Decoder and an Encoder
-	Encoder
-}
-
-// Decode performs a decode and then allows the defaulter to act on the provided object.
-func (d DefaultingSerializer) Decode(data []byte, defaultGVK *schema.GroupVersionKind, into Object) (Object, *schema.GroupVersionKind, error) {
-	obj, gvk, err := d.Decoder.Decode(data, defaultGVK, into)
-	if err != nil {
-		return obj, gvk, err
-	}
-	d.Defaulter.Default(obj)
-	return obj, gvk, nil
-}
-
 // UseOrCreateObject returns obj if the canonical ObjectKind returned by the provided typer matches gvk, or
 // invokes the ObjectCreator to instantiate a new gvk. Returns an error if the typer cannot find the object.
 func UseOrCreateObject(t ObjectTyper, c ObjectCreater, gvk schema.GroupVersionKind, obj Object) (Object, error) {


### PR DESCRIPTION
Keeping unused code around is confusing at least. The Serializer is not used as far as I can tell. If any external project is using it, they should just copy it in their code.