### PR TITLE
kubeadm: Pull sidecar and dnsmasq-nanny images when using kube-dns

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -80,10 +80,14 @@ func GetAllImages(cfg *kubeadmapi.InitConfiguration) []string {
 		imgs = append(imgs, GetEtcdImage(cfg))
 	}
 
-	dnsImage := GetGenericArchImage(cfg.ImageRepository, "k8s-dns-kube-dns", constants.KubeDNSVersion)
+	// Append the appropriate DNS images
 	if features.Enabled(cfg.FeatureGates, features.CoreDNS) {
-		dnsImage = fmt.Sprintf("%s/%s:%s", cfg.ImageRepository, constants.CoreDNS, constants.CoreDNSVersion)
+		imgs = append(imgs, GetGenericImage(cfg.ImageRepository, constants.CoreDNS, constants.CoreDNSVersion))
+	} else {
+		imgs = append(imgs, GetGenericArchImage(cfg.ImageRepository, "k8s-dns-kube-dns", constants.KubeDNSVersion))
+		imgs = append(imgs, GetGenericArchImage(cfg.ImageRepository, "k8s-dns-sidecar", constants.KubeDNSVersion))
+		imgs = append(imgs, GetGenericArchImage(cfg.ImageRepository, "k8s-dns-dnsmasq-nanny", constants.KubeDNSVersion))
 	}
-	imgs = append(imgs, dnsImage)
+
 	return imgs
 }

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -211,6 +211,42 @@ func TestGetAllImages(t *testing.T) {
 			},
 			expect: constants.Etcd,
 		},
+		{
+			name: "CoreDNS image is returned",
+			cfg: &kubeadmapi.InitConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": true,
+				},
+			},
+			expect: constants.CoreDNS,
+		},
+		{
+			name: "main kube-dns image is returned",
+			cfg: &kubeadmapi.InitConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
+				},
+			},
+			expect: "k8s-dns-kube-dns",
+		},
+		{
+			name: "kube-dns sidecar image is returned",
+			cfg: &kubeadmapi.InitConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
+				},
+			},
+			expect: "k8s-dns-sidecar",
+		},
+		{
+			name: "kube-dns dnsmasq-nanny image is returned",
+			cfg: &kubeadmapi.InitConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
+				},
+			},
+			expect: "k8s-dns-dnsmasq-nanny",
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

It appears that sidecar and dnsmasq-nanny images are now required for
kube-dns deployment to work correctly. Thus the following default kube-dns
images are used now:

- k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
- k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
- k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1016

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/assign @luxas
/assign @timothysc
/kind bug

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: Pull sidecar and dnsmasq-nanny images when using kube-dns
```
