### PR TITLE
Fix jessie-dnsutils image build for arm64 & ppc64el

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -103,6 +103,8 @@ push() {
     docker push ${REGISTRY}/${IMAGE}-${arch}:${TAG}
   done
 
+  kube::util::ensure-gnu-sed
+
   # Make archs list into image manifest. Eg: 'amd64 ppc64le' to '${REGISTRY}/${IMAGE}-amd64:${TAG} ${REGISTRY}/${IMAGE}-ppc64le:${TAG}'
   manifest=$(echo $archs | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
   docker manifest create --amend ${REGISTRY}/${IMAGE}:${TAG} ${manifest}

--- a/test/images/jessie-dnsutils/fixup-apt-list.sh
+++ b/test/images/jessie-dnsutils/fixup-apt-list.sh
@@ -1,4 +1,6 @@
-# Copyright 2016 The Kubernetes Authors.
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,17 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM BASEIMAGE
+DEB_ARCH=$(dpkg --print-architecture)
 
-CROSS_BUILD_COPY qemu-QEMUARCH-static /usr/bin/
+# http://security.debian.org/debian-security/dists/jessie/updates/InRelease is missing
+# entries for some platforms, so we just remove the last line in sources.list in
+# /etc/apt/sources.list which is "deb http://deb.debian.org/debian jessie-updates main"
 
-# WARNING: Please note that the script below removes the security packages from arm64 and ppc64el images
-# as they do not exist anymore in the debian repositories for jessie. So we do not recommend using this
-# image for any production use and limit use of this image to just test scenarios.
+case ${DEB_ARCH} in
+    arm64|ppc64el)
+        sed -i '/debian-security/d' /etc/apt/sources.list
+        ;;
+esac
 
-COPY fixup-apt-list.sh /
-RUN ["/fixup-apt-list.sh"]
-
-RUN apt-get -q update && \
-    apt-get install -y dnsutils && \
-    apt-get clean
+exit 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When we run `make all-container WHAT=jessie-dnsutils` from test/images, the build fails as some of the debian repos in sources.list are stale for arm64 & ppc64el. So we just detect this case and remove the lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66618

**Special notes for your reviewer**:
/cc @mkumatag @cjwagner 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
