### PR TITLE
Automated cherry pick of #66261 to upstream release-1.9

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -161,20 +161,16 @@ func (dc *Datacenter) GetDatastoreByName(ctx context.Context, name string) (*Dat
 }
 
 // GetResourcePool gets the resource pool for the given path
-func (dc *Datacenter) GetResourcePool(ctx context.Context, computePath string) (*object.ResourcePool, error) {
+func (dc *Datacenter) GetResourcePool(ctx context.Context, resourcePoolPath string) (*object.ResourcePool, error) {
 	finder := getFinder(dc)
-	var computeResource *object.ComputeResource
+	var resourcePool *object.ResourcePool
 	var err error
-	if computePath == "" {
-		computeResource, err = finder.DefaultComputeResource(ctx)
-	} else {
-		computeResource, err = finder.ComputeResource(ctx, computePath)
-	}
+	resourcePool, err = finder.ResourcePoolOrDefault(ctx, resourcePoolPath)
 	if err != nil {
-		glog.Errorf("Failed to get the ResourcePool for computePath '%s'. err: %+v", computePath, err)
+		glog.Errorf("Failed to get the ResourcePool for path '%s'. err: %+v", resourcePoolPath, err)
 		return nil, err
 	}
-	return computeResource.ResourcePool(ctx)
+	return resourcePool, nil
 }
 
 // GetFolderByPath gets the Folder Object from the given folder path


### PR DESCRIPTION
Cherry pick of #66261 on release-1.9
#66261: Fix locating resourcepool-path specified in the vsphere.conf file

Release note:

```
Fix locating resourcepool-path specified in the vsphere.conf file
```


cc: @kubernetes/vmware