### PR TITLE
modify a duplicate e2e test of DNS configMap

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -43,7 +43,7 @@ var (
 
 var _ = SIGDescribe("DNS configMap federations", func() {
 
-	t := &dnsNameserverTest{dnsTestCommon: newDnsTestCommon()}
+	t := &dnsFederationsConfigMapTest{dnsTestCommon: newDnsTestCommon()}
 
 	It("should be able to change federation configuration [Slow][Serial]", func() {
 		t.c = t.f.ClientSet


### PR DESCRIPTION
**What this PR does / why we need it**:
modify a duplicate e2e test of DNS configMap. It is duplicate with the case in https://github.com/kubernetes/kubernetes/blob/d655c9a87335498857a63d5fcefa7a6d7db1ce93/test/e2e/network/dns_configmap.go#L345
I think it should run dnsFederationsConfigMapTest in original purpose.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
