### PR TITLE
Provide Flex volume metrics if the plugin supports.

### DIFF
--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -220,14 +220,16 @@ type DriverStatus struct {
 }
 
 type DriverCapabilities struct {
-	Attach         bool `json:"attach"`
-	SELinuxRelabel bool `json:"selinuxRelabel"`
+	Attach          bool `json:"attach"`
+	SELinuxRelabel  bool `json:"selinuxRelabel"`
+	SupportsMetrics bool `json:"supportsMetrics"`
 }
 
 func defaultCapabilities() *DriverCapabilities {
 	return &DriverCapabilities{
-		Attach:         true,
-		SELinuxRelabel: true,
+		Attach:          true,
+		SELinuxRelabel:  true,
+		SupportsMetrics: false,
 	}
 }
 

--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -32,7 +32,6 @@ type flexVolumeMounter struct {
 	// the considered volume spec
 	spec     *volume.Spec
 	readOnly bool
-	volume.MetricsNil
 }
 
 var _ volume.Mounter = &flexVolumeMounter{}

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -177,6 +177,14 @@ func (plugin *flexVolumePlugin) newMounterInternal(spec *volume.Spec, pod *api.P
 		return nil, err
 	}
 
+	var metricsProvider volume.MetricsProvider
+	if plugin.capabilities.SupportsMetrics {
+		metricsProvider = volume.NewMetricsStatFS(plugin.host.GetPodVolumeDir(
+			pod.UID, utilstrings.EscapeQualifiedNameForDisk(sourceDriver), spec.Name()))
+	} else {
+		metricsProvider = &volume.MetricsNil{}
+	}
+
 	return &flexVolumeMounter{
 		flexVolume: &flexVolume{
 			driverName:            sourceDriver,
@@ -188,6 +196,7 @@ func (plugin *flexVolumePlugin) newMounterInternal(spec *volume.Spec, pod *api.P
 			podNamespace:          pod.Namespace,
 			podServiceAccountName: pod.Spec.ServiceAccountName,
 			volName:               spec.Name(),
+			MetricsProvider:       metricsProvider,
 		},
 		runner:   runner,
 		spec:     spec,
@@ -202,14 +211,23 @@ func (plugin *flexVolumePlugin) NewUnmounter(volName string, podUID types.UID) (
 
 // newUnmounterInternal is the internal unmounter routine to clean the volume.
 func (plugin *flexVolumePlugin) newUnmounterInternal(volName string, podUID types.UID, mounter mount.Interface, runner exec.Interface) (volume.Unmounter, error) {
+	var metricsProvider volume.MetricsProvider
+	if plugin.capabilities.SupportsMetrics {
+		metricsProvider = volume.NewMetricsStatFS(plugin.host.GetPodVolumeDir(
+			podUID, utilstrings.EscapeQualifiedNameForDisk(plugin.driverName), volName))
+	} else {
+		metricsProvider = &volume.MetricsNil{}
+	}
+
 	return &flexVolumeUnmounter{
 		flexVolume: &flexVolume{
-			driverName: plugin.driverName,
-			execPath:   plugin.getExecutable(),
-			mounter:    mounter,
-			plugin:     plugin,
-			podUID:     podUID,
-			volName:    volName,
+			driverName:      plugin.driverName,
+			execPath:        plugin.getExecutable(),
+			mounter:         mounter,
+			plugin:          plugin,
+			podUID:          podUID,
+			volName:         volName,
+			MetricsProvider: metricsProvider,
 		},
 		runner: runner,
 	}, nil

--- a/pkg/volume/flexvolume/unmounter.go
+++ b/pkg/volume/flexvolume/unmounter.go
@@ -31,7 +31,6 @@ type flexVolumeUnmounter struct {
 	*flexVolume
 	// Runner used to teardown the volume.
 	runner exec.Interface
-	volume.MetricsNil
 }
 
 var _ volume.Unmounter = &flexVolumeUnmounter{}

--- a/pkg/volume/flexvolume/volume.go
+++ b/pkg/volume/flexvolume/volume.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 type flexVolume struct {
@@ -42,6 +43,8 @@ type flexVolume struct {
 	volName string
 	// the underlying plugin
 	plugin *flexVolumePlugin
+	// the metric plugin
+	volume.MetricsProvider
 }
 
 // volume.Volume interface


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables metrics for Flex Drivers if the driver has the capability. By default metrics are not enabled on the driver but when the capability 'supportsMetrics' is set to true then this PR will allow to configure a fs stat metrics plugin to run metrics on the flex plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67400

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flex drivers by default do not produce metrics. Flex plugins can enable metrics collection by setting  the capability 'supportsMetrics' to true. Make sure the file system can support fs stat to produce metrics in this case.
```