### PR TITLE
Automated cherry pick of #65799: Escape illegal characters in remote extra keys

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -160,6 +161,14 @@ func allHeaderValues(h http.Header, headerNames []string) []string {
 	return ret
 }
 
+func unescapeExtraKey(encodedKey string) string {
+	key, err := url.PathUnescape(encodedKey) // Decode %-encoded bytes.
+	if err != nil {
+		return encodedKey // Always record extra strings, even if malformed/unencoded.
+	}
+	return key
+}
+
 func newExtra(h http.Header, headerPrefixes []string) map[string][]string {
 	ret := map[string][]string{}
 
@@ -170,7 +179,7 @@ func newExtra(h http.Header, headerPrefixes []string) map[string][]string {
 				continue
 			}
 
-			extraKey := strings.ToLower(headerName[len(prefix):])
+			extraKey := unescapeExtraKey(strings.ToLower(headerName[len(prefix):]))
 			ret[extraKey] = append(ret[extraKey], vv...)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -152,6 +152,37 @@ func TestRequestHeader(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+
+		"escaped extra keys": {
+			nameHeaders:        []string{"X-Remote-User"},
+			groupHeaders:       []string{"X-Remote-Group"},
+			extraPrefixHeaders: []string{"X-Remote-Extra-"},
+			requestHeaders: http.Header{
+				"X-Remote-User":                                            {"Bob"},
+				"X-Remote-Group":                                           {"one-a", "one-b"},
+				"X-Remote-Extra-Alpha":                                     {"alphabetical"},
+				"X-Remote-Extra-Alph4num3r1c":                              {"alphanumeric"},
+				"X-Remote-Extra-Percent%20encoded":                         {"percent encoded"},
+				"X-Remote-Extra-Almost%zzpercent%xxencoded":                {"not quite percent encoded"},
+				"X-Remote-Extra-Example.com%2fpercent%2520encoded":         {"url with double percent encoding"},
+				"X-Remote-Extra-Example.com%2F%E4%BB%8A%E6%97%A5%E3%81%AF": {"url with unicode"},
+				"X-Remote-Extra-Abc123!#$+.-_*\\^`~|'":                     {"header key legal characters"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name:   "Bob",
+				Groups: []string{"one-a", "one-b"},
+				Extra: map[string][]string{
+					"alpha":                         {"alphabetical"},
+					"alph4num3r1c":                  {"alphanumeric"},
+					"percent encoded":               {"percent encoded"},
+					"almost%zzpercent%xxencoded":    {"not quite percent encoded"},
+					"example.com/percent%20encoded": {"url with double percent encoding"},
+					"example.com/今日は":               {"url with unicode"},
+					"abc123!#$+.-_*\\^`~|'":         {"header key legal characters"},
+				},
+			},
+			expectedOk: true,
+		},
 	}
 
 	for k, testcase := range testcases {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/golang/glog"
@@ -146,6 +147,14 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 	})
 }
 
+func unescapeExtraKey(encodedKey string) string {
+	key, err := url.PathUnescape(encodedKey) // Decode %-encoded bytes.
+	if err != nil {
+		return encodedKey // Always record extra strings, even if malformed/unencoded.
+	}
+	return key
+}
+
 // buildImpersonationRequests returns a list of objectreferences that represent the different things we're requesting to impersonate.
 // Also includes a map[string][]string representing user.Info.Extra
 // Each request must be authorized against the current user before switching contexts.
@@ -175,7 +184,7 @@ func buildImpersonationRequests(headers http.Header) ([]v1.ObjectReference, erro
 		}
 
 		hasUserExtra = true
