### PR TITLE
Fix RunAsGroup.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -152,6 +152,9 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxLinuxConfig(pod *v1.Pod) (
 		if sc.RunAsUser != nil {
 			lc.SecurityContext.RunAsUser = &runtimeapi.Int64Value{Value: int64(*sc.RunAsUser)}
 		}
+		if sc.RunAsGroup != nil {
+			lc.SecurityContext.RunAsGroup = &runtimeapi.Int64Value{Value: int64(*sc.RunAsGroup)}
+		}
 		lc.SecurityContext.NamespaceOptions = namespacesForPod(pod)
 
 		if sc.FSGroup != nil {

--- a/pkg/kubelet/kuberuntime/security_context.go
+++ b/pkg/kubelet/kuberuntime/security_context.go
@@ -108,6 +108,9 @@ func convertToRuntimeSecurityContext(securityContext *v1.SecurityContext) *runti
 	if securityContext.RunAsUser != nil {
 		sc.RunAsUser = &runtimeapi.Int64Value{Value: int64(*securityContext.RunAsUser)}
 	}
+	if securityContext.RunAsGroup != nil {
+		sc.RunAsGroup = &runtimeapi.Int64Value{Value: int64(*securityContext.RunAsGroup)}
+	}
 	if securityContext.Privileged != nil {
 		sc.Privileged = *securityContext.Privileged
 	}


### PR DESCRIPTION
For https://github.com/kubernetes/features/issues/213
See https://github.com/containerd/cri/issues/836

In https://github.com/containerd/cri/issues/836, people thought that this is a containerd issue. However, it turns out that this feature doesn't work at all. @krmayankk

Without the fix:
```
• Failure [10.125 seconds]
[k8s.io] [sig-node] Security Context [Feature:SecurityContext]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
  should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup] [It]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:112

  Expected error:
      <*errors.errorString | 0xc42185bcd0>: {
          s: "expected \"gid=2002\" in container output: Expected\n    <string>: uid=1002 gid=1002\n    \nto contain substring\n    <string>: gid=2002",
      }
      expected "gid=2002" in container output: Expected
          <string>: uid=1002 gid=1002
          
      to contain substring
          <string>: gid=2002
  not to have occurred

/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:2325
```

With the fix:
```
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[k8s.io] [sig-node] Security Context [Feature:SecurityContext] 
  should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:112
[BeforeEach] [k8s.io] [sig-node] Security Context [Feature:SecurityContext]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
STEP: Creating a kubernetes client
Jul  6 15:38:43.994: INFO: >>> kubeConfig: /var/run/kubernetes/admin.kubeconfig
STEP: Building a namespace api object, basename security-context
Jul  6 15:38:44.024: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[It] should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:112
STEP: Creating a pod to test pod.Spec.SecurityContext.RunAsUser
Jul  6 15:38:44.027: INFO: Waiting up to 5m0s for pod "security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064" in namespace "e2e-tests-security-context-hwm7l" to be "success or failure"
Jul  6 15:38:44.029: INFO: Pod "security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064": Phase="Pending", Reason="", readiness=false. Elapsed: 1.17106ms
Jul  6 15:38:46.031: INFO: Pod "security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064": Phase="Pending", Reason="", readiness=false. Elapsed: 2.003308423s
Jul  6 15:38:48.033: INFO: Pod "security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.005287901s
STEP: Saw pod success
Jul  6 15:38:48.033: INFO: Pod "security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064" satisfied condition "success or failure"
Jul  6 15:38:48.034: INFO: Trying to get logs from node 127.0.0.1 pod security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064 container test-container: <nil>
STEP: delete the pod
Jul  6 15:38:48.047: INFO: Waiting for pod security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064 to disappear
Jul  6 15:38:48.049: INFO: Pod security-context-56aac70e-816d-11e8-91cd-8cdcd43ac064 no longer exists
[AfterEach] [k8s.io] [sig-node] Security Context [Feature:SecurityContext]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
Jul  6 15:38:48.049: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-security-context-hwm7l" for this suite.
Jul  6 15:38:54.057: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Jul  6 15:38:54.084: INFO: namespace: e2e-tests-security-context-hwm7l, resource: bindings, ignored listing per whitelist
Jul  6 15:38:54.107: INFO: namespace e2e-tests-security-context-hwm7l deletion completed in 6.056285097s

• [SLOW TEST:10.113 seconds]
[k8s.io] [sig-node] Security Context [Feature:SecurityContext]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
  should support container.SecurityContext.RunAsUser And container.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:112
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[k8s.io] [sig-node] Security Context [Feature:SecurityContext] 
  should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:84
[BeforeEach] [k8s.io] [sig-node] Security Context [Feature:SecurityContext]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:141
STEP: Creating a kubernetes client
Jul  6 15:38:54.108: INFO: >>> kubeConfig: /var/run/kubernetes/admin.kubeconfig
STEP: Building a namespace api object, basename security-context
STEP: Waiting for a default service account to be provisioned in namespace
[It] should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:84
STEP: Creating a pod to test pod.Spec.SecurityContext.RunAsUser
Jul  6 15:38:54.137: INFO: Waiting up to 5m0s for pod "security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064" in namespace "e2e-tests-security-context-hs2vr" to be "success or failure"
Jul  6 15:38:54.138: INFO: Pod "security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064": Phase="Pending", Reason="", readiness=false. Elapsed: 1.374422ms
Jul  6 15:38:56.140: INFO: Pod "security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064": Phase="Pending", Reason="", readiness=false. Elapsed: 2.003249942s
Jul  6 15:38:58.142: INFO: Pod "security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064": Phase="Succeeded", Reason="", readiness=false. Elapsed: 4.005110799s
STEP: Saw pod success
Jul  6 15:38:58.142: INFO: Pod "security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064" satisfied condition "success or failure"
Jul  6 15:38:58.143: INFO: Trying to get logs from node 127.0.0.1 pod security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064 container test-container: <nil>
STEP: delete the pod
Jul  6 15:38:58.149: INFO: Waiting for pod security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064 to disappear
Jul  6 15:38:58.152: INFO: Pod security-context-5cb16d23-816d-11e8-91cd-8cdcd43ac064 no longer exists
[AfterEach] [k8s.io] [sig-node] Security Context [Feature:SecurityContext]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:142
Jul  6 15:38:58.152: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-security-context-hs2vr" for this suite.
Jul  6 15:39:04.157: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Jul  6 15:39:04.175: INFO: namespace: e2e-tests-security-context-hs2vr, resource: bindings, ignored listing per whitelist
Jul  6 15:39:04.193: INFO: namespace e2e-tests-security-context-hs2vr deletion completed in 6.039953722s

• [SLOW TEST:10.085 seconds]
[k8s.io] [sig-node] Security Context [Feature:SecurityContext]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:679
  should support pod.Spec.SecurityContext.RunAsUser And pod.Spec.SecurityContext.RunAsGroup [Feature:RunAsGroup]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/security_context.go:84
------------------------------
SSSSJul  6 15:39:04.193: INFO: Running AfterSuite actions on all node
Jul  6 15:39:04.193: INFO: Running AfterSuite actions on node 1

Ran 2 of 1007 Specs in 50.246 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 1005 Skipped PASS

Ginkgo ran 1 suite in 50.482926642s
Test Suite Passed
2018/07/06 15:39:04 process.go:155: Step './hack/ginkgo-e2e.sh -host=https://localhost:6443 --ginkgo.focus=RunAsGroup' finished in 50.523613088s
2018/07/06 15:39:04 e2e.go:83: Done
```

We should cherry-pick this to 1.10 and 1.11. /cc @kubernetes/sig-node-bugs 

```release-note
Fix `RunAsGroup` which doesn't work since 1.10.
```
