### PR TITLE
fix CRI socket validatioin

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
@@ -20,3 +20,6 @@ package v1alpha3
 
 // DefaultCACertPath defines default location of CA certificate on Linux
 const DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
+
+// DefaultSocketUrlScheme defines default socket url prefix
+const DefaultUrlScheme = "unix"

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
@@ -20,3 +20,6 @@ package v1alpha3
 
 // DefaultCACertPath defines default location of CA certificate on Windows
 const DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
+
+// DefaultSocketUrlScheme defines default socket url prefix
+const DefaultUrlScheme = "tcp"

--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha3:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",
@@ -28,6 +29,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha3:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1alpha3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3"
 	"k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig"
 	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
@@ -108,14 +109,15 @@ func TestValidateNodeRegistrationOptions(t *testing.T) {
 		criSocket      string
 		expectedErrors bool
 	}{
-		{"", "/some/path", true},                                                      // node name can't be empty
-		{"valid-nodename", "", true},                                                  // crisocket can't be empty
-		{"INVALID-NODENAME", "/some/path", true},                                      // Upper cases is invalid
-		{"invalid-nodename-", "/some/path", true},                                     // Can't have trailing dashes
-		{"invalid-node?name", "/some/path", true},                                     // Unsupported characters
-		{"valid-nodename", "relative/path", true},                                     // crisocket must be an absolute path
-		{"valid-nodename", "/some/path", false},                                       // supported
-		{"valid-nodename-with-numbers01234", "/some/path/with/numbers/01234/", false}, // supported, with numbers as well
+		{"", "/some/path", true},                                                              // node name can't be empty
+		{"INVALID-NODENAME", "/some/path", true},                                              // Upper cases is invalid
+		{"invalid-nodename-", "/some/path", true},                                             // Can't have trailing dashes
+		{"invalid-node?name", "/some/path", true},                                             // Unsupported characters
+		{"valid-nodename", "/some/path", false},                                               // supported
+		{"valid-nodename-with-numbers01234", "/some/path/with/numbers/01234/", false},         // supported, with numbers as well
+		{"valid-nodename", kubeadmapiv1alpha3.DefaultUrlScheme + "://" + "/some/path", false}, // supported, with socket url
+		{"valid-nodename", "bla:///some/path", true},                                          // unsupported url scheme
+		{"valid-nodename", ":::", true},                                                       // unparseable url
 	}
 	for _, rt := range tests {
 		nro := kubeadm.NodeRegistrationOptions{Name: rt.nodeName, CRISocket: rt.criSocket}


### PR DESCRIPTION
**What this PR does / why we need it**:

CRI socket doesn't have to be an absolute path, it should be an url.
However, attempt to use it as an url in 'kubeadm init' command line
causes this validation error:

$ sudo ./kubeadm init --cri-socket unix:///var/run/crio/crio.sock
nodeRegistration.criSocket: Invalid value:
"unix:///var/run/crio/crio.sock": path is not absolute

Fixed by adding ValidateSocket function and using it in the 
ValidateNodeRegistrationOptions check instead of ValidateAbsolutePath.

**Which issue(s) this PR fixes** :

[#928](https://github.com/kubernetes/kubeadm/issues/928)

**Release note**:
```release-note
NONE
```
