### PR TITLE
Fixes regression in kubectl logs: the --all-containers=true option didn't work

### DIFF
--- a/pkg/kubectl/polymorphichelpers/logsforobject.go
+++ b/pkg/kubectl/polymorphichelpers/logsforobject.go
@@ -87,7 +87,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.InitContainers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, options, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
 			if err != nil {
 				return nil, err
 			}
@@ -96,7 +96,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.Containers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, options, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
 			if err != nil {
 				return nil, err
 			}
@@ -115,7 +115,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.InitContainers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, options, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
 			if err != nil {
 				return nil, err
 			}
@@ -124,7 +124,7 @@ func logsForObjectWithClient(clientset corev1client.CoreV1Interface, object, opt
 		for _, c := range t.Spec.Containers {
 			currOpts := opts.DeepCopy()
 			currOpts.Container = c.Name
-			currRet, err := logsForObjectWithClient(clientset, t, options, timeout, false)
+			currRet, err := logsForObjectWithClient(clientset, t, currOpts, timeout, false)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes regression introduced in #66398 and adds unit tests for logging with `--all-containers=true`. See #67314 for more details.

**Which issue(s) this PR fixes**:
Fixes #67314

**Special notes for your reviewer**:

I didn't cover cases with `coreinternal.PodList` and `coreinternal.Pod` in tests, because it doesn't look like we need them: I didn't manage to find any callers of the `logsForObjectWithClient` and `logsForObject` functions, so, probably, we can remove them. I'll double check and try to do that separately once this PR is merged.

**Release note**:
```release-note
NONE
```

/sig cli