### PR TITLE
Introduce Azure custom metrics adapter in IMPLEMENTATIONS

### DIFF
--- a/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
+++ b/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
@@ -20,5 +20,7 @@ They are listed here for convenience.***
   implementation of the custom metrics API that attempts to support
   arbitrary metrics following a set label and naming scheme.
 
+- [Microsoft Azure Adapter](https://github.com/jsturtevant/azure-k8-metrics-adapter). An implementation of the custom metrics API that allows you to retrieve arbitrary metrics from Azure Monitor.
+
 - [Google Stackdriver (coming
   soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)

--- a/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
+++ b/staging/src/k8s.io/metrics/IMPLEMENTATIONS.md
@@ -20,7 +20,7 @@ They are listed here for convenience.***
   implementation of the custom metrics API that attempts to support
   arbitrary metrics following a set label and naming scheme.
 
-- [Microsoft Azure Adapter](https://github.com/jsturtevant/azure-k8-metrics-adapter). An implementation of the custom metrics API that allows you to retrieve arbitrary metrics from Azure Monitor.
+- [Microsoft Azure Adapter](https://github.com/Azure/azure-k8s-metrics-adapter). An implementation of the custom metrics API that allows you to retrieve arbitrary metrics from Azure Monitor.
 
 - [Google Stackdriver (coming
   soon)](https://github.com/GoogleCloudPlatform/k8s-stackdriver)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Makes Kubernetes users aware that there is now a Microsoft Azure metrics adapter to use inside the cluster. This can be used to autoscale on with the abitrary metrics API.

All kudos goes to @jsturtevant for this.

**Which issue(s) this PR fixes**:
Relates to [jsturtevant/azure-k8-metrics-adapter #13](https://github.com/jsturtevant/azure-k8-metrics-adapter/issues/13)

**Special notes for your reviewer**: None.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```