### PR TITLE
test/integration: use correct import path

### DIFF
--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
@@ -52,7 +53,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/factory"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	"k8s.io/kubernetes/pkg/util/metrics"
-	"k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 


### PR DESCRIPTION
why aren't we building with `bazel build -- //... -//vendor/... `?
```release-note
NONE
```
