### PR TITLE
fix inconsistent behavior of running kube-proxy on 1.12

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -108,7 +108,16 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - operator: Exists
-      nodeSelector:
-        beta.kubernetes.io/arch: {{ .Arch }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - {{ .Arch }}
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
 `
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

As feature `ScheduleDaemonSetPods` will be promoted to beta in 1.12, it will result in a "Pending" kube-proxy pod for a fresh kubeadm installation. PS: upgrade case should not be impacted.

This PR is to make sure kubeadm behaviors the same in 1.12 on `kube-proxy` daemonset.

**Which issue(s) this PR fixes**:
Fixes part of #66831

**Special notes for your reviewer**:

**Release note**:
```release-note
kube-proxy is now deployed using nodeAffinity with explicit matchExpressions.
```
