### PR TITLE
Fixes empty cache key for namespace lifecycle plugin

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/meta"
 )
 
 const (
@@ -89,7 +90,11 @@ func (l *Lifecycle) Admit(a admission.Attributes) error {
 		// is slow to update, we add the namespace into a force live lookup list to ensure
 		// we are not looking at stale state.
 		if a.GetOperation() == admission.Delete {
-			l.forceLiveLookupCache.Add(a.GetName(), true, forceLiveLookupTTL)
+			meta, err := meta.Accessor(a.GetOldObject())
+			if err != nil {
+				return fmt.Errorf("fail to the name of the namespace to delete: %v", err.Error())
+			}
+			l.forceLiveLookupCache.Add(meta.GetName(), true, forceLiveLookupTTL)
 		}
 		// allow all operations to namespaces
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The `GetName()` method of `admission.Interface` is returning the name parent resource and will always be empty except for sub-resources. 

In the namespace lifecycle admission controller, we are using namespace's name as key, and we must not use `GetName()`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes empty cache key on namespace deletion in NamespaceLifecycle plugin.
```
