### PR TITLE
Adds WriteCertAndKey helper function to cert utils

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -789,11 +789,7 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 				return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
 			}
 
-			if err := certutil.WriteCert(kc.TLSCertFile, cert); err != nil {
-				return nil, err
-			}
-
-			if err := certutil.WriteKey(kc.TLSPrivateKeyFile, key); err != nil {
+			if err := certutil.WriteCertAndKey(kc.TLSCertFile, kc.TLSPrivateKeyFile, cert, key); err != nil {
 				return nil, err
 			}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -283,13 +283,10 @@ func (s *SecureServingOptions) MaybeDefaultWithSelfSignedCerts(publicAddress str
 		if cert, key, err := certutil.GenerateSelfSignedCertKeyWithFixtures(publicAddress, alternateIPs, alternateDNS, s.ServerCert.FixtureDirectory); err != nil {
 			return fmt.Errorf("unable to generate self signed cert: %v", err)
 		} else {
-			if err := certutil.WriteCert(keyCert.CertFile, cert); err != nil {
+			if err := certutil.WriteCertAndKey(keyCert.CertFile, keyCert.KeyFile, cert, key); err != nil {
 				return err
 			}
 
-			if err := certutil.WriteKey(keyCert.KeyFile, key); err != nil {
-				return err
-			}
 			glog.Infof("Generated self-signed cert (%s, %s)", keyCert.CertFile, keyCert.KeyFile)
 		}
 	}

--- a/staging/src/k8s.io/client-go/util/cert/io.go
+++ b/staging/src/k8s.io/client-go/util/cert/io.go
@@ -62,6 +62,15 @@ func canReadFile(path string) bool {
 	return true
 }
 
+// WriteCertAndKey stores certificate and key at the specified location
+func WriteCertAndKey(certPath string, keyPath string, cert []byte, key []byte) error {
+	if err := WriteCert(certPath, cert); err != nil {
+		return err
+	}
+
+	return WriteKey(keyPath, key)
+}
+
 // WriteCert writes the pem-encoded certificate data to certPath.
 // The certificate file will be created with file mode 0644.
 // If the certificate file already exists, it will be overwritten.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This adds a new WriteCertAndKey cert io helper function to make code more clean.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
