### PR TITLE
kube-controller-manager: create self-signed certs

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -423,6 +423,10 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 		return nil, err
 	}
 
+	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -236,7 +236,7 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 }
 
 func (s *SecureServingOptions) MaybeDefaultWithSelfSignedCerts(publicAddress string, alternateDNS []string, alternateIPs []net.IP) error {
-	if s == nil {
+	if s == nil || (s.BindPort == 0 && s.Listener == nil) {
 		return nil
 	}
 	keyCert := &s.ServerCert.CertKey


### PR DESCRIPTION
If secure serving is enabled (not automatically wired yet, but 3rdparties could wire it), create self-signed certs if none are given. Reuses the code from k8s.io/apiserver.