### PR TITLE
kubectl: recreating resources for immutable fields when force is applied

### DIFF
--- a/hack/testdata/service-revision1.yaml
+++ b/hack/testdata/service-revision1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: a
+spec:
+  selector:
+    app: test
+  clusterIP: None
+  ports:
+    - port: 80

--- a/hack/testdata/service-revision2.yaml
+++ b/hack/testdata/service-revision2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: a
+spec:
+  selector:
+    app: test
+  clusterIP: 10.0.0.12
+  ports:
+    - port: 80

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -753,7 +753,7 @@ func (p *patcher) patch(current runtime.Object, modified []byte, source, namespa
 		}
 		patchBytes, patchObject, err = p.patchSimple(current, modified, source, namespace, name, errOut)
 	}
-	if err != nil && errors.IsConflict(err) && p.force {
+	if err != nil && (errors.IsConflict(err) || errors.IsInvalid(err)) && p.force {
 		patchBytes, patchObject, err = p.deleteAndCreate(current, modified, namespace, name)
 	}
 	return patchBytes, patchObject, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66390

**Special notes for your reviewer**:
/assign soltysh juanvallejo
/cc @kubernetes/sig-cli-bugs 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl: recreating resources for immutable fields when force is applied
```
