### PR TITLE
fix kubectl cluster-info bug

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -92,8 +92,6 @@ func (o *ClusterInfoOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) err
 }
 
 func (o *ClusterInfoOptions) Run() error {
-	printService(o.Out, "Kubernetes master", o.Client.Host)
-
 	// TODO use generalized labels once they are implemented (#341)
 	b := o.Builder.
 		WithScheme(legacyscheme.Scheme).
@@ -105,6 +103,8 @@ func (o *ClusterInfoOptions) Run() error {
 		if err != nil {
 			return err
 		}
+		printService(o.Out, "Kubernetes master", o.Client.Host)
+
 		services := r.Object.(*api.ServiceList).Items
 		for _, service := range services {
 			var link string


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
   When api-server is not avaiable,` kubectl cluster-info `still prints information like: the cluster is running at ...
    This patch fixes this bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #65817 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
