### PR TITLE
 Fix NameFromCommandArgs when passing command after -- 

### DIFF
--- a/pkg/kubectl/cmd/create/create.go
+++ b/pkg/kubectl/cmd/create/create.go
@@ -328,8 +328,13 @@ func createAndRefresh(info *resource.Info) error {
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
 func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
-	if len(args) != 1 {
-		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", len(args))
+	argsLen := cmd.ArgsLenAtDash()
+	// ArgsLenAtDash returns -1 when -- was not specified
+	if argsLen == -1 {
+		argsLen = len(args)
+	}
+	if argsLen != 1 {
+		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
 	}
 	return args[0], nil
 }

--- a/pkg/kubectl/cmd/create/create_job.go
+++ b/pkg/kubectl/cmd/create/create_job.go
@@ -85,8 +85,7 @@ func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 		Long:    jobLong,
 		Example: jobExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			argsLenAtDash := cmd.ArgsLenAtDash()
-			cmdutil.CheckErr(o.Complete(f, cmd, args, argsLenAtDash))
+			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
@@ -103,11 +102,12 @@ func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	return cmd
 }
 
-func (o *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, argsLenAtDash int) error {
-	if len(args) == 0 || argsLenAtDash == 0 {
-		return cmdutil.UsageErrorf(cmd, "NAME is required")
+func (o *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
 	}
-	o.Name = args[0]
+	o.Name = name
 	if len(args) > 1 {
 		o.Command = args[1:]
 	}

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -212,6 +212,16 @@ run_deployment_tests() {
   # Clean up
   kubectl delete deployment test-nginx-apps "${kube_flags[@]}"
 
+  ### Test kubectl create deployment with image and command
+  # Pre-Condition: No deployment exists.
+  kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create deployment nginx-with-command --image=k8s.gcr.io/nginx:test-cmd -- /bin/sleep infinity
+  # Post-Condition: Deployment "nginx" is created.
+  kube::test::get_object_assert 'deploy nginx-with-command' "{{$container_name_field}}" 'nginx'
+  # Clean up
+  kubectl delete deployment nginx-with-command "${kube_flags[@]}"
+
   ### Test kubectl create deployment should not fail validation
   # Pre-Condition: No deployment exists.
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes `kubectl create deployment name --image=xyz -- mycommand` invocation. Currently the `NameFromCommandArgs` is unnecessarily parsing arguments after `--`. 

**Special notes for your reviewer**:
/assign @juanvallejo 

**Release note**:
```release-note
None
```
