### PR TITLE
simplify logic for func BuildArgumentListFromMap

### DIFF
--- a/cmd/kubeadm/app/util/arguments.go
+++ b/cmd/kubeadm/app/util/arguments.go
@@ -30,26 +30,26 @@ import (
 func BuildArgumentListFromMap(baseArguments map[string]string, overrideArguments map[string]string) []string {
 	var command []string
 	var keys []string
-	for k := range overrideArguments {
+
+	argsMap := make(map[string]string)
+
+	for k, v := range baseArguments {
+		argsMap[k] = v
+	}
+
+	for k, v := range overrideArguments {
+		argsMap[k] = v
+	}
+
+	for k := range argsMap {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 	for _, k := range keys {
-		v := overrideArguments[k]
-		// values of "" are allowed as well
-		command = append(command, fmt.Sprintf("--%s=%s", k, v))
+		command = append(command, fmt.Sprintf("--%s=%s", k, argsMap[k]))
 	}
-	keys = []string{}
-	for k := range baseArguments {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		v := baseArguments[k]
-		if _, overrideExists := overrideArguments[k]; !overrideExists {
-			command = append(command, fmt.Sprintf("--%s=%s", k, v))
-		}
-	}
+
 	return command
 }
 

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -85,9 +85,9 @@ func TestBuildArgumentListFromMap(t *testing.T) {
 			},
 			expected: []string{
 				"--admission-control=NamespaceLifecycle,LimitRanger",
-				"--something-that-allows-empty-string=",
 				"--allow-privileged=true",
 				"--insecure-bind-address=127.0.0.1",
+				"--something-that-allows-empty-string=",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
simplify the logic to merge two map, we just need only one sort to build the command and make the code more readable.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
