### PR TITLE
 use PodSecurityPolicySpec of policy/v1beta1 instead of extensions/v1beta1

### DIFF
--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -96,6 +96,7 @@ go_library(
         "//staging/src/k8s.io/api/coordination/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/scheduling/v1beta1:go_default_library",

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -34,6 +34,7 @@ import (
 	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -346,14 +347,14 @@ func AddHandlers(h printers.PrintHandler) {
 
 	podSecurityPolicyColumnDefinitions := []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
-		{Name: "Priv", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["privileged"]},
-		{Name: "Caps", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["allowedCapabilities"]},
-		{Name: "SELinux", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["seLinux"]},
-		{Name: "RunAsUser", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["runAsUser"]},
-		{Name: "FsGroup", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["fsGroup"]},
-		{Name: "SupGroup", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["supplementalGroups"]},
-		{Name: "ReadOnlyRootFs", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["readOnlyRootFilesystem"]},
-		{Name: "Volumes", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["volumes"]},
+		{Name: "Priv", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["privileged"]},
+		{Name: "Caps", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["allowedCapabilities"]},
+		{Name: "SELinux", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["seLinux"]},
+		{Name: "RunAsUser", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["runAsUser"]},
+		{Name: "FsGroup", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["fsGroup"]},
+		{Name: "SupGroup", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["supplementalGroups"]},
+		{Name: "ReadOnlyRootFs", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["readOnlyRootFilesystem"]},
+		{Name: "Volumes", Type: "string", Description: policyv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["volumes"]},
 	}
 	h.TableHandler(podSecurityPolicyColumnDefinitions, printPodSecurityPolicy)
 	h.TableHandler(podSecurityPolicyColumnDefinitions, printPodSecurityPolicyList)

--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1beta1:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",

--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	policy "k8s.io/api/policy/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -79,27 +78,9 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 		expectForbidden(err)
 	})
 
