### PR TITLE
fix metrics help comment

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -84,7 +84,7 @@ var (
 		prometheus.SummaryOpts{
 			Subsystem: KubeletSubsystem,
 			Name:      PodStartLatencyKey,
-			Help:      "Latency in microseconds for a single pod to go from pending to running. Broken down by podname.",
+			Help:      "Latency in microseconds for a single pod to go from pending to running.",
 		},
 	)
 	CgroupManagerLatency = prometheus.NewSummaryVec(


### PR DESCRIPTION
**What this PR does / why we need it**:
pod_start_latency_microseconds is not broken down by podname.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
