### PR TITLE
Propagate service annotations to endpoints.

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -486,8 +486,9 @@ func (e *EndpointController) syncService(key string) error {
 		if errors.IsNotFound(err) {
 			currentEndpoints = &v1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   service.Name,
-					Labels: service.Labels,
+					Name:        service.Name,
+					Labels:      service.Labels,
+					Annotations: service.Annotations,
 				},
 			}
 		} else {
@@ -499,16 +500,15 @@ func (e *EndpointController) syncService(key string) error {
 
 	if !createEndpoints &&
 		apiequality.Semantic.DeepEqual(currentEndpoints.Subsets, subsets) &&
-		apiequality.Semantic.DeepEqual(currentEndpoints.Labels, service.Labels) {
+		apiequality.Semantic.DeepEqual(currentEndpoints.Labels, service.Labels) &&
+		apiequality.Semantic.DeepEqual(currentEndpoints.Annotations, service.Annotations) {
 		glog.V(5).Infof("endpoints are equal for %s/%s, skipping update", service.Namespace, service.Name)
 		return nil
 	}
 	newEndpoints := currentEndpoints.DeepCopy()
 	newEndpoints.Subsets = subsets
 	newEndpoints.Labels = service.Labels
-	if newEndpoints.Annotations == nil {
-		newEndpoints.Annotations = make(map[string]string)
-	}
+	newEndpoints.Annotations = service.Annotations
 
 	glog.V(4).Infof("Update endpoints for %v/%v, ready: %d not ready: %d", service.Namespace, service.Name, totalReadyEps, totalNotReadyEps)
 	if createEndpoints {


### PR DESCRIPTION
**What this PR does / why we need it**:

Make annotations defined on a service be propagated to the correspondent endpoints resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #60703

**Special notes for your reviewer**:

* This piece of code was reminiscent of a previous iteration where an annotation was placed on the `newEndpoints` object, but it is not required anymore and hence can be replaced with assignment:

    ```
    if newEndpoints.Annotations == nil {
        newEndpoints.Annotations = make(map[string]string)
    }
    ```

* I decided to adapt existing tests for labels instead of adding a new test specifically for annotations.

**Release note**:

```release-note
Make annotations defined on a service be propagated to the correspondent endpoints resource.
```