### PR TITLE
Bump up order of USERPROFILE preference

### DIFF
--- a/staging/src/k8s.io/client-go/util/homedir/homedir.go
+++ b/staging/src/k8s.io/client-go/util/homedir/homedir.go
@@ -31,15 +31,15 @@ func HomeDir() string {
 				return home
 			}
 		}
+		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
+			if _, err := os.Stat(userProfile); err == nil {
+				return userProfile
+			}
+		}
 		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
 			homeDir := homeDrive + homePath
 			if _, err := os.Stat(homeDir); err == nil {
 				return homeDir
-			}
-		}
-		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
-			if _, err := os.Stat(userProfile); err == nil {
-				return userProfile
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the order preference of home directory detection on Windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #61946 

**Release note**:

```release-note
On Windows systems, %USERPROFILE% is now preferred over %HOMEDRIVE%\%HOMEPATH% as the home folder. This affects the location searched for a kubeconfig file.
```