### PR TITLE
Remove the local manifest list after push

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -112,7 +112,7 @@ push() {
   for arch in ${archs}; do
     docker manifest annotate --arch ${arch} ${REGISTRY}/${IMAGE}:${TAG} ${REGISTRY}/${IMAGE}-${arch}:${TAG}
   done
-  docker manifest push ${REGISTRY}/${IMAGE}:${TAG}
+  docker manifest push --purge ${REGISTRY}/${IMAGE}:${TAG}
 }
 
 # This function is for building the go code


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Manifests seem sticky in docker, so let's try to purge so if
we have re-push a fresh set of containers (with same version number as
before) during testing, the manifests are created fresh.

Change-Id: I41c010c08bd50b68ff6973a4ae1e004824fab178

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