-	// TODO: merge tests for extensions/policy API groups when PSP will be completely moved out of the extensions
-
-	It("should enforce the restricted extensions.PodSecurityPolicy", func() {
-		By("Creating & Binding a restricted policy for the test service account")
-		_, cleanup := createAndBindPSP(f, restrictedPSP("restrictive"))
-		defer cleanup()
-
-		By("Running a restricted pod")
-		pod, err := c.CoreV1().Pods(ns).Create(restrictedPod("allowed"))
-		framework.ExpectNoError(err)
-		framework.ExpectNoError(framework.WaitForPodNameRunningInNamespace(c, pod.Name, pod.Namespace))
-
-		testPrivilegedPods(func(pod *v1.Pod) {
-			_, err := c.CoreV1().Pods(ns).Create(pod)
-			expectForbidden(err)
-		})
-	})
-
 	It("should enforce the restricted policy.PodSecurityPolicy", func() {
 		By("Creating & Binding a restricted policy for the test service account")
-		_, cleanup := createAndBindPSPInPolicy(f, restrictedPSPInPolicy("restrictive"))
+		_, cleanup := createAndBindPSP(f, restrictedPSP("restrictive"))
 		defer cleanup()
 
 		By("Running a restricted pod")
@@ -110,37 +91,15 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 		testPrivilegedPods(func(pod *v1.Pod) {
 			_, err := c.CoreV1().Pods(ns).Create(pod)
 			expectForbidden(err)
-		})
-	})
-
-	It("should allow pods under the privileged extensions.PodSecurityPolicy", func() {
-		By("Creating & Binding a privileged policy for the test service account")
-		// Ensure that the permissive policy is used even in the presence of the restricted policy.
-		_, cleanup := createAndBindPSP(f, restrictedPSP("restrictive"))
-		defer cleanup()
-		expectedPSP, cleanup := createAndBindPSP(f, framework.PrivilegedPSP("permissive"))
-		defer cleanup()
-
-		testPrivilegedPods(func(pod *v1.Pod) {
-			p, err := c.CoreV1().Pods(ns).Create(pod)
-			framework.ExpectNoError(err)
-			framework.ExpectNoError(framework.WaitForPodNameRunningInNamespace(c, p.Name, p.Namespace))
-
-			// Verify expected PSP was used.
-			p, err = c.CoreV1().Pods(ns).Get(p.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			validated, found := p.Annotations[psputil.ValidatedPSPAnnotation]
-			Expect(found).To(BeTrue(), "PSP annotation not found")
-			Expect(validated).To(Equal(expectedPSP.Name), "Unexpected validated PSP")
 		})
 	})
 
 	It("should allow pods under the privileged policy.PodSecurityPolicy", func() {
 		By("Creating & Binding a privileged policy for the test service account")
 		// Ensure that the permissive policy is used even in the presence of the restricted policy.
-		_, cleanup := createAndBindPSPInPolicy(f, restrictedPSPInPolicy("restrictive"))
+		_, cleanup := createAndBindPSP(f, restrictedPSP("restrictive"))
 		defer cleanup()
-		expectedPSP, cleanup := createAndBindPSPInPolicy(f, privilegedPSPInPolicy("permissive"))
+		expectedPSP, cleanup := createAndBindPSP(f, privilegedPSP("permissive"))
 		defer cleanup()
 
 		testPrivilegedPods(func(pod *v1.Pod) {
@@ -229,49 +188,8 @@ func testPrivilegedPods(tester func(pod *v1.Pod)) {
 	})
 }
 
-func createAndBindPSP(f *framework.Framework, pspTemplate *extensionsv1beta1.PodSecurityPolicy) (psp *extensionsv1beta1.PodSecurityPolicy, cleanup func()) {
-	// Create the PodSecurityPolicy object.
-	psp = pspTemplate.DeepCopy()
-	// Add the namespace to the name to ensure uniqueness and tie it to the namespace.
-	ns := f.Namespace.Name
-	name := fmt.Sprintf("%s-%s", ns, psp.Name)
-	psp.Name = name
-	psp, err := f.ClientSet.ExtensionsV1beta1().PodSecurityPolicies().Create(psp)
-	framework.ExpectNoError(err, "Failed to create PSP")
-
-	// Create the Role to bind it to the namespace.
-	_, err = f.ClientSet.RbacV1beta1().Roles(ns).Create(&rbacv1beta1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Rules: []rbacv1beta1.PolicyRule{{
-			APIGroups:     []string{"extensions"},
-			Resources:     []string{"podsecuritypolicies"},
-			ResourceNames: []string{name},
-			Verbs:         []string{"use"},
-		}},
-	})
-	framework.ExpectNoError(err, "Failed to create PSP role")
-
-	// Bind the role to the namespace.
-	framework.BindRoleInNamespace(f.ClientSet.RbacV1beta1(), name, ns, rbacv1beta1.Subject{
-		Kind:      rbacv1beta1.ServiceAccountKind,
-		Namespace: ns,
-		Name:      "default",
-	})
-	framework.ExpectNoError(framework.WaitForNamedAuthorizationUpdate(f.ClientSet.AuthorizationV1beta1(),
-		serviceaccount.MakeUsername(ns, "default"), ns, "use", name,
-		schema.GroupResource{Group: "extensions", Resource: "podsecuritypolicies"}, true))
-
-	return psp, func() {
-		// Cleanup non-namespaced PSP object.
-		f.ClientSet.ExtensionsV1beta1().PodSecurityPolicies().Delete(name, &metav1.DeleteOptions{})
-	}
-}
-
-// createAndBindPSPInPolicy creates a PSP in the policy API group (unlike createAndBindPSP()).
-// TODO: merge these functions when PSP will be completely moved out of the extensions
-func createAndBindPSPInPolicy(f *framework.Framework, pspTemplate *policy.PodSecurityPolicy) (psp *policy.PodSecurityPolicy, cleanup func()) {
+// createAndBindPSP creates a PSP in the policy API group.
+func createAndBindPSP(f *framework.Framework, pspTemplate *policy.PodSecurityPolicy) (psp *policy.PodSecurityPolicy, cleanup func()) {
 	// Create the PodSecurityPolicy object.
 	psp = pspTemplate.DeepCopy()
 	// Add the namespace to the name to ensure uniqueness and tie it to the namespace.
@@ -334,8 +252,7 @@ func restrictedPod(name string) *v1.Pod {
 }
 
 // privilegedPSPInPolicy creates a PodSecurityPolicy (in the "policy" API Group) that allows everything.
-// TODO: replace by PrivilegedPSP when PSP will be completely moved out of the extensions
-func privilegedPSPInPolicy(name string) *policy.PodSecurityPolicy {
+func privilegedPSP(name string) *policy.PodSecurityPolicy {
 	return &policy.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -368,8 +285,7 @@ func privilegedPSPInPolicy(name string) *policy.PodSecurityPolicy {
 }
 
 // restrictedPSPInPolicy creates a PodSecurityPolicy (in the "policy" API Group) that is most strict.
-// TODO: replace by restrictedPSP when PSP will be completely moved out of the extensions
-func restrictedPSPInPolicy(name string) *policy.PodSecurityPolicy {
+func restrictedPSP(name string) *policy.PodSecurityPolicy {
 	return &policy.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -417,61 +333,6 @@ func restrictedPSPInPolicy(name string) *policy.PodSecurityPolicy {
 			},
 			FSGroup: policy.FSGroupStrategyOptions{
 				Rule: policy.FSGroupStrategyRunAsAny,
-			},
-			ReadOnlyRootFilesystem: false,
-		},
-	}
-}
-
-// restrictedPSP creates a PodSecurityPolicy that is most strict.
-func restrictedPSP(name string) *extensionsv1beta1.PodSecurityPolicy {
-	return &extensionsv1beta1.PodSecurityPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Annotations: map[string]string{
-				seccomp.AllowedProfilesAnnotationKey:  v1.SeccompProfileRuntimeDefault,
-				seccomp.DefaultProfileAnnotationKey:   v1.SeccompProfileRuntimeDefault,
-				apparmor.AllowedProfilesAnnotationKey: apparmor.ProfileRuntimeDefault,
-				apparmor.DefaultProfileAnnotationKey:  apparmor.ProfileRuntimeDefault,
-			},
-		},
-		Spec: extensionsv1beta1.PodSecurityPolicySpec{
-			Privileged:               false,
-			AllowPrivilegeEscalation: utilpointer.BoolPtr(false),
-			RequiredDropCapabilities: []v1.Capability{
-				"AUDIT_WRITE",
-				"CHOWN",
-				"DAC_OVERRIDE",
-				"FOWNER",
-				"FSETID",
-				"KILL",
-				"MKNOD",
-				"NET_RAW",
-				"SETGID",
-				"SETUID",
-				"SYS_CHROOT",
-			},
-			Volumes: []extensionsv1beta1.FSType{
-				extensionsv1beta1.ConfigMap,
-				extensionsv1beta1.EmptyDir,
-				extensionsv1beta1.PersistentVolumeClaim,
-				"projected",
-				extensionsv1beta1.Secret,
-			},
-			HostNetwork: false,
-			HostIPC:     false,
-			HostPID:     false,
-			RunAsUser: extensionsv1beta1.RunAsUserStrategyOptions{
-				Rule: extensionsv1beta1.RunAsUserStrategyMustRunAsNonRoot,
-			},
-			SELinux: extensionsv1beta1.SELinuxStrategyOptions{
-				Rule: extensionsv1beta1.SELinuxStrategyRunAsAny,
-			},
-			SupplementalGroups: extensionsv1beta1.SupplementalGroupsStrategyOptions{
-				Rule: extensionsv1beta1.SupplementalGroupsStrategyRunAsAny,
-			},
-			FSGroup: extensionsv1beta1.FSGroupStrategyOptions{
-				Rule: extensionsv1beta1.FSGroupStrategyRunAsAny,
 			},
 			ReadOnlyRootFilesystem: false,
 		},

--- a/test/e2e/framework/psp_util.go
+++ b/test/e2e/framework/psp_util.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	policy "k8s.io/api/policy/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,33 +42,33 @@ var (
 )
 
 // Creates a PodSecurityPolicy that allows everything.
-func PrivilegedPSP(name string) *extensionsv1beta1.PodSecurityPolicy {
+func PrivilegedPSP(name string) *policy.PodSecurityPolicy {
 	allowPrivilegeEscalation := true
-	return &extensionsv1beta1.PodSecurityPolicy{
+	return &policy.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: map[string]string{seccomp.AllowedProfilesAnnotationKey: seccomp.AllowAny},
 		},
-		Spec: extensionsv1beta1.PodSecurityPolicySpec{
+		Spec: policy.PodSecurityPolicySpec{
 			Privileged:               true,
 			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 			AllowedCapabilities:      []corev1.Capability{"*"},
-			Volumes:                  []extensionsv1beta1.FSType{extensionsv1beta1.All},
+			Volumes:                  []policy.FSType{policy.All},
 			HostNetwork:              true,
-			HostPorts:                []extensionsv1beta1.HostPortRange{{Min: 0, Max: 65535}},
+			HostPorts:                []policy.HostPortRange{{Min: 0, Max: 65535}},
 			HostIPC:                  true,
 			HostPID:                  true,
-			RunAsUser: extensionsv1beta1.RunAsUserStrategyOptions{
-				Rule: extensionsv1beta1.RunAsUserStrategyRunAsAny,
+			RunAsUser: policy.RunAsUserStrategyOptions{
+				Rule: policy.RunAsUserStrategyRunAsAny,
 			},
-			SELinux: extensionsv1beta1.SELinuxStrategyOptions{
-				Rule: extensionsv1beta1.SELinuxStrategyRunAsAny,
+			SELinux: policy.SELinuxStrategyOptions{
+				Rule: policy.SELinuxStrategyRunAsAny,
 			},
-			SupplementalGroups: extensionsv1beta1.SupplementalGroupsStrategyOptions{
-				Rule: extensionsv1beta1.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: policy.SupplementalGroupsStrategyOptions{
+				Rule: policy.SupplementalGroupsStrategyRunAsAny,
 			},
-			FSGroup: extensionsv1beta1.FSGroupStrategyOptions{
-				Rule: extensionsv1beta1.FSGroupStrategyRunAsAny,
+			FSGroup: policy.FSGroupStrategyOptions{
+				Rule: policy.FSGroupStrategyRunAsAny,
 			},
 			ReadOnlyRootFilesystem: false,
 			AllowedUnsafeSysctls:   []string{"*"},
@@ -112,7 +112,7 @@ func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
 		}
 
 		psp := PrivilegedPSP(podSecurityPolicyPrivileged)
-		psp, err = f.ClientSet.ExtensionsV1beta1().PodSecurityPolicies().Create(psp)
+		psp, err = f.ClientSet.PolicyV1beta1().PodSecurityPolicies().Create(psp)
 		if !apierrs.IsAlreadyExists(err) {
 			ExpectNoError(err, "Failed to create PSP %s", podSecurityPolicyPrivileged)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
PodSecurityPolicySpec in extensions/v1beta1 API Group is deprecated.
/cc @php-coder 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
