### PR TITLE
Automated cherry pick of #63268: Make kubelet `ReadLogs` backward compatible.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -730,10 +730,7 @@ func (m *kubeGenericRuntimeManager) GetContainerLogs(pod *v1.Pod, containerID ku
 		glog.V(4).Infof("failed to get container status for %v: %v", containerID.String(), err)
 		return fmt.Errorf("Unable to retrieve container logs for %v", containerID.String())
 	}
-	labeledInfo := getContainerInfoFromLabels(status.Labels)
-	annotatedInfo := getContainerInfoFromAnnotations(status.Annotations)
-	path := buildFullContainerLogsPath(pod.UID, labeledInfo.ContainerName, annotatedInfo.RestartCount)
-	return m.ReadLogs(path, containerID.ID, logOptions, stdout, stderr)
+	return m.ReadLogs(status.GetLogPath(), containerID.ID, logOptions, stdout, stderr)
 }
 
 // GetExec gets the endpoint the runtime will serve the exec request from.


### PR DESCRIPTION
Cherry pick of #63268 on release-1.10.

#63268: Make kubelet `ReadLogs` backward compatible.

```release-note
Make kubelet ReadLogs backward compatible.
```