### PR TITLE
kubeadm join the cluster with pre-existing client certificate if provided

### DIFF
--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -36,11 +36,15 @@ const TokenUser = "tls-bootstrap-token-user"
 func For(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Config, error) {
 	// TODO: Print summary info about the CA certificate, along with the checksum signature
 	// we also need an ability for the user to configure the client to validate received CA cert against a checksum
-	clusterinfo, err := GetValidatedClusterInfoObject(cfg)
+	config, err := DiscoverValidatedKubeConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't validate the identity of the API Server: %v", err)
 	}
 
+	if len(cfg.TLSBootstrapToken) == 0 {
+		return config, nil
+	}
+	clusterinfo := kubeconfigutil.GetClusterFromKubeConfig(config)
 	return kubeconfigutil.CreateWithToken(
 		clusterinfo.Server,
 		cfg.ClusterName,
@@ -50,16 +54,16 @@ func For(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Config, error) {
 	), nil
 }
 
-// GetValidatedClusterInfoObject returns a validated Cluster object that specifies where the cluster is and the CA cert to trust
-func GetValidatedClusterInfoObject(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Cluster, error) {
+// DiscoverValidatedKubeConfig returns a validated Config object that specifies where the cluster is and the CA cert to trust
+func DiscoverValidatedKubeConfig(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Config, error) {
 	switch {
 	case len(cfg.DiscoveryFile) != 0:
 		if isHTTPSURL(cfg.DiscoveryFile) {
-			return https.RetrieveValidatedClusterInfo(cfg.DiscoveryFile, cfg.ClusterName)
+			return https.RetrieveValidatedConfigInfo(cfg.DiscoveryFile, cfg.ClusterName)
 		}
-		return file.RetrieveValidatedClusterInfo(cfg.DiscoveryFile, cfg.ClusterName)
+		return file.RetrieveValidatedConfigInfo(cfg.DiscoveryFile, cfg.ClusterName)
 	case len(cfg.DiscoveryToken) != 0:
-		return token.RetrieveValidatedClusterInfo(cfg)
+		return token.RetrieveValidatedConfigInfo(cfg)
 	default:
 		return nil, fmt.Errorf("couldn't find a valid discovery configuration")
 	}

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
 )
 
-// RetrieveValidatedClusterInfo connects to the API Server and makes sure it can talk
+// RetrieveValidatedConfigInfo connects to the API Server and makes sure it can talk
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
-func RetrieveValidatedClusterInfo(httpsURL, clustername string) (*clientcmdapi.Cluster, error) {
+func RetrieveValidatedConfigInfo(httpsURL, clustername string) (*clientcmdapi.Config, error) {
 	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 	response, err := client.Get(httpsURL)
 	if err != nil {
@@ -42,9 +42,9 @@ func RetrieveValidatedClusterInfo(httpsURL, clustername string) (*clientcmdapi.C
 		return nil, err
 	}
 
-	clusterinfo, err := clientcmd.Load(kubeconfig)
+	config, err := clientcmd.Load(kubeconfig)
 	if err != nil {
 		return nil, err
 	}
-	return file.ValidateClusterInfo(clusterinfo, clustername)
+	return file.ValidateConfigInfo(config, clustername)
 }

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -40,10 +40,10 @@ import (
 // BootstrapUser defines bootstrap user name
 const BootstrapUser = "token-bootstrap-client"
 
-// RetrieveValidatedClusterInfo connects to the API Server and tries to fetch the cluster-info ConfigMap
+// RetrieveValidatedConfigInfo connects to the API Server and tries to fetch the cluster-info ConfigMap
 // It then makes sure it can trust the API Server by looking at the JWS-signed tokens and (if cfg.DiscoveryTokenCACertHashes is not empty)
 // validating the cluster CA against a set of pinned public keys
-func RetrieveValidatedClusterInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Cluster, error) {
+func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmdapi.Config, error) {
 	token, err := kubeadmapi.NewBootstrapTokenString(cfg.DiscoveryToken)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func RetrieveValidatedClusterInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmd
 		return nil, err
 	}
 
-	return kubeconfigutil.GetClusterFromKubeConfig(baseKubeConfig), nil
+	return baseKubeConfig, nil
 }
 
 // buildInsecureBootstrapKubeConfig makes a KubeConfig object that connects insecurely to the API Server for bootstrapping purposes

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -25,7 +25,7 @@ import (
 )
 
 // CreateBasic creates a basic, general KubeConfig object that then can be extended
-func CreateBasic(serverURL string, clusterName string, userName string, caCert []byte) *clientcmdapi.Config {
+func CreateBasic(serverURL, clusterName, userName string, caCert []byte) *clientcmdapi.Config {
 	// Use the cluster and the username as the context name
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
support `kubeadm join` with a pre-existing client certificate

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#945

**Special notes for your reviewer**:
/cc @luxas @timothysc  @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm now can join the cluster with pre-existing client certificate if provided
```
