### PR TITLE
[kubeadm] Print required flags when running kubeadm upgrade plan

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/golang/glog"
@@ -156,7 +157,11 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, isExternalE
 
 		UnstableVersionFlag := ""
 		if len(newK8sVersion.PreRelease()) != 0 {
-			UnstableVersionFlag = "--allow-experimental-upgrades"
+			if strings.HasPrefix(newK8sVersion.PreRelease(), "rc") {
+				UnstableVersionFlag = " --allow-release-candidate-upgrades"
+			} else {
+				UnstableVersionFlag = " --allow-experimental-upgrades"
+			}
 		}
 
 		if isExternalEtcd && upgrade.CanUpgradeEtcd() {
@@ -238,7 +243,7 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer, isExternalE
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "You can now apply the upgrade by executing the following command:")
 		fmt.Fprintln(w, "")
-		fmt.Fprintf(w, "\tkubeadm upgrade apply %s %s\n", upgrade.After.KubeVersion, UnstableVersionFlag)
+		fmt.Fprintf(w, "\tkubeadm upgrade apply %s%s\n", upgrade.After.KubeVersion, UnstableVersionFlag)
 		fmt.Fprintln(w, "")
 
 		if upgrade.Before.KubeadmVersion != upgrade.After.KubeadmVersion {

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -302,7 +302,7 @@ Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.9.0-beta.1
+	kubeadm upgrade apply v1.9.0-beta.1 --allow-experimental-upgrades
 
 Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.0-beta.1.
 
@@ -350,7 +350,7 @@ Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.9.0-rc.1
+	kubeadm upgrade apply v1.9.0-rc.1 --allow-release-candidate-upgrades
 
 Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.0-rc.1.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
print required flags when running kubeadm upgrade plan

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Close [kubernetes/kubeadm#935](https://github.com/kubernetes/kubeadm/issues/935)

**Special notes for your reviewer**:
/assign @chuckha 
/assign @neolit123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: print required flags when running kubeadm upgrade plan
```
