### PR TITLE
HPA: Make dynamicRequestSizeInMillicores bigger

### DIFF
--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -43,7 +43,7 @@ import (
 const (
 	dynamicConsumptionTimeInSeconds = 30
 	staticConsumptionTimeInSeconds  = 3600
-	dynamicRequestSizeInMillicores  = 20
+	dynamicRequestSizeInMillicores  = 100
 	dynamicRequestSizeInMegabytes   = 100
 	dynamicRequestSizeCustomMetric  = 10
 	port                            = 80


### PR DESCRIPTION
**What this PR does / why we need it**:

HPA e2e tests specify 20 as requestSizeMillicores on resource-consumer
for making CPU workload to test HPA feature, and the value is
hard-coded as 20. That means the tests expect 2% CPU workload on every
resource-consumer process, but actual CPU usage(4 - 6%) is over than
the expected usage on some environment. Then HPA scales many pods than
the test expected, and the test is failed.

To make these tests stable, this changes the value to 100 (10% CPU
workload on each process).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67051

**Special notes for your reviewer**:

**Release note**: None
