### PR TITLE
kube-apiserver: drop unused loopback token in insecure mode

### DIFF
--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -70,7 +70,6 @@ go_library(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/pborman/uuid"
 	"github.com/spf13/pflag"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -130,8 +129,7 @@ func (s *InsecureServingOptions) ApplyTo(c *server.Config) (*kubeserver.Insecure
 	}
 
 	var err error
-	privilegedLoopbackToken := uuid.NewRandom().String()
-	if c.LoopbackClientConfig, err = ret.NewLoopbackClientConfig(privilegedLoopbackToken); err != nil {
+	if c.LoopbackClientConfig, err = ret.NewLoopbackClientConfig(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -63,7 +63,7 @@ type InsecureServingInfo struct {
 	BindNetwork string
 }
 
-func (s *InsecureServingInfo) NewLoopbackClientConfig(token string) (*rest.Config, error) {
+func (s *InsecureServingInfo) NewLoopbackClientConfig() (*rest.Config, error) {
 	if s == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
The token was not used. Removing the dead code.