### PR TITLE
Automated cherry pick of #65908: switch delete strategy to background deletion

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -3275,13 +3275,15 @@ run_rs_tests() {
   kube::log::status "Deleting rs"
   kubectl delete rs frontend "${kube_flags[@]}"
   # Post-condition: no pods from frontend replica set
-  kube::test::get_object_assert 'pods -l "tier=frontend"' "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert 'pods -l "tier=frontend"' "{{range.items}}{{$id_field}}:{{end}}" ''
 
   ### Create and then delete a replica set with cascade=false, make sure it doesn't delete pods.
   # Pre-condition: no replica set exists
   kube::test::get_object_assert rs "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f hack/testdata/frontend-replicaset.yaml "${kube_flags[@]}"
+  # wait for all 3 pods to be set up
+  kube::test::wait_object_assert 'pods -l "tier=frontend"' "{{range.items}}{{$pod_container_name_field}}:{{end}}" 'php-redis:php-redis:php-redis:'
   kube::log::status "Deleting rs"
   kubectl delete rs frontend "${kube_flags[@]}" --cascade=false
   # Wait for the rs to be deleted.

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -246,7 +246,7 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		if o.GracePeriod >= 0 {
 			options = metav1.NewDeleteOptions(int64(o.GracePeriod))
 		}
-		policy := metav1.DeletePropagationForeground
+		policy := metav1.DeletePropagationBackground
 		if !o.Cascade {
 			policy = metav1.DeletePropagationOrphan
 		}

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -137,9 +137,9 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 		}),
 	}
 
-	// DeleteOptions.PropagationPolicy should be Foreground, when cascade is true (default).
-	foregroundPolicy := metav1.DeletePropagationForeground
-	policy = &foregroundPolicy
+	// DeleteOptions.PropagationPolicy should be Background, when cascade is true (default).
+	backgroundPolicy := metav1.DeletePropagationBackground
+	policy = &backgroundPolicy
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 	cmd := NewCmdDelete(tf, streams)
 	cmd.Flags().Set("namespace", "test")


### PR DESCRIPTION
Cherry pick of #65908 on release-1.11.

Fixes #66110

includes related test fix https://github.com/kubernetes/kubernetes/pull/66038

#65908: switch delete strategy to background deletion

```release-note
`kubectl delete` now deletes daemonset, deployment, statefulset, replicaset, replicationcontroller, and job objects immediately and delegates cleanup of child resources to server-side garbage collection in the background. This resolves hangs that could occur if garbage collection was not responsive when `kubectl delete` was invoked.
```
