### PR TITLE
Add pod.yaml to user-guide

### DIFF
--- a/test/fixtures/doc-yaml/user-guide/pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
This is referenced in k/community for an example on how to run Kubernetes locally: https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md#running-a-user-defined-pod.

It was removed earlier since it was thought as not used in https://github.com/kubernetes/kubernetes/pull/54342. This was the original `pod.yaml`: https://github.com/kubernetes/kubernetes/blob/668bedd9431d234b7471ac48748626885dc38232/test/fixtures/doc-yaml/user-guide/pod.yaml. This PR adds it back again.

Fixes https://github.com/kubernetes/community/issues/2351

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
