### PR TITLE
Only build generators for building platform

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -197,7 +197,7 @@ $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(DEEPCOPY_GEN): $(k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/deepcopy-gen)
-	hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
+	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
 	touch $@
 
 
@@ -291,7 +291,7 @@ $(DEFAULTER_FILES): $(DEFAULTER_GEN)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(DEFAULTER_GEN): $(k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/defaulter-gen)
-	hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/defaulter-gen
+	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/defaulter-gen
 	touch $@
 
 
@@ -388,7 +388,7 @@ $(CONVERSION_FILES): $(CONVERSION_GEN)
 # newer than the binary, and try to rebuild it over and over.  So we touch it,
 # and make is happy.
 $(CONVERSION_GEN): $(k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/conversion-gen)
-	hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/conversion-gen
+	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/code-generator/cmd/conversion-gen
 	touch $@
 
 
@@ -465,7 +465,7 @@ $(OPENAPI_OUTFILE): $(OPENAPI_GEN) $(KNOWN_VIOLATION_FILENAME)
 # newer than the binary, and try to "rebuild" it over and over.  So we touch
 # it, and make is happy.
 $(OPENAPI_GEN): $(k8s.io/kubernetes/vendor/k8s.io/kube-openapi/cmd/openapi-gen)
-	hack/make-rules/build.sh ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
+	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
 	touch $@
 
 
@@ -494,5 +494,5 @@ gen_bindata: $(BINDATA_GEN) FORCE
 # newer than the binary, and try to rebuild it over and over.  So we touch it,
 # and make is happy.
 $(BINDATA_GEN): $(k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata)
-	hack/make-rules/build.sh ./vendor/github.com/jteeuwen/go-bindata/go-bindata
+	KUBE_BUILD_PLATFORMS="" hack/make-rules/build.sh ./vendor/github.com/jteeuwen/go-bindata/go-bindata
 	touch $@


### PR DESCRIPTION
**What this PR does / why we need it**:
The code generator binaries are built using the `hack/make-rules/build.sh` script. If you run a command like `make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64` that passes a `KUBE_BUILD_PLATFORMS` that *doesn't* include the building platform, the code generator binaries will be built on the target platform, but NOT the building platform (which doesn't make sense). Also, if you specify `make cross` it will build the code generators for *all* platforms, which is also unnecessary.

This change ensures that `KUBE_BUILD_PLATFORMS` is an empty string when building the code generators, which ensures that they will only be built for the building platform.

This also fixes an issue when using the linux-based cross build container to target a specific platform other than linux/amd64.

Example command that is broken: `build/run.sh make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64`

**Release note**:
```release-note
NONE
```
