### PR TITLE
kubeadm: use unique CA cert DNs for etcd and front-proxy

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
@@ -142,11 +142,11 @@ func TestKubeConfigSubCommandsThatCreateFilesWithFlags(t *testing.T) {
 	}{
 		kubeadmconstants.AdminKubeConfigFileName: {
 			clientName:    "kubernetes-admin",
-			organizations: []string{kubeadmconstants.MastersGroup},
+			organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 		},
 		kubeadmconstants.KubeletKubeConfigFileName: {
 			clientName:    "system:node:valid-nome-name",
-			organizations: []string{kubeadmconstants.NodesGroup},
+			organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.NodesGroup},
 		},
 		kubeadmconstants.ControllerManagerKubeConfigFileName: {
 			clientName: kubeadmconstants.ControllerManagerUser,
@@ -246,11 +246,11 @@ func TestKubeConfigSubCommandsThatCreateFilesWithConfigFile(t *testing.T) {
 	}{
 		kubeadmconstants.AdminKubeConfigFileName: {
 			clientName:    "kubernetes-admin",
-			organizations: []string{kubeadmconstants.MastersGroup},
+			organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 		},
 		kubeadmconstants.KubeletKubeConfigFileName: {
 			clientName:    "system:node:valid-node-name",
-			organizations: []string{kubeadmconstants.NodesGroup},
+			organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.NodesGroup},
 		},
 		kubeadmconstants.ControllerManagerKubeConfigFileName: {
 			clientName: kubeadmconstants.ControllerManagerUser,

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -49,6 +49,11 @@ const (
 	// CAKeyName defines certificate name
 	CAKeyName = "ca.key"
 
+	// DefaultCertCommonName is the default common name for components certs
+	DefaultCertCommonName = "kubernetes"
+	// DefaultCertOrganization is the default organization for components certs
+	DefaultCertOrganization = "k8s.io"
+
 	// APIServerCertAndKeyBaseName defines API's server certificate and key base name
 	APIServerCertAndKeyBaseName = "apiserver"
 	// APIServerCertName defines API's server certificate name
@@ -73,6 +78,8 @@ const (
 	EtcdCACertName = "etcd/ca.crt"
 	// EtcdCAKeyName defines etcd's CA key name
 	EtcdCAKeyName = "etcd/ca.key"
+	// EtcdCACertCommonName defines etcd's CA common name
+	EtcdCACertCommonName = "kube-etcd"
 
 	// EtcdServerCertAndKeyBaseName defines etcd's server certificate and key base name
 	EtcdServerCertAndKeyBaseName = "etcd/server"
@@ -119,6 +126,8 @@ const (
 	FrontProxyCACertName = "front-proxy-ca.crt"
 	// FrontProxyCAKeyName defines front proxy CA key name
 	FrontProxyCAKeyName = "front-proxy-ca.key"
+	// FrontProxyCACertCommonName defines the front proxy CA common name
+	FrontProxyCACertCommonName = "front-proxy"
 
 	// FrontProxyClientCertAndKeyBaseName defines front proxy certificate and key base name
 	FrontProxyClientCertAndKeyBaseName = "front-proxy-client"

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -327,9 +327,10 @@ func NewAPIServerCertAndKey(cfg *kubeadmapi.InitConfiguration, caCert *x509.Cert
 	}
 
 	config := certutil.Config{
-		CommonName: kubeadmconstants.APIServerCertCommonName,
-		AltNames:   *altNames,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		CommonName:   kubeadmconstants.APIServerCertCommonName,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+		AltNames:     *altNames,
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 	apiCert, apiKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
 	if err != nil {
@@ -344,7 +345,7 @@ func NewAPIServerKubeletClientCertAndKey(caCert *x509.Certificate, caKey *rsa.Pr
 
 	config := certutil.Config{
 		CommonName:   kubeadmconstants.APIServerKubeletClientCertCommonName,
-		Organization: []string{kubeadmconstants.MastersGroup},
+		Organization: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	apiClientCert, apiClientKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
@@ -358,7 +359,11 @@ func NewAPIServerKubeletClientCertAndKey(caCert *x509.Certificate, caKey *rsa.Pr
 // NewEtcdCACertAndKey generate a self signed etcd CA.
 func NewEtcdCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 
-	etcdCACert, etcdCAKey, err := pkiutil.NewCertificateAuthority()
+	config := certutil.Config{
+		CommonName:   kubeadmconstants.EtcdCACertCommonName,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+	}
+	etcdCACert, etcdCAKey, err := pkiutil.NewCertificateAuthorityFromConfig(config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failure while generating etcd CA certificate and key: %v", err)
 	}
@@ -379,9 +384,10 @@ func NewEtcdServerCertAndKey(cfg *kubeadmapi.InitConfiguration, caCert *x509.Cer
 	// Once the upstream issue is resolved, this should be returned to only allowing
 	// ServerAuth usage.
 	config := certutil.Config{
-		CommonName: cfg.NodeRegistration.Name,
-		AltNames:   *altNames,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		CommonName:   cfg.NodeRegistration.Name,
+		AltNames:     *altNames,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
 	etcdServerCert, etcdServerKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
 	if err != nil {
@@ -400,9 +406,10 @@ func NewEtcdPeerCertAndKey(cfg *kubeadmapi.InitConfiguration, caCert *x509.Certi
 	}
 
 	config := certutil.Config{
-		CommonName: cfg.NodeRegistration.Name,
-		AltNames:   *altNames,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		CommonName:   cfg.NodeRegistration.Name,
+		AltNames:     *altNames,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
 	etcdPeerCert, etcdPeerKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
 	if err != nil {
@@ -417,7 +424,7 @@ func NewEtcdHealthcheckClientCertAndKey(caCert *x509.Certificate, caKey *rsa.Pri
 
 	config := certutil.Config{
 		CommonName:   kubeadmconstants.EtcdHealthcheckClientCertCommonName,
-		Organization: []string{kubeadmconstants.MastersGroup},
+		Organization: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	etcdHealcheckClientCert, etcdHealcheckClientKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
@@ -433,7 +440,7 @@ func NewAPIServerEtcdClientCertAndKey(caCert *x509.Certificate, caKey *rsa.Priva
 
 	config := certutil.Config{
 		CommonName:   kubeadmconstants.APIServerEtcdClientCertCommonName,
-		Organization: []string{kubeadmconstants.MastersGroup},
+		Organization: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	apiClientCert, apiClientKey, err := pkiutil.NewCertAndKey(caCert, caKey, config)
@@ -459,7 +466,11 @@ func NewServiceAccountSigningKey() (*rsa.PrivateKey, error) {
 // NewFrontProxyCACertAndKey generate a self signed front proxy CA.
 func NewFrontProxyCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 
-	frontProxyCACert, frontProxyCAKey, err := pkiutil.NewCertificateAuthority()
+	config := certutil.Config{
+		CommonName:   kubeadmconstants.FrontProxyCACertCommonName,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+	}
+	frontProxyCACert, frontProxyCAKey, err := pkiutil.NewCertificateAuthorityFromConfig(config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failure while generating front-proxy CA certificate and key: %v", err)
 	}
@@ -471,8 +482,9 @@ func NewFrontProxyCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 func NewFrontProxyClientCertAndKey(frontProxyCACert *x509.Certificate, frontProxyCAKey *rsa.PrivateKey) (*x509.Certificate, *rsa.PrivateKey, error) {
 
 	config := certutil.Config{
-		CommonName: kubeadmconstants.FrontProxyClientCertCommonName,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		CommonName:   kubeadmconstants.FrontProxyClientCertCommonName,
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
 	}
 	frontProxyClientCert, frontProxyClientKey, err := pkiutil.NewCertAndKey(frontProxyCACert, frontProxyCAKey, config)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -33,16 +33,23 @@ import (
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
-// NewCertificateAuthority creates new certificate and private key for the certificate authority
+// NewCertificateAuthority creates new certificate and private key for the default certificate authority
 func NewCertificateAuthority() (*x509.Certificate, *rsa.PrivateKey, error) {
+
+	config := certutil.Config{
+		CommonName:   kubeadmconstants.DefaultCertCommonName,
+		Organization: []string{kubeadmconstants.DefaultCertOrganization},
+	}
+	return NewCertificateAuthorityFromConfig(config)
+}
+
+// NewCertificateAuthorityFromConfig creates new certificate and private key for the certificate authority from a k8s.io/client-go/util/cert/Config
+func NewCertificateAuthorityFromConfig(config certutil.Config) (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := certutil.NewPrivateKey()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create private key [%v]", err)
 	}
 
-	config := certutil.Config{
-		CommonName: "kubernetes",
-	}
 	cert, err := certutil.NewSelfSignedCACert(config, key)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create self-signed certificate [%v]", err)

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers_test.go
@@ -50,6 +50,31 @@ func TestNewCertificateAuthority(t *testing.T) {
 	}
 }
 
+func TestNewCertificateAuthorityFromConfig(t *testing.T) {
+	config := certutil.Config{
+		CommonName:   "test",
+		Organization: []string{"test"},
+	}
+	cert, key, err := NewCertificateAuthorityFromConfig(config)
+
+	if cert == nil {
+		t.Errorf(
+			"failed NewCertificateAuthorityFromConfig, cert == nil",
+		)
+	}
+	if key == nil {
+		t.Errorf(
+			"failed NewCertificateAuthorityFromConfig, key == nil",
+		)
+	}
+	if err != nil {
+		t.Errorf(
+			"failed NewCertificateAuthorityFromConfig with an error: %v",
+			err,
+		)
+	}
+}
+
 func TestNewCertAndKey(t *testing.T) {
 	var tests = []struct {
 		caKeySize int

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -154,7 +154,7 @@ func getKubeConfigSpecs(cfg *kubeadmapi.InitConfiguration) (map[string]*kubeConf
 			ClientName: "kubernetes-admin",
 			ClientCertAuth: &clientCertAuth{
 				CAKey:         caKey,
-				Organizations: []string{kubeadmconstants.MastersGroup},
+				Organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 			},
 		},
 		kubeadmconstants.KubeletKubeConfigFileName: {
@@ -163,7 +163,7 @@ func getKubeConfigSpecs(cfg *kubeadmapi.InitConfiguration) (map[string]*kubeConf
 			ClientName: fmt.Sprintf("system:node:%s", cfg.NodeRegistration.Name),
 			ClientCertAuth: &clientCertAuth{
 				CAKey:         caKey,
-				Organizations: []string{kubeadmconstants.NodesGroup},
+				Organizations: []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.NodesGroup},
 			},
 		},
 		kubeadmconstants.ControllerManagerKubeConfigFileName: {

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -102,12 +102,12 @@ func TestGetKubeConfigSpecs(t *testing.T) {
 			{
 				kubeConfigFile: kubeadmconstants.AdminKubeConfigFileName,
 				clientName:     "kubernetes-admin",
-				organizations:  []string{kubeadmconstants.MastersGroup},
+				organizations:  []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.MastersGroup},
 			},
 			{
 				kubeConfigFile: kubeadmconstants.KubeletKubeConfigFileName,
 				clientName:     fmt.Sprintf("system:node:%s", cfg.NodeRegistration.Name),
-				organizations:  []string{kubeadmconstants.NodesGroup},
+				organizations:  []string{kubeadmconstants.DefaultCertOrganization, kubeadmconstants.NodesGroup},
 			},
 			{
 				kubeConfigFile: kubeadmconstants.ControllerManagerKubeConfigFileName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Users have reported that the subject DNs for etcd and control
plane components in CA certs are the same. This causes a problem
if one wants to distinguish them.

Make the following changes:
- Add some new constants for the default CommonName and
Organization for certs, and also for etcd and front-proxy CA cert
CommonNames.
- When creating the root CA cert use the default CommonName.
- When creating the etcd CA and the front-proxy CA cert use the new
appropriate constants.
- Add a new helper function in pkiutil that generates a CA from
a Config struct - NewCertificateAuthorityFromConfig().
- Make NewCertificateAuthority() use default constants.
- Set the default cert organization to certs, if it wasn't
set already to something specific.
- Whenever NodesGroup or MastersGroup are used for organization, also
use the default cert organization.
- Add unit test for NewCertificateAuthorityFromConfig().

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#946

**Special notes for your reviewer**:
- while this fixes the above issue, it also always adds a default organization to certs (default is `k8s.io`).
let me know if went a bit overboard with that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: use unique CA cert DNs for etcd and front-proxy and always add k8s.io as organization
```

/cc @detiber @stealthybox @NeilW 
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/kind bug
/area security
/area kubeadm
/area etcd
