### PR TITLE
kubeadm: Migrate cert and PKI helpers to ClusterConfiguration

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -324,7 +324,7 @@ type JoinConfiguration struct {
 // It will override location with CI registry name in case user requests special
 // Kubernetes version from CI build area.
 // (See: kubeadmconstants.DefaultCIImageRepository)
-func (cfg *InitConfiguration) GetControlPlaneImageRepository() string {
+func (cfg *ClusterConfiguration) GetControlPlaneImageRepository() string {
 	if cfg.CIImageRepository != "" {
 		return cfg.CIImageRepository
 	}

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -434,7 +434,7 @@ func NewCmdConfigImagesPull() *cobra.Command {
 			kubeadmutil.CheckErr(err)
 			containerRuntime, err := utilruntime.NewContainerRuntime(utilsexec.New(), internalcfg.GetCRISocket())
 			kubeadmutil.CheckErr(err)
-			imagesPull := NewImagesPull(containerRuntime, images.GetAllImages(internalcfg))
+			imagesPull := NewImagesPull(containerRuntime, images.GetAllImages(&internalcfg.ClusterConfiguration))
 			kubeadmutil.CheckErr(imagesPull.PullAll())
 		},
 	}
@@ -516,7 +516,7 @@ type ImagesList struct {
 
 // Run runs the images command and writes the result to the io.Writer passed in
 func (i *ImagesList) Run(out io.Writer) error {
-	imgs := images.GetAllImages(i.cfg)
+	imgs := images.GetAllImages(&i.cfg.ClusterConfiguration)
 	for _, img := range imgs {
 		fmt.Fprintln(out, img)
 	}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -308,11 +308,11 @@ func (i *Init) Run(out io.Writer) error {
 
 	adminKubeConfigPath := filepath.Join(kubeConfigDir, kubeadmconstants.AdminKubeConfigFileName)
 
-	if res, _ := certsphase.UsingExternalCA(i.cfg); !res {
+	if res, _ := certsphase.UsingExternalCA(&i.cfg.ClusterConfiguration); !res {
 
 		// PHASE 1: Generate certificates
 		glog.V(1).Infof("[init] creating PKI Assets")
-		if err := certsphase.CreatePKIAssets(i.cfg); err != nil {
+		if err := certsphase.CreatePKIAssets(&i.cfg.ClusterConfiguration, &i.cfg.NodeRegistration); err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -408,7 +408,7 @@ func (j *Join) CheckIfReadyForAdditionalControlPlane(clusterConfiguration *kubea
 	}
 
 	// checks if the certificates that must be equal across contolplane instances are provided
-	if ret, err := certsphase.SharedCertificateExists(clusterConfiguration); !ret {
+	if ret, err := certsphase.SharedCertificateExists(&clusterConfiguration.ClusterConfiguration); !ret {
 		return err
 	}
 
@@ -424,7 +424,7 @@ func (j *Join) PrepareForHostingControlPlane(clusterConfiguration *kubeadmapi.In
 	}
 
 	// Generate missing certificates (if any)
-	if err := certsphase.CreatePKIAssets(clusterConfiguration); err != nil {
+	if err := certsphase.CreatePKIAssets(&clusterConfiguration.ClusterConfiguration, &clusterConfiguration.NodeRegistration); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -193,7 +193,7 @@ func RunApply(flags *applyFlags) error {
 	// Use a prepuller implementation based on creating DaemonSets
 	// and block until all DaemonSets are ready; then we know for sure that all control plane images are cached locally
 	glog.V(1).Infof("[upgrade/apply] creating prepuller")
-	prepuller := upgrade.NewDaemonSetPrepuller(upgradeVars.client, upgradeVars.waiter, upgradeVars.cfg)
+	prepuller := upgrade.NewDaemonSetPrepuller(upgradeVars.client, upgradeVars.waiter, &upgradeVars.cfg.ClusterConfiguration)
 	if err := upgrade.PrepullImagesInParallel(prepuller, flags.imagePullTimeout); err != nil {
 		return fmt.Errorf("[upgrade/prepull] Failed prepulled the images for the control plane components error: %v", err)
 	}

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -37,7 +37,7 @@ func GetGenericArchImage(prefix, image, tag string) string {
 }
 
 // GetKubeControlPlaneImage generates and returns the image for the core Kubernetes components or returns the unified control plane image if specified
-func GetKubeControlPlaneImage(image string, cfg *kubeadmapi.InitConfiguration) string {
+func GetKubeControlPlaneImage(image string, cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.UnifiedControlPlaneImage != "" {
 		return cfg.UnifiedControlPlaneImage
 	}
@@ -47,7 +47,7 @@ func GetKubeControlPlaneImage(image string, cfg *kubeadmapi.InitConfiguration) s
 }
 
 // GetEtcdImage generates and returns the image for etcd or returns cfg.Etcd.Local.Image if specified
-func GetEtcdImage(cfg *kubeadmapi.InitConfiguration) string {
+func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	if cfg.Etcd.Local != nil && cfg.Etcd.Local.Image != "" {
 		return cfg.Etcd.Local.Image
 	}
@@ -60,7 +60,7 @@ func GetEtcdImage(cfg *kubeadmapi.InitConfiguration) string {
 }
 
 // GetAllImages returns a list of container images kubeadm expects to use on a control plane node
-func GetAllImages(cfg *kubeadmapi.InitConfiguration) []string {
+func GetAllImages(cfg *kubeadmapi.ClusterConfiguration) []string {
 	imgs := []string{}
 	imgs = append(imgs, GetKubeControlPlaneImage(constants.KubeAPIServer, cfg))
 	imgs = append(imgs, GetKubeControlPlaneImage(constants.KubeControllerManager, cfg))

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -49,44 +49,36 @@ func TestGetKubeControlPlaneImage(t *testing.T) {
 	var tests = []struct {
 		image    string
 		expected string
-		cfg      *kubeadmapi.InitConfiguration
+		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
 			expected: "override",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					UnifiedControlPlaneImage: "override",
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				UnifiedControlPlaneImage: "override",
 			},
 		},
 		{
 			image:    constants.KubeAPIServer,
 			expected: GetGenericArchImage(gcrPrefix, "kube-apiserver", expected),
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					ImageRepository:   gcrPrefix,
-					KubernetesVersion: testversion,
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository:   gcrPrefix,
+				KubernetesVersion: testversion,
 			},
 		},
 		{
 			image:    constants.KubeControllerManager,
 			expected: GetGenericArchImage(gcrPrefix, "kube-controller-manager", expected),
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					ImageRepository:   gcrPrefix,
-					KubernetesVersion: testversion,
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository:   gcrPrefix,
+				KubernetesVersion: testversion,
 			},
 		},
 		{
 			image:    constants.KubeScheduler,
 			expected: GetGenericArchImage(gcrPrefix, "kube-scheduler", expected),
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					ImageRepository:   gcrPrefix,
-					KubernetesVersion: testversion,
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository:   gcrPrefix,
+				KubernetesVersion: testversion,
 			},
 		},
 	}
@@ -105,27 +97,23 @@ func TestGetKubeControlPlaneImage(t *testing.T) {
 func TestGetEtcdImage(t *testing.T) {
 	var tests = []struct {
 		expected string
-		cfg      *kubeadmapi.InitConfiguration
+		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
 			expected: "override",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					Etcd: kubeadmapi.Etcd{
-						Local: &kubeadmapi.LocalEtcd{
-							Image: "override",
-						},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Etcd: kubeadmapi.Etcd{
+					Local: &kubeadmapi.LocalEtcd{
+						Image: "override",
 					},
 				},
 			},
 		},
 		{
 			expected: GetGenericArchImage(gcrPrefix, "etcd", constants.DefaultEtcdVersion),
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					ImageRepository:   gcrPrefix,
-					KubernetesVersion: testversion,
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository:   gcrPrefix,
+				KubernetesVersion: testversion,
 			},
 		},
 	}
@@ -144,78 +132,64 @@ func TestGetEtcdImage(t *testing.T) {
 func TestGetAllImages(t *testing.T) {
 	testcases := []struct {
 		name   string
-		cfg    *kubeadmapi.InitConfiguration
 		expect string
+		cfg    *kubeadmapi.ClusterConfiguration
 	}{
 		{
 			name: "defined CIImageRepository",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					CIImageRepository: "test.repo",
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				CIImageRepository: "test.repo",
 			},
 			expect: "test.repo",
 		},
 		{
 			name: "undefined CIImagerRepository should contain the default image prefix",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					ImageRepository: "real.repo",
-				},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ImageRepository: "real.repo",
 			},
 			expect: "real.repo",
 		},
 		{
 			name: "test that etcd is returned when it is not external",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					Etcd: kubeadmapi.Etcd{
-						Local: &kubeadmapi.LocalEtcd{},
-					},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Etcd: kubeadmapi.Etcd{
+					Local: &kubeadmapi.LocalEtcd{},
 				},
 			},
 			expect: constants.Etcd,
 		},
 		{
 			name: "CoreDNS image is returned",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					FeatureGates: map[string]bool{
-						"CoreDNS": true,
-					},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": true,
 				},
 			},
 			expect: constants.CoreDNS,
 		},
 		{
 			name: "main kube-dns image is returned",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					FeatureGates: map[string]bool{
-						"CoreDNS": false,
-					},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
 				},
 			},
 			expect: "k8s-dns-kube-dns",
 		},
 		{
 			name: "kube-dns sidecar image is returned",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					FeatureGates: map[string]bool{
-						"CoreDNS": false,
-					},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
 				},
 			},
 			expect: "k8s-dns-sidecar",
 		},
 		{
 			name: "kube-dns dnsmasq-nanny image is returned",
-			cfg: &kubeadmapi.InitConfiguration{
-				ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-					FeatureGates: map[string]bool{
-						"CoreDNS": false,
-					},
+			cfg: &kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{
+					"CoreDNS": false,
 				},
 			},
 			expect: "k8s-dns-dnsmasq-nanny",

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -76,7 +76,7 @@ func EnsureProxyAddon(cfg *kubeadmapi.InitConfiguration, client clientset.Interf
 		return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
 	}
 	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ Image, Arch string }{
-		Image: images.GetKubeControlPlaneImage(constants.KubeProxy, cfg),
+		Image: images.GetKubeControlPlaneImage(constants.KubeProxy, &cfg.ClusterConfiguration),
 		Arch:  runtime.GOARCH,
 	})
 	if err != nil {

--- a/cmd/kubeadm/app/phases/certs/certlist_test.go
+++ b/cmd/kubeadm/app/phases/certs/certlist_test.go
@@ -115,13 +115,11 @@ func TestCreateCertificateChain(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	ic := &kubeadmapi.InitConfiguration{
-		NodeRegistration: kubeadmapi.NodeRegistrationOptions{
-			Name: "test-node",
-		},
-		ClusterConfiguration: kubeadmapi.ClusterConfiguration{
-			CertificatesDir: dir,
-		},
+	cc := &kubeadmapi.ClusterConfiguration{
+		CertificatesDir: dir,
+	}
+	nr := &kubeadmapi.NodeRegistrationOptions{
+		Name: "test-node",
 	}
 
 	caCfg := Certificates{
@@ -151,7 +149,7 @@ func TestCreateCertificateChain(t *testing.T) {
 		t.Fatalf("unexpected error getting tree: %v", err)
 	}
 
-	if certTree.CreateTree(ic); err != nil {
+	if certTree.CreateTree(cc, nr); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -251,7 +251,7 @@ func pathForPublicKey(pkiPath, name string) string {
 }
 
 // GetAPIServerAltNames builds an AltNames object for to be used when generating apiserver certificate
-func GetAPIServerAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames, error) {
+func GetAPIServerAltNames(cfg *kubeadmapi.ClusterConfiguration, nr *kubeadmapi.NodeRegistrationOptions) (*certutil.AltNames, error) {
 	// advertise address
 	advertiseAddress := net.ParseIP(cfg.API.AdvertiseAddress)
 	if advertiseAddress == nil {
@@ -272,7 +272,7 @@ func GetAPIServerAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames
 	// create AltNames with defaults DNSNames/IPs
 	altNames := &certutil.AltNames{
 		DNSNames: []string{
-			cfg.NodeRegistration.Name,
+			nr.Name,
 			"kubernetes",
 			"kubernetes.default",
 			"kubernetes.default.svc",
@@ -306,10 +306,10 @@ func GetAPIServerAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames
 // `localhost` is included in the SAN since this is the interface the etcd static pod listens on.
 // Hostname and `API.AdvertiseAddress` are excluded since etcd does not listen on this interface by default.
 // The user can override the listen address with `Etcd.ExtraArgs` and add SANs with `Etcd.ServerCertSANs`.
-func GetEtcdAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames, error) {
+func GetEtcdAltNames(cfg *kubeadmapi.ClusterConfiguration, nr *kubeadmapi.NodeRegistrationOptions) (*certutil.AltNames, error) {
 	// create AltNames with defaults DNSNames/IPs
 	altNames := &certutil.AltNames{
-		DNSNames: []string{cfg.NodeRegistration.Name, "localhost"},
+		DNSNames: []string{nr.Name, "localhost"},
 		IPs:      []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 
@@ -324,7 +324,7 @@ func GetEtcdAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames, err
 // `localhost` is excluded from the SAN since etcd will not refer to itself as a peer.
 // Hostname and `API.AdvertiseAddress` are included if the user chooses to promote the single node etcd cluster into a multi-node one.
 // The user can override the listen address with `Etcd.ExtraArgs` and add SANs with `Etcd.PeerCertSANs`.
-func GetEtcdPeerAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames, error) {
+func GetEtcdPeerAltNames(cfg *kubeadmapi.ClusterConfiguration, nr *kubeadmapi.NodeRegistrationOptions) (*certutil.AltNames, error) {
 	// advertise address
 	advertiseAddress := net.ParseIP(cfg.API.AdvertiseAddress)
 	if advertiseAddress == nil {
@@ -333,7 +333,7 @@ func GetEtcdPeerAltNames(cfg *kubeadmapi.InitConfiguration) (*certutil.AltNames,
 
 	// create AltNames with defaults DNSNames/IPs
 	altNames := &certutil.AltNames{
-		DNSNames: []string{cfg.NodeRegistration.Name, "localhost"},
+		DNSNames: []string{nr.Name, "localhost"},
 		IPs:      []net.IP{advertiseAddress, net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -73,7 +73,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 	staticPodSpecs := map[string]v1.Pod{
 		kubeadmconstants.KubeAPIServer: staticpodutil.ComponentPod(v1.Container{
 			Name:            kubeadmconstants.KubeAPIServer,
-			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeAPIServer, cfg),
+			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeAPIServer, &cfg.ClusterConfiguration),
 			ImagePullPolicy: v1.PullIfNotPresent,
 			Command:         getAPIServerCommand(cfg),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeAPIServer)),
@@ -83,7 +83,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 		}, mounts.GetVolumes(kubeadmconstants.KubeAPIServer)),
 		kubeadmconstants.KubeControllerManager: staticpodutil.ComponentPod(v1.Container{
 			Name:            kubeadmconstants.KubeControllerManager,
-			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeControllerManager, cfg),
+			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeControllerManager, &cfg.ClusterConfiguration),
 			ImagePullPolicy: v1.PullIfNotPresent,
 			Command:         getControllerManagerCommand(cfg, k8sVersion),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeControllerManager)),
@@ -93,7 +93,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.InitConfiguration, k8sVersion *version.Ve
 		}, mounts.GetVolumes(kubeadmconstants.KubeControllerManager)),
 		kubeadmconstants.KubeScheduler: staticpodutil.ComponentPod(v1.Container{
 			Name:            kubeadmconstants.KubeScheduler,
-			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeScheduler, cfg),
+			Image:           images.GetKubeControlPlaneImage(kubeadmconstants.KubeScheduler, &cfg.ClusterConfiguration),
 			ImagePullPolicy: v1.PullIfNotPresent,
 			Command:         getSchedulerCommand(cfg),
 			VolumeMounts:    staticpodutil.VolumeMountMapToSlice(mounts.GetVolumeMounts(kubeadmconstants.KubeScheduler)),

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -289,7 +289,7 @@ func getControllerManagerCommand(cfg *kubeadmapi.InitConfiguration, k8sVersion *
 
 	// If using external CA, pass empty string to controller manager instead of ca.key/ca.crt path,
 	// so that the csrsigning controller fails to start
-	if res, _ := certphase.UsingExternalCA(cfg); res {
+	if res, _ := certphase.UsingExternalCA(&cfg.ClusterConfiguration); res {
 		defaultArguments["cluster-signing-key-file"] = ""
 		defaultArguments["cluster-signing-cert-file"] = ""
 	}

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -892,7 +892,7 @@ func TestGetControllerManagerCommandExternalCA(t *testing.T) {
 			ClusterConfiguration: *test.cfg,
 		}
 
-		if err := certs.CreatePKIAssets(initcfg); err != nil {
+		if err := certs.CreatePKIAssets(&initcfg.ClusterConfiguration, &initcfg.NodeRegistration); err != nil {
 			t.Errorf("failed creating pki assets: %v", err)
 		}
 

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -60,7 +60,7 @@ func GetEtcdPodSpec(cfg *kubeadmapi.InitConfiguration) v1.Pod {
 	return staticpodutil.ComponentPod(v1.Container{
 		Name:            kubeadmconstants.Etcd,
 		Command:         getEtcdCommand(cfg),
-		Image:           images.GetEtcdImage(cfg),
+		Image:           images.GetEtcdImage(&cfg.ClusterConfiguration),
 		ImagePullPolicy: v1.PullIfNotPresent,
 		// Mount the etcd datadir path read-write so etcd can store data in a more persistent manner
 		VolumeMounts: []v1.VolumeMount{

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -199,7 +199,8 @@ func BackupAPIServerCertIfNeeded(cfg *kubeadmapi.InitConfiguration, dryRun bool)
 	return certsphase.CreateCertAndKeyFilesWithCA(
 		&certsphase.KubeadmCertAPIServer,
 		&certsphase.KubeadmCertRootCA,
-		cfg,
+		&cfg.ClusterConfiguration,
+		&cfg.NodeRegistration,
 	)
 }
 

--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -44,12 +44,12 @@ type Prepuller interface {
 // DaemonSetPrepuller makes sure the control plane images are available on all masters
 type DaemonSetPrepuller struct {
 	client clientset.Interface
-	cfg    *kubeadmapi.InitConfiguration
+	cfg    *kubeadmapi.ClusterConfiguration
 	waiter apiclient.Waiter
 }
 
 // NewDaemonSetPrepuller creates a new instance of the DaemonSetPrepuller struct
-func NewDaemonSetPrepuller(client clientset.Interface, waiter apiclient.Waiter, cfg *kubeadmapi.InitConfiguration) *DaemonSetPrepuller {
+func NewDaemonSetPrepuller(client clientset.Interface, waiter apiclient.Waiter, cfg *kubeadmapi.ClusterConfiguration) *DaemonSetPrepuller {
 	return &DaemonSetPrepuller{
 		client: client,
 		cfg:    cfg,

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -188,24 +188,24 @@ func upgradeComponent(component string, waiter apiclient.Waiter, pathMgr StaticP
 	if cfg.Etcd.Local != nil {
 		// ensure etcd certs are generated for etcd and kube-apiserver
 		if component == constants.Etcd || component == constants.KubeAPIServer {
-			caCert, caKey, err := certsphase.KubeadmCertEtcdCA.CreateAsCA(cfg)
+			caCert, caKey, err := certsphase.KubeadmCertEtcdCA.CreateAsCA(&cfg.ClusterConfiguration, &cfg.NodeRegistration)
 			if err != nil {
 				return fmt.Errorf("failed to upgrade the %s CA certificate and key: %v", constants.Etcd, err)
 			}
 
 			if component == constants.Etcd {
-				if err := certsphase.KubeadmCertEtcdServer.CreateFromCA(cfg, caCert, caKey); err != nil {
+				if err := certsphase.KubeadmCertEtcdServer.CreateFromCA(&cfg.ClusterConfiguration, &cfg.NodeRegistration, caCert, caKey); err != nil {
 					return fmt.Errorf("failed to upgrade the %s certificate and key: %v", constants.Etcd, err)
 				}
-				if err := certsphase.KubeadmCertEtcdPeer.CreateFromCA(cfg, caCert, caKey); err != nil {
+				if err := certsphase.KubeadmCertEtcdPeer.CreateFromCA(&cfg.ClusterConfiguration, &cfg.NodeRegistration, caCert, caKey); err != nil {
 					return fmt.Errorf("failed to upgrade the %s peer certificate and key: %v", constants.Etcd, err)
 				}
-				if err := certsphase.KubeadmCertEtcdHealthcheck.CreateFromCA(cfg, caCert, caKey); err != nil {
+				if err := certsphase.KubeadmCertEtcdHealthcheck.CreateFromCA(&cfg.ClusterConfiguration, &cfg.NodeRegistration, caCert, caKey); err != nil {
 					return fmt.Errorf("failed to upgrade the %s healthcheck certificate and key: %v", constants.Etcd, err)
 				}
 			}
 			if component == constants.KubeAPIServer {
-				if err := certsphase.KubeadmCertEtcdAPIClient.CreateFromCA(cfg, caCert, caKey); err != nil {
+				if err := certsphase.KubeadmCertEtcdAPIClient.CreateFromCA(&cfg.ClusterConfiguration, &cfg.NodeRegistration, caCert, caKey); err != nil {
 					return fmt.Errorf("failed to upgrade the %s %s-client certificate and key: %v", constants.KubeAPIServer, constants.Etcd, err)
 				}
 			}

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -430,7 +430,7 @@ func TestStaticPodControlPlane(t *testing.T) {
 			t.Fatalf("couldn't get cert tree: %v", err)
 		}
 
-		if err := tree.CreateTree(oldcfg); err != nil {
+		if err := tree.CreateTree(&oldcfg.ClusterConfiguration, &oldcfg.NodeRegistration); err != nil {
 			t.Fatalf("couldn't get create cert tree: %v", err)
 		}
 
@@ -604,5 +604,11 @@ func TestCleanupDirs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func wrapClusterConfigOnlyFunc(f func(cfg *kubeadmapi.ClusterConfiguration) error) func(cfg *kubeadmapi.ClusterConfiguration, nr *kubeadmapi.NodeRegistrationOptions) error {
+	return func(cfg *kubeadmapi.ClusterConfiguration, nr *kubeadmapi.NodeRegistrationOptions) error {
+		return f(cfg)
 	}
 }

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -1014,7 +1014,7 @@ func RunPullImagesCheck(execer utilsexec.Interface, cfg *kubeadmapi.InitConfigur
 	}
 
 	checks := []Checker{
-		ImagePullCheck{runtime: containerRuntime, imageList: images.GetAllImages(cfg)},
+		ImagePullCheck{runtime: containerRuntime, imageList: images.GetAllImages(&cfg.ClusterConfiguration)},
 	}
 	return RunChecks(checks, os.Stderr, ignorePreflightErrors)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR is the second in a series, targeting the replacement of InitConfiguration with ClusterConfiguration, when the former is not needed. Please, review only the last commit.

This PR migrates cert and PKI helper APIs to use ClusterConfiguration (and away from InitConfiguration).
    
The certificate and PKI related helper APIs used InitConfiguration. With the introduction of ClusterConfiguration it became more viable to use that instead (in most cases in combination with NodeRegistrationOptions).
    
This change will allow us to avoid the use of InitConfiguration outside of kubeadm init

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs kubernetes/kubeadm#963

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/kind enhancement
/assign @luxas
/assign @timothysc
/assign @fabriziopandini
/cc @stealthybox 

Depends on:
- [X] #67441
- [ ] #67503 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
