### PR TITLE
Sort API rule violations before comparison

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -451,7 +451,7 @@ $(OPENAPI_OUTFILE): $(OPENAPI_GEN) $(KNOWN_VIOLATION_FILENAME)
 	    -h $(BOILERPLATE_FILENAME)                                                  \
 	    -r $(REPORT_FILENAME)                                                       \
 	    "$$@";                                                                      \
-	diff $(REPORT_FILENAME) $(KNOWN_VIOLATION_FILENAME) ||                          \
+	diff <(sort $(REPORT_FILENAME)) <(sort $(KNOWN_VIOLATION_FILENAME)) ||          \
 	(echo $(API_RULE_CHECK_FAILURE_MESSAGE); exit 1)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
... in API rule checking, to improve the usability of the API rule checker (API linter). Currently the tool chain doesn't sort the violations, which makes it hard for developers to modify `violation_exceptions.list` when needed. e.g. https://github.com/kubernetes/kubernetes/pull/60195#discussion_r204056998, https://github.com/kubernetes/kubernetes/pull/66722

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig api-machinery