### PR TITLE
do not throw traceback to api server log when remote api connection timeout

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/BUILD
+++ b/staging/src/k8s.io/client-go/discovery/cached/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/discovery/cached/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memcache.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/googleapis/gnostic/OpenAPIv2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -131,7 +132,7 @@ func (d *memCacheClient) Invalidate() {
 		for _, v := range g.Versions {
 			r, err := d.delegate.ServerResourcesForGroupVersion(v.GroupVersion)
 			if err != nil || len(r.APIResources) == 0 {
-				utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", v.GroupVersion, err))
+				glog.Errorf("couldn't get resource list for %v: %v", v.GroupVersion, err)
 				if cur, ok := d.groupToServerResources[v.GroupVersion]; ok {
 					// retain the existing list, if we had it.
 					r = cur


### PR DESCRIPTION
**What this PR does / why we need it**:

In case the remote API is unavailable (request timeout, etc..) we handle this with `util.HandleError()` which leave lengthy traceback in API server log (which does not provide any additional value for debugging anyway). This change is replacing that traceback with simple `glog.Errorf()`.

Example traceback: https://gist.github.com/mfojtik/579a623d293ffe2b9a84312f06fd7657

/cc @sttts 
/cc @deads2k 

**Release note**:
```release-note
NONE
```