### PR TITLE
Detect if GCE PD udev link is wrong and try to correct it

### DIFF
--- a/pkg/volume/gce_pd/BUILD
+++ b/pkg/volume/gce_pd/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/cloudprovider/providers/gce:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
+        "//pkg/util/file:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
@@ -43,6 +44,7 @@ go_test(
         "attacher_test.go",
         "gce_pd_block_test.go",
         "gce_pd_test.go",
+        "gce_util_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -157,7 +157,7 @@ func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devi
 		select {
 		case <-ticker.C:
 			glog.V(5).Infof("Checking GCE PD %q is attached.", pdName)
-			path, err := verifyDevicePath(devicePaths, sdBeforeSet)
+			path, err := verifyDevicePath(devicePaths, sdBeforeSet, pdName)
 			if err != nil {
 				// Log error, if any, and continue checking periodically. See issue #11321
 				glog.Errorf("Error verifying GCE PD (%q) is attached: %v", pdName, err)

--- a/pkg/volume/gce_pd/gce_util_test.go
+++ b/pkg/volume/gce_pd/gce_util_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce_pd
+
+import "testing"
+
+func TestParseScsiSerial(t *testing.T) {
+	cases := []struct {
+		name      string
+		output    string
+		diskName  string
+		expectErr bool
+	}{
+		{
+			name:     "valid",
+			output:   "0Google  PersistentDisk  test-disk",
+			diskName: "test-disk",
+		},
+		{
+			name:     "valid with newline",
+			output:   "0Google  PersistentDisk  test-disk\n",
+			diskName: "test-disk",
+		},
+		{
+			name:      "invalid prefix",
+			output:    "00Google  PersistentDisk  test-disk",
+			expectErr: true,
+		},
+		{
+			name:      "invalid suffix",
+			output:    "0Google  PersistentDisk  test-disk  more",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		serial, err := parseScsiSerial(test.output)
+		if err != nil && !test.expectErr {
+			t.Errorf("test %v failed: %v", test.name, err)
+		}
+		if err == nil && test.expectErr {
+			t.Errorf("test %q failed: got success", test.name)
+		}
+		if serial != test.diskName {
+			t.Errorf("test %v failed: expected serial %q, got %q", test.name, test.diskName, serial)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
udev can miss scsi events and not update device links properly when disks are detached and reattached to the same node in a different order.  This PR workarounds the issue by comparing the udev link name, which is the PD disk name, with the scsi disk serial number returned from scsi_id, and prevents mounting of the disk if the link is wrong.  It will also run `udevadm trigger` on the disk to try to correct the bad link.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This fix prevents a GCE PD volume from being mounted if the udev device link is stale and tries to correct the link.
```
