### PR TITLE
The maxDockerValidatedVersion is now set from 17.03 to 18.06

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -38,7 +38,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix        = "DOCKER_"
-	maxDockerValidatedVersion = "17.03"
+	maxDockerValidatedVersion = "18.06"
 )
 
 // TODO(random-liu): Add more validating items.

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -72,6 +72,26 @@ func TestValidateDockerInfo(t *testing.T) {
 			warn: false,
 		},
 		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.09.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.09.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.12.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.12.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "18.03.0-ce"},
 			err:  false,
 			warn: false,

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.1[1-3]\..*`, `17\.03\..*`}, // Requires [1.11, 17.03].
+		Version:     []string{`1\.1[1-3]\..*`, `18\.06\..*`}, // Requires [1.11, 18.06].
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -69,7 +69,27 @@ func TestValidateDockerInfo(t *testing.T) {
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "17.06.0-ce"},
 			err:  false,
-			warn: true,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.03.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.03.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.06.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "18.06.0-ce"},
+			err:  false,
+			warn: false,
 		},
 	} {
 		warn, err := v.validateDockerInfo(spec, test.info)


### PR DESCRIPTION
If we want to deploy kubernetes v1.11.2 on the latest version of docker (18.06) with kubeadm, we  receive a "Warning  Info" as below 

```
"docker version is greater than the most recently validated version. Docker version:18.06-ce. Max validated version: 17.03
```

So we think it would be better to set maxDockerValidatedVersion from 17.03 to 18.06