### PR TITLE
Support pulling requestheader CA from extension-apiserver-authentication ConfigMap without client CA

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -160,7 +160,11 @@ func (s *DelegatingAuthenticationOptions) ApplyTo(c *server.AuthenticationInfo, 
 
 	clientCA, err := s.getClientCA()
 	if err != nil {
-		return err
+		if _, ignorable := err.(ignorableError); !ignorable {
+			return err
+		} else {
+			glog.Warning(err)
+		}
 	}
 	if err = c.ApplyClientCert(clientCA.ClientCA, servingInfo); err != nil {
 		return fmt.Errorf("unable to load client CA file: %v", err)
@@ -200,7 +204,11 @@ func (s *DelegatingAuthenticationOptions) ToAuthenticationConfig() (authenticato
 
 	clientCA, err := s.getClientCA()
 	if err != nil {
-		return authenticatorfactory.DelegatingAuthenticatorConfig{}, err
+		if _, ignorable := err.(ignorableError); !ignorable {
+			return authenticatorfactory.DelegatingAuthenticatorConfig{}, err
+		} else {
+			glog.Warning(err)
+		}
 	}
 	requestHeader, err := s.getRequestHeader()
 	if err != nil {
@@ -240,7 +248,7 @@ func (s *DelegatingAuthenticationOptions) getClientCA() (*ClientCertAuthenticati
 		return nil, err
 	}
 	if incluster == nil {
-		return nil, fmt.Errorf("cluster doesn't provide client-ca-file")
+		return &s.ClientCert, ignorableError{fmt.Errorf("cluster doesn't provide client-ca-file in configmap/%s in %s, so client certificate authentication to extension api-server won't work.", authenticationConfigMapName, authenticationConfigMapNamespace)}
 	}
 	return incluster, nil
 }
@@ -394,3 +402,5 @@ func (s *DelegatingAuthenticationOptions) newTokenAccessReview() (authentication
 
 	return client.TokenReviews(), nil
 }
+
+type ignorableError struct{ error }


### PR DESCRIPTION
This commit prevents extension API server from erroring out during bootstrap when the core
API server doesn't support certificate based authentication for it's clients i.e. client-ca isn't
present in extension-apiserver-authentication ConfigMap in kube-system.

This can happen in cluster setups where core API server uses Webhook token authentication.

Fixes: https://github.com/kubernetes/kubernetes/issues/65724

**Which issue(s) this PR fixes** 
Fixes #65724

**Special notes for your reviewer**:

**Release note**:
```release-note
Allows extension API server to dynamically discover the requestheader CA certificate when the core API server doesn't use certificate based authentication for it's clients
```
