### PR TITLE
Set hasArch=false for nginx-slim 0.20 image

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -77,7 +77,7 @@ var (
 	Net                      = ImageConfig{e2eRegistry, "net", "1.0", true}
 	Netexec                  = ImageConfig{e2eRegistry, "netexec", "1.0", true}
 	Nettest                  = ImageConfig{e2eRegistry, "nettest", "1.0", true}
-	NginxSlim                = ImageConfig{gcRegistry, "nginx-slim", "0.20", true}
+	NginxSlim                = ImageConfig{gcRegistry, "nginx-slim", "0.20", false}
 	NginxSlimNew             = ImageConfig{gcRegistry, "nginx-slim", "0.21", true}
 	Nonewprivs               = ImageConfig{e2eRegistry, "nonewprivs", "1.0", true}
 	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0", true}


### PR DESCRIPTION
The k8s.gcr.io/nginx-slim 0.20 seems to not have a
different name for each architecture (for instance,
"k8s.gcr.io/nginx-slim-arm64:0.20" gives a pulling error).

Setting hasArch to false avoid adding the arch suffix to
the image name.

This fixes some e2e tests in ARM64 architecture.

Signed-off-by: Miguel Herranz <miguel@midokura.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
