### PR TITLE
Add test for kubectl cluster-info dump

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -845,6 +845,13 @@ metadata:
 		})
 	})
 
+	framework.KubeDescribe("Kubectl cluster-info dump", func() {
+		It("should check if cluster-info dump succeeds", func() {
+			By("running cluster-info dump")
+			framework.RunKubectlOrDie("cluster-info", "dump")
+		})
+	})
+
 	framework.KubeDescribe("Kubectl describe", func() {
 		/*
 			Release : v1.9


### PR DESCRIPTION
kubectl cluster-info dump is currently giving a schema error; adding a
test for it.


```release-note
NONE
```