### PR TITLE
use pause image with fat-manifest

### DIFF
--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	validTmpl    = "image: {{ .ImageRepository }}/pause-{{ .Arch }}:3.1"
-	validTmplOut = "image: k8s.gcr.io/pause-amd64:3.1"
-	doNothing    = "image: k8s.gcr.io/pause-amd64:3.1"
+	validTmpl    = "image: {{ .ImageRepository }}/pause:3.1"
+	validTmplOut = "image: k8s.gcr.io/pause:3.1"
+	doNothing    = "image: k8s.gcr.io/pause:3.1"
 	invalidTmpl1 = "{{ .baz }/d}"
 	invalidTmpl2 = "{{ !foobar }}"
 )


### PR DESCRIPTION
What this PR does / why we need it:
Pause manifest code is merged in #57723, so we should use new image in test.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

Special notes for your reviewer:

Release note: