### PR TITLE
kube-scheduler: allow high ports in secure serving validation

### DIFF
--- a/cmd/kube-scheduler/app/options/insecure_serving.go
+++ b/cmd/kube-scheduler/app/options/insecure_serving.go
@@ -152,8 +152,8 @@ func (o *CombinedInsecureServingOptions) Validate() []error {
 
 	errors := []error{}
 
-	if o.BindPort < 0 || o.BindPort > 32767 {
-		errors = append(errors, fmt.Errorf("--port %v must be between 0 and 32767, inclusive. 0 for turning off insecure (HTTP) port", o.BindPort))
+	if o.BindPort < 0 || o.BindPort > 65335 {
+		errors = append(errors, fmt.Errorf("--port %v must be between 0 and 65335, inclusive. 0 for turning off insecure (HTTP) port", o.BindPort))
 	}
 
 	if len(o.BindAddress) > 0 && net.ParseIP(o.BindAddress) == nil {


### PR DESCRIPTION
Certain operating systems will select high port (>32768) when asked for a free port. This PR changes the validation to allow that.

```release-note
Allow kube-scheduler to listen on ports up to 65535.
```