### PR TITLE
improve kubeconfig file modification time

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -126,6 +126,46 @@ func TestMergeContext(t *testing.T) {
 	matchStringArg(namespace, actual, t)
 }
 
+func TestModifyContext(t *testing.T) {
+	expectedCtx := map[string]bool{
+		"updated": true,
+		"clean":   true,
+	}
+
+	pathOptions := NewDefaultPathOptions()
+	config := createValidTestConfig()
+
+	// define new context and assign it - our path options config
+	config.Contexts["updated"] = &clientcmdapi.Context{
+		Cluster:  "updated",
+		AuthInfo: "updated",
+	}
+	config.CurrentContext = "updated"
+
+	if err := ModifyConfig(pathOptions, *config, true); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	startingConfig, err := pathOptions.GetStartingConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// make sure the current context was updated
+	matchStringArg("updated", startingConfig.CurrentContext, t)
+
+	// there should now be two contexts
+	if len(startingConfig.Contexts) != len(expectedCtx) {
+		t.Fatalf("unexpected nuber of contexts, expecting %v, but found %v", len(expectedCtx), len(startingConfig.Contexts))
+	}
+
+	for key := range startingConfig.Contexts {
+		if !expectedCtx[key] {
+			t.Fatalf("expected context %q to exist", key)
+		}
+	}
+}
+
 func TestCertificateData(t *testing.T) {
 	caData := []byte("ca-data")
 	certData := []byte("cert-data")


### PR DESCRIPTION
In cases where there are few destination filenames for a given
amount of contexts, but a large amount of contexts, this patch
prevents reading and writing to the same file (or small number
of files) over and over again needlessly.

**Release note**:
```release-note
Decrease the amount of time it takes to modify kubeconfig files with large amounts of contexts
```

cc @deads2k 