-		extraKey := strings.ToLower(headerName[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):])
+		extraKey := unescapeExtraKey(strings.ToLower(headerName[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):]))
 
 		// make a separate request for each extra value they're trying to set
 		for _, value := range values {

--- a/staging/src/k8s.io/client-go/transport/round_trippers_test.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers_test.go
@@ -18,6 +18,7 @@ package transport
 
 import (
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -125,6 +126,32 @@ func TestImpersonationRoundTripper(t *testing.T) {
 				ImpersonateUserExtraHeaderPrefix + "Second": {"B", "b"},
 			},
 		},
+		{
+			name: "escape handling",
+			impersonationConfig: ImpersonationConfig{
+				UserName: "user",
+				Extra: map[string][]string{
+					"test.example.com/thing.thing": {"A", "a"},
+				},
+			},
+			expected: map[string][]string{
+				ImpersonateUserHeader:                                               {"user"},
+				ImpersonateUserExtraHeaderPrefix + `Test.example.com%2fthing.thing`: {"A", "a"},
+			},
+		},
+		{
+			name: "double escape handling",
+			impersonationConfig: ImpersonationConfig{
+				UserName: "user",
+				Extra: map[string][]string{
+					"test.example.com/thing.thing%20another.thing": {"A", "a"},
+				},
+			},
+			expected: map[string][]string{
+				ImpersonateUserHeader: {"user"},
+				ImpersonateUserExtraHeaderPrefix + `Test.example.com%2fthing.thing%2520another.thing`: {"A", "a"},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -159,9 +186,10 @@ func TestImpersonationRoundTripper(t *testing.T) {
 
 func TestAuthProxyRoundTripper(t *testing.T) {
 	for n, tc := range map[string]struct {
-		username string
-		groups   []string
-		extra    map[string][]string
+		username      string
+		groups        []string
+		extra         map[string][]string
+		expectedExtra map[string][]string
 	}{
 		"allfields": {
 			username: "user",
@@ -169,6 +197,34 @@ func TestAuthProxyRoundTripper(t *testing.T) {
 			extra: map[string][]string{
 				"one": {"alpha", "bravo"},
 				"two": {"charlie", "delta"},
+			},
+			expectedExtra: map[string][]string{
+				"one": {"alpha", "bravo"},
+				"two": {"charlie", "delta"},
+			},
+		},
+		"escaped extra": {
+			username: "user",
+			groups:   []string{"groupA", "groupB"},
+			extra: map[string][]string{
+				"one":             {"alpha", "bravo"},
+				"example.com/two": {"charlie", "delta"},
+			},
+			expectedExtra: map[string][]string{
+				"one":               {"alpha", "bravo"},
+				"example.com%2ftwo": {"charlie", "delta"},
+			},
+		},
+		"double escaped extra": {
+			username: "user",
+			groups:   []string{"groupA", "groupB"},
+			extra: map[string][]string{
+				"one": {"alpha", "bravo"},
+				"example.com/two%20three": {"charlie", "delta"},
+			},
+			expectedExtra: map[string][]string{
+				"one": {"alpha", "bravo"},
+				"example.com%2ftwo%2520three": {"charlie", "delta"},
 			},
 		},
 	} {
@@ -210,9 +266,64 @@ func TestAuthProxyRoundTripper(t *testing.T) {
 				actualExtra[extraKey] = append(actualExtra[key], values...)
 			}
 		}
-		if e, a := tc.extra, actualExtra; !reflect.DeepEqual(e, a) {
+		if e, a := tc.expectedExtra, actualExtra; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s expected %v, got %v", n, e, a)
 			continue
 		}
+	}
+}
+
+// TestHeaderEscapeRoundTrip tests to see if foo == url.PathUnescape(headerEscape(foo))
+// This behavior is important for client -> API server transmission of extra values.
+func TestHeaderEscapeRoundTrip(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name string
+		key  string
+	}{
+		{
+			name: "alpha",
+			key:  "alphabetical",
+		},
+		{
+			name: "alphanumeric",
+			key:  "alph4num3r1c",
+		},
+		{
+			name: "percent encoded",
+			key:  "percent%20encoded",
+		},
+		{
+			name: "almost percent encoded",
+			key:  "almost%zzpercent%xxencoded",
+		},
+		{
+			name: "illegal char & percent encoding",
+			key:  "example.com/percent%20encoded",
+		},
+		{
+			name: "weird unicode stuff",
+			key:  "example.com/ᛒᚥᛏᛖᚥᚢとロビン",
+		},
+		{
+			name: "header legal chars",
+			key:  "abc123!#$+.-_*\\^`~|'",
+		},
+		{
+			name: "legal path, illegal header",
+			key:  "@=:",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			escaped := headerKeyEscape(tc.key)
+			unescaped, err := url.PathUnescape(escaped)
+			if err != nil {
+				t.Fatalf("url.PathUnescape(%q) returned error: %v", escaped, err)
+			}
+			if tc.key != unescaped {
+				t.Errorf("url.PathUnescape(headerKeyEscape(%q)) returned %q, wanted %q", tc.key, unescaped, tc.key)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #65799 on release-1.11.

#65799: Escape illegal characters in remote extra keys

```release-note
action required: the API server and client-go libraries have been fixed to support additional non-alpha-numeric characters in UserInfo "extra" data keys. Both should be updated in order to properly support extra data containing "/" characters or other characters disallowed in HTTP headers.
```