### PR TITLE
Cleanup & fix PodSecurityPolicy field path usage

### DIFF
--- a/pkg/security/podsecuritypolicy/capabilities/BUILD
+++ b/pkg/security/podsecuritypolicy/capabilities/BUILD
@@ -29,6 +29,7 @@ go_test(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/policy:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )
 

--- a/pkg/security/podsecuritypolicy/capabilities/capabilities.go
+++ b/pkg/security/podsecuritypolicy/capabilities/capabilities.go
@@ -81,7 +81,7 @@ func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList {
+func (s *defaultCapabilities) Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if capabilities == nil {
@@ -94,7 +94,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 
 		// container has no requested caps but we have required caps.  We should have something in
 		// at least the drops on the container.
-		allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities"), capabilities,
+		allErrs = append(allErrs, field.Invalid(fldPath, capabilities,
 			"required capabilities are not set on the securityContext"))
 		return allErrs
 	}
@@ -112,7 +112,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 	for _, cap := range capabilities.Add {
 		sCap := string(cap)
 		if !defaultAdd.Has(sCap) && !allowedAdd.Has(sCap) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "add"), sCap, "capability may not be added"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("add"), sCap, "capability may not be added"))
 		}
 	}
 
@@ -122,7 +122,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, c
 	for _, requiredDrop := range s.requiredDropCapabilities {
 		sDrop := string(requiredDrop)
 		if !containerDrops.Has(sDrop) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "drop"), capabilities.Drop,
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("drop"), capabilities.Drop,
 				fmt.Sprintf("%s is required to be dropped but was not found", sDrop)))
 		}
 	}

--- a/pkg/security/podsecuritypolicy/capabilities/capabilities_test.go
+++ b/pkg/security/podsecuritypolicy/capabilities/capabilities_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/policy"
 )
@@ -329,7 +330,7 @@ func TestValidateAdds(t *testing.T) {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, nil, v.containerCaps)
+		errs := strategy.Validate(field.NewPath("capabilities"), nil, nil, v.containerCaps)
 		if v.expectedError == "" && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue
@@ -390,7 +391,7 @@ func TestValidateDrops(t *testing.T) {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, nil, v.containerCaps)
+		errs := strategy.Validate(field.NewPath("capabilities"), nil, nil, v.containerCaps)
 		if v.expectedError == "" && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue

--- a/pkg/security/podsecuritypolicy/capabilities/types.go
+++ b/pkg/security/podsecuritypolicy/capabilities/types.go
@@ -26,5 +26,5 @@ type Strategy interface {
 	// Generate creates the capabilities based on policy rules.
 	Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList
 }

--- a/pkg/security/podsecuritypolicy/factory.go
+++ b/pkg/security/podsecuritypolicy/factory.go
@@ -139,7 +139,7 @@ func createFSGroupStrategy(opts *policy.FSGroupStrategyOptions) (group.GroupStra
 	case policy.FSGroupStrategyRunAsAny:
 		return group.NewRunAsAny()
 	case policy.FSGroupStrategyMustRunAs:
-		return group.NewMustRunAs(opts.Ranges, fsGroupField)
+		return group.NewMustRunAs(opts.Ranges)
 	default:
 		return nil, fmt.Errorf("Unrecognized FSGroup strategy type %s", opts.Rule)
 	}
@@ -151,7 +151,7 @@ func createSupplementalGroupStrategy(opts *policy.SupplementalGroupsStrategyOpti
 	case policy.SupplementalGroupsStrategyRunAsAny:
 		return group.NewRunAsAny()
 	case policy.SupplementalGroupsStrategyMustRunAs:
-		return group.NewMustRunAs(opts.Ranges, supplementalGroupsField)
+		return group.NewMustRunAs(opts.Ranges)
 	default:
 		return nil, fmt.Errorf("Unrecognized SupplementalGroups strategy type %s", opts.Rule)
 	}

--- a/pkg/security/podsecuritypolicy/group/BUILD
+++ b/pkg/security/podsecuritypolicy/group/BUILD
@@ -30,7 +30,10 @@ go_test(
         "runasany_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//pkg/apis/policy:go_default_library"],
