### PR TITLE
Add unit tests to cover scopes and scope selectors during quota sync logic

### DIFF
--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -380,7 +380,10 @@ func podMatchesSelector(pod *api.Pod, selector api.ScopedResourceSelectorRequire
 	if err != nil {
 		return false, fmt.Errorf("failed to parse and convert selector: %v", err)
 	}
-	m := map[string]string{string(api.ResourceQuotaScopePriorityClass): pod.Spec.PriorityClassName}
+	var m map[string]string
+	if len(pod.Spec.PriorityClassName) != 0 {
+		m = map[string]string{string(api.ResourceQuotaScopePriorityClass): pod.Spec.PriorityClassName}
+	}
 	if labelSelector.Matches(labels.Set(m)) {
 		return true, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds unit tests to cover scopes and scope selectors fields in the quota spec. Existing unit test for quota sync does not cover scopes.

Also while adding tests found a minor issue with 'Exists' scope selector operator. This is also being fixed in this PR.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unit tests for scopes and scope selectors in the quota spec
```
/cc @derekwaynecarr @sjenning @bsalamat @kubernetes/sig-scheduling-pr-reviews @kubernetes/sig-node-pr-reviews 