### PR TITLE
Fix an issue about generation of secret key with invalid key size in gce

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -217,7 +217,7 @@ resources:
     - aesgcm:
         keys:
         - name: key1
-          secret: $(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\r\n')
+          secret: $(dd if=/dev/urandom iflag=fullblock bs=32 count=1 2>/dev/null | base64 | tr -d '\r\n')
 EOM
 )
 fi

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -217,7 +217,7 @@ resources:
     - aesgcm:
         keys:
         - name: key1
-          secret: $(dd if=/dev/random bs=32 count=1 2>/dev/null | base64 | tr -d '\r\n')
+          secret: $(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\r\n')
 EOM
 )
 fi


### PR DESCRIPTION
Replace /dev/random to /dev/urandom to avoid generation of secret key with invalid key size.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In GCE env, AESGCM encryption of secrets by default generates a secret key with /dev/random which sometime generates a key with invalid size.
This cause the cluster/kube-up.sh to fail in gce environment.

This PR replaces /dev/random with  /dev/urandom to have a secret key generated consistently with right size.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67091

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cluster/gce: generate consistent key sizes in config-default.sh using /dev/urandom instead of /dev/random  
```
