### PR TITLE
apiextensions: add optional comment tags

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -86423,6 +86423,9 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition": {
     "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format \u003c.spec.name\u003e.\u003c.spec.group\u003e.",
+    "required": [
+     "spec"
+    ],
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -41,14 +41,17 @@ message CustomResourceColumnDefinition {
   // format is an optional OpenAPI type definition for this column. The 'name' format is applied
   // to the primary identifier column to assist in clients identifying column is the resource name.
   // See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+  // +optional
   optional string format = 3;
 
   // description is a human readable description of this column.
+  // +optional
   optional string description = 4;
 
   // priority is an integer defining the relative importance of this column compared to others. Lower
   // numbers are considered higher priority. Columns that may be omitted in limited space scenarios
   // should be given a higher priority.
+  // +optional
   optional int32 priority = 5;
 
   // JSONPath is a simple JSON path, i.e. with array notation.
@@ -64,6 +67,7 @@ message CustomResourceDefinition {
   optional CustomResourceDefinitionSpec spec = 2;
 
   // Status indicates the actual state of the CustomResourceDefinition
+  // +optional
   optional CustomResourceDefinitionStatus status = 3;
 }
 
@@ -104,15 +108,18 @@ message CustomResourceDefinitionNames {
   optional string plural = 1;
 
   // Singular is the singular name of the resource.  It must be all lowercase  Defaults to lowercased <kind>
+  // +optional
   optional string singular = 2;
 
   // ShortNames are short names for the resource.  It must be all lowercase.
+  // +optional
   repeated string shortNames = 3;
 
   // Kind is the serialized kind of the resource.  It is normally CamelCase and singular.
   optional string kind = 4;
 
   // ListKind is the serialized kind of the list for this resource.  Defaults to <kind>List.
+  // +optional
   optional string listKind = 5;
 
   // Categories is a list of grouped resources custom resources belong to (e.g. 'all')
@@ -157,9 +164,11 @@ message CustomResourceDefinitionSpec {
   // by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
   // major version, then minor version. An example sorted list of versions:
   // v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+  // +optional
   repeated CustomResourceDefinitionVersion versions = 7;
 
   // AdditionalPrinterColumns are additional columns shown e.g. in kubectl next to the name. Defaults to a created-at column.
+  // +optional
   repeated CustomResourceColumnDefinition additionalPrinterColumns = 8;
 }
 
@@ -229,15 +238,18 @@ message CustomResourceSubresourceStatus {
 // CustomResourceSubresources defines the status and scale subresources for CustomResources.
 message CustomResourceSubresources {
   // Status denotes the status subresource for CustomResources
+  // +optional
   optional CustomResourceSubresourceStatus status = 1;
 
   // Scale denotes the scale subresource for CustomResources
+  // +optional
   optional CustomResourceSubresourceScale scale = 2;
 }
 
 // CustomResourceValidation is a list of validation methods for CustomResources.
 message CustomResourceValidation {
   // OpenAPIV3Schema is the OpenAPI v3 schema to be validated against.
+  // +optional
   optional JSONSchemaProps openAPIV3Schema = 1;
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -51,8 +51,10 @@ type CustomResourceDefinitionSpec struct {
 	// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
 	// major version, then minor version. An example sorted list of versions:
 	// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+	// +optional
 	Versions []CustomResourceDefinitionVersion `json:"versions,omitempty" protobuf:"bytes,7,rep,name=versions"`
 	// AdditionalPrinterColumns are additional columns shown e.g. in kubectl next to the name. Defaults to a created-at column.
+	// +optional
 	AdditionalPrinterColumns []CustomResourceColumnDefinition `json:"additionalPrinterColumns,omitempty" protobuf:"bytes,8,rep,name=additionalPrinterColumns"`
 }
 
@@ -76,12 +78,15 @@ type CustomResourceColumnDefinition struct {
 	// format is an optional OpenAPI type definition for this column. The 'name' format is applied
 	// to the primary identifier column to assist in clients identifying column is the resource name.
 	// See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+	// +optional
 	Format string `json:"format,omitempty" protobuf:"bytes,3,opt,name=format"`
 	// description is a human readable description of this column.
+	// +optional
 	Description string `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 	// priority is an integer defining the relative importance of this column compared to others. Lower
 	// numbers are considered higher priority. Columns that may be omitted in limited space scenarios
 	// should be given a higher priority.
+	// +optional
 	Priority int32 `json:"priority,omitempty" protobuf:"bytes,5,opt,name=priority"`
 
 	// JSONPath is a simple JSON path, i.e. with array notation.
@@ -94,12 +99,15 @@ type CustomResourceDefinitionNames struct {
 	// too: plural.group and it must be all lowercase.
 	Plural string `json:"plural" protobuf:"bytes,1,opt,name=plural"`
 	// Singular is the singular name of the resource.  It must be all lowercase  Defaults to lowercased <kind>
+	// +optional
 	Singular string `json:"singular,omitempty" protobuf:"bytes,2,opt,name=singular"`
 	// ShortNames are short names for the resource.  It must be all lowercase.
+	// +optional
 	ShortNames []string `json:"shortNames,omitempty" protobuf:"bytes,3,opt,name=shortNames"`
 	// Kind is the serialized kind of the resource.  It is normally CamelCase and singular.
 	Kind string `json:"kind" protobuf:"bytes,4,opt,name=kind"`
 	// ListKind is the serialized kind of the list for this resource.  Defaults to <kind>List.
+	// +optional
 	ListKind string `json:"listKind,omitempty" protobuf:"bytes,5,opt,name=listKind"`
 	// Categories is a list of grouped resources custom resources belong to (e.g. 'all')
 	// +optional
@@ -192,8 +200,9 @@ type CustomResourceDefinition struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// Spec describes how the user wants the resources to appear
-	Spec CustomResourceDefinitionSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+	Spec CustomResourceDefinitionSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// Status indicates the actual state of the CustomResourceDefinition
+	// +optional
 	Status CustomResourceDefinitionStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
@@ -211,14 +220,17 @@ type CustomResourceDefinitionList struct {
 // CustomResourceValidation is a list of validation methods for CustomResources.
 type CustomResourceValidation struct {
 	// OpenAPIV3Schema is the OpenAPI v3 schema to be validated against.
+	// +optional
 	OpenAPIV3Schema *JSONSchemaProps `json:"openAPIV3Schema,omitempty" protobuf:"bytes,1,opt,name=openAPIV3Schema"`
 }
 
 // CustomResourceSubresources defines the status and scale subresources for CustomResources.
 type CustomResourceSubresources struct {
 	// Status denotes the status subresource for CustomResources
+	// +optional
 	Status *CustomResourceSubresourceStatus `json:"status,omitempty" protobuf:"bytes,1,opt,name=status"`
 	// Scale denotes the scale subresource for CustomResources
+	// +optional
 	Scale *CustomResourceSubresourceScale `json:"scale,omitempty" protobuf:"bytes,2,opt,name=scale"`
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -255,7 +255,7 @@ func ValidateCustomResourceColumnDefinition(col *apiextensions.CustomResourceCol
 	allErrs := field.ErrorList{}
 
 	if len(col.Name) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("header"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), ""))
 	}
 
 	if len(col.Type) == 0 {
@@ -269,8 +269,8 @@ func ValidateCustomResourceColumnDefinition(col *apiextensions.CustomResourceCol
 	}
 
 	if len(col.JSONPath) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("path"), ""))
-	} else if errs := validateSimpleJSONPath(col.JSONPath, fldPath.Child("path")); len(errs) > 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("JSONPath"), ""))
+	} else if errs := validateSimpleJSONPath(col.JSONPath, fldPath.Child("JSONPath")); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
 


### PR DESCRIPTION
Adds `// +optional` comment tags to fields which are optional/omitempty for CRD types.

These tags are used for openapi generation:

https://github.com/kubernetes/kube-openapi/blob/0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803/pkg/generators/openapi.go#L361-L362

https://github.com/kubernetes/kube-openapi/blob/0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803/pkg/generators/openapi.go#L81-L89

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
