### PR TITLE
use v1 version of advanced audit policy in kubemark

### DIFF
--- a/test/kubemark/resources/start-kubemark-master.sh
+++ b/test/kubemark/resources/start-kubemark-master.sh
@@ -346,7 +346,7 @@ function create-master-audit-policy {
       - group: "storage.k8s.io"'
 
   cat <<EOF >"${path}"
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
   # The following requests were manually identified as high-volume and low-risk,


### PR DESCRIPTION
audit api version has been updated to v1 #65891 

**Release note**:
```release-note
NONE
```
