### PR TITLE
Deprecate --sort-by in kubectl get

### DIFF
--- a/pkg/kubectl/cmd/get/humanreadable_flags.go
+++ b/pkg/kubectl/cmd/get/humanreadable_flags.go
@@ -113,6 +113,7 @@ func (f *HumanPrintFlags) AddFlags(c *cobra.Command) {
 	}
 	if f.SortBy != nil {
 		c.Flags().StringVar(f.SortBy, "sort-by", *f.SortBy, "If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string.")
+		c.Flags().MarkDeprecated("sort-by", "and will be removed in a future version.")
 	}
 	if f.ColumnLabels != nil {
 		c.Flags().StringSliceVarP(f.ColumnLabels, "label-columns", "L", *f.ColumnLabels, "Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag options like -L label1 -L label2...")


### PR DESCRIPTION
**What this PR does / why we need it**:
This move is part of the overall kubectl refactorings and unification we as sig-cli
are currently overgoing. The reasons behind this particular change are as follows:

1. sort-by does not work (and never did) with multiple resource types. During sig-cli
meeting from February 28th, all of us agreed that it does not make sense to support
that use case at all.

2. sort-by is (since it's inception) inconsistent when the amount of data is bigger
than the requested page size (by default it's 500 items). This leads to non-deterministic
results and weird errors in automation scripts. A feature that seems to work with a small
data set and fails with a large data set is not desirable.

3. The current implementation relies on specifying jsonpath which is cumbersome,
and also not compatible with the server-side printing mechanism, which is the current
default print mechanism in kubectl get.

/assign @deads2k @juanvallejo 

**Release note**:
```release-note
Deprecate --sort-by in kubectl get. 
```
