### PR TITLE
kubectl convert: fix handling of lists

### DIFF
--- a/pkg/kubectl/cmd/convert_test.go
+++ b/pkg/kubectl/cmd/convert_test.go
@@ -90,6 +90,18 @@ func TestConvertObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "list containing deployments",
+			file: "../../../test/fixtures/pkg/kubectl/cmd/convert/multiple-deployments.yaml",
+			fields: []checkField{
+				{
+					expected: "apiVersion: v1",
+				},
+				{
+					expected: "kind: List",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/kubectl/genericclioptions/printers/name.go
+++ b/pkg/kubectl/genericclioptions/printers/name.go
@@ -50,13 +50,6 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	}
 
 	if meta.IsListType(obj) {
-		// we allow unstructured lists for now because they always contain the GVK information.  We should chase down
-		// callers and stop them from passing unflattened lists
-		// TODO chase the caller that is setting this and remove it.
-		if _, ok := obj.(*unstructured.UnstructuredList); !ok {
-			return fmt.Errorf("list types are not supported by name printing: %T", obj)
-		}
-
 		items, err := meta.ExtractList(obj)
 		if err != nil {
 			return err

--- a/test/fixtures/pkg/kubectl/cmd/convert/multiple-deployments.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/multiple-deployments.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-1
+spec:
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-2
+spec:
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubectl/issues/509

Currently, kubectl just allows `UnstructuredList` for printing. However if the user asks for something that "looks" like a single object but is indeed a list, then we should print the List (see https://github.com/kubernetes/kubernetes/pull/39038#issuecomment-268571325).

This PR allows `kubectl convert` to print lists as before.

/sig cli
/kind bug
/cc juanvallejo soltysh deads2k liggitt 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
