### PR TITLE
Fix panic when choosing zone or zones for volume

### DIFF
--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -520,6 +520,11 @@ func GetPath(mounter volume.Mounter) (string, error) {
 // This means that a StatefulSet's volumes (`claimname-statefulsetname-id`) will spread across available zones,
 // assuming the id values are consecutive.
 func ChooseZoneForVolume(zones sets.String, pvcName string) string {
+	// No zones available, return empty string.
+	if zones.Len() == 0 {
+		return ""
+	}
+
 	// We create the volume in a zone determined by the name
 	// Eventually the scheduler will coordinate placement into an available zone
 	hash, index := getPVCNameHashAndIndexOffset(pvcName)
@@ -541,6 +546,12 @@ func ChooseZoneForVolume(zones sets.String, pvcName string) string {
 
 // ChooseZonesForVolume is identical to ChooseZoneForVolume, but selects a multiple zones, for multi-zone disks.
 func ChooseZonesForVolume(zones sets.String, pvcName string, numZones uint32) sets.String {
+	// No zones available, return empty set.
+	replicaZones := sets.NewString()
+	if zones.Len() == 0 {
+		return replicaZones
+	}
+
 	// We create the volume in a zone determined by the name
 	// Eventually the scheduler will coordinate placement into an available zone
 	hash, index := getPVCNameHashAndIndexOffset(pvcName)
@@ -554,7 +565,6 @@ func ChooseZonesForVolume(zones sets.String, pvcName string, numZones uint32) se
 	// PVC placement (which could also e.g. avoid putting volumes in overloaded or
 	// unhealthy zones)
 	zoneSlice := zones.List()
-	replicaZones := sets.NewString()
 
 	startingIndex := index * numZones
 	for index = startingIndex; index < startingIndex+numZones; index++ {

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -647,6 +647,17 @@ func TestChooseZoneForVolume(t *testing.T) {
 			VolumeName: "medium-henley--4",
 			Expected:   "c", // hash("") + 4 == 2 mod 3
 		},
+		// Test for no zones
+		{
+			Zones:      sets.NewString(),
+			VolumeName: "medium-henley--1",
+			Expected:   "",
+		},
+		{
+			Zones:      nil,
+			VolumeName: "medium-henley--2",
+			Expected:   "",
+		},
 	}
 
 	for _, test := range tests {
@@ -991,6 +1002,17 @@ func TestChooseZonesForVolume(t *testing.T) {
 			VolumeName: "henley-3",
 			NumZones:   3,
 			Expected:   sets.NewString("a" /* hash("henley") == 0 + 3 + 6(startingIndex) */, "b", "c"),
+		},
+		// Test for no zones
+		{
+			Zones:      sets.NewString(),
+			VolumeName: "henley-1",
+			Expected:   sets.NewString(),
+		},
+		{
+			Zones:      nil,
+			VolumeName: "henley-2",
+			Expected:   sets.NewString(),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix panic when choosing zone or zones for volume, so that zoneSlice won't divide by zero now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @ddebroy @andyzhangx 