### PR TITLE
Permanent autocomplete examples

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -69,18 +69,13 @@ var (
 		# Installing bash completion on Linux
 		## Load the kubectl completion code for bash into the current shell
 		    source <(kubectl completion bash)
-		## Write bash completion code to a file and source if from .bash_profile
-		    kubectl completion bash > ~/.kube/completion.bash.inc
-		    printf "
-		      # Kubectl shell completion
-		      source '$HOME/.kube/completion.bash.inc'
-		      " >> $HOME/.bash_profile
-		    source $HOME/.bash_profile
+		## Set the kubectl completion code for bash to autoload on startup
+		    echo "source <(kubectl completion bash)" >> ~/.bashrc
 
 		# Load the kubectl completion code for zsh[1] into the current shell
 		    source <(kubectl completion zsh)
 		# Set the kubectl completion code for zsh[1] to autoload on startup
-		    kubectl completion zsh > "${fpath[1]}/_kubectl"`))
+		    echo "if [ $commands[kubectl] ]; then source <(kubectl completion zsh); fi" >> ~/.zshrc`))
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds better examples of autocomplete configuration for BASH & ZSH shells. Some of the current examples are incorrect.

**Which issue(s) this PR fixes**

None

**Special notes for your reviewer**:

Start with `pkg/kubectl/cmd/completion.go`, lines `72-73` and `78`. Execute `kubectl completion -h` to see the output. Test the new examples in both BASH & ZSH.

**Release note**:

```release-note
NONE
```

**Risk involved?**

No

**Does the documentation need an update?**

Yes, this PR was opened: https://github.com/kubernetes/website/pull/9455