### PR TITLE
remove deprecated shorthand flag

### DIFF
--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -74,10 +74,9 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 			cmdutil.CheckErr(o.Run())
 		},
 	}
-	cmd.Flags().BoolVarP(&o.ClientOnly, "client", "c", o.ClientOnly, "Client version only (no server required).")
-	cmd.Flags().BoolVarP(&o.Short, "short", "", o.Short, "Print just the version number.")
+	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "Client version only (no server required).")
+	cmd.Flags().BoolVar(&o.Short, "short", o.Short, "Print just the version number.")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
-	cmd.Flags().MarkShorthandDeprecated("client", "please use --client instead.")
 	return cmd
 }
 


### PR DESCRIPTION
**Release note**:
```release-note
remove deprecated shorthand flag `-c` from `kubectl version (--client)`
```
