### PR TITLE
Add script to verify generated files

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -40,7 +40,6 @@ QUICK_PATTERNS+=(
   "verify-api-groups.sh"
   "verify-bazel.sh"
   "verify-boilerplate.sh"
-  "verify-generated-files-remake"
   "verify-godep-licenses.sh"
   "verify-gofmt.sh"
   "verify-imports.sh"

--- a/hack/verify-generated-files.sh
+++ b/hack/verify-generated-files.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+_tmpdir="$(kube::realpath $(mktemp -d -t verify-generated-files.XXXXXX))"
+kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
+
+_tmp_gopath="${_tmpdir}/go"
+_tmp_kuberoot="${_tmp_gopath}/src/k8s.io/kubernetes"
+mkdir -p "${_tmp_kuberoot}/.."
+cp -a "${KUBE_ROOT}" "${_tmp_kuberoot}/.."
+
+cd "${_tmp_kuberoot}"
+
+# clean out anything from the temp dir that's not checked in
+git clean -ffxd
+# regenerate any generated code
+make generated_files
+
+diff=$(git diff --name-only)
+
+if [[ -n "${diff}" ]]; then
+  echo "!!! Generated code is out of date:" >&2
+  echo "${diff}" >&2
+  echo >&2
+  echo "Please run make generated_files." >&2
+  exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is probably *really* heavy handed fix to this, but it will catch issues in presubmit.

Basically, takes a copy of the repo, clears out anything that is ignored from the git tree, runs `make generated_files`, and looks for a git diff. If there is one, error. Anything that is properly gitignored won't cause a diff, but anything that is *supposed* to be checked in, but is different, this will catch.

**Special notes for your reviewer**:
I'm open to more elegant answers, but this will at least stop it from happening for now.

**Release note**:
```release-note
NONE
```
