### PR TITLE
remove incomplete check of ipvs modules in hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -126,16 +126,6 @@ if [ "${CLOUD_PROVIDER}" == "openstack" ]; then
     fi
 fi
 
-# load required kernel modules if proxy mode is set to "ipvs".
-if [ "${KUBE_PROXY_MODE}" == "ipvs" ]; then
-    # If required kernel modules are not available, fall back to iptables.
-    sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4
-    if [[ $? -ne 0 ]]; then
-      echo "Required kernel modules for ipvs not found. Falling back to iptables mode."
-      KUBE_PROXY_MODE=iptables
-    fi
-fi
-
 # set feature gates if enable Pod priority and preemption
 if [ "${ENABLE_POD_PRIORITY_PREEMPTION}" == true ]; then
     FEATURE_GATES="$FEATURE_GATES,PodPriority=true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently `hack/local-up-cluster.sh` executes `sudo modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4` to check whether the ipvs required modules exist, which leaves out the scenario https://github.com/kubernetes/kubernetes/issues/63801 mentioned.
Since `func CanUseIPVSProxier` in  `pkg/proxy/ipvs/proxier.go` covers all scenarios, maybe we should just remove this part instead of adding codes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
