### PR TITLE
e2e: don't require heapster

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -839,9 +839,6 @@ metadata:
 			output := framework.RunKubectlOrDie("cluster-info")
 			// Can't check exact strings due to terminal control commands (colors)
 			requiredItems := []string{"Kubernetes master", "is running at"}
-			if framework.ProviderIs("gce", "gke") {
-				requiredItems = append(requiredItems, "Heapster")
-			}
 			for _, item := range requiredItems {
 				if !strings.Contains(output, item) {
 					framework.Failf("Missing %s in kubectl cluster-info", item)


### PR DESCRIPTION
As heapster is now deprecated, we shouldn't require it for e2e tests to pass.


```release-note
NONE
```