### PR TITLE
Adds a build example with KUBE_BUILD_PLATFORMS

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -24,6 +24,7 @@ The following scripts are found in the `build/` directory. Note that all scripts
 * `build/run.sh`: Run a command in a build docker container.  Common invocations:
   *  `build/run.sh make`: Build just linux binaries in the container.  Pass options and packages as necessary.
   *  `build/run.sh make cross`: Build all binaries for all platforms
+  *  `build/run.sh make kubectl KUBE_BUILD_PLATFORMS=darwin/amd64`: Build the specific binary for the specific platform (`kubectl` and `darwin/amd64` respectively in this example)
   *  `build/run.sh make test`: Run all unit tests
   *  `build/run.sh make test-integration`: Run integration test
   *  `build/run.sh make test-cmd`: Run CLI tests


### PR DESCRIPTION
**What this PR does / why we need it**:

I didn't manage to find any guides about how to build the specific binary for the specific platform in docs (in this repo and in the community repo). Also it was quite hard for me to follow build scripts. At the end, I found help on the kubernetes-dev channel in Slack:`KUBE_BUILD_PLATFORMS` seems to do what I want. I think, would be great to have it documented somehow: The "Key scripts" section of the build doc seems to be a good place to mention it.

**Release note**:

```release-note
NONE
```
