### PR TITLE
kubeadm: fix runtime.ImageExists API

### DIFF
--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -172,18 +172,12 @@ func (runtime *DockerRuntime) PullImage(image string) error {
 
 // ImageExists checks to see if the image exists on the system
 func (runtime *CRIRuntime) ImageExists(image string) (bool, error) {
-	out, err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "inspecti", image).CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("output: %s, error: %v", string(out), err)
-	}
-	return true, nil
+	err := runtime.exec.Command("crictl", "-r", runtime.criSocket, "inspecti", image).Run()
+	return err == nil, nil
 }
 
 // ImageExists checks to see if the image exists on the system
 func (runtime *DockerRuntime) ImageExists(image string) (bool, error) {
-	out, err := runtime.exec.Command("docker", "inspect", image).CombinedOutput()
-	if err != nil {
-		return false, fmt.Errorf("output: %s, error: %v", string(out), err)
-	}
-	return true, nil
+	err := runtime.exec.Command("docker", "inspect", image).Run()
+	return err == nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

runtime.ImageExists returns error when underlying 'inspect' command
fails. This makes ImagePullCheck to fail as it doesn't expect
runtime.ImageExists to return an error even if image doesn't exist.

**Which issue(s) this PR fixes**:
Fixes [kubeadm issue 1024](https://github.com/kubernetes/kubeadm/issues/1024)

**Release note**:
```release-note
NONE
```
