### PR TITLE
Automated cherry pick of #66165: Compare stateful set updates semantically

### DIFF
--- a/pkg/apis/apps/validation/BUILD
+++ b/pkg/apis/apps/validation/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/validation:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -18,8 +18,8 @@ package validation
 
 import (
 	"fmt"
-	"reflect"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
@@ -149,7 +149,7 @@ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet) fi
 	restoreStrategy := statefulSet.Spec.UpdateStrategy
 	statefulSet.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy
 
-	if !reflect.DeepEqual(statefulSet.Spec, oldStatefulSet.Spec) {
+	if !apiequality.Semantic.DeepEqual(statefulSet.Spec, oldStatefulSet.Spec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden."))
 	}
 	statefulSet.Spec.Replicas = restoreReplicas


### PR DESCRIPTION
Cherry pick of #66165 on release-1.10.

#66165: Compare stateful set updates semantically

```release-note
fixes a validation error that could prevent updates to StatefulSet objects containing non-normalized resource requests
```