### PR TITLE
ignore unused variable

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -87,6 +87,9 @@ func TestRoutes(t *testing.T) {
 
 func getServers(os *OpenStack) []servers.Server {
 	c, err := os.NewComputeV2()
+	if err != nil {
+		panic(err)
+	}
 	allPages, err := servers.List(c, servers.ListOpts{}).AllPages()
 	if err != nil {
 		panic(err)

--- a/pkg/cloudprovider/providers/photon/photon_test.go
+++ b/pkg/cloudprovider/providers/photon/photon_test.go
@@ -140,7 +140,7 @@ func TestInstances(t *testing.T) {
 	}
 	t.Logf("Found InstanceID(%s) = %s\n", testVM, instanceId)
 
-	instanceId, err = i.InstanceID(context.TODO(), nonExistingVM)
+	_, err = i.InstanceID(context.TODO(), nonExistingVM)
 	if err == cloudprovider.InstanceNotFound {
 		t.Logf("VM %s was not found as expected\n", nonExistingVM)
 	} else if err == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
ignore unused variable 

unused err
https://github.com/kubernetes/kubernetes/blob/162655f42f79e03a0041f7d2dfb1a818be244ef7/pkg/cloudprovider/providers/openstack/openstack_routes_test.go#L89

and
unused instanceId
https://github.com/kubernetes/kubernetes/blob/162655f42f79e03a0041f7d2dfb1a818be244ef7/pkg/cloudprovider/providers/photon/photon_test.go#L143

found in #66303 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
