### PR TITLE
Remove duplicated detect-master for local

### DIFF
--- a/cluster/local/util.sh
+++ b/cluster/local/util.sh
@@ -18,13 +18,7 @@ function prepare-e2e() {
   echo "Local doesn't need special preparations for e2e tests" 1>&2
 }
 
-# Must ensure that the following ENV vars are set
 function detect-master {
-  export KUBE_MASTER_IP="127.0.0.1"
-  export KUBE_MASTER="localhost"
-}
-
-detect-master() {
   KUBE_MASTER=localhost
   KUBE_MASTER_IP=127.0.0.1
   KUBE_MASTER_URL="http://${KUBE_MASTER_IP}:8080"


### PR DESCRIPTION
**What this PR does / why we need it**:

cluster/local/util.sh contains duplicated detect-master() and the
first one is unused at all. This removes the first one for the code
cleanup.

**Release note**: NONE
