### PR TITLE
Fix wrong flexvolume dir on gce ubuntu

### DIFF
--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -129,7 +129,7 @@ func uninstallFlex(c clientset.Interface, node *v1.Node, vendor, driver string) 
 func getFlexDir(c clientset.Interface, node *v1.Node, vendor, driver string) string {
 	volumePluginDir := defaultVolumePluginDir
 	if framework.ProviderIs("gce") {
-		if node == nil && framework.MasterOSDistroIs("gci") {
+		if node == nil && framework.MasterOSDistroIs("gci", "ubuntu") {
 			v, err := getMasterVersion(c)
 			if err != nil {
 				framework.Failf("Error getting master version: %v", err)
@@ -140,7 +140,7 @@ func getFlexDir(c clientset.Interface, node *v1.Node, vendor, driver string) str
 			} else {
 				volumePluginDir = gciVolumePluginDirLegacy
 			}
-		} else if node != nil && framework.NodeOSDistroIs("gci") {
+		} else if node != nil && framework.NodeOSDistroIs("gci", "ubuntu") {
 			if getNodeVersion(node).AtLeast(versionutil.MustParseGeneric(gciVolumePluginDirVersion)) {
 				volumePluginDir = gciVolumePluginDir
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 
Fixes https://github.com/kubernetes/kubernetes/issues/65777

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/65777

**Special notes for your reviewer**: everything is named for gci being the one exception but i assume ubuntu received the change at the same time `gciVolumePluginDirVersion = "1.10.0"`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
