### PR TITLE
Bail out if wrong version of docker cli is used

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -106,6 +106,13 @@ push() {
 
   kube::util::ensure-gnu-sed
 
+  version=$(docker version -f "{{ .Client.Version }}")
+  kube::log::status "Checking docker CLI version"
+  if [[ $(echo ${version} | awk '{split($0,a,"."); printf("%d.%d",a[1],a[2])}')<18.6 ]]; then
+    kube::log::error "Docker CLI version must be at least 18.06 publish images with manifests (version is $version)"
+    exit 1
+  fi
+
   # Make archs list into image manifest. Eg: 'amd64 ppc64le' to '${REGISTRY}/${IMAGE}-amd64:${TAG} ${REGISTRY}/${IMAGE}-ppc64le:${TAG}'
   manifest=$(echo $archs | ${SED} -e "s~[^ ]*~$REGISTRY\/$IMAGE\-&:$TAG~g")
   docker manifest create --amend ${REGISTRY}/${IMAGE}:${TAG} ${manifest}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Docker CLI was recently patched to get the manifest generation to work
properly:
https://github.com/docker/cli/commit/1fd2d66df89890ca7d830a862d66e1275337ef65
https://github.com/docker/cli/pull/1183

So we need at least 18.06 for the manifests to work. Add some version
checking just before we publish manifests to make sure folks use the
right version.

Change-Id: Idca66da94fba2bae2480413444886c65f11249bf


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @ixdy 
/assign @cblecker 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
