### PR TITLE
Fix coordination.Lease validation

### DIFF
--- a/pkg/apis/coordination/validation/validation.go
+++ b/pkg/apis/coordination/validation/validation.go
@@ -24,14 +24,16 @@ import (
 
 // ValidateLease validates a Lease.
 func ValidateLease(lease *coordination.Lease) field.ErrorList {
-	allErrs := validation.ValidateObjectMeta(&lease.ObjectMeta, true, validation.NameIsDNSSubdomain, field.NewPath("objectMeta"))
+	allErrs := validation.ValidateObjectMeta(&lease.ObjectMeta, true, validation.NameIsDNSSubdomain, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateLeaseSpec(&lease.Spec, field.NewPath("spec"))...)
 	return allErrs
 }
 
 // ValidateLeaseUpdate validates an update of Lease object.
 func ValidateLeaseUpdate(lease, oldLease *coordination.Lease) field.ErrorList {
-	return ValidateLease(lease)
+	allErrs := validation.ValidateObjectMetaUpdate(&lease.ObjectMeta, &oldLease.ObjectMeta, field.NewPath("metadata"))
+	allErrs = append(allErrs, ValidateLeaseSpec(&lease.Spec, field.NewPath("spec"))...)
+	return allErrs
 }
 
 // ValidateLeaseSpec validates spec of Lease.

--- a/pkg/apis/coordination/validation/validation_test.go
+++ b/pkg/apis/coordination/validation/validation_test.go
@@ -71,6 +71,10 @@ func TestValidateLeaseSpecUpdate(t *testing.T) {
 	oldLeaseDuration := int32(3)
 	oldLeaseTransitions := int32(3)
 	oldLease := &coordination.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "holder",
+			Namespace: "holder-namespace",
+		},
 		Spec: coordination.LeaseSpec{
 			HolderIdentity:       &oldHolder,
 			LeaseDurationSeconds: &oldLeaseDuration,
@@ -78,7 +82,23 @@ func TestValidateLeaseSpecUpdate(t *testing.T) {
 		},
 	}
 	errs := ValidateLeaseUpdate(lease, oldLease)
-	if len(errs) != 2 {
+	if len(errs) != 3 {
 		t.Errorf("unexpected list of errors: %#v", errs.ToAggregate().Error())
+	}
+
+	validLeaseDuration := int32(10)
+	validLeaseTransitions := int32(20)
+	validLease := &coordination.Lease{
+		ObjectMeta: oldLease.ObjectMeta,
+		Spec: coordination.LeaseSpec{
+			HolderIdentity:       &holder,
+			LeaseDurationSeconds: &validLeaseDuration,
+			LeaseTransitions:     &validLeaseTransitions,
+		},
+	}
+	validLease.ObjectMeta.ResourceVersion = "2"
+	errs = ValidateLeaseUpdate(validLease, oldLease)
+	if len(errs) != 0 {
+		t.Errorf("unexpected list of errors for valid update: %#v", errs.ToAggregate().Error())
 	}
 }


### PR DESCRIPTION
Fix a couple issues I noticed in the coordination.Lease validation logic which copying it for a new API:

- Field path should use the json path names (`objectMeta` -> `matadata`)
- ObjectMeta should be validated on update

**Release note**:
```release-note
NONE
```
