### PR TITLE
The maxDockerValidatedVersion is now set from 17.03 to 18.06

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -38,7 +38,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix        = "DOCKER_"
-	maxDockerValidatedVersion = "17.03"
+	maxDockerValidatedVersion = "18.06"
 )
 
 // TODO(random-liu): Add more validating items.

--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -38,6 +38,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix        = "DOCKER_"
+	// The latest version of docker is 18.06
 	maxDockerValidatedVersion = "18.06"
 )
 

--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -38,7 +38,6 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix        = "DOCKER_"
-	// The latest version of docker is 18.06
 	maxDockerValidatedVersion = "18.06"
 )
 


### PR DESCRIPTION
If we want to deploy kubernetes v1.11.2 on the latest version of docker (18.06) with kubeadm, we  receive a "Warning  Info" as below 

```
"docker version is greater than the most recently validated version. Docker version:18.06-ce. Max validated version: 17.03
```

So we think it would be better to set maxDockerValidatedVersion from 17.03 to 18.06