### PR TITLE
cpumanager: remove duplicate CPU set assignment for existing containers

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -245,7 +245,9 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 			if _, ok := m.state.GetCPUSet(containerID); !ok {
 				if status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
 					glog.V(4).Infof("[cpumanager] reconcileState: container is not present in state - trying to add (pod: %s, container: %s, container id: %s)", pod.Name, container.Name, containerID)
-					err := m.AddContainer(pod, &container, containerID)
+					m.Lock()
+					err := m.policy.AddContainer(m.state, pod, &container, containerID)
+					m.Unlock()
 					if err != nil {
 						glog.Errorf("[cpumanager] reconcileState: failed to add container (pod: %s, container: %s, container id: %s, error: %v)", pod.Name, container.Name, containerID, err)
 						failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When CPU manager reconciliation function calls `AddContainer()`, it calls `updateContainerCPUSet()` function for the container. The reconciliation function calls the same function in a moment, leading to duplicate work. This can be fixed either by short-circuiting the processing after `AddContainer()` or by just calling the policy's `AddContainer()` and leaving reconciliation to do the rest. This commit does the second option.

Also, do not add the container to failure list if `AddContainer()` fails, because the container will have some CPU set assigned to it later. Add a unit test which checks that a container hasn't been classified twice to failed or successful lists.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
