### PR TITLE
Wait for Available in PV protection test

### DIFF
--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -17,6 +17,8 @@ limitations under the License.
 package storage
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -76,6 +78,9 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 		// create the PV
 		pv, err = client.CoreV1().PersistentVolumes().Create(pv)
 		Expect(err).NotTo(HaveOccurred(), "Error creating PV")
+
+		By("Waiting for PV to enter phase Available")
+		framework.ExpectNoError(framework.WaitForPersistentVolumePhase(v1.VolumeAvailable, client, pv.Name, 1*time.Second, 30*time.Second))
 
 		By("Checking that PV Protection finalizer is set")
 		pv, err = client.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

Just after creating a PV, its phase is "Pending" and its finalizers
doesn't contain "kubernetes.io/pv-protection". If the e2e test performs
so faster than the target k8s cluster, the test fails because the PV is
not ready. This adds WaitForPersistentVolumePhase() for waiting the
phase "Available" to avoid such situation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: 
Fixes #67519

**Release note**: NONE
