### PR TITLE
Chage kubeadm file check comment

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -291,7 +291,7 @@ func (fac FileAvailableCheck) Check() (warnings, errors []error) {
 	glog.V(1).Infof("validating the existence of file %s", fac.Path)
 	errors = []error{}
 	if _, err := os.Stat(fac.Path); err == nil {
-		errors = append(errors, fmt.Errorf("%s already exists", fac.Path))
+		errors = append(errors, fmt.Errorf("%s already exists. Be aware to issue 'kubeadm reset' to clean such legacy files.", fac.Path))
 	}
 	return nil, errors
 }


### PR DESCRIPTION
This patch change file check comment, add "Be aware to issue 'kubeadm reset' to clean such legacy files" , The file exist when use kubeadm join  and init node.

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#974

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
