### PR TITLE
client-go/discovery: fix godoc package comment

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/BUILD
+++ b/staging/src/k8s.io/client-go/discovery/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "cached_discovery.go",
         "discovery_client.go",
+        "doc.go",
         "helper.go",
         "round_tripper.go",
         "unstructured.go",

--- a/staging/src/k8s.io/client-go/discovery/doc.go
+++ b/staging/src/k8s.io/client-go/discovery/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package discovery provides ways to discover server-supported
+// API groups, versions and resources.
+package discovery

--- a/staging/src/k8s.io/client-go/discovery/round_tripper.go
+++ b/staging/src/k8s.io/client-go/discovery/round_tripper.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package transport provides a round tripper capable of caching HTTP responses.
 package discovery
 
 import (


### PR DESCRIPTION
Fixes https://github.com/kubernetes/client-go/issues/436

/sig api-machinery
/kind cleanup
/shrug

/assign sttts 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
