### PR TITLE
Support mount options for cephfs with ceph-fuse mount

### DIFF
--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -323,8 +323,8 @@ func (cephfsVolume *cephfs) execMount(mountpoint string) error {
 	}
 	src += hosts[i] + ":" + cephfsVolume.path
 
-	mountOptions := util.JoinMountOptions(cephfsVolume.mountOptions, opt)
-	if err := cephfsVolume.mounter.Mount(src, mountpoint, "ceph", mountOptions); err != nil {
+	opt = util.JoinMountOptions(cephfsVolume.mountOptions, opt)
+	if err := cephfsVolume.mounter.Mount(src, mountpoint, "ceph", opt); err != nil {
 		return fmt.Errorf("CephFS: mount failed: %v", err)
 	}
 
@@ -407,6 +407,17 @@ func (cephfsVolume *cephfs) execFuseMount(mountpoint string) error {
 	mountArgs = append(mountArgs, cephfsVolume.path)
 	mountArgs = append(mountArgs, "--id")
 	mountArgs = append(mountArgs, cephfsVolume.id)
+
+	// build option array
+	opt := []string{}
+	if cephfsVolume.readonly {
+		opt = append(opt, "ro")
+	}
+	opt = util.JoinMountOptions(cephfsVolume.mountOptions, opt)
+	if len(opt) > 0 {
+		mountArgs = append(mountArgs, "-o")
+		mountArgs = append(mountArgs, strings.Join(opt, ","))
+	}
 
 	glog.V(4).Infof("Mounting cmd ceph-fuse with arguments (%s)", mountArgs)
 	command := exec.Command("ceph-fuse", mountArgs...)


### PR DESCRIPTION
**What this PR does / why we need it**:

When cephfs uses ceph-fuse for the mount command, mount option and
readOnly options are disregarded. This patch adds to ceph-fuse as
well.


**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
