### PR TITLE
Fixing kubeadm.conf file path

### DIFF
--- a/cmd/kubeadm/test/cmd/join_test.go
+++ b/cmd/kubeadm/test/cmd/join_test.go
@@ -236,7 +236,7 @@ func TestCmdJoinArgsMixed(t *testing.T) {
 		args     string
 		expected bool
 	}{
-		{"--discovery-token=abcdef.1234567890abcdef --config=/etc/kubernets/kubeadm.config", false},
+		{"--discovery-token=abcdef.1234567890abcdef --config=/etc/kubernetes/kubeadm.config", false},
 	}
 
 	for _, rt := range initTest {


### PR DESCRIPTION
This patch fixed kubeadm.conf file path in this file.