### PR TITLE
juju: Fix kubernetes-worker certificate SANs on AWS

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -361,7 +361,7 @@ def send_data(tls, kube_control):
     sans = [
         hookenv.unit_public_ip(),
         ingress_ip,
-        get_node_name()
+        gethostname()
     ]
 
     # Create a path safe name by removing path characters from the unit name.


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a problem with kubernetes-worker that prevents `kubectl logs` and `kubectl exec` from working when deployed on AWS.

Specifically, this adds hostname back into the certificate request's SANs so that kube-apiserver can talk to kubelet properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/606

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
