### PR TITLE
Simplify device manager: make endpoint stateless

### DIFF
--- a/pkg/kubelet/cm/devicemanager/endpoint.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint.go
@@ -37,8 +37,7 @@ type endpoint interface {
 	stop()
 	allocate(devs []string) (*pluginapi.AllocateResponse, error)
 	preStartContainer(devs []string) (*pluginapi.PreStartContainerResponse, error)
-	getDevices() []pluginapi.Device
-	callback(resourceName string, added, updated, deleted []pluginapi.Device)
+	callback(resourceName string, devices []pluginapi.Device)
 	isStopped() bool
 	stopGracePeriodExpired() bool
 }
@@ -51,15 +50,13 @@ type endpointImpl struct {
 	resourceName string
 	stopTime     time.Time
 
-	devices map[string]pluginapi.Device
-	mutex   sync.Mutex
-
-	cb monitorCallback
+	mutex sync.Mutex
+	cb    monitorCallback
 }
 
 // newEndpoint creates a new endpoint for the given resourceName.
 // This is to be used during normal device plugin registration.
-func newEndpointImpl(socketPath, resourceName string, devices map[string]pluginapi.Device, callback monitorCallback) (*endpointImpl, error) {
+func newEndpointImpl(socketPath, resourceName string, callback monitorCallback) (*endpointImpl, error) {
 	client, c, err := dial(socketPath)
 	if err != nil {
 		glog.Errorf("Can't create new endpoint with path %s err %v", socketPath, err)
@@ -73,41 +70,26 @@ func newEndpointImpl(socketPath, resourceName string, devices map[string]plugina
 		socketPath:   socketPath,
 		resourceName: resourceName,
 
-		devices: devices,
-		cb:      callback,
+		cb: callback,
 	}, nil
 }
 
 // newStoppedEndpointImpl creates a new endpoint for the given resourceName with stopTime set.
 // This is to be used during Kubelet restart, before the actual device plugin re-registers.
-func newStoppedEndpointImpl(resourceName string, devices map[string]pluginapi.Device) *endpointImpl {
+func newStoppedEndpointImpl(resourceName string) *endpointImpl {
 	return &endpointImpl{
 		resourceName: resourceName,
-		devices:      devices,
 		stopTime:     time.Now(),
 	}
 }
 
-func (e *endpointImpl) callback(resourceName string, added, updated, deleted []pluginapi.Device) {
-	e.cb(resourceName, added, updated, deleted)
-}
-
-func (e *endpointImpl) getDevices() []pluginapi.Device {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-	var devs []pluginapi.Device
-
-	for _, d := range e.devices {
-		devs = append(devs, d)
-	}
-
-	return devs
+func (e *endpointImpl) callback(resourceName string, devices []pluginapi.Device) {
+	e.cb(resourceName, devices)
 }
 
 // run initializes ListAndWatch gRPC call for the device plugin and
 // blocks on receiving ListAndWatch gRPC stream updates. Each ListAndWatch
-// stream update contains a new list of device states. listAndWatch compares the new
-// device states with its cached states to get list of new, updated, and deleted devices.
+// stream update contains a new list of device states.
 // It then issues a callback to pass this information to the device manager which
 // will adjust the resource available information accordingly.
 func (e *endpointImpl) run() {
@@ -117,14 +99,6 @@ func (e *endpointImpl) run() {
 
 		return
 	}
-
-	devices := make(map[string]pluginapi.Device)
-
-	e.mutex.Lock()
-	for _, d := range e.devices {
-		devices[d.ID] = d
-	}
-	e.mutex.Unlock()
 
 	for {
 		response, err := stream.Recv()
@@ -136,57 +110,12 @@ func (e *endpointImpl) run() {
 		devs := response.Devices
 		glog.V(2).Infof("State pushed for device plugin %s", e.resourceName)
 
-		newDevs := make(map[string]*pluginapi.Device)
-		var added, updated []pluginapi.Device
-
+		var newDevs []pluginapi.Device
 		for _, d := range devs {
-			dOld, ok := devices[d.ID]
-			newDevs[d.ID] = d
-
-			if !ok {
-				glog.V(2).Infof("New device for Endpoint %s: %v", e.resourceName, d)
-
-				devices[d.ID] = *d
-				added = append(added, *d)
-
-				continue
-			}
-
-			if d.Health == dOld.Health {
-				continue
-			}
-
-			if d.Health == pluginapi.Unhealthy {
-				glog.Errorf("Device %s is now Unhealthy", d.ID)
-			} else if d.Health == pluginapi.Healthy {
-				glog.V(2).Infof("Device %s is now Healthy", d.ID)
-			}
-
-			devices[d.ID] = *d
-			updated = append(updated, *d)
+			newDevs = append(newDevs, *d)
 		}
 
-		var deleted []pluginapi.Device
-		for id, d := range devices {
-			if _, ok := newDevs[id]; ok {
-				continue
-			}
-
-			glog.Errorf("Device %s was deleted", d.ID)
-
-			deleted = append(deleted, d)
-			delete(devices, id)
-		}
-
-		e.mutex.Lock()
-		// NOTE: Return a copy of 'devices' instead of returning a direct reference to local 'devices'
-		e.devices = make(map[string]pluginapi.Device)
-		for _, d := range devices {
-			e.devices[d.ID] = d
-		}
-		e.mutex.Unlock()
-
-		e.callback(e.resourceName, added, updated, deleted)
+		e.callback(e.resourceName, newDevs)
 	}
 }
 

--- a/pkg/kubelet/cm/devicemanager/endpoint_test.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint_test.go
@@ -37,7 +37,7 @@ func TestNewEndpoint(t *testing.T) {
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
 	}
 
-	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []pluginapi.Device) {})
+	p, e := esetup(t, devs, socket, "mock", func(n string, d []pluginapi.Device) {})
 	defer ecleanup(t, p, e)
 }
 
@@ -58,7 +58,7 @@ func TestRun(t *testing.T) {
 
 	callbackCount := 0
 	callbackChan := make(chan int)
-	callback := func(n string, a, u, r []pluginapi.Device) {
+	callback := func(n string, devices []pluginapi.Device) {
 		// Should be called twice:
 		// one for plugin registration, one for plugin update.
 		if callbackCount > 2 {
@@ -67,23 +67,24 @@ func TestRun(t *testing.T) {
 
 		// Check plugin registration
 		if callbackCount == 0 {
-			require.Len(t, a, 3)
-			require.Len(t, u, 0)
-			require.Len(t, r, 0)
+			require.Len(t, devices, 3)
+			require.Equal(t, devices[0].ID, devs[0].ID)
+			require.Equal(t, devices[1].ID, devs[1].ID)
+			require.Equal(t, devices[2].ID, devs[2].ID)
+			require.Equal(t, devices[0].Health, devs[0].Health)
+			require.Equal(t, devices[1].Health, devs[1].Health)
+			require.Equal(t, devices[2].Health, devs[2].Health)
 		}
 
 		// Check plugin update
 		if callbackCount == 1 {
-			require.Len(t, a, 1)
-			require.Len(t, u, 2)
-			require.Len(t, r, 1)
-
-			require.Equal(t, a[0].ID, updated[2].ID)
-			require.Equal(t, u[0].ID, updated[0].ID)
-			require.Equal(t, u[0].Health, updated[0].Health)
-			require.Equal(t, u[1].ID, updated[1].ID)
-			require.Equal(t, u[1].Health, updated[1].Health)
-			require.Equal(t, r[0].ID, devs[1].ID)
+			require.Len(t, devices, 3)
+			require.Equal(t, devices[0].ID, updated[0].ID)
+			require.Equal(t, devices[1].ID, updated[1].ID)
+			require.Equal(t, devices[2].ID, updated[2].ID)
+			require.Equal(t, devices[0].Health, updated[0].Health)
+			require.Equal(t, devices[1].Health, updated[1].Health)
+			require.Equal(t, devices[2].Health, updated[2].Health)
 		}
 
 		callbackCount++
@@ -102,18 +103,7 @@ func TestRun(t *testing.T) {
 	// Wait for the second callback to be issued.
 	<-callbackChan
 
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-
-	require.Len(t, e.devices, 3)
-	for _, dref := range updated {
-		d, ok := e.devices[dref.ID]
-
-		require.True(t, ok)
-		require.Equal(t, d.ID, dref.ID)
-		require.Equal(t, d.Health, dref.Health)
-	}
-
+	require.Equal(t, callbackCount, 2)
 }
 
 func TestAllocate(t *testing.T) {
@@ -123,7 +113,7 @@ func TestAllocate(t *testing.T) {
 	}
 	callbackCount := 0
 	callbackChan := make(chan int)
-	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []pluginapi.Device) {
+	p, e := esetup(t, devs, socket, "mock", func(n string, d []pluginapi.Device) {
 		callbackCount++
 		callbackChan <- callbackCount
 	})
@@ -169,23 +159,13 @@ func TestAllocate(t *testing.T) {
 	require.Equal(t, resp, respOut)
 }
 
-func TestGetDevices(t *testing.T) {
-	e := endpointImpl{
-		devices: map[string]pluginapi.Device{
-			"ADeviceId": {ID: "ADeviceId", Health: pluginapi.Healthy},
-		},
-	}
-	devs := e.getDevices()
-	require.Len(t, devs, 1)
-}
-
 func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string, callback monitorCallback) (*Stub, *endpointImpl) {
 	p := NewDevicePluginStub(devs, socket, resourceName, false)
 
 	err := p.Start()
 	require.NoError(t, err)
 
-	e, err := newEndpointImpl(socket, resourceName, make(map[string]pluginapi.Device), callback)
+	e, err := newEndpointImpl(socket, resourceName, callback)
 	require.NoError(t, err)
 
 	return p, e

--- a/pkg/kubelet/cm/devicemanager/manager_stub.go
+++ b/pkg/kubelet/cm/devicemanager/manager_stub.go
@@ -18,7 +18,6 @@ package devicemanager
 
 import (
 	"k8s.io/api/core/v1"
-	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
@@ -41,11 +40,6 @@ func (h *ManagerStub) Start(activePods ActivePodsFunc, sourcesReady config.Sourc
 // Stop simply returns nil.
 func (h *ManagerStub) Stop() error {
 	return nil
-}
-
-// Devices returns an empty map.
-func (h *ManagerStub) Devices() map[string][]pluginapi.Device {
-	return make(map[string][]pluginapi.Device)
 }
 
 // Allocate simply returns nil.

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"k8s.io/api/core/v1"
-	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -32,11 +31,6 @@ import (
 type Manager interface {
 	// Start starts device plugin registration service.
 	Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady) error
-
-	// Devices is the map of devices that have registered themselves
-	// against the manager.
-	// The map key is the ResourceName of the device plugins.
-	Devices() map[string][]pluginapi.Device
 
 	// Allocate configures and assigns devices to pods. The pods are provided
 	// through the pod admission attributes in the attrs argument. From the


### PR DESCRIPTION
While reviewing devicemanager code, found the caching layer on endpoint is redundant.
Here are the 3 related objects in picture:

**devicemanager  <->  endpoint <-> plugin**

plugin is the source of truth for devices and device health status.
devicemanager maintain healthyDevices, unhealthyDevices, allocatedDevices based on updates
from plugin.

So there is no point for endpoint to cache devices, this patch is removing the cache layer,
endpoint becomes stateless, which i believe should be the case (but i do welcome review
if i missed something here).

also removing the Manager.Devices() since i didn't find any caller of this other than test.

if we need to get all devices from manager in future, it just need to return healthyDevices + unhealthyDevices, so don't have to call endpoint after all.

This patch makes code more readable, data model been simplified.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
this patch simplify the device manager code, make it more maintainable.

**Which issue(s) this PR fixes** *:
this is a refactor of device manager code

**Special notes for your reviewer**:
will need to rebase the code if #58755 get checked-in first.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/sig node
/cc @jiayingz @RenaudWasTaken @vishh @saad-ali @vikaschoudhary16 @vladimirvivien @anfernee 