### PR TITLE
Report cloudstack hostname address

### DIFF
--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_instances.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_instances.go
@@ -69,6 +69,10 @@ func (cs *CSCloud) nodeAddresses(instance *cloudstack.VirtualMachine) ([]v1.Node
 		{Type: v1.NodeInternalIP, Address: instance.Nic[0].Ipaddress},
 	}
 
+	if instance.Hostname != "" {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: instance.Hostname})
+	}
+
 	if instance.Publicip != "" {
 		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.Publicip})
 	} else {

--- a/pkg/cloudprovider/providers/cloudstack/metadata.go
+++ b/pkg/cloudprovider/providers/cloudstack/metadata.go
@@ -39,6 +39,7 @@ type metadata struct {
 type metadataType string
 
 const (
+	metadataTypeHostname     metadataType = "local-hostname"
 	metadataTypeExternalIP   metadataType = "public-ipv4"
 	metadataTypeInternalIP   metadataType = "local-ipv4"
 	metadataTypeInstanceID   metadataType = "instance-id"
@@ -58,10 +59,20 @@ func (m *metadata) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1
 		return nil, fmt.Errorf("could not get internal IP: %v", err)
 	}
 
-	return []v1.NodeAddress{
+	addresses := []v1.NodeAddress{
 		{Type: v1.NodeExternalIP, Address: externalIP},
 		{Type: v1.NodeInternalIP, Address: internalIP},
-	}, nil
+	}
+
+	hostname, err := m.get(metadataTypeHostname)
+	if err != nil {
+		return nil, fmt.Errorf("could not get hostname: %v", err)
+	}
+	if hostname != "" {
+		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
+	}
+
+	return addresses, nil
 }
 
 // NodeAddressesByProviderID returns the addresses of the specified instance.


### PR DESCRIPTION
Cloud providers are now authoritative for the addresses reported by the kubelet. Cloud providers that have hostname information available via metadata should report it for use by the apiserver

```release-note
The cloudstack cloud provider now reports a `Hostname` address type for nodes based on the `local-hostname` metadata key.
```