### PR TITLE
Exit gce kube-up.sh early if openssl is LibreSSL

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -109,6 +109,11 @@ function split_csv() {
 # Verify prereqs
 function verify-prereqs() {
   local cmd
+
+  # we use openssl to generate certs
+  kube::util::test_openssl_installed
+
+  # we use gcloud to create the cluster, gsutil to stage binaries and data
   for cmd in gcloud gsutil; do
     if ! which "${cmd}" >/dev/null; then
       local resp="n"

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -30,8 +30,11 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 
+echo "... calling verify-prereqs" >&2
 verify-prereqs
+echo "... calling verify-kube-binaries" >&2
 verify-kube-binaries
+echo "... calling kube-down" >&2
 kube-down
 
 echo "Done"

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -539,7 +539,14 @@ function kube::util::test_openssl_installed {
     if [ "$?" != "0" ]; then
       echo "Failed to run openssl. Please ensure openssl is installed"
       exit 1
+    elif [ "$(openssl version | cut -d\  -f1)" == "LibreSSL" ]; then
+      echo "LibreSSL is not supported. Please ensure openssl points to an OpenSSL binary"
+      if [ "$(uname -s)" == "Darwin" ]; then
+        echo 'On macOS we recommend using homebrew and adding "$(brew --prefix openssl)/bin" to your PATH'
+      fi
+      exit 1
     fi
+
     OPENSSL_BIN=$(command -v openssl)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

macOS has an openssl binary, but it's actually LibreSSL, which doesn't play well with the easyrsa script that cluster/gce/util.sh uses to generate certs

Instead of waiting until we generate certs to discover easyrsa doesn't work, consider openssl a prereq for gce, and include a check for the version string starting with OpenSSL

Also, mirror kube-up.sh's "... calling" output in kube-down.sh

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/community#1954

```release-note
NONE
```