### PR TITLE
prevent "No resources found" output on forbidden error

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -454,7 +454,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		}
 	}
 	w.Flush()
-	if nonEmptyObjCount == 0 && !o.IgnoreNotFound {
+	if nonEmptyObjCount == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		fmt.Fprintln(o.ErrOut, "No resources found.")
 	}
 	return utilerrors.NewAggregate(allErrs)

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -72,6 +72,10 @@ run_kubectl_get_tests() {
   # Pre-condition: no pods exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
+  output_message=$(! kubectl get foobar 2>&1 "${kube_flags[@]}")
+  # Post-condition: The text "No resources found" should not be part of the output when an error occurs
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
   output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}")
   # Post-condition: The text "No resources found" should be part of the output
   kube::test::if_has_string "${output_message}" 'No resources found'


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

This was originally fixed in https://github.com/kubernetes/kubernetes/pull/35115, but made its way back. Added a small test

cc @soltysh 