### PR TITLE
Add e2e Test Description to User-Agent

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -155,6 +155,15 @@ func (f *Framework) BeforeEach() {
 	if f.ClientSet == nil {
 		By("Creating a kubernetes client")
 		config, err := LoadConfig()
+		testDesc := CurrentGinkgoTestDescription()
+		if len(testDesc.ComponentTexts) > 0 {
+			componentTexts := strings.Join(testDesc.ComponentTexts, " ")
+			config.UserAgent = fmt.Sprintf(
+				"%v -- %v",
+				rest.DefaultKubernetesUserAgent(),
+				componentTexts)
+		}
+
 		Expect(err).NotTo(HaveOccurred())
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst


### PR DESCRIPTION
This PR appends detail e2e test line number and test details to the User-Agent.
It's needed for https://github.com/kubernetes/community/pull/2363 and Conformance Data gathering.

This can be easily tested with any 1.12.0-alpha or later that is configured for audit-logging.

Here is an example using the test-infra/kubetest dind from https://github.com/kubernetes/test-infra/pull/9061

```
  cd ~/go/src/k8s.io/kubernetes/
  go get -u k8s.io/test-infra/kubetest
  kubetest --build=dind
  kubetest --up --deployment=dind
  export KUBERNETES_CONFORMANCE_TEST=y
  export KUBECONFIG=$(ls -rt /tmp/k8s-dind-kubecfg-* | tail -1)
  export DIND_K8S_DATA=$(ls -drt /tmp/dind-k8* | tail -1)
  make -j 8 GOGCFLAGS="-N -l -v" WHAT=test/e2e/e2e.test
  ./_output/local/bin/linux/amd64/e2e.test \
    --ginkgo.focus=\[Conformance\] \
    --ginkgo.seed=1436380640 \
    --v=2 \
    --ginkgo.skip='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort' 
  cp $DIND_KCS_DATA/audit/audit.log .
```

```
e2e.test/v1.12.0 (linux/amd64) kubernetes/94c2c6c -- k8s.io/kubernetes/test/e2e/kubectl/portforward.go:496 -- [sig-cli] Kubectl Port forwarding [k8s.io] With a server listening on localhost [k8s.io] that expects NO client request should support a client that connects, sends DATA, and disconnects
e2e.test/v1.12.0 (linux/amd64) kubernetes/94c2c6c -- k8s.io/kubernetes/test/e2e/network/dns.go:158 -- [sig-network] DNS should provide DNS for ExternalName services
e2e.test/v1.12.0 (linux/amd64) kubernetes/94c2c6c -- k8s.io/kubernetes/test/e2e/framework/framework.go:710 -- [sig-cli] Kubectl client [k8s.io] Kubectl cluster-info should check if Kubernetes master services is included in cluster-info  [Conformance]
e2e.test/v1.12.0 (linux/amd64) kubernetes/94c2c6c -- k8s.io/kubernetes/test/e2e/storage/persistent_volumes-local.go:562 -- [sig-storage] PersistentVolumes-local  StatefulSet with pod affinity should use volumes on one node when pod has affinity
```

Sample log file from e2e run:

[audit.log.gz](https://github.com/kubernetes/kubernetes/files/2298944/audit.log.gz)
