### PR TITLE
Fix docker registry used in e2e test.

### DIFF
--- a/test/e2e/framework/rc_util.go
+++ b/test/e2e/framework/rc_util.go
@@ -216,11 +216,12 @@ func WaitForReplicationControllerwithSelector(c clientset.Interface, namespace s
 	return nil
 }
 
-// trimDockerIO is the function for trimming the docker.io from the beginning of the imagename.
+// trimDockerRegistry is the function for trimming the docker.io/library from the beginning of the imagename.
 // If community docker installed it will not prefix the registry names with the dockerimages vs registry names prefixed with other runtimes or docker installed via RHEL extra repo.
-// So this function will help to trim the docker.io if exists
-func trimDockerIO(imagename string) string {
-	return strings.Replace(imagename, "docker.io/", "", 1)
+// So this function will help to trim the docker.io/library if exists
+func trimDockerRegistry(imagename string) string {
+	imagename = strings.Replace(imagename, "docker.io/", "", 1)
+	return strings.Replace(imagename, "library/", "", 1)
 }
 
 // validatorFn is the function which is individual tests will implement.
@@ -234,7 +235,7 @@ type validatorFn func(c clientset.Interface, podID string) error
 // "testname":  which gets bubbled up to the logging/failure messages if errors happen.
 // "validator" function: This function is given a podID and a client, and it can do some specific validations that way.
 func ValidateController(c clientset.Interface, containerImage string, replicas int, containername string, testname string, validator validatorFn, ns string) {
-	containerImage = trimDockerIO(containerImage)
+	containerImage = trimDockerRegistry(containerImage)
 	getPodsTemplate := "--template={{range.items}}{{.metadata.name}} {{end}}"
 	// NB: kubectl adds the "exists" function to the standard template functions.
 	// This lets us check to see if the "running" entry exists for each of the containers
@@ -266,7 +267,7 @@ waitLoop:
 			}
 
 			currentImage := RunKubectlOrDie("get", "pods", podID, "-o", "template", getImageTemplate, fmt.Sprintf("--namespace=%v", ns))
-			currentImage = trimDockerIO(currentImage)
+			currentImage = trimDockerRegistry(currentImage)
 			if currentImage != containerImage {
 				Logf("%s is created but running wrong image; expected: %s, actual: %s", podID, containerImage, currentImage)
 				continue waitLoop

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	dockerHubRegistry = "docker.io"
-	e2eRegistry       = "gcr.io/kubernetes-e2e-test-images"
-	gcRegistry        = "k8s.gcr.io"
-	PrivateRegistry   = "gcr.io/k8s-authenticated-test"
-	sampleRegistry    = "gcr.io/google-samples"
+	dockerLibraryRegistry = "docker.io/library"
+	e2eRegistry           = "gcr.io/kubernetes-e2e-test-images"
+	gcRegistry            = "k8s.gcr.io"
+	PrivateRegistry       = "gcr.io/k8s-authenticated-test"
+	sampleRegistry        = "gcr.io/google-samples"
 )
 
 type ImageConfig struct {
@@ -52,7 +52,7 @@ var (
 	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.12v2", false}
 	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0", false}
 	AppArmorLoader           = ImageConfig{e2eRegistry, "apparmor-loader", "1.0", false}
-	BusyBox                  = ImageConfig{dockerHubRegistry, "busybox", "1.29", false}
+	BusyBox                  = ImageConfig{dockerLibraryRegistry, "busybox", "1.29", false}
 	CheckMetadataConcealment = ImageConfig{gcRegistry, "check-metadata-concealment", "v0.0.3", false}
 	CudaVectorAdd            = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0", false}
 	Dnsutils                 = ImageConfig{e2eRegistry, "dnsutils", "1.1", false}
@@ -74,8 +74,8 @@ var (
 	Net                      = ImageConfig{e2eRegistry, "net", "1.0", false}
 	Netexec                  = ImageConfig{e2eRegistry, "netexec", "1.0", false}
 	Nettest                  = ImageConfig{e2eRegistry, "nettest", "1.0", false}
-	Nginx                    = ImageConfig{dockerHubRegistry, "nginx", "1.14-alpine", false}
-	NginxNew                 = ImageConfig{dockerHubRegistry, "nginx", "1.15-alpine", false}
+	Nginx                    = ImageConfig{dockerLibraryRegistry, "nginx", "1.14-alpine", false}
+	NginxNew                 = ImageConfig{dockerLibraryRegistry, "nginx", "1.15-alpine", false}
 	Nonewprivs               = ImageConfig{e2eRegistry, "nonewprivs", "1.0", false}
 	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0", false}
 	NoSnatTestProxy          = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0", false}


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/66055#issuecomment-410947650.

Fix docker registry used in e2e test, so that it works with all container runtimes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @kubernetes/sig-node-pr-reviews @kubernetes/sig-testing-pr-reviews 