### PR TITLE
CSI applies fsgroup based on fstype and access modes

### DIFF
--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -127,3 +127,16 @@ func getVolumeDeviceDataDir(specVolID string, host volume.VolumeHost) string {
 	sanitizedSpecVolID := kstrings.EscapeQualifiedNameForDisk(specVolID)
 	return path.Join(host.GetVolumeDevicePluginDir(csiPluginName), sanitizedSpecVolID, "data")
 }
+
+// hasReadWriteOnce returns true if modes contains v1.ReadWriteOnce
+func hasReadWriteOnce(modes []api.PersistentVolumeAccessMode) bool {
+	if modes == nil {
+		return false
+	}
+	for _, mode := range modes {
+		if mode == api.ReadWriteOnce {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a fix for applying fsgroup only when a proper fstype along a safe access mode that will not cause unwanted ownership changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66323 

```release-note
NONE
```

/sig storage