### PR TITLE
Update Cluster Autoscaler version to 1.1.3

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This is a patch release for Cluster Autoscaler version deployed with Kubernetes 1.9. This version was never on the master, so it can't be an automated cherry-pick.

```release-note
Cluster Autoscaler version updated to 1.1.3. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.1.3
```
