### PR TITLE
Catch return/error code after running unit tests

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -384,7 +384,7 @@ for (( i=0; i<${apiVersionsCount}; i++ )); do
   apiVersion=${apiVersions[i]}
   echo "Running tests for APIVersion: $apiVersion"
   # KUBE_TEST_API sets the version of each group to be tested.
-  KUBE_TEST_API="${apiVersion}" runTests "$@" ; RC=$?
+  KUBE_TEST_API="${apiVersion}" runTests "$@" && RC=$? || RC=$?
 done
 
 # We might run the tests for multiple versions, but we want to report only

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -384,7 +384,7 @@ for (( i=0; i<${apiVersionsCount}; i++ )); do
   apiVersion=${apiVersions[i]}
   echo "Running tests for APIVersion: $apiVersion"
   # KUBE_TEST_API sets the version of each group to be tested.
-  KUBE_TEST_API="${apiVersion}" runTests "$@" && RC=$? || RC=$?
+  KUBE_TEST_API="${apiVersion}" runTests "$@" ; RC=$?
 done
 
 # We might run the tests for multiple versions, but we want to report only

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -384,7 +384,7 @@ for (( i=0; i<${apiVersionsCount}; i++ )); do
   apiVersion=${apiVersions[i]}
   echo "Running tests for APIVersion: $apiVersion"
   # KUBE_TEST_API sets the version of each group to be tested.
-  KUBE_TEST_API="${apiVersion}" runTests "$@"
+  KUBE_TEST_API="${apiVersion}" runTests "$@" && RC=$? || RC=$?
 done
 
 # We might run the tests for multiple versions, but we want to report only


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When running `./build/run.sh make test` and some of the unit tests fail,
the `hack/make-rules/test.sh` script is not catching the error code and
fails without any explanation to the user.
Catching the error code permits that the scripts end successfully
showing a summary of tests results

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60946

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
