### PR TITLE
Block dry-run if a webhook would be called

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors/statuserror.go
@@ -45,3 +45,9 @@ func ToStatusErr(webhookName string, result *metav1.Status) *apierrors.StatusErr
 		ErrStatus: *result,
 	}
 }
+
+// NewDryRunUnsupportedErr returns a StatusError with information about the webhook plugin
+func NewDryRunUnsupportedErr(webhookName string) *apierrors.StatusError {
+	reason := fmt.Sprintf("admission webhook %q does not support dry run", webhookName)
+	return apierrors.NewBadRequest(reason)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -82,6 +82,11 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr *generic.Version
 
 // note that callAttrMutatingHook updates attr
 func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *v1beta1.Webhook, attr *generic.VersionedAttributes) error {
+	if attr.IsDryRun() {
+		// TODO: support this
+		webhookerrors.NewDryRunUnsupportedErr(h.Name)
+	}
+
 	// Make the webhook request
 	request := request.CreateAdmissionReview(attr)
 	client, err := a.cm.HookClient(h)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -97,6 +97,11 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr *generic.Versi
 }
 
 func (d *validatingDispatcher) callHook(ctx context.Context, h *v1beta1.Webhook, attr *generic.VersionedAttributes) error {
+	if attr.IsDryRun() {
+		// TODO: support this
+		webhookerrors.NewDryRunUnsupportedErr(h.Name)
+	}
+
 	// Make the webhook request
 	request := request.CreateAdmissionReview(attr)
 	client, err := d.cm.HookClient(h)


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to https://github.com/kubernetes/kubernetes/pull/66391
Suggested in https://github.com/kubernetes/kubernetes/pull/66391#issuecomment-410876436

Makes dry-run safe in case https://github.com/kubernetes/kubernetes/pull/66936 takes a long time to merge

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig api-machinery
cc @lavalamp 