### PR TITLE
Push master ca-certs to kube-system ConfigMap

### DIFF
--- a/cluster/gce/gci/BUILD
+++ b/cluster/gce/gci/BUILD
@@ -5,6 +5,7 @@ load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 go_test(
     name = "go_default_test",
     srcs = [
+        "addons_manifest_test.go",
         "apiserver_manifest_test.go",
         "configure_helper_test.go",
     ],
@@ -16,6 +17,8 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 

--- a/cluster/gce/gci/addons_manifest_test.go
+++ b/cluster/gce/gci/addons_manifest_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gci
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+)
+
+const (
+	/*
+	   Template for defining the environment state of configure-helper.sh
+	   The environment of configure-helper.sh is initially configured via kube-env file. However, as deploy-helper
+	   executes new variables are created. ManifestTestCase does not care where a variable came from. However, future
+	   test scenarios, may require such a distinction.
+	   The list of variables is, by no means, complete - this is what is required to run currently defined tests.
+	*/
+	kubeAddonsEnvTmpl = `
+readonly KUBE_HOME={{.KubeHome}}
+readonly SSL_CERT_FILE={{.SSLCertFile}}
+`
+)
+
+type kubeAddonsEnv struct {
+	KubeHome    string
+	SSLCertFile string
+}
+
+func TestSetupSystemCACertsManifest(t *testing.T) {
+	const fakeCertData = "-----FAKE CERT DATA-----"
+	fakeCertFile, err := ioutil.TempFile("", "fake-cert")
+	require.NoError(t, err)
+	defer os.Remove(fakeCertFile.Name())
+	_, err = fakeCertFile.WriteString(fakeCertData)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		sslCertFileEnv string
+		expectations   func(t *testing.T, certsData string)
+	}{
+		"use host certs": {"", func(t *testing.T, certsData string) {
+			assert.Contains(t, certsData, "-----BEGIN CERTIFICATE-----", "Should container certificate data")
+			assert.Contains(t, certsData, "-----END CERTIFICATE-----", "Should container certificate data")
+		}},
+		"use fake cert": {fakeCertFile.Name(), func(t *testing.T, certsData string) {
+			assert.Equal(t, fakeCertData, certsData, "Should have fake cert data")
+		}},
+		"use non-existent cert file": {"/bogus-certs-file.crt", func(t *testing.T, certsData string) {
+			assert.Empty(t, certsData, "Should not have cert data")
+		}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseDir, err := ioutil.TempDir("", "configure-helper-test") // cleaned up by c.tearDown()
+			require.NoError(t, err, "Failed to create temp directory")
+
+			c := ManifestTestCase{
+				t:                t,
+				kubeHome:         baseDir,
+				manifestFuncName: fmt.Sprintf("setup-system-cacerts-manifest %s", baseDir),
+			}
+			defer c.tearDown()
+
+			c.mustInvokeFunc(kubeAddonsEnvTmpl, kubeAddonsEnv{
+				KubeHome:    c.kubeHome,
+				SSLCertFile: test.sslCertFileEnv,
+			})
+
+			manifestPath := filepath.Join(baseDir, "system-cacerts-configmap.yaml")
+			cm := &v1.ConfigMap{}
+			c.mustLoadManifest(manifestPath, cm)
+
+			certsData := cm.Data["ca-certificates.crt"]
+			certsData = strings.SplitAfter(certsData, "-----END CERTIFICATE-----")[0] // Limit size of error message
+			test.expectations(t, certsData)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

On cluster startup, write the master's root ca-certificates to a ConfigMap (`system-cacerts`) in the `kube-system` namespace.

The purpose is to provide ca-certificates to containers that can otherwise be built on scratch. This will let us migrate several addon containers away from alpine & debian base images.

**Which issue(s) this PR fixes**:
Partially addresses https://github.com/kubernetes/kubernetes/issues/63726

Specifically, it only provides a solution for kube-system addons. This is not a general solution, and should be replaced with the general solution once one exists.

**Special notes for your reviewer**:

Are the cluster/addons manifests consumed by kubeadm or other cluster startup scripts? If so, how should we handle that?
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
```release-note
NONE
```
