### PR TITLE
diff: Fix crash when remote object doesn't exist

### DIFF
--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -265,7 +265,7 @@ type Object interface {
 // InfoObject is an implementation of the Object interface. It gets all
 // the information from the Info object.
 type InfoObject struct {
-	Remote  runtime.Unstructured
+	Remote  *unstructured.Unstructured
 	Info    *resource.Info
 	Encoder runtime.Encoder
 	Parser  *parse.Factory

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -26,6 +26,10 @@ run_kubectl_diff_tests() {
     create_and_use_new_namespace
     kube::log::status "Testing kubectl alpha diff"
 
+    # Test that it works when the live object doesn't exist
+    output_message=$(kubectl alpha diff LOCAL LIVE -f hack/testdata/pod.yaml)
+    kube::test::if_has_string "${output_message}" 'test-pod'
+
     kubectl apply -f hack/testdata/pod.yaml
 
     # Ensure that selfLink has been added, and shown in the diff


### PR DESCRIPTION
Since we're saving nil in an interface rather than the implementation,
we can't compare to nil to check if the remote object exists or
not. Change the struct to save in the implementation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
