### PR TITLE
Automated cherry pick of #66049: Always mark gke-exec-auth-plugin executable

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -273,7 +273,8 @@ function install-exec-auth-plugin {
 
   echo "Downloading gke-exec-auth-plugin binary"
   download-or-bust "${plugin_sha1}" "${plugin_url}"
-  mv "${KUBE_HOME}/gke-exec-auth-plugin" "${KUBE_BIN}"
+  mv "${KUBE_HOME}/gke-exec-auth-plugin" "${KUBE_BIN}/gke-exec-auth-plugin"
+  chmod a+x "${KUBE_BIN}/gke-exec-auth-plugin"
 }
 
 function install-kube-manifests {


### PR DESCRIPTION
Cherry pick of #66049 on release-1.11.

#66049: Always mark gke-exec-auth-plugin executable

```release-note
NONE
```