### PR TITLE
Kubeadm: Add ServerAuth key usage to front-proxy client

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -254,7 +254,10 @@ var (
 		CAName:   "front-proxy-ca",
 		config: certutil.Config{
 			CommonName: kubeadmconstants.FrontProxyClientCertCommonName,
-			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			// This certificate needs both Server and Client Auth flags for the metrics-server
+			// to work correctly.
+			// See https://github.com/kubernetes-incubator/metrics-server/issues/35#issuecomment-360514404
+			Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Kubeadm creates a CA and certificate called `front-proxy-client` which is put into the `extension-apiserver-authentication` configmap. The metrics-server uses the certificates in this configmap. The use of the certificates requires the ability to be used for ServerAuth as well as ClientAuth.

No issue has been added to Kubeadm related to this, but it has been discussed in the metrics-server issues:
* https://github.com/kubernetes-incubator/metrics-server/issues/67
* https://github.com/kubernetes-incubator/metrics-server/issues/35#issuecomment-360514404

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
