### PR TITLE
wire PrintFlags through rollout commands

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout.go
+++ b/pkg/kubectl/cmd/rollout/rollout.go
@@ -56,10 +56,10 @@ func NewCmdRollout(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 		Run:     cmdutil.DefaultSubCommandRun(streams.Out),
 	}
 	// subcommands
-	cmd.AddCommand(NewCmdRolloutHistory(f, streams.Out))
+	cmd.AddCommand(NewCmdRolloutHistory(f, streams))
 	cmd.AddCommand(NewCmdRolloutPause(f, streams))
 	cmd.AddCommand(NewCmdRolloutResume(f, streams))
-	cmd.AddCommand(NewCmdRolloutUndo(f, streams.Out))
+	cmd.AddCommand(NewCmdRolloutUndo(f, streams))
 	cmd.AddCommand(NewCmdRolloutStatus(f, streams))
 
 	return cmd

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -18,16 +18,18 @@ package rollout
 
 import (
 	"fmt"
-	"io"
+
+	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
-
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -42,8 +44,33 @@ var (
 		kubectl rollout history daemonset/abc --revision=3`)
 )
 
-func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
-	options := &resource.FilenameOptions{}
+type RolloutHistoryOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+	ToPrinter  func(string) (printers.ResourcePrinter, error)
+
+	Revision int64
+
+	Builder          func() *resource.Builder
+	Resources        []string
+	Namespace        string
+	EnforceNamespace bool
+
+	HistoryViewer    polymorphichelpers.HistoryViewerFunc
+	RESTClientGetter genericclioptions.RESTClientGetter
+
+	resource.FilenameOptions
+	genericclioptions.IOStreams
+}
+
+func NewRolloutHistoryOptions(streams genericclioptions.IOStreams) *RolloutHistoryOptions {
+	return &RolloutHistoryOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+		IOStreams:  streams,
+	}
+}
+
+func NewCmdRolloutHistory(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRolloutHistoryOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
 
@@ -54,42 +81,65 @@ func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    history_long,
 		Example: history_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(RunHistory(f, cmd, out, args, options))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			cmdutil.CheckErr(o.Run())
 		},
 		ValidArgs: validArgs,
 	}
 
-	cmd.Flags().Int64("revision", 0, "See the details, including podTemplate of the revision specified")
+	cmd.Flags().Int64Var(&o.Revision, "revision", o.Revision, "See the details, including podTemplate of the revision specified")
+
 	usage := "identifying the resource to get from a server."
-	cmdutil.AddFilenameOptionFlags(cmd, options, usage)
+	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+
+	o.PrintFlags.AddFlags(cmd)
+
 	return cmd
 }
 
-func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string, options *resource.FilenameOptions) error {
-	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
-		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
-	}
-	revision := cmdutil.GetFlagInt64(cmd, "revision")
-	if revision < 0 {
-		return fmt.Errorf("revision must be a positive integer: %v", revision)
-	}
+func (o *RolloutHistoryOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	o.Resources = args
 
-	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
+	var err error
+	if o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace(); err != nil {
 		return err
 	}
 
-	r := f.NewBuilder().
+	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
+		o.PrintFlags.NamePrintFlags.Operation = operation
+		return o.PrintFlags.ToPrinter()
+	}
+
+	o.HistoryViewer = polymorphichelpers.HistoryViewerFn
+	o.RESTClientGetter = f
+	o.Builder = f.NewBuilder
+
+	return nil
+}
+
+func (o *RolloutHistoryOptions) Validate() error {
+	if len(o.Resources) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
+		return fmt.Errorf("Required resource not specified.")
+	}
+	if o.Revision < 0 {
+		return fmt.Errorf("revision must be a positive integer: %v", o.Revision)
+	}
+
+	return nil
+}
+
+func (o *RolloutHistoryOptions) Run() error {
+
+	r := o.Builder().
 		WithScheme(legacyscheme.Scheme).
-		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options).
-		ResourceTypeOrNameArgs(true, args...).
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
+		ResourceTypeOrNameArgs(true, o.Resources...).
 		ContinueOnError().
 		Latest().
 		Flatten().
 		Do()
-	err = r.Err()
-	if err != nil {
+	if err := r.Err(); err != nil {
 		return err
 	}
 
@@ -97,22 +147,27 @@ func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []str
 		if err != nil {
 			return err
 		}
+
 		mapping := info.ResourceMapping()
-		historyViewer, err := polymorphichelpers.HistoryViewerFn(f, mapping)
+		historyViewer, err := o.HistoryViewer(o.RESTClientGetter, mapping)
 		if err != nil {
 			return err
 		}
-		historyInfo, err := historyViewer.ViewHistory(info.Namespace, info.Name, revision)
+		historyInfo, err := historyViewer.ViewHistory(info.Namespace, info.Name, o.Revision)
 		if err != nil {
 			return err
 		}
 
-		header := fmt.Sprintf("%s %q", mapping.Resource.Resource, info.Name)
-		if revision > 0 {
-			header = fmt.Sprintf("%s with revision #%d", header, revision)
+		withRevision := ""
+		if o.Revision > 0 {
+			withRevision = fmt.Sprintf("with revision #%d", o.Revision)
 		}
-		fmt.Fprintf(out, "%s\n", header)
-		fmt.Fprintf(out, "%s\n", historyInfo)
-		return nil
+
+		printer, err := o.ToPrinter(fmt.Sprintf("%s\n%s", withRevision, historyInfo))
+		if err != nil {
+			return err
+		}
+
+		return printer.PrintObj(cmdutil.AsDefaultVersionedOrOriginal(info.Object, info.Mapping), o.Out)
 	})
 }

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -38,13 +38,16 @@ import (
 // PauseConfig is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type PauseConfig struct {
-	resource.FilenameOptions
 	PrintFlags *genericclioptions.PrintFlags
 	ToPrinter  func(string) (printers.ResourcePrinter, error)
 
-	Pauser polymorphichelpers.ObjectPauserFunc
-	Infos  []*resource.Info
+	Pauser           polymorphichelpers.ObjectPauserFunc
+	Builder          func() *resource.Builder
+	Namespace        string
+	EnforceNamespace bool
+	Resources        []string
 
+	resource.FilenameOptions
 	genericclioptions.IOStreams
 }
 
@@ -79,7 +82,7 @@ func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		Example: pause_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			allErrs := []error{}
-			err := o.CompletePause(f, cmd, args)
+			err := o.Complete(f, cmd, args)
 			if err != nil {
 				allErrs = append(allErrs, err)
 			}
@@ -92,53 +95,64 @@ func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		ValidArgs: validArgs,
 	}
 
+	o.PrintFlags.AddFlags(cmd)
+
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
 	return cmd
 }
 
-func (o *PauseConfig) CompletePause(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+func (o *PauseConfig) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
 		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
 	}
 
 	o.Pauser = polymorphichelpers.ObjectPauserFn
 
-	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
+	var err error
+	if o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace(); err != nil {
 		return err
 	}
 
-	r := f.NewBuilder().
-		WithScheme(legacyscheme.Scheme).
-		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, &o.FilenameOptions).
-		ResourceTypeOrNameArgs(true, args...).
-		ContinueOnError().
-		Latest().
-		Flatten().
-		Do()
-	err = r.Err()
-	if err != nil {
-		return err
-	}
+	o.Resources = args
+	o.Builder = f.NewBuilder
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		o.PrintFlags.NamePrintFlags.Operation = operation
 		return o.PrintFlags.ToPrinter()
 	}
 
-	o.Infos, err = r.Infos()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
 func (o PauseConfig) RunPause() error {
+	r := o.Builder().
+		WithScheme(legacyscheme.Scheme).
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
+		ResourceTypeOrNameArgs(true, o.Resources...).
+		ContinueOnError().
+		Latest().
+		Flatten().
+		Do()
+	if err := r.Err(); err != nil {
+		return err
+	}
+
 	allErrs := []error{}
-	for _, patch := range set.CalculatePatches(o.Infos, cmdutil.InternalVersionJSONEncoder(), set.PatchFn(o.Pauser)) {
+	infos, err := r.Infos()
+	if err != nil {
+		// restore previous command behavior where
+		// an error caused by retrieving infos due to
+		// at least a single broken object did not result
+		// in an immediate return, but rather an overall
+		// aggregation of errors.
+		allErrs = append(allErrs, err)
+	}
+
+	for _, patch := range set.CalculatePatches(infos, cmdutil.InternalVersionJSONEncoder(), set.PatchFn(o.Pauser)) {
 		info := patch.Info
+
 		if patch.Err != nil {
 			resourceString := info.Mapping.Resource.Resource
 			if len(info.Mapping.Resource.Group) > 0 {

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -17,14 +17,11 @@ limitations under the License.
 package rollout
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -37,17 +34,19 @@ import (
 // UndoOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type UndoOptions struct {
-	resource.FilenameOptions
-
 	PrintFlags *genericclioptions.PrintFlags
 	ToPrinter  func(string) (printers.ResourcePrinter, error)
 
-	Rollbackers []kubectl.Rollbacker
-	Infos       []*resource.Info
-	ToRevision  int64
-	DryRun      bool
+	Builder          func() *resource.Builder
+	ToRevision       int64
+	DryRun           bool
+	Resources        []string
+	Namespace        string
+	EnforceNamespace bool
+	RESTClientGetter genericclioptions.RESTClientGetter
 
-	Out io.Writer
+	resource.FilenameOptions
+	genericclioptions.IOStreams
 }
 
 var (
@@ -65,11 +64,16 @@ var (
 		kubectl rollout undo --dry-run=true deployment/abc`)
 )
 
