### PR TITLE
verify-generated-files: ensure git tree is clean

### DIFF
--- a/hack/verify-generated-files.sh
+++ b/hack/verify-generated-files.sh
@@ -21,6 +21,8 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
+kube::util::ensure_clean_working_dir
+
 _tmpdir="$(kube::realpath $(mktemp -d -t verify-generated-files.XXXXXX))"
 kube::util::trap_add "rm -rf ${_tmpdir}" EXIT
 


### PR DESCRIPTION
**What this PR does / why we need it**: If you have uncommitted changes in your tree, `hack/verify-generated-files.sh` will fail spuriously on those changes. Instead of wasting time generating files, just fail fast if the tree isn't clean.

Follow-up to #65882.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
