### PR TITLE
Fix flakiness in daemonset TestLaunchWithHashCollisiion

### DIFF
--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//test/integration/framework:go_default_library",
     ],
 )

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/factory"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	"k8s.io/kubernetes/pkg/util/metrics"
+	"k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -461,6 +462,22 @@ func validateFailedPlacementEvent(eventClient corev1typed.EventInterface, t *tes
 	}
 }
 
+func updateDS(t *testing.T, dsClient appstyped.DaemonSetInterface, dsName string, updateFunc func(*apps.DaemonSet)) *apps.DaemonSet {
+	var ds *apps.DaemonSet
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newDS, err := dsClient.Get(dsName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updateFunc(newDS)
+		ds, err = dsClient.Update(newDS)
+		return err
+	}); err != nil {
+		t.Fatalf("Failed to update DaemonSet: %v", err)
+	}
+	return ds
+}
+
 func forEachFeatureGate(t *testing.T, tf func(t *testing.T)) {
 	for _, fg := range featureGates() {
 		func() {
@@ -832,7 +849,7 @@ func TestLaunchWithHashCollision(t *testing.T) {
 	// Wait for the DaemonSet to be created before proceeding
 	err = waitForDaemonSetAndControllerRevisionCreated(clientset, ds.Name, ds.Namespace)
 	if err != nil {
-		t.Fatalf("Failed to create DeamonSet: %v", err)
+		t.Fatalf("Failed to create DaemonSet: %v", err)
 	}
 
 	ds, err = dsClient.Get(ds.Name, metav1.GetOptions{})
@@ -875,10 +892,9 @@ func TestLaunchWithHashCollision(t *testing.T) {
 
 	// Make an update of the DaemonSet which we know will create a hash collision when
 	// the next ControllerRevision is created.
-	_, err = dsClient.Update(ds)
-	if err != nil {
-		t.Fatalf("Failed to update DaemonSet: %v", err)
-	}
+	ds = updateDS(t, dsClient, ds.Name, func(updateDS *apps.DaemonSet) {
+		updateDS.Spec.Template.Spec.TerminationGracePeriodSeconds = &one
+	})
 
 	// Wait for any pod with the latest Spec to exist
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Addresses flakiness in test/integration/daemonset TestLaunchWithHashCollision. It makes sure the test waits for the pod to be added to the daemonset before updating the daemonset. The should avoid the race where the daemonset gets updated in between the calls to get and update in the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67273 

**Special notes for your reviewer**:
@janetkuo 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
