### PR TITLE
Add AWS cloudprovider operation (multiple API calls) metrics

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_metrics.go
+++ b/pkg/cloudprovider/providers/aws/aws_metrics.go
@@ -18,6 +18,13 @@ package aws
 
 import "github.com/prometheus/client_golang/prometheus"
 
+const (
+	// OperationAttachDisk measures the time from when we call AttachVolume to when we find, via polling the API, that
+	// the disk has been attached
+	OperationAttachDisk = "attach_disk"
+	OperationDetachDisk = "detach_disk"
+)
+
 var (
 	awsAPIMetric = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -39,9 +46,33 @@ var (
 			Help: "AWS API throttled requests",
 		},
 		[]string{"operation_name"})
+
+	awsOperationMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "cloudprovider_aws_operation_duration_seconds",
+			Help: "Latency of aws operation call",
+		},
+		[]string{"operation"},
+	)
+	awsOperationErrorMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cloudprovider_aws_operation_errors",
+			Help: "aws operation errors",
+		},
+		[]string{"operation"},
+	)
 )
 
 func recordAWSMetric(actionName string, timeTaken float64, err error) {
+	switch actionName {
+	case OperationAttachDisk, OperationDetachDisk:
+		recordAWSOperationMetric(actionName, timeTaken, err)
+	default:
+		recordAWSAPIMetric(actionName, timeTaken, err)
+	}
+}
+
+func recordAWSAPIMetric(actionName string, timeTaken float64, err error) {
 	if err != nil {
 		awsAPIErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
 	} else {
@@ -53,8 +84,18 @@ func recordAWSThrottlesMetric(operation string) {
 	awsAPIThrottlesMetric.With(prometheus.Labels{"operation_name": operation}).Inc()
 }
 
+func recordAWSOperationMetric(actionName string, timeTaken float64, err error) {
+	if err != nil {
+		awsOperationErrorMetric.With(prometheus.Labels{"operation": actionName}).Inc()
+	} else {
+		awsOperationMetric.With(prometheus.Labels{"operation": actionName}).Observe(timeTaken)
+	}
+}
+
 func registerMetrics() {
 	prometheus.MustRegister(awsAPIMetric)
 	prometheus.MustRegister(awsAPIErrorMetric)
 	prometheus.MustRegister(awsAPIThrottlesMetric)
+	prometheus.MustRegister(awsOperationMetric)
+	prometheus.MustRegister(awsOperationErrorMetric)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: there are some operations done by the cloudprovider that perform more than one API call. We should sum API calls as operations when possible. 'AttachDisk' and 'DetachDisk' are the ones we care about most: due to aws idiosyncrasies with device name assignment etc., we are forced to write 'AttachDIsk' and 'DetachDisk' operations such that they do not correspond 1:1 with 'AttachVolume' & 'DetachVolume' API calls and must include periodic polling of volume status via API.

**Special notes for your reviewer**: I copied how vsphere does it for consistency.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add operation duration and operation error metrics to AWS cloudprovider, beginning with "attach_disk" and "detach_disk"
```