-func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
-	o := &UndoOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+func NewRolloutUndoOptions(streams genericclioptions.IOStreams) *UndoOptions {
+	return &UndoOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("rolled back").WithTypeSetter(scheme.Scheme),
+		IOStreams:  streams,
 		ToRevision: int64(0),
 	}
+}
+
+func NewCmdRolloutUndo(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRolloutUndoOptions(streams)
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
 
@@ -81,7 +85,7 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Example: undo_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			allErrs := []error{}
-			err := o.CompleteUndo(f, cmd, out, args)
+			err := o.Complete(f, cmd, args)
 			if err != nil {
 				allErrs = append(allErrs, err)
 			}
@@ -98,19 +102,20 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
+	o.PrintFlags.AddFlags(cmd)
 	return cmd
 }
 
-func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
+func (o *UndoOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 
-	o.Out = out
+	o.Resources = args
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 
-	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
+	var err error
+	if o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace(); err != nil {
 		return err
 	}
 
@@ -122,49 +127,47 @@ func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io
 		return o.PrintFlags.ToPrinter()
 	}
 
-	r := f.NewBuilder().
-		WithScheme(legacyscheme.Scheme).
-		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, &o.FilenameOptions).
-		ResourceTypeOrNameArgs(true, args...).
-		ContinueOnError().
-		Latest().
-		Flatten().
-		Do()
-	err = r.Err()
-	if err != nil {
-		return err
-	}
+	o.RESTClientGetter = f
+	o.Builder = f.NewBuilder
 
