### PR TITLE
add --no-headers option for `kubectl config get-clusters`

### DIFF
--- a/pkg/kubectl/cmd/config/get_clusters.go
+++ b/pkg/kubectl/cmd/config/get_clusters.go
@@ -42,20 +42,27 @@ func NewCmdConfigGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess)
 		Long:    "Display clusters defined in the kubeconfig.",
 		Example: getClustersExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(runGetClusters(out, configAccess))
+			noHeaders := cmdutil.GetFlagBool(cmd, "no-headers")
+			err := runGetClusters(out, configAccess, noHeaders)
+			cmdutil.CheckErr(err)
 		},
 	}
+
+	cmd.Flags().Bool("no-headers", false, "Don't print headers (default print headers).")
 
 	return cmd
 }
 
-func runGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) error {
+func runGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess, noHeaders bool) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(out, "NAME\n")
+	if !noHeaders {
+		fmt.Fprintf(out, "NAME\n")
+	}
+
 	for name := range config.Clusters {
 		fmt.Fprintf(out, "%s\n", name)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
add --no-headers option for `kubectl config get-clusters`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl: add --no-headers option for `kubectl config get-clusters`
```
