### PR TITLE
Supplementary information for common flags and add restart second config

### DIFF
--- a/cluster/centos/master/scripts/apiserver.sh
+++ b/cluster/centos/master/scripts/apiserver.sh
@@ -66,6 +66,8 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}"
 #   LimitRanger, AlwaysDeny, SecurityContextDeny, NamespaceExists,
 #   NamespaceLifecycle, NamespaceAutoProvision, AlwaysAdmit,
 #   ServiceAccount, DefaultStorageClass, DefaultTolerationSeconds, ResourceQuota
+# Mark Deprecated. Use --enable-admission-plugins or --disable-admission-plugins instead since v1.10.
+# It will be removed in a future version.
 KUBE_ADMISSION_CONTROL="--admission-control=${ADMISSION_CONTROL}"
 
 # --client-ca-file="": If set, any request presenting a client certificate signed

--- a/cluster/centos/master/scripts/controller-manager.sh
+++ b/cluster/centos/master/scripts/controller-manager.sh
@@ -30,7 +30,8 @@ KUBE_CONTROLLER_MANAGER_ROOT_CA_FILE="--root-ca-file=/srv/kubernetes/ca.crt"
 # RSA key used to sign service account tokens.
 KUBE_CONTROLLER_MANAGER_SERVICE_ACCOUNT_PRIVATE_KEY_FILE="--service-account-private-key-file=/srv/kubernetes/server.key"
 
-# --leader-elect
+# --leader-elect: Start a leader election client and gain leadership before 
+# executing the main loop. Enable this when running replicated components for high availability.
 KUBE_LEADER_ELECT="--leader-elect"
 EOF
 

--- a/cluster/centos/master/scripts/scheduler.sh
+++ b/cluster/centos/master/scripts/scheduler.sh
@@ -27,9 +27,11 @@ KUBE_LOGTOSTDERR="--logtostderr=true"
 # --v=0: log level for V logs
 KUBE_LOG_LEVEL="--v=4"
 
+# --master: The address of the Kubernetes API server (overrides any value in kubeconfig).
 KUBE_MASTER="--master=${MASTER_ADDRESS}:8080"
 
-# --leader-elect
+# --leader-elect: Start a leader election client and gain leadership before 
+# executing the main loop. Enable this when running replicated components for high availability.
 KUBE_LEADER_ELECT="--leader-elect"
 
 # Add your own!

--- a/cluster/centos/node/scripts/kubelet.sh
+++ b/cluster/centos/node/scripts/kubelet.sh
@@ -87,6 +87,7 @@ EnvironmentFile=-/opt/kubernetes/cfg/kubelet
 ExecStart=/opt/kubernetes/bin/kubelet ${KUBELET_OPTS}
 Restart=on-failure
 KillMode=process
+RestartSec=15s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
the admission-control flag has been marked deprecated, it need to be updated.
And provide them  with supplementary information about flags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/issues/67627

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