-	err = r.Visit(func(info *resource.Info, err error) error {
-		if err != nil {
-			return err
-		}
-		rollbacker, err := polymorphichelpers.RollbackerFn(f, info.ResourceMapping())
-		if err != nil {
-			return err
-		}
-		o.Infos = append(o.Infos, info)
-		o.Rollbackers = append(o.Rollbackers, rollbacker)
-		return nil
-	})
 	return err
 }
 
 func (o *UndoOptions) RunUndo() error {
-	allErrs := []error{}
-	for ix, info := range o.Infos {
-		result, err := o.Rollbackers[ix].Rollback(info.Object, nil, o.ToRevision, o.DryRun)
+	r := o.Builder().
+		WithScheme(legacyscheme.Scheme).
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
+		ResourceTypeOrNameArgs(true, o.Resources...).
+		ContinueOnError().
+		Latest().
+		Flatten().
+		Do()
+	if err := r.Err(); err != nil {
+		return err
+	}
+
+	err := r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
-			allErrs = append(allErrs, cmdutil.AddSourceToErr("undoing", info.Source, err))
-			continue
+			return err
 		}
+		rollbacker, err := polymorphichelpers.RollbackerFn(o.RESTClientGetter, info.ResourceMapping())
+		if err != nil {
+			return err
+		}
+
+		result, err := rollbacker.Rollback(info.Object, nil, o.ToRevision, o.DryRun)
+		if err != nil {
+			return err
+		}
+
 		printer, err := o.ToPrinter(result)
 		if err != nil {
-			allErrs = append(allErrs, err)
-			continue
+			return err
 		}
-		printer.PrintObj(cmdutil.AsDefaultVersionedOrOriginal(info.Object, info.Mapping), o.Out)
-	}
-	return utilerrors.NewAggregate(allErrs)
+
+		return printer.PrintObj(cmdutil.AsDefaultVersionedOrOriginal(info.Object, info.Mapping), o.Out)
+	})
+
+	return err
 }

