### PR TITLE
Re-enable write-read pv check in volume provisioning tests

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -132,7 +132,6 @@ func (h *hostpathCSIDriver) createStorageClassTest(node v1.Node) storageClassTes
 		claimSize:    "1Gi",
 		expectedSize: "1Gi",
 		nodeName:     node.Name,
-		attach:       true,
 	}
 }
 
@@ -198,7 +197,6 @@ func (g *gcePDCSIDriver) createStorageClassTest(node v1.Node) storageClassTest {
 		claimSize:    "5Gi",
 		expectedSize: "5Gi",
 		nodeName:     node.Name,
-		attach:       true,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Except for the recently-added CSI tests, every test that uses testDynamicProvisioning in volume_provisioning has been skipping the 
		`By("checking the created volume is writable and has the PV's mount options")`
and
		`By("checking the created volume is readable and retains data")`
steps due to an unintentional change in https://github.com/kubernetes/kubernetes/pull/59879

**Special notes for your reviewer**: The 'attach' variable name is not descriptive at all, default behaviour is unclear. Tests will take longer of course, but that was always the intention, to not only test provisioning of PV is according to PVC but that you can actually r/w it (hence e2e).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
