### PR TITLE
vsphere: add tests for Cloud Provider Zones implementation

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/BUILD
+++ b/pkg/cloudprovider/providers/vsphere/BUILD
@@ -57,10 +57,14 @@ go_test(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/github.com/vmware/govmomi/lookup/simulator:go_default_library",
+        "//vendor/github.com/vmware/govmomi/property:go_default_library",
         "//vendor/github.com/vmware/govmomi/simulator:go_default_library",
         "//vendor/github.com/vmware/govmomi/simulator/vpx:go_default_library",
         "//vendor/github.com/vmware/govmomi/sts/simulator:go_default_library",
+        "//vendor/github.com/vmware/govmomi/vapi/rest:go_default_library",
         "//vendor/github.com/vmware/govmomi/vapi/simulator:go_default_library",
+        "//vendor/github.com/vmware/govmomi/vapi/tags:go_default_library",
+        "//vendor/github.com/vmware/govmomi/vim25/mo:go_default_library",
     ],
 )
 

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -1371,33 +1371,26 @@ func (vs *VSphere) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 				glog.Errorf("Get category %s error", value)
 				return err
 			}
-			switch {
 
+			switch {
 			case category.Name == vs.cfg.Labels.Zone:
 				zone.FailureDomain = tag.Name
-
 			case category.Name == vs.cfg.Labels.Region:
 				zone.Region = tag.Name
+			}
+		}
 
-			default:
-				zone.FailureDomain = ""
-				zone.Region = ""
-			}
-		}
-		switch {
-		case zone.Region == "":
-			if vs.cfg.Labels.Zone != "" {
-				return fmt.Errorf("The zone in vSphere configuration file not match for node %s ", nodeName)
-			}
-			glog.Infof("No zones support for node %s error", nodeName)
-			return nil
-		case zone.FailureDomain == "":
+		if zone.Region == "" {
 			if vs.cfg.Labels.Region != "" {
-				return fmt.Errorf("The zone in vSphere configuration file not match for node %s ", nodeName)
+				return fmt.Errorf("vSphere region category %q does not match any tags for node %s [%s]", vs.cfg.Labels.Region, nodeName, vs.vmUUID)
 			}
-			glog.Infof("No zones support for node %s error", nodeName)
-			return nil
 		}
+		if zone.FailureDomain == "" {
+			if vs.cfg.Labels.Zone != "" {
+				return fmt.Errorf("vSphere zone category %q does not match any tags for node %s [%s]", vs.cfg.Labels.Zone, nodeName, vs.vmUUID)
+			}
+		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add tests for GetZones()

- Fix bug where a host tag other than region or zone caused an error

- Fix bug where GetZones() errored if zone tag was set, but region was not

Follow up to PR #66795 / towards #64021

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
