### PR TITLE
fix yaml file path for test/e2e/network/example_cluster_dns.go

### DIFF
--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 
 	It("should create pod that uses dns", func() {
 		mkpath := func(file string) string {
-			return filepath.Join(framework.TestContext.RepoRoot, "examples/cluster-dns", file)
+			return filepath.Join(os.Getenv("GOPATH"), "src/k8s.io/examples/staging/cluster-dns", file)
 		}
 
 		// contrary to the example, this test does not use contexts, for simplicity


### PR DESCRIPTION
**What this PR does / why we need it**:
The test is using wrong yaml file path, and framework.TestContext.RepoRoot is not compatible with the test-infra. (RepoRoot need us to use a relative path which is even worse comparing to use GOPATH directly.)

Currently only the following testgrids are running this test. 
https://k8s-testgrid.appspot.com/sig-network-netd#Summary
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
