### PR TITLE
Make kubectl create secret tls work with process substitution

### DIFF
--- a/pkg/kubectl/secret_for_tls.go
+++ b/pkg/kubectl/secret_for_tls.go
@@ -87,6 +87,14 @@ func (s SecretForTLSGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if _, err := tls.X509KeyPair(tlsCrt, tlsKey); err != nil {
+		return nil, fmt.Errorf("failed to load key pair %v", err)
+	}
+	// TODO: Add more validation.
+	// 1. If the certificate contains intermediates, it is a valid chain.
+	// 2. Format etc.
+
 	secret := &v1.Secret{}
 	secret.Name = s.Name
 	secret.Type = v1.SecretTypeTLS
@@ -133,11 +141,5 @@ func (s SecretForTLSGeneratorV1) validate() error {
 	if len(s.Cert) == 0 {
 		return fmt.Errorf("certificate must be specified")
 	}
-	if _, err := tls.LoadX509KeyPair(s.Cert, s.Key); err != nil {
-		return fmt.Errorf("failed to load key pair %v", err)
-	}
-	// TODO: Add more validation.
-	// 1. If the certificate contains intermediates, it is a valid chain.
-	// 2. Format etc.
 	return nil
 }

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -751,6 +751,13 @@ run_secrets_test() {
   # Clean-up
   kubectl delete secret test-secret --namespace=test-secrets
 
+  # Command with process substitution
+  kubectl create secret tls test-secret --namespace=test-secrets --key <(cat hack/testdata/tls.key) --cert <(cat hack/testdata/tls.crt)
+  kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$id_field}}" 'test-secret'
+  kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$secret_type}}" 'kubernetes.io/tls'
+    # Clean-up
+  kubectl delete secret test-secret --namespace=test-secrets
+
   # Create a secret using stringData
   kubectl create --namespace=test-secrets -f - "${kube_flags[@]}" << __EOF__
 {


### PR DESCRIPTION
Fixes #57909

```release-note
`kubectl create secret tls` can now read certificate and key files from process substitution arguments
```