### PR TITLE
[1.10] gc: remove crd and apiservice from ignored resources

### DIFF
--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -196,8 +196,6 @@ func TestAddFlags(t *testing.T) {
 					{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"},
 					{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"},
 					{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"},
-					{Group: "apiregistration.k8s.io", Resource: "apiservices"},
-					{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 				},
 				NodeEvictionRate:                      0.2,
 				SecondaryNodeEvictionRate:             0.05,

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -361,8 +361,6 @@ var ignoredResources = map[schema.GroupResource]struct{}{
 	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:  {},
 	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: {},
 	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:   {},
-	{Group: "apiregistration.k8s.io", Resource: "apiservices"}:             {},
-	{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}: {},
 }
 
 // DefaultIgnoredResources returns the default set of resources that the garbage collector controller


### PR DESCRIPTION
Fixes #65818

This PR cherry-picks CRD and APIService removal from GC ignored resources, from #65856 and #65915.

**Release note**:
```release-note
The garbage collector now supports CustomResourceDefinitions and APIServices.
```

/cc @nikhita @liggitt 
/sig api-machinery
/kind bug
/priority important-soon