### PR TITLE
[WIP] Bump Heapster to v1.5.4

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.3
+  name: heapster-v1.5.4
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.3
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.3
+      version: v1.5.4
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.3
+        version: v1.5.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:
@@ -73,7 +73,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=gcm
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: eventer
           command:
             - /eventer
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -141,7 +141,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.3
+  name: heapster-v1.5.4
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.3
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.3
+      version: v1.5.4
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.3
+        version: v1.5.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:
@@ -74,7 +74,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: eventer
           command:
             - /eventer
@@ -109,7 +109,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -142,7 +142,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.3
+  name: heapster-v1.5.4
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.3
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.3
+      version: v1.5.4
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.3
+        version: v1.5.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:
@@ -73,7 +73,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: eventer
           command:
             - /eventer
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -141,7 +141,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -23,31 +23,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.3
+  name: heapster-v1.5.4
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.3
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.3
+      version: v1.5.4
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.3
+        version: v1.5.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             timeoutSeconds: 5
           command:
             - /heapster
-            - --source=kubernetes.summary_api:''
+            - --source=kubernetes.summary_api:?host_id_annotation=container.googleapis.com/instance_id
             - --sink=stackdriver:?cluster_name={{ cluster_name }}&use_old_resources={{ use_old_resources }}&use_new_resources={{ use_new_resources }}&min_interval_sec=100&batch_export_timeout_sec=110&cluster_location={{ cluster_location }}
         # BEGIN_PROMETHEUS_TO_SD
         - name: prom-to-sd
@@ -109,7 +109,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -23,31 +23,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.3
+  name: heapster-v1.5.4
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.3
+    version: v1.5.4
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.3
+      version: v1.5.4
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.3
+        version: v1.5.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.3
+        - image: k8s.gcr.io/heapster-amd64:v1.5.4
           name: heapster
           livenessProbe:
             httpGet:
@@ -88,7 +88,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.3
+            - --deployment=heapster-v1.5.4
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Heapster to v1.5.4. For Stackdriver sink, uses a node annotation "container.googleapis.com/instance_id" if ExternalID is not available in node spec. This is a part of fixing integration with Stackdriver in Kubernetes 1.11+, the other part is to set this annotation with gcp-controller-manager: https://github.com/kubernetes/cloud-provider-gcp/pull/24

**Release note**:
```release-note
Use node annotation "container.googleapis.com/instance_id" to set Stackdriver label instance_id if ExternalID is not set.
```

Work in progress: waiting for Heapster v1.5.4 release.