+    deps = [
+        "//pkg/apis/policy:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/security/podsecuritypolicy/group/mustrunas.go
+++ b/pkg/security/podsecuritypolicy/group/mustrunas.go
@@ -28,19 +28,17 @@ import (
 // mustRunAs implements the GroupStrategy interface
 type mustRunAs struct {
 	ranges []policy.IDRange
-	field  string
 }
 
 var _ GroupStrategy = &mustRunAs{}
 
 // NewMustRunAs provides a new MustRunAs strategy based on ranges.
-func NewMustRunAs(ranges []policy.IDRange, field string) (GroupStrategy, error) {
+func NewMustRunAs(ranges []policy.IDRange) (GroupStrategy, error) {
 	if len(ranges) == 0 {
 		return nil, fmt.Errorf("ranges must be supplied for MustRunAs")
 	}
 	return &mustRunAs{
 		ranges: ranges,
-		field:  field,
 	}, nil
 }
 
@@ -61,17 +59,17 @@ func (s *mustRunAs) GenerateSingle(_ *api.Pod) (*int64, error) {
 // Validate ensures that the specified values fall within the range of the strategy.
 // Groups are passed in here to allow this strategy to support multiple group fields (fsgroup and
 // supplemental groups).
-func (s *mustRunAs) Validate(_ *api.Pod, groups []int64) field.ErrorList {
+func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, groups []int64) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(groups) == 0 && len(s.ranges) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath(s.field), groups, "unable to validate empty groups against required ranges"))
+		allErrs = append(allErrs, field.Invalid(fldPath, groups, "unable to validate empty groups against required ranges"))
 	}
 
 	for _, group := range groups {
 		if !s.isGroupValid(group) {
 			detail := fmt.Sprintf("group %d must be in the ranges: %v", group, s.ranges)
-			allErrs = append(allErrs, field.Invalid(field.NewPath(s.field), groups, detail))
+			allErrs = append(allErrs, field.Invalid(fldPath, groups, detail))
 		}
 	}
 

--- a/pkg/security/podsecuritypolicy/group/mustrunas_test.go
+++ b/pkg/security/podsecuritypolicy/group/mustrunas_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/policy"
 )
 
