### PR TITLE
fix wrong format output in e2e log

### DIFF
--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -1395,7 +1395,7 @@ func createFileDoesntExistCmd(testFileDir string, testFile string) string {
 // Fail on error
 func podRWCmdExec(pod *v1.Pod, cmd string) string {
 	out, err := utils.PodExec(pod, cmd)
-	framework.Logf("podRWCmdExec out: %q err: %q", out, err)
+	framework.Logf("podRWCmdExec out: %q err: %v", out, err)
 	Expect(err).NotTo(HaveOccurred())
 	return out
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When i run e2e, occuring  some  output log as below:
```
STEP: Creating pod1
STEP: Creating a pod
Jul 28 14:09:12.876: INFO: pod "security-context-bd6750a8-922c-11e8-abe9-286ed488d743" created on Node "127.0.0.1"
Jul 28 14:09:12.876: INFO: Running '/usr/local/bin/kubectl --server=http://127.0.0.1:8080 --kubeconfig=/var/run/kubernetes/admin.kubeconfig exec --namespace=e2e-tests-persistent-local-volumes-test-dlbf7 security-context-bd6750a8-922c-11e8-abe9-286ed488d743 -- /bin/sh -c cat /mnt/volume1/test-file'
Jul 28 14:09:13.119: INFO: stderr: ""
Jul 28 14:09:13.119: INFO: stdout: "test-file-content\n"
Jul 28 14:09:13.119: INFO: podRWCmdExec out: "test-file-content\n" err: %!q(<nil>)
STEP: Writing in pod1
Jul 28 14:09:13.119: INFO: Running '/usr/local/bin/kubectl --server=http://127.0.0.1:8080 --kubeconfig=/var/run/kubernetes/admin.kubeconfig exec --namespace=e2e-tests-persistent-local-volumes-test-dlbf7 security-context-bd6750a8-922c-11e8-abe9-286ed488d743 -- /bin/sh -c mkdir -p /mnt/volume1; echo /tmp/local-volume-test-b97fe819-922c-11e8-abe9-286ed488d743 > /mnt/volume1/test-file'
Jul 28 14:09:13.331: INFO: stderr: ""
Jul 28 14:09:13.331: INFO: stdout: ""
Jul 28 14:09:13.331: INFO: podRWCmdExec out: "" err: %!q(<nil>)
STEP: Deleting pod1
STEP: Deleting pod security-context-bd6750a8-922c-11e8-abe9-286ed488d743 in namespace e2e-tests-persistent-local-volumes-test-dlbf7
STEP: Creating pod2
STEP: Creating a pod
```
the `podRWCmdExec out: "" err: %!q(<nil>)` line are wrong
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
