### PR TITLE
Externalize default storageclass admission controller

### DIFF
--- a/plugin/pkg/admission/storage/storageclass/setdefault/BUILD
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/BUILD
@@ -13,14 +13,14 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/helper:go_default_library",
-        "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/util:go_default_library",
-        "//pkg/client/informers/informers_generated/internalversion:go_default_library",
-        "//pkg/client/listers/storage/internalversion:go_default_library",
-        "//pkg/kubeapiserver/admission:go_default_library",
+        "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/storage/v1:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
@@ -31,12 +31,12 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/util:go_default_library",
-        "//pkg/client/informers/informers_generated/internalversion:go_default_library",
         "//pkg/controller:go_default_library",
+        "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )

--- a/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
+++ b/plugin/pkg/admission/storage/storageclass/setdefault/admission_test.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/golang/glog"
 
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/informers"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/storage"
 	storageutil "k8s.io/kubernetes/pkg/apis/storage/util"
-	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -34,7 +34,7 @@ func TestAdmission(t *testing.T) {
 	empty := ""
 	foo := "foo"
 
-	defaultClass1 := &storage.StorageClass{
+	defaultClass1 := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
@@ -46,7 +46,7 @@ func TestAdmission(t *testing.T) {
 		},
 		Provisioner: "default1",
 	}
-	defaultClass2 := &storage.StorageClass{
+	defaultClass2 := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
@@ -59,7 +59,7 @@ func TestAdmission(t *testing.T) {
 		Provisioner: "default2",
 	}
 	// Class that has explicit default = false
-	classWithFalseDefault := &storage.StorageClass{
+	classWithFalseDefault := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
@@ -72,7 +72,7 @@ func TestAdmission(t *testing.T) {
 		Provisioner: "nondefault1",
 	}
 	// Class with missing default annotation (=non-default)
-	classWithNoDefault := &storage.StorageClass{
+	classWithNoDefault := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
@@ -82,7 +82,7 @@ func TestAdmission(t *testing.T) {
 		Provisioner: "nondefault1",
 	}
 	// Class with empty default annotation (=non-default)
-	classWithEmptyDefault := &storage.StorageClass{
+	classWithEmptyDefault := &storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "StorageClass",
 		},
@@ -131,56 +131,56 @@ func TestAdmission(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		classes           []*storage.StorageClass
+		classes           []*storagev1.StorageClass
 		claim             *api.PersistentVolumeClaim
 		expectError       bool
 		expectedClassName string
 	}{
 		{
 			"no default, no modification of PVCs",
-			[]*storage.StorageClass{classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithNoClass,
 			false,
 			"",
 		},
 		{
 			"one default, modify PVC with class=nil",
-			[]*storage.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithNoClass,
 			false,
 			"default1",
 		},
 		{
 			"one default, no modification of PVC with class=''",
-			[]*storage.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithEmptyClass,
 			false,
 			"",
 		},
 		{
 			"one default, no modification of PVC with class='foo'",
-			[]*storage.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithClass,
 			false,
 			"foo",
 		},
 		{
 			"two defaults, error with PVC with class=nil",
-			[]*storage.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithNoClass,
 			true,
 			"",
 		},
 		{
 			"two defaults, no modification of PVC with class=''",
-			[]*storage.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithEmptyClass,
 			false,
 			"",
 		},
 		{
 			"two defaults, no modification of PVC with class='foo'",
-			[]*storage.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
+			[]*storagev1.StorageClass{defaultClass1, defaultClass2, classWithFalseDefault, classWithNoDefault, classWithEmptyDefault},
 			claimWithClass,
 			false,
 			"foo",
@@ -195,9 +195,9 @@ func TestAdmission(t *testing.T) {
 
 		ctrl := newPlugin()
 		informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-		ctrl.SetInternalKubeInformerFactory(informerFactory)
+		ctrl.SetExternalKubeInformerFactory(informerFactory)
 		for _, c := range test.classes {
-			informerFactory.Storage().InternalVersion().StorageClasses().Informer().GetStore().Add(c)
+			informerFactory.Storage().V1().StorageClasses().Informer().GetStore().Add(c)
 		}
 		attrs := admission.NewAttributesRecord(
 			claim, // new object


### PR DESCRIPTION
now continue with this low hanging fruit. 

and we will seriously step into deep water zone like `resourcequota` 🙃

ref: #66680

/assign deads2k 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
