### PR TITLE
macOS and docker for mac don't play nicely with mktemp

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -56,7 +56,10 @@ build() {
 
     # Create a temporary directory for every architecture and copy the image content
     # and build the image from temporary directory
-    temp_dir=$(mktemp -d)
+    mkdir -p ${KUBE_ROOT}/_tmp
+    temp_dir=$(mktemp -d ${KUBE_ROOT}/_tmp/test-images-build.XXXXXX)
+    kube::util::trap_add "rm -rf ${temp_dir}" EXIT
+
     cp -r ${IMAGE}/* ${temp_dir}
     if [[ -f ${IMAGE}/Makefile ]]; then
       # make bin will take care of all the prerequisites needed


### PR DESCRIPTION
**What this PR does / why we need it**:

On macOS mktemp -d drops something in /var/folders, which isn't
shared by default with Docker for Mac. Thus I can't run docker
with that volume mounted to build binaries for test images. So
instead, tell mktemp to use kubernetes/_tmp as its base, which
is what I see some of the hack/verify-* scripts use

I had to use this patch to build images for:
- https://github.com/kubernetes/kubernetes/pull/67030
- https://github.com/kubernetes/kubernetes/pull/67034
- https://github.com/kubernetes/kubernetes/pull/67035

I am _super_ open to a better way of doing this if I missed something

**Special notes for your reviewer**: Kindly make sure this doesn't break
building images on linux

/release-note-none
/sig release
/cc @dims @ixdy