### PR TITLE
CRDs that don't support SMP need to send JM

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -704,7 +704,7 @@ func (p *patcher) patchSimple(obj runtime.Object, modified []byte, source, names
 		return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf("getting instance of versioned object for %v:", p.mapping.GroupVersionKind), source, err)
 	case err == nil:
 		// Compute a three way strategic merge patch to send to server.
-		patchType = types.StrategicMergePatchType
+		patchType = types.MergePatchType
 
 		// Try to use openapi first if the openapi spec is available and can successfully calculate the patch.
 		// Otherwise, fall back to baked-in types.


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/56719 changed the way we calculate patches. But for CRDs that don't publish openapi schema we'll always try SMP and fail b/c that's not supported. I'm setting JM as the default and only SMP when possible. 

**Special notes for your reviewer**:
/assign @liggitt @mengqiy 
since the two of you were in the original PR

**Release note**:
```release-note
NONE
```
