### PR TITLE
use func ValidateRowPrintHandlerFunc replace of deprecated func Valid…

### DIFF
--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -111,7 +111,7 @@ func (h *HumanReadablePrinter) EnsurePrintHeaders() {
 }
 
 // Handler adds a print handler with a given set of columns to HumanReadablePrinter instance.
-// See ValidatePrintHandlerFunc for required method signature.
+// See ValidateRowPrintHandlerFunc for required method signature.
 func (h *HumanReadablePrinter) Handler(columns, columnsWithWide []string, printFunc interface{}) error {
 	var columnDefinitions []metav1beta1.TableColumnDefinition
 	for i, column := range columns {
@@ -137,7 +137,7 @@ func (h *HumanReadablePrinter) Handler(columns, columnsWithWide []string, printF
 	}
 
 	printFuncValue := reflect.ValueOf(printFunc)
-	if err := ValidatePrintHandlerFunc(printFuncValue); err != nil {
+	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
 		return err
 	}
@@ -221,30 +221,6 @@ func ValidateRowPrintHandlerFunc(printFunc reflect.Value) error {
 		funcType.Out(1) != reflect.TypeOf((*error)(nil)).Elem() {
 		return fmt.Errorf("invalid print handler. The expected signature is: "+
 			"func handler(obj %v, options PrintOptions) ([]metav1beta1.TableRow, error)", funcType.In(0))
-	}
-	return nil
-}
-
-// ValidatePrintHandlerFunc validates print handler signature.
-// printFunc is the function that will be called to print an object.
-// It must be of the following type:
-//  func printFunc(object ObjectType, w io.Writer, options PrintOptions) error
-// where ObjectType is the type of the object that will be printed.
-// DEPRECATED: will be replaced with ValidateRowPrintHandlerFunc
-func ValidatePrintHandlerFunc(printFunc reflect.Value) error {
-	if printFunc.Kind() != reflect.Func {
-		return fmt.Errorf("invalid print handler. %#v is not a function", printFunc)
-	}
-	funcType := printFunc.Type()
-	if funcType.NumIn() != 3 || funcType.NumOut() != 1 {
-		return fmt.Errorf("invalid print handler." +
-			"Must accept 3 parameters and return 1 value.")
-	}
-	if funcType.In(1) != reflect.TypeOf((*io.Writer)(nil)).Elem() ||
-		funcType.In(2) != reflect.TypeOf((*PrintOptions)(nil)).Elem() ||
-		funcType.Out(0) != reflect.TypeOf((*error)(nil)).Elem() {
-		return fmt.Errorf("invalid print handler. The expected signature is: "+
-			"func handler(obj %v, w io.Writer, options PrintOptions) error", funcType.In(0))
 	}
 	return nil
 }


### PR DESCRIPTION
…atePrintHandlerFunc

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
use func ValidateRowPrintHandlerFunc replace of deprecated func ValidatePrintHandlerFunc

> // ValidatePrintHandlerFunc validates print handler signature.	
// printFunc is the function that will be called to print an object.	
// It must be of the following type:	
//  func printFunc(object ObjectType, w io.Writer, options PrintOptions) error	
// where ObjectType is the type of the object that will be printed.	
// DEPRECATED: will be replaced with ValidateRowPrintHandlerFunc


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/kind cleanup

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
