### PR TITLE
add more storage account sku support for azure disk

### DIFF
--- a/pkg/volume/azure_dd/BUILD
+++ b/pkg/volume/azure_dd/BUILD
@@ -75,6 +75,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
+        "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -59,8 +59,6 @@ var (
 		string(api.AzureSharedBlobDisk),
 		string(api.AzureDedicatedBlobDisk),
 		string(api.AzureManagedDisk))
-
-	supportedStorageAccountTypes = sets.NewString("Premium_LRS", "Standard_LRS", "Standard_GRS", "Standard_RAGRS")
 )
 
 func getPath(uid types.UID, volName string, host volume.VolumeHost) string {
@@ -127,11 +125,15 @@ func normalizeStorageAccountType(storageAccountType string) (storage.SkuName, er
 		return defaultStorageAccountType, nil
 	}
 
-	if !supportedStorageAccountTypes.Has(storageAccountType) {
-		return "", fmt.Errorf("azureDisk - %s is not supported sku/storageaccounttype. Supported values are %s", storageAccountType, supportedStorageAccountTypes.List())
+	sku := storage.SkuName(storageAccountType)
+	supportedSkuNames := storage.PossibleSkuNameValues()
+	for _, s := range supportedSkuNames {
+		if sku == s {
+			return sku, nil
+		}
 	}
 
-	return storage.SkuName(storageAccountType), nil
+	return "", fmt.Errorf("azureDisk - %s is not supported sku/storageaccounttype. Supported values are %s", storageAccountType, supportedSkuNames)
 }
 
 func normalizeCachingMode(cachingMode v1.AzureDataDiskCachingMode) (v1.AzureDataDiskCachingMode, error) {

--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -24,6 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage"
+	"github.com/stretchr/testify/assert"
+
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -132,5 +135,55 @@ func TestIoHandler(t *testing.T) {
 		if disk != "/dev/"+devName || err != nil {
 			t.Errorf("no data disk found: disk %v err %v", disk, err)
 		}
+	}
+}
+
+func TestNormalizeStorageAccountType(t *testing.T) {
+	tests := []struct {
+		storageAccountType  string
+		expectedAccountType storage.SkuName
+		expectError         bool
+	}{
+		{
+			storageAccountType:  "",
+			expectedAccountType: storage.StandardLRS,
+			expectError:         false,
+		},
+		{
+			storageAccountType:  "NOT_EXISTING",
+			expectedAccountType: "",
+			expectError:         true,
+		},
+		{
+			storageAccountType:  "Standard_LRS",
+			expectedAccountType: storage.StandardLRS,
+			expectError:         false,
+		},
+		{
+			storageAccountType:  "Premium_LRS",
+			expectedAccountType: storage.PremiumLRS,
+			expectError:         false,
+		},
+		{
+			storageAccountType:  "Standard_GRS",
+			expectedAccountType: storage.StandardGRS,
+			expectError:         false,
+		},
+		{
+			storageAccountType:  "Standard_RAGRS",
+			expectedAccountType: storage.StandardRAGRS,
+			expectError:         false,
+		},
+		{
+			storageAccountType:  "Standard_ZRS",
+			expectedAccountType: storage.StandardZRS,
+			expectError:         false,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := normalizeStorageAccountType(test.storageAccountType)
+		assert.Equal(t, result, test.expectedAccountType)
+		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
 	}
 }


### PR DESCRIPTION
add error msg

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Original hard coded storage account sku list is not good design, swith to use `storage.PossibleSkuNameValues()` to add more sku support for azure disk

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67527

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
add more storage account sku support for azure disk
```

/sig azure
@feiskyer 
FYI @khenidak 