### PR TITLE
kubeadm: Drop arch suffixes

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -43,7 +43,7 @@ func GetKubeControlPlaneImage(image string, cfg *kubeadmapi.ClusterConfiguration
 	}
 	repoPrefix := cfg.GetControlPlaneImageRepository()
 	kubernetesImageTag := kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion)
-	return GetGenericArchImage(repoPrefix, image, kubernetesImageTag)
+	return GetGenericImage(repoPrefix, image, kubernetesImageTag)
 }
 
 // GetEtcdImage generates and returns the image for etcd or returns cfg.Etcd.Local.Image if specified
@@ -56,7 +56,7 @@ func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	if err == nil {
 		etcdImageTag = etcdImageVersion.String()
 	}
-	return GetGenericArchImage(cfg.ImageRepository, constants.Etcd, etcdImageTag)
+	return GetGenericImage(cfg.ImageRepository, constants.Etcd, etcdImageTag)
 }
 
 // GetAllImages returns a list of container images kubeadm expects to use on a control plane node

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -32,6 +32,19 @@ const (
 	gcrPrefix   = "k8s.gcr.io"
 )
 
+func TestGetGenericImage(t *testing.T) {
+	const (
+		prefix = "foo"
+		image  = "bar"
+		tag    = "baz"
+	)
+	expected := fmt.Sprintf("%s/%s:%s", prefix, image, tag)
+	actual := GetGenericImage(prefix, image, tag)
+	if actual != expected {
+		t.Errorf("failed GetGenericImage:\n\texpected: %s\n\t  actual: %s", expected, actual)
+	}
+}
+
 func TestGetGenericArchImage(t *testing.T) {
 	const (
 		prefix = "foo"

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -59,7 +59,7 @@ func TestGetKubeControlPlaneImage(t *testing.T) {
 		},
 		{
 			image:    constants.KubeAPIServer,
-			expected: GetGenericArchImage(gcrPrefix, "kube-apiserver", expected),
+			expected: GetGenericImage(gcrPrefix, "kube-apiserver", expected),
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository:   gcrPrefix,
 				KubernetesVersion: testversion,
@@ -67,7 +67,7 @@ func TestGetKubeControlPlaneImage(t *testing.T) {
 		},
 		{
 			image:    constants.KubeControllerManager,
-			expected: GetGenericArchImage(gcrPrefix, "kube-controller-manager", expected),
+			expected: GetGenericImage(gcrPrefix, "kube-controller-manager", expected),
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository:   gcrPrefix,
 				KubernetesVersion: testversion,
@@ -75,7 +75,7 @@ func TestGetKubeControlPlaneImage(t *testing.T) {
 		},
 		{
 			image:    constants.KubeScheduler,
-			expected: GetGenericArchImage(gcrPrefix, "kube-scheduler", expected),
+			expected: GetGenericImage(gcrPrefix, "kube-scheduler", expected),
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository:   gcrPrefix,
 				KubernetesVersion: testversion,
@@ -110,7 +110,7 @@ func TestGetEtcdImage(t *testing.T) {
 			},
 		},
 		{
-			expected: GetGenericArchImage(gcrPrefix, "etcd", constants.DefaultEtcdVersion),
+			expected: GetGenericImage(gcrPrefix, "etcd", constants.DefaultEtcdVersion),
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository:   gcrPrefix,
 				KubernetesVersion: testversion,

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -108,7 +108,5 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - operator: Exists
-      nodeSelector:
-        beta.kubernetes.io/arch: {{ .Arch }}
 `
 )

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -19,7 +19,6 @@ package proxy
 import (
 	"bytes"
 	"fmt"
-	"runtime"
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
@@ -75,9 +74,8 @@ func EnsureProxyAddon(cfg *kubeadmapi.InitConfiguration, client clientset.Interf
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
 	}
-	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ Image, Arch string }{
+	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ Image string }{
 		Image: images.GetKubeControlPlaneImage(constants.KubeProxy, &cfg.ClusterConfiguration),
-		Arch:  runtime.GOARCH,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -108,9 +108,8 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: KubeProxyDaemonSet19,
-			data: struct{ Image, Arch string }{
+			data: struct{ Image string }{
 				Image: "foo",
-				Arch:  "foo",
 			},
 			expected: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This change removes arch suffixes from control plane images (etcd, kube-apiserver, kube-scheduler, kube-proxy, etc.). These are not needed, as almost all control plane images have a fat manifest now. It also adds a missing unit test for `GetGenericImage`

We have arch suffixes only for kube-dns images now.

Sample output of `kubeadm config images pull` with this change:

```
$ ./_output/bin/kubeadm config images pull
[config/images] Pulled k8s.gcr.io/kube-apiserver:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-controller-manager:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-scheduler:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-proxy:v1.11.1
[config/images] Pulled k8s.gcr.io/pause:3.1
[config/images] Pulled k8s.gcr.io/etcd:3.2.18
[config/images] Pulled k8s.gcr.io/coredns:1.1.3
$ ./_output/bin/kubeadm config images pull --feature-gates=CoreDNS=false
[config/images] Pulled k8s.gcr.io/kube-apiserver:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-controller-manager:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-scheduler:v1.11.1
[config/images] Pulled k8s.gcr.io/kube-proxy:v1.11.1
[config/images] Pulled k8s.gcr.io/pause:3.1
[config/images] Pulled k8s.gcr.io/etcd:3.2.18
[config/images] Pulled k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
[config/images] Pulled k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
[config/images] Pulled k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs kubernetes/kubeadm#1030 kubernetes/kubeadm#51

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/kind feature
/assign @luxas
/assign @timothysc
/assign @dims 
/assign @neolit123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: Control plane images (etcd, kube-apiserver, kube-proxy, etc.) don't use arch suffixes. Arch suffixes are kept for kube-dns only.
```
