### PR TITLE
Remove unused function timeoutFromListOptions()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	"context"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -89,13 +88,6 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 			Watch()
 	}
 	return &ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
-}
-
-func timeoutFromListOptions(options metav1.ListOptions) time.Duration {
-	if options.TimeoutSeconds != nil {
-		return time.Duration(*options.TimeoutSeconds) * time.Second
-	}
-	return 0
 }
 
 // List a set of apiserver resources


### PR DESCRIPTION
**What this PR does / why we need it**:
It removes a function which is not exported and not called or referenced.

Re-opening #60215 after rebase.

**Which issue(s) this PR fixes** 
No issue.

**Special notes for your reviewer**:
I guess it would be useful to know what this was supposed to be doing. I just happened upon it when trying to understand how watch timeouts were configured.

**Release note**:
```release-note
NONE
```
