### PR TITLE
Fix locating resourcepool-path specified in the vsphere.conf file

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -155,20 +155,16 @@ func (dc *Datacenter) GetDatastoreByName(ctx context.Context, name string) (*Dat
 }
 
 // GetResourcePool gets the resource pool for the given path
-func (dc *Datacenter) GetResourcePool(ctx context.Context, computePath string) (*object.ResourcePool, error) {
+func (dc *Datacenter) GetResourcePool(ctx context.Context, resourcePoolPath string) (*object.ResourcePool, error) {
 	finder := getFinder(dc)
-	var computeResource *object.ComputeResource
+	var resourcePool *object.ResourcePool
 	var err error
-	if computePath == "" {
-		computeResource, err = finder.DefaultComputeResource(ctx)
-	} else {
-		computeResource, err = finder.ComputeResource(ctx, computePath)
-	}
+	resourcePool, err = finder.ResourcePoolOrDefault(ctx, resourcePoolPath)
 	if err != nil {
-		glog.Errorf("Failed to get the ResourcePool for computePath '%s'. err: %+v", computePath, err)
+		glog.Errorf("Failed to get the ResourcePool for path '%s'. err: %+v", resourcePoolPath, err)
 		return nil, err
 	}
-	return computeResource.ResourcePool(ctx)
+	return resourcePool, nil
 }
 
 // GetFolderByPath gets the Folder Object from the given folder path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When volume is provisioned using the vsphere storage policy, `resourcepool-path` specified in the `vsphere.conf` file is used for creating a shadow/dummy VM.  Dummy VM is temporarily created and then deleted once volume is created on the compatible Datastore.

At present If user specifies `resourcepool-path` in the `vsphere.conf` file,  volume provisioner is not able to locate the compute resource for the given path. This is because look up is made using `finder.DefaultComputeResource(ctx)` and `finder.ComputeResource(ctx, computePath)`, which is not correct. If user specifies name of the cluster or cluster path then provisioning works.

This is resolved with using correct govmomi method - `func (f *Finder) ResourcePoolOrDefault(ctx context.Context, path string) (*object.ResourcePool, error)`


**Which issue(s) this PR fixes**
Fixes # https://github.com/vmware/kubernetes/issues/493

**Special notes for your reviewer**:
Following testing is performed for this change.

1) specified resource-pool path in the `vsphere.conf` file and verified VM is created under the specified resource pool.

```
resourcepool-path="ClusterFolder-1/cluster-vsan-1/Resources/ShadowVMPool"
```

2) If resource pool is not available, specified cluster's default resource pool path in the `vsphere.conf` file and verified volume provisioning works. For this case, VM is directly created under cluster.

```
resourcepool-path="ClusterFolder-1/cluster-vsan-1/Resources"
```

3) Verified above with having multiple clusters with the same name in one datacenter.
4) Verified with empty resource pool path in the vsphere.conf file. 

```
resourcepool-path=""
```
As expected, provisioning is failing with `Failed to provision volume with StorageClass "vsan-gold-policy": no default resource pool found`.

Refer to this datacenter inventory for the path specified in the `resourcepool-path` configuration.

![image](https://user-images.githubusercontent.com/22985595/42792922-738e3f9c-892c-11e8-9e51-32e2328b116b.png)

Current documentation describes `resourcepool-path`configuration is optional, which needs to be corrected once PR is merged. For policy based provisioning this is not an optional parameter.

Documentation link: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix for resourcepool-path configuration in the vsphere.conf file.
```

cc: @kubernetes/vmware 
