### PR TITLE
fix nil pointer dereference in node_container_manager#enforceExisting

### DIFF
--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -131,6 +131,9 @@ func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.
 		Name:               cName,
 		ResourceParameters: getCgroupConfig(rl),
 	}
+	if cgroupConfig.ResourceParameters == nil {
+		return fmt.Errorf("%q cgroup is not config properly", cgroupConfig.Name)
+	}
 	glog.V(4).Infof("Enforcing limits on cgroup %q with %d cpu shares and %d bytes of memory", cName, cgroupConfig.ResourceParameters.CpuShares, cgroupConfig.ResourceParameters.Memory)
 	if !cgroupManager.Exists(cgroupConfig.Name) {
 		return fmt.Errorf("%q cgroup does not exist", cgroupConfig.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix nil pointer dereference in node_container_manager#enforceExisting

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66189

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
kubelet: fix nil pointer dereference while enforce-node-allocatable flag is not config properly
```
