### PR TITLE
fix logs command to be generic for all resources again

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -236,20 +236,22 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			writer.Write([]byte(fmt.Sprintf("==== START logs for container %s of pod %s/%s ====\n", container.Name, pod.Namespace, pod.Name)))
 			defer writer.Write([]byte(fmt.Sprintf("==== END logs for container %s of pod %s/%s ====\n", container.Name, pod.Namespace, pod.Name)))
 
-			request, err := o.LogsForObject(o.RESTClientGetter, pod, &api.PodLogOptions{Container: container.Name}, timeout)
+			requests, err := o.LogsForObject(o.RESTClientGetter, pod, &api.PodLogOptions{Container: container.Name}, timeout, false)
 			if err != nil {
 				// Print error and return.
 				writer.Write([]byte(fmt.Sprintf("Create log request error: %s\n", err.Error())))
 				return
 			}
 
-			data, err := request.DoRaw()
-			if err != nil {
-				// Print error and return.
-				writer.Write([]byte(fmt.Sprintf("Request log error: %s\n", err.Error())))
-				return
+			for _, request := range requests {
+				data, err := request.DoRaw()
+				if err != nil {
+					// Print error and return.
+					writer.Write([]byte(fmt.Sprintf("Request log error: %s\n", err.Error())))
+					return
+				}
+				writer.Write(data)
 			}
-			writer.Write(data)
 		}
 
 		for ix := range pods.Items {

--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -244,14 +244,14 @@ type logTestMock struct {
 	client internalclientset.Interface
 }
 
-func (m logTestMock) logsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration) (*restclient.Request, error) {
+func (m logTestMock) logsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) ([]*restclient.Request, error) {
 	switch t := object.(type) {
 	case *api.Pod:
 		opts, ok := options.(*api.PodLogOptions)
 		if !ok {
 			return nil, errors.New("provided options object is not a PodLogOptions")
 		}
-		return m.client.Core().Pods(t.Namespace).GetLogs(t.Name, opts), nil
+		return []*restclient.Request{m.client.Core().Pods(t.Namespace).GetLogs(t.Name, opts)}, nil
 	default:
 		return nil, fmt.Errorf("cannot get the logs from %T", object)
 	}

--- a/pkg/kubectl/polymorphichelpers/interface.go
+++ b/pkg/kubectl/polymorphichelpers/interface.go
@@ -30,7 +30,7 @@ import (
 )
 
 // LogsForObjectFunc is a function type that can tell you how to get logs for a runtime.object
-type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration) (*rest.Request, error)
+type LogsForObjectFunc func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) ([]*rest.Request, error)
 
 // LogsForObjectFn gives a way to easily override the function for unit testing if needed.
 var LogsForObjectFn LogsForObjectFunc = logsForObject

--- a/pkg/kubectl/polymorphichelpers/logsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/logsforobject_test.go
@@ -130,7 +130,7 @@ func TestLogsForObject(t *testing.T) {
 
 	for _, test := range tests {
 		fakeClientset := fake.NewSimpleClientset(test.pods...)
-		_, err := logsForObjectWithClient(fakeClientset, test.obj, test.opts, 20*time.Second)
+		_, err := logsForObjectWithClient(fakeClientset, test.obj, test.opts, 20*time.Second, false)
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 			continue


### PR DESCRIPTION
--all-containers should not have been allowed as it was because it only worked for pods.  This approach does not make sense for a polymorphic command.  Rather than roll it back, I'll take the time to make it generic.  Because of this and other pods-only options, we now have inconsistencies with the command that should be addressed separately.

@CaoShuFeng 
/assign @juanvallejo @soltysh 
@kubernetes/sig-cli-maintainers 

```release-note
NONE
```