### PR TITLE
Refactor kubemark docker image building logic

### DIFF
--- a/test/kubemark/common/util.sh
+++ b/test/kubemark/common/util.sh
@@ -26,19 +26,19 @@ function run-cmd-with-retries {
     if [[ "${ret_val:-0}" -ne "0" ]]; then
       if [[ $(echo "${result}" | grep -c "already exists") -gt 0 ]]; then
         if [[ "${attempt}" == 1 ]]; then
-          echo -e "${color_red}Failed to $1 $2 $3 as the resource hasn't been deleted from a previous run.${color_norm}" >& 2
+          echo -e "${color_red}Failed to $1 $2 ${3:-} as the resource hasn't been deleted from a previous run.${color_norm}" >& 2
           exit 1
         fi
-        echo -e "${color_yellow}Succeeded to $1 $2 $3 in the previous attempt, but status response wasn't received.${color_norm}"
+        echo -e "${color_yellow}Succeeded to $1 $2 ${3:-} in the previous attempt, but status response wasn't received.${color_norm}"
         return 0
       fi
-      echo -e "${color_yellow}Attempt $attempt failed to $1 $2 $3. Retrying.${color_norm}" >& 2
+      echo -e "${color_yellow}Attempt $attempt failed to $1 $2 ${3:-}. Retrying.${color_norm}" >& 2
       sleep $(($attempt * 5))
     else
-      echo -e "${color_green}Succeeded to $1 $2 $3.${color_norm}"
+      echo -e "${color_green}Succeeded to $1 $2 ${3:-}.${color_norm}"
       return 0
     fi
   done
-  echo -e "${color_red}Failed to $1 $2 $3.${color_norm}" >& 2
+  echo -e "${color_red}Failed to $1 $2 ${3:-}.${color_norm}" >& 2
   exit 1
 }

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -25,6 +25,12 @@ function run-gcloud-compute-with-retries {
   run-cmd-with-retries gcloud compute "$@"
 }
 
+function authenticate-docker {
+  echo "Configuring registry authentication"
+  mkdir -p "${HOME}/.docker"
+  gcloud beta auth configure-docker -q
+}
+
 function create-master-instance-with-resources {
   GCLOUD_COMMON_ARGS="--project ${PROJECT} --zone ${ZONE}"
 

--- a/test/kubemark/skeleton/util.sh
+++ b/test/kubemark/skeleton/util.sh
@@ -18,6 +18,12 @@
 # Kubermark must implement to use test/kubemark/start-kubemark.sh and
 # test/kubemark/stop-kubemark.sh scripts.
 
+# This function should authenticate docker to be able to read/write to
+# the right container registry (needed for pushing kubemark image).
+function authenticate-docker {
+	echo "Configuring registry authentication" 1>&2
+}
+
 # This function should create a machine instance for the master along
 # with any/all of the following resources:
 # - Attach a PD to the master (optionally 1 more for storing events)

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -190,10 +190,7 @@ function start-master-components {
 
 # Create a docker image for hollow-node and upload it to the appropriate docker registry.
 function create-and-upload-hollow-node-image {
-  echo "Configuring registry authentication"
-  mkdir -p "${HOME}/.docker"
-  gcloud beta auth configure-docker -q
-
+  authenticate-docker
   KUBEMARK_IMAGE_REGISTRY="${KUBEMARK_IMAGE_REGISTRY:-${CONTAINER_REGISTRY}/${PROJECT}}"
   if [[ "${KUBEMARK_BAZEL_BUILD:-}" =~ ^[yY]$ ]]; then
     # Build+push the image through bazel.


### PR DESCRIPTION
This PR:

- cleans up some redundant code in kubemark scripts for image-building
- removes calls to gcloud in image-building (to make it provider independent - ref https://github.com/kubernetes/kubernetes/pull/65242#issuecomment-402479648)

/cc @wojtek-t 

```release-note
NONE
```