### PR TITLE
export KUBE_TEST_ARGS for usage in other scripts

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -70,13 +70,16 @@ runTests() {
   KUBE_RACE="-race"
   # KUBE_TEST_ARGS may contain '$' character which has special meaning in make,
   # pass it through process environment instead.
-  KUBE_TEST_ARGS="${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} --alsologtostderr=true" \
-    make -C "${KUBE_ROOT}" test \
-      WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
-      GOFLAGS="${GOFLAGS:-}" \
-      KUBE_RACE="" \
-      KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
-      KUBE_TEST_API_VERSIONS="$1"
+  KUBE_TEST_ARGS="${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} --alsologtostderr=true"
+  # export KUBE_TEST_ARGS for further references. e.g. hack/make-rules/test.sh
+  export KUBE_TEST_ARGS_AMENDED="${KUBE_TEST_ARGS}"
+
+  make -C "${KUBE_ROOT}" test \
+    WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
+    GOFLAGS="${GOFLAGS:-}" \
+    KUBE_RACE="" \
+    KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
+    KUBE_TEST_API_VERSIONS="$1"
 
   cleanup
 }

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -170,7 +170,7 @@ shift $((OPTIND - 1))
 
 # Use eval to preserve embedded quoted strings.
 eval "goflags=(${GOFLAGS:-})"
-eval "testargs=(${KUBE_TEST_ARGS:-})"
+eval "testargs=(${KUBE_TEST_ARGS_AMENDED:-})"
 
 # Used to filter verbose test output.
 go_test_grep_pattern=".*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

After change in #66061, if you still set KUBE_TEST_ARGS in make command, its amended value will not be passed to hack/make-rules/test.sh

For more details, see #66782

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66782

**Special notes for your reviewer**:

/assign @cofyc
/sig testing

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
export KUBE_TEST_ARGS for usage in other scripts
```
