### PR TITLE
bump glbc to 1.2.3

### DIFF
--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -1,20 +1,20 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v1.2.2
+  name: l7-lb-controller-v1.2.3
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   labels:
     k8s-app: gcp-lb-controller
-    version: v1.2.2
+    version: v1.2.3
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.2
+  - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
```release-note
Bump GLBC version to 1.2.3
```

ref: https://github.com/kubernetes/ingress-gce/compare/v1.2.2...v1.2.3
