### PR TITLE
Don't delete pkg/generated/bindata.go in make clean

### DIFF
--- a/hack/make-rules/clean.sh
+++ b/hack/make-rules/clean.sh
@@ -25,7 +25,6 @@ CLEAN_PATTERNS=(
   "_tmp"
   "doc_tmp"
   ".*/zz_generated.openapi.go"
-  "pkg/generated/bindata.go"
   "test/e2e/generated/bindata.go"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: follow-up to #65985: `pkg/generated/bindata.go` has been re-added to the repo, so `make clean` shouldn't delete it, as doing so makes the tree dirty.

This is mostly problematic for jobs which run `make clean` followed by `make quick-release` or `make release` (like our CI build job), since those won't regenerate `pkg/generated/bindata.go`, as they run builds inside the build container.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```