### PR TITLE
Move dependency within kubernetes core to staging

### DIFF
--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
@@ -36,7 +35,7 @@ import (
 func TestLog(t *testing.T) {
 	tests := []struct {
 		name, version, podPath, logPath string
-		pod                             *api.Pod
+		pod                             *corev1.Pod
 	}{
 		{
 			name: "v1 - pod log",
@@ -70,13 +69,13 @@ func TestLog(t *testing.T) {
 	}
 }
 
-func testPod() *api.Pod {
-	return &api.Pod{
+func testPod() *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
-		Spec: api.PodSpec{
-			RestartPolicy: api.RestartPolicyAlways,
-			DNSPolicy:     api.DNSClusterFirst,
-			Containers: []api.Container{
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyAlways,
+			DNSPolicy:     corev1.DNSClusterFirst,
+			Containers: []corev1.Container{
 				{
 					Name: "bar",
 				},
@@ -303,7 +302,7 @@ func (l *logTestMock) mockConsumeRequest(req *restclient.Request, out io.Writer)
 
 func (l *logTestMock) mockLogsForObject(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) ([]*restclient.Request, error) {
 	switch object.(type) {
-	case *api.Pod:
+	case *corev1.Pod:
 		_, ok := options.(*corev1.PodLogOptions)
 		if !ok {
 			return nil, errors.New("provided options object is not a PodLogOptions")

--- a/pkg/kubectl/cmd/scalejob/BUILD
+++ b/pkg/kubectl/cmd/scalejob/BUILD
@@ -22,10 +22,10 @@ go_test(
     srcs = ["scalejob_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/core:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/batch/v1:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",

--- a/pkg/kubectl/cmd/scalejob/scalejob_test.go
+++ b/pkg/kubectl/cmd/scalejob/scalejob_test.go
@@ -23,10 +23,10 @@ import (
 	batch "k8s.io/api/batch/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	api "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	batchclient "k8s.io/client-go/kubernetes/typed/batch/v1"
 	testcore "k8s.io/client-go/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type errorJobs struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves a dependency from with Kubernetes core (k8s.io/kubernetes/pkg/apis/core) to staging

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Helps Fix: Remove Kubectl dependencies on kubernetes/pkg/api and kubernetes/pkg/apis

https://github.com/kubernetes/kubectl/issues/83

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
