### PR TITLE
Check presence of /dev/disk/by-id before reading it in ScaleIO

### DIFF
--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -339,10 +339,14 @@ func (c *sioClient) getGuid() (string, error) {
 func (c *sioClient) getSioDiskPaths() ([]os.FileInfo, error) {
 	files, err := ioutil.ReadDir(sioDiskIDPath)
 	if err != nil {
-		glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
-		return nil, err
+		if os.IsNotExist(err) {
+			// sioDiskIDPath may not exist yet which is fine
+			return []os.FileInfo{}, nil
+		} else {
+			glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
+			return nil, err
+		}
 	}
-
 	result := []os.FileInfo{}
 	for _, file := range files {
 		if c.diskRegex.MatchString(file.Name()) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In certain OS environments, like RHEL 7.4 using Xen PV driver `xen_blkfront` for boot and data disks, the path `/dev/disk/by-id` does not exist in the OS post boot. When trying to dynamically provision PVs from a ScaleIO storageclass in such an environment, ScaleIO fails when trying to create the PV with:
```
E0711 08:02:50.441964   25246 sio_client.go:342] scaleio: failed to ReadDir /dev/disk/by-id: open /dev/disk/by-id: no such file or directory
E0711 08:02:50.441989   25246 sio_volume.go:123] scaleio: setup of volume k8svol-282bd4fa84d:  open /dev/disk/by-id: no such file or directory
```
This PR avoids the above failure by first checking for the presence of `/dev/disk/by-id` before attempting to read from it as done in other drivers like gce_pd. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Allow ScaleIO volumes to be provisioned without having to first manually create /dev/disk/by-id path on each kubernetes node (if not already present)
```
/sig storage