### PR TITLE
fix_the_checkpoint_no_hostip_bug

### DIFF
--- a/pkg/kubelet/checkpointmanager/checkpoint_manager_test.go
+++ b/pkg/kubelet/checkpointmanager/checkpoint_manager_test.go
@@ -56,6 +56,8 @@ type PortMapping struct {
 	ContainerPort *int32
 	// Port number on the host.
 	HostPort *int32
+	// Host ip to expose.
+	HostIP string
 }
 
 // CheckpointData is a sample example structure to be used in test cases for checkpointing
@@ -151,17 +153,20 @@ func TestCheckpointManager(t *testing.T) {
 	port80 := int32(80)
 	port443 := int32(443)
 	proto := protocol("tcp")
+	ip1234 := "1.2.3.4"
 
 	portMappings := []*PortMapping{
 		{
 			&proto,
 			&port80,
 			&port80,
+			ip1234,
 		},
 		{
 			&proto,
 			&port443,
 			&port443,
+			ip1234,
 		},
 	}
 	checkpoint1 := newFakeCheckpointV1("check1", portMappings, true)

--- a/pkg/kubelet/dockershim/docker_checkpoint.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint.go
@@ -46,6 +46,8 @@ type PortMapping struct {
 	ContainerPort *int32 `json:"container_port,omitempty"`
 	// Port number on the host.
 	HostPort *int32 `json:"host_port,omitempty"`
+	// Host ip to expose.
+	HostIP string `json:"host_ip,omitempty"`
 }
 
 // CheckpointData contains all types of data that can be stored in the checkpoint.

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -643,6 +643,7 @@ func constructPodSandboxCheckpoint(config *runtimeapi.PodSandboxConfig) checkpoi
 			HostPort:      &pm.HostPort,
 			ContainerPort: &pm.ContainerPort,
 			Protocol:      &proto,
+			HostIP:        pm.HostIp,
 		})
 	}
 	if config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == runtimeapi.NamespaceMode_NODE {

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -394,6 +394,7 @@ func (ds *dockerService) GetPodPortMappings(podSandboxID string) ([]*hostport.Po
 			HostPort:      *pm.HostPort,
 			ContainerPort: *pm.ContainerPort,
 			Protocol:      proto,
+			HostIP:        pm.HostIP,
 		})
 	}
 	return portMappings, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The pr fix the bug,when contruct checkpoint in kubelet.Kubelet dont save the hostip.
Then if We want to use hostip and hostport in yaml to create pod,The Kubelet just send "0.0.0.0" to cni plugin .

**Which issue(s) this PR fixes**:
Fixes #65976

**Release note**:

```
NONE

```
