### PR TITLE
Remove duplicate check line in cpumanager

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -30,8 +30,6 @@ import (
 // PolicyStatic is the name of the static policy
 const PolicyStatic policyName = "static"
 
-var _ Policy = &staticPolicy{}
-
 // staticPolicy is a CPU manager policy that does not change CPU
 // assignments for exclusively pinned guaranteed containers after the main
 // container process starts.


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a same [line](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cpumanager/policy_static.go#L81).

**Release note**:
```release-note
NONE
```
