### PR TITLE
Add e2e tests for ceph-csi(rbd/cephfs) volume

### DIFF
--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -128,6 +128,11 @@ func csiDriverSecretAccessClusterRole(
 				Resources: []string{"secrets"},
 				Verbs:     []string{"get", "list"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get", "list"},
+			},
 		},
 	}
 
@@ -189,7 +194,7 @@ func csiClusterRoleBindings(
 
 		binding := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: config.Prefix + "-" + clusterRoleName + "-" + config.Namespace + "-role-binding",
+				Name: config.Prefix + "-" + sa.GetName() + "-" + clusterRoleName + "-" + config.Namespace + "-role-binding",
 			},
 			Subjects: []rbacv1.Subject{
 				{

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -69,7 +69,7 @@ func createClusterRole(
 	}
 	superuserClientset, err := clientset.NewForConfig(rc)
 	framework.ExpectNoError(err, "Failed to create superuser clientset: %v", err)
-	By(fmt.Sprintf("Creating the %s cluster role", role.ObjectMeta.Name))
+	By(fmt.Sprintf("Creating the %s cluster role", role.GetName()))
 	clusterRoleClient := superuserClientset.RbacV1().ClusterRoles()
 
 	ret, err := clusterRoleClient.Create(role)

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -33,6 +33,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/manifest"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -55,10 +56,8 @@ func csiContainerImage(image string) string {
 	return fullName
 }
 
-// Create the driver registrar cluster role if it doesn't exist, no teardown so that tests
-// are parallelizable. This role will be shared with many of the CSI tests.
-func csiDriverRegistrarClusterRole(
-	config framework.VolumeTestConfig,
+func createClusterRole(
+	role *rbacv1.ClusterRole,
 ) *rbacv1.ClusterRole {
 	// TODO(Issue: #62237) Remove impersonation workaround and cluster role when issue resolved
 	By("Creating an impersonating superuser kubernetes clientset to define cluster role")
@@ -70,14 +69,30 @@ func csiDriverRegistrarClusterRole(
 	}
 	superuserClientset, err := clientset.NewForConfig(rc)
 	framework.ExpectNoError(err, "Failed to create superuser clientset: %v", err)
-	By("Creating the CSI driver registrar cluster role")
+	By(fmt.Sprintf("Creating the %s cluster role", role.ObjectMeta.Name))
 	clusterRoleClient := superuserClientset.RbacV1().ClusterRoles()
+
+	ret, err := clusterRoleClient.Create(role)
+	if err != nil {
+		if apierrs.IsAlreadyExists(err) {
+			return ret
+		}
+		framework.ExpectNoError(err, "Failed to create %s cluster role: %v", role.GetName(), err)
+	}
+
+	return ret
+}
+
+// Create the driver registrar cluster role if it doesn't exist, no teardown so that tests
+// are parallelizable. This role will be shared with many of the CSI tests.
+func csiDriverRegistrarClusterRole(
+	config framework.VolumeTestConfig,
+) *rbacv1.ClusterRole {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csiDriverRegistrarClusterRoleName,
 		},
 		Rules: []rbacv1.PolicyRule{
-
 			{
 				APIGroups: []string{""},
 				Resources: []string{"events"},
@@ -91,15 +106,32 @@ func csiDriverRegistrarClusterRole(
 		},
 	}
 
-	ret, err := clusterRoleClient.Create(role)
-	if err != nil {
-		if apierrs.IsAlreadyExists(err) {
-			return ret
-		}
-		framework.ExpectNoError(err, "Failed to create %s cluster role: %v", role.GetName(), err)
+	return createClusterRole(role)
+}
+
+// Create additional cluster role for provisioners which need to access secrets
+func csiDriverSecretAccessClusterRole(
+	config framework.VolumeTestConfig,
+) *rbacv1.ClusterRole {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csiDriverSecretAccessClusterRoleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"storage.k8s.io"},
+				Resources: []string{"storageclasses"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
 	}
 
-	return ret
+	return createClusterRole(role)
 }
 
 func csiServiceAccount(
@@ -279,8 +311,7 @@ func csiHostPathPod(
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "socket-dir",
-							MountPath: "/csi",
-						},
+							MountPath: "/csi"},
 					},
 				},
 				{
@@ -372,41 +403,43 @@ func csiHostPathPod(
 	return ret
 }
 
-func deployGCEPDCSIDriver(
+func deployCSIDriver(
 	client clientset.Interface,
-	config framework.VolumeTestConfig,
 	teardown bool,
-	f *framework.Framework,
+	namespace string,
 	nodeSA *v1.ServiceAccount,
 	controllerSA *v1.ServiceAccount,
+	daemonSetManifest string,
+	statefulSetManifest string,
+	serviceManifset string,
 ) {
 	// Get API Objects from manifests
-	nodeds, err := manifest.DaemonSetFromManifest("test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml", config.Namespace)
+	nodeds, err := manifest.DaemonSetFromManifest(daemonSetManifest, namespace)
 	framework.ExpectNoError(err, "Failed to create DaemonSet from manifest")
 	nodeds.Spec.Template.Spec.ServiceAccountName = nodeSA.GetName()
 
-	controllerss, err := manifest.StatefulSetFromManifest("test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml", config.Namespace)
+	controllerss, err := manifest.StatefulSetFromManifest(statefulSetManifest, namespace)
 	framework.ExpectNoError(err, "Failed to create StatefulSet from manifest")
 	controllerss.Spec.Template.Spec.ServiceAccountName = controllerSA.GetName()
 
-	controllerservice, err := manifest.SvcFromManifest("test/e2e/testing-manifests/storage-csi/gce-pd/controller_service.yaml")
+	controllerservice, err := manifest.SvcFromManifest(serviceManifset)
 	framework.ExpectNoError(err, "Failed to create Service from manifest")
 
 	// Got all objects from manifests now try to delete objects
-	err = client.CoreV1().Services(config.Namespace).Delete(controllerservice.GetName(), nil)
+	err = client.CoreV1().Services(namespace).Delete(controllerservice.GetName(), nil)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {
 			framework.ExpectNoError(err, "Failed to delete Service: %v", controllerservice.GetName())
 		}
 	}
 
-	err = client.AppsV1().StatefulSets(config.Namespace).Delete(controllerss.Name, nil)
+	err = client.AppsV1().StatefulSets(namespace).Delete(controllerss.Name, nil)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {
 			framework.ExpectNoError(err, "Failed to delete StatefulSet: %v", controllerss.GetName())
 		}
 	}
-	err = client.AppsV1().DaemonSets(config.Namespace).Delete(nodeds.Name, nil)
+	err = client.AppsV1().DaemonSets(namespace).Delete(nodeds.Name, nil)
 	if err != nil {
 		if !apierrs.IsNotFound(err) {
 			framework.ExpectNoError(err, "Failed to delete DaemonSet: %v", nodeds.GetName())
@@ -417,13 +450,152 @@ func deployGCEPDCSIDriver(
 	}
 
 	// Create new API Objects through client
-	_, err = client.CoreV1().Services(config.Namespace).Create(controllerservice)
+	_, err = client.CoreV1().Services(namespace).Create(controllerservice)
 	framework.ExpectNoError(err, "Failed to create Service: %v", controllerservice.Name)
 
-	_, err = client.AppsV1().StatefulSets(config.Namespace).Create(controllerss)
+	_, err = client.AppsV1().StatefulSets(namespace).Create(controllerss)
 	framework.ExpectNoError(err, "Failed to create StatefulSet: %v", controllerss.Name)
 
-	_, err = client.AppsV1().DaemonSets(config.Namespace).Create(nodeds)
+	_, err = client.AppsV1().DaemonSets(namespace).Create(nodeds)
 	framework.ExpectNoError(err, "Failed to create DaemonSet: %v", nodeds.Name)
+}
 
+func deployGCEPDCSIDriver(
+	client clientset.Interface,
+	config framework.VolumeTestConfig,
+	teardown bool,
+	f *framework.Framework,
+	nodeSA *v1.ServiceAccount,
+	controllerSA *v1.ServiceAccount,
+) {
+	deployCSIDriver(client, teardown, config.Namespace, nodeSA, controllerSA,
+		"test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml",
+		"test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml",
+		"test/e2e/testing-manifests/storage-csi/gce-pd/controller_service.yaml")
+}
+
+func deployCephServer(
+	client clientset.Interface,
+	f *framework.Framework,
+	namespace string,
+) (*v1.Pod, string) {
+	cephConfig := framework.VolumeTestConfig{
+		Namespace:   namespace,
+		Prefix:      "ceph",
+		ServerImage: imageutils.GetE2EImage(imageutils.VolumeRBDServer),
+		ServerPorts: []int{6789},
+		ServerVolumes: map[string]string{
+			"/lib/modules": "/lib/modules",
+		},
+		ServerReadyMessage: "Ceph is ready",
+	}
+	serverPod, serverIP := framework.CreateStorageServer(client, cephConfig)
+	return serverPod, serverIP
+}
+
+func deleteCephEnvironment(
+	client clientset.Interface,
+	f *framework.Framework,
+	namespace string,
+	secretName string,
+	serverPod *v1.Pod,
+) {
+	secErr := client.CoreV1().Secrets(namespace).Delete(secretName, &metav1.DeleteOptions{})
+	err := framework.DeletePodWithWait(f, client, serverPod)
+	if secErr != nil || err != nil {
+		if secErr != nil {
+			framework.Logf("Ceph server secret delete failed: %v", secErr)
+		}
+		if err != nil {
+			framework.Logf("Ceph server pod delete failed: %v", err)
+		}
+		framework.Failf("Ceph server cleanup failed")
+	}
+}
+
+func deploySecret(
+	client clientset.Interface,
+	namespace string, secretName string,
+	data map[string][]byte,
+) *v1.Secret {
+	secret := &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: data,
+	}
+
+	secret, err := client.CoreV1().Secrets(namespace).Create(secret)
+	if err != nil {
+		framework.Logf("Failed to create secret %s: %v", secretName, err)
+	}
+
+	return secret
+}
+
+func deployRbdSecret(client clientset.Interface, namespace string) *v1.Secret {
+	secretName := "rbd-secret"
+	data := map[string][]byte{
+		// from test/images/volumes-tester/rbd/keyring
+		"admin": []byte("AQDRrKNVbEevChAAEmRC+pW/KBVHxa0w/POILA=="),
+	}
+	return deploySecret(client, namespace, secretName, data)
+}
+
+func deployCephfsSecret(client clientset.Interface, namespace string) *v1.Secret {
+	secretName := "cephfs-secret"
+	data := map[string][]byte{
+		"adminID": []byte("admin"),
+		// from test/images/volumes-tester/rbd/keyring
+		"adminKey": []byte("AQDRrKNVbEevChAAEmRC+pW/KBVHxa0w/POILA=="),
+	}
+	return deploySecret(client, namespace, secretName, data)
+}
+
+func deployRbdCSIDriver(
+	client clientset.Interface,
+	config framework.VolumeTestConfig,
+	teardown bool,
+	f *framework.Framework,
+	nodeSA *v1.ServiceAccount,
+	controllerSA *v1.ServiceAccount,
+	r *rbdCSIDriver,
+) {
+	deployCSIDriver(client, teardown, config.Namespace, nodeSA, controllerSA,
+		"test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml",
+		"test/e2e/testing-manifests/storage-csi/rbd/controller_ss.yaml",
+		"test/e2e/testing-manifests/storage-csi/rbd/controller_service.yaml")
+
+	if teardown {
+		deleteCephEnvironment(client, f, config.Namespace, r.secret.Name, r.serverPod)
+	} else {
+		r.serverPod, r.serverIP = deployCephServer(client, f, config.Namespace)
+		r.secret = deployRbdSecret(client, config.Namespace)
+	}
+}
+
+func deployCephfsCSIDriver(
+	client clientset.Interface,
+	config framework.VolumeTestConfig,
+	teardown bool,
+	f *framework.Framework,
+	nodeSA *v1.ServiceAccount,
+	controllerSA *v1.ServiceAccount,
+	c *cephfsCSIDriver,
+) {
+	deployCSIDriver(client, teardown, config.Namespace, nodeSA, controllerSA,
+		"test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml",
+		"test/e2e/testing-manifests/storage-csi/cephfs/controller_ss.yaml",
+		"test/e2e/testing-manifests/storage-csi/cephfs/controller_service.yaml")
+
+	if teardown {
+		deleteCephEnvironment(client, f, config.Namespace, c.secret.Name, c.serverPod)
+	} else {
+		c.serverPod, c.serverIP = deployCephServer(client, f, config.Namespace)
+		c.secret = deployCephfsSecret(client, config.Namespace)
+	}
 }

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -56,9 +56,9 @@ type csiTestDriver interface {
 var csiTestDrivers = map[string]func(f *framework.Framework, config framework.VolumeTestConfig) csiTestDriver{
 	"hostPath": initCSIHostpath,
 	// Feature tag to skip test in CI, pending fix of #62237
-	"[Feature: GCE PD CSI Plugin] gcePD": initCSIgcePD,
-	"[Feature:Volumes] rbd":              initCSIrbd,
-	"[Feature:Volumes] cephfs":           initCSIcephfs,
+	"[Feature: GCE PD CSI Plugin] csi gcePD": initCSIgcePD,
+	"[Feature:Volumes] csi rbd":              initCSIrbd,
+	"[Feature:Volumes] csi cephfs":           initCSIcephfs,
 }
 
 var _ = utils.SIGDescribe("CSI Volumes", func() {

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -430,6 +430,7 @@ func initCSIrbd(f *framework.Framework, config framework.VolumeTestConfig) csiTe
 	return &rbdCSIDriver{
 		nodeClusterRoles: []string{
 			csiDriverRegistrarClusterRoleName,
+			csiDriverSecretAccessClusterRoleName,
 		},
 		controllerClusterRoles: []string{
 			csiExternalAttacherClusterRoleName,
@@ -451,11 +452,12 @@ func (r *rbdCSIDriver) createStorageClassTest(node v1.Node) storageClassTest {
 			"pool":     "rbd",
 			"csiProvisionerSecretName":      r.secret.Name,
 			"csiProvisionerSecretNamespace": r.config.Namespace,
+			"csiNodePublishSecretName":      r.secret.Name,
+			"csiNodePublishSecretNamespace": r.config.Namespace,
 		},
-		claimSize:          "1Gi",
-		expectedSize:       "1Gi",
-		nodeName:           node.Name,
-		skipWriteReadCheck: true,
+		claimSize:    "1Gi",
+		expectedSize: "1Gi",
+		nodeName:     node.Name,
 	}
 }
 
@@ -500,6 +502,7 @@ func initCSIcephfs(f *framework.Framework, config framework.VolumeTestConfig) cs
 	return &cephfsCSIDriver{
 		nodeClusterRoles: []string{
 			csiDriverRegistrarClusterRoleName,
+			csiDriverSecretAccessClusterRoleName,
 		},
 		controllerClusterRoles: []string{
 			csiExternalAttacherClusterRoleName,
@@ -517,16 +520,18 @@ func (c *cephfsCSIDriver) createStorageClassTest(node v1.Node) storageClassTest 
 		name:        "csi-cephfsplugin",
 		provisioner: "csi-cephfsplugin",
 		parameters: map[string]string{
-			"monitors":        c.serverIP,
+			"monitors":        c.serverIP + ":6789",
+			"mounter":         "kernel",
 			"provisionVolume": "true",
 			"pool":            "cephfs_data",
 			"csiProvisionerSecretName":      c.secret.Name,
 			"csiProvisionerSecretNamespace": c.config.Namespace,
+			"csiNodeStageSecretName":        c.secret.Name,
+			"csiNodeStageSecretNamespace":   c.config.Namespace,
 		},
-		claimSize:          "1Gi",
-		expectedSize:       "1Gi",
-		nodeName:           node.Name,
-		skipWriteReadCheck: true,
+		claimSize:    "1Gi",
+		expectedSize: "1Gi",
+		nodeName:     node.Name,
 	}
 }
 

--- a/test/e2e/testing-manifests/storage-csi/cephfs/controller_service.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/controller_service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-cephfs
+  labels:
+    app: csi-cephfs
+spec:
+  selector:
+    app: csi-cephfs
+  ports:
+    - name: dummy
+      port: 12345

--- a/test/e2e/testing-manifests/storage-csi/cephfs/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/controller_ss.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-provisioner:v0.2.1
+          image: quay.io/k8scsi/csi-provisioner:v0.3.0
           args:
             - "--v=5"
             - "--provisioner=csi-cephfsplugin"
@@ -30,7 +30,7 @@ spec:
               mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/cephfs/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/controller_ss.yaml
@@ -1,0 +1,47 @@
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-cephfs-controller
+spec:
+  serviceName: "csi-cephfs"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-cephfs-driver
+  template:
+    metadata:
+      labels:
+        app: csi-cephfs-driver
+    spec:
+      serviceAccount: cephfs-controller
+      containers:
+        - name: csi-external-provisioner
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/csi-provisioner:v0.2.1
+          args:
+            - "--v=5"
+            - "--provisioner=csi-cephfsplugin"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+        - name: csi-attacher
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-cephfsplugin
+            type: DirectoryOrCreate

--- a/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
@@ -1,0 +1,84 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-cephfs-node
+spec:
+  selector:
+    matchLabels:
+      app: csi-cephfs-driver
+  serviceName: csi-cephfs
+  template:
+    metadata:
+      labels:
+        app: csi-cephfs-driver
+    spec:
+      serviceAccount: cephfs-node
+      containers:
+        - name: csi-driver-registrar
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+        - name: cephfs-driver
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          imagePullPolicy: IfNotPresent
+          image: quay.io/cephcsi/cephfsplugin:v0.3.0
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--drivername=csi-cephfsplugin"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+            - name: device-dir
+              mountPath: /dev
+            - name: sys-dir
+              mountPath: /sys
+            - name: lib-modules-dir
+              mountPath: /lib/modules
+              readOnly: True
+      volumes:
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-cephfsplugin
+            type: DirectoryOrCreate
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys-dir
+          hostPath:
+            path: /sys
+        - name: lib-modules-dir
+          hostPath:
+            path: /lib/modules

--- a/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
@@ -20,8 +20,11 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
             - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi-cephfsplugin/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -30,6 +33,8 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/csi-cephfsplugin
+            - name: registration-dir
+              mountPath: /registration
         - name: cephfs-driver
           securityContext:
             privileged: true
@@ -72,6 +77,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-cephfsplugin
             type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
         - name: device-dir
           hostPath:
             path: /dev

--- a/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/cephfs/node_ds.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: csi-driver-registrar
           imagePullPolicy: Always
-          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -36,7 +36,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           image: quay.io/cephcsi/cephfsplugin:v0.3.0
           args:
             - "--v=5"

--- a/test/e2e/testing-manifests/storage-csi/rbd/controller_service.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/controller_service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: csi-rbd
+  labels:
+    app: csi-rbd
+spec:
+  selector:
+    app: csi-rbd
+  ports:
+    - name: dummy
+      port: 12345

--- a/test/e2e/testing-manifests/storage-csi/rbd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/controller_ss.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-provisioner:v0.2.1
+          image: quay.io/k8scsi/csi-provisioner:v0.3.0
           args:
             - "--v=5"
             - "--provisioner=csi-rbdplugin"
@@ -30,7 +30,7 @@ spec:
               mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/rbd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/controller_ss.yaml
@@ -1,0 +1,47 @@
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-rbd-controller
+spec:
+  serviceName: "csi-rbd"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-rbd-driver
+  template:
+    metadata:
+      labels:
+        app: csi-rbd-driver
+    spec:
+      serviceAccount: rbd-controller
+      containers:
+        - name: csi-external-provisioner
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/csi-provisioner:v0.2.1
+          args:
+            - "--v=5"
+            - "--provisioner=csi-rbdplugin"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+        - name: csi-attacher
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-rbdplugin
+            type: DirectoryOrCreate

--- a/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: csi-driver-registrar
           imagePullPolicy: Always
-          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -37,7 +37,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           imagePullPolicy: Always
-          image: quay.io/cephcsi/rbdplugin:v0.2.0
+          image: quay.io/cephcsi/rbdplugin:v0.3.0
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
@@ -20,8 +20,11 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
             - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -30,6 +33,8 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+            - name: registration-dir
+              mountPath: /registration
         - name: rbd-driver
           securityContext:
             privileged: true
@@ -72,6 +77,10 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-rbdplugin
             type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
         - name: device-dir
           hostPath:
             path: /dev

--- a/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/rbd/node_ds.yaml
@@ -1,0 +1,84 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-rbd-node
+spec:
+  selector:
+    matchLabels:
+      app: csi-rbd-driver
+  serviceName: csi-rbd
+  template:
+    metadata:
+      labels:
+        app: csi-rbd-driver
+    spec:
+      serviceAccount: rbd-node
+      containers:
+        - name: csi-driver-registrar
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+        - name: rbd-driver
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          imagePullPolicy: Always
+          image: quay.io/cephcsi/rbdplugin:v0.2.0
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--drivername=csi-rbdplugin"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+            - name: device-dir
+              mountPath: /dev
+            - name: sys-dir
+              mountPath: /sys
+            - name: lib-modules-dir
+              mountPath: /lib/modules
+              readOnly: True
+      volumes:
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-rbdplugin
+            type: DirectoryOrCreate
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: sys-dir
+          hostPath:
+            path: /sys
+        - name: lib-modules-dir
+          hostPath:
+            path: /lib/modules


### PR DESCRIPTION
**What this PR does / why we need it**:
Add e2e tests for ceph-csi(rbd/cephfs) volume.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66388

**Special notes for your reviewer**:
/sig storage
@rootfs @aruneli @wongma7

Due to the issue discussing in https://github.com/ceph/ceph-csi/issues/48, cephfs test doesn't work well now.
I talked with @rootfs and decided to separate cephfs and rbd. So, this PR enables rbd only.
(Codes for cephfs exists in this PR, but is disabled by commenting out registering init function for it. If needed, I will delete the cephfs codes.)

@jsafrane @msau42 

I plan to apply the same refactoring as https://github.com/kubernetes/kubernetes/issues/66571 to csi tests, once it and this PR are merged.

**Release note**:
```release-note
NONE
```
