### PR TITLE
Fixes incorrect strategicpatch behavior on deleting un-existing keys

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -428,6 +428,52 @@ testCases:
     modified:
       retainKeysMap:
         name: foo
+  - description: retainKeys map can delete an unexisting merging list
+    original:
+      retainKeysMap: {}
+    twoWay:
+      retainKeysMap:
+        mergingList:
+          - name: noxu 
+            $patch: delete
+    modified:
+      retainKeysMap:
+        mergingList: []
+  - description: retainKeys map can replace an unexisting merging list
+    original:
+      retainKeysMap: {}
+    twoWay:
+      retainKeysMap:
+        mergingList:
+          - name: noxu
+            $patch: replace
+    modified:
+      retainKeysMap:
+        mergingList:
+          - name: noxu
+            $patch: replace
+  - description: retainKeys map can delete an unexisting nested map
+    original:
+      retainKeysMap: {}
+    twoWay:
+      retainKeysMap:
+        simpleMap:
+          $patch: delete
+    modified:
+      retainKeysMap:
+        simpleMap: {}
+  - description: retainKeys map can replace an unexisting nested map
+    original:
+      retainKeysMap: {}
+    twoWay:
+      retainKeysMap:
+        simpleMap:
+          $patch: replace
+          noxu: foo
+    modified:
+      retainKeysMap:
+        simpleMap:
+          noxu: foo
   - description: retainKeys map merge an empty map
     original:
       retainKeysMap:

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -22,6 +22,15 @@ const (
 	patchMergeKeyTagKey = "patchMergeKey"
 )
 
+type FieldNotFoundError struct {
+	Name      string
+	JsonField string
+}
+
+func (err FieldNotFoundError) Error() string {
+	return fmt.Sprintf("unable to find api field in struct %s for the json field %q", err.Name, err.JsonField)
+}
+
 // Finds the patchStrategy and patchMergeKey struct tag fields on a given
 // struct field given the struct type and the JSON name of the field.
 // It returns field type, a slice of patch strategies, merge key and error.
@@ -65,7 +74,10 @@ func LookupPatchMetadataForStruct(t reflect.Type, jsonField string) (
 		elemType = tjf.Type
 		return
 	}
-	e = fmt.Errorf("unable to find api field in struct %s for the json field %q", t.Name(), jsonField)
+	e = FieldNotFoundError{
+		Name:      t.Name(),
+		JsonField: jsonField,
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

when we delete an unexisting key via strategic patch, we'll find the key will be unexpectedly created somehow. this pull fixes the behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67546

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes unexpected new key occurrence when deleting unexisting key via strategic patch 
```
