### PR TITLE
test: fix import path to client-go/util/retry

### DIFF
--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
@@ -52,7 +53,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/factory"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	"k8s.io/kubernetes/pkg/util/metrics"
-	"k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change d6ffcae31d79c8b86fe14b97149e070bf6967443 introduced a broken import path
containing the staging/ directory.

This leads in particular to bazel build failures.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
