### PR TITLE
Adds deprecated message to custom flags usage template

### DIFF
--- a/pkg/kubectl/cmd/templates/BUILD
+++ b/pkg/kubectl/cmd/templates/BUILD
@@ -1,6 +1,7 @@
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -38,4 +39,11 @@ filegroup(
     visibility = [
         "//build/visible_to:pkg_kubectl_cmd_templates_CONSUMERS",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["templater_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )

--- a/pkg/kubectl/cmd/templates/templater.go
+++ b/pkg/kubectl/cmd/templates/templater.go
@@ -223,7 +223,11 @@ func flagsUsages(f *flag.FlagSet) string {
 			format = "   %s   " + format
 		}
 
-		fmt.Fprintf(x, format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
+		usage := flag.Usage
+		if len(flag.Deprecated) != 0 {
+			usage += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
+		}
+		fmt.Fprintf(x, format, flag.Shorthand, flag.Name, flag.DefValue, usage)
 	})
 
 	return x.String()

--- a/pkg/kubectl/cmd/templates/templater_test.go
+++ b/pkg/kubectl/cmd/templates/templater_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func Test_flagsUsages_not_deprecated(t *testing.T) {
+	flags := pflag.NewFlagSet("deprecatedflagtest", pflag.ContinueOnError)
+	flags.String("new-flag", "", "The new flag for the some command")
+
+	usage := flagsUsages(flags)
+
+	if strings.Contains(usage, "DEPRECATED") {
+		t.Errorf("template should not contain DEPRECATED text, got '%s'", usage)
+	}
+}
+
+func Test_flagsUsages_deprecated(t *testing.T) {
+	flags := pflag.NewFlagSet("deprecatedflagtest", pflag.ContinueOnError)
+	oldFlag := "old-flag"
+	useInstead := "Use --new-flag instead"
+	flags.String(oldFlag, "", "Old flag for some command")
+	flags.MarkDeprecated(oldFlag, useInstead)
+	tests := []struct {
+		name   string
+		hidden bool
+	}{
+		{
+			name:   "hidden",
+			hidden: true,
+		},
+		{
+			name:   "visible",
+			hidden: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags.Lookup(oldFlag).Hidden = tt.hidden
+
+			usage := flagsUsages(flags)
+
+			if tt.hidden && usage != "" {
+				t.Errorf("%v: template for hidden deprecated flag should be empty, got '%s'", tt.name, usage)
+			} else if !tt.hidden {
+				if !strings.Contains(usage, "DEPRECATED") {
+					t.Errorf("%v: template for deprecated flag should contain DEPRECATED text, got '%s'", tt.name, usage)
+				}
+				if !strings.Contains(usage, useInstead) {
+					t.Errorf("%v: template for deprecated flag should contain the provided use instead message, got '%s'", tt.name, usage)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds deprecated message to custom flags usage template, which allows non-hidden deprecated flags to be decorated with deprecated message.

We only need this if we want a deprecated flag that has been explicitly set to show in the help menu (with `cmd.Flag("flagname").Hidden = false`) to also display it's deprecated message in the flag usage line.

This PR does not affect deprecated flags that are already hidden from the help menu (currently deprecated flags are hidden by default).

This is a follow up of pull request https://github.com/kubernetes/kubernetes/pull/54629.

**Release note**:
```release-note
NONE
```

