### PR TITLE
Update Cluster Autoscaler version to 1.3.1-beta.1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.1-beta.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",
@@ -33,6 +33,7 @@
                     "--logtostderr=true",
                     "--write-status-configmap=true",
                     "--balance-similar-node-groups=true",
+		    "--expendable-pods-priority-cutoff=-10",
                     "{{params}}"
                 ],
                 "env": [


### PR DESCRIPTION
This update Cluster Autoscaler version to 1.3.1-beta.1 and changes the default value for expendable pods priority cutoff in GCP deployment.

```release-note
Cluster Autoscaler version updated to 1.3.1-beta.1. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.3.1-beta.1
Default value for expendable pod priority cutoff in GCP deployment of Cluster Autoscaler changed from 0 to -10.

action required: users deploying workloads with priority lower than 0 may want to use priority lower than -10 to avoid triggering scale-up.
```
