### PR TITLE
Add unit tests for webhooks with dry run

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -84,7 +84,7 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr *generic.Version
 func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *v1beta1.Webhook, attr *generic.VersionedAttributes) error {
 	if attr.IsDryRun() {
 		// TODO: support this
-		webhookerrors.NewDryRunUnsupportedErr(h.Name)
+		return webhookerrors.NewDryRunUnsupportedErr(h.Name)
 	}
 
 	// Make the webhook request

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -79,9 +79,9 @@ func TestAdmit(t *testing.T) {
 
 		var attr admission.Attributes
 		if tt.IsCRD {
-			attr = webhooktesting.NewAttributeUnstructured(ns, tt.AdditionalLabels)
+			attr = webhooktesting.NewAttributeUnstructured(ns, tt.AdditionalLabels, tt.IsDryRun)
 		} else {
-			attr = webhooktesting.NewAttribute(ns, tt.AdditionalLabels)
+			attr = webhooktesting.NewAttribute(ns, tt.AdditionalLabels, tt.IsDryRun)
 		}
 
 		err = wh.Admit(attr)
@@ -147,7 +147,7 @@ func TestAdmitCachedClient(t *testing.T) {
 			continue
 		}
 
-		err = wh.Admit(webhooktesting.NewAttribute(ns, nil))
+		err = wh.Admit(webhooktesting.NewAttribute(ns, nil, false))
 		if tt.ExpectAllow != (err == nil) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -99,7 +99,7 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr *generic.Versi
 func (d *validatingDispatcher) callHook(ctx context.Context, h *v1beta1.Webhook, attr *generic.VersionedAttributes) error {
 	if attr.IsDryRun() {
 		// TODO: support this
-		webhookerrors.NewDryRunUnsupportedErr(h.Name)
+		return webhookerrors.NewDryRunUnsupportedErr(h.Name)
 	}
 
 	// Make the webhook request

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -72,7 +72,7 @@ func TestValidate(t *testing.T) {
 			continue
 		}
 
-		err = wh.Validate(webhooktesting.NewAttribute(ns, nil))
+		err = wh.Validate(webhooktesting.NewAttribute(ns, nil, tt.IsDryRun))
 		if tt.ExpectAllow != (err == nil) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}
@@ -130,7 +130,7 @@ func TestValidateCachedClient(t *testing.T) {
 			continue
 		}
 
-		err = wh.Validate(webhooktesting.NewAttribute(ns, nil))
+		err = wh.Validate(webhooktesting.NewAttribute(ns, nil, false))
 		if tt.ExpectAllow != (err == nil) {
 			t.Errorf("%s: expected allowed=%v, but got err=%v", tt.Name, tt.ExpectAllow, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with https://github.com/kubernetes/kubernetes/pull/67085 and adds a couple test cases that would catch it.

@lavalamp

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
