### PR TITLE
Generate crictl config for preload as well.

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -247,6 +247,11 @@ function install-crictl {
   fi
   local -r crictl="crictl-${crictl_version}-linux-amd64"
 
+  # Create crictl config file.
+  cat > /etc/crictl.yaml <<EOF
+runtime-endpoint: ${CONTAINER_RUNTIME_ENDPOINT:-unix:///var/run/dockershim.sock}
+EOF
+
   if is-preloaded "${crictl}" "${crictl_sha1}"; then
     echo "crictl is preloaded"
     return
@@ -257,11 +262,6 @@ function install-crictl {
   download-or-bust "${crictl_sha1}" "${crictl_path}/${crictl}"
   mv "${KUBE_HOME}/${crictl}" "${KUBE_BIN}/crictl"
   chmod a+x "${KUBE_BIN}/crictl"
-
-  # Create crictl config file.
-  cat > /etc/crictl.yaml <<EOF
-runtime-endpoint: ${CONTAINER_RUNTIME_ENDPOINT:-unix:///var/run/dockershim.sock}
-EOF
 }
 
 function install-exec-auth-plugin {


### PR DESCRIPTION
Generate `/etc/crictl.yaml` also when crictl is preloaded.

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug on GCE that /etc/crictl.yaml is not generated when crictl is preloaded.
```
