### PR TITLE
Cherrypick PR#53604 to 1.8

### DIFF
--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -124,6 +124,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/__PILLAR__DNS__DOMAIN__/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -124,6 +124,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -124,6 +124,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/$DNS_DOMAIN/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -121,6 +121,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/{{ .DNSDomain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cherrypick the change( https://github.com/kubernetes/kubernetes/pull/53604) to add no-negcache flag to dnsmasq 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add --no-negcache flag to kube-dns to prevent caching of NXDOMAIN responses.
```
