### PR TITLE
Remove ARCH specific image consideration from e2e tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -250,11 +250,6 @@ func GetServerArchitecture(c clientset.Interface) string {
 	return arch
 }
 
-// GetPauseImageName fetches the pause image name for the same architecture as the apiserver.
-func GetPauseImageName(c clientset.Interface) string {
-	return imageutils.GetE2EImageWithArch(imageutils.Pause, GetServerArchitecture(c))
-}
-
 func GetServicesProxyRequest(c clientset.Interface, request *restclient.Request) (*restclient.Request, error) {
 	return request.Resource("services").SubResource("proxy"), nil
 }
@@ -5093,7 +5088,7 @@ func (f *Framework) NewTestPod(name string, requests v1.ResourceList, limits v1.
 			Containers: []v1.Container{
 				{
 					Name:  "pause",
-					Image: GetPauseImageName(f.ClientSet),
+					Image: imageutils.GetPauseImageName(),
 					Resources: v1.ResourceRequirements{
 						Requests: requests,
 						Limits:   limits,

--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -168,7 +169,7 @@ func runHugePagesTests(f *framework.Framework) {
 			Spec: apiv1.PodSpec{
 				Containers: []apiv1.Container{
 					{
-						Image: framework.GetPauseImageName(f.ClientSet),
+						Image: imageutils.GetPauseImageName(),
 						Name:  "container" + string(uuid.NewUUID()),
 						Resources: apiv1.ResourceRequirements{
 							Limits: apiv1.ResourceList{

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -18,7 +18,6 @@ package image
 
 import (
 	"fmt"
-	"runtime"
 )
 
 const (
@@ -33,7 +32,6 @@ type ImageConfig struct {
 	registry string
 	name     string
 	version  string
-	hasArch  bool
 }
 
 func (i *ImageConfig) SetRegistry(registry string) {
@@ -49,61 +47,53 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v2", false}
-	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0", false}
-	AppArmorLoader           = ImageConfig{e2eRegistry, "apparmor-loader", "1.0", false}
-	BusyBox                  = ImageConfig{dockerLibraryRegistry, "busybox", "1.29", false}
-	CheckMetadataConcealment = ImageConfig{e2eRegistry, "metadata-concealment", "1.0", false}
-	CudaVectorAdd            = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0", false}
-	Dnsutils                 = ImageConfig{e2eRegistry, "dnsutils", "1.1", false}
-	EchoServer               = ImageConfig{e2eRegistry, "echoserver", "2.1", false}
-	EntrypointTester         = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0", false}
-	Fakegitserver            = ImageConfig{e2eRegistry, "fakegitserver", "1.0", false}
-	GBFrontend               = ImageConfig{sampleRegistry, "gb-frontend", "v6", false}
-	GBRedisSlave             = ImageConfig{sampleRegistry, "gb-redisslave", "v3", false}
-	Hostexec                 = ImageConfig{e2eRegistry, "hostexec", "1.1", false}
-	IpcUtils                 = ImageConfig{e2eRegistry, "ipc-utils", "1.0", false}
-	Iperf                    = ImageConfig{e2eRegistry, "iperf", "1.0", false}
-	JessieDnsutils           = ImageConfig{e2eRegistry, "jessie-dnsutils", "1.0", false}
-	Kitten                   = ImageConfig{e2eRegistry, "kitten", "1.0", false}
-	Liveness                 = ImageConfig{e2eRegistry, "liveness", "1.0", false}
-	LogsGenerator            = ImageConfig{e2eRegistry, "logs-generator", "1.0", false}
-	Mounttest                = ImageConfig{e2eRegistry, "mounttest", "1.0", false}
-	MounttestUser            = ImageConfig{e2eRegistry, "mounttest-user", "1.0", false}
-	Nautilus                 = ImageConfig{e2eRegistry, "nautilus", "1.0", false}
-	Net                      = ImageConfig{e2eRegistry, "net", "1.0", false}
-	Netexec                  = ImageConfig{e2eRegistry, "netexec", "1.0", false}
-	Nettest                  = ImageConfig{e2eRegistry, "nettest", "1.0", false}
-	Nginx                    = ImageConfig{dockerLibraryRegistry, "nginx", "1.14-alpine", false}
-	NginxNew                 = ImageConfig{dockerLibraryRegistry, "nginx", "1.15-alpine", false}
-	Nonewprivs               = ImageConfig{e2eRegistry, "nonewprivs", "1.0", false}
-	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0", false}
-	NoSnatTestProxy          = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0", false}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v2"}
+	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0"}
+	AppArmorLoader           = ImageConfig{e2eRegistry, "apparmor-loader", "1.0"}
+	BusyBox                  = ImageConfig{dockerLibraryRegistry, "busybox", "1.29"}
+	CheckMetadataConcealment = ImageConfig{e2eRegistry, "metadata-concealment", "1.0"}
+	CudaVectorAdd            = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0"}
+	Dnsutils                 = ImageConfig{e2eRegistry, "dnsutils", "1.1"}
+	EchoServer               = ImageConfig{e2eRegistry, "echoserver", "2.1"}
+	EntrypointTester         = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0"}
+	Fakegitserver            = ImageConfig{e2eRegistry, "fakegitserver", "1.0"}
+	GBFrontend               = ImageConfig{sampleRegistry, "gb-frontend", "v6"}
+	GBRedisSlave             = ImageConfig{sampleRegistry, "gb-redisslave", "v3"}
+	Hostexec                 = ImageConfig{e2eRegistry, "hostexec", "1.1"}
+	IpcUtils                 = ImageConfig{e2eRegistry, "ipc-utils", "1.0"}
+	Iperf                    = ImageConfig{e2eRegistry, "iperf", "1.0"}
+	JessieDnsutils           = ImageConfig{e2eRegistry, "jessie-dnsutils", "1.0"}
+	Kitten                   = ImageConfig{e2eRegistry, "kitten", "1.0"}
+	Liveness                 = ImageConfig{e2eRegistry, "liveness", "1.0"}
+	LogsGenerator            = ImageConfig{e2eRegistry, "logs-generator", "1.0"}
+	Mounttest                = ImageConfig{e2eRegistry, "mounttest", "1.0"}
+	MounttestUser            = ImageConfig{e2eRegistry, "mounttest-user", "1.0"}
+	Nautilus                 = ImageConfig{e2eRegistry, "nautilus", "1.0"}
+	Net                      = ImageConfig{e2eRegistry, "net", "1.0"}
+	Netexec                  = ImageConfig{e2eRegistry, "netexec", "1.0"}
+	Nettest                  = ImageConfig{e2eRegistry, "nettest", "1.0"}
+	Nginx                    = ImageConfig{dockerLibraryRegistry, "nginx", "1.14-alpine"}
+	NginxNew                 = ImageConfig{dockerLibraryRegistry, "nginx", "1.15-alpine"}
+	Nonewprivs               = ImageConfig{e2eRegistry, "nonewprivs", "1.0"}
+	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0"}
+	NoSnatTestProxy          = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0"}
 	// When these values are updated, also update cmd/kubelet/app/options/container_runtime.go
-	Pause               = ImageConfig{gcRegistry, "pause", "3.1", false}
-	Porter              = ImageConfig{e2eRegistry, "porter", "1.0", false}
-	PortForwardTester   = ImageConfig{e2eRegistry, "port-forward-tester", "1.0", false}
-	Redis               = ImageConfig{e2eRegistry, "redis", "1.0", false}
-	ResourceConsumer    = ImageConfig{e2eRegistry, "resource-consumer", "1.3", false}
-	ResourceController  = ImageConfig{e2eRegistry, "resource-consumer/controller", "1.0", false}
-	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.1", false}
-	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0", false}
-	VolumeNFSServer     = ImageConfig{e2eRegistry, "volume/nfs", "1.0", false}
-	VolumeISCSIServer   = ImageConfig{e2eRegistry, "volume/iscsi", "1.0", false}
-	VolumeGlusterServer = ImageConfig{e2eRegistry, "volume/gluster", "1.0", false}
-	VolumeRBDServer     = ImageConfig{e2eRegistry, "volume/rbd", "1.0", false}
+	Pause               = ImageConfig{gcRegistry, "pause", "3.1"}
+	Porter              = ImageConfig{e2eRegistry, "porter", "1.0"}
+	PortForwardTester   = ImageConfig{e2eRegistry, "port-forward-tester", "1.0"}
+	Redis               = ImageConfig{e2eRegistry, "redis", "1.0"}
+	ResourceConsumer    = ImageConfig{e2eRegistry, "resource-consumer", "1.3"}
+	ResourceController  = ImageConfig{e2eRegistry, "resource-consumer/controller", "1.0"}
+	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.1"}
+	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0"}
+	VolumeNFSServer     = ImageConfig{e2eRegistry, "volume/nfs", "1.0"}
+	VolumeISCSIServer   = ImageConfig{e2eRegistry, "volume/iscsi", "1.0"}
+	VolumeGlusterServer = ImageConfig{e2eRegistry, "volume/gluster", "1.0"}
+	VolumeRBDServer     = ImageConfig{e2eRegistry, "volume/rbd", "1.0"}
 )
 
 func GetE2EImage(image ImageConfig) string {
-	return GetE2EImageWithArch(image, runtime.GOARCH)
-}
-
-func GetE2EImageWithArch(image ImageConfig, arch string) string {
-	if image.hasArch {
-		return fmt.Sprintf("%s/%s-%s:%s", image.registry, image.name, arch, image.version)
-	} else {
-		return fmt.Sprintf("%s/%s:%s", image.registry, image.name, image.version)
-	}
+	return fmt.Sprintf("%s/%s:%s", image.registry, image.name, image.version)
 }
 
 // GetPauseImageName returns the pause image name with proper version


### PR DESCRIPTION
Change-Id: I309fec49b030a4d457890f25d2f69e7c641c03fd

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
All e2e test images are now using multi-arch manifests so we should stop
looking up and using images that are specific to runtime.GOARCH

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
