### PR TITLE
Automated cherry pick of #66172: Reverting commit #56600 as GCE PD is allocated in chunks of #66324: Fixing E2E tests for disk resizing

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -772,8 +772,8 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 	}
 
 	requestBytes := newSize.Value()
-	// GCE resizes in chunks of GBs (not GiB)
-	requestGB := volumeutil.RoundUpSize(requestBytes, 1000*1000*1000)
+	// GCE resizes in chunks of GiBs
+	requestGB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
 	newSizeQuant := resource.MustParse(fmt.Sprintf("%dG", requestGB))
 
 	// If disk is already of size equal or greater than requested size, we simply return

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -773,11 +773,11 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 
 	requestBytes := newSize.Value()
 	// GCE resizes in chunks of GiBs
-	requestGB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
-	newSizeQuant := resource.MustParse(fmt.Sprintf("%dG", requestGB))
+	requestGIB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
+	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", requestGIB))
 
 	// If disk is already of size equal or greater than requested size, we simply return
-	if disk.SizeGb >= requestGB {
+	if disk.SizeGb >= requestGIB {
 		return newSizeQuant, nil
 	}
 
@@ -786,7 +786,7 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 	switch zoneInfo := disk.ZoneInfo.(type) {
 	case singleZone:
 		mc = newDiskMetricContextZonal("resize", disk.Region, zoneInfo.zone)
-		resizeOp, err := gce.manager.ResizeDiskOnCloudProvider(disk, requestGB, zoneInfo.zone)
+		resizeOp, err := gce.manager.ResizeDiskOnCloudProvider(disk, requestGIB, zoneInfo.zone)
 
 		if err != nil {
 			return oldSize, mc.Observe(err)
@@ -799,7 +799,7 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 	case multiZone:
 		if utilfeature.DefaultFeatureGate.Enabled(features.GCERegionalPersistentDisk) {
 			mc = newDiskMetricContextRegional("resize", disk.Region)
-			resizeOp, err := gce.manager.RegionalResizeDiskOnCloudProvider(disk, requestGB)
+			resizeOp, err := gce.manager.RegionalResizeDiskOnCloudProvider(disk, requestGIB)
 
 			if err != nil {
 				return oldSize, mc.Observe(err)

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -422,7 +422,7 @@ func (c *gcePersistentDiskProvisioner) Provision() (*v1.PersistentVolume, error)
 			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   c.options.PVC.Spec.AccessModes,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dG", sizeGB)),
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{

--- a/pkg/volume/gce_pd/gce_pd_test.go
+++ b/pkg/volume/gce_pd/gce_pd_test.go
@@ -177,7 +177,7 @@ func TestPlugin(t *testing.T) {
 	}
 	cap := persistentSpec.Spec.Capacity[v1.ResourceStorage]
 	size := cap.Value()
-	if size != 100*util.GB {
+	if size != 100*util.GIB {
 		t.Errorf("Provision() returned unexpected volume size: %v", size)
 	}
 

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -86,8 +86,8 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (strin
 
 	name := volumeutil.GenerateVolumeName(c.options.ClusterName, c.options.PVName, 63) // GCE PD name can have up to 63 characters
 	capacity := c.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	// GCE PDs are allocated in chunks of GBs (not GiBs)
-	requestGB := volumeutil.RoundUpToGB(capacity)
+	// GCE PDs are allocated in chunks of GiBs
+	requestGB := volumeutil.RoundUpToGiB(capacity)
 
 	// Apply Parameters.
 	// Values for parameter "replication-type" are canonicalized to lower case.

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -258,8 +258,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						"type": "pd-ssd",
 						"zone": cloudZone,
 					},
-					claimSize:    "1.5G",
-					expectedSize: "2G",
+					claimSize:    "1.5Gi",
+					expectedSize: "2Gi",
 					pvCheck: func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-ssd")
 					},
@@ -271,8 +271,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					parameters: map[string]string{
 						"type": "pd-standard",
 					},
-					claimSize:    "1.5G",
-					expectedSize: "2G",
+					claimSize:    "1.5Gi",
+					expectedSize: "2Gi",
 					pvCheck: func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-standard")
 					},
@@ -437,8 +437,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				parameters: map[string]string{
 					"type": "pd-standard",
 				},
-				claimSize:    "1G",
-				expectedSize: "1G",
+				claimSize:    "1Gi",
+				expectedSize: "1Gi",
 				pvCheck: func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -471,8 +471,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				parameters: map[string]string{
 					"type": "pd-standard",
 				},
-				claimSize:    "1G",
-				expectedSize: "1G",
+				claimSize:    "1Gi",
+				expectedSize: "1Gi",
 				pvCheck: func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -522,7 +522,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				name:        "unmanaged_zone",
 				provisioner: "kubernetes.io/gce-pd",
 				parameters:  map[string]string{"zone": unmanagedZone},
-				claimSize:   "1G",
+				claimSize:   "1Gi",
 			}
 			sc := newStorageClass(test, ns, suffix)
 			sc, err = c.StorageV1().StorageClasses().Create(sc)
@@ -715,13 +715,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				name:         "default",
 				claimSize:    "2Gi",
 				expectedSize: "2Gi",
-			}
-			// gce or gke
-			if getDefaultPluginName() == "kubernetes.io/gce-pd" {
-				// using GB not GiB as e2e test unit since gce-pd returns GB,
-				// or expectedSize may be greater than claimSize.
-				test.claimSize = "2G"
-				test.expectedSize = "2G"
 			}
 
 			claim := newClaim(test, ns, "default")


### PR DESCRIPTION
Cherry pick of #66172 #66324 on release-1.10.

#66172: Reverting commit #56600 as GCE PD is allocated in chunks of
#66324: Fixing E2E tests for disk resizing

```release-note 
none 
```