### PR TITLE
Bump to k8s.gcr.io/metadata-proxy:v0.1.10

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -44,7 +44,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: metadata-proxy
-        image: k8s.gcr.io/metadata-proxy:v0.1.9
+        image: k8s.gcr.io/metadata-proxy:v0.1.10
         securityContext:
           privileged: true
         # Request and limit resources to get guaranteed QoS.


### PR DESCRIPTION
This PR bumps the metadata-proxy to a version which is compatible with `gcloud`'s GCE Metadata access_token logic.

```release-note
Fixed an issue which prevented `gcloud` from working on GCE when metadata concealment was enabled.
```
