### PR TITLE
Fix empty string reclaim policy being considered valid in StorageClass

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -114,10 +114,8 @@ var supportedReclaimPolicy = sets.NewString(string(api.PersistentVolumeReclaimDe
 // provisioning for storage classes with impossible reclaim policies, e.g. EBS is not Recyclable
 func validateReclaimPolicy(reclaimPolicy *api.PersistentVolumeReclaimPolicy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if len(string(*reclaimPolicy)) > 0 {
-		if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))
-		}
+	if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))
 	}
 	return allErrs
 }

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -95,14 +95,16 @@ func TestValidateStorageClass(t *testing.T) {
 
 	errorCases := map[string]storage.StorageClass{
 		"namespace is present": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
-			Provisioner:   "kubernetes.io/foo-provisioner",
-			ReclaimPolicy: &deleteReclaimPolicy,
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			Provisioner:       "kubernetes.io/foo-provisioner",
+			ReclaimPolicy:     &deleteReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 		"invalid provisioner": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
-			Provisioner:   "kubernetes.io/invalid/provisioner",
-			ReclaimPolicy: &deleteReclaimPolicy,
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			Provisioner:       "kubernetes.io/invalid/provisioner",
+			ReclaimPolicy:     &deleteReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 		"invalid empty parameter name": {
 			ObjectMeta:  metav1.ObjectMeta{Name: "foo"},
@@ -110,30 +112,34 @@ func TestValidateStorageClass(t *testing.T) {
 			Parameters: map[string]string{
 				"": "value",
 			},
-			ReclaimPolicy: &deleteReclaimPolicy,
+			ReclaimPolicy:     &deleteReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 		"provisioner: Required value": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
-			Provisioner:   "",
-			ReclaimPolicy: &deleteReclaimPolicy,
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			Provisioner:       "",
+			ReclaimPolicy:     &deleteReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 		"too long parameters": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
-			Provisioner:   "kubernetes.io/foo",
-			Parameters:    longParameters,
-			ReclaimPolicy: &deleteReclaimPolicy,
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			Provisioner:       "kubernetes.io/foo",
+			Parameters:        longParameters,
+			ReclaimPolicy:     &deleteReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 		"invalid reclaimpolicy": {
-			ObjectMeta:    metav1.ObjectMeta{Name: "foo"},
-			Provisioner:   "kubernetes.io/foo",
-			ReclaimPolicy: &recycleReclaimPolicy,
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			Provisioner:       "kubernetes.io/foo",
+			ReclaimPolicy:     &recycleReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
 		},
 	}
 
 	// Error cases are not expected to pass validation.
 	for testName, storageClass := range errorCases {
-		if errs := ValidateStorageClass(&storageClass); len(errs) == 0 {
-			t.Errorf("Expected failure for test: %s", testName)
+		if errs := ValidateStorageClass(&storageClass); len(errs) != 1 {
+			t.Errorf("Expected exactly 1 failure for test: %s", testName)
 		}
 	}
 }

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -39,6 +39,7 @@ func TestValidateStorageClass(t *testing.T) {
 	deleteReclaimPolicy := api.PersistentVolumeReclaimPolicy("Delete")
 	retainReclaimPolicy := api.PersistentVolumeReclaimPolicy("Retain")
 	recycleReclaimPolicy := api.PersistentVolumeReclaimPolicy("Recycle")
+	emptyReclaimPolicy := api.PersistentVolumeReclaimPolicy("")
 	successCases := []storage.StorageClass{
 		{
 			// empty parameters
@@ -132,6 +133,12 @@ func TestValidateStorageClass(t *testing.T) {
 			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
 			Provisioner:       "kubernetes.io/foo",
 			ReclaimPolicy:     &recycleReclaimPolicy,
+			VolumeBindingMode: &immediateMode1,
+		},
+		"invalid empty string reclaimpolicy": {
+			ObjectMeta:        metav1.ObjectMeta{Name: "foo"},
+			Provisioner:       "kubernetes.io/foo",
+			ReclaimPolicy:     &emptyReclaimPolicy,
 			VolumeBindingMode: &immediateMode1,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: currently, storage classes are allowed to be created with `reclaimPolicy==""` which has no documented meaning. Our docs say that if storageclass.reclaimPolicy is unspecified/nil, the default reclaimPolicy is Delete but they say nothing about empty string/"". So we should make "" invalid.

If the empty string from `storageClass.ReclaimPolicy` gets passed to a PV, the PV defaulting resets it to `Retain`. IMO this is okay since `PV.Spec.PersistentVolumeReclaimPolicy` is not a pointer and we can consider this PV empty string behaviour "legacy" behaviour. But storageclasses should know better and should not be able to have reclaimPolicy=="" when we have documented that it must be either "nil" or one of the 2 valid policies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: commit 1 fixes an issue where the error validation tests would succeed no matter what because none of them had volumeBindingMode set.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
