### PR TITLE
use v1 version of advanced audit policy in kubeadm

### DIFF
--- a/cmd/kubeadm/app/util/audit/BUILD
+++ b/cmd/kubeadm/app/util/audit/BUILD
@@ -11,7 +11,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/install:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1:go_default_library",
     ],
 )
 
@@ -23,7 +23,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit/install:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/audit/utils.go
+++ b/cmd/kubeadm/app/util/audit/utils.go
@@ -26,27 +26,27 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/apis/audit/install"
-	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 // CreateDefaultAuditLogPolicy writes the default audit log policy to disk.
 func CreateDefaultAuditLogPolicy(policyFile string) error {
-	policy := auditv1beta1.Policy{
+	policy := auditv1.Policy{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: auditv1beta1.SchemeGroupVersion.String(),
+			APIVersion: auditv1.SchemeGroupVersion.String(),
 			Kind:       "Policy",
 		},
-		Rules: []auditv1beta1.PolicyRule{
+		Rules: []auditv1.PolicyRule{
 			{
-				Level: auditv1beta1.LevelMetadata,
+				Level: auditv1.LevelMetadata,
 			},
 		},
 	}
 	return writePolicyToDisk(policyFile, &policy)
 }
 
-func writePolicyToDisk(policyFile string, policy *auditv1beta1.Policy) error {
+func writePolicyToDisk(policyFile string, policy *auditv1.Policy) error {
 	// creates target folder if not already exists
 	if err := os.MkdirAll(filepath.Dir(policyFile), 0700); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v", filepath.Dir(policyFile), err)
@@ -59,7 +59,7 @@ func writePolicyToDisk(policyFile string, policy *auditv1beta1.Policy) error {
 	codecs := serializer.NewCodecFactory(scheme)
 
 	// writes the policy to disk
-	serialized, err := util.MarshalToYamlForCodecs(policy, auditv1beta1.SchemeGroupVersion, codecs)
+	serialized, err := util.MarshalToYamlForCodecs(policy, auditv1.SchemeGroupVersion, codecs)
 
 	if err != nil {
 		return fmt.Errorf("failed to marshal audit policy to YAML: %v", err)

--- a/cmd/kubeadm/app/util/audit/utils_test.go
+++ b/cmd/kubeadm/app/util/audit/utils_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/apis/audit/install"
-	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 )
 
 func cleanup(t *testing.T, path string) {
@@ -54,7 +54,7 @@ func TestCreateDefaultAuditLogPolicy(t *testing.T) {
 	scheme := runtime.NewScheme()
 	install.Install(scheme)
 	codecs := serializer.NewCodecFactory(scheme)
-	policy := auditv1beta1.Policy{}
+	policy := auditv1.Policy{}
 	err = runtime.DecodeInto(codecs.UniversalDecoder(), policyBytes, &policy)
 	if err != nil {
 		t.Fatalf("failed to decode written policy: %v", err)


### PR DESCRIPTION
audit api version has been updated to v1 #65891 

**Release note**:
```release-note
kubeadm uses audit policy v1 instead of v1beta1
```