### PR TITLE
Return combined list of mount options from MountOptionFromSpec().

### DIFF
--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -521,21 +521,25 @@ func UnmountViaEmptyDir(dir string, host volume.VolumeHost, volName string, volS
 
 // MountOptionFromSpec extracts and joins mount options from volume spec with supplied options
 func MountOptionFromSpec(spec *volume.Spec, options ...string) []string {
+	var specMoList, annMoList, finalMoList []string
 	pv := spec.PersistentVolume
 
 	if pv != nil {
 		// Use beta annotation first
 		if mo, ok := pv.Annotations[v1.MountOptionAnnotation]; ok {
-			moList := strings.Split(mo, ",")
-			return JoinMountOptions(moList, options)
+			annMoList = strings.Split(mo, ",")
 		}
 
+		// Get mountoptions from spec mountoptins field
 		if len(pv.Spec.MountOptions) > 0 {
-			return JoinMountOptions(pv.Spec.MountOptions, options)
+			specMoList = pv.Spec.MountOptions
 		}
 	}
 
-	return options
+	// Combine the mount options.
+	finalMoList = JoinMountOptions(annMoList, specMoList)
+
+	return JoinMountOptions(finalMoList, options)
 }
 
 // JoinMountOptions joins mount options eliminating duplicates


### PR DESCRIPTION
At present, MountOptionFromSpec() return when `MountOptionAnnotation`
has been set in pv spec, there could be scenarios where pv spec
has both annotation and also pv.spec.mountoptions set for a PV.
In these sitations it will never gather mount options from pv.spec.mountoptions.

This patch enables MountOptionFromSpec to return combined
list if mount options are present in both annotation and spec.mountoptions
field.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
