### PR TITLE
 Reduce API calls for Azure instance metadata

### DIFF
--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -74,6 +74,7 @@ go_test(
     srcs = [
         "azure_backoff_test.go",
         "azure_cache_test.go",
+        "azure_instances_test.go",
         "azure_loadbalancer_test.go",
         "azure_metrics_test.go",
         "azure_routes_test.go",

--- a/pkg/cloudprovider/providers/azure/azure_fakes.go
+++ b/pkg/cloudprovider/providers/azure/azure_fakes.go
@@ -302,6 +302,13 @@ func (fVMC *fakeAzureVirtualMachinesClient) List(ctx context.Context, resourceGr
 	return result, nil
 }
 
+func (fVMC *fakeAzureVirtualMachinesClient) setFakeStore(store map[string]map[string]compute.VirtualMachine) {
+	fVMC.mutex.Lock()
+	defer fVMC.mutex.Unlock()
+
+	fVMC.FakeStore = store
+}
+
 type fakeAzureSubnetsClient struct {
 	mutex     *sync.Mutex
 	FakeStore map[string]map[string]network.Subnet

--- a/pkg/cloudprovider/providers/azure/azure_instance_metadata.go
+++ b/pkg/cloudprovider/providers/azure/azure_instance_metadata.go
@@ -59,6 +59,13 @@ type InstanceMetadata struct {
 	baseURL string
 }
 
+// ComputeMetadata represents compute information
+type ComputeMetadata struct {
+	Name   string `json:"name,omitempty"`
+	Zone   string `json:"zone,omitempty"`
+	VMSize string `json:"vmSize,omitempty"`
+}
+
 // NewInstanceMetadata creates an instance of the InstanceMetadata accessor object.
 func NewInstanceMetadata() *InstanceMetadata {
 	return &InstanceMetadata{

--- a/pkg/cloudprovider/providers/azure/azure_instances_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func setTestVirtualMachines(c *Cloud, vmList []string) {
+	virtualMachineClient := c.VirtualMachinesClient.(*fakeAzureVirtualMachinesClient)
+	store := map[string]map[string]compute.VirtualMachine{
+		"rg": make(map[string]compute.VirtualMachine),
+	}
+
+	for i := range vmList {
+		nodeName := vmList[i]
+		instanceID := fmt.Sprintf("/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/%s", nodeName)
+		store["rg"][nodeName] = compute.VirtualMachine{
+			Name:     &nodeName,
+			ID:       &instanceID,
+			Location: &c.Location,
+		}
+	}
+
+	virtualMachineClient.setFakeStore(store)
+}
+
+func TestInstanceID(t *testing.T) {
+	cloud := getTestCloud()
+	cloud.metadata = &InstanceMetadata{}
+
+	testcases := []struct {
+		name         string
+		vmList       []string
+		nodeName     string
+		metadataName string
+		expected     string
+		expectError  bool
+	}{
+		{
+			name:         "InstanceID should get instanceID if node's name are equal to metadataName",
+			vmList:       []string{"vm1"},
+			nodeName:     "vm1",
+			metadataName: "vm1",
+			expected:     "/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1",
+		},
+		{
+			name:         "InstanceID should get instanceID from Azure API if node is not local instance",
+			vmList:       []string{"vm2"},
+			nodeName:     "vm2",
+			metadataName: "vm1",
+			expected:     "/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm2",
+		},
+		{
+			name:        "InstanceID should report error if VM doesn't exist",
+			vmList:      []string{"vm1"},
+			nodeName:    "vm3",
+			expectError: true,
+		},
+	}
+
+	for _, test := range testcases {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Errorf("Test [%s] unexpected error: %v", test.name, err)
+		}
+
+		mux := http.NewServeMux()
+		mux.Handle("/instance/compute", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, fmt.Sprintf("{\"name\":\"%s\"}", test.metadataName))
+		}))
+		go func() {
+			http.Serve(listener, mux)
+		}()
+		defer listener.Close()
+
+		cloud.metadata.baseURL = "http://" + listener.Addr().String() + "/"
+		setTestVirtualMachines(cloud, test.vmList)
+		instanceID, err := cloud.InstanceID(context.Background(), types.NodeName(test.nodeName))
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Test [%s] unexpected nil err", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test [%s] unexpected error: %v", test.name, err)
+			}
+		}
+
+		if instanceID != test.expected {
+			t.Errorf("Test [%s] unexpected instanceID: %s, expected %q", test.name, instanceID, test.expected)
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -1715,8 +1715,8 @@ func TestGetZone(t *testing.T) {
 		mux.Handle("/v1/InstanceInfo/FD", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, test.faultDomain)
 		}))
-		mux.Handle("/instance/compute/zone", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, test.zone)
+		mux.Handle("/instance/compute", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, fmt.Sprintf("{\"zone\":\"%s\"}", test.zone))
 		}))
 		go func() {
 			http.Serve(listener, mux)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Azure cloud provider gets a lot of `"Too many requests"` error when getting availability zones, instance types and node addresses. Hence kubelet won't be able to initialize itself sometimes.

This PR reduces such calls and alos switches to json API which is more stable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/Azure/acs-engine/issues/3681

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduce API calls for Azure instance metadata.
```

cc @ritazh @khenidak @andyzhangx 