### PR TITLE
Start kubelet before restarting docker. 

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2693,11 +2693,11 @@ function main() {
   fi
 
   override-kubectl
+  start-kubelet
   # Run the containerized mounter once to pre-cache the container image.
   if [[ "${CONTAINER_RUNTIME:-docker}" == "docker" ]]; then
     assemble-docker-flags
   fi
-  start-kubelet
 
   if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
     compute-master-manifest-variables


### PR DESCRIPTION
Executing assemble-docker-flags takes around 2-3 seconds and it can be executed after executing kubelet sevice start. assemble-docker-flags will be executed while kubelet is started so node start up will be 2-3 seconds shorter.