### PR TITLE
Don't validate HealthzBindAddress in KubeProxyConfiguration if it's empty

### DIFF
--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
@@ -60,7 +60,9 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(newPath.Child("BindAddress"), config.BindAddress, "not a valid textual representation of an IP address"))
 	}
 
-	allErrs = append(allErrs, validateHostPort(config.HealthzBindAddress, newPath.Child("HealthzBindAddress"))...)
+	if config.HealthzBindAddress != "" {
+		allErrs = append(allErrs, validateHostPort(config.HealthzBindAddress, newPath.Child("HealthzBindAddress"))...)
+	}
 	allErrs = append(allErrs, validateHostPort(config.MetricsBindAddress, newPath.Child("MetricsBindAddress"))...)
 
 	if config.ClusterCIDR != "" {

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -82,6 +82,26 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 			},
 		},
+		{
+			BindAddress:        "192.168.59.103",
+			HealthzBindAddress: "",
+			MetricsBindAddress: "127.0.0.1:10249",
+			ClusterCIDR:        "192.168.59.0/24",
+			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+			ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+			IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+				MasqueradeAll: true,
+				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+			},
+			Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				Max:        pointer.Int32Ptr(2),
+				MaxPerCore: pointer.Int32Ptr(1),
+				Min:        pointer.Int32Ptr(1),
+				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+			},
+		},
 	}
 
 	for _, successCase := range successCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/49087 added validation for
the HealthzBindAddress field in the KubeProxyConfiguration, but if you pass in
--healthz-port=0 to the kube-proxy CLI, it sets this field to the empty string.
However, an empty string is not a valid value for this field.

This change allows validation to pass if HealthzBindAddress is empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #65118

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix validation for HealthzBindAddress in kube-proxy when --healthz-port is set to 0
```