### PR TITLE
kubeadm:  coverage improvement about ValidateVersion function

### DIFF
--- a/cmd/kubeadm/app/features/BUILD
+++ b/cmd/kubeadm/app/features/BUILD
@@ -33,5 +33,8 @@ go_test(
     name = "go_default_test",
     srcs = ["features_test.go"],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+    deps = [
+        "//pkg/util/version:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+    ],
 )

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -170,14 +170,14 @@ func NewFeatureGate(f *FeatureList, value string) (map[string]bool, error) {
 // ResolveFeatureGateDependencies resolve dependencies between feature gates
 func ResolveFeatureGateDependencies(featureGate map[string]bool) {
 
+	// if HighAvailability enabled and StoreCertsInSecrets disabled, both StoreCertsInSecrets
+	// and SelfHosting should enabled
+	if Enabled(featureGate, HighAvailability) && !Enabled(featureGate, StoreCertsInSecrets) {
+		featureGate[StoreCertsInSecrets] = true
+	}
+
 	// if StoreCertsInSecrets enabled, SelfHosting should enabled
 	if Enabled(featureGate, StoreCertsInSecrets) {
 		featureGate[SelfHosting] = true
-	}
-
-	// if HighAvailability enabled, both StoreCertsInSecrets and SelfHosting should enabled
-	if Enabled(featureGate, HighAvailability) && !Enabled(featureGate, StoreCertsInSecrets) {
-		featureGate[SelfHosting] = true
-		featureGate[StoreCertsInSecrets] = true
 	}
 }

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -21,7 +21,10 @@ import (
 	"testing"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/util/version"
 )
+
+var TestMinVersion = version.MustParseSemantic("v1.10.0-alpha.1")
 
 func TestKnownFeatures(t *testing.T) {
 	var someFeatures = FeatureList{
@@ -121,7 +124,7 @@ func TestNewFeatureGate(t *testing.T) {
 func TestValidateVersion(t *testing.T) {
 	var someFeatures = FeatureList{
 		"feature1": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
-		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}},
+		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}, MinimumVersion: TestMinVersion},
 	}
 
 	var tests = []struct {
@@ -133,9 +136,15 @@ func TestValidateVersion(t *testing.T) {
 			requestedFeatures: map[string]bool{"feature1": true},
 			expectedError:     false,
 		},
-		{ //no min version
+		{ //min version but correct value given
 			requestedFeatures: map[string]bool{"feature2": true},
+			requestedVersion:  "v1.10.0",
 			expectedError:     false,
+		},
+		{ //min version and incorrect value given
+			requestedFeatures: map[string]bool{"feature2": true},
+			requestedVersion:  "v1.9.2",
+			expectedError:     true,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In commit log :https://github.com/kubernetes/kubernetes/pull/63920/commits/2ef81576448c94b49546738aac94b70dc13b35d1, remove the `MinimumVersion support` for all featuregate, but the `MinimumVersion` still as a parameter in `Feature` struct for `future featuregate`.
However,https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/features/features.go#L79-L87 still have judgement about `MinimumVersion` in `ValidateVersion` function, we also need test it. 
This PR  make `test coverage` about `ValidateVersion` function from `20%` to `90%`. Details as below.

Before changed, the `test coverage` are:
```
root@shap000101123:/ycj/kubernetes-community/src/k8s.io/kubernetes/cmd/kubeadm/app/features# go tool cover -func=size_coverage.out
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:71:	ValidateVersion			20.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:92:	Enabled				100.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:101:	Supports			100.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:111:	Keys				0.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:120:	KnownFeatures			90.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:139:	NewFeatureGate			94.1%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:171:	ResolveFeatureGateDependencies	100.0%
total:								(statements)			73.1%
```
After change, the `test coverage` are:
```
root@shap000101123:/ycj/kubernetes-community/src/k8s.io/kubernetes/cmd/kubeadm/app/features# go tool cover -func=size_coverage.out
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:71:	ValidateVersion			90.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:92:	Enabled				100.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:101:	Supports			100.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:111:	Keys				0.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:120:	KnownFeatures			90.0%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:139:	NewFeatureGate			94.1%
k8s.io/kubernetes/cmd/kubeadm/app/features/features.go:171:	ResolveFeatureGateDependencies	100.0%
total:								(statements)			86.5%
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@luxas  @neolit123 @fabriziopandini @dixudx 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
