### PR TITLE
kubectl: Drop backOff from DrainOptions

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,7 +64,6 @@ type DrainOptions struct {
 	GracePeriodSeconds int
 	IgnoreDaemonsets   bool
 	Timeout            time.Duration
-	backOff            clockwork.Clock
 	DeleteLocalData    bool
 	Selector           string
 	PodSelector        string
@@ -199,7 +197,6 @@ func NewDrainOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 		PrintFlags: genericclioptions.NewPrintFlags("drained").WithTypeSetter(scheme.Scheme),
 
 		IOStreams:          ioStreams,
-		backOff:            clockwork.NewRealClock(),
 		GracePeriodSeconds: -1,
 	}
 }


### PR DESCRIPTION
The property was added in b73fae6c (#35483), but b358b2df (#37604) removed the last consumer.  CC  @mengqiy, who authored both of those PRs.

```release-note
NONE
``` 