### PR TITLE
fix panic fake SAR client expansion

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_subjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_subjectaccessreview_expansion.go
@@ -23,5 +23,8 @@ import (
 
 func (c *FakeSubjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
 	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("subjectaccessreviews"), sar), &authorizationapi.SubjectAccessReview{})
+	if obj == nil {
+		return nil, err
+	}
 	return obj.(*authorizationapi.SubjectAccessReview), err
 }


### PR DESCRIPTION
if the object is nil, the type assertion fails.

@kubernetes/sig-api-machinery-bugs 

```release-note
NONE
```