### PR TITLE
attach: Move the AttachFunc default function to the initializer

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -89,7 +89,8 @@ func NewAttachOptions(streams genericclioptions.IOStreams) *AttachOptions {
 		StreamOptions: StreamOptions{
 			IOStreams: streams,
 		},
-		Attach: &DefaultRemoteAttach{},
+		Attach:     &DefaultRemoteAttach{},
+		AttachFunc: defaultAttachFunc,
 	}
 }
 
@@ -192,8 +193,6 @@ func (o *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 	o.Config = config
-
-	o.AttachFunc = defaultAttachFunc
 
 	if o.CommandName == "" {
 		o.CommandName = cmd.CommandPath()


### PR DESCRIPTION
Fixes a partially constructed AttachOptions

**What this PR does / why we need it**: NewAttachOptions partially constructs an AttachOptions structure. The defaultAttachFunc should be set automatically, so the caller can potentially override the default behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/cc @kubernetes/sig-cli-api-reviews 