### PR TITLE
[GCE] ILB tests - move t.Parallel() out of for loop

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -80,6 +80,8 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 }
 
 func TestEnsureInternalBackendServiceGroups(t *testing.T) {
+	t.Parallel()
+
 	for desc, tc := range map[string]struct {
 		mockModifier func(*cloud.MockGCE)
 	}{
@@ -96,8 +98,6 @@ func TestEnsureInternalBackendServiceGroups(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			t.Parallel()
-
 			vals := DefaultTestClusterValues()
 			nodeNames := []string{"test-node-1"}
 

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -117,12 +117,12 @@ func TestEnsureInternalBackendServiceGroups(t *testing.T) {
 			err = gce.ensureInternalBackendService(bsName, "description", svc.Spec.SessionAffinity, cloud.SchemeInternal, "TCP", igLinks, "")
 			require.NoError(t, err)
 
-			// Update the BackendService with new Instances
+			// Update the BackendService with new InstanceGroups
 			if tc.mockModifier != nil {
 				tc.mockModifier(gce.c.(*cloud.MockGCE))
 			}
-			newNodeNames := []string{"new-test-node-1", "new-test-node-2"}
-			err = gce.ensureInternalBackendServiceGroups(bsName, newNodeNames)
+			newIGLinks := []string{"new-test-ig-1", "new-test-ig-2"}
+			err = gce.ensureInternalBackendServiceGroups(bsName, newIGLinks)
 			if tc.mockModifier != nil {
 				assert.Error(t, err)
 				return
@@ -132,10 +132,8 @@ func TestEnsureInternalBackendServiceGroups(t *testing.T) {
 			bs, err := gce.GetRegionBackendService(bsName, gce.region)
 			assert.NoError(t, err)
 
-			// Check that the instances are updated
-			newNodes, err := createAndInsertNodes(gce, newNodeNames, vals.ZoneName)
-			newIgLinks, err := gce.ensureInternalInstanceGroups(igName, newNodes)
-			backends := backendsFromGroupLinks(newIgLinks)
+			// Check that the Backends reflect the new InstanceGroups
+			backends := backendsFromGroupLinks(newIGLinks)
 			assert.Equal(t, bs.Backends, backends)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves `t.Parallel()` to the top of the test case instead of within the for loop. `t.Parallel()` within a `t.Run` block causes the for loop to advance to the next test case - see https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721 for more details. 

Verified the fix by running the test multiple times locally, with @smarterclayton 's command `go test ./pkg/cloudprovider/providers/gce/ -test.run=TestEnsureInternalBackendServiceGroups/GetRegionBackendService_failed -count=10`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65883

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
cc @grayluck 
