### PR TITLE
expose default LogsForObject consumeRequest func

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -214,7 +214,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 		return err
 	}
 
-	o.ConsumeRequestFn = consumeRequest
+	o.ConsumeRequestFn = DefaultConsumeRequest
 
 	o.GetPodTimeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {
@@ -305,7 +305,7 @@ func (o LogsOptions) RunLogs() error {
 	return nil
 }
 
-func consumeRequest(request *rest.Request, out io.Writer) error {
+func DefaultConsumeRequest(request *rest.Request, out io.Writer) error {
 	readCloser, err := request.Stream()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -530,7 +530,7 @@ func logOpts(restClientGetter genericclioptions.RESTClientGetter, pod *corev1.Po
 		return err
 	}
 	for _, request := range requests {
-		if err := consumeRequest(request, opts.Out); err != nil {
+		if err := DefaultConsumeRequest(request, opts.Out); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Expose the `consumeRequest` func to make it reusable for other consumers of the `LogsForObject` polymorphic func