### PR TITLE
WIP: Add completions index to job controller

### DIFF
--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package job
 
 import (
+	"strconv"
+
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 )
@@ -28,4 +30,8 @@ func IsJobFinished(j *batch.Job) bool {
 		}
 	}
 	return false
+}
+
+func getCompletionsIndex(pod *v1.Pod) (int, error) {
+	return strconv.Atoi(pod.Labels["job-completions-index"])
 }

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -36,10 +36,10 @@ func getCompletionsIndex(pod *v1.Pod) (int, error) {
 	return strconv.Atoi(pod.Labels["job-completions-index"])
 }
 
-func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int) v1.PodTemplateSpec {
+func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1.PodTemplateSpec {
 	if completionsIndex > 0 {
 		job := job.DeepCopy()
-		job.Spec.Template.Labels["job-completions-index"] = strconv.Itoa(completionsIndex)
+		job.Spec.Template.Labels["job-completions-index"] = strconv.Itoa(int(completionsIndex))
 	}
 	return job.Spec.Template
 }

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -35,3 +35,11 @@ func IsJobFinished(j *batch.Job) bool {
 func getCompletionsIndex(pod *v1.Pod) (int, error) {
 	return strconv.Atoi(pod.Labels["job-completions-index"])
 }
+
+func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int) v1.PodTemplateSpec {
+	if completionsIndex > 0 {
+		job := job.DeepCopy()
+		job.Spec.Template.Labels["job-completions-index"] = strconv.Itoa(completionsIndex)
+	}
+	return job.Spec.Template
+}

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+const CompletionsIndexName = "job-completions-index"
+
 func IsJobFinished(j *batch.Job) bool {
 	for _, c := range j.Status.Conditions {
 		if (c.Type == batch.JobComplete || c.Type == batch.JobFailed) && c.Status == v1.ConditionTrue {
@@ -33,13 +35,15 @@ func IsJobFinished(j *batch.Job) bool {
 }
 
 func getCompletionsIndex(pod *v1.Pod) (int, error) {
-	return strconv.Atoi(pod.Labels["job-completions-index"])
+	return strconv.Atoi(pod.Labels[CompletionsIndexName])
 }
 
 func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1.PodTemplateSpec {
 	if completionsIndex > 0 {
-		job := job.DeepCopy()
-		job.Spec.Template.Labels["job-completions-index"] = strconv.Itoa(int(completionsIndex))
+		job = job.DeepCopy()
+		template := job.Spec.Template
+		template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
+		job.Spec.Template = template
 	}
 	return job.Spec.Template
 }

--- a/pkg/controller/job/utils_test.go
+++ b/pkg/controller/job/utils_test.go
@@ -21,6 +21,9 @@ import (
 
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"strconv"
 )
 
 func TestIsJobFinished(t *testing.T) {
@@ -78,5 +81,122 @@ func TestIsJobFinished(t *testing.T) {
 				t.Errorf("test name: %s, job was expected to be finished", name)
 			}
 		}
+	}
+}
+
+func TestGetCompletionsIndex(t *testing.T) {
+	testCases := map[string]struct {
+		pod    *v1.Pod
+		result int
+		error  bool
+	}{
+		"Pod has index 1": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "1",
+					},
+				},
+			},
+			1,
+			false,
+		},
+		"Pod has index 5555": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "5555",
+					},
+				},
+			},
+			5555,
+			false,
+		},
+		"Pod has index -1": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "-1",
+					},
+				},
+			},
+			-1,
+			false,
+		},
+		"Pod has err": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "a",
+					},
+				},
+			},
+			1,
+			true,
+		},
+	}
+
+	for name, tc := range testCases {
+		result, err := getCompletionsIndex(tc.pod)
+		if tc.error {
+			if err == nil {
+				t.Errorf("test name: %s, get completions index should return error", name)
+			}
+			continue
+		}
+		if result != tc.result {
+			t.Errorf("test name: %s, result should be %d, but %d", name, tc.result, result)
+		}
+	}
+}
+
+func TestAddCompletionsIndexToPodTemplate(t *testing.T) {
+	job := &batch.Job{
+		Spec: batch.JobSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+		},
+	}
+	testCases := map[string]struct {
+		job                    *batch.Job
+		completionsIndex       int32
+		shouldEq               bool
+		shouldCompletionsIndex int
+	}{
+		"template add index 1": {
+			job,
+			1,
+			false,
+			1,
+		},
+		"template add index 0": {
+			job,
+			0,
+			true,
+			-1,
+		},
+		"template add index -1": {
+			job,
+			-1,
+			true,
+			-1,
+		},
+	}
+
+	for name, tc := range testCases {
+		result := addCompletionsIndexToPodTemplate(tc.job, tc.completionsIndex)
+		if tc.shouldEq {
+			if !reflect.DeepEqual(result, job.Spec.Template) {
+				t.Errorf("test name: %s, resut should eq job.Spec.Template", name)
+			}
+			continue
+		}
+		if result.Labels[CompletionsIndexName] != strconv.Itoa(tc.shouldCompletionsIndex) {
+			t.Errorf("test name: %s, labels CompletionsIndexName should be %d, but %s", name, tc.shouldCompletionsIndex, result.Labels[CompletionsIndexName])
+		}
+
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
implemented ` Each pod passed a different index in the range 1 to .spec.completions.`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
* Has anyone implemented this feature now？
* Is there a problem with my implementation design?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
