### PR TITLE
Add sig/api-machinery label to apimachinery OWNERS files

### DIFF
--- a/cmd/cloud-controller-manager/OWNERS
+++ b/cmd/cloud-controller-manager/OWNERS
@@ -9,3 +9,5 @@ reviewers:
 - wlan0
 - andrewsykim
 - stewart-yu
+labels:
+- sig/api-machinery

--- a/cmd/controller-manager/OWNERS
+++ b/cmd/controller-manager/OWNERS
@@ -10,3 +10,5 @@ reviewers:
 - liggitt
 - sttts
 - stewart-yu
+labels:
+- sig/api-machinery

--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -21,3 +21,6 @@ reviewers:
 - sttts
 - hzxuzhonghu
 - CaoShuFeng
+labels:
+- sig/api-machinery
+- area/apiserver

--- a/cmd/kube-controller-manager/OWNERS
+++ b/cmd/kube-controller-manager/OWNERS
@@ -63,3 +63,5 @@ reviewers:
 - thockin
 - timothysc
 - wojtek-t
+labels:
+- sig/api-machinery

--- a/pkg/controller/garbagecollector/OWNERS
+++ b/pkg/controller/garbagecollector/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 - caesarxuchao
 - lavalamp
 - deads2k
+labels:
+- sig/api-machinery

--- a/pkg/controller/namespace/OWNERS
+++ b/pkg/controller/namespace/OWNERS
@@ -1,3 +1,5 @@
 reviewers:
 - derekwaynecarr
 - smarterclayton
+labels:
+- sig/api-machinery

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -8,3 +8,6 @@ reviewers:
 - lavalamp
 - liggitt
 - sttts
+labels:
+- sig/api-machinery
+- area/apiserver

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -39,3 +39,5 @@ reviewers:
 - hongchaodeng
 - jszczepkowski
 - enj
+labels:
+- sig/api-machinery

--- a/pkg/quota/OWNERS
+++ b/pkg/quota/OWNERS
@@ -7,3 +7,5 @@ reviewers:
 - derekwaynecarr
 - smarterclayton
 - vishh
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -7,3 +7,6 @@ approvers:
 - deads2k
 - lavalamp
 - sttts
+labels:
+- sig/api-machinery
+- area/custom-resources

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -19,3 +19,5 @@ reviewers:
 - sttts
 - ncdc
 - tallclair
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -17,3 +17,6 @@ reviewers:
 - enj
 - hzxuzhonghu
 - CaoShuFeng
+labels:
+- sig/api-machinery
+- area/apiserver

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -13,3 +13,5 @@ reviewers:
 - soltysh
 - sttts
 - yliaog
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/code-generator/OWNERS
+++ b/staging/src/k8s.io/code-generator/OWNERS
@@ -6,3 +6,6 @@ reviewers:
 - lavalamp
 - wojtek-t
 - sttts
+labels:
+- sig/api-machinery
+- area/code-generation

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -10,3 +10,5 @@ reviewers:
 - liggitt
 - sttts
 - cheftako
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -10,3 +10,5 @@ reviewers:
 - deads2k
 - sttts
 - liggitt
+labels:
+- sig/api-machinery

--- a/staging/src/k8s.io/sample-controller/OWNERS
+++ b/staging/src/k8s.io/sample-controller/OWNERS
@@ -7,3 +7,5 @@ reviewers:
 - sttts
 - munnerz
 - nikhita
+labels:
+- sig/api-machinery


### PR DESCRIPTION
Inspired by https://github.com/kubernetes/kubernetes/pull/67548. List of OWNERS files taken from https://github.com/kubernetes/community/blob/master/sig-api-machinery/README.md#subprojects.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
