### PR TITLE
device manager: don't do operations on nil pointer

### DIFF
--- a/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
+++ b/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
@@ -165,10 +165,10 @@ func (m *Stub) Register(kubeletEndpoint, resourceName string, pluginSockDir stri
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}))
-	defer conn.Close()
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	client := pluginapi.NewRegistrationClient(conn)
 	reqt := &pluginapi.RegisterRequest{
 		Version:      pluginapi.Version,


### PR DESCRIPTION
**What this PR does / why we need it**:

In the device plugin stub, if `grpc.DialContext()` fails, a `nil` connection is returned. Check the
error before calling `conn.Close()`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
