### PR TITLE
[1.9] GC: remove CRD and APIService from ignored resources

### DIFF
--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -190,8 +190,6 @@ func TestAddFlags(t *testing.T) {
 				{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"},
 				{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"},
 				{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"},
-				{Group: "apiregistration.k8s.io", Resource: "apiservices"},
-				{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 			},
 			NodeEvictionRate:                      0.2,
 			SecondaryNodeEvictionRate:             0.05,

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -361,8 +361,6 @@ var ignoredResources = map[schema.GroupResource]struct{}{
 	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:  {},
 	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: {},
 	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:   {},
-	{Group: "apiregistration.k8s.io", Resource: "apiservices"}:             {},
-	{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}: {},
 }
 
 // DefaultIgnoredResources returns the default set of resources that the garbage collector controller


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/65818

This cherry-picks the GC bits for CRD and APIService from https://github.com/kubernetes/kubernetes/pull/65856. See https://github.com/kubernetes/kubernetes/pull/65856#issuecomment-403095816 for more details.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The garbage collector now supports CustomResourceDefinitions and APIServices.
```