### PR TITLE
support tilde(~) character in --from-file path

### DIFF
--- a/pkg/kubectl/util/util.go
+++ b/pkg/kubectl/util/util.go
@@ -17,38 +17,38 @@ limitations under the License.
 package util
 
 import (
-    "crypto/md5"
-    "errors"
-    "fmt"
-    "path"
-    "path/filepath"
-    "strings"
-    "time"
-    "os"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+	"os"
     runtimeOs "runtime"
 
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ParseRFC3339 parses an RFC3339 date in either RFC3339Nano or RFC3339 format.
 func ParseRFC3339(s string, nowFn func() metav1.Time) (metav1.Time, error) {
-    if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
-        return metav1.Time{Time: t}, nil
-    }
-    t, err := time.Parse(time.RFC3339, s)
-    if err != nil {
-        return metav1.Time{}, err
-    }
-    return metav1.Time{Time: t}, nil
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return metav1.Time{Time: t}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return metav1.Time{}, err
+	}
+	return metav1.Time{Time: t}, nil
 }
 
 func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
-    data, err := runtime.Encode(codec, obj)
-    if err != nil {
-        return "", err
-    }
-    return fmt.Sprintf("%x", md5.Sum(data)), nil
+	data, err := runtime.Encode(codec, obj)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(data)), nil
 }
 
 // ParseFileSource parses the source given.
@@ -60,37 +60,37 @@ func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
 //
 // Key names cannot include '='.
 func ParseFileSource(source string) (keyName, filePath string, err error) {
-    numSeparators := strings.Count(source, "=")
-    switch {
-    case numSeparators == 0:
-        return path.Base(filepath.ToSlash(source)), parseFilePath(source), nil
-    case numSeparators == 1 && strings.HasPrefix(source, "="):
-        return "", "", fmt.Errorf("key name for file path %v missing.", strings.TrimPrefix(source, "="))
-    case numSeparators == 1 && strings.HasSuffix(source, "="):
-        return "", "", fmt.Errorf("file path for key name %v missing.", strings.TrimSuffix(source, "="))
-    case numSeparators > 1:
-        return "", "", errors.New("Key names or file paths cannot contain '='.")
-    default:
-        components := strings.Split(source, "=")
-        return components[0], parseFilePath(components[1]), nil
-    }
+	numSeparators := strings.Count(source, "=")
+	switch {
+	case numSeparators == 0:
+		return path.Base(filepath.ToSlash(source)), parseFilePath(source), nil
+	case numSeparators == 1 && strings.HasPrefix(source, "="):
+		return "", "", fmt.Errorf("key name for file path %v missing.", strings.TrimPrefix(source, "="))
+	case numSeparators == 1 && strings.HasSuffix(source, "="):
+		return "", "", fmt.Errorf("file path for key name %v missing.", strings.TrimSuffix(source, "="))
+	case numSeparators > 1:
+		return "", "", errors.New("Key names or file paths cannot contain '='.")
+	default:
+		components := strings.Split(source, "=")
+		return components[0], parseFilePath(components[1]), nil
+	}
 }
 
 // ParseLiteralSource parses the source key=val pair into its component pieces.
 // This functionality is distinguished from strings.SplitN(source, "=", 2) since
 // it returns an error in the case of empty keys, values, or a missing equals sign.
 func ParseLiteralSource(source string) (keyName, value string, err error) {
-    // leading equal is invalid
-    if strings.Index(source, "=") == 0 {
-        return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
-    }
-    // split after the first equal (so values can have the = character)
-    items := strings.SplitN(source, "=", 2)
-    if len(items) != 2 {
-        return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
-    }
+	// leading equal is invalid
+	if strings.Index(source, "=") == 0 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+	// split after the first equal (so values can have the = character)
+	items := strings.SplitN(source, "=", 2)
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
 
-    return items[0], items[1], nil
+	return items[0], items[1], nil
 }
 
 // this function returns home directory and has been copied from 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
this pr allows support for ~ character in --from-file option of kubectl
example:  `kubectl create secret generic db-user-pass --from-file=~/username.txt --from-file=~/password.txt`
**Which issue(s) this PR fixes** 
Fixes # https://github.com/kubernetes/kubectl/issues/276

/kind bug
/area kubectl
/assign @nikhita


**Special notes for your reviewer**:
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
