### PR TITLE
vsphere: enable TestInvalidCaCert

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/connection_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/connection_test.go
@@ -170,8 +170,6 @@ func TestWithInvalidCaCertPath(t *testing.T) {
 }
 
 func TestInvalidCaCert(t *testing.T) {
-	t.Skip("Waiting for https://github.com/vmware/govmomi/pull/1154")
-
 	connection := &vclib.VSphereConnection{
 		Hostname: "should-not-matter",
 		Port:     "should-not-matter",


### PR DESCRIPTION
This test can be enabled now with the govmomi vendor update in 5c44fd871f

**What this PR does / why we need it**:

Enables a test that had been skipped due to vendor dependency.

```release-note
NONE
```
