### PR TITLE
Clean deprecated `ShowAll` variable in PrintOptions

### DIFF
--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -47,7 +47,6 @@ type PrintOptions struct {
 	WithNamespace      bool
 	WithKind           bool
 	Wide               bool
-	ShowAll            bool
 	ShowLabels         bool
 	AbsoluteTimestamps bool
 	Kind               schema.GroupKind


### PR DESCRIPTION

show-all option has been deprecated in v1.10. I think it's time to clean it.
ref:https://github.com/kubernetes/kubernetes/pull/60210
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
