### PR TITLE
apiextensions: allow complex json paths for additionalPrinterColumns

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor/tableconvertor.go
@@ -103,17 +103,21 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 				continue
 			}
 
-			// as we only support simple JSON path, we can assume to have only one result (or none, filtered out above)
-			value := results[0][0].Interface()
+			// multiple results (eg. array of arrays) can only be represented as strings.
+			// for other formats, we only support simple JSON path, so we can assume to have only one result (or none, filtered out above)
 			if customHeaders[i].Type == "string" {
-				if err := column.PrintResults(buf, []reflect.Value{reflect.ValueOf(value)}); err == nil {
+				values := []reflect.Value{}
+				for _, v := range results[0] {
+					values = append(values, reflect.ValueOf(v.Interface()))
+				}
+				if err := column.PrintResults(buf, values); err == nil {
 					cells = append(cells, buf.String())
 					buf.Reset()
 				} else {
 					cells = append(cells, nil)
 				}
 			} else {
-				cells = append(cells, cellForJSONValue(customHeaders[i].Type, value))
+				cells = append(cells, cellForJSONValue(customHeaders[i].Type, results[0][0].Interface()))
 			}
 		}
 		return cells, nil


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubectl/issues/517

We only supported simple JSON Paths until now. This allows to specify complicated ones like array of arrays. Constructs like these, however, can only be represented as strings - since we support only a few formats and denoting multiple values in other formats is not feasible.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts 
/sig api-machinery
/area custom-resources