### PR TITLE
Add labels to kubectl OWNERS files

### DIFF
--- a/cmd/kubectl/OWNERS
+++ b/cmd/kubectl/OWNERS
@@ -2,3 +2,6 @@ approvers:
 - sig-cli-maintainers
 reviewers:
 - sig-cli
+labels:
+- area/kubectl
+- sig/cli

--- a/pkg/kubectl/OWNERS
+++ b/pkg/kubectl/OWNERS
@@ -3,4 +3,5 @@ approvers:
 reviewers:
 - sig-cli
 labels:
+- area/kubectl
 - sig/cli


### PR DESCRIPTION
**What this PR does / why we need it**:

This change makes it possible to automatically add the two labels: `area/kubectl` and `sig/cli` to PRs that touch the paths in question.

this already exists for kubeadm:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS#L17-L19

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs https://github.com/kubernetes/community/issues/1808

**Special notes for your reviewer**:
none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/area kubectl
@kubernetes/sig-cli-pr-reviews 
/cc @cblecker @tpepper 
