### PR TITLE
fix azure disk create failure due to sdk upgrade

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
@@ -489,7 +489,9 @@ func (c *BlobDiskController) createStorageAccount(storageAccountName string, sto
 		glog.V(2).Infof("azureDisk - Creating storage account %s type %s", storageAccountName, string(storageAccountType))
 
 		cp := storage.AccountCreateParameters{
-			Sku:      &storage.Sku{Name: storageAccountType},
+			Sku: &storage.Sku{Name: storageAccountType},
+			// switch to use StorageV2 as it's recommended according to https://docs.microsoft.com/en-us/azure/storage/common/storage-account-options
+			Kind:     storage.StorageV2,
 			Tags:     map[string]*string{"created-by": to.StringPtr("azure-dd")},
 			Location: &location}
 		ctx, cancel := getContextWithCancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
fix azure storage account creation failure, this happens only on unmanaged k8s cluster on Azure.

This bug is due to azure-sdk-for-go API change introduced in v1.11:
https://github.com/Azure/azure-sdk-for-go/blob/fbe7db0e3f9793ba3e5704efbab84f51436c136e/services/storage/mgmt/2017-10-01/storage/models.go#L381-L382

there is a new field `Kind` which is required, so any sdk upgrade from and old version would break the storage account creation since old code won't use `Kind`. I have filed an issue to azure-sdk-for-go: https://github.com/Azure/azure-sdk-for-go/issues/2182
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67234

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix azure disk create failure due to sdk upgrade
```

/kind bug
/sig azure

/assign @feiskyer 
FYI @khenidak @brendandburns 