### PR TITLE
Automated cherry pick of #66341: kubeadm: stop setting UID in the kubelet ConfigMap

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/kubelet/dynamic.go
+++ b/cmd/kubeadm/app/phases/kubelet/dynamic.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
@@ -38,23 +37,22 @@ func EnableDynamicConfigForNode(client clientset.Interface, nodeName string, kub
 		nodeName, configMapName, metav1.NamespaceSystem)
 	fmt.Println("[kubelet] WARNING: The Dynamic Kubelet Config feature is alpha and off by default. It hasn't been well-tested yet at this stage, use with caution.")
 
-	kubeletConfigMap, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(configMapName, metav1.GetOptions{})
+	_, err := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("couldn't get the kubelet configuration ConfigMap: %v", err)
 	}
 
 	// Loop on every falsy return. Return with an error if raised. Exit successfully if true is returned.
 	return apiclient.PatchNode(client, nodeName, func(n *v1.Node) {
-		patchNodeForDynamicConfig(n, configMapName, kubeletConfigMap.UID)
+		patchNodeForDynamicConfig(n, configMapName)
 	})
 }
 
-func patchNodeForDynamicConfig(n *v1.Node, configMapName string, configMapUID types.UID) {
+func patchNodeForDynamicConfig(n *v1.Node, configMapName string) {
 	n.Spec.ConfigSource = &v1.NodeConfigSource{
 		ConfigMap: &v1.ConfigMapNodeConfigSource{
 			Name:             configMapName,
 			Namespace:        metav1.NamespaceSystem,
-			UID:              configMapUID,
 			KubeletConfigKey: kubeadmconstants.KubeletBaseConfigurationConfigMapKey,
 		},
 	}


### PR DESCRIPTION
Cherry pick of #66341 on release-1.11.

#66341: kubeadm: stop setting UID in the kubelet ConfigMap