### PR TITLE
export a method to expose which ports were forwarded

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -340,3 +340,20 @@ func (pf *PortForwarder) Close() {
 		}
 	}
 }
+
+// GetPorts will return the ports that were forwarded; this can be used to
+// retrieve the locally-bound port in cases where the input was port 0. This
+// function will signal an error if the Ready channel is nil or if the
+// listeners are not ready yet; this function will succeed after the Ready
+// channel has been closed.
+func (pf *PortForwarder) GetPorts() ([]ForwardedPort, error) {
+	if pf.Ready == nil {
+		return nil, fmt.Errorf("no Ready channel provided")
+	}
+	select {
+	case <-pf.Ready:
+		return pf.ports, nil
+	default:
+		return nil, fmt.Errorf("listeners not ready")
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -99,8 +99,17 @@ func TestParsePortsAndNew(t *testing.T) {
 		if dialer.dialed {
 			t.Fatalf("%d: expected not dialed", i)
 		}
-		if e, a := test.expected, pf.ports; !reflect.DeepEqual(e, a) {
-			t.Fatalf("%d: ports: expected %#v, got %#v", i, e, a)
+		if _, portErr := pf.GetPorts(); portErr == nil {
+			t.Fatalf("%d: GetPorts: error expected but got nil", i)
+		}
+
+		// mock-signal the Ready channel
+		close(readyChan)
+
+		if ports, portErr := pf.GetPorts(); portErr != nil {
+			t.Fatalf("%d: GetPorts: unable to retrieve ports: %s", i, portErr)
+		} else if !reflect.DeepEqual(test.expected, ports) {
+			t.Fatalf("%d: ports: expected %#v, got %#v", i, test.expected, ports)
 		}
 		if e, a := expectedStopChan, pf.stopChan; e != a {
 			t.Fatalf("%d: stopChan: expected %#v, got %#v", i, e, a)


### PR DESCRIPTION
**What this PR does / why we need it**:

The port-forwarding mechanism in client-go currently doesn't provide any
convenient method to retrieve the locally-bound port in cases where the
port requested was "0" (use any port). (It's only possible by parsing it
out of the output log stream).

**Special notes for your reviewer**:

Because this is a non-breaking client API change with no end-user-visible
changes (just end-developer changes :) ). I've marked this "no release
note." Let me know if you disagree and I'll add one.

**Release note**:
```release-note
NONE
```