### PR TITLE
Add namespace for (cluster)role(binding) cloud-provider.

### DIFF
--- a/cluster/gce/addons/loadbalancing/cloud-provider-binding.yaml
+++ b/cluster/gce/addons/loadbalancing/cloud-provider-binding.yaml
@@ -3,12 +3,12 @@ kind: RoleBinding
 metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-  name: cloud-provider
+  name: gce:cloud-provider
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cloud-provider
+  name: gce:cloud-provider
 subjects:
 - kind: ServiceAccount
   name: cloud-provider
@@ -19,11 +19,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-  name: cloud-provider
+  name: gce:cloud-provider
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cloud-provider
+  name: gce:cloud-provider
 subjects:
 - kind: ServiceAccount
   name: cloud-provider

--- a/cluster/gce/addons/loadbalancing/cloud-provider-role.yaml
+++ b/cluster/gce/addons/loadbalancing/cloud-provider-role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-  name: cloud-provider
+  name: gce:cloud-provider
   namespace: kube-system
 rules:
 - apiGroups:
@@ -23,7 +23,51 @@ kind: ClusterRole
 metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
+  name: gce:cloud-provider
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
   name: cloud-provider
+  namespace: kube-system
+  annotations:
+    kubernetes.io/deprecation: 'cloud-provider role is DEPRECATED in the
+      concern of potential collisions and will be removed in 1.16. Do not use
+      this role.'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: cloud-provider
+  annotations:
+    kubernetes.io/deprecation: 'cloud-provider clusterrole is DEPRECATED in the
+      concern of potential collisions and will be removed in 1.16. Do not use
+      this role.'
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Add namespace for (cluster)role(binding) cloud-provider.
Change the addonmanager mode to be from reconcile to EnsureExists.

Needs to be cherrypicked together with https://github.com/kubernetes/kubernetes/pull/59686.

**Special notes for your reviewer**:
/assign @bowei @tallclair 
/sig auth

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Role, ClusterRole and their bindings for cloud-provider is put under system namespace. Their addonmanager mode switches to EnsureExists.
```

Manual tested. Cluster can be created succesfully using kube-up.sh with desired (cluster)role(binding)s.