### PR TITLE
apiserver: make loopback logic in SecureServingOptions reusable

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -433,7 +433,7 @@ func BuildGenericConfig(
 	if insecureServingInfo, lastErr = s.InsecureServing.ApplyTo(genericConfig); lastErr != nil {
 		return
 	}
-	if lastErr = s.SecureServing.ApplyTo(genericConfig); lastErr != nil {
+	if lastErr = s.SecureServing.ApplyTo(&genericConfig.SecureServing, &genericConfig.LoopbackClientConfig); lastErr != nil {
 		return
 	}
 	if lastErr = s.Authentication.ApplyTo(genericConfig); lastErr != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -83,7 +83,7 @@ func (o *RecommendedOptions) ApplyTo(config *server.RecommendedConfig, scheme *r
 	if err := o.Etcd.ApplyTo(&config.Config); err != nil {
 		return err
 	}
-	if err := o.SecureServing.ApplyTo(&config.Config); err != nil {
+	if err := o.SecureServing.ApplyTo(&config.Config.SecureServing, &config.Config.LoopbackClientConfig); err != nil {
 		return err
 	}
 	if err := o.Authentication.ApplyTo(&config.Config.Authentication, config.SecureServing, config.OpenAPIConfig); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -485,7 +485,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			// get port
 			secureOptions.BindPort = ln.Addr().(*net.TCPAddr).Port
 			config.LoopbackClientConfig = &restclient.Config{}
-			if err := secureOptions.ApplyTo(&config); err != nil {
+			if err := secureOptions.ApplyTo(&config.SecureServing, &config.LoopbackClientConfig); err != nil {
 				t.Fatalf("failed applying the SecureServingOptions: %v", err)
 			}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pborman/uuid"
 
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
 	certutil "k8s.io/client-go/util/cert"
 )
 
@@ -35,16 +36,16 @@ func WithLoopback(o *SecureServingOptions) *SecureServingOptionsWithLoopback {
 }
 
 // ApplyTo fills up serving information in the server configuration.
-func (s *SecureServingOptionsWithLoopback) ApplyTo(c *server.Config) error {
-	if s == nil || s.SecureServingOptions == nil {
+func (s *SecureServingOptionsWithLoopback) ApplyTo(secureServingInfo **server.SecureServingInfo, loopbackClientConfig **rest.Config) error {
+	if s == nil || s.SecureServingOptions == nil || secureServingInfo == nil {
 		return nil
 	}
 
-	if err := s.SecureServingOptions.ApplyTo(&c.SecureServing); err != nil {
+	if err := s.SecureServingOptions.ApplyTo(secureServingInfo); err != nil {
 		return err
 	}
 
-	if c.SecureServing == nil {
+	if *secureServingInfo == nil || loopbackClientConfig == nil {
 		return nil
 	}
 
@@ -59,18 +60,18 @@ func (s *SecureServingOptionsWithLoopback) ApplyTo(c *server.Config) error {
 		return fmt.Errorf("failed to generate self-signed certificate for loopback connection: %v", err)
 	}
 
-	secureLoopbackClientConfig, err := c.SecureServing.NewLoopbackClientConfig(uuid.NewRandom().String(), certPem)
+	secureLoopbackClientConfig, err := (*secureServingInfo).NewLoopbackClientConfig(uuid.NewRandom().String(), certPem)
 	switch {
 	// if we failed and there's no fallback loopback client config, we need to fail
-	case err != nil && c.LoopbackClientConfig == nil:
+	case err != nil && secureLoopbackClientConfig == nil:
 		return err
 
 	// if we failed, but we already have a fallback loopback client config (usually insecure), allow it
-	case err != nil && c.LoopbackClientConfig != nil:
+	case err != nil && secureLoopbackClientConfig != nil:
 
 	default:
-		c.LoopbackClientConfig = secureLoopbackClientConfig
-		c.SecureServing.SNICerts[server.LoopbackClientServerNameOverride] = &tlsCert
+		*loopbackClientConfig = secureLoopbackClientConfig
+		(*secureServingInfo).SNICerts[server.LoopbackClientServerNameOverride] = &tlsCert
 	}
 
 	return nil


### PR DESCRIPTION
For reuse in other components this PR separates the loopback logic from the GenericApiServer config.