### PR TITLE
[WIP] make metav1.AddToGroupVersion an API scheme installer

### DIFF
--- a/staging/src/k8s.io/api/admission/v1beta1/register.go
+++ b/staging/src/k8s.io/api/admission/v1beta1/register.go
@@ -36,7 +36,7 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes, metav1.InstallInGroupVersion(SchemeGroupVersion))
 	localSchemeBuilder = &SchemeBuilder
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
@@ -46,6 +46,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AdmissionReview{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/register.go
@@ -35,7 +35,7 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes, metav1.InstallInGroupVersion(SchemeGroupVersion))
 	localSchemeBuilder = &SchemeBuilder
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
@@ -46,6 +46,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&InitializerConfiguration{},
 		&InitializerConfigurationList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/register.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/register.go
@@ -35,7 +35,7 @@ func Resource(resource string) schema.GroupResource {
 var (
 	// TODO: move SchemeBuilder with zz_generated.deepcopy.go to k8s.io/api.
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes, metav1.InstallInGroupVersion(SchemeGroupVersion))
 	localSchemeBuilder = &SchemeBuilder
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
@@ -48,6 +48,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MutatingWebhookConfiguration{},
 		&MutatingWebhookConfigurationList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
Updates the function that adds meta types to a scheme to be a scheme installer for clear composition.

@sttts @k8s-mirror-api-machinery-misc 