### PR TITLE
Automated cherry pick of #67372: fix apiserver crashed when priority classs already exists

### DIFF
--- a/pkg/registry/scheduling/rest/storage_scheduling.go
+++ b/pkg/registry/scheduling/rest/storage_scheduling.go
@@ -85,7 +85,7 @@ func AddSystemPriorityClasses() genericapiserver.PostStartHookFunc {
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						_, err := schedClientSet.PriorityClasses().Create(pc)
-						if err != nil {
+						if err != nil && !apierrors.IsAlreadyExists(err) {
 							return false, err
 						} else {
 							glog.Infof("created PriorityClass %s with value %v", pc.Name, pc.Value)


### PR DESCRIPTION
Cherry pick of #67372 on release-1.11.

#67372: fix apiserver crashed when priority classs already exists

```release-note
kube-apiserver: fixes error creating system priority classes when starting multiple apiservers simultaneously
```
