### PR TITLE
use v1 version of advanced audit policy in juju config.yaml

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -2,7 +2,7 @@ options:
   audit-policy:
     type: string
     default: |
-      apiVersion: audit.k8s.io/v1beta1
+      apiVersion: audit.k8s.io/v1
       kind: Policy
       rules:
       # Don't log read-only requests from the apiserver


### PR DESCRIPTION
audit api version has been updated to v1 #65891 

**Release note**:
```release-note
NONE
```