### PR TITLE
translations: remove generating bindata section

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -40,11 +40,6 @@ file. `poedit` does this automatically on save, but you can also run
 
 We use the English translation as the `msgid`.
 
-## Regenerating the bindata file
-Run `./hack/generate-bindata.sh`, this will turn the translation files
-into generated code which will in turn be packaged into the Kubernetes
-binaries.
-
 ## Extracting strings
 
 There is a script in `translations/extract.py` that knows how to do some


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In the translations README, there is a section left over regarding
regenerating the bindata file. 'pkg/generated/bindata.go' is now
generated at build time (see #62432), so it seems a bit confusing
to leave this section in the README.

This PR just removes the section about generating the bindata.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
I did a quick search through and this was one of the only remaining references to generating `bindata.go` I could find, but I may be wrong.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
