### PR TITLE
Log volume process failure event to pod.

### DIFF
--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -135,6 +135,7 @@ ComponentConfigs:
     PodPidsLimit: -1
     PodsPerCore: 0
     Port: 10250
+    ProcessVolumeFailureEventInterval: 10s
     ProtectKernelDefaults: false
     QOSReserved: null
     ReadOnlyPort: 0

--- a/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
@@ -144,6 +144,7 @@ nodeStatusUpdateFrequency: 10s
 oomScoreAdj: -999
 podPidsLimit: -1
 port: 10250
+processVolumeFailureEventInterval: 10s
 registryBurst: 10
 registryPullQPS: 5
 resolvConf: /etc/resolv.conf

--- a/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -139,6 +139,7 @@ nodeStatusUpdateFrequency: 10s
 oomScoreAdj: -999
 podPidsLimit: -1
 port: 10250
+processVolumeFailureEventInterval: 10s
 registryBurst: 10
 registryPullQPS: 5
 resolvConf: /etc/resolv.conf

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -93,6 +93,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ContainerLogMaxFiles = 5
 			obj.ContainerLogMaxSize = "10Mi"
 			obj.ConfigMapAndSecretChangeDetectionStrategy = "Watch"
+			obj.ProcessVolumeFailureEventInterval = metav1.Duration{Duration: 10 * time.Second}
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -217,5 +217,6 @@ var (
 		"TypeMeta.APIVersion",
 		"TypeMeta.Kind",
 		"VolumeStatsAggPeriod.Duration",
+		"ProcessVolumeFailureEventInterval.Duration",
 	)
 )

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -305,6 +305,11 @@ type KubeletConfiguration struct {
 	// This flag accepts a list of options. Acceptable options are `pods`, `system-reserved` & `kube-reserved`.
 	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
 	EnforceNodeAllocatable []string
+	// This flag specifies the interval of reporting volume processing failure event to pod.
+	// E.g. when configuring a wrong FlexVolume name in pod, "no volume plugin matched" error would be thrown out.
+	// Volume manager can generate a lot of similar errors because of its desired state of world loop.
+	// User can config the interval of error events reported to pod by this kubelet flag.
+	ProcessVolumeFailureEventInterval metav1.Duration
 }
 
 type KubeletAuthorizationMode string

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -209,4 +209,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement
 	}
+	if obj.ProcessVolumeFailureEventInterval == zeroDuration {
+		obj.ProcessVolumeFailureEventInterval = metav1.Duration{Duration: 10 * time.Second}
+	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -327,6 +327,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
+	out.ProcessVolumeFailureEventInterval = in.ProcessVolumeFailureEventInterval
 	return nil
 }
 
@@ -456,6 +457,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
+	out.ProcessVolumeFailureEventInterval = in.ProcessVolumeFailureEventInterval
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -179,6 +179,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	out.ProcessVolumeFailureEventInterval = in.ProcessVolumeFailureEventInterval
 	return
 }
 

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -51,6 +51,7 @@ const (
 	FailedAttachVolume                   = "FailedAttachVolume"
 	FailedDetachVolume                   = "FailedDetachVolume"
 	FailedMountVolume                    = "FailedMount"
+	FailedProcessVolume                  = "FailedProcessVolume"
 	VolumeResizeFailed                   = "VolumeResizeFailed"
 	VolumeResizeSuccess                  = "VolumeResizeSuccessful"
 	FileSystemResizeFailed               = "FileSystemResizeFailed"

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -811,7 +811,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.getPodsDir(),
 		kubeDeps.Recorder,
 		experimentalCheckNodeCapabilitiesBeforeMount,
-		keepTerminatedPodVolumes)
+		keepTerminatedPodVolumes,
+		kubeCfg.ProcessVolumeFailureEventInterval.Duration)
 
 	klet.reasonCache = NewReasonCache()
 	klet.workQueue = queue.NewBasicWorkQueue(klet.clock)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -336,7 +336,8 @@ func newTestKubeletWithImageList(
 		kubelet.getPodsDir(),
 		kubelet.recorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount*/
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		10*time.Second)
 
 	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -106,7 +106,8 @@ func TestRunOnce(t *testing.T) {
 		kb.getPodsDir(),
 		kb.recorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount */
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		10*time.Second)
 
 	// TODO: Factor out "StatsProvider" from Kubelet so we don't have a cyclic dependency
 	volumeStatsAggPeriod := time.Second * 10

