### PR TITLE
Use OWNERS-based labeling for kind/api-change

### DIFF
--- a/pkg/api/OWNERS
+++ b/pkg/api/OWNERS
@@ -1,4 +1,15 @@
-approvers:
-- api-approvers
-reviewers:
-- api-reviewers
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    approvers:
+      - api-approvers
+    reviewers:
+      - api-reviewers
+
+  # examples:
+  #   pkg/api/types.go
+  #   pkg/api/*/register.go
+  "([^/]+/)?(register|types)\\.go$":
+    labels:
+      - kind/api-change

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -1,44 +1,55 @@
-approvers:
-- erictune
-- lavalamp
-- smarterclayton
-- thockin
-- liggitt
-# - bgrant0607 # manual escalations only
-reviewers:
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- yujuhong
-- brendandburns
-- derekwaynecarr
-- caesarxuchao
-- vishh
-- mikedanese
-- liggitt
-- nikhiljindal
-- gmarek
-- erictune
-- pmorie
-- sttts
-- dchen1107
-- saad-ali
-- luxas
-- janetkuo
-- justinsb
-- pwittrock
-- ncdc
-- tallclair
-- yifan-gu
-- eparis
-- mwielgus
-- feiskyer
-- soltysh
-- piosz
-- dims
-- errordeveloper
-- madhusudancs
-- krousey
-- rootfs
-- jszczepkowski
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    approvers:
+    - erictune
+    - lavalamp
+    - smarterclayton
+    - thockin
+    - liggitt
+    # - bgrant0607 # manual escalations only
+    reviewers:
+    - lavalamp
+    - smarterclayton
+    - wojtek-t
+    - deads2k
+    - yujuhong
+    - brendandburns
+    - derekwaynecarr
+    - caesarxuchao
+    - vishh
+    - mikedanese
+    - liggitt
+    - nikhiljindal
+    - gmarek
+    - erictune
+    - pmorie
+    - sttts
+    - dchen1107
+    - saad-ali
+    - luxas
+    - janetkuo
+    - justinsb
+    - pwittrock
+    - ncdc
+    - tallclair
+    - yifan-gu
+    - eparis
+    - mwielgus
+    - feiskyer
+    - soltysh
+    - piosz
+    - dims
+    - errordeveloper
+    - madhusudancs
+    - krousey
+    - rootfs
+    - jszczepkowski
+
+  # examples:
+  #   pkg/apis/*/types.go
+  #   pkg/apis/*/*/types.go
+  "[^/]+/([^/]+/)?(register|types)\\.go$":
+    labels:
+      - kind/api-change


### PR DESCRIPTION
**What this PR does / why we need it**:

This replaces the following path-label munger config, except
we're using kind/api-change for everything instead of two
different kind/ labels

```
^pkg/api/([^/]+/)?types.go$    kind/api-change
^pkg/api/([^/]+/)?register.go$ kind/new-api
^pkg/apis/[^/]+/([^/]+/)?types.go$    kind/api-change
^pkg/apis/[^/]+/([^/]+/)?register.go$ kind/new-api
```

This fixes https://github.com/kubernetes/test-infra/issues/9007

**Special notes for your reviewer**:
This can be merged independently of us turning path-label off of
mungegithub. While both labeling options are active, they won't
clash, just race. 

```release-note
NONE
```