### PR TITLE
Add a check for docker version to push fat manifest images

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -92,8 +92,17 @@ build() {
   done
 }
 
+docker_version_check() {
+  docker_version=$(docker version --format '{{.Client.Version}}' | cut -d"-" -f1)
+  if [[ ${docker_version} != 18.06.0 && ${docker_version} < 18.06.0 ]]; then
+    echo "Minimum docker version 18.06.0 is required for creating and pushing manifest images[found: ${docker_version}]"
+    exit 1
+  fi
+}
+
 # This function will push the docker images
 push() {
+  docker_version_check
   TAG=$(<${IMAGE}/VERSION)
   if [[ -f ${IMAGE}/BASEIMAGE ]]; then
     archs=$(listArchs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
This is for adding a check to avoid any corrupted fat manifest creation.

**Special notes for your reviewer**:
@dims @luxas 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
