### PR TITLE
Make error messages more helpful in some e2e tests

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -80,16 +80,17 @@ var _ = SIGDescribe("DNS", func() {
 		}
 		headlessService := framework.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create headless service %s", dnsTestServiceName)
 		defer func() {
 			By("deleting the test headless service")
 			defer GinkgoRecover()
 			f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(headlessService.Name, nil)
 		}()
 
-		regularService := framework.CreateServiceSpec("test-service-2", "", false, testServiceSelector)
+		regularServiceName := "test-service-2"
+		regularService := framework.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
 		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(regularService)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create regular service %s", regularServiceName)
 		defer func() {
 			By("deleting the test service")
 			defer GinkgoRecover()
@@ -130,7 +131,7 @@ var _ = SIGDescribe("DNS", func() {
 		podHostname := "dns-querier-2"
 		headlessService := framework.CreateServiceSpec(serviceName, "", true, testServiceSelector)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create headless service %s", serviceName)
 		defer func() {
 			By("deleting the test headless service")
 			defer GinkgoRecover()
@@ -161,7 +162,7 @@ var _ = SIGDescribe("DNS", func() {
 		serviceName := "dns-test-service-3"
 		externalNameService := framework.CreateServiceSpec(serviceName, "foo.example.com", false, nil)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(externalNameService)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ExternalName service %s", serviceName)
 		defer func() {
 			By("deleting the test externalName service")
 			defer GinkgoRecover()
@@ -185,7 +186,7 @@ var _ = SIGDescribe("DNS", func() {
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.ExternalName = "bar.example.com"
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to change externalName of service %s", serviceName)
 		wheezyProbeCmd, wheezyFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "wheezy")
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "jessie")
 		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
@@ -205,7 +206,7 @@ var _ = SIGDescribe("DNS", func() {
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
 			}
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to change service type to clusterIP for service %s", serviceName)
 		wheezyProbeCmd, wheezyFileName = createTargetedProbeCommand(hostFQDN, "A", "wheezy")
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, "A", "jessie")
 		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
@@ -216,7 +217,7 @@ var _ = SIGDescribe("DNS", func() {
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 
 		svc, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(externalNameService.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to get service %s", externalNameService.Name)
 
 		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, svc.Spec.ClusterIP)
 	})

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -80,7 +80,7 @@ var _ = SIGDescribe("DNS", func() {
 		}
 		headlessService := framework.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create headless service %s", dnsTestServiceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to create headless service: %s", dnsTestServiceName)
 		defer func() {
 			By("deleting the test headless service")
 			defer GinkgoRecover()
@@ -90,7 +90,7 @@ var _ = SIGDescribe("DNS", func() {
 		regularServiceName := "test-service-2"
 		regularService := framework.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
 		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(regularService)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create regular service %s", regularServiceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to create regular service: %s", regularServiceName)
 		defer func() {
 			By("deleting the test service")
 			defer GinkgoRecover()
@@ -131,7 +131,7 @@ var _ = SIGDescribe("DNS", func() {
 		podHostname := "dns-querier-2"
 		headlessService := framework.CreateServiceSpec(serviceName, "", true, testServiceSelector)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create headless service %s", serviceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to create headless service: %s", serviceName)
 		defer func() {
 			By("deleting the test headless service")
 			defer GinkgoRecover()
@@ -162,7 +162,7 @@ var _ = SIGDescribe("DNS", func() {
 		serviceName := "dns-test-service-3"
 		externalNameService := framework.CreateServiceSpec(serviceName, "foo.example.com", false, nil)
 		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(externalNameService)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create ExternalName service %s", serviceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to create ExternalName service: %s", serviceName)
 		defer func() {
 			By("deleting the test externalName service")
 			defer GinkgoRecover()
@@ -186,7 +186,7 @@ var _ = SIGDescribe("DNS", func() {
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.ExternalName = "bar.example.com"
 		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to change externalName of service %s", serviceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to change externalName of service: %s", serviceName)
 		wheezyProbeCmd, wheezyFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "wheezy")
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, "CNAME", "jessie")
 		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
@@ -206,7 +206,7 @@ var _ = SIGDescribe("DNS", func() {
 				{Port: 80, Name: "http", Protocol: v1.ProtocolTCP},
 			}
 		})
-		Expect(err).NotTo(HaveOccurred(), "Failed to change service type to clusterIP for service %s", serviceName)
+		Expect(err).NotTo(HaveOccurred(), "failed to change service type to ClusterIP for service: %s", serviceName)
 		wheezyProbeCmd, wheezyFileName = createTargetedProbeCommand(hostFQDN, "A", "wheezy")
 		jessieProbeCmd, jessieFileName = createTargetedProbeCommand(hostFQDN, "A", "jessie")
 		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
@@ -217,7 +217,7 @@ var _ = SIGDescribe("DNS", func() {
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
 
 		svc, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Get(externalNameService.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), "Failed to get service %s", externalNameService.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to get service: %s", externalNameService.Name)
 
 		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, svc.Spec.ClusterIP)
 	})
@@ -233,7 +233,7 @@ var _ = SIGDescribe("DNS", func() {
 			testDNSNameFull: testInjectedIP,
 		})
 		testServerPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(testServerPod)
-		Expect(err).NotTo(HaveOccurred(), "failed to create pod %s", testServerPod.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create pod: %s", testServerPod.Name)
 		framework.Logf("Created pod %v", testServerPod)
 		defer func() {
 			framework.Logf("Deleting pod %s...", testServerPod.Name)
@@ -264,7 +264,7 @@ var _ = SIGDescribe("DNS", func() {
 			},
 		}
 		testUtilsPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(testUtilsPod)
-		Expect(err).NotTo(HaveOccurred(), "failed to create pod %s", testUtilsPod.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to create pod: %s", testUtilsPod.Name)
 		framework.Logf("Created pod %v", testUtilsPod)
 		defer func() {
 			framework.Logf("Deleting pod %s...", testUtilsPod.Name)

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -65,8 +65,9 @@ func (t *dnsTestCommon) init() {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": "kube-dns"}))
 	options := metav1.ListOptions{LabelSelector: label.String()}
 
-	pods, err := t.f.ClientSet.CoreV1().Pods("kube-system").List(options)
-	Expect(err).NotTo(HaveOccurred(), "Failed to list pods")
+	namespace := "kube-system"
+	pods, err := t.f.ClientSet.CoreV1().Pods(namespace).List(options)
+	Expect(err).NotTo(HaveOccurred(), "failed to list pods in namespace: %s", namespace)
 	Expect(len(pods.Items)).Should(BeNumerically(">=", 1))
 
 	t.dnsPod = &pods.Items[0]
@@ -155,23 +156,23 @@ func (t *dnsTestCommon) setConfigMap(cm *v1.ConfigMap) {
 		}.AsSelector().String(),
 	}
 	cmList, err := t.c.CoreV1().ConfigMaps(t.ns).List(options)
-	Expect(err).NotTo(HaveOccurred(), "Failed to list ConfigMaps")
+	Expect(err).NotTo(HaveOccurred(), "failed to list ConfigMaps in namespace: %s", t.ns)
 
 	if len(cmList.Items) == 0 {
 		By(fmt.Sprintf("Creating the ConfigMap (%s:%s) %+v", t.ns, t.name, *cm))
 		_, err := t.c.CoreV1().ConfigMaps(t.ns).Create(cm)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create ConfigMap")
+		Expect(err).NotTo(HaveOccurred(), "failed to create ConfigMap (%s:%s) %+v", t.ns, t.name, *cm)
 	} else {
 		By(fmt.Sprintf("Updating the ConfigMap (%s:%s) to %+v", t.ns, t.name, *cm))
 		_, err := t.c.CoreV1().ConfigMaps(t.ns).Update(cm)
-		Expect(err).NotTo(HaveOccurred(), "Failed to update ConfigMap")
+		Expect(err).NotTo(HaveOccurred(), "failed to update ConfigMap (%s:%s) to %+v", t.ns, t.name, *cm)
 	}
 }
 
 func (t *dnsTestCommon) fetchDNSConfigMapData() map[string]string {
 	if t.name == "coredns" {
 		pcm, err := t.c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(t.name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), "Failed to get DNS ConfigMap")
+		Expect(err).NotTo(HaveOccurred(), "failed to get DNS ConfigMap: %s", t.name)
 		return pcm.Data
 	}
 	return nil
@@ -190,7 +191,7 @@ func (t *dnsTestCommon) deleteConfigMap() {
 	By(fmt.Sprintf("Deleting the ConfigMap (%s:%s)", t.ns, t.name))
 	t.cm = nil
 	err := t.c.CoreV1().ConfigMaps(t.ns).Delete(t.name, nil)
-	Expect(err).NotTo(HaveOccurred(), "Failed to delete config map %s", t.name)
+	Expect(err).NotTo(HaveOccurred(), "failed to delete config map: %s", t.name)
 }
 
 func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
@@ -222,9 +223,9 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 
 	var err error
 	t.utilPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.utilPod)
-	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %v", t.utilPod)
+	Expect(err).NotTo(HaveOccurred(), "failed to create pod: %v", t.utilPod)
 	framework.Logf("Created pod %v", t.utilPod)
-	Expect(t.f.WaitForPodRunning(t.utilPod.Name)).NotTo(HaveOccurred(), "Pod failed to start running %v", t.utilPod)
+	Expect(t.f.WaitForPodRunning(t.utilPod.Name)).NotTo(HaveOccurred(), "pod failed to start running: %v", t.utilPod)
 
 	t.utilService = &v1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -247,7 +248,7 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 	}
 
 	t.utilService, err = t.c.CoreV1().Services(t.f.Namespace.Name).Create(t.utilService)
-	Expect(err).NotTo(HaveOccurred(), "Failed to create service")
+	Expect(err).NotTo(HaveOccurred(), "failed to create service: %s/%s", t.f.Namespace.Name, t.utilService.ObjectMeta.Name)
 	framework.Logf("Created service %v", t.utilService)
 }
 
@@ -270,7 +271,7 @@ func (t *dnsTestCommon) deleteCoreDNSPods() {
 
 	for _, pod := range pods.Items {
 		err = podClient.Delete(pod.Name, metav1.NewDeleteOptions(0))
-		Expect(err).NotTo(HaveOccurred(), "Failed to delete pod %s", pod.Name)
+		Expect(err).NotTo(HaveOccurred(), "failed to delete pod: %s", pod.Name)
 	}
 }
 
@@ -313,13 +314,13 @@ func (t *dnsTestCommon) createDNSPodFromObj(pod *v1.Pod) {
 
 	var err error
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.dnsServerPod)
-	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %v", t.dnsServerPod)
+	Expect(err).NotTo(HaveOccurred(), "failed to create pod: %v", t.dnsServerPod)
 	framework.Logf("Created pod %v", t.dnsServerPod)
-	Expect(t.f.WaitForPodRunning(t.dnsServerPod.Name)).NotTo(HaveOccurred(), "Pod failed to start running %v", t.dnsServerPod)
+	Expect(t.f.WaitForPodRunning(t.dnsServerPod.Name)).NotTo(HaveOccurred(), "pod failed to start running: %v", t.dnsServerPod)
 
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Get(
 		t.dnsServerPod.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s", t.dnsServerPod.Name)
+	Expect(err).NotTo(HaveOccurred(), "failed to get pod: %s", t.dnsServerPod.Name)
 }
 
 func (t *dnsTestCommon) createDNSServer(aRecords map[string]string) {

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -66,7 +66,7 @@ func (t *dnsTestCommon) init() {
 	options := metav1.ListOptions{LabelSelector: label.String()}
 
 	pods, err := t.f.ClientSet.CoreV1().Pods("kube-system").List(options)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to list pods")
 	Expect(len(pods.Items)).Should(BeNumerically(">=", 1))
 
 	t.dnsPod = &pods.Items[0]
@@ -155,23 +155,23 @@ func (t *dnsTestCommon) setConfigMap(cm *v1.ConfigMap) {
 		}.AsSelector().String(),
 	}
 	cmList, err := t.c.CoreV1().ConfigMaps(t.ns).List(options)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to list ConfigMaps")
 
 	if len(cmList.Items) == 0 {
 		By(fmt.Sprintf("Creating the ConfigMap (%s:%s) %+v", t.ns, t.name, *cm))
 		_, err := t.c.CoreV1().ConfigMaps(t.ns).Create(cm)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ConfigMap")
 	} else {
 		By(fmt.Sprintf("Updating the ConfigMap (%s:%s) to %+v", t.ns, t.name, *cm))
 		_, err := t.c.CoreV1().ConfigMaps(t.ns).Update(cm)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to update ConfigMap")
 	}
 }
 
 func (t *dnsTestCommon) fetchDNSConfigMapData() map[string]string {
 	if t.name == "coredns" {
 		pcm, err := t.c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(t.name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to get DNS ConfigMap")
 		return pcm.Data
 	}
 	return nil
@@ -190,7 +190,7 @@ func (t *dnsTestCommon) deleteConfigMap() {
 	By(fmt.Sprintf("Deleting the ConfigMap (%s:%s)", t.ns, t.name))
 	t.cm = nil
 	err := t.c.CoreV1().ConfigMaps(t.ns).Delete(t.name, nil)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to delete config map %s", t.name)
 }
 
 func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
@@ -222,9 +222,9 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 
 	var err error
 	t.utilPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.utilPod)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %v", t.utilPod)
 	framework.Logf("Created pod %v", t.utilPod)
-	Expect(t.f.WaitForPodRunning(t.utilPod.Name)).NotTo(HaveOccurred())
+	Expect(t.f.WaitForPodRunning(t.utilPod.Name)).NotTo(HaveOccurred(), "Pod failed to start running %v", t.utilPod)
 
 	t.utilService = &v1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -247,7 +247,7 @@ func (t *dnsTestCommon) createUtilPodLabel(baseName string) {
 	}
 
 	t.utilService, err = t.c.CoreV1().Services(t.f.Namespace.Name).Create(t.utilService)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to create service")
 	framework.Logf("Created service %v", t.utilService)
 }
 
@@ -270,7 +270,7 @@ func (t *dnsTestCommon) deleteCoreDNSPods() {
 
 	for _, pod := range pods.Items {
 		err = podClient.Delete(pod.Name, metav1.NewDeleteOptions(0))
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to delete pod %s", pod.Name)
 	}
 }
 
@@ -313,13 +313,13 @@ func (t *dnsTestCommon) createDNSPodFromObj(pod *v1.Pod) {
 
 	var err error
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Create(t.dnsServerPod)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to create pod %v", t.dnsServerPod)
 	framework.Logf("Created pod %v", t.dnsServerPod)
-	Expect(t.f.WaitForPodRunning(t.dnsServerPod.Name)).NotTo(HaveOccurred())
+	Expect(t.f.WaitForPodRunning(t.dnsServerPod.Name)).NotTo(HaveOccurred(), "Pod failed to start running %v", t.dnsServerPod)
 
 	t.dnsServerPod, err = t.c.CoreV1().Pods(t.f.Namespace.Name).Get(
 		t.dnsServerPod.Name, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to get pod %s", t.dnsServerPod.Name)
 }
 
 func (t *dnsTestCommon) createDNSServer(aRecords map[string]string) {

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -81,8 +81,9 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		namespaces := []*v1.Namespace{nil, nil}
 		for i := range namespaces {
 			var err error
-			namespaces[i], err = f.CreateNamespace(fmt.Sprintf("dnsexample%d", i), nil)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+			namespaceName := fmt.Sprintf("dnsexample%d", i)
+			namespaces[i], err = f.CreateNamespace(namespaceName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create namespace: %s", namespaceName)
 		}
 
 		for _, ns := range namespaces {
@@ -104,7 +105,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"name": backendRcName}))
 			options := metav1.ListOptions{LabelSelector: label.String()}
 			pods, err := c.CoreV1().Pods(ns.Name).List(options)
-			Expect(err).NotTo(HaveOccurred(), "Failed to list pods in namespace %s", ns.Name)
+			Expect(err).NotTo(HaveOccurred(), "failed to list pods in namespace: %s", ns.Name)
 			err = framework.PodsResponding(c, ns.Name, backendPodName, false, pods)
 			Expect(err).NotTo(HaveOccurred(), "waiting for all pods to respond")
 			framework.Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
@@ -151,7 +152,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		// wait for pods to print their result
 		for _, ns := range namespaces {
 			_, err := framework.LookForStringInLog(ns.Name, frontendPodName, frontendPodContainerName, podOutput, framework.PodStartTimeout)
-			Expect(err).NotTo(HaveOccurred(), "Pod %s failed to print result in logs", frontendPodName)
+			Expect(err).NotTo(HaveOccurred(), "pod %s failed to print result in logs", frontendPodName)
 		}
 	})
 })
@@ -163,10 +164,10 @@ func getNsCmdFlag(ns *v1.Namespace) string {
 // pass enough context with the 'old' parameter so that it replaces what your really intended.
 func prepareResourceWithReplacedString(inputFile, old, new string) string {
 	f, err := os.Open(inputFile)
-	Expect(err).NotTo(HaveOccurred(), "Failed to open file")
+	Expect(err).NotTo(HaveOccurred(), "failed to open file: %s", inputFile)
 	defer f.Close()
 	data, err := ioutil.ReadAll(f)
-	Expect(err).NotTo(HaveOccurred(), "Failed to read from file")
+	Expect(err).NotTo(HaveOccurred(), "failed to read from file: %s", inputFile)
 	podYaml := strings.Replace(string(data), old, new, 1)
 	return podYaml
 }

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		for i := range namespaces {
 			var err error
 			namespaces[i], err = f.CreateNamespace(fmt.Sprintf("dnsexample%d", i), nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
 		}
 
 		for _, ns := range namespaces {
@@ -104,7 +104,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"name": backendRcName}))
 			options := metav1.ListOptions{LabelSelector: label.String()}
 			pods, err := c.CoreV1().Pods(ns.Name).List(options)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to list pods in namespace %s", ns.Name)
 			err = framework.PodsResponding(c, ns.Name, backendPodName, false, pods)
 			Expect(err).NotTo(HaveOccurred(), "waiting for all pods to respond")
 			framework.Logf("found %d backend pods responding in namespace %s", len(pods.Items), ns.Name)
@@ -151,7 +151,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		// wait for pods to print their result
 		for _, ns := range namespaces {
 			_, err := framework.LookForStringInLog(ns.Name, frontendPodName, frontendPodContainerName, podOutput, framework.PodStartTimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Pod %s failed to print result in logs", frontendPodName)
 		}
 	})
 })
@@ -163,10 +163,10 @@ func getNsCmdFlag(ns *v1.Namespace) string {
 // pass enough context with the 'old' parameter so that it replaces what your really intended.
 func prepareResourceWithReplacedString(inputFile, old, new string) string {
 	f, err := os.Open(inputFile)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to open file")
 	defer f.Close()
 	data, err := ioutil.ReadAll(f)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Failed to read from file")
 	podYaml := strings.Replace(string(data), old, new, 1)
 	return podYaml
 }


### PR DESCRIPTION
Related to issues 34059 and 10322

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes error messages more helpful in some e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is my first time writing Go/Contributing to Kubernetes - let me know if I've missed anything! :-)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
