### PR TITLE
add admissionv1beta1 in scheme

### DIFF
--- a/test/images/webhook/scheme.go
+++ b/test/images/webhook/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,5 +34,6 @@ func init() {
 
 func addToScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(admissionv1beta1.AddToScheme(scheme))
 	utilruntime.Must(admissionregistrationv1beta1.AddToScheme(scheme))
 }


### PR DESCRIPTION
We need to register admissionv1beta1 types for decoding in https://github.com/kubernetes/kubernetes/blob/master/test/images/webhook/main.go#L71-L72

```release-note
NONE
```
