### PR TITLE
Better error message when checking rollout status for StatefulSet wit…

### DIFF
--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -105,7 +105,7 @@ func (s *DaemonSetStatusViewer) Status(namespace, name string, revision int64) (
 		return "", false, err
 	}
 	if daemon.Spec.UpdateStrategy.Type != appsv1.RollingUpdateDaemonSetStrategyType {
-		return "", true, fmt.Errorf("Status is available only for RollingUpdate strategy type")
+		return "", true, fmt.Errorf("rollout status is only available for %s strategy type", appsv1.RollingUpdateStatefulSetStrategyType)
 	}
 	if daemon.Generation <= daemon.Status.ObservedGeneration {
 		if daemon.Status.UpdatedNumberScheduled < daemon.Status.DesiredNumberScheduled {
@@ -125,8 +125,8 @@ func (s *StatefulSetStatusViewer) Status(namespace, name string, revision int64)
 	if err != nil {
 		return "", false, err
 	}
-	if sts.Spec.UpdateStrategy.Type == apps.OnDeleteStatefulSetStrategyType {
-		return "", true, fmt.Errorf("%s updateStrategy does not have a Status", apps.OnDeleteStatefulSetStrategyType)
+	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		return "", true, fmt.Errorf("rollout status is only available for %s strategy type", appsv1.RollingUpdateStatefulSetStrategyType)
 	}
 	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
 		return "Waiting for statefulset spec update to be observed...\n", false, nil

--- a/pkg/kubectl/rollout_status_test.go
+++ b/pkg/kubectl/rollout_status_test.go
@@ -405,7 +405,7 @@ func TestDaemonSetStatusViewerStatusWithWrongUpdateStrategyType(t *testing.T) {
 	client := fake.NewSimpleClientset(d).Apps()
 	dsv := &DaemonSetStatusViewer{c: client}
 	msg, done, err := dsv.Status("bar", "foo", 0)
-	errMsg := "Status is available only for RollingUpdate strategy type"
+	errMsg := "rollout status is only available for RollingUpdate strategy type"
 	if err == nil || err.Error() != errMsg {
 		t.Errorf("Status for daemon sets with UpdateStrategy type different than RollingUpdate should return error. Instead got: msg: %s\ndone: %t\n err: %v", msg, done, err)
 	}


### PR DESCRIPTION
…h OnDelete strategy type

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The error message when checking the rollout status for a StatefulSet with the OnDelete strategy type can be confusing (ref #64500). It gives the impression that something has gone wrong when the issue is simply that there is no rollout status. The error message is updated to use similar language as for DaemonSet in the same situation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improved error message when checking the rollout status of StatefulSet with OnDelete strategy type
```
