### PR TITLE
Fix omitempty tags for optional API fields

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -75515,6 +75515,9 @@
     ]
    },
    "io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec": {
+    "required": [
+     "namespace"
+    ],
     "properties": {
      "namespace": {
       "description": "Namespace to evaluate rules for. Required.",
@@ -75870,6 +75873,9 @@
     ]
    },
    "io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec": {
+    "required": [
+     "namespace"
+    ],
     "properties": {
      "namespace": {
       "description": "Namespace to evaluate rules for. Required.",
@@ -80372,6 +80378,9 @@
    },
    "io.k8s.api.core.v1.PodDNSConfigOption": {
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "description": "Required.",

--- a/api/swagger-spec/apps_v1.json
+++ b/api/swagger-spec/apps_v1.json
@@ -8721,6 +8721,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -6355,6 +6355,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -8721,6 +8721,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/authorization.k8s.io_v1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1.json
@@ -723,6 +723,9 @@
    },
    "v1.SelfSubjectRulesReviewSpec": {
     "id": "v1.SelfSubjectRulesReviewSpec",
+    "required": [
+     "namespace"
+    ],
     "properties": {
      "namespace": {
       "type": "string",

--- a/api/swagger-spec/authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1beta1.json
@@ -723,6 +723,9 @@
    },
    "v1beta1.SelfSubjectRulesReviewSpec": {
     "id": "v1beta1.SelfSubjectRulesReviewSpec",
+    "required": [
+     "namespace"
+    ],
     "properties": {
      "namespace": {
       "type": "string",

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -3695,6 +3695,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/batch_v1beta1.json
+++ b/api/swagger-spec/batch_v1beta1.json
@@ -3750,6 +3750,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -3750,6 +3750,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -9363,6 +9363,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -18315,9 +18315,7 @@
     "description": "Event is a report of an event somewhere in the cluster.",
     "required": [
      "metadata",
-     "involvedObject",
-     "reportingComponent",
-     "reportingInstance"
+     "involvedObject"
     ],
     "properties": {
      "kind": {
@@ -21964,6 +21962,9 @@
    "v1.PodDNSConfigOption": {
     "id": "v1.PodDNSConfigOption",
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "required": [
+     "name"
+    ],
     "properties": {
      "name": {
       "type": "string",

--- a/docs/api-reference/apps/v1/definitions.html
+++ b/docs/api-reference/apps/v1/definitions.html
@@ -6340,7 +6340,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -6338,7 +6338,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -6617,7 +6617,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/authorization.k8s.io/v1/definitions.html
+++ b/docs/api-reference/authorization.k8s.io/v1/definitions.html
@@ -734,7 +734,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Namespace to evaluate rules for. Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/authorization.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/authorization.k8s.io/v1beta1/definitions.html
@@ -1371,7 +1371,7 @@ When an object is created, the system will populate this list with the current s
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Namespace to evaluate rules for. Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -5208,7 +5208,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/batch/v1beta1/definitions.html
+++ b/docs/api-reference/batch/v1beta1/definitions.html
@@ -5239,7 +5239,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/batch/v2alpha1/definitions.html
+++ b/docs/api-reference/batch/v2alpha1/definitions.html
@@ -5095,7 +5095,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -7307,7 +7307,7 @@ If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Po
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -4765,7 +4765,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Required.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -5490,14 +5490,14 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">reportingComponent</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Name of the controller that emitted this Event, e.g. <code>kubernetes.io/kubelet</code>.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">reportingInstance</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ID of the controller instance, e.g. <code>kubelet-xyzf</code>.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -134,12 +134,12 @@ type TokenRequestSpec struct {
 	// token issuer may return a token with a different validity duration so a
 	// client needs to check the 'expiration' field in a response.
 	// +optional
-	ExpirationSeconds *int64 `json:"expirationSeconds" protobuf:"varint,4,opt,name=expirationSeconds"`
+	ExpirationSeconds *int64 `json:"expirationSeconds,omitempty" protobuf:"varint,4,opt,name=expirationSeconds"`
 
 	// BoundObjectRef is a reference to an object that the token will be bound to.
 	// The token will only be valid for as long as the bound objet exists.
 	// +optional
-	BoundObjectRef *BoundObjectReference `json:"boundObjectRef" protobuf:"bytes,3,opt,name=boundObjectRef"`
+	BoundObjectRef *BoundObjectReference `json:"boundObjectRef,omitempty" protobuf:"bytes,3,opt,name=boundObjectRef"`
 }
 
 // TokenRequestStatus is the result of a token request.

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -213,7 +213,7 @@ type SelfSubjectRulesReview struct {
 
 type SelfSubjectRulesReviewSpec struct {
 	// Namespace to evaluate rules for. Required.
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
+	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 }
 
 // SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -213,7 +213,7 @@ type SelfSubjectRulesReview struct {
 
 type SelfSubjectRulesReviewSpec struct {
 	// Namespace to evaluate rules for. Required.
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
+	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
 }
 
 // SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2967,7 +2967,7 @@ type PodDNSConfig struct {
 // PodDNSConfigOption defines DNS resolver options of a pod.
 type PodDNSConfigOption struct {
 	// Required.
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// +optional
 	Value *string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 }
@@ -4556,11 +4556,11 @@ type Event struct {
 
 	// Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
 	// +optional
-	ReportingController string `json:"reportingComponent" protobuf:"bytes,14,opt,name=reportingComponent"`
+	ReportingController string `json:"reportingComponent,omitempty" protobuf:"bytes,14,opt,name=reportingComponent"`
 
 	// ID of the controller instance, e.g. `kubelet-xyzf`.
 	// +optional
-	ReportingInstance string `json:"reportingInstance" protobuf:"bytes,15,opt,name=reportingInstance"`
+	ReportingInstance string `json:"reportingInstance,omitempty" protobuf:"bytes,15,opt,name=reportingInstance"`
 }
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening


### PR DESCRIPTION
Fixes omitempty json tags for optional API fields

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
