### PR TITLE
AzureDisk: Parse zoned first before using it

### DIFF
--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -180,6 +180,11 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 		return nil, err
 	}
 
+	zoned, err = parseZoned(strZoned, kind)
+	if err != nil {
+		return nil, err
+	}
+
 	if kind != v1.AzureManagedDisk {
 		if resourceGroup != "" {
 			return nil, errors.New("StorageClass option 'resourceGroup' can be used only for managed disks")
@@ -188,11 +193,6 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 		if zoned {
 			return nil, errors.New("StorageClass option 'zoned' parameter is only supported for managed disks")
 		}
-	}
-
-	zoned, err = parseZoned(strZoned, kind)
-	if err != nil {
-		return nil, err
 	}
 
 	if !zoned && (zonePresent || zonesPresent) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`zoned` should be parsed first before using.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/pull/67121#discussion_r208639436

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @ddebroy @khenidak @andyzhangx 