### PR TITLE
Set DefaultCRISocket on Windows

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -47,8 +47,6 @@ const (
 	DefaultImageRepository = "k8s.gcr.io"
 	// DefaultManifestsDir defines default manifests directory
 	DefaultManifestsDir = "/etc/kubernetes/manifests"
-	// DefaultCRISocket defines the default cri socket
-	DefaultCRISocket = "/var/run/dockershim.sock"
 	// DefaultClusterName defines the default cluster name
 	DefaultClusterName = "kubernetes"
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults_unix.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults_unix.go
@@ -18,5 +18,9 @@ limitations under the License.
 
 package v1alpha2
 
-// DefaultCACertPath defines default location of CA certificate on Linux
-const DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
+const (
+	// DefaultCACertPath defines default location of CA certificate on Linux
+	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
+	// DefaultCRISocket defines the default cri socket
+	DefaultCRISocket = "/var/run/dockershim.sock"
+)

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults_windows.go
@@ -18,5 +18,9 @@ limitations under the License.
 
 package v1alpha2
 
-// DefaultCACertPath defines default location of CA certificate on Windows
-const DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
+const (
+	// DefaultCACertPath defines default location of CA certificate on Windows
+	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
+	// DefaultCRISocket defines the default cri socket
+	DefaultCRISocket = "tcp://localhost:2375"
+)

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -42,8 +42,6 @@ const (
 	DefaultImageRepository = "k8s.gcr.io"
 	// DefaultManifestsDir defines default manifests directory
 	DefaultManifestsDir = "/etc/kubernetes/manifests"
-	// DefaultCRISocket defines the default cri socket
-	DefaultCRISocket = "/var/run/dockershim.sock"
 	// DefaultClusterName defines the default cluster name
 	DefaultClusterName = "kubernetes"
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
@@ -18,8 +18,11 @@ limitations under the License.
 
 package v1alpha3
 
-// DefaultCACertPath defines default location of CA certificate on Linux
-const DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
-
-// DefaultSocketUrlScheme defines default socket url prefix
-const DefaultUrlScheme = "unix"
+const (
+	// DefaultCACertPath defines default location of CA certificate on Linux
+	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
+	// DefaultSocketUrlScheme defines default socket url prefix
+	DefaultUrlScheme = "unix"
+	// DefaultCRISocket defines the default cri socket
+	DefaultCRISocket = "/var/run/dockershim.sock"
+)

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
@@ -18,8 +18,11 @@ limitations under the License.
 
 package v1alpha3
 
-// DefaultCACertPath defines default location of CA certificate on Windows
-const DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
-
-// DefaultSocketUrlScheme defines default socket url prefix
-const DefaultUrlScheme = "tcp"
+const (
+	// DefaultCACertPath defines default location of CA certificate on Windows
+	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
+	// DefaultSocketUrlScheme defines default socket url prefix
+	DefaultUrlScheme = "tcp"
+	// DefaultCRISocket defines the default cri socket
+	DefaultCRISocket = "tcp://localhost:2375"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Updates the default location for the CRI socket on Windows to a TCP URI. This is documented by Docker [here](https://docs.docker.com/docker-for-windows/faqs/#how-do-i-connect-to-the-remote-docker-engine-api).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: --cri-socket now defaults to tcp://localhost:2375 when running on Windows
```
