### PR TITLE
fix error binding of edit output format

### DIFF
--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -76,10 +76,10 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 
 	// bind flag structs
 	o.RecordFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd)
 
 	usage := "to use to edit the resource"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
-	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "Output format. One of: yaml|json.")
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddIncludeUninitializedFlag(cmd)

--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -209,7 +209,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 	}
 
 	if o.EditBeforeCreate {
-		return RunEditOnCreate(f, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions)
+		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions)
 	}
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	if err != nil {
@@ -298,13 +298,13 @@ func (o *CreateOptions) raw(f cmdutil.Factory) error {
 	return nil
 }
 
-func RunEditOnCreate(f cmdutil.Factory, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions) error {
+func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions) error {
 	editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, ioStreams)
 	editOptions.FilenameOptions = *options
 	editOptions.ValidateOptions = cmdutil.ValidateOptions{
 		EnableValidation: cmdutil.GetFlagBool(cmd, "validate"),
 	}
-	editOptions.Output = cmdutil.GetFlagString(cmd, "output")
+	editOptions.PrintFlags = printFlags
 	editOptions.ApplyAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
 	editOptions.RecordFlags = recordFlags
 

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied/test.yaml
@@ -6,7 +6,7 @@ args:
 outputFormat: yaml
 namespace: myproject
 expectedStdout:
-- service/svc1 edited
+- 'targetPort: 92'
 expectedExitCode: 0
 steps:
 - type: request

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -60,7 +60,6 @@ type EditOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 	ToPrinter  func(string) (printers.ResourcePrinter, error)
 
-	Output             string
 	OutputPatch        bool
 	WindowsLineEndings bool
 
@@ -95,7 +94,6 @@ func NewEditOptions(editMode EditMode, ioStreams genericclioptions.IOStreams) *E
 		Recorder: genericclioptions.NoopRecorder{},
 
 		IOStreams: ioStreams,
-		Output:    "yaml",
 	}
 }
 
@@ -118,12 +116,12 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 	if o.EditMode != NormalEditMode && o.EditMode != EditBeforeCreateMode && o.EditMode != ApplyEditMode {
 		return fmt.Errorf("unsupported edit mode %q", o.EditMode)
 	}
-	if o.Output != "" {
-		if o.Output != "yaml" && o.Output != "json" {
-			return fmt.Errorf("invalid output format %s, only yaml|json supported", o.Output)
+	if *o.PrintFlags.OutputFormat != "" {
+		if *o.PrintFlags.OutputFormat != "yaml" && *o.PrintFlags.OutputFormat != "json" {
+			return fmt.Errorf("invalid output format %s, only yaml|json supported", *o.PrintFlags.OutputFormat)
 		}
 	}
-	o.editPrinterOptions = getPrinter(o.Output)
+	o.editPrinterOptions = getPrinter(*o.PrintFlags.OutputFormat)
 
 	if o.OutputPatch && o.EditMode != NormalEditMode {
 		return fmt.Errorf("the edit mode doesn't support output the patch")

--- a/pkg/kubectl/genericclioptions/json_yaml_flags.go
+++ b/pkg/kubectl/genericclioptions/json_yaml_flags.go
@@ -25,6 +25,9 @@ import (
 )
 
 func (f *JSONYamlPrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
 	return []string{"json", "yaml"}
 }
 

--- a/pkg/kubectl/genericclioptions/name_flags.go
+++ b/pkg/kubectl/genericclioptions/name_flags.go
@@ -41,6 +41,9 @@ func (f *NamePrintFlags) Complete(successTemplate string) error {
 }
 
 func (f *NamePrintFlags) AllowedFormats() []string {
+	if f == nil {
+		return []string{}
+	}
 	return []string{"name"}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubectl edit xxx/xxx -o json` won't print result in json format
**Release note**:
```release-note
NONE
```
