### PR TITLE
propagate --allow-missing-keys val before obtaining template printer

### DIFF
--- a/pkg/kubectl/genericclioptions/kube_template_flags.go
+++ b/pkg/kubectl/genericclioptions/kube_template_flags.go
@@ -45,9 +45,13 @@ func (f *KubeTemplatePrintFlags) ToPrinter(outputFormat string) (printers.Resour
 		return nil, NoCompatiblePrinterError{}
 	}
 
+	// propagate final missing keys value
+	f.JSONPathPrintFlags.AllowMissingKeys = f.AllowMissingKeys
 	if p, err := f.JSONPathPrintFlags.ToPrinter(outputFormat); !IsNoCompatiblePrinterError(err) {
 		return p, err
 	}
+
+	f.JSONPathPrintFlags.AllowMissingKeys = f.AllowMissingKeys
 	return f.GoTemplatePrintFlags.ToPrinter(outputFormat)
 }
 


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Propagates the value of --allow-missing-keys to the GoTemplatePrinter and JSONPathPrinter before calling their ToPrinter methods.

cc @deads2k 