### PR TITLE
Fix some test images - update version and arch

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -48,7 +48,7 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v1", true}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v1", false}
 	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0", false}
 	AppArmorLoader           = ImageConfig{gcRegistry, "apparmor-loader", "0.1", false}
 	BusyBox                  = ImageConfig{gcRegistry, "busybox", "1.24", false}
@@ -58,8 +58,8 @@ var (
 	EchoServer               = ImageConfig{gcRegistry, "echoserver", "1.10", false}
 	EntrypointTester         = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0", false}
 	Fakegitserver            = ImageConfig{e2eRegistry, "fakegitserver", "1.0", false}
-	GBFrontend               = ImageConfig{sampleRegistry, "gb-frontend", "v5", false}
-	GBRedisSlave             = ImageConfig{sampleRegistry, "gb-redisslave", "v2", false}
+	GBFrontend               = ImageConfig{sampleRegistry, "gb-frontend", "v6", false}
+	GBRedisSlave             = ImageConfig{sampleRegistry, "gb-redisslave", "v3", false}
 	Hostexec                 = ImageConfig{e2eRegistry, "hostexec", "1.1", false}
 	IpcUtils                 = ImageConfig{e2eRegistry, "ipc-utils", "1.0", false}
 	Iperf                    = ImageConfig{e2eRegistry, "iperf", "1.0", false}


### PR DESCRIPTION
- gb-frontend and gb-redisslave are now *REALLY* multi-arch manifest
lists.
- Fix bad merge from #66066 for AdmissionWebhook

Change-Id: I0995394d638ab00b0d1d30ad7099351b806dfd9d

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
