### PR TITLE
hairpin ipset could only contain local endpoints

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -761,6 +761,9 @@ func (proxier *Proxier) syncProxyRules() {
 				glog.Errorf("Failed to cast BaseEndpointInfo %q", e.String())
 				continue
 			}
+			if !ep.IsLocal {
+				continue
+			}
 			epIP := ep.IP()
 			epPort, err := ep.Port()
 			// Error parsing this endpoint has been logged. Skip to next endpoint.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently all endpoints in the cluster are inserted into the hairpin ipset KUBE-LOOP-BACK.  This ipset is only for local hairpin traffic. No need to take all endpoints in the cluster.

There may be scaling problem if we have all endpoints in the ipset.  By only take local ones, we get slightly less memory consumption, faster matching and faster updating.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