@@ -40,7 +41,7 @@ func TestMustRunAsOptions(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		_, err := NewMustRunAs(v.ranges, "")
+		_, err := NewMustRunAs(v.ranges)
 		if v.pass && err != nil {
 			t.Errorf("error creating strategy for %s: %v", k, err)
 		}
@@ -77,7 +78,7 @@ func TestGenerate(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		s, err := NewMustRunAs(v.ranges, "")
+		s, err := NewMustRunAs(v.ranges)
 		if err != nil {
 			t.Errorf("error creating strategy for %s: %v", k, err)
 		}
@@ -161,11 +162,11 @@ func TestValidate(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		s, err := NewMustRunAs(v.ranges, "")
+		s, err := NewMustRunAs(v.ranges)
 		if err != nil {
 			t.Errorf("error creating strategy for %s: %v", k, err)
 		}
-		errs := s.Validate(nil, v.groups)
+		errs := s.Validate(field.NewPath(""), nil, v.groups)
 		if v.expectedError == "" && len(errs) > 0 {
 			t.Errorf("unexpected errors for %s: %v", k, errs)
 		}

--- a/pkg/security/podsecuritypolicy/group/runasany.go
+++ b/pkg/security/podsecuritypolicy/group/runasany.go
@@ -43,7 +43,7 @@ func (s *runAsAny) GenerateSingle(_ *api.Pod) (*int64, error) {
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(_ *api.Pod, groups []int64) field.ErrorList {
+func (s *runAsAny) Validate(fldPath *field.Path, _ *api.Pod, groups []int64) field.ErrorList {
 	return field.ErrorList{}
 
 }

--- a/pkg/security/podsecuritypolicy/group/runasany_test.go
+++ b/pkg/security/podsecuritypolicy/group/runasany_test.go
@@ -18,6 +18,8 @@ package group
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestRunAsAnyGenerate(t *testing.T) {
@@ -53,7 +55,7 @@ func TestRunAsAnyValidte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	errs := s.Validate(nil, nil)
+	errs := s.Validate(field.NewPath(""), nil, nil)
 	if len(errs) != 0 {
 		t.Errorf("unexpected errors: %v", errs)
 	}

--- a/pkg/security/podsecuritypolicy/group/types.go
+++ b/pkg/security/podsecuritypolicy/group/types.go
@@ -31,5 +31,5 @@ type GroupStrategy interface {
 	// value to return if configured with multiple ranges.  This is used for FSGroup.
 	GenerateSingle(pod *api.Pod) (*int64, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, groups []int64) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, groups []int64) field.ErrorList
 }

--- a/pkg/security/podsecuritypolicy/types.go
+++ b/pkg/security/podsecuritypolicy/types.go
@@ -39,9 +39,9 @@ type Provider interface {
 	// It modifies the SecurityContext of the container and annotations of the pod.
 	DefaultContainerSecurityContext(pod *api.Pod, container *api.Container) error
 	// Ensure a pod is in compliance with the given constraints.
-	ValidatePod(pod *api.Pod, fldPath *field.Path) field.ErrorList
-	// Ensure a container's SecurityContext is in compliance with the given constraints
-	ValidateContainerSecurityContext(pod *api.Pod, container *api.Container, fldPath *field.Path) field.ErrorList
+	ValidatePod(pod *api.Pod) field.ErrorList
+	// Ensure a container's SecurityContext is in compliance with the given constraints.
+	ValidateContainer(pod *api.Pod, container *api.Container, containerPath *field.Path) field.ErrorList
 	// Get the name of the PSP that this provider was initialized with.
 	GetPSPName() string
 }

--- a/pkg/security/podsecuritypolicy/user/mustrunas.go
+++ b/pkg/security/podsecuritypolicy/user/mustrunas.go
@@ -49,17 +49,17 @@ func (s *mustRunAs) Generate(pod *api.Pod, container *api.Container) (*int64, er
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
+func (s *mustRunAs) Validate(scPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if runAsUser == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("runAsUser"), ""))
+		allErrs = append(allErrs, field.Required(scPath.Child("runAsUser"), ""))
 		return allErrs
 	}
 
 	if !s.isValidUID(*runAsUser) {
 		detail := fmt.Sprintf("must be in the ranges: %v", s.opts.Ranges)
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsUser"), *runAsUser, detail))
+		allErrs = append(allErrs, field.Invalid(scPath.Child("runAsUser"), *runAsUser, detail))
 	}
 	return allErrs
 }

--- a/pkg/security/podsecuritypolicy/user/nonroot.go
+++ b/pkg/security/podsecuritypolicy/user/nonroot.go
@@ -41,18 +41,18 @@ func (s *nonRoot) Generate(pod *api.Pod, container *api.Container) (*int64, erro
 // or if the UID is set it is not root.  Validation will fail if RunAsNonRoot is set to false.
 // In order to work properly this assumes that the kubelet performs a final check on runAsUser
 // or the image UID when runAsUser is nil.
-func (s *nonRoot) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
+func (s *nonRoot) Validate(scPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if runAsNonRoot == nil && runAsUser == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("runAsNonRoot"), "must be true"))
+		allErrs = append(allErrs, field.Required(scPath.Child("runAsNonRoot"), "must be true"))
 		return allErrs
 	}
 	if runAsNonRoot != nil && *runAsNonRoot == false {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsNonRoot"), *runAsNonRoot, "must be true"))
+		allErrs = append(allErrs, field.Invalid(scPath.Child("runAsNonRoot"), *runAsNonRoot, "must be true"))
 		return allErrs
 	}
 	if runAsUser != nil && *runAsUser == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsUser"), *runAsUser, "running with the root UID is forbidden"))
+		allErrs = append(allErrs, field.Invalid(scPath.Child("runAsUser"), *runAsUser, "running with the root UID is forbidden"))
 		return allErrs
 	}
 	return allErrs

--- a/pkg/security/podsecuritypolicy/user/runasany.go
+++ b/pkg/security/podsecuritypolicy/user/runasany.go
@@ -38,6 +38,6 @@ func (s *runAsAny) Generate(pod *api.Pod, container *api.Container) (*int64, err
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
+func (s *runAsAny) Validate(_ *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	return field.ErrorList{}
 }

--- a/pkg/security/podsecuritypolicy/user/types.go
+++ b/pkg/security/podsecuritypolicy/user/types.go
@@ -26,5 +26,6 @@ type RunAsUserStrategy interface {
 	// Generate creates the uid based on policy rules.
 	Generate(pod *api.Pod, container *api.Container) (*int64, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList
+	// scPath is the field path to the container's security context
+	Validate(scPath *field.Path, pod *api.Pod, container *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList
 }

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -1876,7 +1876,7 @@ func TestAssignSecurityContext(t *testing.T) {
 	}
 
 	for k, v := range testCases {
-		errs := assignSecurityContext(provider, v.pod, nil)
+		errs := assignSecurityContext(provider, v.pod)
 		if v.shouldValidate && len(errs) > 0 {
 			t.Errorf("%s expected to validate but received errors %v", k, errs)
 			continue


### PR DESCRIPTION
I noticed the field paths were incorrect for a bunch of PodSecurityPolicy validation errors. This PR fixes the errors, and makes it more explicit what the paths are pointing to in some cases.

**Release note**:
```release-note
NONE
```

/kind cleanup
/sig auth