### PR TITLE
WIP - Require all conversions to be strictly defined

### DIFF
--- a/pkg/apis/core/register.go
+++ b/pkg/apis/core/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 package core
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,9 +43,6 @@ var (
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {
-	if err := scheme.AddIgnoredConversionType(&metav1.TypeMeta{}, &metav1.TypeMeta{}); err != nil {
-		return err
-	}
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},
 		&PodList{},

--- a/pkg/scheduler/api/register.go
+++ b/pkg/scheduler/api/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 package api
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -45,9 +44,6 @@ func init() {
 }
 
 func addKnownTypes(scheme *runtime.Scheme) error {
-	if err := scheme.AddIgnoredConversionType(&metav1.TypeMeta{}, &metav1.TypeMeta{}); err != nil {
-		return err
-	}
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Policy{},
 	)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
@@ -54,9 +54,6 @@ func Kind(kind string) schema.GroupKind {
 
 // addToGroupVersion registers common meta types into schemas.
 func addToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion) error {
-	if err := scheme.AddIgnoredConversionType(&metav1.TypeMeta{}, &metav1.TypeMeta{}); err != nil {
-		return err
-	}
 	err := scheme.AddConversionFuncs(
 		metav1.Convert_string_To_labels_Selector,
 		metav1.Convert_labels_Selector_To_string,

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter.go
@@ -463,6 +463,13 @@ func (f FieldMatchingFlags) IsSet(flag FieldMatchingFlags) bool {
 // Not safe for objects with cyclic references!
 func (c *Converter) ConvertExplicit(src, dest interface{}, flags FieldMatchingFlags, meta *Meta) error {
 	pair := typePair{reflect.TypeOf(src), reflect.TypeOf(dest)}
+
+	if pair.source.Kind() == reflect.Ptr && pair.source == pair.dest {
+		sV, dV := reflect.ValueOf(src), reflect.ValueOf(dest)
+		dV.Set(sV)
+		return nil
+	}
+
 	scope := &scope{
 		converter: c,
 		flags:     flags,

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -41,9 +41,6 @@ func TestScheme(t *testing.T) {
 	scheme.AddKnownTypeWithName(internalGVK, &runtimetesting.InternalSimple{})
 	scheme.AddKnownTypeWithName(externalGVK, &runtimetesting.ExternalSimple{})
 
-	// If set, would clear TypeMeta during conversion.
-	//scheme.AddIgnoredConversionType(&TypeMeta{}, &TypeMeta{})
-
 	// test that scheme is an ObjectTyper
 	var _ runtime.ObjectTyper = scheme
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
@@ -26,6 +26,9 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddDefaultConversion((*api.Config)(nil), (*Config)(nil)); err != nil {
+		return err
+	}
 	return scheme.AddConversionFuncs(
 		func(in *Cluster, out *api.Cluster, s conversion.Scope) error {
 			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)


### PR DESCRIPTION
Provide stronger restrictions around what reflective conversions are performed by having runtime.Scheme require explicit registered conversions.

Builds on top of #65771