### PR TITLE
fix dockershim ut

### DIFF
--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -173,7 +173,7 @@ func TestEnsureSandboxImageExists(t *testing.T) {
 			injectImage:  true,
 			imgNeedsAuth: true,
 			injectErr:    libdocker.ImageNotFoundError{ID: "image_id"},
-			calls:        []string{"inspect_image", "pull"},
+			calls:        []string{"inspect_image", "pull", "pull"},
 			err:          true,
 		},
 	} {


### PR DESCRIPTION
```release-note
NONE
```

Fix for the following failure

```
--- FAIL: TestEnsureSandboxImageExists (0.00s)
	helpers_test.go:180: TestCase: "should not pull image when it already exists"
	helpers_test.go:180: TestCase: "should pull image when it doesn't exist"
	helpers_test.go:180: TestCase: "should return error when inspect image fails"
	helpers_test.go:180: TestCase: "should return error when image pull needs private auth, but none provided"
	helpers_test.go:192: 
			Error Trace:	helpers_test.go:192
			Error:      	Received unexpected error:
			            	expected []string{"inspect_image", "pull"}, got []string{"inspect_image", "pull", "pull"}
			Test:       	TestEnsureSandboxImageExists

```