### PR TITLE
kubectl: update message for a no-op patch

### DIFF
--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -331,5 +331,5 @@ func patchOperation(didPatch bool) string {
 	if didPatch {
 		return "patched"
 	}
-	return "not patched"
+	return "patched (no change)"
 }

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -439,9 +439,9 @@ run_pod_tests() {
   output_message=$(! kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"metadata":{"labels":"invalid"}}' 2>&1)
   kube::test::if_has_string "${output_message}" 'cannot restore map from string'
 
-  ## Patch exits with error message "not patched" and exit code 0 when no-op occurs
+  ## Patch exits with error message "patched (no change)" and exit code 0 when no-op occurs
   output_message=$(kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"metadata":{"labels":{"name":"valid-pod"}}}' 2>&1)
-  kube::test::if_has_string "${output_message}" 'not patched'
+  kube::test::if_has_string "${output_message}" 'patched (no change)'
 
   ## Patch pod can change image
   # Command


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/67344

/cc liggitt juanvallejo soltysh timoreimann 
/sig cli

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
