### PR TITLE
Make dockershim support kata-containers

### DIFF
--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -99,6 +99,7 @@ go_test(
     deps = [
         "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",
+        "//pkg/kubelet/checkpointmanager/errors:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",
         "//pkg/kubelet/dockershim/libdocker:go_default_library",

--- a/pkg/kubelet/dockershim/docker_checkpoint.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint.go
@@ -52,8 +52,7 @@ type PortMapping struct {
 type CheckpointData struct {
 	PortMappings []*PortMapping `json:"port_mappings,omitempty"`
 	HostNetwork  bool           `json:"host_network,omitempty"`
-	// PodIP  is the IP of the sandbox.
-	PodIP    string             `json:"pod_ip"`
+	PodIP        string         `json:"pod_ip"`
 }
 
 // PodSandboxCheckpoint is the checkpoint structure for a sandbox

--- a/pkg/kubelet/dockershim/docker_checkpoint.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint.go
@@ -52,6 +52,8 @@ type PortMapping struct {
 type CheckpointData struct {
 	PortMappings []*PortMapping `json:"port_mappings,omitempty"`
 	HostNetwork  bool           `json:"host_network,omitempty"`
+	// PodIP  is the IP of the sandbox.
+	PodIP    string             `json:"pod_ip"`
 }
 
 // PodSandboxCheckpoint is the checkpoint structure for a sandbox

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -135,7 +135,8 @@ func (ds *dockerService) CreateContainer(_ context.Context, r *runtimeapi.Create
 			},
 		},
 		HostConfig: &dockercontainer.HostConfig{
-			Binds: generateMountBindings(config.GetMounts()),
+			Binds:   generateMountBindings(config.GetMounts()),
+			Runtime: sandboxConfig.GetAnnotations()[untrustedWorkloadLabelKey],
 		},
 	}
 

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -162,7 +162,7 @@ func (ds *dockerService) RunPodSandbox(ctx context.Context, r *runtimeapi.RunPod
 	// on the host as well, to satisfy parts of the pod spec that aren't
 	// recognized by the CNI standard yet.
 	cID := kubecontainer.BuildContainerID(runtimeName, createResp.ID)
-	err = ds.network.SetUpPod(config.GetMetadata().Namespace, config.GetMetadata().Name, cID, config.Annotations)
+	_, err = ds.network.SetUpPod(config.GetMetadata().Namespace, config.GetMetadata().Name, cID, config.Annotations)
 	if err != nil {
 		errList := []error{fmt.Errorf("failed to set up sandbox container %q network for pod %q: %v", createResp.ID, config.Metadata.Name, err)}
 

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -352,7 +352,7 @@ func (ds *dockerService) getIP(podSandboxID string, sandbox *dockertypes.Contain
 	// Get pod IP from checkpoint first.
 	checkpoint := &PodSandboxCheckpoint{Version: schemaVersion, Data: &CheckpointData{}}
 	checkpointErr := ds.checkpointManager.GetCheckpoint(podSandboxID, checkpoint)
-	if checkpointErr == nil {
+	if checkpointErr == nil && checkpoint.Data.PodIP != "" {
 		return checkpoint.Data.PodIP
 	}
 	glog.Warningf("Failed to retrieve pod IP from checkpoint for sandbox %q: %v", podSandboxID, checkpointErr)
@@ -592,6 +592,7 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 		HostConfig: hc,
 	}
 
+	hc.Runtime = c.GetAnnotations()[untrustedWorkloadLabelKey]
 	// Apply platform-specific options.
 	if err := ds.applySandboxPlatformOptions(hc, c, createConfig, image, securityOptSeparator); err != nil {
 		return nil, err

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -276,7 +276,7 @@ func TestSetUpPodFailure(t *testing.T) {
 	)
 	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
 	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
-	mockPlugin.EXPECT().SetUpPod(ns, name, cID).Return(errors.New("setup pod error")).AnyTimes()
+	mockPlugin.EXPECT().SetUpPod(ns, name, cID).Return("", errors.New("setup pod error")).AnyTimes()
 	// If SetUpPod() fails, we expect TearDownPod() to immediately follow
 	mockPlugin.EXPECT().TearDownPod(ns, name, cID)
 	// Assume network plugin doesn't return error, dockershim should still be able to return not ready correctly.

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -68,6 +68,9 @@ const (
 	containerLogPathLabelKey    = "io.kubernetes.container.logpath"
 	sandboxIDLabelKey           = "io.kubernetes.sandbox.id"
 
+	// untrustedWorkloadLabelKey is the sandbox annotation for untrusted workload.
+	untrustedWorkloadLabelKey = "io.kubernetes.docker.untrusted.workload"
+
 	// The expiration time of version cache.
 	versionCacheTTL = 60 * time.Second
 

--- a/pkg/kubelet/dockershim/docker_service_test.go
+++ b/pkg/kubelet/dockershim/docker_service_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	checkpointerr "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
@@ -54,8 +55,11 @@ func (ckm *mockCheckpointManager) CreateCheckpoint(checkpointKey string, checkpo
 }
 
 func (ckm *mockCheckpointManager) GetCheckpoint(checkpointKey string, checkpoint checkpointmanager.Checkpoint) error {
-	*(checkpoint.(*PodSandboxCheckpoint)) = *(ckm.checkpoint[checkpointKey])
-	return nil
+	if _, ok := ckm.checkpoint[checkpointKey]; ok {
+		*(checkpoint.(*PodSandboxCheckpoint)) = *(ckm.checkpoint[checkpointKey])
+		return nil
+	}
+	return checkpointerr.ErrCheckpointNotFound
 }
 
 func (ckm *mockCheckpointManager) RemoveCheckpoint(checkpointKey string) error {

--- a/pkg/kubelet/dockershim/network/cni/BUILD
+++ b/pkg/kubelet/dockershim/network/cni/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/bandwidth:go_default_library",
         "//vendor/github.com/containernetworking/cni/libcni:go_default_library",
         "//vendor/github.com/containernetworking/cni/pkg/types:go_default_library",
+        "//vendor/github.com/containernetworking/cni/pkg/types/current:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -241,7 +241,7 @@ func TestCNIPlugin(t *testing.T) {
 	bandwidthAnnotation["kubernetes.io/egress-bandwidth"] = "1M"
 
 	// Set up the pod
-	err = plug.SetUpPod("podNamespace", "podName", containerID, bandwidthAnnotation)
+	_, err = plug.SetUpPod("podNamespace", "podName", containerID, bandwidthAnnotation)
 	if err != nil {
 		t.Errorf("Expected nil: %v", err)
 	}

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_unsupported.go
@@ -42,8 +42,8 @@ func (plugin *kubenetNetworkPlugin) Name() string {
 	return "kubenet"
 }
 
-func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID, annotations map[string]string) error {
-	return fmt.Errorf("Kubenet is not supported in this build")
+func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID, annotations map[string]string) (string, error) {
+	return "", fmt.Errorf("Kubenet is not supported in this build")
 }
 
 func (plugin *kubenetNetworkPlugin) TearDownPod(namespace string, name string, id kubecontainer.ContainerID) error {

--- a/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
+++ b/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
@@ -102,10 +102,10 @@ func (_mr *_MockNetworkPluginRecorder) Name() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Name")
 }
 
-func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID, annotations map[string]string) error {
+func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID, annotations map[string]string) (string, error) {
 	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
-	return ret0
+	return "", ret0
 }
 
 func (_mr *_MockNetworkPluginRecorder) SetUpPod(arg0, arg1, arg2 interface{}) *gomock.Call {

--- a/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
+++ b/pkg/kubelet/dockershim/network/testing/mock_network_plugin.go
@@ -104,8 +104,9 @@ func (_mr *_MockNetworkPluginRecorder) Name() *gomock.Call {
 
 func (_m *MockNetworkPlugin) SetUpPod(_param0 string, _param1 string, _param2 container.ContainerID, annotations map[string]string) (string, error) {
 	ret := _m.ctrl.Call(_m, "SetUpPod", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return "", ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockNetworkPluginRecorder) SetUpPod(arg0, arg1, arg2 interface{}) *gomock.Call {

--- a/pkg/kubelet/dockershim/network/testing/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/testing/plugins_test.go
@@ -108,7 +108,7 @@ func TestPluginManager(t *testing.T) {
 				// concurrently.
 				allCreatedWg.Wait()
 
-				if err := pm.SetUpPod("", name, id, nil); err != nil {
+				if _, err := pm.SetUpPod("", name, id, nil); err != nil {
 					t.Errorf("Failed to set up pod %q: %v", name, err)
 					return
 				}
@@ -159,11 +159,11 @@ func (p *hookableFakeNetworkPlugin) Capabilities() utilsets.Int {
 	return utilsets.NewInt()
 }
 
-func (p *hookableFakeNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID, annotations map[string]string) error {
+func (p *hookableFakeNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID, annotations map[string]string) (string, error) {
 	if p.setupHook != nil {
 		p.setupHook(namespace, name, id)
 	}
-	return nil
+	return "", nil
 }
 
 func (p *hookableFakeNetworkPlugin) TearDownPod(string, string, kubecontainer.ContainerID) error {
@@ -210,7 +210,7 @@ func TestMultiPodParallelNetworkOps(t *testing.T) {
 		// Setup will block on the runner pod completing.  If network
 		// operations locking isn't correct (eg pod network operations
 		// block other pods) setUpPod() will never return.
-		if err := pm.SetUpPod("", podName, containerID, nil); err != nil {
+		if _, err := pm.SetUpPod("", podName, containerID, nil); err != nil {
 			t.Errorf("Failed to set up waiter pod: %v", err)
 			return
 		}
@@ -230,7 +230,7 @@ func TestMultiPodParallelNetworkOps(t *testing.T) {
 		podName := "runner"
 		containerID := kubecontainer.ContainerID{ID: podName}
 
-		if err := pm.SetUpPod("", podName, containerID, nil); err != nil {
+		if _, err := pm.SetUpPod("", podName, containerID, nil); err != nil {
 			t.Errorf("Failed to set up runner pod: %v", err)
 			return
 		}

--- a/pkg/kubelet/dockershim/network/testing/plugins_test.go
+++ b/pkg/kubelet/dockershim/network/testing/plugins_test.go
@@ -93,7 +93,7 @@ func TestPluginManager(t *testing.T) {
 		podName := fmt.Sprintf("pod%d", i)
 		containerID := kubecontainer.ContainerID{ID: podName}
 
-		fnp.EXPECT().SetUpPod("", podName, containerID).Return(nil).Times(4)
+		fnp.EXPECT().SetUpPod("", podName, containerID).Return("", nil).Times(4)
 		fnp.EXPECT().GetPodNetworkStatus("", podName, containerID).Return(&network.PodNetworkStatus{IP: net.ParseIP("1.2.3.4")}, nil).Times(4)
 		fnp.EXPECT().TearDownPod("", podName, containerID).Return(nil).Times(4)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR contains 3 commits
1. return IP info when setting up network
2. cache Pod IP
    Above two commits, mainly to obtain IP address of sandbox when cni pugin is called, and cache the sandbox IP locally. 

    Because the IP address that set by cni plugin will be removed from the veth device in network namespace by kata-runtime when creating the VM (in which containers will be created), if we use  `kata-containers` as the oci-runtime, This will cause dockershim to fail to get the pod IP through cni plugin.  Just like [this issue description](https://github.com/containerd/cri-containerd/issues/524) in `containerd/cri`. So, we should cache the pod IP.

3. make k8s(dockershim) to support selecting oci-runtime
    Add an annotation field in pod definition, so that dockershim can select the oci-runtime according to pod definition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67007

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
