### PR TITLE
reserve bash for debian-base image

### DIFF
--- a/build/debian-base/Dockerfile.build
+++ b/build/debian-base/Dockerfile.build
@@ -40,7 +40,6 @@ RUN apt-mark hold apt gnupg adduser passwd libsemanage1 libcap2
 # The root packages were evaluated based on whether they were needed in the container image.
 # Several utilities (e.g. ping) were kept for usefulness, but may be removed in later versions.
 RUN echo "Yes, do as I say!" | apt-get purge \
-    bash \
     debconf-i18n \
     e2fslibs \
     e2fsprogs \
@@ -87,8 +86,6 @@ RUN apt-get autoremove -y && \
         /var/log/* \
         /var/cache/debconf/* \
         /usr/share/common-licenses* \
-        /usr/share/bash-completion \
-        ~/.bashrc \
         ~/.profile \
         /etc/systemd \
         /lib/lsb \


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, debian-base image purge `bash` explicitly and some upper level image may depends on `bash` to run some scripts, such as in custom plugins support in node-problem-detector.

Bash is a fundamental binary in GNU/Linux environment. It should be available on debian-base image, too. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Cross fix https://github.com/kubernetes/node-problem-detector/issues/185

**Special notes for your reviewer**:
This may increase debian-base image size. But it should not increase image size a lot.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
