### PR TITLE
Promoting configmap binarydata support [NodeConformance] test to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -35,6 +35,7 @@ test/e2e/common/configmap_volume.go: "should be consumable from pods in volume w
 test/e2e/common/configmap_volume.go: "should be consumable from pods in volume with mappings and Item mode set"
 test/e2e/common/configmap_volume.go: "should be consumable from pods in volume with mappings as non-root"
 test/e2e/common/configmap_volume.go: "updates should be reflected in volume"
+test/e2e/common/configmap_volume.go: "binary data should be reflected in volume"
 test/e2e/common/configmap_volume.go: "optional updates should be reflected in volume"
 test/e2e/common/configmap_volume.go: "should be consumable in multiple volumes in the same pod"
 test/e2e/common/container_probe.go: "with readiness probe should not be ready before initial delay and never restart"

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -184,7 +184,12 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
-	It("binary data should be reflected in volume [NodeConformance]", func() {
+	/*
+		Release: v1.12
+		Testname: ConfigMap Volume, text data, binary data
+		Description: The ConfigMap that is created with text data and binary data MUST be accessible to read from the newly created Pod using the volume mount that is mapped to custom path in the Pod. ConfigMap's text data and binary data MUST be verified by reading the content from the mounted files in the Pod.
+	*/
+	framework.ConformanceIt("binary data should be reflected in volume [NodeConformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**e2e:** _[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]_
Promotes mentioned e2e to conformance as it -
1. Validates ConfigMap's binarydata support effectively
2. Improves API Coverage for prioritized api lists. (https://github.com/cncf/k8s-conformance/issues/220#issuecomment-393344061)

> GET /api/v1/namespaces/{namespace}/pods
GET /api/v1/namespaces/{namespace}/pods/{name}
GET /api/v1/namespaces/{namespace}/pods/{name}/log
POST /api/v1/namespaces/{namespace}/pods
PUT /api/v1/namespaces/{namespace}/pods/{name}/status
DELETE /api/v1/namespaces/{namespace}/pods
DELETE /api/v1/namespaces/{namespace}/pods/{name}

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
No Flakes found.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/area conformance
@kubernetes/sig-node-pr-reviews