### PR TITLE
remove redundant set EnableProfiling EnableIndex to true

### DIFF
--- a/pkg/master/master_openapi_test.go
+++ b/pkg/master/master_openapi_test.go
@@ -44,7 +44,6 @@ func TestValidOpenAPISpec(t *testing.T) {
 	etcdserver, config, sharedInformers, assert := setUp(t)
 	defer etcdserver.Terminate(t)
 
-	config.GenericConfig.EnableIndex = true
 	config.GenericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapigen.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(legacyscheme.Scheme))
 	config.GenericConfig.OpenAPIConfig.Info = &spec.Info{
 		InfoProps: spec.InfoProps{

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -407,8 +407,6 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 	config.Authorization.Authorizer = &authz
 
 	config.EnableSwaggerUI = true
-	config.EnableIndex = true
-	config.EnableProfiling = true
 	config.SwaggerConfig = DefaultSwaggerConfig()
 
 	kubeVersion := fakeVersion()

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -463,7 +463,6 @@ func TestServerRunWithSNI(t *testing.T) {
 			v := fakeVersion()
 			config.Version = &v
 
-			config.EnableIndex = true
 			secureOptions := WithLoopback(&SecureServingOptions{
 				BindAddress: net.ParseIP("127.0.0.1"),
 				BindPort:    6443,

--- a/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
+++ b/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestAdmission(t *testing.T) {
 	masterConfig := framework.NewMasterConfig()
-	masterConfig.GenericConfig.EnableProfiling = true
 	masterConfig.GenericConfig.AdmissionControl = defaulttolerationseconds.NewDefaultTolerationSeconds()
 	_, s, closeFn := framework.RunAMaster(masterConfig)
 	defer closeFn()

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -321,7 +321,6 @@ type CloseFunc func()
 func RunAMaster(masterConfig *master.Config) (*master.Master, *httptest.Server, CloseFunc) {
 	if masterConfig == nil {
 		masterConfig = NewMasterConfig()
-		masterConfig.GenericConfig.EnableProfiling = true
 	}
 	return startMasterOrDie(masterConfig, nil, nil)
 }

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -424,7 +424,6 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	informers := informers.NewSharedInformerFactory(rootClientset, controller.NoResyncPeriodFunc())
 
 	masterConfig := framework.NewMasterConfig()
-	masterConfig.GenericConfig.EnableIndex = true
 	masterConfig.GenericConfig.Authentication.Authenticator = authenticator
 	masterConfig.GenericConfig.Authorization.Authorizer = authorizer
 	masterConfig.GenericConfig.AdmissionControl = serviceAccountAdmission


### PR DESCRIPTION
The kube-apiserver always hardcoded `EnableIndex`, 'EnableProfiling'  to true, so no use to set these again in each test.

https://github.com/kubernetes/kubernetes/blob/1b6b2ee790d5dcab1e6852cc40be598b3ccd3fba/staging/src/k8s.io/apiserver/pkg/server/config.go#L262-L264

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
