### PR TITLE
Use gcr.io/k8s-testimages/logexporter:v0.1.2.

### DIFF
--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: k8s.gcr.io/logexporter:v0.1.1
+        image: gcr.io/k8s-testimages/logexporter:v0.1.2
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes a version of logexporter used in our tests.
Version v0.1.2 contains fixes from https://github.com/kubernetes/test-infra/pull/8978 to help debugging #67120 

```release-note
NONE
```

/assign @shyamjvs 
