### PR TITLE
Run ceph-fuse in isolated systemd scope

### DIFF
--- a/pkg/util/mount/BUILD
+++ b/pkg/util/mount/BUILD
@@ -14,6 +14,8 @@ go_library(
         "mount_windows.go",
         "nsenter_mount.go",
         "nsenter_mount_unsupported.go",
+        "systemd.go",
+        "systemd_unsupported.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/util/mount",
     visibility = ["//visibility:public"],

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -108,7 +108,8 @@ func (n *NsenterMounter) makeNsenterArgs(source, target, fstype string, options 
 		//   Kubelet container can be restarted and the fuse daemon survives.
 		// * When the daemon dies (e.g. during unmount) systemd removes the
 		//   scope automatically.
-		mountCmd, mountArgs = addSystemdScope(systemdRunPath, target, mountCmd, mountArgs)
+		description := fmt.Sprintf("Kubernetes transient mount for %s", target)
+		mountCmd, mountArgs = AddSystemdScope(systemdRunPath, description, mountCmd, mountArgs)
 	} else {
 		// Fall back to simple mount when the host has no systemd.
 		// Complete command line:

--- a/pkg/util/mount/systemd.go
+++ b/pkg/util/mount/systemd.go
@@ -1,0 +1,59 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"github.com/golang/glog"
+)
+
+const (
+	defaultSystemdRunPath = "systemd-run"
+)
+
+// DetectSystemd returns true if OS runs with systemd as init. When not sure
+// (permission errors, ...), it returns false.
+// There may be different ways how to detect systemd, this one makes sure that
+// systemd-runs works.
+func DetectSystemd(exec Exec, systemdRunPath string) bool {
+	if systemdRunPath == "" {
+		systemdRunPath = defaultSystemdRunPath
+	}
+	// Try to run systemd-run --scope /bin/true, that should be enough
+	// to make sure that systemd is really running and not just installed,
+	// which happens when running in a container with a systemd-based image
+	// but with different pid 1.
+	output, err := exec.Run(systemdRunPath, "--description=Kubernetes systemd probe", "--scope", "true")
+	if err != nil {
+		glog.V(4).Infof("Cannot run systemd-run, assuming non-systemd OS")
+		glog.V(4).Infof("systemd-run failed with: %v", err)
+		glog.V(4).Infof("systemd-run output: %s", string(output))
+		return false
+	}
+	return true
+}
+
+// AddSystemdScope adds "system-run --scope" to given command line. This helps
+// to run command in isolated scope.
+func AddSystemdScope(systemdRunPath string, description, command string, args []string) (string, []string) {
+	if systemdRunPath == "" {
+		systemdRunPath = defaultSystemdRunPath
+	}
+	systemdRunArgs := []string{"--description", description, "--scope", "--", command}
+	return systemdRunPath, append(systemdRunArgs, args...)
+}

--- a/pkg/util/mount/systemd_unsupported.go
+++ b/pkg/util/mount/systemd_unsupported.go
@@ -1,0 +1,29 @@
+// +build !linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+// DetectSystemd returns true if OS runs with systemd as init.
+func DetectSystemd(exec Exec, systemdRunPath string) bool {
+	return false
+}
+
+// AddSystemdScope adds "system-run --scope" to given command line.
+func AddSystemdScope(systemdRunPath string, description, command string, args []string) (string, []string) {
+	return command, args
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Run ceph-fuse in isolated systemd scope. Then on kubelet restart, fuse daemon will not be killed.

Why we need to run fuse daemon in its own system scope, see https://github.com/kubernetes/kubernetes/pull/49640.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67643

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cephfs plugin to mount cephfs fuse in isolated systemd scope to prevent ceph fuse daemons from being killed on kubelet restart.
```
