### PR TITLE
Automated cherry pick of #66249: fill in normal restmapping info with the legacy guess

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/restmapper.go
+++ b/staging/src/k8s.io/client-go/discovery/restmapper.go
@@ -98,18 +98,20 @@ func NewRESTMapper(groupResources []*APIGroupResources, versionInterfaces meta.V
 					scope = meta.RESTScopeRoot
 				}
 
-				// this is for legacy resources and servers which don't list singular forms.  For those we must still guess.
-				if len(resource.SingularName) == 0 {
-					versionMapper.Add(gv.WithKind(resource.Kind), scope)
-					// TODO this is producing unsafe guesses that don't actually work, but it matches previous behavior
-					versionMapper.Add(gv.WithKind(resource.Kind+"List"), scope)
+				// if we have a slash, then this is a subresource and we shouldn't create mappings for those.
+				if strings.Contains(resource.Name, "/") {
 					continue
 				}
 
 				plural := gv.WithResource(resource.Name)
 				singular := gv.WithResource(resource.SingularName)
-				versionMapper.AddSpecific(gv.WithKind(resource.Kind), plural, singular, scope)
+				// this is for legacy resources and servers which don't list singular forms.  For those we must still guess.
+				if len(resource.SingularName) == 0 {
+					_, singular = meta.UnsafeGuessKindToResource(gv.WithKind(resource.Kind))
+				}
+
 				versionMapper.AddSpecific(gv.WithKind(strings.ToLower(resource.Kind)), plural, singular, scope)
+				versionMapper.AddSpecific(gv.WithKind(resource.Kind), plural, singular, scope)
 				// TODO this is producing unsafe guesses that don't actually work, but it matches previous behavior
 				versionMapper.Add(gv.WithKind(resource.Kind+"List"), scope)
 			}


### PR DESCRIPTION
Fixes 1.10 part of https://github.com/kubernetes/kubernetes/issues/67235

Cherry pick of #66249 on release-1.10.

#66249: fill in normal restmapping info with the legacy guess

```release-note
Fix creation of custom resources when the CRD contains non-conventional pluralization and subresources
```