### PR TITLE
Automated cherry pick of #65313: Adds cri-tools as a dependency to kubeadm deb/rpms

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -160,6 +160,7 @@ k8s_deb(
         "kubelet (>= 1.8.0)",
         "kubectl (>= 1.8.0)",
         "kubernetes-cni (>= 0.5.1)",
+        "cri-tools (>= 1.11.0)",
     ],
     description = """Kubernetes Cluster Bootstrapping Tool
 The Kubernetes command line tool for bootstrapping a Kubernetes cluster.

--- a/build/rpms/kubeadm.spec
+++ b/build/rpms/kubeadm.spec
@@ -6,6 +6,7 @@ Summary: Container Cluster Manager - Kubernetes Cluster Bootstrapping Tool
 Requires: kubelet >= 1.8.0
 Requires: kubectl >= 1.8.0
 Requires: kubernetes-cni >= 0.5.1
+Requires: cri-tools >= 1.11.0
 
 URL: https://kubernetes.io
 


### PR DESCRIPTION
Cherry pick of #65313 on release-1.11.

#65313: Adds cri-tools as a dependency to kubeadm deb/rpms

```release-note
Adds cri-tools as a dependency to kubeadm deb/rpms
```