### PR TITLE
Automated cherry pick of #65388

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -789,14 +789,11 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 		// add service Cluster IP:Port to kubeServiceAccess ip set for the purpose of solving hairpin.
 		// proxier.kubeServiceAccessSet.activeEntries.Insert(entry.String())
-		// Install masquerade rules if 'masqueradeAll' or 'clusterCIDR' is specified.
-		if proxier.masqueradeAll || len(proxier.clusterCIDR) > 0 {
-			if valid := proxier.ipsetList[kubeClusterIPSet].validateEntry(entry); !valid {
-				glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeClusterIPSet].Name))
-				continue
-			}
-			proxier.ipsetList[kubeClusterIPSet].activeEntries.Insert(entry.String())
+		if valid := proxier.ipsetList[kubeClusterIPSet].validateEntry(entry); !valid {
+			glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeClusterIPSet].Name))
+			continue
 		}
+		proxier.ipsetList[kubeClusterIPSet].activeEntries.Insert(entry.String())
 		// ipvs call
 		serv := &utilipvs.VirtualServer{
 			Address:   svcInfo.ClusterIP,


### PR DESCRIPTION
This PR has already been merged in master
(this is my first use of the cherry-pick script, let me know if something is missing)

```release-note
Allow access to ClusterIP from the host network namespace when kube-proxy is started in IPVS mode without either masqueradeAll or clusterCIDR flags
```