### PR TITLE
[kubeadm] fix panic when node annotation is nil

### DIFF
--- a/cmd/kubeadm/app/phases/patchnode/patchnode.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode.go
@@ -36,5 +36,8 @@ func AnnotateCRISocket(client clientset.Interface, nodeName string, criSocket st
 }
 
 func annotateNodeWithCRISocket(n *v1.Node, criSocket string) {
+	if n.ObjectMeta.Annotations == nil {
+		n.ObjectMeta.Annotations = make(map[string]string)
+	}
 	n.ObjectMeta.Annotations[constants.AnnotationKubeadmCRISocket] = criSocket
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
kubeadm will panic, when the node annotation is nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @neolit123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm:  Fix panic when node annotation is nil
```
