### PR TITLE
Fixes "name" fields of create admission attrbute

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
@@ -55,7 +55,7 @@ func TestAudit(t *testing.T) {
 	type eventCheck func(events []*auditinternal.Event) error
 
 	// fixtures
-	simpleFoo := &genericapitesting.Simple{Other: "foo"}
+	simpleFoo := &genericapitesting.Simple{ObjectMeta: metav1.ObjectMeta{Name: "noxu"}, Other: "foo"}
 	simpleFooJSON, _ := runtime.Encode(testCodec, simpleFoo)
 
 	simpleCPrime := &genericapitesting.Simple{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -114,6 +114,16 @@ func createHandler(r rest.NamedCreater, scope RequestScope, admit admission.Inte
 		}
 		trace.Step("Conversion done")
 
+		// we set includeName only on creating sub-resources in which case the name can successfully
+		// extracted from request info.
+		if !includeName {
+			if _, name, err = scope.Namer.ObjectName(obj); err != nil {
+				err = errors.NewBadRequest(fmt.Sprintf("invalid object to create: %v", err))
+				scope.err(err, w, req)
+				return
+			}
+		}
+
 		ae := request.AuditEventFrom(ctx)
 		admit = admission.WithAudit(admit, ae)
 		audit.LogRequestObject(ae, obj, scope.Resource, scope.Subresource, scope.Serializer)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

On CREATE operation, `GetName()` will always be empty unless it's a sub-resource creation. And it seems violated the document here: [https://github.com/kubernetes/kubernetes/blob/bc98f7a5f2086a62af80ad92f7201e7af5e0ef03/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go#L31](https://github.com/kubernetes/kubernetes/blob/bc98f7a5f2086a62af80ad92f7201e7af5e0ef03/staging/src/k8s.io/apiserver/pkg/admission/interfaces.go#L31)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set name field correctly for CREATE admission attributes.
```
