### PR TITLE
correct the name from kubeClient to externalKubeClient in log message

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -582,7 +582,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		}
 		externalKubeClient, err = clientset.NewForConfig(clientConfig)
 		if err != nil {
-			glog.Warningf("New kubeClient from clientConfig error: %v", err)
+			glog.Warningf("New externalKubeClient from clientConfig error: %v", err)
 		}
 
 		// make a separate client for events


### PR DESCRIPTION
**What this PR does / why we need it**:

correct the name from kubeClient to externalKubeClient in log message

```release-note
NONE
```