### PR TITLE
kubeadm: make error output more verbose

### DIFF
--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -186,12 +186,12 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 
 func TestImagesPull(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
-		RunScript: []fakeexec.FakeRunAction{
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
+		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
 		},
 	}
 
@@ -219,8 +219,8 @@ func TestImagesPull(t *testing.T) {
 		t.Fatalf("expected nil but found %v", err)
 	}
 
-	if fcmd.RunCalls != len(images) {
-		t.Errorf("expected %d docker calls, got %d", len(images), fcmd.RunCalls)
+	if fcmd.CombinedOutputCalls != len(images) {
+		t.Errorf("expected %d calls, got %d", len(images), fcmd.CombinedOutputCalls)
 	}
 }
 

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -701,14 +701,14 @@ func TestSetHasItemOrAll(t *testing.T) {
 
 func TestImagePullCheck(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
-		RunScript: []fakeexec.FakeRunAction{
-			func() ([]byte, []byte, error) { return nil, nil, nil }, // Test case 1
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, &fakeexec.FakeExitError{Status: 1} }, // Test case 2
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
+		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return nil, nil }, // Test case 1
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return []byte("error"), &fakeexec.FakeExitError{Status: 1} }, // Test case 2
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Included error output of the docker/crictl into the
kubeadm error output. This should help users to understand better
why runtime is failing.

**Release note**:
```release-note
NONE
```
