### PR TITLE
add pod's controller info for  kubectl get pod -o wide

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -84,6 +84,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 		{Name: "IP", Type: "string", Priority: 1, Description: apiv1.PodStatus{}.SwaggerDoc()["podIP"]},
 		{Name: "Node", Type: "string", Priority: 1, Description: apiv1.PodSpec{}.SwaggerDoc()["nodeName"]},
+		{Name: "Owner", Type: "string", Priority: 1, Description: metav1.ObjectMeta{}.SwaggerDoc()["ownerReferences"]},
 	}
 	h.TableHandler(podColumnDefinitions, printPodList)
 	h.TableHandler(podColumnDefinitions, printPod)
@@ -643,6 +644,11 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1beta1.TableR
 		if len(pod.Status.NominatedNodeName) > 0 {
 			row.Cells = append(row.Cells, pod.Status.NominatedNodeName)
 		}
+		podOwner := "<none>"
+		if len(pod.OwnerReferences) > 0 {
+			podOwner = fmt.Sprintf("%s/%s", pod.OwnerReferences[0].Kind, pod.OwnerReferences[0].Name)
+		}
+		row.Cells = append(row.Cells, podOwner)
 	}
 
 	return []metav1beta1.TableRow{row}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
print pod's owner (controller) when using kubelet get pod -o wide
```
[root@hpa-vm:/opt/kubernetes/1.4.5]$ kubectl get pod -o wide
NAME             READY     STATUS    RESTARTS   AGE       IP             NODE           OWNER
ds-nginx-hfjhl   1/1       Running   0          15m       172.16.2.3     10.62.40.149   DaemonSet/ds-nginx
nginx-knm5d      1/1       Running   0          37m       172.16.2.2     10.62.40.149   ReplicationController/nginx
static-pod       1/1       Running   0          1h        10.62.40.149   10.62.40.149   <none>

```
we can find the pod's controller quickly through `kubectl get node -o wide` 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
