### PR TITLE
correct kubelet service file permission

### DIFF
--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -27,5 +27,5 @@ install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ {kubelet.service
 
 %files
 %{_bindir}/kubelet
-%{_sysconfdir}/systemd/system/kubelet.service
+%attr(644,-,-) %{_sysconfdir}/systemd/system/kubelet.service
 %{_sysconfdir}/kubernetes/manifests/


### PR DESCRIPTION
```release-note
Fix kubelet service file permission warning
```
To fix below waring:
7月 26 12:47:58 test-0.localdomain systemd[1]: Configuration file /etc/systemd/system/kubelet.service is marked executable. Please remove executable permission bits. Proceeding anyway.

The service file should be in 644 mode rather than 755.