### PR TITLE
[WIP] fix an issue that scheduling doesn't consider NodeLost status of a node

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -197,10 +197,13 @@ func ApplyFeatureGates() {
 
 		// Fit is determined based on whether a pod can tolerate all of the node's taints
 		factory.RegisterMandatoryFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints)
-		// Insert Key "PodToleratesNodeTaints" and "CheckNodeUnschedulable" To All Algorithm Provider
+		// A NodeLost node is skipped upon scheduling
+		factory.RegisterMandatoryFitPredicate(predicates.CheckNodeLostPred, predicates.CheckNodeLostPredicate)
+		// Insert Key "PodToleratesNodeTaints" and "CheckNodeLost" To All Algorithm Provider
 		// The key will insert to all providers which in algorithmProviderMap[]
 		// if you just want insert to specific provider, call func InsertPredicateKeyToAlgoProvider()
 		factory.InsertPredicateKeyToAlgorithmProviderMap(predicates.PodToleratesNodeTaintsPred)
+		factory.InsertPredicateKeyToAlgorithmProviderMap(predicates.CheckNodeLostPred)
 
 		glog.Warningf("TaintNodesByCondition is enabled, PodToleratesNodeTaints predicate is mandatory")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In 1.12 feature TaintNodesByCondition is enabled by default, so internally it disregards conditions instead of taints - as node lifecycle controller would create respective taints.
But it all depends on a prerequisite that the network works as expected - say kubelet can update Node with new taint properly. However it's not always the case, #67536 describes a scenario that when one node gets lost, and a replacement comes in, old pods on disappeared node didn't get scheduled (onto new node) well.

This PR tries to fix this problem:

- introduce CheckNodeLostPredicate
- mark CheckNodeLostPredicate as mandatory when TaintNodesByCondition is true
- TODO: add some testcases if necessary 

And note that NodeLost is not an API status; it's more a semantic status when node meets network issue so can't communicate back to apiserver.

**Which issue(s) this PR fixes**:
Fixes #67536

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
