### PR TITLE
Allow to use an existing subnet when IP aliases are enabled on GCE.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1880,7 +1880,7 @@ function expand-default-subnetwork() {
 
 function create-subnetworks() {
   case ${ENABLE_IP_ALIASES} in
-    true) echo "IP aliases are enabled. Creating subnetworks.";;
+    true) echo "IP aliases are enabled.";;
     false)
       echo "IP aliases are disabled."
       if [[ "${ENABLE_BIG_CLUSTER_SUBNETS}" = "true" ]]; then
@@ -1896,6 +1896,11 @@ function create-subnetworks() {
     *) echo "${color_red}Invalid argument to ENABLE_IP_ALIASES${color_norm}"
        exit 1;;
   esac
+
+  if [[ -n ${SUBNETWORK:-} ]]; then
+    IP_ALIAS_SUBNETWORK=${SUBNETWORK}
+    echo "IP aliases use an existing subnet: ${SUBNETWORK}"
+  fi
 
   # Look for the alias subnet, it must exist and have a secondary
   # range configured.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Without this PR, we are not able to create a K8s cluster with IP alias on an existing subnet (with secondary ranges) on GCE.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
