### PR TITLE
NamespacedResourcesDeleter should use ObjectMeta.finalizers instead of NamespaceSpec.finalizers

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -41,14 +41,14 @@ import (
 
 func TestFinalized(t *testing.T) {
 	testNamespace := &v1.Namespace{
-		Spec: v1.NamespaceSpec{
-			Finalizers: []v1.FinalizerName{"a", "b"},
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{"a", "b"},
 		},
 	}
 	if finalized(testNamespace) {
 		t.Errorf("Unexpected result, namespace is not finalized")
 	}
-	testNamespace.Spec.Finalizers = []v1.FinalizerName{}
+	testNamespace.ObjectMeta.Finalizers = []string{}
 	if !finalized(testNamespace) {
 		t.Errorf("Expected object to be finalized")
 	}
@@ -60,9 +60,7 @@ func TestFinalizeNamespaceFunc(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test",
 			ResourceVersion: "1",
-		},
-		Spec: v1.NamespaceSpec{
-			Finalizers: []v1.FinalizerName{"kubernetes", "other"},
+			Finalizers:      []string{"kubernetes", "other"},
 		},
 	}
 	d := namespacedResourcesDeleter{
@@ -77,11 +75,11 @@ func TestFinalizeNamespaceFunc(t *testing.T) {
 	if !actions[0].Matches("create", "namespaces") || actions[0].GetSubresource() != "finalize" {
 		t.Errorf("Expected finalize-namespace action %v", actions[0])
 	}
-	finalizers := actions[0].(core.CreateAction).GetObject().(*v1.Namespace).Spec.Finalizers
+	finalizers := actions[0].(core.CreateAction).GetObject().(*v1.Namespace).ObjectMeta.Finalizers
 	if len(finalizers) != 1 {
 		t.Errorf("There should be a single finalizer remaining")
 	}
-	if "other" != string(finalizers[0]) {
+	if "other" != finalizers[0] {
 		t.Errorf("Unexpected finalizer value, %v", finalizers[0])
 	}
 }
@@ -94,9 +92,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 			Name:              namespaceName,
 			ResourceVersion:   "1",
 			DeletionTimestamp: &now,
-		},
-		Spec: v1.NamespaceSpec{
-			Finalizers: []v1.FinalizerName{"kubernetes"},
+			Finalizers:        []string{"kubernetes"},
 		},
 		Status: v1.NamespaceStatus{
 			Phase: v1.NamespaceTerminating,
@@ -244,9 +240,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test",
 			ResourceVersion: "1",
-		},
-		Spec: v1.NamespaceSpec{
-			Finalizers: []v1.FinalizerName{"kubernetes"},
+			Finalizers:      []string{"kubernetes"},
 		},
 		Status: v1.NamespaceStatus{
 			Phase: v1.NamespaceActive,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fix the namespace registry custom Delete implementation to populate ObjectMeta.finalizers instead of NamespaceSpec.finalizers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
