### PR TITLE
Check config path for command "kubeadm alpha phase kubelet write-env-file"

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/kubelet.go
@@ -125,6 +125,10 @@ func NewCmdKubeletWriteEnvFile() *cobra.Command {
 		Long:    kubeletWriteEnvFileLongDesc,
 		Example: kubeletWriteEnvFileExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(cfgPath) == 0 {
+				kubeadmutil.CheckErr(fmt.Errorf("The --config flag is mandatory"))
+			}
+
 			err := RunKubeletWriteEnvFile(cfgPath)
 			kubeadmutil.CheckErr(err)
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Explicitly check the `--config` flag of command `kubeadm alpha phase kubelet write-env-file`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/1043

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
