### PR TITLE
log the event of scheduler 

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -148,6 +148,7 @@ func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error 
 
 	// Prepare the event broadcaster.
 	if c.Broadcaster != nil && c.EventClient != nil {
+		c.Broadcaster.StartLogging(glog.Infof)
 		c.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.EventClient.Events("")})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
print the result of pod scheduler 
```
I0821 01:56:46.065753   28603 event.go:221] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-xxrvd", UID:"675c2f22-a4a2-11e8-bcf3-002dc92800b3", APIVersion:"v1", ResourceVersion:"14951646", FieldPath:""}): type: 'Normal' reason: 'Scheduled' Successfully assigned default/nginx-xxrvd to 10.62.40.149

I0821 02:12:40.681420   28603 event.go:221] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-bjg2h", UID:"8cc7fc54-a4a4-11e8-bcf3-002dc92800b3", APIVersion:"v1", ResourceVersion:"14952774", FieldPath:""}): type: 'Warning' reason: 'FailedScheduling' 0/1 nodes are available: 1 Insufficient cpu.
I0821 02:12:50.689476   28603 event.go:221] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-bjg2h", UID:"8cc7fc54-a4a4-11e8-bcf3-002dc92800b3", APIVersion:"v1", ResourceVersion:"14952774", FieldPath:""}): type: 'Warning' reason: 'FailedScheduling' 0/1 nodes are available: 1 Insufficient cpu.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67589 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
