### PR TITLE
Use the passed-in streams in kubectl top

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -98,6 +98,11 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 		}
 	}
 
+	// actually make use of the passed in streams if not already set
+	if (o.IOStreams == genericclioptions.IOStreams{}) {
+		o.IOStreams = streams
+	}
+
 	cmd := &cobra.Command{
 		Use: "node [NAME | -l label]",
 		DisableFlagsInUseLine: true,

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -87,6 +87,11 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 		}
 	}
 
+	// actually make use of the passed in streams if not already set
+	if (o.IOStreams == genericclioptions.IOStreams{}) {
+		o.IOStreams = streams
+	}
+
 	cmd := &cobra.Command{
 		Use: "pod [NAME | -l label]",
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
Previously, the kubectl top constructor ignored the passed-in IO streams
unless no other options were set.  This behavior is a bit confusing, and
can lead to strange foot-guns from people trying to use the kubectl top code
(but is not user-facing).

Now, we make use of the streams as long as something else didn't
explicitly set them in the options struct.

**Release note**:
```release-note
NONE
```
