### PR TITLE
Fine grained control of equiv class cache based on predicate

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -526,7 +526,9 @@ func podFitsOnNode(
 			)
 			//TODO (yastij) : compute average predicate restrictiveness to export it as Prometheus metric
 			if predicate, exist := predicateFuncs[predicateKey]; exist {
-				if eCacheAvailable {
+				// Use equivalence class cache to boost predicate if eCache is available and helpful for given pod,
+				// node and predicate combination.
+				if eCacheAvailable && nodeCache.MightHelp(pod, nodeInfoToUse.Node(), predicateKey) {
 					fit, reasons, err = nodeCache.RunPredicate(predicate, predicateKey, pod, metaToUse, nodeInfoToUse, equivClass, cache)
 				} else {
 					fit, reasons, err = predicate(pod, metaToUse, nodeInfoToUse)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Based on [discussion here](https://github.com/kubernetes/kubernetes/pull/65714#issuecomment-410102800), ecache internally has a inevitable map access which may be slower than normal predicate if:
1. The predicate itself is simple and cheap, we created a `cheapPredicates` list for this.
2. The pod does not has required fields to run this predicate, so the predicate will return immediately.

In this PR, we will bypass these predicates to avoid performance decrease in large scale cluster.

Ref: #65714 

**Performance Evaluation:**

Combined with #66862,

`BenchmarkScheduling` shows no noticeable difference since pod spec is almost "empty":

[Disabled](https://github.com/resouer/temp/blob/master/torch_lock_skip_false.map.5000.svg) VS [Enabled](https://github.com/resouer/temp/blob/master/torch_lock_skip_true.map.5000.svg)

`BenchmarkSchedulingAntiAffinity` shows great improvement since pod has affinity defined:

[Disabled](https://github.com/resouer/temp/blob/master/torch_lock_skip_false.map.affinity.5000.svg) VS [Enabled](https://github.com/resouer/temp/blob/master/torch_lock_skip_true.map.affinity.5000.svg)

**Future Improvement:**

In the future, we can actually start two goroutines to run two algorithm separately, and use the quickest one. So we can avoid hard coding cheap predicates in this way.

**Special notes for your reviewer**:

cc @bsalamat 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fine grained control of equiv class cache based on predicate
```
