### PR TITLE
 Kubelet: only apply default hard evictions of nodefs.inodesFree on Linux

### DIFF
--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -81,12 +81,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.KubeAPIQPS = 5
 			obj.KubeAPIBurst = 10
 			obj.HairpinMode = v1beta1.PromiscuousBridge
-			obj.EvictionHard = map[string]string{
-				"memory.available":  "100Mi",
-				"nodefs.available":  "10%",
-				"nodefs.inodesFree": "5%",
-				"imagefs.available": "15%",
-			}
+			obj.EvictionHard = kubeletconfigv1beta1.DefaultEvictionHard
 			obj.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 5 * time.Minute}
 			obj.MakeIPTablesUtilChains = true
 			obj.IPTablesMasqueradeBit = kubeletconfigv1beta1.DefaultIPTablesMasqueradeBit

--- a/pkg/kubelet/apis/config/v1beta1/BUILD
+++ b/pkg/kubelet/apis/config/v1beta1/BUILD
@@ -9,6 +9,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "defaults.go",
+        "defaults_linux.go",
+        "defaults_others.go",
         "doc.go",
         "register.go",
         "zz_generated.conversion.go",

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -178,12 +178,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 		obj.SerializeImagePulls = utilpointer.BoolPtr(true)
 	}
 	if obj.EvictionHard == nil {
-		obj.EvictionHard = map[string]string{
-			"memory.available":  "100Mi",
-			"nodefs.available":  "10%",
-			"nodefs.inodesFree": "5%",
-			"imagefs.available": "15%",
-		}
+		obj.EvictionHard = DefaultEvictionHard
 	}
 	if obj.EvictionPressureTransitionPeriod == zeroDuration {
 		obj.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 5 * time.Minute}

--- a/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// DefaultEvictionHard includes default options for hard eviction.
+var DefaultEvictionHard = map[string]string{
+	"memory.available":  "100Mi",
+	"nodefs.available":  "10%",
+	"nodefs.inodesFree": "5%",
+	"imagefs.available": "15%",
+}

--- a/pkg/kubelet/apis/config/v1beta1/defaults_others.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_others.go
@@ -1,0 +1,26 @@
+// +build !linux
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// DefaultEvictionHard includes default options for hard eviction.
+var DefaultEvictionHard = map[string]string{
+	"memory.available":  "100Mi",
+	"nodefs.available":  "10%",
+	"imagefs.available": "15%",
+}

--- a/pkg/kubelet/dockershim/docker_image_windows.go
+++ b/pkg/kubelet/dockershim/docker_image_windows.go
@@ -45,9 +45,8 @@ func (ds *dockerService) ImageFsInfo(_ context.Context, _ *runtimeapi.ImageFsInf
 
 	filesystems := []*runtimeapi.FilesystemUsage{
 		{
-			Timestamp:  time.Now().UnixNano(),
-			UsedBytes:  &runtimeapi.UInt64Value{Value: fsinfo.Usage},
-			InodesUsed: &runtimeapi.UInt64Value{Value: 0},
+			Timestamp: time.Now().UnixNano(),
+			UsedBytes: &runtimeapi.UInt64Value{Value: fsinfo.Usage},
 			FsId: &runtimeapi.FilesystemIdentifier{
 				Mountpoint: info.DockerRootDir,
 			},

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -182,9 +182,11 @@ func (p *criStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 	// TODO(yguo0905): Support returning stats of multiple image filesystems.
 	for _, fs := range resp {
 		s := &statsapi.FsStats{
-			Time:       metav1.NewTime(time.Unix(0, fs.Timestamp)),
-			UsedBytes:  &fs.UsedBytes.Value,
-			InodesUsed: &fs.InodesUsed.Value,
+			Time:      metav1.NewTime(time.Unix(0, fs.Timestamp)),
+			UsedBytes: &fs.UsedBytes.Value,
+		}
+		if fs.InodesUsed != nil {
+			s.InodesUsed = &fs.InodesUsed.Value
 		}
 		imageFsInfo := p.getFsInfo(fs.GetFsId())
 		if imageFsInfo != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Kubelet sets default hard evictions of `nodefs.inodesFree ` for all platforms today. This will cause errors on Windows and a lot `no observation found for eviction signal nodefs.inodesFree` errors will be logs for kubelet.

```
kubelet.err.log:4961:W0711 22:21:12.378789    2872 helpers.go:808] eviction manager: no observation found for eviction signal nodefs.inodesFree
kubelet.err.log:4967:W0711 22:21:30.411371    2872 helpers.go:808] eviction manager: no observation found for eviction signal nodefs.inodesFree
kubelet.err.log:4974:W0711 22:21:48.446456    2872 helpers.go:808] eviction manager: no observation found for eviction signal nodefs.inodesFree
kubelet.err.log:4978:W0711 22:22:06.482441    2872 helpers.go:808] eviction manager: no observation found for eviction signal nodefs.inodesFree
```

This PR updates the default hard eviction value and only apply nodefs.inodesFree on Linux.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66088

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubelet only applies default hard evictions of nodefs.inodesFree on Linux
```
