### PR TITLE
Update to use debian-base:0.3.2

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -61,7 +61,7 @@ else
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
 	# Ensure we don't get surprised by umask settings
-	chmod 0755 qemu-$(QEMUARCH)-static
+	chmod 0755 $(TEMP_DIR)/qemu-$(QEMUARCH)-static
 	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
 endif
 	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -23,7 +23,7 @@ TAG=0.10.1
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -20,7 +20,7 @@ TAG=v10.1
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2


### PR DESCRIPTION
**What this PR does / why we need it**: uses the fixed debian-base image from #67222.
Also includes a small fix for a bug in the debian-base Makefile that I introduced in that same PR.

This is basically a rehash of #67026.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```