### PR TITLE
[wip]fix externalTrafficPolicy: Local breaks internal reachability

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -980,7 +980,6 @@ func (proxier *Proxier) syncProxyRules() {
 				}
 			}
 		}
-		// FIXME: do we need REJECT rules for load-balancer ingress if !hasEndpoints?
 
 		// Capture nodeports.  If we had more than 2 rules it might be
 		// worthwhile to make a new per-service chain for nodeport rules, but
@@ -1194,7 +1193,7 @@ func (proxier *Proxier) syncProxyRules() {
 				"-m", "comment", "--comment",
 				fmt.Sprintf(`"%s has no local endpoints"`, svcNameString),
 				"-j",
-				string(KubeMarkDropChain),
+				string(svcChain),
 			)
 			writeLine(proxier.natRules, args...)
 		} else {


### PR DESCRIPTION

**What this PR does / why we need it**:
When externalTrafficPolicy=local from nodes that don't have local endpoints can't access external address.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65387

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
