### PR TITLE
fix an issue in NodeInfo.Clone()

### DIFF
--- a/pkg/scheduler/cache/node_info.go
+++ b/pkg/scheduler/cache/node_info.go
@@ -400,8 +400,13 @@ func (n *NodeInfo) Clone() *NodeInfo {
 		clone.pods = append([]*v1.Pod(nil), n.pods...)
 	}
 	if len(n.usedPorts) > 0 {
-		for k, v := range n.usedPorts {
-			clone.usedPorts[k] = v
+		// util.HostPortInfo is a map-in-map struct
+		// make sure it's deep copied
+		for ip, portMap := range n.usedPorts {
+			clone.usedPorts[ip] = make(map[util.ProtocolPort]struct{})
+			for protocolPort, v := range portMap {
+				clone.usedPorts[ip][protocolPort] = v
+			}
 		}
 	}
 	if len(n.podsWithAffinity) > 0 {

--- a/pkg/scheduler/cache/node_info_test.go
+++ b/pkg/scheduler/cache/node_info_test.go
@@ -495,6 +495,7 @@ func TestNodeInfoClone(t *testing.T) {
 		ni := test.nodeInfo.Clone()
 		// Modify the field to check if the result is a clone of the origin one.
 		test.nodeInfo.generation += 10
+		test.nodeInfo.usedPorts.Remove("127.0.0.1", "TCP", 80)
 		if !reflect.DeepEqual(test.expected, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
 		}


### PR DESCRIPTION
- usedPorts is a map-in-map struct, add fix to ensure it's deep copied
- updated unit test

**What this PR does / why we need it**:

Due to PR "Refactor HostIP predicate algorithm #55910", internal `usedPorts` data structure was changed from "map[string]bool" to "map[string]map[ProtocolPort]struct{}".

However, it breaks behavior of `NodeInfo.Clone()`: in the before, one loop `for k, v := range usedPorts` worked fine because it's a safe assignment, but it's not safe any more for a map-in-map using original code. A similar go playground sample is here: https://play.golang.org/p/puqMN71cmSO.

**Which issue(s) this PR fixes**:
Fixes #67453 (_Might_ also related with #66568)

**Special notes for your reviewer**:
- No matter pod preemption is enabled or disabled, #67453 can be triggered.
- As #55910 was introduced in 1.10, this fix needs to back ported to 1.10 and 1.11 release branches.

**Release note**:
```release-note
Fix an issue that pods using hostNetwork keep increasing.
```