### PR TITLE
Add HealthzPort to KubeProxyConfiguration.

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -112,8 +112,6 @@ type Options struct {
 
 	// master is used to override the kubeconfig's URL to the apiserver.
 	master string
-	// healthzPort is the port to be used by the healthz server.
-	healthzPort int32
 
 	scheme *runtime.Scheme
 	codecs serializer.CodecFactory
@@ -133,7 +131,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Var(componentconfig.IPVar{Val: &o.config.BindAddress}, "bind-address", "The IP address for the proxy server to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces)")
 	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
-	fs.Int32Var(&o.healthzPort, "healthz-port", o.healthzPort, "The port to bind the health check server. Use 0 to disable.")
+	fs.Int32Var(&o.config.HealthzPort, "healthz-port", ports.ProxyHealthzPort, "The port to bind the health check server. Use 0 to disable.")
 	fs.Var(componentconfig.IPVar{Val: &o.config.HealthzBindAddress}, "healthz-bind-address", "The IP address and port for the health check server to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces)")
 	fs.Var(componentconfig.IPVar{Val: &o.config.MetricsBindAddress}, "metrics-bind-address", "The IP address and port for the metrics server to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces)")
 	fs.Int32Var(o.config.OOMScoreAdj, "oom-score-adj", utilpointer.Int32PtrDerefOr(o.config.OOMScoreAdj, int32(qos.KubeProxyOOMScoreAdj)), "The oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]")
@@ -182,7 +180,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 func NewOptions() *Options {
 	return &Options{
 		config:      new(kubeproxyconfig.KubeProxyConfiguration),
-		healthzPort: ports.ProxyHealthzPort,
 		scheme:      scheme.Scheme,
 		codecs:      scheme.Codecs,
 		CleanupIPVS: true,
@@ -191,11 +188,6 @@ func NewOptions() *Options {
 
 // Complete completes all the required options.
 func (o *Options) Complete() error {
-	if len(o.ConfigFile) == 0 && len(o.WriteConfigTo) == 0 {
-		glog.Warning("WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.")
-		o.applyDeprecatedHealthzPortToConfig()
-	}
-
 	// Load the config file here in Complete, so that Validate validates the fully-resolved config.
 	if len(o.ConfigFile) > 0 {
 		if c, err := o.loadConfigFromFile(o.ConfigFile); err != nil {
@@ -267,26 +259,6 @@ func (o *Options) writeConfigFile() error {
 	glog.Infof("Wrote configuration to: %s\n", o.WriteConfigTo)
 
 	return nil
-}
-
-// applyDeprecatedHealthzPortToConfig sets o.config.HealthzBindAddress from
-// flags passed on the command line based on the following rules:
-//
-// 1. If --healthz-port is 0, disable the healthz server.
-// 2. Otherwise, use the value of --healthz-port for the port portion of
-//    o.config.HealthzBindAddress
-func (o *Options) applyDeprecatedHealthzPortToConfig() {
-	if o.healthzPort == 0 {
-		o.config.HealthzBindAddress = ""
-		return
-	}
-
-	index := strings.Index(o.config.HealthzBindAddress, ":")
-	if index != -1 {
-		o.config.HealthzBindAddress = o.config.HealthzBindAddress[0:index]
-	}
-
-	o.config.HealthzBindAddress = fmt.Sprintf("%s:%d", o.config.HealthzBindAddress, o.healthzPort)
 }
 
 // loadConfigFromFile loads the contents of file and decodes it as a

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -127,8 +128,8 @@ func newProxyServer(
 
 	var healthzServer *healthcheck.HealthzServer
 	var healthzUpdater healthcheck.HealthzUpdater
-	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
+	if config.HealthzPort != 0 {
+		healthzServer = healthcheck.NewDefaultHealthzServer(net.JoinHostPort(config.HealthzBindAddress, strconv.Itoa(int(config.HealthzPort))), 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
 		healthzUpdater = healthzServer
 	}
 

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	_ "net/http/pprof"
+	"strconv"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,7 +87,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	var healthzServer *healthcheck.HealthzServer
 	var healthzUpdater healthcheck.HealthzUpdater
 	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
+		healthzServer = healthcheck.NewDefaultHealthzServer(net.JoinHostPort(config.HealthzBindAddress, strconv.Itoa(int(config.HealthzPort))), 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
 		healthzUpdater = healthzServer
 	}
 

--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -39,7 +39,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress:        "192.168.59.103",
-						HealthzBindAddress: "0.0.0.0:10256",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						ClusterCIDR:        "192.168.59.0/24",
 						UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -70,8 +71,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						// only BindAddress is invalid
-						BindAddress:        "10.10.12.11:2000",
-						HealthzBindAddress: "0.0.0.0:10256",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						ClusterCIDR:        "192.168.59.0/24",
 						UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -104,7 +105,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress: "10.10.12.11",
 						// only HealthzBindAddress is invalid
-						HealthzBindAddress: "0.0.0.0",
+						HealthzBindAddress: "127.0.0.256",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						ClusterCIDR:        "192.168.59.0/24",
 						UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -128,7 +130,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					},
 				},
 			},
-			msg:       "must be IP:port",
+			msg:       "not a valid textual representation of an IP address",
 			expectErr: true,
 		},
 		{
@@ -136,7 +138,42 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress:        "10.10.12.11",
-						HealthzBindAddress: "0.0.0.0:12345",
+						HealthzBindAddress: "0.0.0.0",
+						// only HealthzPort is invalid
+						HealthzPort:        -1,
+						MetricsBindAddress: "127.0.0.1:10249",
+						ClusterCIDR:        "192.168.59.0/24",
+						UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+						ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+						IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+							MasqueradeAll: true,
+							SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+							MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+						},
+						IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
+							SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
+							MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
+						},
+						Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+							Max:        utilpointer.Int32Ptr(2),
+							MaxPerCore: utilpointer.Int32Ptr(1),
+							Min:        utilpointer.Int32Ptr(1),
+							TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+							TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+						},
+					},
+				},
+			},
+			msg:       "must be between 1 and 65535",
+			expectErr: true,
+		},
+		{
+			masterConfig: &kubeadm.InitConfiguration{
+				ComponentConfigs: kubeadm.ComponentConfigs{
+					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
+						BindAddress:        "10.10.12.11",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						// only MetricsBindAddress is invalid
 						MetricsBindAddress: "127.0.0.1",
 						ClusterCIDR:        "192.168.59.0/24",
@@ -169,7 +206,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress:        "10.10.12.11",
-						HealthzBindAddress: "0.0.0.0:12345",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						// only ClusterCIDR is invalid
 						ClusterCIDR:      "192.168.59.0",
@@ -202,7 +240,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress:        "10.10.12.11",
-						HealthzBindAddress: "0.0.0.0:12345",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						ClusterCIDR:        "192.168.59.0/24",
 						// only UDPIdleTimeout is invalid
@@ -235,7 +274,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					KubeProxy: &kubeproxyconfig.KubeProxyConfiguration{
 						BindAddress:        "10.10.12.11",
-						HealthzBindAddress: "0.0.0.0:12345",
+						HealthzBindAddress: "0.0.0.0",
+						HealthzPort:        10256,
 						MetricsBindAddress: "127.0.0.1:10249",
 						ClusterCIDR:        "192.168.59.0/24",
 						UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -44,7 +44,8 @@ ComponentConfigs:
     FeatureGates:
       ServiceNodeExclusion: true
       SupportIPVSProxyMode: true
-    HealthzBindAddress: 0.0.0.0:10256
+    HealthzBindAddress: 0.0.0.0
+    HealthzPort: 10256
     HostnameOverride: ""
     IPTables:
       MasqueradeAll: false

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
@@ -46,7 +46,8 @@ kubeProxy:
     featureGates:
       ServiceNodeExclusion: true
       SupportIPVSProxyMode: true
-    healthzBindAddress: 0.0.0.0:10256
+    healthzBindAddress: 0.0.0.0
+    healthzPort: 10256
     hostnameOverride: ""
     iptables:
       masqueradeAll: false

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
@@ -58,7 +58,8 @@ enableProfiling: false
 featureGates:
   ServiceNodeExclusion: true
   SupportIPVSProxyMode: true
-healthzBindAddress: 0.0.0.0:10256
+healthzBindAddress: 0.0.0.0
+healthzPort: 10256
 hostnameOverride: ""
 iptables:
   masqueradeAll: false

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -53,7 +53,8 @@ conntrack:
   tcpCloseWaitTimeout: 1h0m0s
   tcpEstablishedTimeout: 24h0m0s
 enableProfiling: false
-healthzBindAddress: 0.0.0.0:10256
+healthzBindAddress: 0.0.0.0
+healthzPort: 10256
 hostnameOverride: ""
 iptables:
   masqueradeAll: false

--- a/pkg/proxy/apis/kubeproxyconfig/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/kubeproxyconfig/fuzzer/fuzzer.go
@@ -40,7 +40,8 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.Conntrack.TCPCloseWaitTimeout = &metav1.Duration{Duration: time.Duration(c.Int63()) * time.Hour}
 			obj.Conntrack.TCPEstablishedTimeout = &metav1.Duration{Duration: time.Duration(c.Int63()) * time.Hour}
 			obj.FeatureGates = map[string]bool{c.RandString(): true}
-			obj.HealthzBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
+			obj.HealthzBindAddress = fmt.Sprintf("%d.%d.%d.%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256))
+			obj.HealthzPort = c.Int31n(65536)
 			obj.IPTables.MasqueradeBit = utilpointer.Int32Ptr(c.Int31())
 			obj.MetricsBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
 			obj.OOMScoreAdj = utilpointer.Int32Ptr(c.Int31())

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -106,8 +106,10 @@ type KubeProxyConfiguration struct {
 	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
 	// for all interfaces)
 	BindAddress string
-	// healthzBindAddress is the IP address and port for the health check server to serve on,
-	// defaulting to 0.0.0.0:10256
+	// healthzPort is the port of the health check server (set to 0 to disable)
+	HealthzPort int32
+	// healthzBindAddress is the IP address for the health check server to serve on,
+	// defaulting to 0.0.0.0
 	HealthzBindAddress string
 	// metricsBindAddress is the IP address and port for the metrics server to serve on,
 	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/defaults.go
@@ -36,10 +36,11 @@ func SetDefaults_KubeProxyConfiguration(obj *KubeProxyConfiguration) {
 	if len(obj.BindAddress) == 0 {
 		obj.BindAddress = "0.0.0.0"
 	}
+	if obj.HealthzPort == nil {
+		obj.HealthzPort = pointer.Int32Ptr(ports.ProxyHealthzPort)
+	}
 	if obj.HealthzBindAddress == "" {
-		obj.HealthzBindAddress = fmt.Sprintf("0.0.0.0:%v", ports.ProxyHealthzPort)
-	} else if !strings.Contains(obj.HealthzBindAddress, ":") {
-		obj.HealthzBindAddress += fmt.Sprintf(":%v", ports.ProxyHealthzPort)
+		obj.HealthzBindAddress = "0.0.0.0"
 	}
 	if obj.MetricsBindAddress == "" {
 		obj.MetricsBindAddress = fmt.Sprintf("127.0.0.1:%v", ports.ProxyStatusPort)

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
@@ -102,8 +102,10 @@ type KubeProxyConfiguration struct {
 	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
 	// for all interfaces)
 	BindAddress string `json:"bindAddress"`
-	// healthzBindAddress is the IP address and port for the health check server to serve on,
-	// defaulting to 0.0.0.0:10256
+	// healthzPort is the port of the health check server (set to 0 to disable)
+	HealthzPort *int32 `json:"healthzPort,omitempty"`
+	// healthzBindAddress is the IP address for the health check server to serve on,
+	// defaulting to 0.0.0.0
 	HealthzBindAddress string `json:"healthzBindAddress"`
 	// metricsBindAddress is the IP address and port for the metrics server to serve on,
 	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
@@ -81,6 +81,9 @@ func Convert_kubeproxyconfig_ClientConnectionConfiguration_To_v1alpha1_ClientCon
 func autoConvert_v1alpha1_KubeProxyConfiguration_To_kubeproxyconfig_KubeProxyConfiguration(in *KubeProxyConfiguration, out *kubeproxyconfig.KubeProxyConfiguration, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.BindAddress = in.BindAddress
+	if err := v1.Convert_Pointer_int32_To_int32(&in.HealthzPort, &out.HealthzPort, s); err != nil {
+		return err
+	}
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.EnableProfiling = in.EnableProfiling
@@ -116,6 +119,9 @@ func Convert_v1alpha1_KubeProxyConfiguration_To_kubeproxyconfig_KubeProxyConfigu
 func autoConvert_kubeproxyconfig_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *kubeproxyconfig.KubeProxyConfiguration, out *KubeProxyConfiguration, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.BindAddress = in.BindAddress
+	if err := v1.Convert_int32_To_Pointer_int32(&in.HealthzPort, &out.HealthzPort, s); err != nil {
+		return err
+	}
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.EnableProfiling = in.EnableProfiling

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.deepcopy.go
@@ -52,6 +52,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 			(*out)[key] = val
 		}
 	}
+	if in.HealthzPort != nil {
+		in, out := &in.HealthzPort, &out.HealthzPort
+		*out = new(int32)
+		**out = **in
+	}
 	out.ClientConnection = in.ClientConnection
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)

--- a/pkg/proxy/apis/kubeproxyconfig/validation/BUILD
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/proxy/apis/kubeproxyconfig:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -39,7 +39,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 	successCases := []kubeproxyconfig.KubeProxyConfiguration{
 		{
 			BindAddress:        "192.168.59.103",
-			HealthzBindAddress: "0.0.0.0:10256",
+			HealthzPort:        12345,
+			HealthzBindAddress: "0.0.0.0",
 			MetricsBindAddress: "127.0.0.1:10249",
 			ClusterCIDR:        "192.168.59.0/24",
 			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -64,7 +65,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		},
 		{
 			BindAddress:        "192.168.59.103",
-			HealthzBindAddress: "0.0.0.0:10256",
+			HealthzPort:        12345,
+			HealthzBindAddress: "0.0.0.0",
 			MetricsBindAddress: "127.0.0.1:10249",
 			ClusterCIDR:        "192.168.59.0/24",
 			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -84,6 +86,7 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		},
 		{
 			BindAddress:        "192.168.59.103",
+			HealthzPort:        0,
 			HealthzBindAddress: "",
 			MetricsBindAddress: "127.0.0.1:10249",
 			ClusterCIDR:        "192.168.59.0/24",
@@ -118,7 +121,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				// only BindAddress is invalid
 				BindAddress:        "10.10.12.11:2000",
-				HealthzBindAddress: "0.0.0.0:10256",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				ClusterCIDR:        "192.168.59.0/24",
 				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -141,7 +145,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress: "10.10.12.11",
-				// only HealthzBindAddress is invalid
+				// only HealthzPort is invalid
+				HealthzPort:        -1,
 				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				ClusterCIDR:        "192.168.59.0/24",
@@ -160,12 +165,38 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
 			},
-			msg: "must be IP:port",
+			msg: "must be between 1 and 65535",
+		},
+		{
+			config: kubeproxyconfig.KubeProxyConfiguration{
+				BindAddress: "10.10.12.11",
+				HealthzPort: 12345,
+				// only HealthzBindAddress is invalid
+				HealthzBindAddress: "127.0.0.256",
+				MetricsBindAddress: "127.0.0.1:10249",
+				ClusterCIDR:        "192.168.59.0/24",
+				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+				ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+				IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+					MasqueradeAll: true,
+					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+				},
+				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+					Max:        pointer.Int32Ptr(2),
+					MaxPerCore: pointer.Int32Ptr(1),
+					Min:        pointer.Int32Ptr(1),
+					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+				},
+			},
+			msg: "not a valid textual representation of an IP address",
 		},
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				// only MetricsBindAddress is invalid
 				MetricsBindAddress: "127.0.0.1",
 				ClusterCIDR:        "192.168.59.0/24",
@@ -189,7 +220,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				// only ClusterCIDR is invalid
 				ClusterCIDR:      "192.168.59.0",
@@ -213,7 +245,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				ClusterCIDR:        "192.168.59.0/24",
 				// only UDPIdleTimeout is invalid
@@ -237,7 +270,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "10.10.12.11",
-				HealthzBindAddress: "0.0.0.0:12345",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				ClusterCIDR:        "192.168.59.0/24",
 				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
@@ -261,7 +295,8 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 		{
 			config: kubeproxyconfig.KubeProxyConfiguration{
 				BindAddress:        "192.168.59.103",
-				HealthzBindAddress: "0.0.0.0:10256",
+				HealthzPort:        12345,
+				HealthzBindAddress: "0.0.0.0",
 				MetricsBindAddress: "127.0.0.1:10249",
 				ClusterCIDR:        "192.168.59.0/24",
 				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
KubeProxyConfiguration now lacks of `HealthzPort` to disable health check server, it just has `HealthzBindAddress` and can only disable through cmd option `healthz-port` rather than yaml or json.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66155

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
1. Support to set HealthzPort in KubeProxyConfiguration to disable kube-proxy health check server
2. The format of HealthzBindAddress is changed to ip address format without port
```
