### PR TITLE
Allow adding default capabilities to unprivileged addons

### DIFF
--- a/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
+++ b/cluster/gce/addons/podsecuritypolicies/unprivileged-addon.yaml
@@ -19,6 +19,22 @@ metadata:
 spec:
   privileged: false
   allowPrivilegeEscalation: false
+  # The docker default set of capabilities
+  allowedCapabilities:
+  - SETPCAP
+  - MKNOD
+  - AUDIT_WRITE
+  - CHOWN
+  - NET_RAW
+  - DAC_OVERRIDE
+  - FOWNER
+  - FSETID
+  - KILL
+  - SETGID
+  - SETUID
+  - NET_BIND_SERVICE
+  - SYS_CHROOT
+  - SETFCAP
   volumes:
   - 'emptyDir'
   - 'configMap'


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow adding the default set of capabilities back to unprivileged addons, when using the the default GCE PodSecurityPolicies. This is useful when paired with `drop: [ 'all' ]`

This is not a relaxation of permissions, as a pod that didn't touch capabilities (implicitly has the default set) is already allowed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/dns/issues/254

**Release note**:
```release-note
NONE
```