### PR TITLE
Handle errors

### DIFF
--- a/cmd/kubeadm/app/util/marshal_test.go
+++ b/cmd/kubeadm/app/util/marshal_test.go
@@ -135,7 +135,9 @@ func TestMarshalUnmarshalToYamlForCodecs(t *testing.T) {
 
 	kubeadmapiv1alpha3.SetDefaults_InitConfiguration(cfg)
 	scheme := runtime.NewScheme()
-	kubeadmapiv1alpha3.AddToScheme(scheme)
+	if err := kubeadmapiv1alpha3.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
 	codecs := serializer.NewCodecFactory(scheme)
 
 	bytes, err := MarshalToYamlForCodecs(cfg, kubeadmapiv1alpha3.SchemeGroupVersion, codecs)

--- a/pkg/kubectl/scheme/install.go
+++ b/pkg/kubectl/scheme/install.go
@@ -57,7 +57,7 @@ import (
 func init() {
 	// Register external types for Scheme
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	scheme.AddToScheme(Scheme)
+	utilruntime.Must(scheme.AddToScheme(Scheme))
 
 	utilruntime.Must(Scheme.SetVersionPriority(corev1.SchemeGroupVersion))
 	utilruntime.Must(Scheme.SetVersionPriority(admissionv1alpha1.SchemeGroupVersion))

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -170,8 +170,8 @@ func newFakeScheme(t *testing.T) *runtime.Scheme {
 	require.NoError(t, apiv1.AddToScheme(ret))
 	require.NoError(t, extensionsapiv1beta1.AddToScheme(ret))
 
-	ret.SetVersionPriority(apiv1.SchemeGroupVersion)
-	ret.SetVersionPriority(extensionsapiv1beta1.SchemeGroupVersion)
+	require.NoError(t, ret.SetVersionPriority(apiv1.SchemeGroupVersion))
+	require.NoError(t, ret.SetVersionPriority(extensionsapiv1beta1.SchemeGroupVersion))
 
 	return ret
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/cache:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -239,8 +239,12 @@ func convertToSARExtra(extra map[string][]string) map[string]authorization.Extra
 // requests to the exact path specified in the kubeconfig file, so arbitrary non-API servers can be targeted.
 func subjectAccessReviewInterfaceFromKubeconfig(kubeConfigFile string) (authorizationclient.SubjectAccessReviewInterface, error) {
 	localScheme := runtime.NewScheme()
-	scheme.AddToScheme(localScheme)
-	localScheme.SetVersionPriority(groupVersions...)
+	if err := scheme.AddToScheme(localScheme); err != nil {
+		return nil, err
+	}
+	if err := localScheme.SetVersionPriority(groupVersions...); err != nil {
+		return nil, err
+	}
 
 	gw, err := webhook.NewGenericWebhook(localScheme, scheme.Codecs, kubeConfigFile, groupVersions, 0)
 	if err != nil {

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
@@ -94,7 +95,7 @@ func NewController(
 	// Create event broadcaster
 	// Add sample-controller types to the default Kubernetes Scheme so Events can be
 	// logged for sample-controller types.
-	samplescheme.AddToScheme(scheme.Scheme)
+	utilruntime.Must(samplescheme.AddToScheme(scheme.Scheme))
 	glog.V(4).Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a followup PR for https://github.com/kubernetes/kubernetes/pull/64664 to handle errors returned from `.AddToScheme()` in places where they are not handled.

**Release note**:
```release-note
NONE
```
/kind cleanup
/sig api-machinery
/cc @sttts