### PR TITLE
Add String method to audit.Backend interface

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/types.go
@@ -39,4 +39,7 @@ type Backend interface {
 	// events are delivered. It can be assumed that this method is called after
 	// the stopCh channel passed to the Run method has been closed.
 	Shutdown()
+
+	// Returns the backend PluginName.
+	String() string
 }

--- a/staging/src/k8s.io/apiserver/pkg/audit/union_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/union_test.go
@@ -40,6 +40,10 @@ func (f *fakeBackend) Shutdown() {
 	// Nothing to do here.
 }
 
+func (f *fakeBackend) String() string {
+	return ""
+}
+
 func TestUnion(t *testing.T) {
 	backends := []Backend{
 		new(fakeBackend),

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/fake.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/fake/fake.go
@@ -44,3 +44,7 @@ func (b *Backend) ProcessEvents(ev ...*auditinternal.Event) {
 		b.OnRequest(ev)
 	}
 }
+
+func (b *Backend) String() string {
+	return ""
+}

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -111,8 +111,14 @@ type auditSinkFunc func(events ...*auditinternal.Event)
 func (f auditSinkFunc) ProcessEvents(events ...*auditinternal.Event) {
 	f(events...)
 }
+
 func (auditSinkFunc) Run(stopCh <-chan struct{}) error {
 	return nil
 }
+
 func (auditSinkFunc) Shutdown() {
+}
+
+func (auditSinkFunc) String() string {
+	return ""
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add `String()` method to `audit.Backend` interface.  Should enforce backend to implement this method.
Because https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/audit/union.go#L65

We encountered this issue when we upgrade recently and we implemented our private backend.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
