### PR TITLE
update exit code to 0 if patch not needed

### DIFF
--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -245,14 +245,8 @@ func (o *PatchOptions) RunPatch() error {
 			if err != nil {
 				return err
 			}
-			printer.PrintObj(info.Object, o.Out)
 
-			// if object was not successfully patched, exit with error code 1
-			if !didPatch {
-				return cmdutil.ErrExit
-			}
-
-			return nil
+			return printer.PrintObj(info.Object, o.Out)
 		}
 
 		count++


### PR DESCRIPTION
**Release note**:
```release-note
The `kubectl patch` command no longer exits with exit code 1 when a redundant patch results in a no-op
```

The specific logic in the `patch` command that exited with code 1, was only doing so when there was no diff between an existing object and its patched counterpart. (In case of errors, we just return those, which eventually ends up exiting with code 1 anyway). This patch removes this block, as we should not be treating patch no-ops as errors.

Fixes https://github.com/kubernetes/kubernetes/issues/58212

cc @soltysh 