### PR TITLE
Update resource-consumer usage

### DIFF
--- a/test/images/resource-consumer/README.md
+++ b/test/images/resource-consumer/README.md
@@ -48,7 +48,7 @@ Custom metrics in Prometheus format are exposed on "/metrics" endpoint.
 
 ### CURL example
 ```console
-$ kubectl run resource-consumer --image=k8s.gcr.io/resource_consumer:beta --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080
+$ kubectl run resource-consumer --image=gcr.io/kubernetes-e2e-test-images/resource-consumer:1.3 --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080 --requests='cpu=500m,memory=256Mi'
 $ kubectl get services resource-consumer
 ```
 
@@ -62,7 +62,7 @@ $ curl --data "millicores=300&durationSec=600" http://<EXTERNAL-IP>:8080/Consume
 
 ## Image
 
-Docker image of Resource Consumer can be found in Google Container Registry as k8s.gcr.io/resource_consumer:beta
+Docker image of Resource Consumer can be found in Google Container Registry as gcr.io/kubernetes-e2e-test-images/resource-consumer:1.3
 
 ## Use cases
 


### PR DESCRIPTION

**What this PR does / why we need it**:

The e2e tests are using version 1.3 of resource-consumer from
gcr.io/kubernetes-e2e-test-images since [1]. In addition, HPA
works fine for a deployment with --requrests flag.
So this updates the README.md for fitting current condition.

[1]: https://github.com/kubernetes/kubernetes/blob/master/test/utils/image/manifest.go#L86

**Release note**: NONE
