### PR TITLE
Force delete pods on a dead node

### DIFF
--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -94,7 +94,8 @@ func DeletePods(kubeClient clientset.Interface, recorder record.EventRecorder, n
 
 		glog.V(2).Infof("Starting deletion of pod %v/%v", pod.Namespace, pod.Name)
 		recorder.Eventf(&pod, v1.EventTypeNormal, "NodeControllerEviction", "Marking for deletion Pod %s from Node %s", pod.Name, nodeName)
-		if err := kubeClient.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil); err != nil {
+		deleteOptions := metav1.NewDeleteOptions(0)
+		if err := kubeClient.CoreV1().Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err != nil {
 			return false, err
 		}
 		remaining = true


### PR DESCRIPTION
When node becomes 'NotReady', we should force delete the pods on
the dead node.
Fixes #66125


**Release note**:
```release-note
NONE
```
