### PR TITLE
add completions index feature to Parallel Jobs

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -795,7 +795,7 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeededPods []*v1.Pod
 							}
 							allocation.Unlock()
 							if completionsIndex == 0 {
-								// TODO log warning
+								glog.Warningf("not has available completions index to create pod, activePods: %+v, succeededPods: %+v", activePods, succeededPods)
 								return
 							}
 						}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -477,7 +477,8 @@ func (jm *JobController) syncJob(key string) (bool, error) {
 
 	activePods := controller.FilterActivePods(pods)
 	active := int32(len(activePods))
-	succeeded, failed := getStatus(pods)
+	succeededPods, failedPods := getStatusPods(pods)
+	succeeded, failed := int32(len(succeededPods)), int32(len(failedPods))
 	conditions := len(job.Status.Conditions)
 	// job first start
 	if job.Status.StartTime == nil {
@@ -533,7 +534,7 @@ func (jm *JobController) syncJob(key string) (bool, error) {
 		jm.recorder.Event(&job, v1.EventTypeWarning, failureReason, failureMessage)
 	} else {
 		if jobNeedsSync && job.DeletionTimestamp == nil {
-			active, manageJobErr = jm.manageJob(activePods, succeeded, &job)
+			active, manageJobErr = jm.manageJob(activePods, succeededPods, &job)
 		}
 		completions := succeeded
 		complete := false
@@ -671,19 +672,20 @@ func newCondition(conditionType batch.JobConditionType, reason, message string) 
 	}
 }
 
-// getStatus returns no of succeeded and failed pods running a job
-func getStatus(pods []*v1.Pod) (succeeded, failed int32) {
-	succeeded = int32(filterPods(pods, v1.PodSucceeded))
-	failed = int32(filterPods(pods, v1.PodFailed))
+// getStatusPods returns no of succeeded and failed pods running a job
+func getStatusPods(pods []*v1.Pod) (succeededPods, failedPods []*v1.Pod) {
+	succeededPods = filterPods(pods, v1.PodSucceeded)
+	failedPods = filterPods(pods, v1.PodFailed)
 	return
 }
 
 // manageJob is the core method responsible for managing the number of running
 // pods according to what is specified in the job.Spec.
 // Does NOT modify <activePods>.
-func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *batch.Job) (int32, error) {
+func (jm *JobController) manageJob(activePods []*v1.Pod, succeededPods []*v1.Pod, job *batch.Job) (int32, error) {
 	var activeLock sync.Mutex
 	active := int32(len(activePods))
+	succeeded := int32(len(succeededPods))
 	parallelism := *job.Spec.Parallelism
 	jobKey, err := controller.KeyFunc(job)
 	if err != nil {
@@ -753,6 +755,31 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 		errCh = make(chan error, diff)
 		klog.V(4).Infof("Too few pods running job %q, need %d, creating %d", jobKey, wantActive, diff)
 
+		allocation := sync.Mutex{}
+		availableCompletionsIndexes := make([]int32, 0)
+		if *job.Spec.Completions > 0 {
+			// find duplicate index active pods & delete duplicate index active pods
+			duplicateIndexActivePods := findDuplicateIndexActivePods(activePods, succeededPods)
+			wait := sync.WaitGroup{}
+			wait.Add(len(duplicateIndexActivePods))
+			for i := range duplicateIndexActivePods {
+				go func(ix int) {
+					defer wait.Done()
+					if err := jm.podControl.DeletePod(job.Namespace, activePods[ix].Name, job); err != nil {
+						defer utilruntime.HandleError(err)
+						// Decrement the expected number of deletes because the informer won't observe this deletion
+						glog.V(2).Infof("Failed to delete %v, decrementing expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
+						jm.expectations.DeletionObserved(jobKey)
+						errCh <- err
+					}
+				}(i)
+			}
+			wait.Wait()
+
+			// find available completions indexes in now
+			availableCompletionsIndexes = getAvailableCompletionsIndexes(activePods, succeededPods, *job.Spec.Completions)
+		}
+
 		active += diff
 		wait := sync.WaitGroup{}
 
@@ -770,7 +797,22 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 			for i := int32(0); i < batchSize; i++ {
 				go func() {
 					defer wait.Done()
-					err := jm.podControl.CreatePodsWithControllerRef(job.Namespace, &job.Spec.Template, job, metav1.NewControllerRef(job, controllerKind))
+					completionsIndex := int32(0)
+					if *job.Spec.Completions > 0 {
+						// allocation completions index
+						allocation.Lock()
+						if len(availableCompletionsIndexes) > 0 {
+							completionsIndex = availableCompletionsIndexes[0]
+							availableCompletionsIndexes = availableCompletionsIndexes[1:]
+						}
+						allocation.Unlock()
+						if completionsIndex == 0 {
+							// TODO log warning
+							return
+						}
+					}
+					podTemplateSpec := addCompletionsIndexToPodTemplate(job, completionsIndex)
+					err := jm.podControl.CreatePodsWithControllerRef(job.Namespace, &podTemplateSpec, job, metav1.NewControllerRef(job, controllerKind))
 					if err != nil && errors.IsTimeout(err) {
 						// Pod is created but its initialization has timed out.
 						// If the initialization is successful eventually, the
@@ -823,6 +865,53 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 	return active, nil
 }
 
+func getAvailableCompletionsIndexes(activePods, succeededPods []*v1.Pod, completions int32) []int32 {
+	podsHasIndex := func() map[int]bool {
+		hasIndexes := make(map[int]bool, len(activePods)+len(succeededPods))
+		for i := range succeededPods {
+			if index, err := getCompletionsIndex(succeededPods[i]); err == nil {
+				hasIndexes[index] = true
+			}
+		}
+		for i := range activePods {
+			if index, err := getCompletionsIndex(activePods[i]); err == nil {
+				hasIndexes[index] = true
+			}
+		}
+		return hasIndexes
+	}()
+	availableCompletionsIndexes := make([]int32, 0, completions)
+	for i := 1; i <= int(completions); i++ {
+		if _, ok := podsHasIndex[i]; !ok {
+			availableCompletionsIndexes = append(availableCompletionsIndexes, int32(i))
+		}
+	}
+	return availableCompletionsIndexes
+}
+
+func findDuplicateIndexActivePods(activePods, succeededPods []*v1.Pod) []*v1.Pod {
+	duplicateIndexActivePods := make([]*v1.Pod, 0)
+	succeededPodsHasIndex := getCompletionsIndexMap(succeededPods)
+	for i := range activePods {
+		if index, err := getCompletionsIndex(activePods[i]); err == nil {
+			if _, ok := succeededPodsHasIndex[index]; ok {
+				duplicateIndexActivePods = append(duplicateIndexActivePods, activePods[i])
+			}
+		}
+	}
+	return duplicateIndexActivePods
+}
+
+func getCompletionsIndexMap(pods []*v1.Pod) map[int]bool {
+	hasIndexes := make(map[int]bool, len(pods))
+	for i := range pods {
+		if index, err := getCompletionsIndex(pods[i]); err == nil {
+			hasIndexes[index] = true
+		}
+	}
+	return hasIndexes
+}
+
 func (jm *JobController) updateJobStatus(job *batch.Job) error {
 	jobClient := jm.kubeClient.BatchV1().Jobs(job.Namespace)
 	var err error
@@ -862,12 +951,12 @@ func getBackoff(queue workqueue.RateLimitingInterface, key interface{}) time.Dur
 }
 
 // filterPods returns pods based on their phase.
-func filterPods(pods []*v1.Pod, phase v1.PodPhase) int {
-	result := 0
+func filterPods(pods []*v1.Pod, phase v1.PodPhase) []*v1.Pod {
+	resultPods := make([]*v1.Pod, 0, len(pods)/2)
 	for i := range pods {
 		if phase == pods[i].Status.Phase {
-			result++
+			resultPods = append(resultPods, pods[i])
 		}
 	}
-	return result
+	return resultPods
 }

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -694,158 +694,151 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeededPods []*v1.Pod
 		return 0, nil
 	}
 
-	// ensure that running pods are not duplicated
-	if completions > 0 {
-		// find need stop active pods & delete these active pods
-		duplicateIndexActivePods := getNeedStopActivePods(activePods, succeededPods)
-		if len(duplicateIndexActivePods) > 0 {
-			chanErr := make(chan error)
-			jm.deleteJobPods(job, duplicateIndexActivePods, chanErr)
-			return active, <- chanErr
-		}
-
-	}
-
 	var errCh chan error
-	if active > parallelism {
-		diff := active - parallelism
-		errCh = make(chan error, diff)
-		jm.expectations.ExpectDeletions(jobKey, int(diff))
-		klog.V(4).Infof("Too many pods running job %q, need %d, deleting %d", jobKey, parallelism, diff)
-		// Sort the pods in the order such that not-ready < ready, unscheduled
-		// < scheduled, and pending < running. This ensures that we delete pods
-		// in the earlier stages whenever possible.
-		sort.Sort(controller.ActivePods(activePods))
+	// ensure that running pods are not duplicated
+	// find need stop active pods & delete these active pods
+	if duplicateIndexActivePods := getNeedStopActivePods(activePods, succeededPods); completions > 0 && len(duplicateIndexActivePods) > 0 {
+			errCh := make(chan error, len(duplicateIndexActivePods))
+			jm.deleteJobPods(job, duplicateIndexActivePods, errCh)
+	} else {
+		if active > parallelism {
+			diff := active - parallelism
+			errCh = make(chan error, diff)
+			jm.expectations.ExpectDeletions(jobKey, int(diff))
+			klog.V(4).Infof("Too many pods running job %q, need %d, deleting %d", jobKey, parallelism, diff)
+			// Sort the pods in the order such that not-ready < ready, unscheduled
+			// < scheduled, and pending < running. This ensures that we delete pods
+			// in the earlier stages whenever possible.
+			sort.Sort(controller.ActivePods(activePods))
 
-		active -= diff
-		wait := sync.WaitGroup{}
-		wait.Add(int(diff))
-		for i := int32(0); i < diff; i++ {
-			go func(ix int32) {
-				defer wait.Done()
-				if err := jm.podControl.DeletePod(job.Namespace, activePods[ix].Name, job); err != nil {
-					defer utilruntime.HandleError(err)
-					// Decrement the expected number of deletes because the informer won't observe this deletion
-					klog.V(2).Infof("Failed to delete %v, decrementing expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
-					jm.expectations.DeletionObserved(jobKey)
-					activeLock.Lock()
-					active++
-					activeLock.Unlock()
-					errCh <- err
-				}
-			}(i)
-		}
-		wait.Wait()
-
-	} else if active < parallelism {
-		wantActive := int32(0)
-		if job.Spec.Completions == nil {
-			// Job does not specify a number of completions.  Therefore, number active
-			// should be equal to parallelism, unless the job has seen at least
-			// once success, in which leave whatever is running, running.
-			if succeeded > 0 {
-				wantActive = active
-			} else {
-				wantActive = parallelism
-			}
-		} else {
-			// Job specifies a specific number of completions.  Therefore, number
-			// active should not ever exceed number of remaining completions.
-			wantActive = *job.Spec.Completions - succeeded
-			if wantActive > parallelism {
-				wantActive = parallelism
-			}
-		}
-		diff := wantActive - active
-		if diff < 0 {
-			utilruntime.HandleError(fmt.Errorf("More active than wanted: job %q, want %d, have %d", jobKey, wantActive, active))
-			diff = 0
-		}
-		if diff == 0 {
-			return active, nil
-		}
-		jm.expectations.ExpectCreations(jobKey, int(diff))
-		errCh = make(chan error, diff)
-		klog.V(4).Infof("Too few pods running job %q, need %d, creating %d", jobKey, wantActive, diff)
-
-
-		allocation := sync.Mutex{}
-		availableCompletionsIndexes := make([]int32, 0)
-		if completions > 0 {
-			// find available completions indexes in now
-			availableCompletionsIndexes = getAvailableCompletionsIndexes(activePods, succeededPods, completions)
-		}
-
-		active += diff
-		wait := sync.WaitGroup{}
-
-		// Batch the pod creates. Batch sizes start at SlowStartInitialBatchSize
-		// and double with each successful iteration in a kind of "slow start".
-		// This handles attempts to start large numbers of pods that would
-		// likely all fail with the same error. For example a project with a
-		// low quota that attempts to create a large number of pods will be
-		// prevented from spamming the API service with the pod create requests
-		// after one of its pods fails.  Conveniently, this also prevents the
-		// event spam that those failures would generate.
-		for batchSize := int32(integer.IntMin(int(diff), controller.SlowStartInitialBatchSize)); diff > 0; batchSize = integer.Int32Min(2*batchSize, diff) {
-			errorCount := len(errCh)
-			wait.Add(int(batchSize))
-			for i := int32(0); i < batchSize; i++ {
-				go func() {
+			active -= diff
+			wait := sync.WaitGroup{}
+			wait.Add(int(diff))
+			for i := int32(0); i < diff; i++ {
+				go func(ix int32) {
 					defer wait.Done()
-					completionsIndex := int32(0)
-					if completions > 0 {
-						// allocation completions index
-						allocation.Lock()
-						if len(availableCompletionsIndexes) > 0 {
-							completionsIndex = availableCompletionsIndexes[0]
-							availableCompletionsIndexes = availableCompletionsIndexes[1:]
-						}
-						allocation.Unlock()
-						if completionsIndex == 0 {
-							// TODO log warning
-							return
-						}
-					}
-					podTemplateSpec := addCompletionsIndexToPodTemplate(job, completionsIndex)
-					err := jm.podControl.CreatePodsWithControllerRef(job.Namespace, &podTemplateSpec, job, metav1.NewControllerRef(job, controllerKind))
-					if err != nil && errors.IsTimeout(err) {
-						// Pod is created but its initialization has timed out.
-						// If the initialization is successful eventually, the
-						// controller will observe the creation via the informer.
-						// If the initialization fails, or if the pod keeps
-						// uninitialized for a long time, the informer will not
-						// receive any update, and the controller will create a new
-						// pod when the expectation expires.
-						return
-					}
-					if err != nil {
+					if err := jm.podControl.DeletePod(job.Namespace, activePods[ix].Name, job); err != nil {
 						defer utilruntime.HandleError(err)
-						// Decrement the expected number of creates because the informer won't observe this pod
-						klog.V(2).Infof("Failed creation, decrementing expectations for job %q/%q", job.Namespace, job.Name)
-						jm.expectations.CreationObserved(jobKey)
+						// Decrement the expected number of deletes because the informer won't observe this deletion
+						klog.V(2).Infof("Failed to delete %v, decrementing expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
+						jm.expectations.DeletionObserved(jobKey)
 						activeLock.Lock()
-						active--
+						active++
 						activeLock.Unlock()
 						errCh <- err
 					}
-				}()
+				}(i)
 			}
 			wait.Wait()
-			// any skipped pods that we never attempted to start shouldn't be expected.
-			skippedPods := diff - batchSize
-			if errorCount < len(errCh) && skippedPods > 0 {
-				klog.V(2).Infof("Slow-start failure. Skipping creation of %d pods, decrementing expectations for job %q/%q", skippedPods, job.Namespace, job.Name)
-				active -= skippedPods
-				for i := int32(0); i < skippedPods; i++ {
-					// Decrement the expected number of creates because the informer won't observe this pod
-					jm.expectations.CreationObserved(jobKey)
+		} else if active < parallelism {
+			wantActive := int32(0)
+			if job.Spec.Completions == nil {
+				// Job does not specify a number of completions.  Therefore, number active
+				// should be equal to parallelism, unless the job has seen at least
+				// once success, in which leave whatever is running, running.
+				if succeeded > 0 {
+					wantActive = active
+				} else {
+					wantActive = parallelism
 				}
-				// The skipped pods will be retried later. The next controller resync will
-				// retry the slow start process.
-				break
+			} else {
+				// Job specifies a specific number of completions.  Therefore, number
+				// active should not ever exceed number of remaining completions.
+				wantActive = *job.Spec.Completions - succeeded
+				if wantActive > parallelism {
+					wantActive = parallelism
+				}
 			}
-			diff -= batchSize
+			diff := wantActive - active
+			if diff < 0 {
+				utilruntime.HandleError(fmt.Errorf("More active than wanted: job %q, want %d, have %d", jobKey, wantActive, active))
+				diff = 0
+			}
+			if diff == 0 {
+				return active, nil
+			}
+			jm.expectations.ExpectCreations(jobKey, int(diff))
+			errCh = make(chan error, diff)
+			klog.V(4).Infof("Too few pods running job %q, need %d, creating %d", jobKey, wantActive, diff)
+
+			allocation := sync.Mutex{}
+			availableCompletionsIndexes := make([]int32, 0)
+			if completions > 0 {
+				// find available completions indexes in now
+				availableCompletionsIndexes = getAvailableCompletionsIndexes(activePods, succeededPods, completions)
+			}
+
+			active += diff
+			wait := sync.WaitGroup{}
+
+			// Batch the pod creates. Batch sizes start at SlowStartInitialBatchSize
+			// and double with each successful iteration in a kind of "slow start".
+			// This handles attempts to start large numbers of pods that would
+			// likely all fail with the same error. For example a project with a
+			// low quota that attempts to create a large number of pods will be
+			// prevented from spamming the API service with the pod create requests
+			// after one of its pods fails.  Conveniently, this also prevents the
+			// event spam that those failures would generate.
+			for batchSize := int32(integer.IntMin(int(diff), controller.SlowStartInitialBatchSize)); diff > 0; batchSize = integer.Int32Min(2*batchSize, diff) {
+				errorCount := len(errCh)
+				wait.Add(int(batchSize))
+				for i := int32(0); i < batchSize; i++ {
+					go func() {
+						defer wait.Done()
+						completionsIndex := int32(0)
+						if completions > 0 {
+							// allocation completions index
+							allocation.Lock()
+							if len(availableCompletionsIndexes) > 0 {
+								completionsIndex = availableCompletionsIndexes[0]
+								availableCompletionsIndexes = availableCompletionsIndexes[1:]
+							}
+							allocation.Unlock()
+							if completionsIndex == 0 {
+								// TODO log warning
+								return
+							}
+						}
+						podTemplateSpec := addCompletionsIndexToPodTemplate(job, completionsIndex)
+						err := jm.podControl.CreatePodsWithControllerRef(job.Namespace, &podTemplateSpec, job, metav1.NewControllerRef(job, controllerKind))
+						if err != nil && errors.IsTimeout(err) {
+							// Pod is created but its initialization has timed out.
+							// If the initialization is successful eventually, the
+							// controller will observe the creation via the informer.
+							// If the initialization fails, or if the pod keeps
+							// uninitialized for a long time, the informer will not
+							// receive any update, and the controller will create a new
+							// pod when the expectation expires.
+							return
+						}
+						if err != nil {
+							defer utilruntime.HandleError(err)
+							// Decrement the expected number of creates because the informer won't observe this pod
+							klog.V(2).Infof("Failed creation, decrementing expectations for job %q/%q", job.Namespace, job.Name)
+							jm.expectations.CreationObserved(jobKey)
+							activeLock.Lock()
+							active--
+							activeLock.Unlock()
+							errCh <- err
+						}
+					}()
+				}
+				wait.Wait()
+				// any skipped pods that we never attempted to start shouldn't be expected.
+				skippedPods := diff - batchSize
+				if errorCount < len(errCh) && skippedPods > 0 {
+					klog.V(2).Infof("Slow-start failure. Skipping creation of %d pods, decrementing expectations for job %q/%q", skippedPods, job.Namespace, job.Name)
+					active -= skippedPods
+					for i := int32(0); i < skippedPods; i++ {
+						// Decrement the expected number of creates because the informer won't observe this pod
+						jm.expectations.CreationObserved(jobKey)
+						// The skipped pods will be retried later. The next controller resync will
+						// retry the slow start process.
+						break
+					}
+					diff -= batchSize
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -17,9 +17,13 @@ limitations under the License.
 package job
 
 import (
+	"strconv"
+
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 )
+
+const CompletionsIndexName = "job-completions-index"
 
 func IsJobFinished(j *batch.Job) bool {
 	for _, c := range j.Status.Conditions {
@@ -28,4 +32,18 @@ func IsJobFinished(j *batch.Job) bool {
 		}
 	}
 	return false
+}
+
+func getCompletionsIndex(pod *v1.Pod) (int, error) {
+	return strconv.Atoi(pod.Labels[CompletionsIndexName])
+}
+
+func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1.PodTemplateSpec {
+	if completionsIndex > 0 {
+		job = job.DeepCopy()
+		template := job.Spec.Template
+		template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
+		job.Spec.Template = template
+	}
+	return job.Spec.Template
 }

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -61,3 +61,79 @@ func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1
 	}
 	return template
 }
+
+
+func getLen(pods []*v1.Pod, completions int32) int32 {
+	if completions > 0 {
+		return distinctPods(pods)
+	}
+	return int32(len(pods))
+}
+
+// distinctPods get distinct pod number
+func distinctPods(pods []*v1.Pod) int32 {
+	keyMap := make(map[int]bool, 0)
+	for i := range pods {
+		index, err := getCompletionsIndex(pods[i])
+		if err != nil {
+			continue
+		}
+		keyMap[index] = true
+	}
+	return int32(len(keyMap))
+}
+
+func getAvailableCompletionsIndexes(activePods, succeededPods []*v1.Pod, completions int32) []int32 {
+	podsHasIndexes := func() map[int]bool {
+		hasIndexes := make(map[int]bool, len(activePods)+len(succeededPods))
+		for i := range succeededPods {
+			if index, err := getCompletionsIndex(succeededPods[i]); err == nil {
+				hasIndexes[index] = true
+			}
+		}
+		for i := range activePods {
+			if index, err := getCompletionsIndex(activePods[i]); err == nil {
+				hasIndexes[index] = true
+			}
+		}
+		return hasIndexes
+	}()
+	availableCompletionsIndexes := make([]int32, 0, completions)
+	for i := 1; i <= int(completions); i++ {
+		if _, ok := podsHasIndexes[i]; !ok {
+			availableCompletionsIndexes = append(availableCompletionsIndexes, int32(i))
+		}
+	}
+	return availableCompletionsIndexes
+}
+
+// getNeedStopActivePods find succeeded index in active pods and active pods duplicate index pods
+func getNeedStopActivePods(activePods, succeededPods []*v1.Pod) []*v1.Pod {
+	duplicateIndexActivePods := make([]*v1.Pod, 0)
+	succeededPodsHasIndexes, _ := getCompletionsIndexesAndDuplicateIndexPods(succeededPods)
+	for i := range activePods {
+		if index, err := getCompletionsIndex(activePods[i]); err == nil {
+			if _, ok := succeededPodsHasIndexes[index]; ok {
+				duplicateIndexActivePods = append(duplicateIndexActivePods, activePods[i])
+			}
+		}
+	}
+	_, duplicateIndexPods := getCompletionsIndexesAndDuplicateIndexPods(activePods)
+	return append(duplicateIndexActivePods, duplicateIndexPods...)
+}
+
+// getCompletionsIndexesAndDuplicateIndexPods get all index in pods and get duplicate index pods
+func getCompletionsIndexesAndDuplicateIndexPods(pods []*v1.Pod) (map[int]bool, []*v1.Pod) {
+	hasIndexes := make(map[int]bool, len(pods))
+	duplicateIndexPods := make([]*v1.Pod, 0)
+	for i := range pods {
+		if index, err := getCompletionsIndex(pods[i]); err == nil {
+			if _, ok := hasIndexes[index]; ok {
+				duplicateIndexPods = append(duplicateIndexPods, pods[i])
+			}
+			hasIndexes[index] = true
+
+		}
+	}
+	return hasIndexes, duplicateIndexPods
+}

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -43,25 +43,25 @@ func getCompletionsIndex(pod *v1.Pod) (int, error) {
 
 func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1.PodTemplateSpec {
 	template := job.Spec.Template
-	if completionsIndex > 0 {
-		job = job.DeepCopy()
-		template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
-		addEnvFunc := func(containers []v1.Container) {
-			for i := range containers {
-				container := containers[i]
-				container.Env = append(container.Env, v1.EnvVar{
-					Name:  CompletionsIndexEnvArgName,
-					Value: strconv.Itoa(int(completionsIndex)),
-				})
-				containers[i] = container
-			}
-		}
-		addEnvFunc(template.Spec.Containers)
-		addEnvFunc(template.Spec.InitContainers)
+	if completionsIndex <= 0 {
+		return template
 	}
+	job = job.DeepCopy()
+	template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
+	addEnvFunc := func(containers []v1.Container) {
+		for i := range containers {
+			container := containers[i]
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  CompletionsIndexEnvArgName,
+				Value: strconv.Itoa(int(completionsIndex)),
+			})
+			containers[i] = container
+		}
+	}
+	addEnvFunc(template.Spec.Containers)
+	addEnvFunc(template.Spec.InitContainers)
 	return template
 }
-
 
 func getLen(pods []*v1.Pod, completions int32) int32 {
 	if completions > 0 {

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -49,6 +49,9 @@ func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1
 	job = job.DeepCopy()
 	template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
 	addEnvFunc := func(containers []v1.Container) {
+		if containers == nil {
+			return
+		}
 		for i := range containers {
 			container := containers[i]
 			container.Env = append(container.Env, v1.EnvVar{

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -63,8 +63,8 @@ func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1
 	return template
 }
 
-func getLen(pods []*v1.Pod, completions int32) int32 {
-	if completions > 0 {
+func getLen(pods []*v1.Pod, distinct bool) int32 {
+	if distinct {
 		return distinctPods(pods)
 	}
 	return int32(len(pods))
@@ -116,6 +116,9 @@ func getNeedStopActivePods(activePods, succeededPods []*v1.Pod) []*v1.Pod {
 			if _, ok := succeededPodsHasIndexes[index]; ok {
 				duplicateIndexActivePods = append(duplicateIndexActivePods, activePods[i])
 			}
+		} else {
+			// if label cont't switch to int, stop
+			duplicateIndexActivePods = append(duplicateIndexActivePods, activePods[i])
 		}
 	}
 	_, duplicateIndexPods := getCompletionsIndexesAndDuplicateIndexPods(activePods)

--- a/pkg/controller/job/utils.go
+++ b/pkg/controller/job/utils.go
@@ -46,7 +46,7 @@ func addCompletionsIndexToPodTemplate(job *batch.Job, completionsIndex int32) v1
 	if completionsIndex <= 0 {
 		return template
 	}
-	job = job.DeepCopy()
+	template = *template.DeepCopy()
 	template.Labels[CompletionsIndexName] = strconv.Itoa(int(completionsIndex))
 	addEnvFunc := func(containers []v1.Container) {
 		if containers == nil {

--- a/pkg/controller/job/utils_test.go
+++ b/pkg/controller/job/utils_test.go
@@ -21,6 +21,9 @@ import (
 
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"strconv"
 )
 
 func TestIsJobFinished(t *testing.T) {
@@ -78,5 +81,122 @@ func TestIsJobFinished(t *testing.T) {
 				t.Errorf("test name: %s, job was expected to be finished", name)
 			}
 		}
+	}
+}
+
+func TestGetCompletionsIndex(t *testing.T) {
+	testCases := map[string]struct {
+		pod    *v1.Pod
+		result int
+		error  bool
+	}{
+		"Pod has index 1": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "1",
+					},
+				},
+			},
+			1,
+			false,
+		},
+		"Pod has index 5555": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "5555",
+					},
+				},
+			},
+			5555,
+			false,
+		},
+		"Pod has index -1": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "-1",
+					},
+				},
+			},
+			-1,
+			false,
+		},
+		"Pod has err": {
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						CompletionsIndexName: "a",
+					},
+				},
+			},
+			1,
+			true,
+		},
+	}
+
+	for name, tc := range testCases {
+		result, err := getCompletionsIndex(tc.pod)
+		if tc.error {
+			if err == nil {
+				t.Errorf("test name: %s, get completions index should return error", name)
+			}
+			continue
+		}
+		if result != tc.result {
+			t.Errorf("test name: %s, result should be %d, but %d", name, tc.result, result)
+		}
+	}
+}
+
+func TestAddCompletionsIndexToPodTemplate(t *testing.T) {
+	job := &batch.Job{
+		Spec: batch.JobSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+		},
+	}
+	testCases := map[string]struct {
+		job                    *batch.Job
+		completionsIndex       int32
+		shouldEq               bool
+		shouldCompletionsIndex int
+	}{
+		"template add index 1": {
+			job,
+			1,
+			false,
+			1,
+		},
+		"template add index 0": {
+			job,
+			0,
+			true,
+			-1,
+		},
+		"template add index -1": {
+			job,
+			-1,
+			true,
+			-1,
+		},
+	}
+
+	for name, tc := range testCases {
+		result := addCompletionsIndexToPodTemplate(tc.job, tc.completionsIndex)
+		if tc.shouldEq {
+			if !reflect.DeepEqual(result, job.Spec.Template) {
+				t.Errorf("test name: %s, resut should eq job.Spec.Template", name)
+			}
+			continue
+		}
+		if result.Labels[CompletionsIndexName] != strconv.Itoa(tc.shouldCompletionsIndex) {
+			t.Errorf("test name: %s, labels CompletionsIndexName should be %d, but %s", name, tc.shouldCompletionsIndex, result.Labels[CompletionsIndexName])
+		}
+
 	}
 }

--- a/pkg/controller/job/utils_test.go
+++ b/pkg/controller/job/utils_test.go
@@ -157,6 +157,27 @@ func TestAddCompletionsIndexToPodTemplate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{},
 				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+
+							},
+						},
+						{
+							Env:[]v1.EnvVar{
+
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -197,6 +218,20 @@ func TestAddCompletionsIndexToPodTemplate(t *testing.T) {
 		if result.Labels[CompletionsIndexName] != strconv.Itoa(tc.shouldCompletionsIndex) {
 			t.Errorf("test name: %s, labels CompletionsIndexName should be %d, but %s", name, tc.shouldCompletionsIndex, result.Labels[CompletionsIndexName])
 		}
-
+		containers := append(result.Spec.Containers, result.Spec.InitContainers...)
+		for _, c := range containers {
+			hasEnv := false
+			for _, env := range c.Env {
+				if env.Name == CompletionsIndexEnvArgName {
+					hasEnv = true
+					if env.Value != strconv.Itoa(tc.shouldCompletionsIndex) {
+						t.Errorf("test name: %s, env CompletionsIndexEnvArgName should be %d, but %s", name, tc.shouldCompletionsIndex, env.Value)
+					}
+				}
+			}
+			if !hasEnv {
+				t.Errorf("test name: %s, env CompletionsIndexEnvArgName must have", name)
+			}
+		}
 	}
 }

--- a/pkg/controller/job/utils_test.go
+++ b/pkg/controller/job/utils_test.go
@@ -367,8 +367,7 @@ func TestGetAvailableCompletionsIndexes(t *testing.T) {
 				pod3,
 			},
 			3,
-			[]int32{
-			},
+			[]int32{},
 		},
 	}
 	for name, tc := range testCases {
@@ -379,7 +378,7 @@ func TestGetAvailableCompletionsIndexes(t *testing.T) {
 	}
 }
 
-func TestGetNeedStopActivePods(t *testing.T)  {
+func TestGetNeedStopActivePods(t *testing.T) {
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -464,7 +463,7 @@ func TestGetNeedStopActivePods(t *testing.T)  {
 	}
 }
 
-func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T)  {
+func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T) {
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -483,7 +482,7 @@ func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T)  {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				CompletionsIndexName: "2",
-				"test": "test",
+				"test":               "test",
 			},
 		},
 	}
@@ -502,8 +501,8 @@ func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T)  {
 		},
 	}
 	testCases := map[string]struct {
-		pods    []*v1.Pod
-		hasIndexes        map[int]bool
+		pods               []*v1.Pod
+		hasIndexes         map[int]bool
 		duplicateIndexPods []*v1.Pod
 	}{
 		"pods is 2,3": {
@@ -517,8 +516,7 @@ func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T)  {
 				3: true,
 				1: true,
 			},
-			[]*v1.Pod{
-			},
+			[]*v1.Pod{},
 		},
 		"pods is 2,3,2,4": {
 			[]*v1.Pod{

--- a/pkg/controller/job/utils_test.go
+++ b/pkg/controller/job/utils_test.go
@@ -211,6 +211,7 @@ func TestAddCompletionsIndexToPodTemplate(t *testing.T) {
 		}
 		if result.Labels[CompletionsIndexName] != strconv.Itoa(tc.shouldCompletionsIndex) {
 			t.Errorf("test name: %s, labels CompletionsIndexName should be %d, but %s", name, tc.shouldCompletionsIndex, result.Labels[CompletionsIndexName])
+			continue
 		}
 		containers := append(result.Spec.Containers, result.Spec.InitContainers...)
 		for _, c := range containers {
@@ -373,7 +374,7 @@ func TestGetAvailableCompletionsIndexes(t *testing.T) {
 	for name, tc := range testCases {
 		result := getAvailableCompletionsIndexes(tc.activePods, tc.succeededPods, tc.completions)
 		if !reflect.DeepEqual(result, tc.result) {
-			t.Errorf("test name: %s, result should be %#v, but %#v", name, tc.result, result)
+			t.Errorf("test name: %s, result should be %+v, but %+v", name, tc.result, result)
 		}
 	}
 }
@@ -458,7 +459,7 @@ func TestGetNeedStopActivePods(t *testing.T)  {
 	for name, tc := range testCases {
 		result := getNeedStopActivePods(tc.activePods, tc.succeededPods)
 		if !reflect.DeepEqual(result, tc.result) {
-			t.Errorf("test name: %s, result should be %#v, but %#v", name, tc.result, result)
+			t.Errorf("test name: %s, result should be %+v, but %+v", name, tc.result, result)
 		}
 	}
 }
@@ -559,7 +560,7 @@ func TestGetCompletionsIndexesAndDuplicateIndexPods(t *testing.T)  {
 		bool1 := reflect.DeepEqual(indexes, tc.hasIndexes)
 		bool2 := reflect.DeepEqual(dupPods, tc.duplicateIndexPods)
 		if !(bool1 && bool2) {
-			t.Errorf("test name: %s, result should be indexes: %#v; dupPods: %#v, but indexes: %#v; dupPods: %#v", name, tc.hasIndexes, tc.duplicateIndexPods, indexes, dupPods)
+			t.Errorf("test name: %s, result should be indexes: %+v; dupPods: %+v, but indexes: %+v; dupPods: %+v", name, tc.hasIndexes, tc.duplicateIndexPods, indexes, dupPods)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`implemented Each pod passed a different index in the range 1 to .spec.completions.`

![image](https://user-images.githubusercontent.com/16189465/42632204-11139dfa-860f-11e8-8bd5-6eed9ef58ad4.png)

[文档地址](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)，进入文档搜索`Parallel Jobs`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
* `Has anyone implemented this feature now？`
* `Is there a problem with my implementation design?`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add completions index feature to job controller
```
