### PR TITLE
Revert "Update kube::util::ensure-cfssl"

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -707,15 +707,50 @@ function kube::util::join {
 #  CFSSLJSON_BIN: The path of the installed cfssljson binary
 #
 function kube::util::ensure-cfssl {
-  echo "Installing cfssl from vendor"
-  GOBIN="${KUBE_OUTPUT_BINPATH:-}" go install k8s.io/kubernetes/vendor/github.com/cloudflare/cfssl/cmd/cfssl
-  GOBIN="${KUBE_OUTPUT_BINPATH:-}" go install k8s.io/kubernetes/vendor/github.com/cloudflare/cfssl/cmd/cfssljson
-  CFSSL_BIN="$(PATH="${KUBE_OUTPUT_BINPATH:-}:${PATH}" command -v cfssl)"
-  CFSSLJSON_BIN="$(PATH="${KUBE_OUTPUT_BINPATH:-}:${PATH}" command -v cfssljson)"
-  if [[ ! -x ${CFSSL_BIN} || ! -x ${CFSSLJSON_BIN} ]]; then
-    echo "Failed to install cfssl." >&2
-    exit 1
+  if command -v cfssl &>/dev/null && command -v cfssljson &>/dev/null; then
+    CFSSL_BIN=$(command -v cfssl)
+    CFSSLJSON_BIN=$(command -v cfssljson)
+    return 0
   fi
+
+  # Create a temp dir for cfssl if no directory was given
+  local cfssldir=${1:-}
+  if [[ -z "${cfssldir}" ]]; then
+    kube::util::ensure-temp-dir
+    cfssldir="${KUBE_TEMP}/cfssl"
+  fi
+
+  mkdir -p "${cfssldir}"
+  pushd "${cfssldir}" > /dev/null
+
+    echo "Unable to successfully run 'cfssl' from $PATH; downloading instead..."
+    kernel=$(uname -s)
+    case "${kernel}" in
+      Linux)
+        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+        ;;
+      Darwin)
+        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
+        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
+        ;;
+      *)
+        echo "Unknown, unsupported platform: ${kernel}." >&2
+        echo "Supported platforms: Linux, Darwin." >&2
+        exit 2
+    esac
+
+    chmod +x cfssl || true
+    chmod +x cfssljson || true
+
+    CFSSL_BIN="${cfssldir}/cfssl"
+    CFSSLJSON_BIN="${cfssldir}/cfssljson"
+    if [[ ! -x ${CFSSL_BIN} || ! -x ${CFSSLJSON_BIN} ]]; then
+      echo "Failed to download 'cfssl'. Please install cfssl and cfssljson and verify they are in \$PATH."
+      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
+      exit 1
+    fi
+  popd > /dev/null
 }
 
 # kube::util::ensure_dockerized


### PR DESCRIPTION
This reverts commit 7a10073e4aefbda1d0e026353fd055db5cf8f140.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: this change broke using the cluster scripts without a git checkout of kubernetes in your go path (in CI for other projects we get these from artifact tarballs)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67286

**Special notes for your reviewer**: this unbreaks CI, we'll probably want to follow up with a change that actually uses vendor similar to this soon though.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
