### PR TITLE
gcp client auth plugin: persist default cache on unauthorized

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -174,7 +174,13 @@ func parseScopes(gcpConfig map[string]string) []string {
 }
 
 func (g *gcpAuthProvider) WrapTransport(rt http.RoundTripper) http.RoundTripper {
-	return &conditionalTransport{&oauth2.Transport{Source: g.tokenSource, Base: rt}, g.persister}
+	var resetCache map[string]string
+	if cts, ok := g.tokenSource.(*cachedTokenSource); ok {
+		resetCache = cts.baseCache()
+	} else {
+		resetCache = make(map[string]string)
+	}
+	return &conditionalTransport{&oauth2.Transport{Source: g.tokenSource, Base: rt}, g.persister, resetCache}
 }
 
 func (g *gcpAuthProvider) Login() error { return nil }
@@ -244,6 +250,19 @@ func (t *cachedTokenSource) update(tok *oauth2.Token) map[string]string {
 	}
 	ret["access-token"] = t.accessToken
 	ret["expiry"] = t.expiry.Format(time.RFC3339Nano)
+	return ret
+}
+
+// baseCache is the base configuration value for this TokenSource, without any cached ephemeral tokens.
+func (t *cachedTokenSource) baseCache() map[string]string {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+	ret := map[string]string{}
+	for k, v := range t.cache {
+		ret[k] = v
+	}
+	delete(ret, "access-token")
+	delete(ret, "expiry")
 	return ret
 }
 
@@ -337,6 +356,7 @@ func parseJSONPath(input interface{}, name, template string) (string, error) {
 type conditionalTransport struct {
 	oauthTransport *oauth2.Transport
 	persister      restclient.AuthProviderConfigPersister
+	resetCache     map[string]string
 }
 
 var _ net.RoundTripperWrapper = &conditionalTransport{}
@@ -354,8 +374,7 @@ func (t *conditionalTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 	if res.StatusCode == 401 {
 		glog.V(4).Infof("The credentials that were supplied are invalid for the target cluster")
-		emptyCache := make(map[string]string)
-		t.persister.Persist(emptyCache)
+		t.persister.Persist(t.resetCache)
 	}
 
 	return res, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an edge case error introduced by #46694. It changes the gcp auth client plugin's roundtripper to persist the default cache instead of an empty map. An empty cache is not correct for commandTokenSource, which uses the cache to store calling details for the external command it execs to generate refresh tokens. Persisting a completely empty cache breaks that behavior.

This bug caused an issue where running `kubectl` command against a GKE cluster with an expired refresh token would break token refresh permanently until `gcloud container clusters get-credentials` was re-run.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug that caused `kubectl` commands to sometimes fail to refresh access token when running against GKE clusters.

```
