### PR TITLE
Automated cherry pick of #67456: fix an issue in NodeInfo.Clone()

### DIFF
--- a/pkg/scheduler/cache/node_info.go
+++ b/pkg/scheduler/cache/node_info.go
@@ -399,8 +399,13 @@ func (n *NodeInfo) Clone() *NodeInfo {
 		clone.pods = append([]*v1.Pod(nil), n.pods...)
 	}
 	if len(n.usedPorts) > 0 {
-		for k, v := range n.usedPorts {
-			clone.usedPorts[k] = v
+		// util.HostPortInfo is a map-in-map struct
+		// make sure it's deep copied
+		for ip, portMap := range n.usedPorts {
+			clone.usedPorts[ip] = make(map[util.ProtocolPort]struct{})
+			for protocolPort, v := range portMap {
+				clone.usedPorts[ip][protocolPort] = v
+			}
 		}
 	}
 	if len(n.podsWithAffinity) > 0 {

--- a/pkg/scheduler/cache/node_info_test.go
+++ b/pkg/scheduler/cache/node_info_test.go
@@ -540,6 +540,7 @@ func TestNodeInfoClone(t *testing.T) {
 		ni := test.nodeInfo.Clone()
 		// Modify the field to check if the result is a clone of the origin one.
 		test.nodeInfo.generation += 10
+		test.nodeInfo.usedPorts.Remove("127.0.0.1", "TCP", 80)
 		if !reflect.DeepEqual(test.expected, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
 		}


### PR DESCRIPTION
Cherry pick of #67456 on release-1.11.

#67456: fix an issue in NodeInfo.Clone()