### PR TITLE
Change the default of the read-only-port to 10255 when use dynamic config

### DIFF
--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/defaults.go
@@ -58,6 +58,9 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 	if obj.Port == 0 {
 		obj.Port = ports.KubeletPort
 	}
+	if obj.ReadOnlyPort == 0 {
+		obj.ReadOnlyPort = ports.KubeletReadOnlyPort
+	}
 	if obj.Authentication.Anonymous.Enabled == nil {
 		obj.Authentication.Anonymous.Enabled = utilpointer.BoolPtr(false)
 	}

--- a/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1beta1/types.go
@@ -124,7 +124,7 @@ type KubeletConfiguration struct {
 	// no authentication/authorization.
 	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
 	// it may disrupt components that interact with the Kubelet server.
-	// Default: 0 (disabled)
+	// Default: 10255
 	// +optional
 	ReadOnlyPort int32 `json:"readOnlyPort,omitempty"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,


### PR DESCRIPTION
**What this PR does / why we need it**:
When not use the dynamic config, the ReadOnlyPort's default value is 10255, i thought the same default value in the different conditions should be needed for this option (or for compatibility), thank you.