### PR TITLE
Mark --pod/-p flag of kubectl exec command as deprecated

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -85,6 +85,7 @@ func NewCmdExec(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 	cmd.Flags().StringVarP(&options.PodName, "pod", "p", options.PodName, "Pod name")
+	cmd.Flags().MarkDeprecated("pod", "This flag is deprecated and will be removed in future. Use exec POD_NAME instead.")
 	// TODO support UID
 	cmd.Flags().StringVarP(&options.ContainerName, "container", "c", options.ContainerName, "Container name. If omitted, the first container in the pod will be chosen")
 	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", options.Stdin, "Pass stdin to the container")

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -154,7 +154,6 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 		return cmdutil.UsageErrorf(cmd, execUsageStr)
 	}
 	if len(p.PodName) != 0 {
-		printDeprecationWarning(p.ErrOut, "exec POD_NAME", "-p POD_NAME")
 		if len(argsIn) < 1 {
 			return cmdutil.UsageErrorf(cmd, execUsageStr)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Marks the `--pod` (`-p` shorthand) flag of kubectl `exec` command as deprecated.
Hides the flag from the help menu, but shows a message when command is executed with this flag.

**Which issue this PR fixes**:
Fixes:  https://github.com/kubernetes/kubectl/issues/104

This is a remake of PR https://github.com/kubernetes/kubernetes/pull/54629.

**Release note**:
```release-note
Flag --pod (-p shorthand) of kubectl exec command marked as deprecated
```

