### PR TITLE
fix issue that pull image failed from a cross-subscription Azure Container Registry by SP access

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure/azure_credentials_test.go
@@ -43,19 +43,25 @@ func Test(t *testing.T) {
 		{
 			Name: to.StringPtr("foo"),
 			RegistryProperties: &containerregistry.RegistryProperties{
-				LoginServer: to.StringPtr("foo-microsoft.azurecr.io"),
+				LoginServer: to.StringPtr("*.azurecr.io"),
 			},
 		},
 		{
 			Name: to.StringPtr("bar"),
 			RegistryProperties: &containerregistry.RegistryProperties{
-				LoginServer: to.StringPtr("bar-microsoft.azurecr.io"),
+				LoginServer: to.StringPtr("*.azurecr.cn"),
 			},
 		},
 		{
 			Name: to.StringPtr("baz"),
 			RegistryProperties: &containerregistry.RegistryProperties{
-				LoginServer: to.StringPtr("baz-microsoft.azurecr.io"),
+				LoginServer: to.StringPtr("*.azurecr.de"),
+			},
+		},
+		{
+			Name: to.StringPtr("bus"),
+			RegistryProperties: &containerregistry.RegistryProperties{
+				LoginServer: to.StringPtr("*.azurecr.us"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
after granting sp access to azure ACR , pull image from ACR would fail, and after wait about 15-30min(or restart kubelet directly), pull image would succeed. Root cause is that `servicePrincipalToken` needs to be refreshed when doing `registryClient.List`, otherwise it will always return empty registry list. Pull image error would be like following:
```
Events:
  Type     Reason                 Age              From                               Message
  ----     ------                 ----             ----                               -------
  Warning  FailedScheduling       8m (x3 over 8m)  default-scheduler                  0/1 nodes are available: 1 Insufficient cpu.
  Normal   Scheduled              8m               default-scheduler                  Successfully assigned nginx-server-776564f79c-zhtjk to aks-nodepool1-20881069-0
  Normal   SuccessfulMountVolume  8m               kubelet, aks-nodepool1-20881069-0  MountVolume.SetUp succeeded for volume "default-token-4t7tk"
  Normal   SuccessfulMountVolume  8m               kubelet, aks-nodepool1-20881069-0  MountVolume.SetUp succeeded for volume "pvc-5c1f0521-739f-11e8-9b69-0a58ac1f09c2"
  Warning  Failed                 8m (x5 over 8m)  kubelet, aks-nodepool1-20881069-0  Error: ImagePullBackOff
  Normal   BackOff                8m (x5 over 8m)  kubelet, aks-nodepool1-20881069-0  Back-off pulling image "andyacr.azurecr.io/nginx-server:1.0.0"
  Warning  Failed                 8m (x2 over 8m)  kubelet, aks-nodepool1-20881069-0  Error: ErrImagePull
  Warning  Failed                 8m (x2 over 8m)  kubelet, aks-nodepool1-20881069-0  Failed to pull image "andyacr.azurecr.io/nginx-server:1.0.0": rpc error: code = Unknown desc = Error response from daemon: Get https://andyacr.azurecr.io/v2/nginx-server/manifests/1.0.0: unauthorized: authentication required
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65225

**Special notes for your reviewer**:
After discuss with dong, `registryClient.List` won't be necessary, instead we return `{"*.azurecr.io", "*.azurecr.cn", "*.azurecr.de", "*.azurecr.us"}` like aws, gce code logic, it will do the url matching.
I will cherry pick this PR to all supported version, every version has this issue.

**Neet to mention that** this PR would also make image pull from a cross-subscription ACR work after we grant SP access to an ACR in a different subs. Original code won’t work because it’s using the SubscriptionID of current AKS cluster, since ACR is in a different subs, registryClient.List will never get cross subs ACR repos.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix issue that pull image failed from a cross-subscription Azure Container Registry
```

/sig azure
/assign @feiskyer @khenidak @brendandburns @karataliu 