### PR TITLE
pkg/controller: remove old clientbuilder methods

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -67,13 +67,12 @@ func startHPAControllerWithLegacyClient(ctx ControllerContext) (bool, error) {
 }
 
 func startHPAControllerWithMetricsClient(ctx ControllerContext, metricsClient metrics.MetricsClient) (bool, error) {
-	hpaClientGoClient := ctx.ClientBuilder.ClientGoClientOrDie("horizontal-pod-autoscaler")
 	hpaClient := ctx.ClientBuilder.ClientOrDie("horizontal-pod-autoscaler")
 	hpaClientConfig := ctx.ClientBuilder.ConfigOrDie("horizontal-pod-autoscaler")
 
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
 	// so we want to re-fetch every time when we actually ask for it
-	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(hpaClientGoClient.Discovery())
+	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(hpaClient.Discovery())
 	scaleClient, err := scale.NewForConfig(hpaClientConfig, ctx.RESTMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
 		return false, err
@@ -85,7 +84,7 @@ func startHPAControllerWithMetricsClient(ctx ControllerContext, metricsClient me
 		ctx.ComponentConfig.HPAController.HorizontalPodAutoscalerTolerance,
 	)
 	go podautoscaler.NewHorizontalController(
-		hpaClientGoClient.CoreV1(),
+		hpaClient.CoreV1(),
 		scaleClient,
 		hpaClient.AutoscalingV1(),
 		ctx.RESTMapper,

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -24,7 +24,7 @@ import (
 
 func startBootstrapSignerController(ctx ControllerContext) (bool, error) {
 	bsc, err := bootstrap.NewBootstrapSigner(
-		ctx.ClientBuilder.ClientGoClientOrDie("bootstrap-signer"),
+		ctx.ClientBuilder.ClientOrDie("bootstrap-signer"),
 		ctx.InformerFactory.Core().V1().Secrets(),
 		ctx.InformerFactory.Core().V1().ConfigMaps(),
 		bootstrap.DefaultBootstrapSignerOptions(),
@@ -38,7 +38,7 @@ func startBootstrapSignerController(ctx ControllerContext) (bool, error) {
 
 func startTokenCleanerController(ctx ControllerContext) (bool, error) {
 	tcc, err := bootstrap.NewTokenCleaner(
-		ctx.ClientBuilder.ClientGoClientOrDie("token-cleaner"),
+		ctx.ClientBuilder.ClientOrDie("token-cleaner"),
 		ctx.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),
 	)

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -46,8 +46,6 @@ type ControllerClientBuilder interface {
 	ConfigOrDie(name string) *restclient.Config
 	Client(name string) (clientset.Interface, error)
 	ClientOrDie(name string) clientset.Interface
-	ClientGoClient(name string) (clientset.Interface, error)
-	ClientGoClientOrDie(name string) clientset.Interface
 }
 
 // SimpleControllerClientBuilder returns a fixed client with different user agents
@@ -79,22 +77,6 @@ func (b SimpleControllerClientBuilder) Client(name string) (clientset.Interface,
 
 func (b SimpleControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
-	if err != nil {
-		glog.Fatal(err)
-	}
-	return client
-}
-
-func (b SimpleControllerClientBuilder) ClientGoClient(name string) (clientset.Interface, error) {
-	clientConfig, err := b.Config(name)
-	if err != nil {
-		return nil, err
-	}
-	return clientset.NewForConfig(clientConfig)
-}
-
-func (b SimpleControllerClientBuilder) ClientGoClientOrDie(name string) clientset.Interface {
-	client, err := b.ClientGoClient(name)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -269,22 +251,6 @@ func (b SAControllerClientBuilder) Client(name string) (clientset.Interface, err
 
 func (b SAControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
-	if err != nil {
-		glog.Fatal(err)
-	}
-	return client
-}
-
-func (b SAControllerClientBuilder) ClientGoClient(name string) (clientset.Interface, error) {
-	clientConfig, err := b.Config(name)
-	if err != nil {
-		return nil, err
-	}
-	return clientset.NewForConfig(clientConfig)
-}
-
-func (b SAControllerClientBuilder) ClientGoClientOrDie(name string) clientset.Interface {
-	client, err := b.ClientGoClient(name)
 	if err != nil {
 		glog.Fatal(err)
 	}


### PR DESCRIPTION
everything has moved to client-go now so these are the same as the original Client* methods. The only functional change is the collapse of the "horizontal-pod-autoscaler" from one client to two. This should have no effect because the GoClient was used only for discovery.

```release-note
NONE
```
