### PR TITLE
Set ExecSync tty to true by default

### DIFF
--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -84,8 +84,8 @@ func (ds *dockerService) ExecSync(_ context.Context, req *runtimeapi.ExecSyncReq
 		nil, // in
 		ioutils.WriteCloserWrapper(&stdoutBuffer),
 		ioutils.WriteCloserWrapper(&stderrBuffer),
-		false, // tty
-		nil,   // resize
+		true, // tty
+		nil,  // resize
 		timeout)
 
 	var exitCode int32


### PR DESCRIPTION
**What this PR does / why we need it**:

Many probes run "sh -i -c" to pick up defaults, which fails
with an ioctl error as tty was set to false by default. Makes
sense to change the default to true.

```
NONE

```
Signed-off-by: umohnani8 <umohnani@redhat.com>

cc @mrunalp 