### PR TITLE
Support get log level dynamically

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -414,7 +414,7 @@ func (s *Server) InstallDebuggingHandlers(criHandler http.Handler) {
 
 	// Setup flags handlers.
 	// so far, only logging related endpoints are considered valid to add for these debug flags.
-	s.restfulCont.Handle("/debug/flags/v", routes.StringFlagPutHandler(logs.GlogSetter))
+	s.restfulCont.Handle("/debug/flags/v", routes.StringFlagPutOrGetHandler(logs.GlogSetter, logs.GlogGetter))
 
 	// The /runningpods endpoint is used for testing only.
 	ws = new(restful.WebService)

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -565,7 +565,7 @@ func installAPI(s *GenericAPIServer, c *Config) {
 			goruntime.SetBlockProfileRate(1)
 		}
 		// so far, only logging related endpoints are considered valid to add for these debug flags.
-		routes.DebugFlags{}.Install(s.Handler.NonGoRestfulMux, "v", routes.StringFlagPutHandler(logs.GlogSetter))
+		routes.DebugFlags{}.Install(s.Handler.NonGoRestfulMux, "v", routes.StringFlagPutOrGetHandler(logs.GlogSetter, logs.GlogGetter))
 	}
 	if c.EnableMetrics {
 		if c.EnableProfiling {

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
@@ -93,8 +93,11 @@ func (f DebugFlags) addFlag(flag string) {
 // StringFlagSetterFunc is a func used for setting string type flag.
 type StringFlagSetterFunc func(string) (string, error)
 
-// StringFlagPutHandler wraps an http Handler to set string type flag.
-func StringFlagPutHandler(setter StringFlagSetterFunc) http.HandlerFunc {
+// StringFlagGetterFunc is a func used for getting string type flag.
+type StringFlagGetterFunc func() string
+
+// StringFlagPutOrGetHandler wraps an http Handler to set or get string type flag.
+func StringFlagPutOrGetHandler(setter StringFlagSetterFunc, getter StringFlagGetterFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == "PUT":
@@ -109,6 +112,10 @@ func StringFlagPutHandler(setter StringFlagSetterFunc) http.HandlerFunc {
 				writePlainText(http.StatusBadRequest, err.Error(), w)
 				return
 			}
+			writePlainText(http.StatusOK, response, w)
+			return
+		case req.Method == "GET":
+			response := getter()
 			writePlainText(http.StatusOK, response, w)
 			return
 		default:

--- a/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
@@ -77,3 +77,10 @@ func GlogSetter(val string) (string, error) {
 	}
 	return fmt.Sprintf("successfully set glog.logging.verbosity to %s", val), nil
 }
+
+// GlogGetter is used to get glog level.
+func GlogGetter() string {
+	currentLevel := flag.Lookup("v").Value.(flag.Getter).Get().(glog.Level)
+	return currentLevel.String()
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I see there are set log level dynamically in PR #63777 #64601 
I think it is helpful for getting log level dynamically

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 when you want to get glog level , you can send a GET request like `curl -X GET http://127.0.0.1:8080/debug/flags/v` .
```
