### PR TITLE
Unset CDPATH in build scripts

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -19,6 +19,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Unset CDPATH, having it set messes up with script import paths
+unset CDPATH
+
 USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently trying to build k8s fails if you have CDPATH set in your env. This is a minor change that allows building k8s without manually unsetting the variable. 

```release-note
```
