### PR TITLE
Bump Heapster to v1.6.0-beta.1

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.4
+  name: heapster-v1.6.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.4
+    version: v1.6.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.4
+      version: v1.6.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.4
+        version: v1.6.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -73,7 +73,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=gcm
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -141,7 +141,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.4
+  name: heapster-v1.6.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.4
+    version: v1.6.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.4
+      version: v1.6.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.4
+        version: v1.6.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -74,7 +74,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -109,7 +109,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -142,7 +142,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -36,31 +36,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.4
+  name: heapster-v1.6.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.4
+    version: v1.6.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.4
+      version: v1.6.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.4
+        version: v1.6.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -73,7 +73,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -108,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -141,7 +141,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -23,31 +23,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.4
+  name: heapster-v1.6.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.4
+    version: v1.6.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.4
+      version: v1.6.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.4
+        version: v1.6.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -110,7 +110,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -23,31 +23,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.4
+  name: heapster-v1.6.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.4
+    version: v1.6.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.4
+      version: v1.6.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.4
+        version: v1.6.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/heapster-amd64:v1.5.4
+        - image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -88,7 +88,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.4
+            - --deployment=heapster-v1.6.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Heapster to version v1.6.0-beta.1

**Release note**:
```release-note
Bump Heapster to v1.6.0-beta.1
```
