### PR TITLE
[kubeadm] Use KubeletRunDirectory instead of hard-coded way

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -202,7 +202,6 @@ const (
 	KubeletBaseConfigMapRolePrefix = "kubeadm:kubelet-config-"
 
 	// KubeletRunDirectory specifies the directory where the kubelet runtime information is stored.
-	// TODO: Make hard-coded "/var/lib/kubelet" strings reference this constant.
 	KubeletRunDirectory = "/var/lib/kubelet"
 
 	// KubeletConfigurationFileName specifies the file name on the node which stores initial remote configuration of kubelet

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -44,6 +44,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/util/version:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/utils/exec"
 )
 
@@ -249,7 +250,7 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			expected: map[string]string{
 				"container-runtime":          "remote",
 				"container-runtime-endpoint": "/var/run/containerd.sock",
-				"dynamic-config-dir":         "/var/lib/kubelet/dynamic-config",
+				"dynamic-config-dir":         fmt.Sprintf("%s/dynamic-config", kubeadmconstants.KubeletRunDirectory),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix `TODO: Make hard-coded "/var/lib/kubelet" strings reference this constant.`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
cc @neolit123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
