### PR TITLE
Get load balancer name per provider

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -64,7 +64,7 @@ type Clusters interface {
 
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
-func GetLoadBalancerName(service *v1.Service) string {
+func DefaultLoadBalancerName(service *v1.Service) string {
 	//GCE requires that the name of a load balancer starts with a lower case letter.
 	ret := "a" + string(service.UID)
 	ret = strings.Replace(ret, "-", "", -1)
@@ -96,6 +96,9 @@ type LoadBalancer interface {
 	// Implementations must treat the *v1.Service parameter as read-only and not modify it.
 	// Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 	GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error)
+	// GetLoadBalancerName returns the name of the load balancer. Implementations must treat the
+	// *v1.Service parameter as read-only and not modify it.
+	GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string
 	// EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
 	// Implementations must treat the *v1.Service and *v1.Node
 	// parameters as read-only and not modify them.

--- a/pkg/cloudprovider/providers/azure/azure_standard_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_standard_test.go
@@ -171,7 +171,7 @@ func TestMapLoadBalancerNameToVMSet(t *testing.T) {
 	}
 }
 
-func TestGetLoadBalancerName(t *testing.T) {
+func TestGetAzureLoadBalancerName(t *testing.T) {
 	az := getTestCloud()
 	az.PrimaryAvailabilitySetName = "primary"
 
@@ -247,7 +247,7 @@ func TestGetLoadBalancerName(t *testing.T) {
 		} else {
 			az.Config.LoadBalancerSku = loadBalancerSkuBasic
 		}
-		loadbalancerName := az.getLoadBalancerName(c.clusterName, c.vmSet, c.isInternal)
+		loadbalancerName := az.getAzureLoadBalancerName(c.clusterName, c.vmSet, c.isInternal)
 		assert.Equal(t, c.expected, loadbalancerName, c.description)
 	}
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"k8s.io/api/core/v1"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 type loadBalancer struct {
@@ -238,11 +237,16 @@ func (cs *CSCloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName st
 	return nil
 }
 
+// GetLoadBalancerName retrieves the name of the LoadBalancer.
+func (cs *CSCloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+	return cs.GetLoadBalancerName(ctx, clusterName, service)
+}
+
 // getLoadBalancer retrieves the IP address and ID and all the existing rules it can find.
 func (cs *CSCloud) getLoadBalancer(service *v1.Service) (*loadBalancer, error) {
 	lb := &loadBalancer{
 		CloudStackClient: cs.client,
-		name:             cloudprovider.GetLoadBalancerName(service),
+		name:             cs.GetLoadBalancerName(context.TODO(), "", service),
 		projectID:        cs.projectID,
 		rules:            make(map[string]*cloudstack.LoadBalancerRule),
 	}

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -154,6 +154,11 @@ func (f *FakeCloud) GetLoadBalancer(ctx context.Context, clusterName string, ser
 	return status, f.Exists, f.Err
 }
 
+// GetLoadBalancerName is a stub implementation of LoadBalancer.GetLoadBalancerName.
+func (f *FakeCloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+	return cloudprovider.DefaultLoadBalancerName(service)
+}
+
 // EnsureLoadBalancer is a test-spy implementation of LoadBalancer.EnsureLoadBalancer.
 // It adds an entry "create" into the internal method call record.
 func (f *FakeCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
@@ -162,7 +167,7 @@ func (f *FakeCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, 
 		f.Balancers = make(map[string]FakeBalancer)
 	}
 
-	name := cloudprovider.GetLoadBalancerName(service)
+	name := f.GetLoadBalancerName(ctx, clusterName, service)
 	spec := service.Spec
 
 	zone, err := f.GetZone(context.TODO())

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
@@ -92,7 +92,7 @@ func LoadBalancerSrcRanges() []string {
 
 // GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
 func (gce *GCECloud) GetLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(svc)
+	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
 	fwd, err := gce.GetRegionForwardingRule(loadBalancerName, gce.region)
 	if err == nil {
 		status := &v1.LoadBalancerStatus{}
@@ -103,9 +103,14 @@ func (gce *GCECloud) GetLoadBalancer(ctx context.Context, clusterName string, sv
 	return nil, false, ignoreNotFound(err)
 }
 
+// GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName.
+func (gce *GCECloud) GetLoadBalancerName(ctx context.Context, clusterName string, svc *v1.Service) string {
+	return cloudprovider.DefaultLoadBalancerName(svc)
+}
+
 // EnsureLoadBalancer is an implementation of LoadBalancer.EnsureLoadBalancer.
 func (gce *GCECloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(svc)
+	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
 	desiredScheme := getSvcScheme(svc)
 	clusterID, err := gce.ClusterID.GetID()
 	if err != nil {
@@ -154,7 +159,7 @@ func (gce *GCECloud) EnsureLoadBalancer(ctx context.Context, clusterName string,
 
 // UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
 func (gce *GCECloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(svc)
+	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
 	scheme := getSvcScheme(svc)
 	clusterID, err := gce.ClusterID.GetID()
 	if err != nil {
@@ -175,7 +180,7 @@ func (gce *GCECloud) UpdateLoadBalancer(ctx context.Context, clusterName string,
 
 // EnsureLoadBalancerDeleted is an implementation of LoadBalancer.EnsureLoadBalancerDeleted.
 func (gce *GCECloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, svc *v1.Service) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(svc)
+	loadBalancerName := gce.GetLoadBalancerName(ctx, clusterName, svc)
 	scheme := getSvcScheme(svc)
 	clusterID, err := gce.ClusterID.GetID()
 	if err != nil {

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/mock"
@@ -330,7 +329,7 @@ func TestUpdateExternalLoadBalancer(t *testing.T) {
 	err = gce.updateExternalLoadBalancer("", svc, newNodes)
 	assert.NoError(t, err)
 
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
 	pool, err := gce.GetTargetPool(lbName, gce.region)
 	require.NoError(t, err)
@@ -401,7 +400,7 @@ func TestLoadBalancerWrongTierResourceDeletion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cloud.NetworkTierPremium, desiredTier)
 
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	serviceName := types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
 
 	// create ForwardingRule and Address with the wrong tier
@@ -484,7 +483,7 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := fakeLoadbalancerService("")
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	ipAddr := status.Ingress[0].IP
 
 	lbIP := svc.Spec.LoadBalancerIP
@@ -566,7 +565,7 @@ func TestTargetPoolNeedsRecreation(t *testing.T) {
 
 	svc := fakeLoadbalancerService("")
 	serviceName := svc.ObjectMeta.Name
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
 	require.NoError(t, err)
 	hostNames := nodeNames(nodes)
@@ -619,7 +618,7 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 	region := vals.Region
 
 	ipAddr := status.Ingress[0].IP
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
 	ipnet, err := netsets.ParseIPNets("0.0.0.0/0")
 	require.NoError(t, err)
@@ -804,7 +803,7 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	clusterID := vals.ClusterID
 
 	ipAddr := status.Ingress[0].IP
-	lbName := cloudprovider.GetLoadBalancerName(svc)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	region := vals.Region
 
 	hcToCreate := makeHttpHealthCheck(MakeNodesHealthCheckName(clusterID), GetNodesHealthCheckPath(), GetNodesHealthCheckPort())
@@ -869,7 +868,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 	require.NoError(t, err)
 	gce.createFirewall(
 		svc,
-		cloudprovider.GetLoadBalancerName(svc),
+		gce.GetLoadBalancerName(context.TODO(), "", svc),
 		gce.region,
 		"A sad little firewall",
 		ipnet,
@@ -882,7 +881,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 
 	gce.updateFirewall(
 		svc,
-		cloudprovider.GetLoadBalancerName(svc),
+		gce.GetLoadBalancerName(context.TODO(), "", svc),
 		gce.region,
 		"A sad little firewall",
 		ipnet,

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_utils_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -37,7 +38,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	v1_service "k8s.io/kubernetes/pkg/api/v1/service"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/meta"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce/cloud/mock"
@@ -220,7 +220,7 @@ func fakeClusterID(clusterID string) ClusterID {
 }
 
 func assertExternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
-	lbName := cloudprovider.GetLoadBalancerName(apiService)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	hcName := MakeNodesHealthCheckName(vals.ClusterID)
 
 	// Check that Firewalls are created for the LoadBalancer and the HealthCheck
@@ -257,7 +257,7 @@ func assertExternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Servi
 }
 
 func assertExternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
-	lbName := cloudprovider.GetLoadBalancerName(apiService)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	hcName := MakeNodesHealthCheckName(vals.ClusterID)
 
 	if firewallsDeleted {
@@ -292,7 +292,7 @@ func assertExternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v
 }
 
 func assertInternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {
-	lbName := cloudprovider.GetLoadBalancerName(apiService)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 
 	// Check that Instance Group is created
 	igName := makeInstanceGroupName(vals.ClusterID)
@@ -345,7 +345,7 @@ func assertInternalLbResources(t *testing.T, gce *GCECloud, apiService *v1.Servi
 }
 
 func assertInternalLbResourcesDeleted(t *testing.T, gce *GCECloud, apiService *v1.Service, vals TestClusterValues, firewallsDeleted bool) {
-	lbName := cloudprovider.GetLoadBalancerName(apiService)
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", apiService)
 	sharedHealthCheck := !v1_service.RequestsOnlyLocalTraffic(apiService)
 	hcName := makeHealthCheckName(lbName, vals.ClusterID, sharedHealthCheck)
 

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -460,7 +460,7 @@ func (lbaas *LbaasV2) createLoadBalancer(service *v1.Service, name string, inter
 
 // GetLoadBalancer returns whether the specified load balancer exists and its status
 func (lbaas *LbaasV2) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(service)
+	loadBalancerName := lbaas.GetLoadBalancerName(ctx, clusterName, service)
 	loadbalancer, err := getLoadbalancerByName(lbaas.lb, loadBalancerName)
 	if err == ErrNotFound {
 		return nil, false, nil
@@ -483,6 +483,11 @@ func (lbaas *LbaasV2) GetLoadBalancer(ctx context.Context, clusterName string, s
 	}
 
 	return status, true, err
+}
+
+// GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName.
+func (lbaas *LbaasV2) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
+	return cloudprovider.DefaultLoadBalancerName(service)
 }
 
 // The LB needs to be configured with instance addresses on the same
@@ -731,7 +736,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 		return nil, fmt.Errorf("unsupported load balancer affinity: %v", affinity)
 	}
 
-	name := cloudprovider.GetLoadBalancerName(apiService)
+	name := lbaas.GetLoadBalancerName(ctx, clusterName, apiService)
 	loadbalancer, err := getLoadbalancerByName(lbaas.lb, name)
 	if err != nil {
 		if err != ErrNotFound {
@@ -1173,7 +1178,7 @@ func (lbaas *LbaasV2) ensureSecurityGroup(clusterName string, apiService *v1.Ser
 
 // UpdateLoadBalancer updates hosts under the specified load balancer.
 func (lbaas *LbaasV2) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(service)
+	loadBalancerName := lbaas.GetLoadBalancerName(ctx, clusterName, service)
 	glog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v)", clusterName, loadBalancerName, nodes)
 
 	lbaas.opts.SubnetID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetID)
@@ -1396,7 +1401,7 @@ func (lbaas *LbaasV2) updateSecurityGroup(clusterName string, apiService *v1.Ser
 
 // EnsureLoadBalancerDeleted deletes the specified load balancer
 func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
-	loadBalancerName := cloudprovider.GetLoadBalancerName(service)
+	loadBalancerName := lbaas.GetLoadBalancerName(ctx, clusterName, service)
 	glog.V(4).Infof("EnsureLoadBalancerDeleted(%v, %v)", clusterName, loadBalancerName)
 
 	loadbalancer, err := getLoadbalancerByName(lbaas.lb, loadBalancerName)

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -497,7 +497,7 @@ func (s *ServiceController) needsUpdate(oldService *v1.Service, newService *v1.S
 }
 
 func (s *ServiceController) loadBalancerName(service *v1.Service) string {
-	return cloudprovider.GetLoadBalancerName(service)
+	return s.balancer.GetLoadBalancerName(context.TODO(), "", service)
 }
 
 func getPortsForLB(service *v1.Service) ([]*v1.ServicePort, error) {
@@ -686,7 +686,7 @@ func (s *ServiceController) lockedUpdateLoadBalancerHosts(service *v1.Service, h
 
 	// It's only an actual error if the load balancer still exists.
 	if _, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service); err != nil {
-		glog.Errorf("External error while checking if load balancer %q exists: name, %v", cloudprovider.GetLoadBalancerName(service), err)
+		glog.Errorf("External error while checking if load balancer %q exists: name, %v", s.balancer.GetLoadBalancerName(context.TODO(), s.clusterName, service), err)
 	} else if !exists {
 		return nil
 	}

--- a/test/e2e/framework/firewall_util.go
+++ b/test/e2e/framework/firewall_util.go
@@ -54,7 +54,7 @@ func ConstructFirewallForLBService(svc *v1.Service, nodeTag string) *compute.Fir
 		Failf("can not construct firewall rule for non-loadbalancer type service")
 	}
 	fw := compute.Firewall{}
-	fw.Name = MakeFirewallNameForLBService(cloudprovider.GetLoadBalancerName(svc))
+	fw.Name = MakeFirewallNameForLBService(cloudprovider.DefaultLoadBalancerName(svc))
 	fw.TargetTags = []string{nodeTag}
 	if svc.Spec.LoadBalancerSourceRanges == nil {
 		fw.SourceRanges = []string{"0.0.0.0/0"}
@@ -80,7 +80,7 @@ func ConstructHealthCheckFirewallForLBService(clusterID string, svc *v1.Service,
 		Failf("can not construct firewall rule for non-loadbalancer type service")
 	}
 	fw := compute.Firewall{}
-	fw.Name = MakeHealthCheckFirewallNameForLBService(clusterID, cloudprovider.GetLoadBalancerName(svc), isNodesHealthCheck)
+	fw.Name = MakeHealthCheckFirewallNameForLBService(clusterID, cloudprovider.DefaultLoadBalancerName(svc), isNodesHealthCheck)
 	fw.TargetTags = []string{nodeTag}
 	fw.SourceRanges = gcecloud.LoadBalancerSrcRanges()
 	healthCheckPort := gcecloud.GetNodesHealthCheckPort()

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 			})
 			Expect(cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)).NotTo(HaveOccurred())
 			By("Waiting for the local traffic health check firewall rule to be deleted")
-			localHCFwName := framework.MakeHealthCheckFirewallNameForLBService(clusterID, cloudprovider.GetLoadBalancerName(svc), false)
+			localHCFwName := framework.MakeHealthCheckFirewallNameForLBService(clusterID, cloudprovider.DefaultLoadBalancerName(svc), false)
 			_, err := framework.WaitForFirewallRule(gceCloud, localHCFwName, false, framework.LoadBalancerCleanupTimeout)
 			Expect(err).NotTo(HaveOccurred())
 		}()

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svcTier).To(Equal(cloud.NetworkTierStandard))
 		// Record the LB name for test cleanup.
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 
 		// Wait and verify the LB.
 		ingressIP := waitAndVerifyLBWithTier(jig, ns, svcName, "", createTimeout, lagTimeout)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -620,9 +620,9 @@ var _ = SIGDescribe("Services", func() {
 				s.Spec.Type = v1.ServiceTypeLoadBalancer
 			})
 		}
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(tcpService))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(tcpService))
 		if loadBalancerSupportsUDP {
-			serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(udpService))
+			serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(udpService))
 		}
 
 		By("waiting for the TCP service to have a load balancer")
@@ -1637,7 +1637,7 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		jig := framework.NewServiceTestJig(cs, serviceName)
 
 		svc := jig.CreateOnlyLocalLoadBalancerService(namespace, serviceName, loadBalancerCreateTimeout, true, nil)
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 		healthCheckNodePort := int(svc.Spec.HealthCheckNodePort)
 		if healthCheckNodePort == 0 {
 			framework.Failf("Service HealthCheck NodePort was not allocated")
@@ -1709,7 +1709,7 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 				}
 
 			})
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 		defer func() {
 			jig.ChangeServiceType(svc.Namespace, svc.Name, v1.ServiceTypeClusterIP, loadBalancerCreateTimeout)
 			Expect(cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)).NotTo(HaveOccurred())
@@ -1764,7 +1764,7 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		nodes := jig.GetNodes(framework.MaxNodesForEndpointsTests)
 
 		svc := jig.CreateOnlyLocalLoadBalancerService(namespace, serviceName, loadBalancerCreateTimeout, true, nil)
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 		defer func() {
 			jig.ChangeServiceType(svc.Namespace, svc.Name, v1.ServiceTypeClusterIP, loadBalancerCreateTimeout)
 			Expect(cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)).NotTo(HaveOccurred())
@@ -1817,7 +1817,7 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		}
 
 		svc := jig.CreateOnlyLocalLoadBalancerService(namespace, serviceName, loadBalancerCreateTimeout, true, nil)
-		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
 		defer func() {
 			jig.ChangeServiceType(svc.Namespace, svc.Name, v1.ServiceTypeClusterIP, loadBalancerCreateTimeout)
 			Expect(cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)).NotTo(HaveOccurred())
@@ -2024,7 +2024,7 @@ func execAffinityTestForLBService(f *framework.Framework, cs clientset.Interface
 	jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
 	defer func() {
 		framework.StopServeHostnameService(cs, ns, serviceName)
-		lb := cloudprovider.GetLoadBalancerName(svc)
+		lb := cloudprovider.DefaultLoadBalancerName(svc)
 		framework.Logf("cleaning load balancer resource for %s", lb)
 		framework.CleanupServiceResources(cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
GetLoadBalancerName() should be implemented per cloud provider as opposed to one neutral implementation.

This PR will address this by moving `cloudprovider.GetLoadBalancerName()` to the `LoadBalancer interface` and then provide an implementation for each cloud provider, while maintaining previously expected functionality.

**Which issue(s) this PR fixes**:
Fixes  [#43173](https://github.com/kubernetes/kubernetes/issues/43173)

**Special notes for your reviewer**:
This is a work in progress. Looking for feedback as I work on this, from any interested parties.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
