### PR TITLE
Fail container start if its requested device plugin resource is unknown.

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -378,9 +378,7 @@ func (m *ManagerImpl) addEndpointProbeMode(resourceName string, socketPath strin
 func (m *ManagerImpl) registerEndpoint(resourceName string, options *pluginapi.DevicePluginOptions, e *endpointImpl) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	if options != nil {
-		m.pluginOpts[resourceName] = options
-	}
+	m.pluginOpts[resourceName] = options
 	m.endpoints[resourceName] = e
 	glog.V(2).Infof("Registered endpoint %v", e)
 }
@@ -721,11 +719,8 @@ func (m *ManagerImpl) callPreStartContainerIfNeeded(podUID, contName, resource s
 	opts, ok := m.pluginOpts[resource]
 	if !ok {
 		m.mutex.Unlock()
-		glog.V(4).Infof("Plugin options not found in cache for resource: %s. Skip PreStartContainer", resource)
-		return nil
-	}
-
-	if !opts.PreStartRequired {
+		return fmt.Errorf("Plugin options not found in cache for resource: %s", resource)
+	} else if opts == nil || !opts.PreStartRequired {
 		m.mutex.Unlock()
 		glog.V(4).Infof("Plugin options indicate to skip PreStartContainer for resource, %v", resource)
 		return nil

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -670,6 +670,8 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	nodeInfo := getTestNodeInfo(v1.ResourceList{})
 	pluginOpts := make(map[string]*pluginapi.DevicePluginOptions)
+	pluginOpts[res1.resourceName] = nil
+	pluginOpts[res2.resourceName] = nil
 	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources, pluginOpts)
 	as.Nil(err)
 
@@ -766,6 +768,8 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 	pluginOpts := make(map[string]*pluginapi.DevicePluginOptions)
+	pluginOpts[res1.resourceName] = nil
+	pluginOpts[res2.resourceName] = nil
 	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources, pluginOpts)
 	as.Nil(err)
 


### PR DESCRIPTION
With the change, Kubelet device manager now checks whether it has cached option state for the requested device plugin resource to make sure the resource is in ready state when we start the container.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/67107

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fail container start if its requested device plugin resource hasn't registered after Kubelet restart.
```
