### PR TITLE
client-go: update documentation for remotecommand.StreamOptions

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
@@ -30,8 +30,8 @@ import (
 	spdy "k8s.io/client-go/transport/spdy"
 )
 
-// StreamOptions holds information pertaining to the current streaming session: supported stream
-// protocols, input/output streams, if the client is requesting a TTY, and a terminal size queue to
+// StreamOptions holds information pertaining to the current streaming session:
+// input/output streams, if the client is requesting a TTY, and a terminal size queue to
 // support terminal resizing.
 type StreamOptions struct {
 	Stdin             io.Reader


### PR DESCRIPTION
**What this PR does / why we need it**:

The ability to explicitly define the supported protocols was removed in commit 12c7874c0d88e9099ab2a29915d26751f0d23c2a
Adjust documentation accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