--- a/pkg/kubelet/volumemanager/populator/BUILD
+++ b/pkg/kubelet/volumemanager/populator/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/features:go_default_library",
         "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/status:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
@@ -28,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -158,7 +158,8 @@ func NewVolumeManager(
 	kubeletPodsDir string,
 	recorder record.EventRecorder,
 	checkNodeCapabilitiesBeforeMount bool,
-	keepTerminatedPodVolumes bool) VolumeManager {
+	keepTerminatedPodVolumes bool,
+	processVolumeFailureEventInterval time.Duration) VolumeManager {
 
 	vm := &volumeManager{
 		kubeClient:          kubeClient,
@@ -182,7 +183,9 @@ func NewVolumeManager(
 		vm.desiredStateOfWorld,
 		vm.actualStateOfWorld,
 		kubeContainerRuntime,
-		keepTerminatedPodVolumes)
+		keepTerminatedPodVolumes,
+		recorder,
+		processVolumeFailureEventInterval)
 	vm.reconciler = reconciler.NewReconciler(
 		kubeClient,
 		controllerAttachDetachEnabled,

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -233,7 +233,8 @@ func newTestVolumeManager(tmpDir string, podManager kubepod.Manager, kubeClient 
 		"",
 		fakeRecorder,
 		false, /* experimentalCheckNodeCapabilitiesBeforeMount */
-		false /* keepTerminatedPodVolumes */)
+		false, /* keepTerminatedPodVolumes */
+		10*time.Second)
 
 	return vm
 }

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -706,6 +706,13 @@ type KubeletConfiguration struct {
 	// Default: ["pods"]
 	// +optional
 	EnforceNodeAllocatable []string `json:"enforceNodeAllocatable,omitempty"`
+	// This flag specifies the interval of reporting volume processing failure event to pod.
+	// E.g. when configuring a wrong FlexVolume name in pod, "no volume plugin matched" error would be thrown out.
+	// Volume manager can generate a lot of similar errors because of its desired state of world loop.
+	// User can config the interval of error events reported to pod by this kubelet flag.
+	// Default: "10s"
+	// +optional
+	ProcessVolumeFailureEventInterval metav1.Duration `json:"processVolumeFailureEventInterval,omitempty"`
 }
 
 type KubeletAuthorizationMode string

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -279,6 +279,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	out.ProcessVolumeFailureEventInterval = in.ProcessVolumeFailureEventInterval
 	return
 }
 


### PR DESCRIPTION
When volume manager or attach/detach controller start to process
a volume and encounter errors, there is no error event recorded
in Pod so that user have to wait until attach time out to realize
that something wrong with the volume. Besides, the time out event
does not show the detail error information to the user.

Need to log volume process failure event to pod to show user the
detail volume handling error immediately once the error happens.

Fixes #58272

Note to reviewers:
This is only a rebased PR #58273 by @xingzhou -- the original PR looks to be stalled, but we're still interested in the functionality so I'm re-trying to push it through again.

There is one aspect I'm still quite unsure about: it adds a new kubelet option to configure the interval to configure the failure event emission interval... I don't know of a better way to do this but adding new kubelet option is really an invasive change. I would prefer to remove that part.

```release-note
kubelet: add the ProcessVolumeFailureEventInterval configuration option that can be used to control the interval between reporting volume processing failure events.
```