### PR TITLE
Forcefully detach the volumes on pod deletion if kubelet is unavailable 

### DIFF
--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -127,6 +127,13 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 			glog.Errorf("podLister Get failed for pod %q (UID %q) with %v", dswPodKey, dswPodUID, err)
 			continue
 		default:
+			// we can detect the terminated pods(volumes) as well as pods(volumes) which are not terminated but in unavailable node here.
+			// if pod.DeletionTimestamp is set, and after pod.DeletionGracePeriodSeconds, the pod is still not deleted, we assume that
+			// the pod is in broken node, and we should trigger detach for pod volumes.
+			// BTW: if the node is unavailable, we will trigger pod deletion operation after podEvictionTimeout(defaulting to 5 minutes),
+			// and DeletionGracePeriodSeconds will be set as well.
+			// dswp will loop every 1 minute, and the volume will be forcefully detached in 6 minutes by A/D controller.
+			// so the volumes in broken node will be detached in at most 5 + 6  + ( DeletionGracePeriodSeconds/60 + 1 ) minutes.
 			volumeActionFlag := util.DetermineVolumeAction(
 				informerPod,
 				dswp.desiredStateOfWorld,

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -162,13 +162,13 @@ func TestPodDeletionWithDswp(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -207,6 +207,86 @@ func TestPodDeletionWithDswp(t *testing.T) {
 	close(stopCh)
 }
 
+// Via integration test we can verify that if pod delete
+// event is triggered, but the pod is in the broken node - it still
+// gets cleaned up by Desired State of World populator.
+func TestPodDeletionOnUnavailableNodeByDswp(t *testing.T) {
+	_, server, closeFn := framework.RunAMaster(framework.NewIntegrationTestMasterConfig())
+	defer closeFn()
+	namespaceName := "test-pod-deletion"
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-sandbox",
+			Annotations: map[string]string{
+				util.ControllerManagedAttachAnnotation: "true",
+			},
+		},
+	}
+
+	ns := framework.CreateTestingNamespace(namespaceName, server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	testClient, ctrl, _, informers := createAdClients(ns, t, server, defaultSyncPeriod, defaultTimerConfig)
+	pod := fakePodWithVol(namespaceName)
+	tgp := int64(1)
+	pod.Spec.TerminationGracePeriodSeconds = &tgp
+	pod.Status = v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{},
+				},
+			},
+		},
+		Phase: v1.PodPhase("Running"),
+	}
+
+	podStopCh := make(chan struct{})
+
+	_, err := testClient.CoreV1().Nodes().Create(node)
+	if err != nil {
+		t.Fatalf("Failed to created node : %v", err)
+	}
+
+	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
+
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
+		t.Errorf("Failed to create pod : %v", err)
+	}
+
+	podInformer := informers.Core().V1().Pods().Informer()
+	go podInformer.Run(podStopCh)
+
+	// start controller loop
+	stopCh := make(chan struct{})
+	go informers.Core().V1().PersistentVolumeClaims().Informer().Run(stopCh)
+	go informers.Core().V1().PersistentVolumes().Informer().Run(stopCh)
+	go ctrl.Run(stopCh)
+
+	waitToObservePods(t, podInformer, 1)
+
+	waitForPodsInDSWP(t, ctrl.GetDesiredStateOfWorld())
+
+	// pods in the broken node will be evicted in 5 minutes,
+	// here we do not need to wait for 5 minutes, set deletion timestamp and grace period directly
+	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	dgp := int64(1)
+	pod.DeletionGracePeriodSeconds = &dgp
+	pod.Status.Phase = v1.PodPhase("Unknown")
+	err = podInformer.GetStore().Update(pod)
+	if err != nil {
+		t.Fatalf("Error updating pod : %v", err)
+	}
+
+	waitToObservePods(t, podInformer, 1)
+	time.Sleep(2 * time.Second)
+	// the populator loop turns every 1 minute
+	waitForPodFuncInDSWP(t, ctrl.GetDesiredStateOfWorld(), 80*time.Second, "expected 0 pods in dsw after pod delete", 0)
+
+	close(podStopCh)
+	close(stopCh)
+}
+
 func TestPodUpdateWithWithADC(t *testing.T) {
 	_, server, closeFn := framework.RunAMaster(framework.NewIntegrationTestMasterConfig())
 	defer closeFn()
@@ -229,13 +309,13 @@ func TestPodUpdateWithWithADC(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -264,7 +344,7 @@ func TestPodUpdateWithWithADC(t *testing.T) {
 
 	pod.Status.Phase = v1.PodSucceeded
 
-	if _, err := testClient.Core().Pods(ns.Name).UpdateStatus(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(pod); err != nil {
 		t.Errorf("Failed to update pod : %v", err)
 	}
 
@@ -297,13 +377,13 @@ func TestPodUpdateWithKeepTerminatedPodVolumes(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -332,7 +412,7 @@ func TestPodUpdateWithKeepTerminatedPodVolumes(t *testing.T) {
 
 	pod.Status.Phase = v1.PodSucceeded
 
-	if _, err := testClient.Core().Pods(ns.Name).UpdateStatus(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).UpdateStatus(pod); err != nil {
 		t.Errorf("Failed to update pod : %v", err)
 	}
 
@@ -474,13 +554,13 @@ func TestPodAddedByDswp(t *testing.T) {
 	pod := fakePodWithVol(namespaceName)
 	podStopCh := make(chan struct{})
 
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
 	go informers.Core().V1().Nodes().Informer().Run(podStopCh)
 
-	if _, err := testClient.Core().Pods(ns.Name).Create(pod); err != nil {
+	if _, err := testClient.CoreV1().Pods(ns.Name).Create(pod); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -549,7 +629,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 			},
 		},
 	}
-	if _, err := testClient.Core().Nodes().Create(node); err != nil {
+	if _, err := testClient.CoreV1().Nodes().Create(node); err != nil {
 		t.Fatalf("Failed to created node : %v", err)
 	}
 
@@ -557,10 +637,10 @@ func TestPVCBoundWithADC(t *testing.T) {
 	pvcs := []*v1.PersistentVolumeClaim{}
 	for i := 0; i < 3; i++ {
 		pod, pvc := fakePodWithPVC(fmt.Sprintf("fakepod-pvcnotbound-%d", i), fmt.Sprintf("fakepvc-%d", i), namespaceName)
-		if _, err := testClient.Core().Pods(pod.Namespace).Create(pod); err != nil {
+		if _, err := testClient.CoreV1().Pods(pod.Namespace).Create(pod); err != nil {
 			t.Errorf("Failed to create pod : %v", err)
 		}
-		if _, err := testClient.Core().PersistentVolumeClaims(pvc.Namespace).Create(pvc); err != nil {
+		if _, err := testClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc); err != nil {
 			t.Errorf("Failed to create pvc : %v", err)
 		}
 		pvcs = append(pvcs, pvc)
@@ -568,7 +648,7 @@ func TestPVCBoundWithADC(t *testing.T) {
 	// pod with no pvc
 	podNew := fakePodWithVol(namespaceName)
 	podNew.SetName("fakepod")
-	if _, err := testClient.Core().Pods(podNew.Namespace).Create(podNew); err != nil {
+	if _, err := testClient.CoreV1().Pods(podNew.Namespace).Create(podNew); err != nil {
 		t.Errorf("Failed to create pod : %v", err)
 	}
 
@@ -608,7 +688,7 @@ func createPVForPVC(t *testing.T, testClient *clientset.Clientset, pvc *v1.Persi
 			StorageClassName: *pvc.Spec.StorageClassName,
 		},
 	}
-	if _, err := testClient.Core().PersistentVolumes().Create(pv); err != nil {
+	if _, err := testClient.CoreV1().PersistentVolumes().Create(pv); err != nil {
 		t.Errorf("Failed to create pv : %v", err)
 	}
 }


### PR DESCRIPTION
Forcely detach the volumes on pod deletion if kubelet is unavailable 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65392

**Special notes for your reviewer**:

**Release note**:
```release-note
Forcely detach the volumes on pod deletion if kubelet is unavailable 
```

/sig storage
/kind bug
/assign @verult 