### PR TITLE
Updating ceph to use CSI for k8s >= 1.10

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions.yaml
+++ b/cluster/juju/layers/kubernetes-master/actions.yaml
@@ -1,7 +1,7 @@
 restart:
   description: Restart the Kubernetes master services on demand.
 create-rbd-pv:
-  description: Create RADOS Block Device (RDB) volume in Ceph and creates PersistentVolume.
+  description: Create RADOS Block Device (RDB) volume in Ceph and creates PersistentVolume. Note this is deprecated on Kubernetes >= 1.10 in favor of CSI, where PersistentVolumes are created dynamically to back PersistentVolumeClaims.
   params:
     name:
       type: string

--- a/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
+++ b/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
@@ -38,6 +38,14 @@ def main():
     this script thinks the environment is 'sane' enough to provision volumes.
     '''
 
+    # k8s >= 1.10 uses CSI and doesn't directly create persistent volumes
+    if get_version('kube-apiserver') >= (1, 10):
+       print('This action is deprecated in favor of CSI creation of persistent volumes')
+       print('in Kubernetes >= 1.10. Just create the PVC and a PV will be created')
+       print('for you.')
+       action_fail('Deprecated, just create PVC.')
+       return
+
     # validate relationship pre-reqs before additional steps can be taken
     if not validate_relation():
         print('Failed ceph relationship check')
@@ -87,6 +95,23 @@ def main():
         cmd = ['kubectl', 'create', '-f', temp_template]
         debug_command(cmd)
         check_call(cmd)
+
+
+def get_version(bin_name):
+    """Get the version of an installed Kubernetes binary.
+
+    :param str bin_name: Name of binary
+    :return: 3-tuple version (maj, min, patch)
+
+    Example::
+
+        >>> `get_version('kubelet')
+        (1, 6, 0)
+
+    """
+    cmd = '{} --version'.format(bin_name).split()
+    version_string = check_output(cmd).decode('utf-8')
+    return tuple(int(q) for q in re.findall("[0-9]+", version_string)[:3])
 
 
 def action_get_or_default(key):

--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -99,3 +99,9 @@ options:
     default: true
     description: |
       If true the metrics server for Kubernetes will be deployed onto the cluster.
+  default-storage:
+    type: string
+    default: "auto"
+    description: |
+      The storage class to make the default storage class. Allowed values are "auto",
+      "none", "ceph-xfs", "ceph-ext4". Note: Only works in Kubernetes >= 1.10

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -683,12 +683,14 @@ def configure_cdk_addons():
         cephEnabled = "true"
     else:
         cephEnabled = "false"
-    ceph = endpoint_from_flag('ceph-storage.available')
-    if ceph:
-        b64_ceph_key = base64.b64encode(ceph.key().encode('utf-8'))
-        ceph_admin_key = b64_ceph_key.decode('ascii')
-        ceph_kubernetes_key = b64_ceph_key.decode('ascii')
-        ceph_mon_hosts = ceph.mon_hosts()
+    ceph_ep = endpoint_from_flag('ceph-storage.available')
+    ceph = {}
+    default_storage = ''
+    if ceph_ep:
+        b64_ceph_key = base64.b64encode(ceph_ep.key().encode('utf-8'))
+        ceph['admin_key'] = b64_ceph_key.decode('ascii')
+        ceph['kubernetes_key'] = b64_ceph_key.decode('ascii')
+        ceph['mon_hosts'] = ceph_ep.mon_hosts()
         default_storage = hookenv.config('default-storage')
 
     args = [
@@ -700,10 +702,10 @@ def configure_cdk_addons():
         'enable-metrics=' + metricsEnabled,
         'enable-gpu=' + str(gpuEnable).lower(),
         'enable-ceph=' + cephEnabled,
-        'ceph-admin-key=' + (ceph_admin_key or ''),
-        'ceph-kubernetes-key=' + (ceph_admin_key or ''),
-        'ceph-mon-hosts="' + (ceph_mon_hosts or '') + '"',
-        'default-storage=' + (default_storage or ''),
+        'ceph-admin-key=' + (ceph.get('admin_key', '')),
+        'ceph-kubernetes-key=' + (ceph.get('admin_key', '')),
+        'ceph-mon-hosts="' + (ceph.get('mon_hosts', '')) + '"',
+        'default-storage=' + default_storage,
     ]
     check_call(['snap', 'set', 'cdk-addons'] + args)
     if not addons_ready():

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -27,6 +27,7 @@ import ipaddress
 from charms.leadership import leader_get, leader_set
 
 from shutil import move
+from tempfile import TemporaryDirectory
 
 from pathlib import Path
 from shlex import split
@@ -666,6 +667,7 @@ def kick_api_server(tls):
 
 
 @when('kubernetes-master.components.started')
+@when('leadership.is_leader')
 def configure_cdk_addons():
     ''' Configure CDK addons '''
     remove_state('cdk-addons.configured')
@@ -758,6 +760,11 @@ def ceph_storage(ceph_admin):
     configuration, and the ceph secret key file used for authentication.
     This method will install the client package, and render the requisit files
     in order to consume the ceph-storage relation.'''
