### PR TITLE
kubelet/cm/cpumanager: Fix unused variable "skipIfPermissionsError"

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -199,7 +199,6 @@ func TestCPUManagerGenerate(t *testing.T) {
 		isTopologyBroken           bool
 		expectedPolicy             string
 		expectedError              error
-		skipIfPermissionsError     bool
 	}{
 		{
 			description:                "set none policy",
@@ -218,7 +217,6 @@ func TestCPUManagerGenerate(t *testing.T) {
 			cpuPolicyName:              "static",
 			nodeAllocatableReservation: v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(3, resource.DecimalSI)},
 			expectedPolicy:             "static",
-			skipIfPermissionsError:     true,
 		},
 		{
 			description:                "static policy - broken topology",
@@ -226,21 +224,18 @@ func TestCPUManagerGenerate(t *testing.T) {
 			nodeAllocatableReservation: v1.ResourceList{},
 			isTopologyBroken:           true,
 			expectedError:              fmt.Errorf("could not detect number of cpus"),
-			skipIfPermissionsError:     true,
 		},
 		{
 			description:                "static policy - broken reservation",
 			cpuPolicyName:              "static",
 			nodeAllocatableReservation: v1.ResourceList{},
 			expectedError:              fmt.Errorf("unable to determine reserved CPU resources for static policy"),
-			skipIfPermissionsError:     true,
 		},
 		{
 			description:                "static policy - no CPU resources",
 			cpuPolicyName:              "static",
 			nodeAllocatableReservation: v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(0, resource.DecimalSI)},
 			expectedError:              fmt.Errorf("the static policy requires systemreserved.cpu + kubereserved.cpu to be greater than zero"),
-			skipIfPermissionsError:     true,
 		},
 	}
 


### PR DESCRIPTION
The variable "skipIfPermissionsError" is not needed even when
permission error happened.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

