### PR TITLE
vSphere Cloud Provider: avoid read race during logout

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/connection.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection.go
@@ -131,7 +131,14 @@ func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Cl
 
 // Logout calls SessionManager.Logout for the given connection.
 func (connection *VSphereConnection) Logout(ctx context.Context) {
-	m := session.NewManager(connection.Client)
+	clientLock.Lock()
+	c := connection.Client
+	clientLock.Unlock()
+	if c == nil {
+		return
+	}
+
+	m := session.NewManager(c)
 
 	hasActiveSession, err := m.SessionIsActive(ctx)
 	if err != nil {

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -510,11 +510,8 @@ func buildVSphereFromConfig(cfg VSphereConfig) (*VSphere, error) {
 
 func logout(vs *VSphere) {
 	for _, vsphereIns := range vs.vsphereInstanceMap {
-		if vsphereIns.conn.Client != nil {
-			vsphereIns.conn.Logout(context.TODO())
-		}
+		vsphereIns.conn.Logout(context.TODO())
 	}
-
 }
 
 // Instances returns an implementation of Instances for vSphere.


### PR DESCRIPTION
**What this PR does / why we need it**:

The `go test -race` will sometimes detect a read race in the vSphere Cloud Provider logout function, causing tests to fail.

**Which issue(s) this PR fixes**:
Fixes #65696

**Special notes for your reviewer**:

The Client nil check was added in 6d1c4a3 , but there was not any
go test coverage of that code path until e22f9ca

**Release note**:

```release-note
none
```
