### PR TITLE
Makes kubectl wait exit with status 1 and print an error message, if there is no resources matching selectors

### DIFF
--- a/pkg/kubectl/cmd/wait/wait_test.go
+++ b/pkg/kubectl/cmd/wait/wait_test.go
@@ -68,7 +68,7 @@ func TestWaitForDeletion(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		info       *resource.Info
+		infos      []*resource.Info
 		fakeClient func() *dynamicfakeclient.FakeDynamicClient
 		timeout    time.Duration
 		uidMap     UIDMap
@@ -78,12 +78,14 @@ func TestWaitForDeletion(t *testing.T) {
 	}{
 		{
 			name: "missing on get",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -100,13 +102,30 @@ func TestWaitForDeletion(t *testing.T) {
 			},
 		},
 		{
+			name:  "handles no infos",
+			infos: []*resource.Info{},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				return dynamicfakeclient.NewSimpleDynamicClient(scheme)
+			},
+			timeout:     10 * time.Second,
+			expectedErr: errNoMatchingResources.Error(),
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
 			name: "uid conflict on get",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -146,12 +165,14 @@ func TestWaitForDeletion(t *testing.T) {
 		},
 		{
 			name: "times out",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -177,12 +198,14 @@ func TestWaitForDeletion(t *testing.T) {
 		},
 		{
 			name: "handles watch close out",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -228,12 +251,14 @@ func TestWaitForDeletion(t *testing.T) {
 		},
 		{
 			name: "handles watch delete",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -267,7 +292,7 @@ func TestWaitForDeletion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
 			o := &WaitOptions{
-				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.info),
+				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.infos...),
 				UIDMap:         test.uidMap,
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
@@ -299,7 +324,7 @@ func TestWaitForCondition(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		info       *resource.Info
+		infos      []*resource.Info
 		fakeClient func() *dynamicfakeclient.FakeDynamicClient
 		timeout    time.Duration
 
@@ -308,12 +333,14 @@ func TestWaitForCondition(t *testing.T) {
 	}{
 		{
 			name: "present on get",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -337,13 +364,30 @@ func TestWaitForCondition(t *testing.T) {
 			},
 		},
 		{
+			name:  "handles no infos",
+			infos: []*resource.Info{},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				return dynamicfakeclient.NewSimpleDynamicClient(scheme)
+			},
+			timeout:     10 * time.Second,
+			expectedErr: errNoMatchingResources.Error(),
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
 			name: "times out",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -372,12 +416,14 @@ func TestWaitForCondition(t *testing.T) {
 		},
 		{
 			name: "handles watch close out",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -423,12 +469,14 @@ func TestWaitForCondition(t *testing.T) {
 		},
 		{
 			name: "handles watch condition change",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -461,12 +509,14 @@ func TestWaitForCondition(t *testing.T) {
 		},
 		{
 			name: "handles watch created",
-			info: &resource.Info{
-				Mapping: &meta.RESTMapping{
-					Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
 				},
-				Name:      "name-foo",
-				Namespace: "ns-foo",
 			},
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
@@ -500,7 +550,7 @@ func TestWaitForCondition(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
 			o := &WaitOptions{
-				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.info),
+				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.infos...),
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It makes the `kubectl wait` command print an error message and exit with exit code 1, if there is no resource matching users's query. This can happen when user specifies selectors. Example:

```
kubectl wait deployment -l app=something-that-does-not-exist --for condition=available --timeout=5s
```

**Which issue(s) this PR fixes**:
Fixes #66456

**Special notes for your reviewer**:

This is my first contribution into the project (except one line change in docs) and don't have much experience with Go. I learned a lot while working on this (about resource finders and the `Visitor` interface and it's implementations), but it is very likely that I'm doing something wrong :)

I'm keen to continue contributing into the project (into the cli part for now), so I will really appreciate detailed feedback, if you have a chance to provide it (point me into a right direction and/or explain why it's not a good idea to do something in a certain way).

Thanks!

**Release note**:
```release-note
kubectl: the wait command now prints an error message and exits with the code 1, if there is no resources matching selectors
```
