### PR TITLE
kubeadm: rename cri-socket-path -> cri-socket

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -514,5 +514,7 @@ func AddImagesCommonConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1alpha3.I
 
 // AddImagesPullFlags adds flags related to the `kubeadm config images pull` command
 func AddImagesPullFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1alpha3.InitConfiguration) {
+	flagSet.StringVar(&cfg.NodeRegistration.CRISocket, "cri-socket", cfg.NodeRegistration.CRISocket, "Specify the CRI socket to connect to.")
 	flagSet.StringVar(&cfg.NodeRegistration.CRISocket, "cri-socket-path", cfg.NodeRegistration.CRISocket, "Path to the CRI socket.")
+	flagSet.MarkDeprecated("cri-socket-path", "Please, use --cri-socket instead")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Renamed command line option cri-socket-path for 2 reasons:
- to be consistent with the rest of kubeadm code
  reset/init/join/apply subcommands use --cri-socket
- name is misleading as CRI socket can be also an url, not just a path


**Release note**:
```release-note
renamed command line option  --cri-socket-path of the kubeadm subcommand "kubeadm config images pull" to --cri-socket to be consistent with the rest of kubeadm subcommands.
```
