### PR TITLE
dd status=none does not exist on macOS

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -214,7 +214,7 @@ resources:
     - aesgcm:
         keys:
         - name: key1
-          secret: $(dd if=/dev/random bs=32 count=1 status=none | base64 | tr -d '\r\n')
+          secret: $(dd if=/dev/random bs=32 count=1 2>/dev/null | base64 | tr -d '\r\n')
 EOM
 )
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

When running cluster/kubectl.sh on macOS 10.13.6, the use of the
`status=none` operand leads to `dd: unknown operand status` being
printed out as an error message. Redirecting to /dev/null does
the same thing, supressing transfer status.

```release-note
NONE
```