### PR TITLE
kubectl: Drop typer from DrainOptions

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -70,7 +69,6 @@ type DrainOptions struct {
 	Selector           string
 	PodSelector        string
 	nodeInfos          []*resource.Info
-	typer              runtime.ObjectTyper
 
 	genericclioptions.IOStreams
 }


### PR DESCRIPTION
The property was added in c6e9ad06 (#16698), but beb5ea64 (#59227) removed the only initializer.  This removal is similar to #66266, but for a different property.

CC @juanvallejo, who filed #59227.

```release-note
NONE
```