### PR TITLE
Remove `auto_unmount` mount option from pv spec annotation.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -322,7 +322,11 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 		}
 
 	}
+
+	//Add backup-volfile-servers and auto_unmount options.
 	options = append(options, "backup-volfile-servers="+dstrings.Join(addrlist[:], ":"))
+	options = append(options, "auto_unmount")
+
 	mountOptions := volutil.JoinMountOptions(b.mountOptions, options)
 
 	// with `backup-volfile-servers` mount option in place, it is not required to
@@ -719,6 +723,7 @@ func (p *glusterfsVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTop
 	if len(pv.Spec.AccessModes) == 0 {
 		pv.Spec.AccessModes = p.plugin.GetAccessModes()
 	}
+
 	pv.Spec.MountOptions = p.options.MountOptions
 
 	gidStr := strconv.FormatInt(int64(gid), 10)
@@ -728,7 +733,6 @@ func (p *glusterfsVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTop
 		volutil.VolumeDynamicallyCreatedByKey: heketiAnn,
 		glusterTypeAnn:                        "file",
 		"Description":                         glusterDescAnn,
-		v1.MountOptionAnnotation:              "auto_unmount",
 		heketiVolIDAnn:                        volID,
 	}
 


### PR DESCRIPTION
At present, `auto_unmount` option is recorded at PV annotation of glusterfs PV.
Due to the preference given in MountOptionFromSpec() for annotation mount options
over sc supplied mount options(Ref PR# https://github.com/kubernetes/kubernetes/pull/66576),
the sc supplied mount options are not honoured in glusterfs plugin
eventhough the driver returns `true` for storage class mountoptions
support at probe.

This patch removes `auto_unmount` option from annotation of the pv spec

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
