### PR TITLE
StatefulSet.Spec.VolumeClaimTemplates: Allow add custom labels

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -149,7 +149,14 @@ func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1
 		claim := templates[i]
 		claim.Name = getPersistentVolumeClaimName(set, &claim, ordinal)
 		claim.Namespace = set.Namespace
-		claim.Labels = set.Spec.Selector.MatchLabels
+		if claim.Labels == nil {
+			claim.Labels = set.Spec.Selector.MatchLabels
+		} else {
+			for k, v := range set.Spec.Selector.MatchLabels {
+				claim.Labels[k] = v
+			}
+		}
+
 		claims[templates[i].Name] = claim
 	}
 	return claims


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR gives ability adding custom labels to PVC using StatefulSet.Spec.VolumeClaimTemplates

**Which issue(s) this PR fixes** 
Fixes #58987

**Special notes for your reviewer**:

**Release note**:
```release-note
Allowed to specify custom labels for PVC using StatefulSet.Spec.VolumeClaimTemplates
```
