### PR TITLE
Stop sorting downward api file lines

### DIFF
--- a/pkg/fieldpath/BUILD
+++ b/pkg/fieldpath/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/fieldpath",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
     ],
 )

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -21,13 +21,19 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // FormatMap formats map[string]string to a string.
 func FormatMap(m map[string]string) (fmtStr string) {
-	for key, value := range m {
-		fmtStr += fmt.Sprintf("%v=%q\n", key, value)
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
 	}
 	fmtStr = strings.TrimSuffix(fmtStr, "\n")
 

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"sort"
-	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -244,7 +242,7 @@ func CollectData(items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.Volu
 				glog.Errorf("Unable to extract field %s: %s", fileInfo.FieldRef.FieldPath, err.Error())
 				errlist = append(errlist, err)
 			} else {
-				fileProjection.Data = []byte(sortLines(values))
+				fileProjection.Data = []byte(values)
 			}
 		} else if fileInfo.ResourceFieldRef != nil {
 			containerName := fileInfo.ResourceFieldRef.ContainerName
@@ -255,21 +253,13 @@ func CollectData(items []v1.DownwardAPIVolumeFile, pod *v1.Pod, host volume.Volu
 				glog.Errorf("Unable to extract field %s: %s", fileInfo.ResourceFieldRef.Resource, err.Error())
 				errlist = append(errlist, err)
 			} else {
-				fileProjection.Data = []byte(sortLines(values))
+				fileProjection.Data = []byte(values)
 			}
 		}
 
 		data[fPath] = fileProjection
 	}
 	return data, utilerrors.NewAggregate(errlist)
-}
-
-// sortLines sorts the strings generated from map based data
-// (annotations and labels)
-func sortLines(values string) string {
-	splitted := strings.Split(values, "\n")
-	sort.Strings(splitted)
-	return strings.Join(splitted, "\n")
 }
 
 func (d *downwardAPIVolume) GetPath() string {

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -82,8 +82,9 @@ func TestDownwardAPI(t *testing.T) {
 		"key3": "value3",
 	}
 	annotations := map[string]string{
-		"a1": "value1",
-		"a2": "value2",
+		"a1":        "value1",
+		"a2":        "value2",
+		"multiline": "c\nb\na",
 	}
 	testCases := []struct {
 		name           string
@@ -318,8 +319,8 @@ func doVerifyLinesInFile(t *testing.T, volumePath, filename string, expected str
 		t.Errorf(err.Error())
 		return
 	}
-	actualStr := sortLines(string(data))
-	expectedStr := sortLines(expected)
+	actualStr := string(data)
+	expectedStr := expected
 	if actualStr != expectedStr {
 		t.Errorf("Found `%s`, expected `%s`", actualStr, expectedStr)
 	}


### PR DESCRIPTION
Fixes #65159

```release-note
fixes an issue with multi-line annotations injected via downward API files getting scrambled
```