### PR TITLE
Update http.Transport if it already exists in ExecProvider

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -179,21 +180,10 @@ func (a *Authenticator) UpdateTransportConfig(c *transport.Config) error {
 		return &roundTripper{a, rt}
 	}
 
-	getCert := c.TLS.GetCert
-	c.TLS.GetCert = func() (*tls.Certificate, error) {
-		// If previous GetCert is present and returns a valid non-nil
-		// certificate, use that. Otherwise use cert from exec plugin.
-		if getCert != nil {
-			cert, err := getCert()
-			if err != nil {
-				return nil, err
-			}
-			if cert != nil {
-				return cert, nil
-			}
-		}
-		return a.cert()
+	if c.TLS.GetCert != nil {
+		return errors.New("can't add TLS certificate callback: transport.Config.TLS.GetCert already set")
 	}
+	c.TLS.GetCert = a.cert
 
 	var dial func(ctx context.Context, network, addr string) (net.Conn, error)
 	if c.Dial != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This unbreaks ExecPlugin. Without the change, we hit this error
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/transport/transport.go#L32

**Release note**:
```release-note
Fix kubelet startup failure when using ExecPlugin in kubeconfig
```
