### PR TITLE
Fix validate-cluster.sh for clusters with more than 500 nodes.

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -98,7 +98,13 @@ while true; do
   #
   # We are assigning the result of kubectl_retry get nodes operation to the res
   # variable in that way, to prevent stopping the whole script on an error.
-  node=$(kubectl_retry get nodes) && res="$?" || res="$?"
+  #
+  # Bash command substitution $(kubectl_...) removes all trailing whitespaces
+  # which are important for line counting.
+  # Use trick from https://unix.stackexchange.com/a/383411 to avoid
+  # newline truncation.
+  node=$(kubectl_retry get nodes --no-headers; ret=$?; echo .; exit "$ret") && res="$?" || res="$?"
+  node="${node%.}"
   if [ "${res}" -ne "0" ]; then
     if [[ "${attempt}" -gt "${last_run:-$MAX_ATTEMPTS}" ]]; then
       echo -e "${color_red} Failed to get nodes.${color_norm}"
@@ -107,8 +113,9 @@ while true; do
       continue
     fi
   fi
-  found=$(($(echo "${node}" | wc -l) - 1))
-  ready=$(($(echo "${node}" | grep -v "NotReady" | wc -l ) - 1))
+  found=$(echo -n "${node}" | wc -l)
+  # Use grep || true so that empty result doesn't return nonzero exit code.
+  ready=$(echo -n "${node}" | grep -c -v "NotReady" || true)
 
   if (( "${found}" == "${EXPECTED_NUM_NODES}" )) && (( "${ready}" == "${EXPECTED_NUM_NODES}")); then
     break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Without the change, validate-cluster.sh counts nodes using 'wc -l' minus one (header).
kubectl repeats header every 500 rows, so for bigger clusters this doesn't work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67597

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
