### PR TITLE
Fix test case: invalid version should not trigger network operations

### DIFF
--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -90,8 +90,8 @@ func TestCmdInitKubernetesVersion(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "invalid version string is detected",
-			args:     "--kubernetes-version=foobar",
+			name:     "invalid semantic version string is detected",
+			args:     "--kubernetes-version=v1.1",
 			expected: false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**: current invalid version value in the test case triggers network operation to check it validity via `https://dl.k8s.io/`. Using incorrect semantic version will achieve same result of test case without possibility to trigger network connection.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@neolit123 

**Release note**:
```release-note
NONE
```
