### PR TITLE
add nodeshutdown detach feature to detach volumes when a node is shutdown

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -49,6 +49,8 @@ import (
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/pkg/util/taints"
 )
 
 // TimerConfig contains configuration of internal attach/detach timers and
@@ -602,9 +604,15 @@ func (adc *attachDetachController) addNodeToDswp(node *v1.Node, nodeName types.N
 			keepTerminatedPodVolumes = (t == "true")
 		}
 
+		shutdownTaint := &v1.Taint{
+			Key:    algorithm.TaintNodeShutdown,
+			Effect: v1.TaintEffectNoSchedule,
+		}
+
+		isShutdownNode := taints.TaintExists(node.Spec.Taints,shutdownTaint)
 		// Node specifies annotation indicating it should be managed by attach
 		// detach controller. Add it to desired state of world.
-		adc.desiredStateOfWorld.AddNode(nodeName, keepTerminatedPodVolumes)
+		adc.desiredStateOfWorld.AddNode(nodeName, keepTerminatedPodVolumes, isShutdownNode)
 	}
 }
 

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
+	"k8s.io/kubernetes/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 // Reconciler runs a periodic loop to reconcile the desired state of the world with
@@ -227,6 +229,15 @@ func (rc *reconciler) reconcile() {
 			// If timeout is true, skip verifySafeToDetach check
 			glog.V(5).Infof(attachedVolume.GenerateMsgDetailed("Starting attacherDetacher.DetachVolume", ""))
 			verifySafeToDetach := !timeout
+			if utilfeature.DefaultFeatureGate.Enabled(features.NodeShutdown) {
+				isShutdownNode := rc.desiredStateOfWorld.NodeIsShutdown(attachedVolume.NodeName)
+
+				if isShutdownNode {
+					glog.V(1).Infof("node %v is shutdown, the volume is safe to detach.", attachedVolume.NodeName)
+					verifySafeToDetach = !isShutdownNode
+				}
+
+			}
 			err = rc.attacherDetacher.DetachVolume(attachedVolume.AttachedVolume, verifySafeToDetach, rc.actualStateOfWorld)
 			if err == nil {
 				if !timeout {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -343,6 +343,12 @@ const (
 	//
 	// Enables CSI to use raw block storage volumes
 	CSIBlockVolume utilfeature.Feature = "CSIBlockVolume"
+
+	// owner: @yastij
+	// alpha: v1.12
+	//
+	// Enables detaching volumes when a node reports nodeShutdown taint
+	NodeShutdown utilfeature.Feature = "nodeShutdown"
 )
 
 func init() {
@@ -401,6 +407,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	KubeletPluginsWatcher:                       {Default: false, PreRelease: utilfeature.Alpha},
 	ResourceQuotaScopeSelectors:                 {Default: false, PreRelease: utilfeature.Alpha},
 	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},
+	NodeShutdown:                                {Default: false, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:


### PR DESCRIPTION
**What this PR does / why we need it**: part of kubernetes/features#551

**Which issue(s) this PR fixes**: Fixes #66181

**Special notes for your reviewer**: 


**Release note**:

```release-note
add detach logic when a node reports a nodeShutdown taint
```
