### PR TITLE
fix get-kube-local.sh 2 wrong parameters.

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -55,8 +55,9 @@ function run {
 }
 
 # Creates a kubeconfig file for the kubelet.
-# Args: destination file path
+# Args: the IP address of the API server (e.g. "http://localhost:8080"), destination file path
 function create-kubelet-kubeconfig() {
+  #local api_addr="${1}"
   local destination="${2}"
   if [[ -z "${destination}" ]]; then
     echo "Must provide destination path to create Kubelet kubeconfig file!"
@@ -85,7 +86,7 @@ EOF
 function create_cluster {
   echo "Creating a local cluster:"
   echo -e -n "\tStarting kubelet..."
-  create-kubelet-kubeconfig "${KUBELET_KUBECONFIG}"
+  create-kubelet-kubeconfig "http://localhost:8080" "${KUBELET_KUBECONFIG}"
   run "docker run \
   --volume=/:/rootfs:ro \
   --volume=/sys:/sys:ro \
@@ -103,7 +104,7 @@ function create_cluster {
       --containerized \
       --hostname-override="127.0.0.1" \
       --address="0.0.0.0" \
-      --kubeconfig=${KUBELET_KUBECONFIG}/kubelet.kubeconfig \
+      --kubeconfig=${KUBELET_KUBECONFIG} \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --allow-privileged=true \
       --cluster-dns=10.0.0.10 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**bug fix**
1. run ./get-kube-local.sh, and get this error.
>  ./get-kube-local.sh: line 60: 2: unbound variable
2. remove duplicate filename in docker run command: `--kubeconfig=${KUBELET_KUBECONFIG}`

**Special notes for your reviewer**:
code detail:
line 88: create-kubelet-kubeconfig "${KUBELET_KUBECONFIG}" 
line 59: function create-kubelet-kubeconfig() {
line 60:  local destination="${1}"

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
      NONE
```
