### PR TITLE
Add autocompletion support for kubectl explain

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -204,6 +204,25 @@ __kubectl_cp()
     esac
 }
 
+__kubectl_explain() {
+    local kubectl_out
+
+    # TODO: support autocomplete for field names
+    if [[ "$cur" = *"."* ]]; then
+        return
+    fi
+
+    if [[ $(type -t compopt) = "builtin" ]]; then
+        compopt -o nospace
+    fi
+
+    if kubectl_out=( $(kubectl api-resources $(__kubectl_override_flags) -o name --cached --request-timeout=5s 2>/dev/null) ); then
+        kubectl_out=( "${kubectl_out[@]%%.*}" ) # remove .<api-group> from <resource-name>.<api-group>
+        kubectl_out=( "${kubectl_out[@]/%/.}" ) # add "." suffix to <resource-name>
+        COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
+    fi
+}
+
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_edit | kubectl_patch |\
@@ -238,6 +257,10 @@ __custom_func() {
             ;;
         kubectl_cp)
             __kubectl_cp
+            return
+            ;;
+        kubectl_explain)
+            __kubectl_explain
             return
             ;;
         *)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: With this PR, kubectl explain supports completion for resource-name.

```
$ kubectl explain <tab><tab>
apiservices.                 configmaps.                 endpoints.                 localsubjectaccessreviews.      persistentvolumes.     replicationcontrollers.    selfsubjectrulesreviews.  tokenreviews.
bindings.                    controllerrevisions.        events.                    mutatingwebhookconfigurations.  poddisruptionbudgets.  resourcequotas.            serviceaccounts.          validatingwebhookconfigurations.
certificatesigningrequests.  cronjobs.                   horizontalpodautoscalers.  namespaces.                     pods.                  rolebindings.              services.                 volumeattachments.
clusterrolebindings.         customresourcedefinitions.  ingresses.                 networkpolicies.                podsecuritypolicies.   roles.                     statefulsets.
clusterroles.                daemonsets.                 jobs.                      nodes.                          podtemplates.          secrets.                   storageclasses.
componentstatuses.           deployments.                limitranges.               persistentvolumeclaims.         replicasets.           selfsubjectaccessreviews.  subjectaccessreviews.
```

I tested this on both bash and zsh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #63173

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl explain supports completion.
```
