### PR TITLE
handle recover from panic

### DIFF
--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -70,11 +70,12 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disrupti
 		wg.Add(scale)
 		for i := 0; i < scale; i++ {
 			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
 				wave := fmt.Sprintf("wave%v", strconv.Itoa(i))
 				framework.Logf("Starting logging soak, wave = %v", wave)
 				RunLogPodsWithSleepOf(f, kbRateInSeconds, wave, totalLogTime)
 				framework.Logf("Completed logging soak, wave %v", i)
-				wg.Done()
 			}()
 			// Niceness.
 			time.Sleep(millisecondsBetweenWaves)


### PR DESCRIPTION
The upgrade jobs like https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-stable1-beta-upgrade-master/700 are panic on this test and didn't print any output

add a recover to the sub go-routine.

/sig-instrumentation
/cc jayunit100
