### PR TITLE
CSI plugin now calls NodeGetInfo() to get driver's node ID

### DIFF
--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -61,6 +61,7 @@ type NodeClient struct {
 	nodePublishedVolumes map[string]string
 	nodeStagedVolumes    map[string]string
 	stageUnstageSet      bool
+	nodeGetInfoResp      *csipb.NodeGetInfoResponse
 	nextErr              error
 }
 
@@ -76,6 +77,10 @@ func NewNodeClient(stageUnstageSet bool) *NodeClient {
 // SetNextError injects next expected error
 func (f *NodeClient) SetNextError(err error) {
 	f.nextErr = err
+}
+
+func (f *NodeClient) SetNodeGetInfoResp(resp *csipb.NodeGetInfoResponse) {
+	f.nodeGetInfoResp = resp
 }
 
 // GetNodePublishedVolumes returns node published volumes
@@ -177,6 +182,14 @@ func (f *NodeClient) NodeUnstageVolume(ctx context.Context, req *csipb.NodeUnsta
 // NodeGetId implements method
 func (f *NodeClient) NodeGetId(ctx context.Context, in *csipb.NodeGetIdRequest, opts ...grpc.CallOption) (*csipb.NodeGetIdResponse, error) {
 	return nil, nil
+}
+
+// NodeGetId implements csi method
+func (f *NodeClient) NodeGetInfo(ctx context.Context, in *csipb.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipb.NodeGetInfoResponse, error) {
+	if f.nextErr != nil {
+		return nil, f.nextErr
+	}
+	return f.nodeGetInfoResp, nil
 }
 
 // NodeGetCapabilities implements csi method

--- a/pkg/volume/csi/labelmanager/labelmanager.go
+++ b/pkg/volume/csi/labelmanager/labelmanager.go
@@ -34,7 +34,6 @@ const (
 	// Name of node annotation that contains JSON map of driver names to node
 	// names
 	annotationKey = "csi.volume.kubernetes.io/nodeid"
-	csiPluginName = "kubernetes.io/csi"
 )
 
 // labelManagementStruct is struct of channels used for communication between the driver registration
@@ -46,7 +45,7 @@ type labelManagerStruct struct {
 
 // Interface implements an interface for managing labels of a node
 type Interface interface {
-	AddLabels(driverName string) error
+	AddLabels(driverName string, driverNodeId string) error
 }
 
 // NewLabelManager initializes labelManagerStruct and returns available interfaces
@@ -59,8 +58,8 @@ func NewLabelManager(nodeName types.NodeName, kubeClient kubernetes.Interface) I
 
 // nodeLabelManager waits for labeling requests initiated by the driver's registration
 // process.
-func (lm labelManagerStruct) AddLabels(driverName string) error {
-	err := verifyAndAddNodeId(string(lm.nodeName), lm.k8s.CoreV1().Nodes(), driverName, string(lm.nodeName))
+func (lm labelManagerStruct) AddLabels(driverName string, driverNodeId string) error {
+	err := verifyAndAddNodeId(string(lm.nodeName), lm.k8s.CoreV1().Nodes(), driverName, driverNodeId)
 	if err != nil {
 		return fmt.Errorf("failed to update node %s's annotation with error: %+v", lm.nodeName, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67040

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/sig storage
@sbezverk @vladimirvivien @saad-ali 