### PR TITLE
hyperkube-base: perform magic COPY incantation to make apt-get update work properly

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -14,6 +14,15 @@
 
 FROM BASEIMAGE
 
+# For mysterious reasons, apt-get update fails on cross-build architectures
+# unless we explicitly copy the qemu-ARCH-static binary into the build.
+#
+# It already exists in the base image, but that apparently isnt' good enough??
+#
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+
 RUN echo CACHEBUST>/dev/null && clean-install \
     bash
 

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -29,6 +29,20 @@ CNI_VERSION=v0.6.0
 TEMP_DIR:=$(shell mktemp -d)
 CNI_TARBALL=cni-plugins-$(ARCH)-$(CNI_VERSION).tgz
 
+QEMUVERSION=v2.9.1
+ifeq ($(ARCH),arm)
+	QEMUARCH=arm
+endif
+ifeq ($(ARCH),arm64)
+	QEMUARCH=aarch64
+endif
+ifeq ($(ARCH),ppc64le)
+	QEMUARCH=ppc64le
+endif
+ifeq ($(ARCH),s390x)
+	QEMUARCH=s390x
+endif
+
 .PHONY: all build push clean
 
 all: push
@@ -43,16 +57,26 @@ clean:
 build: cni-tars/$(CNI_TARBALL)
 	cp Dockerfile $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+	cd $(TEMP_DIR) && sed -i "s|ARCH|$(QEMUARCH)|g" Dockerfile
 
 ifeq ($(CACHEBUST),1)
 	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
 endif
 
+ifeq ($(ARCH),amd64)
+	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
+	cd $(TEMP_DIR) && sed -i "/CROSS_BUILD_/d" Dockerfile
+else
+	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
+	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
+endif
+
 	mkdir -p ${TEMP_DIR}/cni-bin/bin
 	tar -xz -C ${TEMP_DIR}/cni-bin/bin -f "cni-tars/${CNI_TARBALL}"
 
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 


### PR DESCRIPTION
This PR seriously bothers me.

I've attempted to build a new release of the `debian-hyperkube-base` images (after #67026), but I'm unable to cross-build any of the non-amd64 images, while the `debian-iptables` images build without issue.

The errors were around signatures on the apt repositories:
```
Step 2/6 : RUN echo 2e285e3b-2127-4c83-af22-db258c7ae7ce>/dev/null && clean-install     bash
 ---> Running in 8169361d8294
Get:1 http://security.debian.org/debian-security stretch/updates InRelease [94.3 kB]
Ign:1 http://security.debian.org/debian-security stretch/updates InRelease
Get:3 http://security.debian.org/debian-security stretch/updates/main armhf Packages [372 kB]
Ign:2 http://cdn-fastly.deb.debian.org/debian stretch InRelease
Get:4 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Ign:4 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease
Get:6 http://cdn-fastly.deb.debian.org/debian stretch-updates/main armhf Packages [5112 B]
Get:5 http://cdn-fastly.deb.debian.org/debian stretch Release [118 kB]
Get:7 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg [2434 B]
Ign:7 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg
Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main armhf Packages [6927 kB]
Fetched 7610 kB in 5s (1465 kB/s)
Reading package lists...
W: GPG error: http://security.debian.org/debian-security stretch/updates InRelease: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/security.debian.org_debian-security_dists_stretch_updates_InRelease
W: The repository 'http://security.debian.org/debian-security stretch/updates InRelease' is not signed.
W: GPG error: http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/deb.debian.org_debian_dists_stretch-updates_InRelease
W: The repository 'http://deb.debian.org/debian stretch-updates InRelease' is not signed.
W: GPG error: http://cdn-fastly.deb.debian.org/debian stretch Release: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/deb.debian.org_debian_dists_stretch_Release
W: The repository 'http://deb.debian.org/debian stretch Release' is not signed.
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  bash-doc
Recommended packages:
  bash-completion
The following NEW packages will be installed:
  bash
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1371 kB of archives.
After this operation, 5573 kB of additional disk space will be used.
WARNING: The following packages cannot be authenticated!
  bash
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
The command '/bin/sh -c echo 2e285e3b-2127-4c83-af22-db258c7ae7ce>/dev/null && clean-install     bash' returned a non-zero code: 100
```

Through trial and error, I discovered that the only difference between the `debian-iptables` image builds and `debian-hyperkube-base` builds were that the iptables builds download the `qemu-ARCH-static` binaries and `COPY` them into the container.

The `qemu-ARCH-static` binaries already exist in the base image (`debian-base`), and the version, permissions, sha256sum, and other metadata are unchanged. Somehow copying it again (via the `COPY` directive) matters.

If I `COPY` to some other path, it doesn't work.

For even more spookiness, building the hyperkube-base image from `debian-base:0.3` works without issue.

If I remove the `COPY` lines from the `debian-iptables` Dockerfile, I can't build that image anymore. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
