### PR TITLE
declare conversion dependencies

### DIFF
--- a/pkg/apis/batch/v1beta1/doc.go
+++ b/pkg/apis/batch/v1beta1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
+// +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch/v1
 // +k8s:conversion-gen-external-types=k8s.io/api/batch/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v1beta1

--- a/pkg/apis/batch/v2alpha1/doc.go
+++ b/pkg/apis/batch/v2alpha1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
+// +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch/v1
 // +k8s:conversion-gen-external-types=k8s.io/api/batch/v2alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v2alpha1


### PR DESCRIPTION
fixes #65988

verified all packages regenerate cleanly individually with:
```
for x in $(find . -name *zz*conversion* | xargs -n 1 dirname); do touch $x; make generated_files; git status; done
```

```release-note
NONE
```