### PR TITLE
code-generator:informer-gen fix tag source in versioninterface

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
@@ -68,7 +68,7 @@ func (g *versionInterfaceGenerator) GenerateType(c *generator.Context, t *types.
 
 	sw.Do(versionTemplate, m)
 	for _, typeDef := range g.types {
-		tags, err := util.ParseClientGenTags(typeDef.SecondClosestCommentLines)
+		tags, err := util.ParseClientGenTags(append(typeDef.SecondClosestCommentLines, typeDef.CommentLines...))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
All invocations of util.ParseClientGenTags in informer-gen accepts
both t.SecondClosestCommentLines and t.CommentLines
