### PR TITLE
WIP: Reduce CPU usage for stable scale-down e2e test

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", fu
 		It("Should scale from 2 pods to 1 pod", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    2,
-				totalInitialCPUUsage:        50,
+				totalInitialCPUUsage:        30,
 				perPodCPURequest:            200,
 				targetCPUUtilizationPercent: 50,
 				minPods:                     1,


### PR DESCRIPTION
**What this PR does / why we need it**:

In current test case of "Should scale from 2 pods to 1 pod",
targetCPUUtilizationPercent and totalInitialCPUUsage are the same as 50%.
That means the test expects scale-down (from 2 pods to 1 pod) happens
under this condition like

```
 $ kubectl get hpa --all-namespaces
 NAMESPACE                                    NAME       REFERENCE                        TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
 e2e-tests-horizontal-pod-autoscaling-6j9j8   rc-light   ReplicationController/rc-light   52%/50%   1         2         2          2m
```

However it is hard to happen because the algorithm[1] is like
```
  The target number of pods is calculated from the following formula:

    TargetNumOfPods = ceil(sum(CurrentPodsCPUUtilization) / Target)
```
So totalInitialCPUUsage should be smaller than targetCPUUtilizationPercent
for making TargetNumOfPods=1 stable as the test expected. This does it.

[1]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/autoscaling/horizontal-pod-autoscaler.md#autoscaling-algorithm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66949

**Special notes for your reviewer**:

**Release note**: NONE
