### PR TITLE
remove unused predicate CheckNodeUnschedulablePred

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -71,8 +71,6 @@ const (
 	NoDiskConflictPred = "NoDiskConflict"
 	// PodToleratesNodeTaintsPred defines the name of predicate PodToleratesNodeTaints.
 	PodToleratesNodeTaintsPred = "PodToleratesNodeTaints"
-	// CheckNodeUnschedulablePred defines the name of predicate CheckNodeUnschedulablePredicate.
-	CheckNodeUnschedulablePred = "CheckNodeUnschedulable"
 	// PodToleratesNodeNoExecuteTaintsPred defines the name of predicate PodToleratesNodeNoExecuteTaints.
 	PodToleratesNodeNoExecuteTaintsPred = "PodToleratesNodeNoExecuteTaints"
 	// CheckNodeLabelPresencePred defines the name of predicate CheckNodeLabelPresence.
@@ -133,7 +131,7 @@ const (
 // The order is based on the restrictiveness & complexity of predicates.
 // Design doc: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/predicates-ordering.md
 var (
-	predicatesOrdering = []string{CheckNodeConditionPred, CheckNodeUnschedulablePred,
+	predicatesOrdering = []string{CheckNodeConditionPred,
 		GeneralPred, HostNamePred, PodFitsHostPortsPred,
 		MatchNodeSelectorPred, PodFitsResourcesPred, NoDiskConflictPred,
 		PodToleratesNodeTaintsPred, PodToleratesNodeNoExecuteTaintsPred, CheckNodeLabelPresencePred,
@@ -1530,19 +1528,6 @@ func (c *PodAffinityChecker) satisfiesPodsAffinityAntiAffinity(pod *v1.Pod,
 			podName(pod), node.Name)
 	}
 	return nil, nil
-}
-
-// CheckNodeUnschedulablePredicate checks if a pod can be scheduled on a node with Unschedulable spec.
-func CheckNodeUnschedulablePredicate(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
-	if nodeInfo == nil || nodeInfo.Node() == nil {
-		return false, []algorithm.PredicateFailureReason{ErrNodeUnknownCondition}, nil
-	}
-
-	if nodeInfo.Node().Spec.Unschedulable {
-		return false, []algorithm.PredicateFailureReason{ErrNodeUnschedulable}, nil
-	}
-
-	return true, nil, nil
 }
 
 // PodToleratesNodeTaints checks if a pod tolerations can tolerate the node taints


### PR DESCRIPTION
according to https://github.com/kubernetes/kubernetes/pull/61161, the  predicate CheckNodeUnschedulablePred is not used.

**Special notes for your reviewer**:
/assign @k82cn 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
