### PR TITLE
Update `kubectl get` sorter to deal with server-side printing

### DIFF
--- a/hack/testdata/sorted-pods/sorted-pod1.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod1.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: sorted-pod1
+  creationTimestamp: 2018-08-30T14:10:58Z
   labels:
     name: sorted-pod3-label
 spec:
   containers:
-  - name: kubernetes-pause
+  - name: kubernetes-pause2
     image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/sorted-pods/sorted-pod2.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod2.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: sorted-pod2
+  creationTimestamp: 2018-08-30T14:10:55Z
   labels:
     name: sorted-pod2-label
 spec:
   containers:
-  - name: kubernetes-pause
+  - name: kubernetes-pause1
     image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/sorted-pods/sorted-pod3.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod3.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: sorted-pod3
+  creationTimestamp: 2018-08-30T14:10:53Z
   labels:
     name: sorted-pod1-label
 spec:
   containers:
-  - name: kubernetes-pause
+  - name: kubernetes-pause3
     image: k8s.gcr.io/pause:2.0

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -144,6 +144,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -81,6 +81,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",

--- a/pkg/kubectl/sorter.go
+++ b/pkg/kubectl/sorter.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/integer"
 	"k8s.io/client-go/util/jsonpath"
@@ -111,12 +112,7 @@ func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput stri
 	// Note that this requires empty fields to be considered later, when sorting.
 	var fieldFoundOnce bool
 	for _, obj := range objs {
-		var values [][]reflect.Value
-		if unstructured, ok := obj.(*unstructured.Unstructured); ok {
-			values, err = parser.FindResults(unstructured.Object)
-		} else {
-			values, err = parser.FindResults(reflect.ValueOf(obj).Elem().Interface())
-		}
+		values, err := findJSONPathResults(parser, obj)
 		if err != nil {
 			return nil, err
 		}
@@ -274,20 +270,12 @@ func (r *RuntimeSort) Less(i, j int) bool {
 		panic(err)
 	}
 
-	if unstructured, ok := iObj.(*unstructured.Unstructured); ok {
-		iValues, err = parser.FindResults(unstructured.Object)
-	} else {
-		iValues, err = parser.FindResults(reflect.ValueOf(iObj).Elem().Interface())
-	}
+	iValues, err = findJSONPathResults(parser, iObj)
 	if err != nil {
 		glog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, r.field, err)
 	}
 
-	if unstructured, ok := jObj.(*unstructured.Unstructured); ok {
-		jValues, err = parser.FindResults(unstructured.Object)
-	} else {
-		jValues, err = parser.FindResults(reflect.ValueOf(jObj).Elem().Interface())
-	}
+	jValues, err = findJSONPathResults(parser, jObj)
 	if err != nil {
 		glog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
 	}
@@ -315,4 +303,78 @@ func (r *RuntimeSort) OriginalPosition(ix int) int {
 		return -1
 	}
 	return r.origPosition[ix]
+}
+
+type TableSorter struct {
+	field string
+	obj   *metav1beta1.Table
+}
+
+func (t *TableSorter) Len() int {
+	return len(t.obj.Rows)
+}
+
+func (t *TableSorter) Swap(i, j int) {
+	t.obj.Rows[i], t.obj.Rows[j] = t.obj.Rows[j], t.obj.Rows[i]
+}
+
+func (t *TableSorter) Less(i, j int) bool {
+	iObj := t.obj.Rows[i].Object.Object
+	jObj := t.obj.Rows[j].Object.Object
+
+	var iValues [][]reflect.Value
+	var jValues [][]reflect.Value
+	var err error
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	err = parser.Parse(t.field)
+	if err != nil {
+		glog.Fatalf("sorting error: %v\n", err)
+	}
+
+	// TODO(juanvallejo): this is expensive for very large sets.
+	// To improve runtime complexity, build an array which contains all
+	// resolved fields, and sort that instead.
+	iValues, err = findJSONPathResults(parser, iObj)
+	if err != nil {
+		glog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, t.field, err)
+	}
+
+	jValues, err = findJSONPathResults(parser, jObj)
+	if err != nil {
+		glog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, t.field, err)
+	}
+
+	if len(iValues) == 0 || len(iValues[0]) == 0 || len(jValues) == 0 || len(jValues[0]) == 0 {
+		glog.Fatalf("couldn't find any field with path %q in the list of objects", t.field)
+	}
+
+	iField := iValues[0][0]
+	jField := jValues[0][0]
+
+	less, err := isLess(iField, jField)
+	if err != nil {
+		glog.Fatalf("Field %s in %T is an unsortable type: %s, err: %v", t.field, iObj, iField.Kind().String(), err)
+	}
+	return less
+}
+
+func (t *TableSorter) Sort() error {
+	sort.Sort(t)
+	return nil
+}
+
+func NewTableSorter(table *metav1beta1.Table, field string) *TableSorter {
+	return &TableSorter{
+		obj:   table,
+		field: field,
+	}
+}
+
+func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
+	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
+		return parser.FindResults(unstructuredObj.Object)
+	}
+
+	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
 }


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

### Why?

Currently, we default to non-server-side printing when sorting items in `kubectl get`. This means that instead of taking advantage of having the server tell `kubectl` how to display information, `kubectl` falls back to using hardcoded resource types to figure out how to print its output. This does not really work with resources that `kubectl` does not know about, and it goes against our goal of snipping any dependencies that `kubectl` has on the core repo.

This patch adds a sorter capable of dealing with Table objects sent by the server when using "server-side printing".

A few things left to take care of:

- ~~[ ] When printing `all` resources, this implementation does not handle sorting every single Table object, but rather _only_ the rows in each object. As a result, output will contain sorted resources of the same _kind_, but the overall list of mixed resources will _not_ itself be sorted. Example:~~

```bash
$ kubectl get all --sort-by .metadata.name
NAME            READY     STATUS    RESTARTS   AGE
# pods here will be sorted:
pod/bar         0/2       Pending   0          31m
pod/foo         1/1       Running   0          37m

NAME                        DESIRED   CURRENT   READY     AGE
# replication controllers here will be sorted as well:
replicationcontroller/baz   1         1         1         37m
replicationcontroller/buz   1         1         1         37m

# ... but the overall mixed list of rc's and pods will not be sorted
```
This occurs because each Table object received from the server contains all rows for that resource _kind_. We would need a way to build an ambiguous Table object containing all rows for all objects regardless of their type to have a fully sorted mixed-object output.

- [ ] handle sorting by column-names, rather than _only_ with jsonpaths (Tracked in https://github.com/kubernetes/kubernetes/issues/68027)

cc @soltysh @kubernetes/sig-cli-maintainers @seans3 @mengqiy 