### PR TITLE
Create WORKSPACE file before running bazel in kubemark

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -194,6 +194,7 @@ function create-and-upload-hollow-node-image {
   KUBEMARK_IMAGE_REGISTRY="${KUBEMARK_IMAGE_REGISTRY:-${CONTAINER_REGISTRY}/${PROJECT}}"
   if [[ "${KUBEMARK_BAZEL_BUILD:-}" =~ ^[yY]$ ]]; then
     # Build+push the image through bazel.
+    touch WORKSPACE # Needed for bazel.
     build_cmd=("bazel" "run" "//cluster/images/kubemark:push" "--define" "REGISTRY=${KUBEMARK_IMAGE_REGISTRY}" "--define" "IMAGE_TAG=${KUBEMARK_IMAGE_TAG}")
     run-cmd-with-retries "${build_cmd[@]}"
   else


### PR DESCRIPTION
As the canary run after https://github.com/kubernetes/test-infra/pull/8616 failed with:

```
I0709 19:06:05.281] Extracting Bazel installation...
I0709 19:06:13.369] ERROR: The 'run' command is only supported from within a workspace.
W0709 19:06:13.469] [0;33mAttempt 1 failed to bazel run //cluster/images/kubemark:push. Retrying.[0m
```

Ref https://github.com/kubernetes/test-infra/issues/8348

/cc @krzyzacy 

```release-note
NONE
```