### PR TITLE
Give APIServer pretty column output

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -655,6 +655,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/api/meta/table",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -752,6 +756,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/duration",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/BUILD
@@ -11,7 +11,10 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd",
     importpath = "k8s.io/kube-aggregator/pkg/registry/apiservice/etcd",
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta/table:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",


### PR DESCRIPTION
Simple server side render that prints the implementing service (if any)
and the available condition.

```
$ kubectl get apiservice
NAME                               SERVICE                      AVAILABLE                 AGE
v1.                                Local                        True                      10m
v1.apps                            Local                        True                      10m
v1.authentication.k8s.io           Local                        True                      10m
v2beta1.autoscaling                Local                        True                      10m
v1beta1.metrics                    kube-system/metrics-server   False (DiscoveryFailed)   10m
```

@liggitt @deads2k helps to debug why controllers block (aggregate api is down)

```release-note
`kubectl get apiservice` now shows the target service and whether the service is available
```