### PR TITLE
vSphere: set vCenter client UserAgent

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/vclib/BUILD
@@ -24,6 +24,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib",
     deps = [
+        "//pkg/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/vmware/govmomi/find:go_default_library",

--- a/pkg/cloudprovider/providers/vsphere/vclib/connection.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/pem"
+	"fmt"
 	"net"
 	neturl "net/url"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"k8s.io/kubernetes/pkg/version"
 )
 
 // VSphereConnection contains information for connecting to vCenter
@@ -178,6 +180,9 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 		glog.Errorf("Failed to create new client. err: %+v", err)
 		return nil, err
 	}
+
+	k8sVersion := version.Get().GitVersion
+	client.UserAgent = fmt.Sprintf("kubernetes-cloudprovider/%s", k8sVersion)
 
 	err = connection.login(ctx, client)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the client UserAgent makes it easier to identify vCenter sessions
used by the vSphere Cloud Provider.  This is useful to remove sessions that
have leaked, such as when a VCP process goes away without calling Logout().
And to test that VCP properly re-authenticates when a session is removed.

Example use:
``` console
% govc session.ls | grep kubernetes-cloudprovider | awk '{print $1}' | xargs -n1 govc session.rm
```

**Special notes for your reviewer**:

Prior to the change, the session UserAgent is listed as `Go-http-client/1.1`, with the change as `kubernetes-cloudprovider/v1.12.0-...`

Format based on the azure provider client User-Agent: https://github.com/kubernetes/kubernetes/blob/ac99da5e3e0c0df07f12cca153df3baed0b6dd49/pkg/cloudprovider/providers/azure/azure.go#L386-L393

``` console
% govc session.ls
Key                                   Name                                                               Time              Idle   Host        Agent
5217bfbf-ed78-3538-c4f4-137dfdc87d97  VSPHERE.LOCAL\Administrator                                        2018-07-09 05:26  3m32s  10.0.0.237  kubernetes-cloudprovider/v1.12.0-alpha.0.1990+ac99da5e3e0c0d-dirty
52259ed5-417e-dab4-07bc-f1b01c06f6ce  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-07-09 05:25  4m41s  10.0.0.208  cl/1.0.0
5225b5d4-1c0a-e8e4-887e-5fa46fee0dc2  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:25  old    127.0.0.1   VMware vim-java 1.0
52385c6f-31b5-876e-3e44-35dc7120fe55  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:26  old    127.0.0.1   VMware vim-java 1.0
524b23c3-52b3-2fb8-00d4-914f1b34e9b1  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:25  old    127.0.0.1   VMware vim-java 1.0
524b6a02-0590-0c1b-db95-0d67b2c36875  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:26  1m26s  127.0.0.1   VMware vim-java 1.0
528b6f73-a658-f488-2651-05f3ec182757  VSPHERE.LOCAL\Administrator                                        2018-07-09 05:28  55s    10.0.0.237  Go-http-client/1.1
52987a71-c671-09e4-6613-ff480aa43882  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:25  old    127.0.0.1   VMware vim-java 1.0
52aa9262-a0c7-a79f-7983-2d3858ecc562  VSPHERE.LOCAL\Administrator                                        2018-07-09 05:09    .    10.0.0.154  govc/0.18.0
52b270fe-2e84-6209-04ff-f4597846ca79  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:26  old    127.0.0.1   VMware vim-java 1.0
52d7e734-80a9-0887-e6cb-13a92c1e4e30  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:25  old    127.0.0.1   VMware vim-java 1.0
52f5365e-6945-44c6-dc3c-0e3c90444bb0  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:26  old    127.0.0.1   VMware vim-java 1.0
52f58503-4943-e4c7-1d90-a3ec7d16ba71  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:26  old    127.0.0.1   VMware vim-java 1.0
52fd2f13-d1a9-7ff9-b779-c87b1e4e0490  VSPHERE.LOCAL\vpxd-extension-09179ffe-ed51-4dee-91a6-c60162932acd  2018-05-26 16:30  6m46s  10.0.0.208  VMware vim-java 1.0
```

**Release note**:

```release-note
NONE
```
