### PR TITLE
Bump cluster-proportional-autoscaler to 1.2.0

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -29,7 +29,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
@@ -82,7 +82,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.2.0
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/pull/47.

Major changes in cluster-proportional-autoscaler 1.2.0:
- Watch nodes instead of periodic polls.

RBAC permission is slightly edited to allow dns-autoscaler to watch nodes.

/assign @shyamjvs 
cc @wojtek-t
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
