### PR TITLE
Fix bazel

### DIFF
--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -23,9 +23,8 @@ go_test(
         "version_test.go",
     ],
     args = ["--kubeadm-path=$(location //cmd/kubeadm:kubeadm)"],
-    data = ["//cmd/kubeadm"],
+    data = ["//cmd/kubeadm"] + glob(["testdata/**"]),
     embed = [":go_default_library"],
-    rundir = ".",
     tags = [
         "integration",
         "skip",

--- a/cmd/kubeadm/test/cmd/completion_test.go
+++ b/cmd/kubeadm/test/cmd/completion_test.go
@@ -19,6 +19,8 @@ package kubeadm
 import "testing"
 
 func TestCmdCompletion(t *testing.T) {
+	kubeadmPath := getKubeadmPath()
+
 	if *kubeadmCmdSkip {
 		t.Log("kubeadm cmd tests being skipped")
 		t.Skip()
@@ -33,7 +35,7 @@ func TestCmdCompletion(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		_, _, actual := RunCmd(*kubeadmPath, "completion", rt.args)
+		_, _, actual := RunCmd(kubeadmPath, "completion", rt.args)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdCompletion running 'kubeadm completion %s' with an error: %v\n\texpected: %t\n\t  actual: %t",

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -23,9 +23,10 @@ import (
 )
 
 func runKubeadmInit(args ...string) (string, string, error) {
+	kubeadmPath := getKubeadmPath()
 	kubeadmArgs := []string{"init", "--dry-run", "--ignore-preflight-errors=all"}
 	kubeadmArgs = append(kubeadmArgs, args...)
-	return RunCmd(*kubeadmPath, kubeadmArgs...)
+	return RunCmd(kubeadmPath, kubeadmArgs...)
 }
 
 func TestCmdInitToken(t *testing.T) {

--- a/cmd/kubeadm/test/cmd/join_test.go
+++ b/cmd/kubeadm/test/cmd/join_test.go
@@ -20,7 +20,8 @@ import "testing"
 
 // kubeadmReset executes "kubeadm reset" and restarts kubelet.
 func kubeadmReset() error {
-	_, _, err := RunCmd(*kubeadmPath, "reset")
+	kubeadmPath := getKubeadmPath()
+	_, _, err := RunCmd(kubeadmPath, "reset")
 	return err
 }
 
@@ -38,8 +39,9 @@ func TestCmdJoinConfig(t *testing.T) {
 		{"--config=/does/not/exist/foo/bar", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinConfig running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -67,8 +69,9 @@ func TestCmdJoinDiscoveryFile(t *testing.T) {
 		{"--discovery-file=file:wrong", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinDiscoveryFile running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -96,8 +99,9 @@ func TestCmdJoinDiscoveryToken(t *testing.T) {
 		{"--discovery-token=token://asdf:asdf", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinDiscoveryToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -124,8 +128,9 @@ func TestCmdJoinNodeName(t *testing.T) {
 		{"--node-name=foobar", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinNodeName running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -153,8 +158,9 @@ func TestCmdJoinTLSBootstrapToken(t *testing.T) {
 		{"--tls-bootstrap-token=token://asdf:asdf", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinTLSBootstrapToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -182,8 +188,9 @@ func TestCmdJoinToken(t *testing.T) {
 		{"--token=token://asdf:asdf", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinToken running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -203,6 +210,7 @@ func TestCmdJoinBadArgs(t *testing.T) {
 		t.Skip()
 	}
 
+	kubeadmPath := getKubeadmPath()
 	var initTest = []struct {
 		args     string
 		expected bool
@@ -212,7 +220,7 @@ func TestCmdJoinBadArgs(t *testing.T) {
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinBadArgs 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -239,8 +247,9 @@ func TestCmdJoinArgsMixed(t *testing.T) {
 		{"--discovery-token=abcdef.1234567890abcdef --config=/etc/kubernetes/kubeadm.config", false},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
+		_, _, actual := RunCmd(kubeadmPath, "join", rt.args, "--ignore-preflight-errors=all")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdJoinArgsMixed running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",

--- a/cmd/kubeadm/test/cmd/version_test.go
+++ b/cmd/kubeadm/test/cmd/version_test.go
@@ -49,8 +49,9 @@ func TestCmdVersion(t *testing.T) {
 		{"", NormalExpectedRegex, true},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range versionTest {
-		stdout, _, actual := RunCmd(*kubeadmPath, "version", rt.args)
+		stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
@@ -88,8 +89,9 @@ func TestCmdVersionOutputJsonOrYaml(t *testing.T) {
 		{"--output=yaml", "yaml", true},
 	}
 
+	kubeadmPath := getKubeadmPath()
 	for _, rt := range versionTest {
-		stdout, _, actual := RunCmd(*kubeadmPath, "version", rt.args)
+		stdout, _, actual := RunCmd(kubeadmPath, "version", rt.args)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdVersion running 'kubeadm version %s' with an error: %v\n\texpected: %t\n\t  actual: %t",


### PR DESCRIPTION
**What this PR does / why we need it**:

`bazel test //cmd/kubeadm/...` has been broken for a while. This is incredibly annoying to me, because I use it constantly during my workflow. This should fix it.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```
