### PR TITLE
Update the comment of StatefulSet e2e test

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -231,9 +231,8 @@ var _ = SIGDescribe("StatefulSet", func() {
 			By("Waiting for stateful pod at index 1 to enter running.")
 			sst.WaitForRunning(2, 1, ss)
 
-			// Now we have 1 healthy and 1 unhealthy stateful pod. Deleting the healthy stateful pod should *not*
-			// create a new stateful pod till the remaining stateful pod becomes healthy, which won't happen till
-			// we set the healthy bit.
+			// Now we have 1 healthy and 1 unhealthy stateful pod. Deleting the healthy stateful
+			// pod can create a new stateful pod even if the other stateful pod is still unhealthy.
 
 			By("Deleting healthy stateful pod at index 0.")
 			sst.DeleteStatefulPodAtIndex(0, ss)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the commit[1], we have changed the StatefulSet e2e test
"should not deadlock when a pod's predecessor fails" to verify
the delete of the healthy stateful pod should create a new pod
even if the other pod is still unhealthy. However the comment
is not changed and that makes confusions when debugging the
test.
This updates the comment for avoiding confusions.

[1]: https://github.com/kubernetes/kubernetes/commit/4d99b4d825a74f7f22f1709e580574b70fe796d9#diff-d6cf821393f7e9ea6770d35ab5749d4dL172

**Release note**: NONE
