### PR TITLE
Add volume state metrics to AWS cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -258,6 +258,9 @@ const DefaultVolumeType = "gp2"
 // Used to call RecognizeWellKnownRegions just once
 var once sync.Once
 
+// Used to call registerControllerMetrics() just once
+var registerControllerMetricsOnce sync.Once
+
 // AWS implements PVLabeler.
 var _ cloudprovider.PVLabeler = (*Cloud)(nil)
 
@@ -1155,6 +1158,10 @@ func (c *Cloud) Initialize(clientBuilder controller.ControllerClientBuilder) {
 	c.eventBroadcaster.StartLogging(glog.Infof)
 	c.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.kubeClient.CoreV1().Events("")})
 	c.eventRecorder = c.eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "aws-cloud-provider"})
+
+	registerControllerMetricsOnce.Do(func() {
+		registerControllerMetrics(c)
+	})
 }
 
 // Clusters returns the list of clusters.

--- a/pkg/cloudprovider/providers/aws/aws_metrics.go
+++ b/pkg/cloudprovider/providers/aws/aws_metrics.go
@@ -55,7 +55,7 @@ var (
 		[]string{"node", "state"}, nil)
 	awsVolumesInStateDurationMinutes = prometheus.NewDesc(
 		prometheus.BuildFQName("", "cloudprovider_aws", "volumes_in_state_duration_minutes"),
-		"Time spent by AWS EBS volumes in state attaching, detaching, or busy",
+		"Time spent by AWS EBS volumes in state attaching",
 		[]string{"volume", "state"}, nil)
 )
 
@@ -124,7 +124,7 @@ func getVolumesInStateDuration(instances []*ec2.Instance) map[string]map[string]
 			attachTime := *ebs.AttachTime
 
 			switch state {
-			case "attaching", "detaching", "busy":
+			case "attaching":
 				duration := time.Since(attachTime).Minutes()
 				durationsByVolume[volume] = map[string]float64{state: duration}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: https://aws.amazon.com/premiumsupport/knowledge-center/ebs-stuck-attaching/ EBS volumes frequently get stuck attaching even under normal operation. Kubernetes tries to minimize it with e.g. `waitForAttachmentStatus` code in AWS cloudprovider. But it has limited knowledge about volume state and cannot do much about stuck volumes anyway. So let's query the AWS API and surface this info to metrics consumers.

add
`cloudprovider_aws_volumes_in_state_duration_minutes` with labels `volume` and `state`
and
`cloudprovider_aws_volumes_in_state_total` with labels `node` and `state`
where `state` can be
`attaching`, `detaching`, or `busy`

**Special notes for your reviewer**: How costly is it to call describeinstances every time Collect is called? Should we cache the metrics and only call describeInstances e.g. once a minute?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TODO
```
