### PR TITLE
drop rest.ConnectRequest in webhook admission

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -191,7 +191,10 @@ func (a *Webhook) Dispatch(attr admission.Attributes) error {
 		}
 		versionedAttr.VersionedOldObject = out
 	}
-	if obj := attr.GetObject(); obj != nil {
+	// Don't try to convert CONNECT requests because the object will be a
+	// rest.ConnectRequest. This will cause the converter to return an error. For
+	// now, just drop that information and continue with the admission check.
+	if obj := attr.GetObject(); obj != nil && attr.GetOperation() != admission.Connect {
 		out, err := a.convertor.ConvertToGVK(obj, attr.GetKind())
 		if err != nil {
 			return apierrors.NewInternalError(err)


### PR DESCRIPTION
Instead of trying to convert them to something they are not.

This mitigates #59759 by turning an INTERNAL error into a successful
admission request that omits some of the request information. Eventually
we will probably want to forward CONNECT options, but they aren't
currently versioned.


cc @cjcullen @alexcope @kubernetes/sig-api-machinery-pr-reviews 
```release-note
NONE
```
