### PR TITLE
kubeadm: Improve kubeadm init cmd tests

### DIFF
--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -30,7 +30,10 @@ go_test(
         "integration",
         "skip",
     ],
-    deps = ["//vendor/github.com/ghodss/yaml:go_default_library"],
+    deps = [
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/renstrom/dedent:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package kubeadm
 
-import "testing"
+import (
+	"testing"
 
-// kubeadmReset executes "kubeadm reset" and restarts kubelet.
-func kubeadmReset() error {
-	_, _, err := RunCmd(*kubeadmPath, "reset")
-	return err
+	"github.com/renstrom/dedent"
+)
+
+func runKubeadmInit(args ...string) (string, string, error) {
+	kubeadmArgs := []string{"init", "--dry-run", "--ignore-preflight-errors=all"}
+	kubeadmArgs = append(kubeadmArgs, args...)
+	return RunCmd(*kubeadmPath, kubeadmArgs...)
 }
 
 func TestCmdInitToken(t *testing.T) {
@@ -30,26 +34,46 @@ func TestCmdInitToken(t *testing.T) {
 		t.Skip()
 	}
 
-	var initTest = []struct {
+	initTest := []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--discovery=token://abcd:1234567890abcd", false},     // invalid token size
-		{"--discovery=token://Abcdef:1234567890abcdef", false}, // invalid token non-lowercase
+		{
+			name:     "invalid token size",
+			args:     "--token=abcd:1234567890abcd",
+			expected: false,
+		},
+		{
+			name:     "invalid token non-lowercase",
+			args:     "--token=Abcdef:1234567890abcdef",
+			expected: false,
+		},
+		{
+			name:     "valid token is accepted",
+			args:     "--token=abcdef.0123456789abcdef",
+			expected: true,
+		},
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdInitToken running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, err := runKubeadmInit(rt.args)
+			if (err == nil) != rt.expected {
+				t.Fatalf(dedent.Dedent(`
+					CmdInitToken test case %q failed with an error: %v
+					command 'kubeadm init %s'
+						expected: %t
+						err: %t
+					`),
+					rt.name,
+					err,
+					rt.args,
+					rt.expected,
+					(err == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -59,25 +83,41 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 		t.Skip()
 	}
 
-	var initTest = []struct {
+	initTest := []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--kubernetes-version=foobar", false},
+		{
+			name:     "invalid version string is detected",
+			args:     "--kubernetes-version=foobar",
+			expected: false,
+		},
+		{
+			name:     "valid version is accepted",
+			args:     "--kubernetes-version=1.11.0",
+			expected: true,
+		},
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdInitKubernetesVersion running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, err := runKubeadmInit(rt.args)
+			if (err == nil) != rt.expected {
+				t.Fatalf(dedent.Dedent(`
+					CmdInitKubernetesVersion test case %q failed with an error: %v
+					command 'kubeadm init %s'
+						expected: %t
+						err: %t
+					`),
+					rt.name,
+					err,
+					rt.args,
+					rt.expected,
+					(err == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -87,26 +127,56 @@ func TestCmdInitConfig(t *testing.T) {
 		t.Skip()
 	}
 
-	var initTest = []struct {
+	initTest := []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--config=foobar", false},
-		{"--config=/does/not/exist/foo/bar", false},
+		{
+			name:     "fail on non existing path",
+			args:     "--config=/does/not/exist/foo/bar",
+			expected: false,
+		},
+		{
+			name:     "can't load v1alpha1 config",
+			args:     "--config=testdata/init/v1alpha1.yaml",
+			expected: false,
+		},
+		{
+			name:     "can load v1alpha2 config",
+			args:     "--config=testdata/init/v1alpha2.yaml",
+			expected: true,
+		},
+		{
+			name:     "can load v1alpha3 config",
+			args:     "--config=testdata/init/v1alpha3.yaml",
+			expected: true,
+		},
+		{
+			name:     "don't allow mixed arguments",
+			args:     "--kubernetes-version=1.11.0 --config=testdata/init/v1alpha3.yaml",
+			expected: false,
+		},
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdInitConfig running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, err := runKubeadmInit(rt.args)
+			if (err == nil) != rt.expected {
+				t.Fatalf(dedent.Dedent(`
+						CmdInitConfig test case %q failed with an error: %v
+						command 'kubeadm init %s'
+							expected: %t
+							err: %t
+						`),
+					rt.name,
+					err,
+					rt.args,
+					rt.expected,
+					(err == nil),
+				)
+			}
+		})
 	}
 }
 
@@ -116,52 +186,50 @@ func TestCmdInitAPIPort(t *testing.T) {
 		t.Skip()
 	}
 
-	var initTest = []struct {
+	initTest := []struct {
+		name     string
 		args     string
 		expected bool
 	}{
-		{"--api-port=foobar", false},
+		{
+			name:     "fail on non-string port",
+			args:     "--apiserver-bind-port=foobar",
+			expected: false,
+		},
+		{
+			name:     "fail on too large port number",
+			args:     "--apiserver-bind-port=100000",
+			expected: false,
+		},
+		{
+			name:     "fail on negative port number",
+			args:     "--apiserver-bind-port=-6000",
+			expected: false,
+		},
+		{
+			name:     "accept a valid port number",
+			args:     "--apiserver-bind-port=6000",
+			expected: true,
+		},
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdInitAPIPort running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
-	}
-}
-
-func TestCmdInitArgsMixed(t *testing.T) {
-	if *kubeadmCmdSkip {
-		t.Log("kubeadm cmd tests being skipped")
-		t.Skip()
-	}
-
-	var initTest = []struct {
-		args     string
-		expected bool
-	}{
-		{"--api-port=1000 --config=/etc/kubernets/kubeadm.config", false},
-	}
-
-	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
-		if (actual == nil) != rt.expected {
-			t.Errorf(
-				"failed CmdInitArgsMixed running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
-				rt.args,
-				actual,
-				rt.expected,
-				(actual == nil),
-			)
-		}
-		kubeadmReset()
+		t.Run(rt.name, func(t *testing.T) {
+			_, _, err := runKubeadmInit(rt.args)
+			if (err == nil) != rt.expected {
+				t.Fatalf(dedent.Dedent(`
+							CmdInitAPIPort test case %q failed with an error: %v
+							command 'kubeadm init %s'
+								expected: %t
+								err: %t
+							`),
+					rt.name,
+					err,
+					rt.args,
+					rt.expected,
+					(err == nil),
+				)
+			}
+		})
 	}
 }

--- a/cmd/kubeadm/test/cmd/join_test.go
+++ b/cmd/kubeadm/test/cmd/join_test.go
@@ -18,6 +18,12 @@ package kubeadm
 
 import "testing"
 
+// kubeadmReset executes "kubeadm reset" and restarts kubelet.
+func kubeadmReset() error {
+	_, _, err := RunCmd(*kubeadmPath, "reset")
+	return err
+}
+
 func TestCmdJoinConfig(t *testing.T) {
 	if *kubeadmCmdSkip {
 		t.Log("kubeadm cmd tests being skipped")

--- a/cmd/kubeadm/test/cmd/testdata/init/v1alpha1.yaml
+++ b/cmd/kubeadm/test/cmd/testdata/init/v1alpha1.yaml
@@ -1,0 +1,2 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration

--- a/cmd/kubeadm/test/cmd/testdata/init/v1alpha2.yaml
+++ b/cmd/kubeadm/test/cmd/testdata/init/v1alpha2.yaml
@@ -1,0 +1,2 @@
+apiVersion: kubeadm.k8s.io/v1alpha2
+kind: MasterConfiguration

--- a/cmd/kubeadm/test/cmd/testdata/init/v1alpha3.yaml
+++ b/cmd/kubeadm/test/cmd/testdata/init/v1alpha3.yaml
@@ -1,0 +1,2 @@
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: InitConfiguration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR improves kubeadm init cmd tests in the following ways:

- Fix a few cases that were always successful (despite completely wrong).
- Add more test cases (for different configs in particular)
- Use dry run, to avoid modifying the system and using kubeadm reset

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes NONE

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @luxas
/assign @timothysc

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