+
+    # deprecated in 1.10 in favor of using CSI
+    if get_version('kube-apiserver') >= (1, 10):
+        return
+
     ceph_context = {
         'mon_hosts': ceph_admin.mon_hosts(),
         'fsid': ceph_admin.fsid(),
@@ -815,6 +822,140 @@ def ceph_storage(ceph_admin):
     # have performed the necessary pre-req steps to interface with a ceph
     # deployment.
     set_state('ceph-storage.configured')
+
+
+@when('config.changed.default-storage')
+def render_ceph():
+    remove_state('ceph-storage.configured')
+
+
+@when('ceph-storage.available')
+@when('cdk-addons.configured')
+@when_not('ceph-storage.configured')
+def ceph_csi_storage(ceph_admin):
+    '''Ceph on kubernetes will require a few things put on the cluster.
+    This includes a provisioner and storage class. This method will
+    put those things on the cluster.'''
+
+    # Pre-CSI versions still use the old apt version and manual volume
+    # creation, so skip the CSI stuff
+    if get_version('kube-apiserver') < (1, 10):
+        return
+
+    if ceph_admin.key():
+        encoded_key = base64.b64encode(ceph_admin.key().encode('utf-8'))
+    else:
+        # We didn't have a key, and cannot proceed. Do not set state and
+        # allow this method to re-execute
+        return
+
+    ceph_context = {
+        'mon_hosts': ceph_admin.mon_hosts(),
+        'fsid': ceph_admin.fsid(),
+        'auth_supported': ceph_admin.auth(),
+        'use_syslog': "true",
+        'ceph_public_network': '',
+        'ceph_cluster_network': '',
+        'loglevel': 1,
+        'hostname': socket.gethostname(),
+        'admin_key': encoded_key.decode('ascii'),
+        'kubernetes_key': encoded_key.decode('ascii'),
+    }
+
+    # Install the ceph common utilities.
+    apt_install(['ceph-common'], fatal=True)
+
+    etc_ceph_directory = '/etc/ceph'
+    if not os.path.isdir(etc_ceph_directory):
+        os.makedirs(etc_ceph_directory)
+    charm_ceph_conf = os.path.join(etc_ceph_directory, 'ceph.conf')
+    # Render the ceph configuration from the ceph conf template
+    render('ceph.conf', charm_ceph_conf, ceph_context)
+
+    config = hookenv.config()
+    default_storage = config.get('default-storage')
+
+    # Create the ceph yamls from templates in cdk-addons
+    with TemporaryDirectory() as template_path:
+        addon_path = str(_cdk_addons_template_path())
+        render('rbd-secrets.yaml',
+               '{}/rbd-secrets.yaml'.format(template_path), ceph_context,
+               templates_dir=addon_path)
+        render('rbdplugin.yaml',
+               '{}/rbdplugin.yaml'.format(template_path), ceph_context,
+               templates_dir=addon_path)
+        render('csi-provisioner.yaml',
+               '{}/csi-provisioner.yaml'.format(template_path), ceph_context,
+               templates_dir=addon_path)
+        render('csi-attacher.yaml',
+               '{}/csi-attacher.yaml'.format(template_path), ceph_context,
+               templates_dir=addon_path)
+        ceph_context['pool_name'] = 'ext4-pool'
+        ceph_context['fs_type'] = 'ext4'
+        ceph_context['sc_name'] = 'ceph-ext4'
+        if default_storage == 'ceph-ext4':
+            ceph_context['default'] = True
+        else:
+            ceph_context['default'] = False
+        render('rbd-storage-class.yaml',
+               '{}/rbd-storage-class-ext4.yaml'.format(template_path),
+               ceph_context, templates_dir=addon_path)
+        ceph_context['pool_name'] = 'xfs-pool'
+        ceph_context['fs_type'] = 'ext4'
+        ceph_context['sc_name'] = 'ceph-xfs'
+        if default_storage == 'ceph-xfs' or default_storage == 'auto':
+            ceph_context['default'] = True
+        else:
+            ceph_context['default'] = False
+        render('rbd-storage-class.yaml',
+               '{}/rbd-storage-class-xfs.yaml'.format(template_path),
+               ceph_context, templates_dir=addon_path)
+
+        try:
+            # At first glance this is deceptive. The apply stanza will create
+            # if it doesn't exist, otherwise it will update the entry
+            cmd = ['kubectl', 'apply', '-f', template_path]
+            check_call(cmd)
+        except:  # NOQA
+            # the enlistment in kubernetes failed, return and prepare for
+            # re-exec
+            return
+
+    # when complete, set a state relating to configuration of the storage
+    # backend that will allow other modules to hook into this and verify we
+    # have performed the necessary pre-req steps to interface with a ceph
+    # deployment.
+    set_state('ceph-storage.configured')
+
+
+@when_not('ceph-storage.available')
+@when('ceph-storage.configured')
+def remove_ceph():
+    # Pre-CSI versions still use the old apt version and manual volume
+    # creation, so skip the CSI stuff
+    if get_version('kube-apiserver') < (1, 10):
+        return
+
+    ceph_things = [['secret', 'csi-ceph-secret'],
+                   ['sc', 'ceph-xfs'],
+                   ['sc', 'ceph-ext4'],
+                   ['serviceaccount', 'csi-rbdplugin'],
+                   ['clusterrole', 'csi-rbdplugin'],
+                   ['clusterrolebinding', 'csi-rbdplugin'],
+                   ['daemonset', 'csi-rbdplugin'],
+                   ['serviceaccount', 'csi-attacher'],
+                   ['clusterrole', 'external-attacher-runner'],
+                   ['clusterrolebinding', 'csi-attacher-role'],
+                   ['service', 'csi-attacher'],
+                   ['statefulset', 'csi-attacher'],
+                   ['serviceaccount', 'csi-provisioner'],
+                   ['clusterrole', 'external-provisioner-runner'],
+                   ['clusterrolebinding', 'csi-provisioner-role'],
+                   ['service', 'csi-provisioner'],
+                   ['statefulset', 'csi-provisioner']]
+    for entity in ceph_things:
+        cmd = 'kubectl delete {} {}'.format(entity[0], entity[1])
+        check_call(split(cmd))
 
 
 @when('nrpe-external-master.available')
@@ -1579,6 +1720,10 @@ def _gcp_creds_path(component):
 
 def _daemon_env_path(component):
     return _snap_common_path(component) / 'environment'
+
+
+def _cdk_addons_template_path():
+    return Path('/snap/cdk-addons/current/templates')
 
 
 def _write_gcp_snap_config(component):

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -666,7 +666,7 @@ def kick_api_server(tls):
     tls_client.reset_certificate_write_flag('server')
 
 
-@when('kubernetes-master.components.started')
+@when_any('kubernetes-master.components.started', 'ceph-storage.configured')
 @when('leadership.is_leader')
 def configure_cdk_addons():
     ''' Configure CDK addons '''
@@ -678,6 +678,19 @@ def configure_cdk_addons():
     dbEnabled = str(hookenv.config('enable-dashboard-addons')).lower()
     dnsEnabled = str(hookenv.config('enable-kube-dns')).lower()
     metricsEnabled = str(hookenv.config('enable-metrics')).lower()
+    if (is_state('ceph-storage.configured') and
+            get_version('kube-apiserver') >= (1, 10)):
+        cephEnabled = "true"
+    else:
+        cephEnabled = "false"
+    ceph = endpoint_from_flag('ceph-storage.available')
+    if ceph:
+        b64_ceph_key = base64.b64encode(ceph.key().encode('utf-8'))
+        ceph_admin_key = b64_ceph_key.decode('ascii')
+        ceph_kubernetes_key = b64_ceph_key.decode('ascii')
+        ceph_mon_hosts = ceph.mon_hosts()
+        default_storage = hookenv.config('default-storage')
+
     args = [
         'arch=' + arch(),
         'dns-ip=' + get_deprecated_dns_ip(),
@@ -685,7 +698,12 @@ def configure_cdk_addons():
         'enable-dashboard=' + dbEnabled,
         'enable-kube-dns=' + dnsEnabled,
         'enable-metrics=' + metricsEnabled,
-        'enable-gpu=' + str(gpuEnable).lower()
+        'enable-gpu=' + str(gpuEnable).lower(),
+        'enable-ceph=' + cephEnabled,
+        'ceph-admin-key=' + (ceph_admin_key or ''),
+        'ceph-kubernetes-key=' + (ceph_admin_key or ''),
+        'ceph-mon-hosts="' + (ceph_mon_hosts or '') + '"',
+        'default-storage=' + (default_storage or ''),
     ]
     check_call(['snap', 'set', 'cdk-addons'] + args)
     if not addons_ready():
@@ -763,6 +781,10 @@ def ceph_storage(ceph_admin):
 
     # deprecated in 1.10 in favor of using CSI
     if get_version('kube-apiserver') >= (1, 10):
+        # this is actually false, but by setting this flag we won't keep
+        # running this function for no reason. Also note that we watch this
+        # flag to run cdk-addons.apply.
+        set_state('ceph-storage.configured')
         return
 
     ceph_context = {
@@ -822,140 +844,6 @@ def ceph_storage(ceph_admin):
     # have performed the necessary pre-req steps to interface with a ceph
     # deployment.
     set_state('ceph-storage.configured')
-
-
-@when('config.changed.default-storage')
-def render_ceph():
-    remove_state('ceph-storage.configured')
-
-
-@when('ceph-storage.available')
-@when('cdk-addons.configured')
-@when_not('ceph-storage.configured')
-def ceph_csi_storage(ceph_admin):
-    '''Ceph on kubernetes will require a few things put on the cluster.
-    This includes a provisioner and storage class. This method will
-    put those things on the cluster.'''
-
-    # Pre-CSI versions still use the old apt version and manual volume
-    # creation, so skip the CSI stuff
-    if get_version('kube-apiserver') < (1, 10):
-        return
-
-    if ceph_admin.key():
-        encoded_key = base64.b64encode(ceph_admin.key().encode('utf-8'))
-    else:
-        # We didn't have a key, and cannot proceed. Do not set state and
-        # allow this method to re-execute
-        return
-
-    ceph_context = {
-        'mon_hosts': ceph_admin.mon_hosts(),
-        'fsid': ceph_admin.fsid(),
-        'auth_supported': ceph_admin.auth(),
-        'use_syslog': "true",
-        'ceph_public_network': '',
-        'ceph_cluster_network': '',
-        'loglevel': 1,
-        'hostname': socket.gethostname(),
-        'admin_key': encoded_key.decode('ascii'),
-        'kubernetes_key': encoded_key.decode('ascii'),
-    }
-
-    # Install the ceph common utilities.
-    apt_install(['ceph-common'], fatal=True)
-
-    etc_ceph_directory = '/etc/ceph'
-    if not os.path.isdir(etc_ceph_directory):
-        os.makedirs(etc_ceph_directory)
-    charm_ceph_conf = os.path.join(etc_ceph_directory, 'ceph.conf')
-    # Render the ceph configuration from the ceph conf template
-    render('ceph.conf', charm_ceph_conf, ceph_context)
-
-    config = hookenv.config()
-    default_storage = config.get('default-storage')
-
-    # Create the ceph yamls from templates in cdk-addons
-    with TemporaryDirectory() as template_path:
-        addon_path = str(_cdk_addons_template_path())
-        render('rbd-secrets.yaml',
-               '{}/rbd-secrets.yaml'.format(template_path), ceph_context,
-               templates_dir=addon_path)
-        render('rbdplugin.yaml',
-               '{}/rbdplugin.yaml'.format(template_path), ceph_context,
-               templates_dir=addon_path)
-        render('csi-provisioner.yaml',
-               '{}/csi-provisioner.yaml'.format(template_path), ceph_context,
-               templates_dir=addon_path)
-        render('csi-attacher.yaml',
-               '{}/csi-attacher.yaml'.format(template_path), ceph_context,
-               templates_dir=addon_path)
-        ceph_context['pool_name'] = 'ext4-pool'
-        ceph_context['fs_type'] = 'ext4'
-        ceph_context['sc_name'] = 'ceph-ext4'
-        if default_storage == 'ceph-ext4':
-            ceph_context['default'] = True
-        else:
-            ceph_context['default'] = False
-        render('rbd-storage-class.yaml',
-               '{}/rbd-storage-class-ext4.yaml'.format(template_path),
-               ceph_context, templates_dir=addon_path)
-        ceph_context['pool_name'] = 'xfs-pool'
-        ceph_context['fs_type'] = 'ext4'
-        ceph_context['sc_name'] = 'ceph-xfs'
-        if default_storage == 'ceph-xfs' or default_storage == 'auto':
-            ceph_context['default'] = True
-        else:
-            ceph_context['default'] = False
-        render('rbd-storage-class.yaml',
-               '{}/rbd-storage-class-xfs.yaml'.format(template_path),
-               ceph_context, templates_dir=addon_path)
-
-        try:
-            # At first glance this is deceptive. The apply stanza will create
-            # if it doesn't exist, otherwise it will update the entry
-            cmd = ['kubectl', 'apply', '-f', template_path]
-            check_call(cmd)
-        except:  # NOQA
-            # the enlistment in kubernetes failed, return and prepare for
-            # re-exec
-            return
-
-    # when complete, set a state relating to configuration of the storage
-    # backend that will allow other modules to hook into this and verify we
-    # have performed the necessary pre-req steps to interface with a ceph
-    # deployment.
-    set_state('ceph-storage.configured')
-
-
-@when_not('ceph-storage.available')
-@when('ceph-storage.configured')
-def remove_ceph():
-    # Pre-CSI versions still use the old apt version and manual volume
-    # creation, so skip the CSI stuff
-    if get_version('kube-apiserver') < (1, 10):
-        return
-
-    ceph_things = [['secret', 'csi-ceph-secret'],
-                   ['sc', 'ceph-xfs'],
-                   ['sc', 'ceph-ext4'],
-                   ['serviceaccount', 'csi-rbdplugin'],
-                   ['clusterrole', 'csi-rbdplugin'],
-                   ['clusterrolebinding', 'csi-rbdplugin'],
-                   ['daemonset', 'csi-rbdplugin'],
-                   ['serviceaccount', 'csi-attacher'],
-                   ['clusterrole', 'external-attacher-runner'],
-                   ['clusterrolebinding', 'csi-attacher-role'],
-                   ['service', 'csi-attacher'],
-                   ['statefulset', 'csi-attacher'],
-                   ['serviceaccount', 'csi-provisioner'],
-                   ['clusterrole', 'external-provisioner-runner'],
-                   ['clusterrolebinding', 'csi-provisioner-role'],
-                   ['service', 'csi-provisioner'],
-                   ['statefulset', 'csi-provisioner']]
-    for entity in ceph_things:
-        cmd = 'kubectl delete {} {}'.format(entity[0], entity[1])
-        check_call(split(cmd))
 
 
 @when('nrpe-external-master.available')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Updates the ceph charms to use CSI if the k8s version is >= 1.10
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubernetes juju charms will now use CSI for ceph.
```
