### PR TITLE
Fail update-godep-licenses if bash version lower than 4

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -140,6 +140,7 @@ if ((${BASH_VERSINFO[0]}<4)); then
     echo "$ brew install md5sha1sum bash jq"
   fi
   echo
+  exit 9
 fi
 
 # This variable can be injected, as in the verify script.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
trying to update godeps on mac OSX fails without any information, this patch exits the script with a return error code just after printing the cause of the failure in the screen to the user

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65784 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
