### PR TITLE
kubeadm: fix CRI ListKubeContainers API

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -249,12 +249,10 @@ func TestRemoveContainers(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			func() ([]byte, error) { return []byte("id1\nid2"), nil },
-		},
-		RunScript: []fakeexec.FakeRunAction{
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, nil },
+			func() ([]byte, error) { return []byte(""), nil },
+			func() ([]byte, error) { return []byte(""), nil },
+			func() ([]byte, error) { return []byte(""), nil },
+			func() ([]byte, error) { return []byte(""), nil },
 		},
 	}
 	fexec := fakeexec.FakeExec{

--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -108,9 +108,7 @@ func (runtime *CRIRuntime) ListKubeContainers() ([]string, error) {
 	}
 	pods := []string{}
 	for _, pod := range strings.Fields(string(out)) {
-		if strings.HasPrefix(pod, "k8s_") {
-			pods = append(pods, pod)
-		}
+		pods = append(pods, pod)
 	}
 	return pods, nil
 }

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -128,7 +128,7 @@ func TestIsRunning(t *testing.T) {
 func TestListKubeContainers(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
-			func() ([]byte, error) { return []byte("k8s_p1\nk8s_p2\nid3"), nil },
+			func() ([]byte, error) { return []byte("k8s_p1\nk8s_p2"), nil },
 			func() ([]byte, error) { return nil, &fakeexec.FakeExitError{Status: 1} },
 			func() ([]byte, error) { return []byte("k8s_p1\nk8s_p2"), nil },
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Current implementation of this API always returns
checks output of 'crictl pods -q' and filters out everything
that doesn't start with k8s_. 'crictl pods -q' returns only pod ids,
so everything is always filtered out.

Removing filtering by name prefix should fix this.

**Which issue this PR fixes**
Fixes: kubernetes/kubeadm#926

**Release note**:
```release-note
NONE
```