### PR TITLE
Tolerate nil input in GetValueFromIntOrPercent

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -863,11 +863,11 @@ func WaitForObservedDeployment(getDeploymentFunc func() (*apps.Deployment, error
 // 2 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
 // 1 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1)
 func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
-	surge, err := intstrutil.GetValueFromIntOrPercent(maxSurge, int(desired), true)
+	surge, err := intstrutil.GetValueFromIntOrPercent(intstrutil.ValueOrDefault(maxSurge, intstrutil.FromInt(0)), int(desired), true)
 	if err != nil {
 		return 0, 0, err
 	}
-	unavailable, err := intstrutil.GetValueFromIntOrPercent(maxUnavailable, int(desired), false)
+	unavailable, err := intstrutil.GetValueFromIntOrPercent(intstrutil.ValueOrDefault(maxUnavailable, intstrutil.FromInt(0)), int(desired), false)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -18,6 +18,7 @@ package intstr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"runtime/debug"
@@ -142,7 +143,17 @@ func (intstr *IntOrString) Fuzz(c fuzz.Continue) {
 	}
 }
 
+func ValueOrDefault(intOrPercent *IntOrString, defaultValue IntOrString) *IntOrString {
+	if intOrPercent == nil {
+		return &defaultValue
+	}
+	return intOrPercent
+}
+
 func GetValueFromIntOrPercent(intOrPercent *IntOrString, total int, roundUp bool) (int, error) {
+	if intOrPercent == nil {
+		return 0, errors.New("nil value for IntOrString")
+	}
 	value, isPercent, err := getIntOrPercentValue(intOrPercent)
 	if err != nil {
 		return 0, fmt.Errorf("invalid value for IntOrString: %v", err)

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
@@ -174,3 +174,10 @@ func TestGetValueFromIntOrPercent(t *testing.T) {
 		}
 	}
 }
+
+func TestGetValueFromIntOrPercentNil(t *testing.T) {
+	_, err := GetValueFromIntOrPercent(nil, 0, false)
+	if err == nil {
+		t.Errorf("expected error got none")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
`GetValueFromIntOrPercent` accepts pointer argument but does not validate it. This PR fixes that problem preventing from panics.

/assign @deads2k @sttts 

**Release note**:
```release-note
NONE
```
