### PR TITLE
Bail out on error when adding feature gate flags

### DIFF
--- a/pkg/features/BUILD
+++ b/pkg/features/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"github.com/golang/glog"
+
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -347,6 +349,10 @@ const (
 
 func init() {
 	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	err := utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	if err != nil {
+		glog.Fatal(err)
+	}
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/features/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/features/BUILD
@@ -10,7 +10,10 @@ go_library(
     srcs = ["kube_features.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/features",
     importpath = "k8s.io/apiextensions-apiserver/pkg/features",
-    deps = ["//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"github.com/golang/glog"
+
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
@@ -43,7 +45,10 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	err := utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	if err != nil {
+		glog.Fatal(err)
+	}
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/staging/src/k8s.io/apiserver/pkg/features/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/features/BUILD
@@ -10,7 +10,10 @@ go_library(
     srcs = ["kube_features.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/features",
     importpath = "k8s.io/apiserver/pkg/features",
-    deps = ["//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -17,6 +17,8 @@ limitations under the License.
 package features
 
 import (
+	"github.com/golang/glog"
+
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
@@ -67,6 +69,10 @@ const (
 
 func init() {
 	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	err := utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	if err != nil {
+		glog.Fatal(err)
+	}
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.


### PR DESCRIPTION
Change-Id: I4d97da29745a3e7cad6f5c351ba4c6b30dd3a65f
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Just got bit by this when updating dependencies on openstack cloud provider, we were earlier on 1.10.x where CustomResourceSubresources was Alpha. since there was no obvious error the only indication something was wrong that the feature gate needed in a CI job was not available in the openstack-cloud-controller-manager

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