--- a/pkg/kubectl/genericclioptions/print_flags.go
+++ b/pkg/kubectl/genericclioptions/print_flags.go
@@ -90,7 +90,7 @@ func (f *PrintFlags) ToPrinter() (printers.ResourcePrinter, error) {
 	// to honoring the --template argument.
 	if f.TemplatePrinterFlags != nil && f.TemplatePrinterFlags.TemplateArgument != nil &&
 		len(*f.TemplatePrinterFlags.TemplateArgument) > 0 &&
-		(len(outputFormat) == 0 || (f.outputDefaulted && !f.outputFlag.Changed)) {
+		(len(outputFormat) == 0 || (f.outputDefaulted && f.outputFlag != nil && !f.outputFlag.Changed)) {
 		outputFormat = "go-template"
 	}
 

--- a/test/cmd/template-output.sh
+++ b/test/cmd/template-output.sh
@@ -98,7 +98,7 @@ run_template_output_tests() {
   kube::test::if_has_string "${output_message}" 'cm:'
 
   # check that "create deployment" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]}" create deployment deploy --dry-run --image=nginx --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]}" create deployment deploy --image=nginx --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'deploy:'
 
   # check that "create job" command supports --template output
@@ -209,6 +209,22 @@ EOF
   output_message=$(kubectl "${kube_flags[@]}" config view)
   kube::test::if_has_string "${output_message}" 'kind: Config'
 
+  # check that "rollout pause" supports --template output
+  output_message=$(kubectl "${kube_flags[@]}" rollout pause deploy/deploy --template="{{ .metadata.name }}:")
+  kube::test::if_has_string "${output_message}" 'deploy:'
+
+   # check that "rollout history" supports --template output
+  output_message=$(kubectl "${kube_flags[@]}" rollout history deploy/deploy --template="{{ .metadata.name }}:")
+  kube::test::if_has_string "${output_message}" 'deploy:'
+
+  # check that "rollout resume" supports --template output
+  output_message=$(kubectl "${kube_flags[@]}" rollout resume deploy/deploy --template="{{ .metadata.name }}:")
+  kube::test::if_has_string "${output_message}" 'deploy:'
+
+  # check that "rollout undo" supports --template output
+  output_message=$(kubectl "${kube_flags[@]}" rollout undo deploy/deploy --template="{{ .metadata.name }}:")
+  kube::test::if_has_string "${output_message}" 'deploy:'
+
   # check that "config view" command supports --template output
   # and that commands that set a default output (yaml in this case),
   # default to "go-template" as their output format when a --template
@@ -227,6 +243,7 @@ EOF
   kubectl delete rc cassandra "${kube_flags[@]}"
   kubectl delete clusterrole myclusterrole "${kube_flags[@]}"
   kubectl delete clusterrolebinding foo "${kube_flags[@]}"
+  kubectl delete deployment deploy "${kube_flags[@]}"
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
Binds PrintFlags to rollout commands.
Adds tests ensuring --template printing is supported by rollout cmds.

Fixes https://github.com/kubernetes/kubernetes/issues/65778

**Release note**:
```release-note
NONE
```

cc @soltysh @deads2k 