### PR TITLE
WIP Make Kubelet flags visible to docs generators

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -279,6 +279,15 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine(), cleanFlagSet.FlagUsagesWrapped(2))
 	})
 
+	// Make a copy of the clean FlagSet and add these flags to the command,
+	// so that docs generators can also see the registered flags.
+	// This shouldn't affect flag parsing, since we disable Cobra's parsing
+	// via cmd.DisableFlagParsing, but we still make a copy in case something
+	// mutates the command's FlagSet under the hood in any code path (runtime or docs generation).
+	docsFlagSet := pflag.NewFlagSet(componentKubelet, pflag.ExitOnError)
+	docsFlagSet.AddFlagSet(cleanFlagSet)
+	cmd.Flags().AddFlagSet(docsFlagSet)
+
 	return cmd
 }
 


### PR DESCRIPTION
The Kubelet avoids using Cobra flag parsing to keep tight control of its
command line. We hadn't initially used the Cobra Command's flagset at
all, which meant many flags were missing from the generated Kubelet
docs. ~With this change, Kubelet's `--help` flag and the generated docs
report the same set of flags (verified with `diff -b`).~

Edit: needs more work, this fix still allows docs generator to pick up global flags.

Fixes https://github.com/kubernetes/website/issues/9413

```release-note
NONE
```
