### PR TITLE
WIP attempt to reduce latency to node ready after CIDR is assigned

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -56,22 +56,22 @@ func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
 
 // updatePodCIDR updates the pod CIDR in the runtime state if it is different
 // from the current CIDR.
-func (kl *Kubelet) updatePodCIDR(cidr string) {
+func (kl *Kubelet) updatePodCIDR(cidr string) error {
 	podCIDR := kl.runtimeState.podCIDR()
 
 	if podCIDR == cidr {
-		return
+		return nil
 	}
 
 	// kubelet -> generic runtime -> runtime shim -> network plugin
 	// docker/non-cri implementations have a passthrough UpdatePodCIDR
 	if err := kl.getRuntime().UpdatePodCIDR(cidr); err != nil {
-		glog.Errorf("Failed to update pod CIDR: %v", err)
-		return
+		return fmt.Errorf("failed to update pod CIDR: %v", err)
 	}
 
 	glog.Infof("Setting Pod CIDR: %v -> %v", podCIDR, cidr)
 	kl.runtimeState.setPodCIDR(cidr)
+	return nil
 }
 
 // syncNetworkUtil ensures the network utility are present on host.

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -367,6 +367,8 @@ func (kl *Kubelet) setVolumeLimits(node *v1.Node) {
 // It synchronizes node status to master, registering the kubelet first if
 // necessary.
 func (kl *Kubelet) syncNodeStatus() {
+	kl.syncNodeStatusMux.Lock()
+	defer kl.syncNodeStatusMux.Unlock()
 	if kl.kubeClient == nil || kl.heartbeatClient == nil {
 		return
 	}
@@ -419,7 +421,9 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	}
 
 	if node.Spec.PodCIDR != "" {
-		kl.updatePodCIDR(node.Spec.PodCIDR)
+		if err := kl.updatePodCIDR(node.Spec.PodCIDR); err != nil {
+			glog.Errorf(err.Error())
+		}
 	}
 
 	kl.setNodeStatus(node)


### PR DESCRIPTION
This adds code to send an immediate status update when the Kubelet sees that it has a CIDR, which we think will significantly decrease the latency to node ready.

Waiting to test performance and clean this up before removing the WIP label, nobody needs to review this yet.

/cc @mwielgus @krzysztof-jastrzebski @dchen1107 @losipiuk 

```release-note
NONE
```
