### PR TITLE
Fixed where the busybox image in test commom package was used as string

### DIFF
--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -245,7 +245,7 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 					},
 					{
 						Name:    containerName2,
-						Image:   "busybox",
+						Image:   busyboxImage,
 						Command: []string{"hexdump", "-C", "/etc/configmap-volume/dump.bin"},
 						VolumeMounts: []v1.VolumeMount{
 							{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed where the busybox image in test commom package was used as string 
In all test/common packages, use a variable "busyboxImage" in util.go but it only as a String in this file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
