### PR TITLE
Upgrade debian-base to 0.3.1 for CVEs

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.3
+TAG ?= 0.3.1
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,11 +19,11 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=debian-hyperkube-base
-TAG=0.10
+TAG=0.10.1
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10
+TAG=v10.1
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.9.1
@@ -34,7 +34,7 @@ ifeq ($(ARCH),s390x)
 	QEMUARCH=s390x
 endif
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Upgrade debian-base to 0.3.1 in response to CVE fixes in debian-base

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Bumps up the version number of related components.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump up version number of debian-base, debian-hyperkube-base and debian-iptables. 
Also updates dependencies of users of debian-base. 
debian-base version 0.3.1 is already available.
```
