### PR TITLE
Allow running various storage e2e tests on custom images

### DIFF
--- a/test/e2e/common/volumes.go
+++ b/test/e2e/common/volumes.go
@@ -62,7 +62,7 @@ var _ = Describe("[sig-storage] GCP Volumes", func() {
 	var c clientset.Interface
 
 	BeforeEach(func() {
-		framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
+		framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu", "custom")
 
 		namespace = f.Namespace
 		c = f.ClientSet

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -204,8 +204,8 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 
 	BeforeEach(func() {
 		framework.SkipUnlessProviderIs("gce", "local")
-		framework.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci")
-		framework.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci")
+		framework.SkipUnlessMasterOSDistroIs("debian", "ubuntu", "gci", "custom")
+		framework.SkipUnlessNodeOSDistroIs("debian", "ubuntu", "gci", "custom")
 		framework.SkipUnlessSSHKeyPresent()
 
 		cs = f.ClientSet

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -1003,7 +1003,7 @@ type glusterSource struct {
 }
 
 func initGluster() volSource {
-	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
+	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu", "custom")
 	return &glusterSource{}
 }
 

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -128,7 +128,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 	Describe("GlusterFS", func() {
 		It("should be mountable", func() {
 			//TODO (copejon) GFS is not supported on debian image.
-			framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
+			framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu", "custom")
 
 			// create gluster server and endpoints
 			config, _, _ := framework.NewGlusterfsServer(cs, namespace.Name)
@@ -357,7 +357,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 		It("should be mountable with xfs", func() {
 			// xfs is not supported on gci
 			// and not installed by default on debian
-			framework.SkipUnlessNodeOSDistroIs("ubuntu")
+			framework.SkipUnlessNodeOSDistroIs("ubuntu", "custom")
 			testGCEPD(f, config, cs, "xfs")
 		})
 	})


### PR DESCRIPTION
Ubuntu image is treated as custom image in some e2e tests. We whitelist both ubuntu and custom to run the storage tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/assign @msau42 
/release-note-none
/sig storage