### PR TITLE
Fix truncating and batch backends integration.

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
@@ -102,6 +102,7 @@ type bufferedBackend struct {
 var _ audit.Backend = &bufferedBackend{}
 
 // NewBackend returns a buffered audit backend that wraps delegate backend.
+// Buffered backend automatically runs and shuts down the delegate backend.
 func NewBackend(delegate audit.Backend, config BatchConfig) audit.Backend {
 	var throttle flowcontrol.RateLimiter
 	if config.ThrottleEnable {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/truncate/truncate.go
@@ -62,6 +62,7 @@ type backend struct {
 var _ audit.Backend = &backend{}
 
 // NewBackend returns a new truncating backend, using configuration passed in the parameters.
+// Truncate backend automatically runs and shut downs the delegate backend.
 func NewBackend(delegateBackend audit.Backend, config Config, groupVersion schema.GroupVersion) audit.Backend {
 	return &backend{
 		delegateBackend: delegateBackend,
@@ -128,12 +129,11 @@ func truncate(e *auditinternal.Event) *auditinternal.Event {
 }
 
 func (b *backend) Run(stopCh <-chan struct{}) error {
-	// Nothing to do here
-	return nil
+	return b.delegateBackend.Run(stopCh)
 }
 
 func (b *backend) Shutdown() {
-	// Nothing to do here
+	b.delegateBackend.Shutdown()
 }
 
 func (b *backend) calcSize(e *auditinternal.Event) (int64, error) {


### PR DESCRIPTION
Truncating backend was not starting batch thread that is responsible for reading events from the channel.

Fixes https://github.com/kubernetes/kubernetes/pull/65819

```release-note
Fix an issue with dropped audit logs, when truncating and batch backends enabled at the same time.
```
