### PR TITLE
Revert #67190: new version breaks exporting logs

### DIFF
--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v0.1.2
+        image: k8s.gcr.io/logexporter:v0.1.1
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Apparently #67190 breaks log gathering in bigger scale tests.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @shyamjvs 
