### PR TITLE
Automated cherry pick of #66174: Check presence of sioDiskIDPath before reading it

### DIFF
--- a/pkg/volume/scaleio/sio_client.go
+++ b/pkg/volume/scaleio/sio_client.go
@@ -339,10 +339,14 @@ func (c *sioClient) getGuid() (string, error) {
 func (c *sioClient) getSioDiskPaths() ([]os.FileInfo, error) {
 	files, err := ioutil.ReadDir(sioDiskIDPath)
 	if err != nil {
-		glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
-		return nil, err
+		if os.IsNotExist(err) {
+			// sioDiskIDPath may not exist yet which is fine
+			return []os.FileInfo{}, nil
+		} else {
+			glog.Error(log("failed to ReadDir %s: %v", sioDiskIDPath, err))
+			return nil, err
+		}
 	}
-
 	result := []os.FileInfo{}
 	for _, file := range files {
 		if c.diskRegex.MatchString(file.Name()) {


### PR DESCRIPTION
Cherry pick of #66174 on release-1.11.

#66174: Check presence of sioDiskIDPath before reading it

```release-note
Allow ScaleIO volumes to be provisioned without having to first manually create /dev/disk/by-id path on each kubernetes node (if not already present)
```