### PR TITLE
Automated cherry pick of #65931: kubeadm: run kube-proxy on non-master tainted nodes

### DIFF
--- a/build/root/BUILD.root
+++ b/build/root/BUILD.root
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
 # gazelle:exclude _artifacts
 # gazelle:exclude _gopath
 # gazelle:exclude _output
@@ -81,4 +83,15 @@ genrule(
     outs = ["version"],
     cmd = "grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt | awk '{print $$2}' >$@",
     stamp = 1,
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["k8s-commiters.go"],
+    importpath = "k8s.io/kubernetes",
+)
+
+go_binary(
+    name = "kubernetes",
+    embed = [":go_default_library"],
 )

--- a/cmd/kubeadm/app/phases/addons/proxy/BUILD
+++ b/cmd/kubeadm/app/phases/addons/proxy/BUILD
@@ -34,7 +34,6 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/proxy",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -104,8 +104,6 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: {{ .MasterTaintKey }}
-        effect: NoSchedule
       nodeSelector:
         beta.kubernetes.io/arch: {{ .Arch }}
 `

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -29,7 +29,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	kubeproxyconfigscheme "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/scheme"
@@ -76,12 +75,11 @@ func EnsureProxyAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Inte
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
 	}
-	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ ImageRepository, Arch, Version, ImageOverride, MasterTaintKey string }{
+	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ ImageRepository, Arch, Version, ImageOverride string }{
 		ImageRepository: cfg.GetControlPlaneImageRepository(),
 		Arch:            runtime.GOARCH,
 		Version:         kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion),
 		ImageOverride:   cfg.UnifiedControlPlaneImage,
-		MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)


### PR DESCRIPTION
Cherry pick of #65931 on release-1.11.

#65931: kubeadm: run kube-proxy on non-master tainted nodes