### PR TITLE
Increase inotify max_user_instance limit from 200 to 1000

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
       - name: init-inotify-limit
         image: busybox
-        command: ['sysctl', '-w', 'fs.inotify.max_user_instances=200']
+        command: ['sysctl', '-w', 'fs.inotify.max_user_instances=1000']
         securityContext:
           privileged: true
       volumes:


### PR DESCRIPTION
Fixes:https://github.com/kubernetes/kubernetes/issues/64614
Related:https://github.com/kubernetes/kubernetes/issues/41713

Tested on local GCP cluster with 1000, it works.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek @Random-Liu @shyamjvs @jiayingz @saad-ali @RenaudWasTaken @figo 