### PR TITLE
WIP: Move mount.FakeMounter into subdir testing.

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -198,6 +198,7 @@ go_test(
         "//pkg/kubelet/volumemanager:go_default_library",
         "//pkg/scheduler/cache:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/aws_ebs:go_default_library",

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -135,6 +135,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/kubelet/eviction/api:go_default_library",
             "//pkg/util/mount:go_default_library",
+            "//pkg/util/mount/testing:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 )
 
 func fakeContainerMgrMountInt() mount.Interface {
-	return &mount.FakeMounter{
+	return &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{
 				Device: "cgroup",
@@ -64,7 +65,7 @@ func TestCgroupMountValidationSuccess(t *testing.T) {
 }
 
 func TestCgroupMountValidationMemoryMissing(t *testing.T) {
-	mountInt := &mount.FakeMounter{
+	mountInt := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{
 				Device: "cgroup",
@@ -88,7 +89,7 @@ func TestCgroupMountValidationMemoryMissing(t *testing.T) {
 }
 
 func TestCgroupMountValidationMultipleSubsystem(t *testing.T) {
-	mountInt := &mount.FakeMounter{
+	mountInt := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{
 				Device: "cgroup",
@@ -118,7 +119,7 @@ func TestSoftRequirementsValidationSuccess(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 	req.NoError(ioutil.WriteFile(path.Join(tempDir, "cpu.cfs_period_us"), []byte("0"), os.ModePerm))
 	req.NoError(ioutil.WriteFile(path.Join(tempDir, "cpu.cfs_quota_us"), []byte("0"), os.ModePerm))
-	mountInt := &mount.FakeMounter{
+	mountInt := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{
 				Device: "cgroup",

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -46,7 +46,7 @@ import (
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/server/portforward"
 	"k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
 
@@ -259,7 +259,7 @@ func TestMakeMounts(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			fm := &mount.FakeMounter{}
+			fm := &mounttesting.FakeMounter{}
 			pod := v1.Pod{
 				Spec: v1.PodSpec{
 					HostNetwork: true,
@@ -311,7 +311,7 @@ func TestMakeMounts(t *testing.T) {
 }
 
 func TestDisabledSubpath(t *testing.T) {
-	fm := &mount.FakeMounter{}
+	fm := &mounttesting.FakeMounter{}
 	pod := v1.Pod{
 		Spec: v1.PodSpec{
 			HostNetwork: true,

--- a/pkg/kubelet/kubelet_pods_windows_test.go
+++ b/pkg/kubelet/kubelet_pods_windows_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 )
 
 func TestMakeMountsWindows(t *testing.T) {
@@ -65,7 +65,7 @@ func TestMakeMountsWindows(t *testing.T) {
 		},
 	}
 
-	fm := &mount.FakeMounter{}
+	fm := &mounttesting.FakeMounter{}
 	mounts, _, _ := makeMounts(&pod, "/pod", &container, "fakepodname", "", "", podVolumes, fm, nil)
 
 	expectedMounts := []kubecontainer.Mount{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -66,6 +66,7 @@ import (
 	kubeletvolume "k8s.io/kubernetes/pkg/kubelet/volumemanager"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/aws_ebs"
 	"k8s.io/kubernetes/pkg/volume/azure_dd"
@@ -173,7 +174,7 @@ func newTestKubeletWithImageList(
 	kubelet.kubeClient = fakeKubeClient
 	kubelet.heartbeatClient = fakeKubeClient.CoreV1()
 	kubelet.os = &containertest.FakeOS{}
-	kubelet.mounter = &mount.FakeMounter{}
+	kubelet.mounter = &mounttesting.FakeMounter{}
 
 	kubelet.hostname = testKubeletHostname
 	kubelet.nodeName = types.NodeName(testKubeletHostname)
@@ -323,7 +324,7 @@ func newTestKubeletWithImageList(
 		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, token.NewManager(kubelet.kubeClient), allPlugins, prober)
 	require.NoError(t, err, "Failed to initialize VolumePluginMgr")
 
-	kubelet.mounter = &mount.FakeMounter{}
+	kubelet.mounter = &mounttesting.FakeMounter{}
 	kubelet.volumeManager = kubeletvolume.NewVolumeManager(
 		controllerAttachDetachEnabled,
 		kubelet.nodeName,

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -124,7 +124,7 @@ func TestRunOnce(t *testing.T) {
 
 	kb.evictionManager = evictionManager
 	kb.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)
-	kb.mounter = &mount.FakeMounter{}
+	kb.mounter = &mounttesting.FakeMounter{}
 	if err := kb.setupDataDirs(); err != nil {
 		t.Errorf("Failed to init data dirs: %v", err)
 	}

--- a/pkg/kubelet/volumemanager/BUILD
+++ b/pkg/kubelet/volumemanager/BUILD
@@ -49,7 +49,7 @@ go_test(
         "//pkg/kubelet/secret:go_default_library",
         "//pkg/kubelet/status:go_default_library",
         "//pkg/kubelet/status/testing:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/kubelet/volumemanager/reconciler/BUILD
+++ b/pkg/kubelet/volumemanager/reconciler/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//pkg/features:go_default_library",
         "//pkg/kubelet/volumemanager/cache:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -83,7 +84,7 @@ func Test_Run_Positive_DoNothing(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 
@@ -127,7 +128,7 @@ func Test_Run_Positive_VolumeAttachAndMount(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -205,7 +206,7 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabled(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -284,7 +285,7 @@ func Test_Run_Positive_VolumeAttachMountUnmountDetach(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -374,7 +375,7 @@ func Test_Run_Positive_VolumeUnmountControllerAttachEnabled(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -464,7 +465,7 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -551,7 +552,7 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -639,7 +640,7 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -737,7 +738,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 	pod := &v1.Pod{
@@ -1019,7 +1020,7 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 		asw,
 		hasAddedPods,
 		oex,
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		volumePluginMgr,
 		kubeletPodsDir)
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/secret"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -229,7 +229,7 @@ func newTestVolumeManager(tmpDir string, podManager kubepod.Manager, kubeClient 
 		kubeClient,
 		plugMgr,
 		&containertest.FakeRuntime{},
-		&mount.FakeMounter{},
+		&mounttesting.FakeMounter{},
 		"",
 		fakeRecorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount */

--- a/pkg/util/mount/BUILD
+++ b/pkg/util/mount/BUILD
@@ -7,7 +7,6 @@ go_library(
         "exec.go",
         "exec_mount.go",
         "exec_mount_unsupported.go",
-        "fake.go",
         "mount.go",
         "mount_linux.go",
         "mount_unsupported.go",
@@ -18,7 +17,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/util/mount",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -38,6 +36,7 @@ go_library(
             "//pkg/util/io:go_default_library",
             "//pkg/util/nsenter:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+            "//vendor/github.com/golang/glog:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
@@ -58,6 +57,7 @@ go_library(
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/util/file:go_default_library",
             "//pkg/util/nsenter:go_default_library",
+            "//vendor/github.com/golang/glog:go_default_library",
         ],
         "//conditions:default": [],
     }),
@@ -98,7 +98,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/util/mount/testing:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/util/mount/testing/BUILD
+++ b/pkg/util/mount/testing/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testing.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/mount/testing",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/mount/testing/testing.go
+++ b/pkg/util/mount/testing/testing.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount
+package testing
 
 import (
 	"errors"

--- a/pkg/util/removeall/BUILD
+++ b/pkg/util/removeall/BUILD
@@ -11,7 +11,7 @@ go_test(
     srcs = ["removeall_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
     ],
 )

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -24,14 +24,14 @@ import (
 	"testing"
 
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 )
 
 type fakeMounter struct {
-	mount.FakeMounter
+	mounttesting.FakeMounter
 }
 
-// IsLikelyNotMountPoint overrides mount.FakeMounter.IsLikelyNotMountPoint for our use.
+// IsLikelyNotMountPoint overrides mounttesting.FakeMounter.IsLikelyNotMountPoint for our use.
 func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	name := path.Base(file)
 	if strings.HasPrefix(name, "mount") {

--- a/pkg/volume/aws_ebs/BUILD
+++ b/pkg/volume/aws_ebs/BUILD
@@ -44,7 +44,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/cloudprovider/providers/aws:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/aws_ebs/aws_ebs_test.go
+++ b/pkg/volume/aws_ebs/aws_ebs_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -120,7 +120,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 	fakeManager := &fakePDManager{}
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*awsElasticBlockStorePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -277,7 +277,7 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 		},
 	}
 
-	mounter, err := plug.(*awsElasticBlockStorePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	mounter, err := plug.(*awsElasticBlockStorePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Error creating new mounter:%v", err)
 	}
@@ -285,7 +285,7 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 		t.Errorf("Volume Mounter can be type-assert to Unmounter")
 	}
 
-	unmounter, err := plug.(*awsElasticBlockStorePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	unmounter, err := plug.(*awsElasticBlockStorePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Error creating new unmounter:%v", err)
 	}

--- a/pkg/volume/azure_file/BUILD
+++ b/pkg/volume/azure_file/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//pkg/cloudprovider/providers/azure:go_default_library",
         "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -140,7 +141,7 @@ func testPlugin(t *testing.T, tmpDir string, volumeHost volume.VolumeHost) {
 			},
 		},
 	}
-	fake := &mount.FakeMounter{}
+	fake := &mounttesting.FakeMounter{}
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
 	mounter, err := plug.(*azureFilePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), pod, &fakeAzureSvc{}, fake)
 	if err != nil {
@@ -166,7 +167,7 @@ func testPlugin(t *testing.T, tmpDir string, volumeHost volume.VolumeHost) {
 		}
 	}
 
-	unmounter, err := plug.(*azureFilePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mount.FakeMounter{})
+	unmounter, err := plug.(*azureFilePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}
@@ -262,14 +263,14 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 			},
 		},
 	}
-	fake := &mount.FakeMounter{}
+	fake := &mounttesting.FakeMounter{}
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
 	mounter, err := plug.(*azureFilePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), pod, &fakeAzureSvc{}, fake)
 	if _, ok := mounter.(volume.Unmounter); ok {
 		t.Errorf("Volume Mounter can be type-assert to Unmounter")
 	}
 
-	unmounter, err := plug.(*azureFilePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mount.FakeMounter{})
+	unmounter, err := plug.(*azureFilePlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mounttesting.FakeMounter{})
 	if _, ok := unmounter.(volume.Mounter); ok {
 		t.Errorf("Volume Unmounter can be type-assert to Mounter")
 	}

--- a/pkg/volume/cephfs/BUILD
+++ b/pkg/volume/cephfs/BUILD
@@ -30,7 +30,7 @@ go_test(
     srcs = ["cephfs_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -76,7 +76,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 
-	mounter, err := plug.(*cephfsPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &mount.FakeMounter{}, "secrets")
+	mounter, err := plug.(*cephfsPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &mounttesting.FakeMounter{}, "secrets")
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestPlugin(t *testing.T) {
 			t.Errorf("SetUp() failed: %v", err)
 		}
 	}
-	unmounter, err := plug.(*cephfsPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mount.FakeMounter{})
+	unmounter, err := plug.(*cephfsPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}

--- a/pkg/volume/cinder/BUILD
+++ b/pkg/volume/cinder/BUILD
@@ -50,7 +50,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/cloudprovider:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -149,7 +149,7 @@ func TestPlugin(t *testing.T) {
 			},
 		},
 	}
-	mounter, err := plug.(*cinderPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{0}, &mount.FakeMounter{})
+	mounter, err := plug.(*cinderPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{0}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestPlugin(t *testing.T) {
 		}
 	}
 
-	unmounter, err := plug.(*cinderPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{0}, &mount.FakeMounter{})
+	unmounter, err := plug.(*cinderPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{0}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}

--- a/pkg/volume/empty_dir/BUILD
+++ b/pkg/volume/empty_dir/BUILD
@@ -41,6 +41,7 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/util/mount/testing:go_default_library",
             "//pkg/volume:go_default_library",
             "//pkg/volume/testing:go_default_library",
             "//pkg/volume/util:go_default_library",

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -117,7 +118,7 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 			VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{Medium: config.medium}},
 		}
 
-		physicalMounter = mount.FakeMounter{}
+		physicalMounter = mounttesting.FakeMounter{}
 		mountDetector   = fakeMountDetector{}
 		pod             = &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/volume/fc/BUILD
+++ b/pkg/volume/fc/BUILD
@@ -40,6 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -163,7 +164,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	fakeManager := NewFakeDiskManager()
 	defer fakeManager.Cleanup()
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	fakeExec := mount.NewFakeExec(nil)
 	mounter, err := plug.(*fcPlugin).newMounterInternal(spec, types.UID("poduid"), fakeManager, fakeMounter, fakeExec)
 	if err != nil {
@@ -226,7 +227,7 @@ func doTestPluginNilMounter(t *testing.T, spec *volume.Spec) {
 	}
 	fakeManager := NewFakeDiskManager()
 	defer fakeManager.Cleanup()
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	fakeExec := mount.NewFakeExec(nil)
 	mounter, err := plug.(*fcPlugin).newMounterInternal(spec, types.UID("poduid"), fakeManager, fakeMounter, fakeExec)
 	if err == nil {
@@ -428,7 +429,7 @@ func Test_ConstructVolumeSpec(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skipf("Test_ConstructVolumeSpec is not supported on GOOS=%s", runtime.GOOS)
 	}
-	fm := &mount.FakeMounter{
+	fm := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/fc/50060e801049cfd1-lun-0"},
@@ -479,7 +480,7 @@ func Test_ConstructVolumeSpec(t *testing.T) {
 }
 
 func Test_ConstructVolumeSpecNoRefs(t *testing.T) {
-	fm := &mount.FakeMounter{
+	fm := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{Device: "/dev/sdd", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
 		},

--- a/pkg/volume/flexvolume/BUILD
+++ b/pkg/volume/flexvolume/BUILD
@@ -57,7 +57,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/filesystem:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/flexvolume/mounter_test.go
+++ b/pkg/volume/flexvolume/mounter_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 )
 
 func TestSetUpAt(t *testing.T) {
@@ -37,7 +37,7 @@ func TestSetUpAt(t *testing.T) {
 			ServiceAccountName: "my-sa",
 		},
 	}
-	mounter := &mount.FakeMounter{}
+	mounter := &mounttesting.FakeMounter{}
 
 	plugin, rootDir := testPlugin()
 	plugin.unsupportedCommands = []string{"unsupportedCmd"}

--- a/pkg/volume/flexvolume/unmounter_test.go
+++ b/pkg/volume/flexvolume/unmounter_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 )
 
 func TestTearDownAt(t *testing.T) {
-	mounter := &mount.FakeMounter{}
+	mounter := &mounttesting.FakeMounter{}
 
 	plugin, rootDir := testPlugin()
 	plugin.runner = fakeRunner(

--- a/pkg/volume/flocker/BUILD
+++ b/pkg/volume/flocker/BUILD
@@ -40,7 +40,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/flocker/flocker_test.go
+++ b/pkg/volume/flocker/flocker_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 
@@ -153,7 +153,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 	fakeManager := &fakeFlockerUtil{}
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*flockerPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)

--- a/pkg/volume/gce_pd/BUILD
+++ b/pkg/volume/gce_pd/BUILD
@@ -47,7 +47,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/kubelet/apis:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -114,7 +114,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 	fakeManager := &fakePDManager{}
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*gcePersistentDiskPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)

--- a/pkg/volume/glusterfs/BUILD
+++ b/pkg/volume/glusterfs/BUILD
@@ -44,7 +44,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -106,7 +106,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	ep := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Subsets: []v1.EndpointSubset{{
 		Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}}}}}
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
-	mounter, err := plug.(*glusterfsPlugin).newMounterInternal(spec, ep, pod, &mount.FakeMounter{})
+	mounter, err := plug.(*glusterfsPlugin).newMounterInternal(spec, ep, pod, &mounttesting.FakeMounter{})
 	volumePath := mounter.GetPath()
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -128,7 +128,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 			t.Errorf("SetUp() failed: %v", err)
 		}
 	}
-	unmounter, err := plug.(*glusterfsPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mount.FakeMounter{})
+	unmounter, err := plug.(*glusterfsPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}

--- a/pkg/volume/host_path/BUILD
+++ b/pkg/volume/host_path/BUILD
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//pkg/util/file:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utilfile "k8s.io/kubernetes/pkg/util/file"
 	utilmount "k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -386,7 +387,7 @@ func TestOSFileTypeChecker(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		fakeFTC := &utilmount.FakeMounter{
+		fakeFTC := &mounttesting.FakeMounter{
 			Filesystem: map[string]utilmount.FileType{
 				tc.path: utilmount.FileType(tc.desiredType),
 			},

--- a/pkg/volume/iscsi/BUILD
+++ b/pkg/volume/iscsi/BUILD
@@ -40,6 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -159,7 +160,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 	fakeManager := NewFakeDiskManager()
 	defer fakeManager.Cleanup()
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	fakeExec := mount.NewFakeExec(nil)
 	mounter, err := plug.(*iscsiPlugin).newMounterInternal(spec, types.UID("poduid"), fakeManager, fakeMounter, fakeExec, nil)
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -25,11 +25,12 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 func TestGetDevicePrefixRefCount(t *testing.T) {
-	fm := &mount.FakeMounter{
+	fm := &mounttesting.FakeMounter{
 		MountPoints: []mount.MountPoint{
 			{Device: "/dev/sdb",
 				Path: "/127.0.0.1:3260-iqn.2014-12.com.example:test.tgt00-lun-0"},

--- a/pkg/volume/nfs/BUILD
+++ b/pkg/volume/nfs/BUILD
@@ -32,6 +32,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/nfs/nfs_test.go
+++ b/pkg/volume/nfs/nfs_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -108,7 +109,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fake := &mount.FakeMounter{}
+	fake := &mounttesting.FakeMounter{}
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
 	mounter, err := plug.(*nfsPlugin).newMounterInternal(spec, pod, fake)
 	if err != nil {

--- a/pkg/volume/photon_pd/BUILD
+++ b/pkg/volume/photon_pd/BUILD
@@ -38,7 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/cloudprovider/providers/photon:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/photon_pd/photon_pd_test.go
+++ b/pkg/volume/photon_pd/photon_pd_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -113,7 +113,7 @@ func TestPlugin(t *testing.T) {
 		},
 	}
 	fakeManager := &fakePDManager{}
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*photonPersistentDiskPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -217,7 +217,7 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 		},
 	}
 
-	mounter, err := plug.(*photonPersistentDiskPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	mounter, err := plug.(*photonPersistentDiskPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), &fakePDManager{}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Fatalf("Error creating new mounter:%v", err)
 	}
@@ -225,7 +225,7 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 		t.Errorf("Volume Mounter can be type-assert to Unmounter")
 	}
 
-	unmounter, err := plug.(*photonPersistentDiskPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{}, &mount.FakeMounter{})
+	unmounter, err := plug.(*photonPersistentDiskPlugin).newUnmounterInternal("vol1", types.UID("poduid"), &fakePDManager{}, &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Fatalf("Error creating new unmounter:%v", err)
 	}

--- a/pkg/volume/portworx/BUILD
+++ b/pkg/volume/portworx/BUILD
@@ -11,7 +11,7 @@ go_test(
     srcs = ["portworx_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/portworx/portworx_test.go
+++ b/pkg/volume/portworx/portworx_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -148,7 +148,7 @@ func TestPlugin(t *testing.T) {
 	}
 	fakeManager := &fakePortworxManager{}
 	// Test Mounter
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*portworxVolumePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)

--- a/pkg/volume/quobyte/BUILD
+++ b/pkg/volume/quobyte/BUILD
@@ -34,7 +34,7 @@ go_test(
     srcs = ["quobyte_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/quobyte/quobyte_test.go
+++ b/pkg/volume/quobyte/quobyte_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -89,7 +89,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	}
 
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
-	mounter, err := plug.(*quobytePlugin).newMounterInternal(spec, pod, &mount.FakeMounter{})
+	mounter, err := plug.(*quobytePlugin).newMounterInternal(spec, pod, &mounttesting.FakeMounter{})
 	volumePath := mounter.GetPath()
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -104,7 +104,7 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 	if err := mounter.SetUp(nil); err != nil {
 		t.Errorf("Expected success, got: %v", err)
 	}
-	unmounter, err := plug.(*quobytePlugin).newUnmounterInternal("vol", types.UID("poduid"), &mount.FakeMounter{})
+	unmounter, err := plug.(*quobytePlugin).newUnmounterInternal("vol", types.UID("poduid"), &mounttesting.FakeMounter{})
 	if err != nil {
 		t.Errorf("Failed to make a new unmounter: %v", err)
 	}

--- a/pkg/volume/rbd/BUILD
+++ b/pkg/volume/rbd/BUILD
@@ -45,6 +45,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -233,7 +234,7 @@ func (fake *fakeDiskManager) ExpandImage(rbdExpander *rbdVolumeExpander, oldSize
 }
 
 // checkMounterLog checks fakeMounter must have expected logs, and the last action msut equal to expectedAction.
-func checkMounterLog(t *testing.T, fakeMounter *mount.FakeMounter, expected int, expectedAction mount.FakeAction) {
+func checkMounterLog(t *testing.T, fakeMounter *mounttesting.FakeMounter, expected int, expectedAction mount.FakeAction) {
 	if len(fakeMounter.Log) != expected {
 		t.Fatalf("fakeMounter should have %d logs, actual: %d", expected, len(fakeMounter.Log))
 	}
@@ -252,7 +253,7 @@ func doTestPlugin(t *testing.T, c *testcase) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fakeMounter := fakeVolumeHost.GetMounter(plug.GetPluginName()).(*mount.FakeMounter)
+	fakeMounter := fakeVolumeHost.GetMounter(plug.GetPluginName()).(*mounttesting.FakeMounter)
 	fakeNodeName := types.NodeName("localhost")
 	fdm := NewFakeDiskManager()
 
@@ -605,7 +606,7 @@ func TestConstructVolumeSpec(t *testing.T) {
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	fakeMounter := fakeVolumeHost.GetMounter(plug.GetPluginName()).(*mount.FakeMounter)
+	fakeMounter := fakeVolumeHost.GetMounter(plug.GetPluginName()).(*mounttesting.FakeMounter)
 
 	pool, image, volumeName := "pool", "image", "vol"
 	podMountPath := fmt.Sprintf("%s/pods/pod123/volumes/kubernetes.io~rbd/%s", tmpDir, volumeName)

--- a/pkg/volume/storageos/BUILD
+++ b/pkg/volume/storageos/BUILD
@@ -39,6 +39,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/storageos/storageos_test.go
+++ b/pkg/volume/storageos/storageos_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -188,7 +189,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Couldn't get secret from %v/%v", pod.Namespace, secretName)
 	}
 
-	mounter, err := plug.(*storageosPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), pod, apiCfg, fakeManager, &mount.FakeMounter{}, mount.NewFakeExec(nil))
+	mounter, err := plug.(*storageosPlugin).newMounterInternal(volume.NewSpecFromVolume(spec), pod, apiCfg, fakeManager, &mounttesting.FakeMounter{}, mount.NewFakeExec(nil))
 	if err != nil {
 		t.Fatalf("Failed to make a new Mounter: %v", err)
 	}
@@ -222,7 +223,7 @@ func TestPlugin(t *testing.T) {
 
 	// Test Unmounter
 	fakeManager = &fakePDManager{}
-	unmounter, err := plug.(*storageosPlugin).newUnmounterInternal("vol1-pvname", types.UID("poduid"), fakeManager, &mount.FakeMounter{}, mount.NewFakeExec(nil))
+	unmounter, err := plug.(*storageosPlugin).newUnmounterInternal("vol1-pvname", types.UID("poduid"), fakeManager, &mounttesting.FakeMounter{}, mount.NewFakeExec(nil))
 	if err != nil {
 		t.Errorf("Failed to make a new Unmounter: %v", err)
 	}
@@ -362,7 +363,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	fakeManager := &fakePDManager{}
 	fakeConfig := &fakeConfig{}
 	apiCfg := fakeConfig.GetAPIConfig()
-	mounter, err := plug.(*storageosPlugin).newMounterInternal(spec, pod, apiCfg, fakeManager, &mount.FakeMounter{}, mount.NewFakeExec(nil))
+	mounter, err := plug.(*storageosPlugin).newMounterInternal(spec, pod, apiCfg, fakeManager, &mounttesting.FakeMounter{}, mount.NewFakeExec(nil))
 	if err != nil {
 		t.Fatalf("error creating a new internal mounter:%v", err)
 	}

--- a/pkg/volume/storageos/storageos_util_test.go
+++ b/pkg/volume/storageos/storageos_util_test.go
@@ -23,7 +23,7 @@ import (
 	storageostypes "github.com/storageos/go-api/types"
 	"k8s.io/api/core/v1"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 
@@ -222,7 +222,7 @@ func TestAttachVolume(t *testing.T) {
 			volName:      testVolName,
 			volNamespace: testNamespace,
 			manager:      util,
-			mounter:      &mount.FakeMounter{},
+			mounter:      &mounttesting.FakeMounter{},
 			plugin:       plug.(*storageosPlugin),
 		},
 		deviceDir: tmpDir,

--- a/pkg/volume/testing/BUILD
+++ b/pkg/volume/testing/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//pkg/cloudprovider:go_default_library",
         "//pkg/util/io:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	. "k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -81,7 +82,7 @@ func NewFakeVolumeHostWithNodeName(rootDir string, kubeClient clientset.Interfac
 
 func newFakeVolumeHost(rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, cloud cloudprovider.Interface) *fakeVolumeHost {
 	host := &fakeVolumeHost{rootDir: rootDir, kubeClient: kubeClient, cloud: cloud}
-	host.mounter = &mount.FakeMounter{}
+	host.mounter = &mounttesting.FakeMounter{}
 	host.writer = &io.StdWriter{}
 	host.exec = mount.NewFakeExec(nil)
 	host.pluginMgr.InitPlugins(plugins, nil /* prober */, host)

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -57,6 +57,7 @@ go_test(
     deps = [
         "//pkg/apis/core/install:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//pkg/volume:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -31,6 +31,7 @@ import (
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 
 	"reflect"
 	"strings"
@@ -381,7 +382,7 @@ func TestDoUnmountMountPoint(t *testing.T) {
 		},
 	}
 
-	fake := &mount.FakeMounter{}
+	fake := &mounttesting.FakeMounter{}
 
 	for _, tt := range tests {
 		err := doUnmountMountPoint(tt.mountPath, fake, false, tt.corruptedMnt)

--- a/pkg/volume/vsphere_volume/BUILD
+++ b/pkg/volume/vsphere_volume/BUILD
@@ -40,7 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/cloudprovider/providers/vsphere/vclib:go_default_library",
-        "//pkg/util/mount:go_default_library",
+        "//pkg/util/mount/testing:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/volume/vsphere_volume/vsphere_volume_test.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utiltesting "k8s.io/client-go/util/testing"
-	"k8s.io/kubernetes/pkg/util/mount"
+	mounttesting "k8s.io/kubernetes/pkg/util/mount/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -109,7 +109,7 @@ func TestPlugin(t *testing.T) {
 
 	// Test Mounter
 	fakeManager := &fakePDManager{}
-	fakeMounter := &mount.FakeMounter{}
+	fakeMounter := &mounttesting.FakeMounter{}
 	mounter, err := plug.(*vsphereVolumePlugin).newMounterInternal(volume.NewSpecFromVolume(spec), types.UID("poduid"), fakeManager, fakeMounter)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Move mount.FakeMounter into subdir testing so it doesn't get linked into non-test code. 

Suggested by @thockin, see https://github.com/kubernetes/kubernetes/pull/64426#discussion_r192220239.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
