### PR TITLE
Log real file's name and line

### DIFF
--- a/pkg/kubectl/util/logs/logs.go
+++ b/pkg/kubectl/util/logs/logs.go
@@ -38,7 +38,7 @@ type GlogWriter struct{}
 
 // Write implements the io.Writer interface.
 func (writer GlogWriter) Write(data []byte) (n int, err error) {
-	glog.Info(string(data))
+	glog.InfoDepth(1, string(data))
 	return len(data), nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
@@ -46,7 +46,7 @@ type GlogWriter struct{}
 
 // Write implements the io.Writer interface.
 func (writer GlogWriter) Write(data []byte) (n int, err error) {
-	glog.Info(string(data))
+	glog.InfoDepth(1, string(data))
 	return len(data), nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Have correct location of emission in the logs

**Release note**:

pkg/kubectl/util/logs & staging/src/k8s.io/apiserver/pkg/util/logs
use `glog.info(...)` but this function is not made to be wrapped because
the underlying mechanism use a fixed call trace length to determine
where the log has been emited.

This results is having `logs.go:49` in the logs which is in the body
of the wrapper function and thus useless.

Instead use `glog.infoDepth(1, ...)` which tells the underlying mechanism
to go back 1 more level in the call trace to determine where the log
has been emitted.
