### PR TITLE
change TRUNCATED to DATA+OMITTED in kubectl config view

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
@@ -29,6 +29,8 @@ import (
 func init() {
 	sDec, _ := base64.StdEncoding.DecodeString("REDACTED+")
 	redactedBytes = []byte(string(sDec))
+	sDec, _ = base64.StdEncoding.DecodeString("DATA+OMITTED")
+	dataOmittedBytes = []byte(string(sDec))
 }
 
 // IsConfigEmpty returns true if the config is empty.
@@ -79,7 +81,10 @@ func MinifyConfig(config *Config) error {
 	return nil
 }
 
-var redactedBytes []byte
+var (
+	redactedBytes    []byte
+	dataOmittedBytes []byte
+)
 
 // Flatten redacts raw data entries from the config object for a human-readable view.
 func ShortenConfig(config *Config) {
@@ -97,7 +102,7 @@ func ShortenConfig(config *Config) {
 	}
 	for key, cluster := range config.Clusters {
 		if len(cluster.CertificateAuthorityData) > 0 {
-			cluster.CertificateAuthorityData = redactedBytes
+			cluster.CertificateAuthorityData = dataOmittedBytes
 		}
 		config.Clusters[key] = cluster
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
@@ -229,7 +229,7 @@ func Example_minifyAndShorten() {
 	// clusters:
 	//   cow-cluster:
 	//     LocationOfOrigin: ""
-	//     certificate-authority-data: REDACTED
+	//     certificate-authority-data: DATA+OMITTED
 	//     server: http://cow.org:8080
 	// contexts:
 	//   federal-context:
@@ -276,14 +276,15 @@ func TestShortenSuccess(t *testing.T) {
 	}
 
 	redacted := string(redactedBytes)
+	dataOmitted := string(dataOmittedBytes)
 	if len(mutatingConfig.Clusters) != 2 {
 		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
 	}
 	if !reflect.DeepEqual(startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster]) {
 		t.Errorf("expected %v, got %v", startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster])
 	}
-	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != redacted {
-		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
+	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != dataOmitted {
+		t.Errorf("expected %v, got %v", dataOmitted, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
 	}
 
 	if len(mutatingConfig.AuthInfos) != 2 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the discussion in #61573, this PR switches the replacement text for CA certificate data and client certificates and secrets printed using `kubectl config view`. Currently, `REDACTED` is used, which might give a false impression that the data is a secret (which is not true for the public certificates).

This PR changes `REDACTED` to `DATA+OMITTED`. The printed string is the base64 encoded string on the byte stream. Some trickery is involved to print a readable string (refer to [this comment](https://github.com/kubernetes/kubernetes/pull/66023/files#diff-aec000ca3f293c94dcd99b4a9d1c5c3cL86) for more info).

**Which issue(s) this PR fixes**:
Fixes #61573

**Special notes for your reviewer**:


**Release note**:
```release-note
Switched certificate data replacement from "REDACTED" to "DATA+OMITTED"
```
