### PR TITLE
release-1.11: update to debian-base 0.3.2, debian-iptables v10.2 and hyperkube-base 0.10.2

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10
+  debian_iptables_version=v10.1
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10.1
+  debian_iptables_version=v10.2
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -57,9 +57,11 @@ ifeq ($(ARCH),amd64)
 	sed "/CROSS_BUILD_/d" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
 else
 	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
-	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	# Ensure we don't get surprised by umask settings
+	chmod 0755 qemu-$(QEMUARCH)-static
 	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
 endif
 	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.3
+TAG ?= 0.3.1
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -61,7 +61,7 @@ else
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
 	# Ensure we don't get surprised by umask settings
-	chmod 0755 qemu-$(QEMUARCH)-static
+	chmod 0755 $(TEMP_DIR)/qemu-$(QEMUARCH)-static
 	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
 endif
 	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.3.1
+TAG ?= 0.3.2
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64

--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -38,6 +38,7 @@ RUN echo CACHEBUST>/dev/null && clean-install \
     jq \
     kmod \
     openssh-client \
+    netbase \
     nfs-common \
     socat \
     udev \

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -23,7 +23,7 @@ TAG=0.10.1
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -51,8 +51,10 @@ endif
 	mkdir -p ${TEMP_DIR}/cni-bin/bin
 	tar -xz -C ${TEMP_DIR}/cni-bin/bin -f "cni-tars/${CNI_TARBALL}"
 
+ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+endif
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=debian-hyperkube-base
-TAG=0.10.1
+TAG=0.10.2
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,11 +19,11 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=debian-hyperkube-base
-TAG=0.10
+TAG=0.10.1
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/Dockerfile
+++ b/build/debian-iptables/Dockerfile
@@ -19,4 +19,5 @@ RUN clean-install \
     ebtables \
     ipset \
     iptables \
-    kmod
+    kmod \
+    netbase

--- a/build/debian-iptables/Dockerfile
+++ b/build/debian-iptables/Dockerfile
@@ -14,10 +14,6 @@
 
 FROM BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
-
 RUN clean-install \
     conntrack \
     ebtables \

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -19,37 +19,16 @@ IMAGE=debian-iptables
 TAG=v10.1
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-QEMUVERSION=v2.9.1
-
-ifeq ($(ARCH),arm)
-	QEMUARCH=arm
-endif
-ifeq ($(ARCH),arm64)
-	QEMUARCH=aarch64
-endif
-ifeq ($(ARCH),ppc64le)
-	QEMUARCH=ppc64le
-endif
-ifeq ($(ARCH),s390x)
-	QEMUARCH=s390x
-endif
 
 BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
 
 build:
 	cp ./* $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
-	cd $(TEMP_DIR) && sed -i "s|ARCH|$(QEMUARCH)|g" Dockerfile
 
-ifeq ($(ARCH),amd64)
-	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
-	cd $(TEMP_DIR) && sed -i "/CROSS_BUILD_/d" Dockerfile
-else
-	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
-	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
 
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10
+TAG=v10.1
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.9.1
@@ -34,7 +34,7 @@ ifeq ($(ARCH),s390x)
 	QEMUARCH=s390x
 endif
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -20,7 +20,7 @@ TAG=v10.1
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
 
 build:
 	cp ./* $(TEMP_DIR)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10.1
+TAG=v10.2
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -67,18 +67,18 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:fb18678f8203ca1bd2fad2671e3ebd80cb408a1baae423d4ad39c05f4caac4e1",
+    digest = "sha256:58e53e477d204fe32f761ec2718b792f653063d4192ae89efc79e4b6a8dbba91",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10",  # ignored, but kept here for documentation
+    tag = "v10.1",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:cc782ed16599000ca4c85d47ec6264753747ae1e77520894dca84b104a7621e2",
+    digest = "sha256:1c83ca9c8ac4a06e4585802edf8a1cd954011152409116e9c801f4736b97b956",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.10",  # ignored, but kept here for documentation
+    tag = "0.10.1",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -67,18 +67,18 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:58e53e477d204fe32f761ec2718b792f653063d4192ae89efc79e4b6a8dbba91",
+    digest = "sha256:0987db7ce42949d20ed2647a65d4bee0b616b4d40c7ea54769cc24b7ad003677",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10.1",  # ignored, but kept here for documentation
+    tag = "v10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:1c83ca9c8ac4a06e4585802edf8a1cd954011152409116e9c801f4736b97b956",
+    digest = "sha256:c50522965140c9f206900bf47d547d601c04943e1e59801ba5f70235773cfbb6",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.10.1",  # ignored, but kept here for documentation
+    tag = "0.10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10.1
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10.2
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -39,8 +39,10 @@ endif
 
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 
+ifneq ($(ARCH),amd64)
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+endif
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(shell pwd)/../../../$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10.1
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -78,6 +78,8 @@ build() {
         # Register qemu-*-static for all supported processors except the current one
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
         curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/${QEMUVERSION}/x86_64_qemu-${QEMUARCHS[$arch]}-static.tar.gz | tar -xz -C ${temp_dir}
+        # Ensure we don't get surprised by umask settings
+        chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"
         sed -i "s/CROSS_BUILD_//g" Dockerfile
       fi
     fi

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3.1
-arm=k8s.gcr.io/debian-base-arm:0.3.1
-arm64=k8s.gcr.io/debian-base-arm64:0.3.1
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1
+amd64=k8s.gcr.io/debian-base-amd64:0.3.2
+arm=k8s.gcr.io/debian-base-arm:0.3.2
+arm64=k8s.gcr.io/debian-base-arm64:0.3.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.2

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=k8s.gcr.io/debian-base-amd64:0.3
-arm=k8s.gcr.io/debian-base-arm:0.3
-arm64=k8s.gcr.io/debian-base-arm64:0.3
-ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3
+amd64=k8s.gcr.io/debian-base-amd64:0.3.1
+arm=k8s.gcr.io/debian-base-arm:0.3.1
+arm64=k8s.gcr.io/debian-base-arm64:0.3.1
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.3.1


### PR DESCRIPTION
Cherry pick of #67026 #67222 #67283 #67365 #68764 #68769 #68801 on release-1.11.

#67026: Upgrade debian-base to 0.3.1 for CVEs
#67222: ensure qemu-ARCH-static binary is world readable and
#67283: Add missing tmpdir path to chmod
#67365: Update to debian-iptables v10.1 and hyperkube-base 0.10.1
#68764: Install netbase in debian-iptables and debian-hyperkube-base as it is needed by ipvs
#68769: Update to use debian-iptables v10.2 and debian-hyperkube-base
#68801: bazel: update debian-iptables and debian-hyperkube-base

Fixes #68703

```release-note
Update to use debian-iptables v10.2 and debian-hyperkube-base 0.10.2 with upstream security fixes, and install netbase in these images, as it is needed by ipvs.
```