### PR TITLE
Automated cherry pick of #66007: Return vmUUID when renewing nodeinfo in VCP

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -351,7 +351,12 @@ func (nm *NodeManager) renewNodeInfo(nodeInfo *NodeInfo, reconnect bool) (*NodeI
 		}
 	}
 	vm := nodeInfo.vm.RenewVM(vsphereInstance.conn.Client)
-	return &NodeInfo{vm: &vm, dataCenter: vm.Datacenter, vcServer: nodeInfo.vcServer}, nil
+	return &NodeInfo{
+		vm:         &vm,
+		dataCenter: vm.Datacenter,
+		vcServer:   nodeInfo.vcServer,
+		vmUUID:     nodeInfo.vmUUID,
+	}, nil
 }
 
 func (nodeInfo *NodeInfo) VM() *vclib.VirtualMachine {


### PR DESCRIPTION
Cherry pick of #66007 on release-1.11.

#66007: Return vmUUID when renewing nodeinfo in VCP

```release-note
Preserve vmUUID when renewing nodeinfo in vSphere cloud provider
```
