### PR TITLE
Removes dependency on RBAC within kubernetes core

### DIFF
--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -19,7 +19,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/set",
     visibility = ["//build/visible_to:pkg_kubectl_cmd_set_CONSUMERS"],
     deps = [
-        "//pkg/apis/rbac:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/set/env:go_default_library",
         "//pkg/kubectl/cmd/templates:go_default_library",

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -183,7 +182,7 @@ func (o *SubjectOptions) Validate() error {
 		}
 
 		for _, info := range o.Infos {
-			_, ok := info.Object.(*rbac.ClusterRoleBinding)
+			_, ok := info.Object.(*rbacv1.ClusterRoleBinding)
 			if ok && tokens[0] == "" {
 				return fmt.Errorf("serviceaccount must be <namespace>:<name>, namespace must be specified")
 			}
@@ -198,16 +197,16 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 		subjects := []rbacv1.Subject{}
 		for _, user := range sets.NewString(o.Users...).List() {
 			subject := rbacv1.Subject{
-				Kind:     rbac.UserKind,
-				APIGroup: rbac.GroupName,
+				Kind:     rbacv1.UserKind,
+				APIGroup: rbacv1.GroupName,
 				Name:     user,
 			}
 			subjects = append(subjects, subject)
 		}
 		for _, group := range sets.NewString(o.Groups...).List() {
 			subject := rbacv1.Subject{
-				Kind:     rbac.GroupKind,
-				APIGroup: rbac.GroupName,
+				Kind:     rbacv1.GroupKind,
+				APIGroup: rbacv1.GroupName,
 				Name:     group,
 			}
 			subjects = append(subjects, subject)
@@ -220,7 +219,7 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 				namespace = o.namespace
 			}
 			subject := rbacv1.Subject{
-				Kind:      rbac.ServiceAccountKind,
+				Kind:      rbacv1.ServiceAccountKind,
 				Namespace: namespace,
 				Name:      name,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an unneeded dependency. Kubectl should depend on repo "k8s.io/api/rbac"; not "k8s.io/kubernetes/pkg/apis/rbac"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # 

https://github.com/kubernetes/kubectl/issues/91

```release-note
NONE
```
