### PR TITLE
Add labels to kubelet OWNERS files

### DIFF
--- a/cmd/kubelet/OWNERS
+++ b/cmd/kubelet/OWNERS
@@ -7,4 +7,5 @@ approvers:
 reviewers:
 - sig-node-reviewers
 labels:
+- area/kubelet
 - sig/node

--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -8,4 +8,5 @@ approvers:
 reviewers:
 - sig-node-reviewers
 labels:
+- area/kubelet
 - sig/node


### PR DESCRIPTION
**What this PR does / why we need it**:

This change makes it possible to automatically add the two labels: `area/kubelet` to PRs that touch the paths in question.

this already exists for kubeadm:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS#L17-L19

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
refs https://github.com/kubernetes/community/issues/1808

**Special notes for your reviewer**:
none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/area kubelet
@kubernetes/sig-node-pr-reviews 
