### PR TITLE
Automated cherry pick of #66138: Don't validate HealthzBindAddress in KubeProxyConfiguration

### DIFF
--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
@@ -60,7 +60,9 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(newPath.Child("BindAddress"), config.BindAddress, "not a valid textual representation of an IP address"))
 	}
 
-	allErrs = append(allErrs, validateHostPort(config.HealthzBindAddress, newPath.Child("HealthzBindAddress"))...)
+	if config.HealthzBindAddress != "" {
+		allErrs = append(allErrs, validateHostPort(config.HealthzBindAddress, newPath.Child("HealthzBindAddress"))...)
+	}
 	allErrs = append(allErrs, validateHostPort(config.MetricsBindAddress, newPath.Child("MetricsBindAddress"))...)
 
 	if config.ClusterCIDR != "" {

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -82,6 +82,26 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 			},
 		},
+		{
+			BindAddress:        "192.168.59.103",
+			HealthzBindAddress: "",
+			MetricsBindAddress: "127.0.0.1:10249",
+			ClusterCIDR:        "192.168.59.0/24",
+			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+			ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+			IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+				MasqueradeAll: true,
+				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+			},
+			Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				Max:        pointer.Int32Ptr(2),
+				MaxPerCore: pointer.Int32Ptr(1),
+				Min:        pointer.Int32Ptr(1),
+				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+			},
+		},
 	}
 
 	for _, successCase := range successCases {


### PR DESCRIPTION
Cherry pick of #66138 on release-1.10.

#66138: Don't validate HealthzBindAddress in KubeProxyConfiguration