### PR TITLE
Fix expected pod creations/deletions estimate in load test

### DIFF
--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -320,12 +320,19 @@ var _ = SIGDescribe("Load capacity", func() {
 			// We would like to spread scaling replication controllers over time
 			// to make it possible to create/schedule & delete them in the meantime.
 			// Currently we assume that <throughput> pods/second average throughput.
-			// The expected number of created/deleted pods is less than totalPods/3.
-			scalingTime := time.Duration(totalPods/(3*throughput)) * time.Second
+
+			// The expected number of created/deleted pods is totalPods/4 when scaling
+			// for the first time, with each RC changing its size from X to a uniform
+			// random value in the interval [X/2, 3X/2].
+			scalingTime := time.Duration(totalPods/(4*throughput)) * time.Second
 			framework.Logf("Starting to scale %v objects first time...", itArg.kind)
 			scaleAllResources(configs, scalingTime, testPhaseDurations.StartPhase(300, "scaling first time"))
 			By("============================================================================")
 
+			// The expected number of created/deleted pods is totalPods/3 when scaling for
+			// the second time, with each RC changing its size from a uniform random value
+			// in the interval [X/2, 3X/2] to another uniform random value in same interval.
+			scalingTime = time.Duration(totalPods/(3*throughput)) * time.Second
 			framework.Logf("Starting to scale %v objects second time...", itArg.kind)
 			scaleAllResources(configs, scalingTime, testPhaseDurations.StartPhase(400, "scaling second time"))
 			By("============================================================================")


### PR DESCRIPTION
Fixing a wrongly computed expectation for first round of scaling in load test. Luckily as a side-effect, this should also speed up load test by:

- 25s on 100-node cluster
- 2m on 500-node cluster (so helps our presubmit - https://github.com/kubernetes/test-infra/issues/8348)
- 20m on 5000-node cluster

That said, I'm not 100% sure if this won't start causing failures in practice.

/cc @gmarek @mborsz 

```release-note
NONE
```