### PR TITLE
kubeadm: fix ImagePullCheck output

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -829,14 +829,15 @@ func (ImagePullCheck) Name() string {
 // Check pulls images required by kubeadm. This is a mutating check
 func (ipc ImagePullCheck) Check() (warnings, errors []error) {
 	for _, image := range ipc.imageList {
-		glog.V(1).Infoln("pulling ", image)
 		ret, err := ipc.runtime.ImageExists(image)
 		if ret && err == nil {
+			glog.V(1).Infof("image exists: %s", image)
 			continue
 		}
 		if err != nil {
 			errors = append(errors, fmt.Errorf("failed to check if image %s exists: %v", image, err))
 		}
+		glog.V(1).Infof("pulling %s", image)
 		if err := ipc.runtime.PullImage(image); err != nil {
 			errors = append(errors, fmt.Errorf("failed to pull image %s: %v", image, err))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

ImagePullCheck outputs "pulling <image>" line even if image
already exists and is not pulled.
    
Fixed the output to reflect the reality. ImagePullCheck now outputs
either "pulling <image>" or "image <image> exists".

**Release note**:
```release-note
NONE
```
