### PR TITLE
verify-generated-docs: Use exit code rather than comparison to empty …

### DIFF
--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -36,7 +36,7 @@ kube::util::ensure-temp-dir
 kube::util::gen-docs "${KUBE_TEMP}"
 
 # Verify the list matches the expected list (diff should be empty)
-if [[ "$(diff ${KUBE_ROOT}/docs/.generated_docs ${KUBE_TEMP}/docs/.generated_docs)" != "" ]]; then
+if ! diff "${KUBE_ROOT}/docs/.generated_docs" "${KUBE_TEMP}/docs/.generated_docs"; then
   echo "List of generated docs doesn't match a freshly built list. Please run hack/update-generated-docs.sh"
   exit 1
 fi


### PR DESCRIPTION
…string

Checking the exit code rather than the empty string has the advantage
that you can identify what was found (comparison consumes the string, so
it's not printed). It makes debugging much easier when something is wrong.

One of my pull-request is failing saying that I need to run update, but it keeps saying that even after I ran update. And since I can't see what's wrong, it's quite hard to debug.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
