### PR TITLE
stop adding internal types to external schemes

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -220,7 +220,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/testing:go_default_library",

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -57,10 +57,8 @@ go_library(
     ],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/apis/certificates:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/apply/parse:go_default_library",
         "//pkg/kubectl/apply/strategy:go_default_library",
@@ -94,6 +92,7 @@ go_library(
         "//pkg/util/taints:go_default_library",
         "//pkg/version:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
+        "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/spf13/cobra"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -33,8 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
-
-	"github.com/spf13/cobra"
 )
 
 func NewCmdCertificate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
@@ -63,7 +62,7 @@ type CertificateOptions struct {
 	csrNames    []string
 	outputStyle string
 
-	clientSet internalclientset.Interface
+	clientSet kubernetes.Interface
 	builder   *resource.Builder
 
 	genericclioptions.IOStreams
@@ -83,7 +82,7 @@ func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 	}
 
 	o.builder = f.NewBuilder()
-	o.clientSet, err = f.ClientSet()
+	o.clientSet, err = f.KubernetesClientSet()
 	if err != nil {
 		return err
 	}
@@ -135,18 +134,18 @@ func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOS
 }
 
 func (o *CertificateOptions) RunCertificateApprove(force bool) error {
-	return o.modifyCertificateCondition(o.builder, o.clientSet, force, func(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, bool) {
+	return o.modifyCertificateCondition(o.builder, o.clientSet, force, func(csr *certificatesv1beta1.CertificateSigningRequest) (*certificatesv1beta1.CertificateSigningRequest, bool) {
 		var alreadyApproved bool
 		for _, c := range csr.Status.Conditions {
-			if c.Type == certificates.CertificateApproved {
+			if c.Type == certificatesv1beta1.CertificateApproved {
 				alreadyApproved = true
 			}
 		}
 		if alreadyApproved {
 			return csr, true
 		}
-		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
-			Type:           certificates.CertificateApproved,
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1beta1.CertificateSigningRequestCondition{
+			Type:           certificatesv1beta1.CertificateApproved,
 			Reason:         "KubectlApprove",
 			Message:        "This CSR was approved by kubectl certificate approve.",
 			LastUpdateTime: metav1.Now(),
@@ -187,18 +186,18 @@ func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 }
 
 func (o *CertificateOptions) RunCertificateDeny(force bool) error {
-	return o.modifyCertificateCondition(o.builder, o.clientSet, force, func(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, bool) {
+	return o.modifyCertificateCondition(o.builder, o.clientSet, force, func(csr *certificatesv1beta1.CertificateSigningRequest) (*certificatesv1beta1.CertificateSigningRequest, bool) {
 		var alreadyDenied bool
 		for _, c := range csr.Status.Conditions {
-			if c.Type == certificates.CertificateDenied {
+			if c.Type == certificatesv1beta1.CertificateDenied {
 				alreadyDenied = true
 			}
 		}
 		if alreadyDenied {
 			return csr, true
 		}
-		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
-			Type:           certificates.CertificateDenied,
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1beta1.CertificateSigningRequestCondition{
+			Type:           certificatesv1beta1.CertificateDenied,
 			Reason:         "KubectlDeny",
 			Message:        "This CSR was denied by kubectl certificate deny.",
 			LastUpdateTime: metav1.Now(),
@@ -207,10 +206,10 @@ func (o *CertificateOptions) RunCertificateDeny(force bool) error {
 	})
 }
 
-func (options *CertificateOptions) modifyCertificateCondition(builder *resource.Builder, clientSet internalclientset.Interface, force bool, modify func(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, bool)) error {
+func (options *CertificateOptions) modifyCertificateCondition(builder *resource.Builder, clientSet kubernetes.Interface, force bool, modify func(csr *certificatesv1beta1.CertificateSigningRequest) (*certificatesv1beta1.CertificateSigningRequest, bool)) error {
 	var found int
 	r := builder.
-		WithScheme(legacyscheme.Scheme).
+		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		FilenameParam(false, &options.FilenameOptions).
 		ResourceNames("certificatesigningrequest", options.csrNames...).
@@ -223,7 +222,7 @@ func (options *CertificateOptions) modifyCertificateCondition(builder *resource.
 			return err
 		}
 		for i := 0; ; i++ {
-			csr := info.Object.(*certificates.CertificateSigningRequest)
+			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
 				csr, err = clientSet.Certificates().

--- a/pkg/kubectl/cmd/cmd_printing_test.go
+++ b/pkg/kubectl/cmd/cmd_printing_test.go
@@ -23,10 +23,10 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	genericprinters "k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/printers"
 )
 
@@ -84,7 +84,7 @@ func TestIllegalPackageSourceCheckerThroughPrintFlags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			printFlags := genericclioptions.NewPrintFlags("succeeded").WithTypeSetter(scheme.Scheme)
+			printFlags := genericclioptions.NewPrintFlags("succeeded").WithTypeSetter(legacyscheme.Scheme)
 			printFlags.OutputFormat = &tc.output
 
 			printer, err := printFlags.ToPrinter()
@@ -132,7 +132,7 @@ func TestIllegalPackageSourceCheckerDirectlyThroughPrinters(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	customColumns, err := printers.NewCustomColumnsPrinterFromSpec("NAME:.metadata.name", scheme.Codecs.UniversalDecoder(), true)
+	customColumns, err := printers.NewCustomColumnsPrinterFromSpec("NAME:.metadata.name", legacyscheme.Codecs.UniversalDecoder(), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -26,26 +26,19 @@ import (
 	"reflect"
 	stdstrings "strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
-
-// This init should be removed after switching this command and its tests to user external types.
-func init() {
-	utilruntime.Must(api.AddToScheme(scheme.Scheme))
-}
 
 func initTestErrorHandler(t *testing.T) {
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
@@ -70,50 +63,55 @@ func defaultClientConfig() *restclient.Config {
 	}
 }
 
-func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList) {
-	pods := &api.PodList{
+func testData() (*corev1.PodList, *corev1.ServiceList, *corev1.ReplicationControllerList) {
+	pods := &corev1.PodList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "15",
 		},
-		Items: []api.Pod{
+		Items: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
-				Spec:       apitesting.DeepEqualSafePodSpec(),
+				Spec:       apitesting.V1DeepEqualSafePodSpec(),
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
-				Spec:       apitesting.DeepEqualSafePodSpec(),
+				Spec:       apitesting.V1DeepEqualSafePodSpec(),
 			},
 		},
 	}
-	svc := &api.ServiceList{
+	svc := &corev1.ServiceList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "16",
 		},
-		Items: []api.Service{
+		Items: []corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
-				Spec: api.ServiceSpec{
+				Spec: corev1.ServiceSpec{
 					SessionAffinity: "None",
-					Type:            api.ServiceTypeClusterIP,
+					Type:            corev1.ServiceTypeClusterIP,
 				},
 			},
 		},
 	}
-	rc := &api.ReplicationControllerList{
+	rc := &corev1.ReplicationControllerList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "17",
 		},
-		Items: []api.ReplicationController{
+		Items: []corev1.ReplicationController{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "rc1", Namespace: "test", ResourceVersion: "18"},
-				Spec: api.ReplicationControllerSpec{
-					Replicas: 1,
+				Spec: corev1.ReplicationControllerSpec{
+					Replicas: int32ptr(1),
 				},
 			},
 		},
 	}
 	return pods, svc, rc
+}
+
+func int32ptr(val int) *int32 {
+	t := int32(val)
+	return &t
 }
 
 func objBody(codec runtime.Codec, obj runtime.Object) io.ReadCloser {
@@ -130,98 +128,6 @@ func bytesBody(bodyBytes []byte) io.ReadCloser {
 
 func stringBody(body string) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(body)))
-}
-
-func newAllPhasePodList() *api.PodList {
-	nodeName := "kubernetes-node-abcd"
-	return &api.PodList{
-		Items: []api.Pod{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test1",
-					CreationTimestamp: metav1.Time{Time: time.Now().AddDate(-10, 0, 0)},
-				},
-				Spec: api.PodSpec{
-					Containers: make([]api.Container, 2),
-					NodeName:   nodeName,
-				},
-				Status: api.PodStatus{
-					Phase: api.PodPending,
-					ContainerStatuses: []api.ContainerStatus{
-						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
-						{RestartCount: 3},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test2",
-					CreationTimestamp: metav1.Time{Time: time.Now().AddDate(-10, 0, 0)},
-				},
-				Spec: api.PodSpec{
-					Containers: make([]api.Container, 2),
-					NodeName:   nodeName,
-				},
-				Status: api.PodStatus{
-					Phase: api.PodRunning,
-					ContainerStatuses: []api.ContainerStatus{
-						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
-						{RestartCount: 3},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test3",
-					CreationTimestamp: metav1.Time{Time: time.Now().AddDate(-10, 0, 0)},
-				},
-				Spec: api.PodSpec{
-					Containers: make([]api.Container, 2),
-					NodeName:   nodeName,
-				},
-				Status: api.PodStatus{
-					Phase: api.PodSucceeded,
-					ContainerStatuses: []api.ContainerStatus{
-						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
-						{RestartCount: 3},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test4",
-					CreationTimestamp: metav1.Time{Time: time.Now().AddDate(-10, 0, 0)},
-				},
-				Spec: api.PodSpec{
-					Containers: make([]api.Container, 2),
-					NodeName:   nodeName,
-				},
-				Status: api.PodStatus{
-					Phase: api.PodFailed,
-					ContainerStatuses: []api.ContainerStatus{
-						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
-						{RestartCount: 3},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test5",
-					CreationTimestamp: metav1.Time{Time: time.Now().AddDate(-10, 0, 0)},
-				},
-				Spec: api.PodSpec{
-					Containers: make([]api.Container, 2),
-					NodeName:   nodeName,
-				},
-				Status: api.PodStatus{
-					Phase: api.PodUnknown,
-					ContainerStatuses: []api.ContainerStatus{
-						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
-						{RestartCount: 3},
-					},
-				},
-			}},
-	}
 }
 
 func TestNormalizationFuncGlobalExistence(t *testing.T) {

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest/fake"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
@@ -274,7 +274,7 @@ func TestDeleteObjectGraceZero(t *testing.T) {
 					return &http.Response{StatusCode: 404, Header: defaultHeader(), Body: objBody(codec, &metav1.Status{})}, nil
 				}
 			case p == "/api/v1/namespaces/test" && m == "GET":
-				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &api.Namespace{})}, nil
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &corev1.Namespace{})}, nil
 			case p == "/namespaces/test/pods/nginx" && m == "DELETE":
 				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods.Items[0])}, nil
 			default:
@@ -371,8 +371,8 @@ func TestDeleteAllNotFound(t *testing.T) {
 	initTestErrorHandler(t)
 	_, svc, _ := testData()
 	// Add an item to the list which will result in a 404 on delete
-	svc.Items = append(svc.Items, api.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
-	notFoundError := &errors.NewNotFound(api.Resource("services"), "foo").ErrStatus
+	svc.Items = append(svc.Items, corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	notFoundError := &errors.NewNotFound(corev1.Resource("services"), "foo").ErrStatus
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
@@ -426,8 +426,8 @@ func TestDeleteAllIgnoreNotFound(t *testing.T) {
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 
 	// Add an item to the list which will result in a 404 on delete
-	svc.Items = append(svc.Items, api.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
-	notFoundError := &errors.NewNotFound(api.Resource("services"), "foo").ErrStatus
+	svc.Items = append(svc.Items, corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	notFoundError := &errors.NewNotFound(corev1.Resource("services"), "foo").ErrStatus
 
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: unstructuredSerializer,

--- a/pkg/kubectl/cmd/exec_test.go
+++ b/pkg/kubectl/cmd/exec_test.go
@@ -29,11 +29,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/remotecommand"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -172,7 +172,7 @@ func TestExec(t *testing.T) {
 	version := "v1"
 	tests := []struct {
 		name, podPath, execPath string
-		pod                     *api.Pod
+		pod                     *corev1.Pod
 		execErr                 bool
 	}{
 		{
@@ -251,20 +251,20 @@ func TestExec(t *testing.T) {
 	}
 }
 
-func execPod() *api.Pod {
-	return &api.Pod{
+func execPod() *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
-		Spec: api.PodSpec{
-			RestartPolicy: api.RestartPolicyAlways,
-			DNSPolicy:     api.DNSClusterFirst,
-			Containers: []api.Container{
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyAlways,
+			DNSPolicy:     corev1.DNSClusterFirst,
+			Containers: []corev1.Container{
 				{
 					Name: "bar",
 				},
 			},
 		},
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
 		},
 	}
 }

--- a/pkg/kubectl/cmd/expose_test.go
+++ b/pkg/kubectl/cmd/expose_test.go
@@ -27,18 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest/fake"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
-
-// This init should be removed after switching this command and its tests to user external types.
-func init() {
-	utilruntime.Must(api.AddToScheme(scheme.Scheme))
-}
 
 func TestRunExposeService(t *testing.T) {
 	tests := []struct {

--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -68,7 +68,6 @@ go_test(
     deps = [
         "//pkg/api/testing:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/core/v1:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
@@ -88,7 +87,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -39,14 +39,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/diff"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/kube-openapi/pkg/util/proto"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/apis/core/v1"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
@@ -57,13 +55,6 @@ import (
 )
 
 var openapiSchemaPath = filepath.Join("..", "..", "..", "..", "api", "openapi-spec", "swagger.json")
-
-// This init should be removed after switching this command and its tests to user external types.
-func init() {
-	utilruntime.Must(api.AddToScheme(scheme.Scheme))
-	utilruntime.Must(scheme.Scheme.AddConversionFuncs(v1.Convert_core_PodSpec_To_v1_PodSpec))
-	utilruntime.Must(scheme.Scheme.AddConversionFuncs(v1.Convert_v1_PodSecurityContext_To_core_PodSecurityContext))
-}
 
 var unstructuredSerializer = resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer
 

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -28,14 +28,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -50,7 +49,7 @@ type PortForwardOptions struct {
 	PodName       string
 	RESTClient    *restclient.RESTClient
 	Config        *restclient.Config
-	PodClient     coreclient.PodsGetter
+	PodClient     corev1client.PodsGetter
 	Ports         []string
 	PortForwarder portForwarder
 	StopChannel   chan struct{}
@@ -143,7 +142,7 @@ func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts Po
 // It rewrites ports as needed if the Service port declares targetPort.
 // It returns an error when a named targetPort can't find a match in the pod, or the Service did not declare
 // the port.
-func translateServicePortToTargetPort(ports []string, svc v1.Service, pod v1.Pod) ([]string, error) {
+func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod corev1.Pod) ([]string, error) {
 	var translated []string
 	for _, port := range ports {
 		// port is in the form of [LOCAL PORT]:REMOTE PORT
@@ -210,7 +209,7 @@ func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 
 	// handle service port mapping to target port if needed
 	switch t := obj.(type) {
-	case *v1.Service:
+	case *corev1.Service:
 		o.Ports, err = translateServicePortToTargetPort(args[1:], *t, *forwardablePod)
 		if err != nil {
 			return err
@@ -219,12 +218,12 @@ func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 		o.Ports = args[1:]
 	}
 
-	clientset, err := f.ClientSet()
+	clientset, err := f.KubernetesClientSet()
 	if err != nil {
 		return err
 	}
 
-	o.PodClient = clientset.Core()
+	o.PodClient = clientset.CoreV1()
 
 	o.Config, err = f.ToRESTConfig()
 	if err != nil {
@@ -263,7 +262,7 @@ func (o PortForwardOptions) RunPortForward() error {
 		return err
 	}
 
-	if pod.Status.Phase != api.PodRunning {
+	if pod.Status.Phase != corev1.PodRunning {
 		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
 	}
 

--- a/pkg/kubectl/cmd/replace_test.go
+++ b/pkg/kubectl/cmd/replace_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest/fake"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -41,7 +41,7 @@ func TestReplaceObject(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
 			case p == "/api/v1/namespaces/test" && m == http.MethodGet:
-				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &api.Namespace{})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &corev1.Namespace{})}, nil
 			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == http.MethodDelete:
 				deleted = true
 				fallthrough
@@ -98,7 +98,7 @@ func TestReplaceMultipleObject(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
 			case p == "/api/v1/namespaces/test" && m == http.MethodGet:
-				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &api.Namespace{})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &corev1.Namespace{})}, nil
 			case p == "/namespaces/test/replicationcontrollers/redis-master" && m == http.MethodDelete:
 				redisMasterDeleted = true
 				fallthrough
@@ -167,7 +167,7 @@ func TestReplaceDirectory(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
 			case p == "/api/v1/namespaces/test" && m == http.MethodGet:
-				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &api.Namespace{})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &corev1.Namespace{})}, nil
 			case strings.HasPrefix(p, "/namespaces/test/replicationcontrollers/") && m == http.MethodPut:
 				created[p] = true
 				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &rc.Items[0])}, nil
@@ -223,7 +223,7 @@ func TestForceReplaceObjectNotFound(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
 			case p == "/api/v1/namespaces/test" && m == http.MethodGet:
-				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &api.Namespace{})}, nil
+				return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(codec, &corev1.Namespace{})}, nil
 			case p == "/namespaces/test/replicationcontrollers/redis-master" && (m == http.MethodGet || m == http.MethodDelete):
 				return &http.Response{StatusCode: http.StatusNotFound, Header: defaultHeader(), Body: stringBody("")}, nil
 			case p == "/namespaces/test/replicationcontrollers" && m == http.MethodPost:

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -219,7 +219,11 @@ func (o *RollingUpdateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 		return err
 	}
 
-	o.ClientSet, err = f.ClientSet()
+	clientConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	o.ClientSet, err = internalclientset.NewForConfig(clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,35 +55,35 @@ func TestGetRestartPolicy(t *testing.T) {
 	tests := []struct {
 		input       string
 		interactive bool
-		expected    api.RestartPolicy
+		expected    corev1.RestartPolicy
 		expectErr   bool
 	}{
 		{
 			input:    "",
-			expected: api.RestartPolicyAlways,
+			expected: corev1.RestartPolicyAlways,
 		},
 		{
 			input:       "",
 			interactive: true,
-			expected:    api.RestartPolicyOnFailure,
+			expected:    corev1.RestartPolicyOnFailure,
 		},
 		{
-			input:       string(api.RestartPolicyAlways),
+			input:       string(corev1.RestartPolicyAlways),
 			interactive: true,
-			expected:    api.RestartPolicyAlways,
+			expected:    corev1.RestartPolicyAlways,
 		},
 		{
-			input:       string(api.RestartPolicyNever),
+			input:       string(corev1.RestartPolicyNever),
 			interactive: true,
-			expected:    api.RestartPolicyNever,
+			expected:    corev1.RestartPolicyNever,
 		},
 		{
-			input:    string(api.RestartPolicyAlways),
-			expected: api.RestartPolicyAlways,
+			input:    string(corev1.RestartPolicyAlways),
+			expected: corev1.RestartPolicyAlways,
 		},
 		{
-			input:    string(api.RestartPolicyNever),
-			expected: api.RestartPolicyNever,
+			input:    string(corev1.RestartPolicyNever),
+			expected: corev1.RestartPolicyNever,
 		},
 		{
 			input:     "foo",
@@ -234,7 +235,6 @@ func TestRunArgsFollowDashRules(t *testing.T) {
 }
 
 func TestGenerateService(t *testing.T) {
-
 	tests := []struct {
 		port             string
 		args             []string

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -45,11 +44,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
-
-// This init should be removed after switching this command and its tests to user external types.
-func init() {
-	utilruntime.Must(api.AddToScheme(scheme.Scheme))
-}
 
 func TestGetRestartPolicy(t *testing.T) {
 	tests := []struct {

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -164,7 +163,7 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
 	o.builder = f.NewBuilder().
-		WithScheme(legacyscheme.Scheme).
+		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace()
 	if o.selector != "" {
@@ -246,11 +245,7 @@ func (o TaintOptions) RunTaint() error {
 			return err
 		}
 
-		obj, err := legacyscheme.Scheme.ConvertToVersion(info.Object, v1.SchemeGroupVersion)
-		if err != nil {
-			glog.V(1).Info(err)
-			return fmt.Errorf("object was not a node.v1.: %T", info.Object)
-		}
+		obj := info.Object
 		name, namespace := info.Name, info.Namespace
 		oldData, err := json.Marshal(obj)
 		if err != nil {

--- a/pkg/kubectl/cmd/taint_test.go
+++ b/pkg/kubectl/cmd/taint_test.go
@@ -23,31 +23,30 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
-func generateNodeAndTaintedNode(oldTaints []v1.Taint, newTaints []v1.Taint) (*v1.Node, *v1.Node) {
-	var taintedNode *v1.Node
+func generateNodeAndTaintedNode(oldTaints []corev1.Taint, newTaints []corev1.Taint) (*corev1.Node, *corev1.Node) {
+	var taintedNode *corev1.Node
 
 	// Create a node.
-	node := &v1.Node{
+	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "node-name",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 		},
-		Spec: v1.NodeSpec{
+		Spec: corev1.NodeSpec{
 			Taints: oldTaints,
 		},
-		Status: v1.NodeStatus{},
+		Status: corev1.NodeStatus{},
 	}
 
 	// A copy of the same node, but tainted.
@@ -57,7 +56,7 @@ func generateNodeAndTaintedNode(oldTaints []v1.Taint, newTaints []v1.Taint) (*v1
 	return node, taintedNode
 }
 
-func equalTaints(taintsA, taintsB []v1.Taint) bool {
+func equalTaints(taintsA, taintsB []corev1.Taint) bool {
 	if len(taintsA) != len(taintsB) {
 		return false
 	}
@@ -80,8 +79,8 @@ func equalTaints(taintsA, taintsB []v1.Taint) bool {
 func TestTaint(t *testing.T) {
 	tests := []struct {
 		description string
-		oldTaints   []v1.Taint
-		newTaints   []v1.Taint
+		oldTaints   []corev1.Taint
+		newTaints   []corev1.Taint
 		args        []string
 		expectFatal bool
 		expectTaint bool
@@ -89,7 +88,7 @@ func TestTaint(t *testing.T) {
 		// success cases
 		{
 			description: "taints a node with effect NoSchedule",
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "bar",
 				Effect: "NoSchedule",
@@ -100,7 +99,7 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "taints a node with effect PreferNoSchedule",
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "bar",
 				Effect: "PreferNoSchedule",
@@ -111,12 +110,12 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "update an existing taint on the node, change the value from bar to barz",
-			oldTaints: []v1.Taint{{
+			oldTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "bar",
 				Effect: "NoSchedule",
 			}},
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "barz",
 				Effect: "NoSchedule",
@@ -127,7 +126,7 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "taints a node with two taints",
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "dedicated",
 				Value:  "namespaceA",
 				Effect: "NoSchedule",
@@ -142,7 +141,7 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "node has two taints with the same key but different effect, remove one of them by indicating exact key and effect",
-			oldTaints: []v1.Taint{{
+			oldTaints: []corev1.Taint{{
 				Key:    "dedicated",
 				Value:  "namespaceA",
 				Effect: "NoSchedule",
@@ -151,7 +150,7 @@ func TestTaint(t *testing.T) {
 				Value:  "namespaceA",
 				Effect: "PreferNoSchedule",
 			}},
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "dedicated",
 				Value:  "namespaceA",
 				Effect: "PreferNoSchedule",
@@ -162,7 +161,7 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "node has two taints with the same key but different effect, remove all of them with wildcard",
-			oldTaints: []v1.Taint{{
+			oldTaints: []corev1.Taint{{
 				Key:    "dedicated",
 				Value:  "namespaceA",
 				Effect: "NoSchedule",
@@ -171,14 +170,14 @@ func TestTaint(t *testing.T) {
 				Value:  "namespaceA",
 				Effect: "PreferNoSchedule",
 			}},
-			newTaints:   []v1.Taint{},
+			newTaints:   []corev1.Taint{},
 			args:        []string{"node", "node-name", "dedicated-"},
 			expectFatal: false,
 			expectTaint: true,
 		},
 		{
 			description: "node has two taints, update one of them and remove the other",
-			oldTaints: []v1.Taint{{
+			oldTaints: []corev1.Taint{{
 				Key:    "dedicated",
 				Value:  "namespaceA",
 				Effect: "NoSchedule",
@@ -187,7 +186,7 @@ func TestTaint(t *testing.T) {
 				Value:  "bar",
 				Effect: "PreferNoSchedule",
 			}},
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "barz",
 				Effect: "PreferNoSchedule",
@@ -218,12 +217,12 @@ func TestTaint(t *testing.T) {
 		},
 		{
 			description: "can't update existing taint on the node, since 'overwrite' flag is not set",
-			oldTaints: []v1.Taint{{
+			oldTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "bar",
 				Effect: "NoSchedule",
 			}},
-			newTaints: []v1.Taint{{
+			newTaints: []corev1.Taint{{
 				Key:    "foo",
 				Value:  "bar",
 				Effect: "NoSchedule",
@@ -237,16 +236,17 @@ func TestTaint(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			oldNode, expectNewNode := generateNodeAndTaintedNode(test.oldTaints, test.newTaints)
-			new_node := &v1.Node{}
+			new_node := &corev1.Node{}
 			tainted := false
 			tf := cmdtesting.NewTestFactory()
 			defer tf.Cleanup()
 
-			codec := legacyscheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-			ns := legacyscheme.Codecs
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+			ns := scheme.Codecs
 
 			tf.Client = &fake.RESTClient{
 				NegotiatedSerializer: ns,
+				GroupVersion:         corev1.SchemeGroupVersion,
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					m := &MyReq{req}
 					switch {
@@ -267,7 +267,7 @@ func TestTaint(t *testing.T) {
 						if err != nil {
 							t.Fatalf("%s: unexpected error: %v", test.description, err)
 						}
-						appliedPatch, err := strategicpatch.StrategicMergePatch(oldJSON, data, &v1.Node{})
+						appliedPatch, err := strategicpatch.StrategicMergePatch(oldJSON, data, &corev1.Node{})
 						if err != nil {
 							t.Fatalf("%s: unexpected error: %v", test.description, err)
 						}
@@ -308,7 +308,10 @@ func TestTaint(t *testing.T) {
 			func() {
 				defer func() {
 					// Recover from the panic below.
-					_ = recover()
+					if r := recover(); r != nil {
+						t.Logf("Recovered: %v", r)
+					}
+
 					// Restore cmdutil behavior
 					cmdutil.DefaultBehaviorOnFatal()
 				}()

--- a/pkg/kubectl/cmd/testing/BUILD
+++ b/pkg/kubectl/cmd/testing/BUILD
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//build/visible_to:pkg_kubectl_cmd_testing_CONSUMERS"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
@@ -363,26 +362,6 @@ func (f *TestFactory) KubernetesClientSet() (*kubernetes.Clientset, error) {
 	clientset.PolicyV1beta1().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	clientset.DiscoveryClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 
-	return clientset, nil
-}
-
-func (f *TestFactory) ClientSet() (internalclientset.Interface, error) {
-	// Swap the HTTP client out of the REST client with the fake
-	// version.
-	fakeClient := f.Client.(*fake.RESTClient)
-	clientset := internalclientset.NewForConfigOrDie(f.ClientConfigVal)
-	clientset.Core().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Authentication().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Authorization().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Autoscaling().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Batch().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Certificates().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Extensions().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Rbac().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Storage().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Apps().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.Policy().RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
-	clientset.DiscoveryClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client
 	return clientset, nil
 }
 

--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -40,7 +40,7 @@ import (
 type TopNodeOptions struct {
 	ResourceName    string
 	Selector        string
-	NodeClient      corev1.CoreV1Interface
+	NodeClient      corev1client.CoreV1Interface
 	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
 	Printer         *metricsutil.TopCmdPrinter

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/metricsutil"
@@ -45,7 +45,7 @@ type TopPodOptions struct {
 	Selector        string
 	AllNamespaces   bool
 	PrintContainers bool
-	PodClient       corev1.PodsGetter
+	PodClient       corev1client.PodsGetter
 	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
 	Printer         *metricsutil.TopCmdPrinter

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
@@ -40,9 +39,6 @@ import (
 // commands are decoupled from the factory).
 type Factory interface {
 	genericclioptions.RESTClientGetter
-
-	// ClientSet gives you back an internal, generated clientset
-	ClientSet() (internalclientset.Interface, error)
 
 	// DynamicClient returns a dynamic client ready for use
 	DynamicClient() (dynamic.Interface, error)

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 	openapivalidation "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/validation"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -85,14 +84,6 @@ func (f *factoryImpl) KubernetesClientSet() (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 	return kubernetes.NewForConfig(clientConfig)
-}
-
-func (f *factoryImpl) ClientSet() (internalclientset.Interface, error) {
-	clientConfig, err := f.ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-	return internalclientset.NewForConfig(clientConfig)
 }
 
 func (f *factoryImpl) DynamicClient() (dynamic.Interface, error) {

--- a/pkg/kubectl/metricsutil/metrics_client.go
+++ b/pkg/kubectl/metricsutil/metrics_client.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
@@ -47,14 +47,14 @@ var (
 )
 
 type HeapsterMetricsClient struct {
-	SVCClient         corev1.ServicesGetter
+	SVCClient         corev1client.ServicesGetter
 	HeapsterNamespace string
 	HeapsterScheme    string
 	HeapsterService   string
 	HeapsterPort      string
 }
 
-func NewHeapsterMetricsClient(svcClient corev1.ServicesGetter, namespace, scheme, service, port string) *HeapsterMetricsClient {
+func NewHeapsterMetricsClient(svcClient corev1client.ServicesGetter, namespace, scheme, service, port string) *HeapsterMetricsClient {
 	return &HeapsterMetricsClient{
 		SVCClient:         svcClient,
 		HeapsterNamespace: namespace,
@@ -62,10 +62,6 @@ func NewHeapsterMetricsClient(svcClient corev1.ServicesGetter, namespace, scheme
 		HeapsterService:   service,
 		HeapsterPort:      port,
 	}
-}
-
-func DefaultHeapsterMetricsClient(svcClient corev1.ServicesGetter) *HeapsterMetricsClient {
-	return NewHeapsterMetricsClient(svcClient, DefaultHeapsterNamespace, DefaultHeapsterScheme, DefaultHeapsterService, DefaultHeapsterPort)
 }
 
 func podMetricsUrl(namespace string, name string) (string, error) {

--- a/staging/src/k8s.io/client-go/rest/fake/fake.go
+++ b/staging/src/k8s.io/client-go/rest/fake/fake.go
@@ -94,14 +94,10 @@ func (c *RESTClient) request(verb string) *restclient.Request {
 
 	ns := c.NegotiatedSerializer
 	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
-	internalVersion := schema.GroupVersion{
-		Group:   c.GroupVersion.Group,
-		Version: runtime.APIVersionInternal,
-	}
 	serializers := restclient.Serializers{
 		// TODO this was hardcoded before, but it doesn't look right
 		Encoder: ns.EncoderForVersion(info.Serializer, c.GroupVersion),
-		Decoder: ns.DecoderToVersion(info.Serializer, internalVersion),
+		Decoder: ns.DecoderToVersion(info.Serializer, c.GroupVersion),
 	}
 	if info.StreamSerializer != nil {
 		serializers.StreamingSerializer = info.StreamSerializer.Serializer


### PR DESCRIPTION
at some point someone starting internal types to external schemes in kubectl tests.  This fixes that mistake.

@kubernetes/sig-cli-maintainers 
/assign @soltysh 

```release-note
NONE
```