### PR TITLE
feature gate influxdb test

### DIFF
--- a/test/e2e/instrumentation/monitoring/influxdb.go
+++ b/test/e2e/instrumentation/monitoring/influxdb.go
@@ -34,7 +34,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = instrumentation.SIGDescribe("Monitoring", func() {
+var _ = instrumentation.SIGDescribe("Monitoring [Feature:Influxdb]", func() {
 	f := framework.NewDefaultFramework("monitoring")
 
 	BeforeEach(func() {


### PR DESCRIPTION
influxdb test has been removed as of 1.11 so it should be behind
a feature gate for older releases

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: puts deprecated and oft-failing test behind a feature gate

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66833 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
