### PR TITLE
Use DeepEqual instead of =

### DIFF
--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -106,7 +106,7 @@ func TestHugePageSizeFromResourceName(t *testing.T) {
 			if err != nil && !tc.expectErr {
 				t.Errorf("[%v]did not expect error but got: %v", i, err)
 			}
-			if v != tc.expectVal {
+			if !reflect.DeepEqual(v, tc.expectVal) {
 				t.Errorf("Got %v but expected %v", v, tc.expectVal)
 			}
 		})


### PR DESCRIPTION

**What this PR does / why we need it**:
We should use DeepEqual here
`
			if v != tc.expectVal {
				t.Errorf("Got %v but expected %v", v, tc.expectVal)
			}
`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
NONE
```
