### PR TITLE
Remove patch retry conflict detection

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -155,18 +155,20 @@ func patchResource(
 
 	namespace := request.NamespaceValue(ctx)
 
-	var (
-		originalObjJS           []byte
-		originalPatchedObjJS    []byte
-		originalObjMap          map[string]interface{}
-		getOriginalPatchMap     func() (map[string]interface{}, error)
-		lastConflictErr         error
-		originalResourceVersion string
-	)
+	var lastConflictErr error
 
 	// applyPatch is called every time GuaranteedUpdate asks for the updated object,
 	// and is given the currently persisted object as input.
 	applyPatch := func(_ request.Context, _, currentObject runtime.Object) (runtime.Object, error) {
+		// make these local vars so every patch attempt is handled as if it were the first attempt
+		var (
+			originalObjJS           []byte
+			originalPatchedObjJS    []byte
+			originalObjMap          map[string]interface{}
+			getOriginalPatchMap     func() (map[string]interface{}, error)
+			originalResourceVersion string
+		)
+
 		// Make sure we actually have a persisted currentObject
 		if hasUID, err := hasUID(currentObject); err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -532,8 +532,7 @@ func TestPatchResourceWithConflict(t *testing.T) {
 		startingPod: &example.Pod{},
 		changedPod:  &example.Pod{},
 		updatePod:   &example.Pod{},
-
-		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io "foo": existing 2, new 1`,
+		expectedPod: &example.Pod{},
 	}
 
 	tc.startingPod.Name = name
@@ -556,6 +555,13 @@ func TestPatchResourceWithConflict(t *testing.T) {
 	tc.updatePod.ResourceVersion = "2"
 	tc.updatePod.APIVersion = examplev1.SchemeGroupVersion.String()
 	tc.updatePod.Spec.NodeName = "anywhere"
+
+	tc.expectedPod.Name = name
+	tc.expectedPod.Namespace = namespace
+	tc.expectedPod.UID = uid
+	tc.expectedPod.ResourceVersion = "2"
+	tc.expectedPod.APIVersion = examplev1.SchemeGroupVersion.String()
+	tc.expectedPod.Spec.NodeName = "there"
 
 	tc.Run(t)
 }


### PR DESCRIPTION
Minimal backport of #63146
Fixes #58002

Fixes spurious patch errors for CRDs
Fixes patch errors for nodes when the watch cache has a persistently stale version of an object

```release-note
fixes spurious "meaningful conflict" error encountered by nodes attempting to update status, which could cause them to be considered unready
```