### PR TITLE
use temp file for kubeconfig in test

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -132,8 +132,16 @@ func TestModifyContext(t *testing.T) {
 		"clean":   true,
 	}
 
+	tempPath, err := ioutil.TempFile("", "testclientcmd-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(tempPath.Name())
+
 	pathOptions := NewDefaultPathOptions()
 	config := createValidTestConfig()
+
+	pathOptions.GlobalFile = tempPath.Name()
 
 	// define new context and assign it - our path options config
 	config.Contexts["updated"] = &clientcmdapi.Context{


### PR DESCRIPTION
Followup to https://github.com/kubernetes/kubernetes/pull/67093

Updates client_config_test to use a temporary file for kubeconfig.

**Release note**:
```release-note
NONE
```

cc @deads2k @soltysh 