### PR TITLE
move easyrsa check to gce prereq check

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -113,6 +113,15 @@ function verify-prereqs() {
   # we use openssl to generate certs
   kube::util::test_openssl_installed
 
+  # ensure a version supported by easyrsa is installed
+  if [ "$(openssl version | cut -d\  -f1)" == "LibreSSL" ]; then
+    echo "LibreSSL is not supported. Please ensure openssl points to an OpenSSL binary"
+    if [ "$(uname -s)" == "Darwin" ]; then
+      echo 'On macOS we recommend using homebrew and adding "$(brew --prefix openssl)/bin" to your PATH'
+    fi
+    exit 1
+  fi
+
   # we use gcloud to create the cluster, gsutil to stage binaries and data
   for cmd in gcloud gsutil; do
     if ! which "${cmd}" >/dev/null; then

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -539,12 +539,6 @@ function kube::util::test_openssl_installed {
     if [ "$?" != "0" ]; then
       echo "Failed to run openssl. Please ensure openssl is installed"
       exit 1
-    elif [ "$(openssl version | cut -d\  -f1)" == "LibreSSL" ]; then
-      echo "LibreSSL is not supported. Please ensure openssl points to an OpenSSL binary"
-      if [ "$(uname -s)" == "Darwin" ]; then
-        echo 'On macOS we recommend using homebrew and adding "$(brew --prefix openssl)/bin" to your PATH'
-      fi
-      exit 1
     fi
 
     OPENSSL_BIN=$(command -v openssl)


### PR DESCRIPTION
fixes #67044

the check added in https://github.com/kubernetes/kubernetes/pull/66690 was broader than required... only paths that use easyrsa need to be so restrictive

this restores local-up-cluster.sh on osx

/assign @spiffxp 

```release-note
NONE
```