### PR TITLE
refuse serviceaccount projection volume request when pod has no servceaccount bounded

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7670,6 +7670,35 @@ func TestValidatePod(t *testing.T) {
 				},
 			},
 		},
+		"serviceaccount token projected volume with no serviceaccount name specified": {
+			expectedError: "must not be specified when serviceAccountName is not set",
+			spec: core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
+				Spec: core.PodSpec{
+					Containers:    []core.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+					RestartPolicy: core.RestartPolicyAlways,
+					DNSPolicy:     core.DNSClusterFirst,
+					Volumes: []core.Volume{
+						{
+							Name: "projected-volume",
+							VolumeSource: core.VolumeSource{
+								Projected: &core.ProjectedVolumeSource{
+									Sources: []core.VolumeProjection{
+										{
+											ServiceAccountToken: &core.ServiceAccountTokenProjection{
+												Audience:          "foo-audience",
+												ExpirationSeconds: 6000,
+												Path:              "foo-path",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for k, v := range errorCases {
 		if errs := ValidatePod(&v.spec); len(errs) == 0 {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, if user starts a cluster with ServiceAccount admission plugin disabled, then creates a Pod 
like this:
```
kind: Pod 
apiVersion: v1
metadata:
  labels:
    run: nginx
  name: busybox2
spec:
      containers:
      - image: gcr.io/google-containers/nginx
        name: nginx
        volumeMounts:
        - mountPath: /var/run/secrets/tokens
          name: token
      - image: ubuntu
        name: ttt 
        volumeMounts:
        - mountPath: /var/run/secrets/tokens
          name: token
        command: [ "/bin/bash", "-c", "--" ]
        args: [ "while true; do sleep 30; done;" ]
      volumes:
      - name: token
        projected:
          sources:
          - serviceAccountToken:
              path: tokenPath
              expirationSeconds: 6000
              audience: gakki-audiences
```
The pod creation will fail with error info like:
Events:
```
  Type     Reason       Age               From                Message
  ----     ------       ----              ----                -------
  Normal   Scheduled    23s               default-scheduler   Successfully assigned office/busybox2 to 127.0.0.1
  Warning  FailedMount  8s (x6 over 23s)  kubelet, 127.0.0.1  MountVolume.SetUp failed for volume "token" : failed to fetch token: resource name may not be empty
```
We should refuse the projection request earlier. This patch fix this.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
