### PR TITLE
stop mutating selector input by sorting the passed slice in place

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -166,7 +166,6 @@ func NewRequirement(key string, op selection.Operator, vals []string) (*Requirem
 			return nil, err
 		}
 	}
-	sort.Strings(vals)
 	return &Requirement{key: key, operator: op, strValues: vals}, nil
 }
 


### PR DESCRIPTION
Alternative to https://github.com/kubernetes/kubernetes/pull/66480
Fixes https://github.com/kubernetes/kubernetes/issues/66298

The sort was introduced when https://github.com/kubernetes/kubernetes/pull/35194 went in to avoid maps.  Near as I can tell, no caller actually requires it and the string representation would still be stable because the order doesn't change.  This simply removes the sort and lets the values stay in the order specified.

@kubernetes/sig-api-machinery-pr-reviews 
@Huang-Wei