### PR TITLE
kubeadm: fix offline and air-gapped support

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -231,6 +231,9 @@ func NewInit(cfgPath string, externalcfg *kubeadmapiv1alpha3.InitConfiguration, 
 	if err != nil {
 		return nil, err
 	}
+	if err := configutil.VerifyAPIServerBindAddress(cfg.APIEndpoint.AdvertiseAddress); err != nil {
+		return nil, err
+	}
 
 	glog.V(1).Infof("[init] validating feature gates")
 	if err := features.ValidateVersion(features.InitFeatureGates, cfg.FeatureGates, cfg.KubernetesVersion); err != nil {

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -277,6 +277,9 @@ func NewJoin(cfgPath string, args []string, defaultcfg *kubeadmapiv1alpha3.JoinC
 	if err != nil {
 		return nil, err
 	}
+	if err := configutil.VerifyAPIServerBindAddress(internalcfg.APIEndpoint.AdvertiseAddress); err != nil {
+		return nil, err
+	}
 
 	fmt.Println("[preflight] running pre-flight checks")
 

--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -222,6 +222,8 @@ func makeCommandForCert(cert *certsphase.KubeadmCert, caCert *certsphase.Kubeadm
 	certCmd.Run = func(cmd *cobra.Command, args []string) {
 		internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(*cfgPath, cfg)
 		kubeadmutil.CheckErr(err)
+		err = configutil.VerifyAPIServerBindAddress(internalcfg.APIEndpoint.AdvertiseAddress)
+		kubeadmutil.CheckErr(err)
 
 		err = certsphase.CreateCertAndKeyFilesWithCA(cert, caCert, internalcfg)
 		kubeadmutil.CheckErr(err)

--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -188,6 +188,8 @@ func runCmdControlPlane(cmdFunc func(outDir string, cfg *kubeadmapi.InitConfigur
 		// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
 		internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(*cfgPath, cfg)
 		kubeadmutil.CheckErr(err)
+		err = configutil.VerifyAPIServerBindAddress(internalcfg.APIEndpoint.AdvertiseAddress)
+		kubeadmutil.CheckErr(err)
 
 		if err := features.ValidateVersion(features.InitFeatureGates, internalcfg.FeatureGates, internalcfg.KubernetesVersion); err != nil {
 			kubeadmutil.CheckErr(err)

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/fake:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -134,7 +133,7 @@ func NewCmdUpgradeControlPlane() *cobra.Command {
 			flags.nodeName = nodeName
 
 			if flags.advertiseAddress == "" {
-				ip, err := netutil.ChooseBindAddress(nil)
+				ip, err := configutil.ChooseAPIServerBindAddress(nil)
 				if err != nil {
 					kubeadmutil.CheckErr(err)
 					return

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -311,6 +311,9 @@ const (
 	// YAMLDocumentSeparator is the separator for YAML documents
 	// TODO: Find a better place for this constant
 	YAMLDocumentSeparator = "---\n"
+
+	// DefaultAPIServerBindAddress is the default bind address for the API Server
+	DefaultAPIServerBindAddress = "0.0.0.0"
 )
 
 var (

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -24,6 +24,8 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//pkg/util/version:go_default_library",
+        "//pkg/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
@@ -33,6 +35,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -223,3 +223,53 @@ func TestLowercaseSANs(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyAPIServerBindAddress(t *testing.T) {
+	tests := []struct {
+		name          string
+		address       string
+		expectedError bool
+	}{
+		{
+			name:    "valid address: IPV4",
+			address: "192.168.0.1",
+		},
+		{
+			name:    "valid address: IPV6",
+			address: "2001:db8:85a3::8a2e:370:7334",
+		},
+		{
+			name:          "invalid address: not a global unicast 0.0.0.0",
+			address:       "0.0.0.0",
+			expectedError: true,
+		},
+		{
+			name:          "invalid address: not a global unicast 127.0.0.1",
+			address:       "127.0.0.1",
+			expectedError: true,
+		},
+		{
+			name:          "invalid address: not a global unicast ::",
+			address:       "::",
+			expectedError: true,
+		},
+		{
+			name:          "invalid address: cannot parse IPV4",
+			address:       "255.255.255.255.255",
+			expectedError: true,
+		},
+		{
+			name:          "invalid address: cannot parse IPV6",
+			address:       "2a00:800::2a00:800:10102a00",
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := VerifyAPIServerBindAddress(test.address); (err != nil) != test.expectedError {
+				t.Errorf("expected error: %v, got %v, error: %v", test.expectedError, (err != nil), err)
+			}
+		})
+	}
+}

--- a/cmd/kubeadm/app/util/config/masterconfig.go
+++ b/cmd/kubeadm/app/util/config/masterconfig.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	netutil "k8s.io/apimachinery/pkg/util/net"
 	bootstraputil "k8s.io/client-go/tools/bootstrap/token/util"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
@@ -107,9 +106,9 @@ func SetAPIEndpointDynamicDefaults(cfg *kubeadmapi.APIEndpoint) error {
 	if addressIP == nil && cfg.AdvertiseAddress != "" {
 		return fmt.Errorf("couldn't use \"%s\" as \"apiserver-advertise-address\", must be ipv4 or ipv6 address", cfg.AdvertiseAddress)
 	}
-	// Choose the right address for the API Server to advertise. If the advertise address is localhost or 0.0.0.0, the default interface's IP address is used
-	// This is the same logic as the API Server uses
-	ip, err := netutil.ChooseBindAddress(addressIP)
+	// This is the same logic as the API Server uses, except that if no interface is found the address is set to 0.0.0.0, which is invalid and cannot be used
+	// for bootstrapping a cluster.
+	ip, err := ChooseAPIServerBindAddress(addressIP)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -290,3 +290,93 @@ func TestNormalizedBuildVersionVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestKubeadmVersion(t *testing.T) {
+	type T struct {
+		name         string
+		input        string
+		output       string
+		outputError  bool
+		parsingError bool
+	}
+	cases := []T{
+		{
+			name:   "valid version with label and metadata",
+			input:  "v1.8.0-alpha.2.1231+afabd012389d53a",
+			output: "v1.8.0-alpha.2",
+		},
+		{
+			name:   "valid version with label and extra metadata",
+			input:  "v1.8.0-alpha.2.1231+afabd012389d53a.extra",
+			output: "v1.8.0-alpha.2",
+		},
+		{
+			name:   "valid patch version with label and extra metadata",
+			input:  "v1.11.3-beta.0.38+135cc4c1f47994",
+			output: "v1.11.2",
+		},
+		{
+			name:   "valid version with label extra",
+			input:  "v1.8.0-alpha.2.1231",
+			output: "v1.8.0-alpha.2",
+		},
+		{
+			name:   "valid patch version with label",
+			input:  "v1.9.11-beta.0",
+			output: "v1.9.10",
+		},
+		{
+			name:   "handle version with partial label",
+			input:  "v1.8.0-alpha",
+			output: "v1.8.0-alpha.0",
+		},
+		{
+			name:   "handle version missing 'v'",
+			input:  "1.11.0",
+			output: "v1.11.0",
+		},
+		{
+			name:   "valid version without label and metadata",
+			input:  "v1.8.0",
+			output: "v1.8.0",
+		},
+		{
+			name:   "valid patch version without label and metadata",
+			input:  "v1.8.2",
+			output: "v1.8.2",
+		},
+		{
+			name:         "invalid version",
+			input:        "foo",
+			parsingError: true,
+		},
+		{
+			name:         "invalid version with stray dash",
+			input:        "v1.9.11-",
+			parsingError: true,
+		},
+		{
+			name:         "invalid version without patch release",
+			input:        "v1.9",
+			parsingError: true,
+		},
+		{
+			name:        "invalid version with label and metadata",
+			input:       "v1.8.0-alpha.2.1231+afabd012389d53a",
+			output:      "v1.8.0-alpha.3",
+			outputError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := kubeadmVersion(tc.input)
+			if (err != nil) != tc.parsingError {
+				t.Fatalf("expected error: %v, got: %v", tc.parsingError, err != nil)
+			}
+			if (output != tc.output) != tc.outputError {
+				t.Fatalf("expected output: %s, got: %s, for input: %s", tc.output, output, tc.input)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -669,7 +669,7 @@ func TestGetAllDefaultRoutes(t *testing.T) {
 		expected   []Route
 		errStrFrag string
 	}{
-		{"no routes", noInternetConnection, v6noDefaultRoutes, 0, nil, "No default routes"},
+		{"no routes", noInternetConnection, v6noDefaultRoutes, 0, nil, "no default routes"},
 		{"only v4 route", gatewayfirst, v6noDefaultRoutes, 1, routeV4, ""},
 		{"only v6 route", noInternetConnection, v6gatewayfirst, 1, routeV6, ""},
 		{"v4 and v6 routes", gatewayfirst, v6gatewayfirst, 2, bothRoutes, ""},


### PR DESCRIPTION
**What this PR does / why we need it**:

1.

Change the error output of getAllDefaultRoutes() so that it includes
information on which files were probed for the IP routing tables
even if such files are obvious.

Introduce a new error type which can be used to figure out of this
error is exactly of the "no routes" type.

2.

If netutil.ChooseBindAddress() fails looking up IP route tables
it will fail with an error in which case the kubeadm config
code will hard stop.

This scenario is possible if the Linux user intentionally disables
the WiFi from the distribution settings. In such a case the distro
could empty files such files as /proc/net/route and ChooseBindAddress()
will return an error.

For improved offline support, don't error on such scenarios but instead
show a warning. This is done by using the NoRoutesError type.
Also default the address to 0.0.0.0.

While doing that, prevent some commands like `init`, `join` and also
phases like `controlplane` and `certs` from using such an invalid
address.

3.

If there is no internet, label versions fail and this breaks
air-gapped setups unless the users pass an explicit version.

To work around that:
- Remain using 'release/stable-x.xx' as the default version.
- On timeout or any error different from status 404 return error
- On status 404 fallback to using the version of the client via
kubeadmVersion()

Add unit tests for kubeadmVersion().

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs kubernetes/kubeadm#1041

**Special notes for your reviewer**:
1st and second commits fix offline support.
3rd commit fixes air-gabbed support (as discussed in the linked issue)

the api-machinery change is only fmt.Errorf() related.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: fix air-gapped support and also allow some kubeadm commands to work without an available networking interface
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/cc @kubernetes/sig-api-machinery-pr-reviews 
/assign @kad
/assign @xiangpengzhao 
/area UX
/area kubeadm
/kind bug
