### PR TITLE
update logic of adding default DS pod tolerations

### DIFF
--- a/pkg/controller/daemon/BUILD
+++ b/pkg/controller/daemon/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1691,41 +1691,7 @@ func setDaemonSetToleration(ds *apps.DaemonSet, tolerations []v1.Toleration) {
 	ds.Spec.Template.Spec.Tolerations = tolerations
 }
 
-// DaemonSet should launch a critical pod even when the node with OutOfDisk taints.
-// TODO(#48843) OutOfDisk taints will be removed in 1.10
-func TestTaintOutOfDiskNodeDaemonLaunchesCriticalPod(t *testing.T) {
-	for _, f := range []bool{true, false} {
-		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()
-		for _, strategy := range updateStrategies() {
-			ds := newDaemonSet("critical")
-			ds.Spec.UpdateStrategy = *strategy
-			setDaemonSetCritical(ds)
-			manager, podControl, _, err := newTestController(ds)
-			if err != nil {
-				t.Fatalf("error creating DaemonSets controller: %v", err)
-			}
-
-			node := newNode("not-enough-disk", nil)
-			node.Status.Conditions = []v1.NodeCondition{{Type: v1.NodeOutOfDisk, Status: v1.ConditionTrue}}
-			node.Spec.Taints = []v1.Taint{{Key: schedulerapi.TaintNodeOutOfDisk, Effect: v1.TaintEffectNoSchedule}}
-			manager.nodeStore.Add(node)
-
-			// NOTE: Whether or not TaintNodesByCondition is enabled, it'll add toleration to DaemonSet pods.
-
-			// Without enabling critical pod annotation feature gate, we shouldn't create critical pod
-			defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExperimentalCriticalPodAnnotation, false)()
-			manager.dsStore.Add(ds)
-			syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 0, 0)
-
-			// With enabling critical pod annotation feature gate, we will create critical pod
-			defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ExperimentalCriticalPodAnnotation, true)()
-			manager.dsStore.Add(ds)
-			syncAndValidateDaemonSets(t, manager, ds, podControl, 1, 0, 0)
-		}
-	}
-}
-
-// DaemonSet should launch a pod even when the node with MemoryPressure/DiskPressure taints.
+// DaemonSet should launch a pod even when the node with MemoryPressure/DiskPressure/PIDPressure taints.
 func TestTaintPressureNodeDaemonLaunchesPod(t *testing.T) {
 	for _, f := range []bool{true, false} {
 		defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ScheduleDaemonSetPods, f)()
@@ -1742,10 +1708,12 @@ func TestTaintPressureNodeDaemonLaunchesPod(t *testing.T) {
 			node.Status.Conditions = []v1.NodeCondition{
 				{Type: v1.NodeDiskPressure, Status: v1.ConditionTrue},
 				{Type: v1.NodeMemoryPressure, Status: v1.ConditionTrue},
+				{Type: v1.NodePIDPressure, Status: v1.ConditionTrue},
 			}
 			node.Spec.Taints = []v1.Taint{
 				{Key: schedulerapi.TaintNodeDiskPressure, Effect: v1.TaintEffectNoSchedule},
 				{Key: schedulerapi.TaintNodeMemoryPressure, Effect: v1.TaintEffectNoSchedule},
+				{Key: schedulerapi.TaintNodePIDPressure, Effect: v1.TaintEffectNoSchedule},
 			}
 			manager.nodeStore.Add(node)
 

--- a/pkg/controller/daemon/util/BUILD
+++ b/pkg/controller/daemon/util/BUILD
@@ -13,14 +13,11 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
-        "//pkg/features:go_default_library",
-        "//pkg/kubelet/types:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/controller/daemon/util/daemonset_util.go
+++ b/pkg/controller/daemon/util/daemonset_util.go
@@ -24,11 +24,8 @@ import (
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
-	"k8s.io/kubernetes/pkg/features"
-	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 )
 
@@ -49,7 +46,7 @@ func GetTemplateGeneration(ds *apps.DaemonSet) (*int64, error) {
 }
 
 // AddOrUpdateDaemonPodTolerations apply necessary tolerations to DeamonSet Pods, e.g. node.kubernetes.io/not-ready:NoExecute.
-func AddOrUpdateDaemonPodTolerations(spec *v1.PodSpec, isCritical bool) {
+func AddOrUpdateDaemonPodTolerations(spec *v1.PodSpec) {
 	// DaemonSet pods shouldn't be deleted by NodeController in case of node problems.
 	// Add infinite toleration for taint notReady:NoExecute here
 	// to survive taint-based eviction enforced by NodeController
@@ -71,8 +68,7 @@ func AddOrUpdateDaemonPodTolerations(spec *v1.PodSpec, isCritical bool) {
 	})
 
 	// According to TaintNodesByCondition feature, all DaemonSet pods should tolerate
-	// MemoryPressure, DisPressure, Unschedulable and NetworkUnavailable taints,
-	// and the critical pods should tolerate OutOfDisk taint.
+	// MemoryPressure, DiskPressure, PIDPressure, Unschedulable and NetworkUnavailable taints.
 	v1helper.AddOrUpdateTolerationInPodSpec(spec, &v1.Toleration{
 		Key:      schedulerapi.TaintNodeDiskPressure,
 		Operator: v1.TolerationOpExists,
@@ -81,6 +77,12 @@ func AddOrUpdateDaemonPodTolerations(spec *v1.PodSpec, isCritical bool) {
 
 	v1helper.AddOrUpdateTolerationInPodSpec(spec, &v1.Toleration{
 		Key:      schedulerapi.TaintNodeMemoryPressure,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	})
+
+	v1helper.AddOrUpdateTolerationInPodSpec(spec, &v1.Toleration{
+		Key:      schedulerapi.TaintNodePIDPressure,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	})
@@ -98,33 +100,15 @@ func AddOrUpdateDaemonPodTolerations(spec *v1.PodSpec, isCritical bool) {
 			Effect:   v1.TaintEffectNoSchedule,
 		})
 	}
-
-	// TODO(#48843) OutOfDisk taints will be removed in 1.10
-	if isCritical {
-		v1helper.AddOrUpdateTolerationInPodSpec(spec, &v1.Toleration{
-			Key:      schedulerapi.TaintNodeOutOfDisk,
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoExecute,
-		})
-		v1helper.AddOrUpdateTolerationInPodSpec(spec, &v1.Toleration{
-			Key:      schedulerapi.TaintNodeOutOfDisk,
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		})
-	}
 }
 
 // CreatePodTemplate returns copy of provided template with additional
 // label which contains templateGeneration (for backward compatibility),
 // hash of provided template and sets default daemon tolerations.
-func CreatePodTemplate(ns string, template v1.PodTemplateSpec, generation *int64, hash string) v1.PodTemplateSpec {
+func CreatePodTemplate(template v1.PodTemplateSpec, generation *int64, hash string) v1.PodTemplateSpec {
 	newTemplate := *template.DeepCopy()
 
-	// TODO(k82cn): when removing CritialPod feature, also remove 'ns' parameter.
-	isCritical := utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalCriticalPodAnnotation) &&
-		kubelettypes.IsCritical(ns, newTemplate.Annotations)
-
-	AddOrUpdateDaemonPodTolerations(&newTemplate.Spec, isCritical)
+	AddOrUpdateDaemonPodTolerations(&newTemplate.Spec)
 
 	if newTemplate.ObjectMeta.Labels == nil {
 		newTemplate.ObjectMeta.Labels = make(map[string]string)

--- a/pkg/controller/daemon/util/daemonset_util_test.go
+++ b/pkg/controller/daemon/util/daemonset_util_test.go
@@ -154,7 +154,7 @@ func TestCreatePodTemplate(t *testing.T) {
 	}
 	for _, test := range tests {
 		podTemplateSpec := v1.PodTemplateSpec{}
-		newPodTemplate := CreatePodTemplate("", podTemplateSpec, test.templateGeneration, test.hash)
+		newPodTemplate := CreatePodTemplate(podTemplateSpec, test.templateGeneration, test.hash)
 		val, exists := newPodTemplate.ObjectMeta.Labels[extensions.DaemonSetTemplateGenerationKey]
 		if !exists || val != fmt.Sprint(*test.templateGeneration) {
 			t.Errorf("Expected podTemplateSpec to have generation label value: %d, got: %s", *test.templateGeneration, val)

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -145,20 +145,8 @@ func TestTaintNodeByCondition(t *testing.T) {
 		Effect:   v1.TaintEffectNoSchedule,
 	}
 
-	unreachableToleration := v1.Toleration{
-		Key:      schedulerapi.TaintNodeUnreachable,
-		Operator: v1.TolerationOpExists,
-		Effect:   v1.TaintEffectNoSchedule,
-	}
-
 	unschedulableToleration := v1.Toleration{
 		Key:      schedulerapi.TaintNodeUnschedulable,
-		Operator: v1.TolerationOpExists,
-		Effect:   v1.TaintEffectNoSchedule,
-	}
-
-	outOfDiskToleration := v1.Toleration{
-		Key:      schedulerapi.TaintNodeOutOfDisk,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	}
@@ -241,46 +229,6 @@ func TestTaintNodeByCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "unreachable node",
-			existingTaints: []v1.Taint{
-				{
-					Key:    schedulerapi.TaintNodeUnreachable,
-					Effect: v1.TaintEffectNoSchedule,
-				},
-			},
-			nodeConditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionUnknown, // node status is "Unknown"
-				},
-			},
-			expectedTaints: []v1.Taint{
-				{
-					Key:    schedulerapi.TaintNodeUnreachable,
-					Effect: v1.TaintEffectNoSchedule,
-				},
-			},
-			pods: []podCase{
-				{
-					pod:  bestEffortPod,
-					fits: false,
-				},
-				{
-					pod:  burstablePod,
-					fits: false,
-				},
-				{
-					pod:  guaranteePod,
-					fits: false,
-				},
-				{
-					pod:         bestEffortPod,
-					tolerations: []v1.Toleration{unreachableToleration},
-					fits:        true,
-				},
-			},
-		},
-		{
 			name:          "unschedulable node",
 			unschedulable: true, // node.spec.unschedulable = true
 			nodeConditions: []v1.NodeCondition{
@@ -312,50 +260,6 @@ func TestTaintNodeByCondition(t *testing.T) {
 					pod:         bestEffortPod,
 					tolerations: []v1.Toleration{unschedulableToleration},
 					fits:        true,
-				},
-			},
-		},
-		{
-			name: "out of disk node",
-			nodeConditions: []v1.NodeCondition{
-				{
-					Type:   v1.NodeOutOfDisk,
-					Status: v1.ConditionTrue,
-				},
-				{
-					Type:   v1.NodeReady,
-					Status: v1.ConditionTrue,
-				},
-			},
-			expectedTaints: []v1.Taint{
-				{
-					Key:    schedulerapi.TaintNodeOutOfDisk,
-					Effect: v1.TaintEffectNoSchedule,
-				},
-			},
-			// In OutOfDisk condition, only pods with toleration can be scheduled.
-			pods: []podCase{
-				{
-					pod:  bestEffortPod,
-					fits: false,
-				},
-				{
-					pod:  burstablePod,
-					fits: false,
-				},
-				{
-					pod:  guaranteePod,
-					fits: false,
-				},
-				{
-					pod:         bestEffortPod,
-					tolerations: []v1.Toleration{outOfDiskToleration},
-					fits:        true,
-				},
-				{
-					pod:         bestEffortPod,
-					tolerations: []v1.Toleration{diskPressureToleration},
-					fits:        false,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

- update DS pod default tolerations: add PIDPressure, remove OutOfDisk
- remove useless tolerations testcases

**Which issue(s) this PR fixes**:

- Fixes partial of comment https://github.com/kubernetes/kubernetes/issues/66348#issuecomment-410419351.

**Special notes for your reviewer**:

Correct the behavior of daemonset controller as "out-of-disk" toleration doesn't fit any more.

**Release note**:
```release-note
`node.kubernetes.io/pid-pressure` toleration is added for DaemonSet pods, and `node.kubernetes.io/out-of-disk` isn't added any more even if it's a critical pod.
```

/sig scheduling
/sig apps