### PR TITLE
use const v1.ProtocolTCP replace of string TCP in test/e2e/network/

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -202,7 +202,7 @@ var _ = SIGDescribe("DNS", func() {
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeClusterIP
 			s.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: "TCP"},
+				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
 			}
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -213,7 +213,7 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 					Image:   imageutils.GetE2EImage(imageutils.Dnsutils),
 					Command: []string{"sleep", "10000"},
 					Ports: []v1.ContainerPort{
-						{ContainerPort: servicePort, Protocol: "TCP"},
+						{ContainerPort: servicePort, Protocol: v1.ProtocolTCP},
 					},
 				},
 			},
@@ -238,7 +238,7 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 			Selector: map[string]string{"app": baseName},
 			Ports: []v1.ServicePort{
 				{
-					Protocol:   "TCP",
+					Protocol:   v1.ProtocolTCP,
 					Port:       servicePort,
 					TargetPort: intstr.FromInt(servicePort),
 				},

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 
 		By("Creating a LoadBalancer type service with ExternalTrafficPolicy=Global")
 		svc := jig.CreateLoadBalancerService(ns, serviceName, framework.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
-			svc.Spec.Ports = []v1.ServicePort{{Protocol: "TCP", Port: framework.FirewallTestHttpPort}}
+			svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: framework.FirewallTestHttpPort}}
 			svc.Spec.LoadBalancerSourceRanges = firewallTestSourceRanges
 		})
 		defer func() {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -57,7 +57,7 @@ var (
 			Ports: []v1.ServicePort{{
 				Port:       int32(defaultServeHostnameServicePort),
 				TargetPort: intstr.FromInt(9376),
-				Protocol:   "TCP",
+				Protocol:   v1.ProtocolTCP,
 			}},
 			Selector: map[string]string{
 				"name": defaultServeHostnameServiceName,
@@ -897,7 +897,7 @@ var _ = SIGDescribe("Services", func() {
 			s.Spec.Type = v1.ServiceTypeClusterIP
 			s.Spec.ExternalName = ""
 			s.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: "TCP"},
+				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
 			}
 		})
 		jig.SanityCheckService(clusterIPService, v1.ServiceTypeClusterIP)
@@ -921,7 +921,7 @@ var _ = SIGDescribe("Services", func() {
 			s.Spec.Type = v1.ServiceTypeNodePort
 			s.Spec.ExternalName = ""
 			s.Spec.Ports = []v1.ServicePort{
-				{Port: 80, Name: "http", Protocol: "TCP"},
+				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
 			}
 		})
 		jig.SanityCheckService(nodePortService, v1.ServiceTypeNodePort)


### PR DESCRIPTION
**What this PR does / why we need it**:
use const v1.ProtocolTCP replace of string TCP in test/e2e/network/
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
