### PR TITLE
Make OpenStack cloud provider report a node hostname address

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -53,7 +53,10 @@ import (
 
 const (
 	// ProviderName is the name of the openstack provider
-	ProviderName     = "openstack"
+	ProviderName = "openstack"
+
+	// TypeHostName is the name type of openstack instance
+	TypeHostName     = "hostname"
 	availabilityZone = "availability_zone"
 	defaultTimeOut   = 60 * time.Second
 )
@@ -494,6 +497,15 @@ func nodeAddresses(srv *servers.Server) ([]v1.NodeAddress, error) {
 			v1.NodeAddress{
 				Type:    v1.NodeExternalIP,
 				Address: srv.AccessIPv6,
+			},
+		)
+	}
+
+	if srv.Metadata[TypeHostName] != "" {
+		v1helper.AddToNodeAddresses(&addrs,
+			v1.NodeAddress{
+				Type:    v1.NodeHostName,
+				Address: srv.Metadata[TypeHostName],
 			},
 		)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -444,6 +444,10 @@ func TestNodeAddresses(t *testing.T) {
 				},
 			},
 		},
+		Metadata: map[string]string{
+			"name":       "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy",
+			TypeHostName: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal",
+		},
 	}
 
 	addrs, err := nodeAddresses(&srv)
@@ -462,6 +466,7 @@ func TestNodeAddresses(t *testing.T) {
 		{Type: v1.NodeExternalIP, Address: "50.56.176.35"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.36"},
 		{Type: v1.NodeExternalIP, Address: "50.56.176.99"},
+		{Type: v1.NodeHostName, Address: "a1-yinvcez57-0-bvynoyawrhcg-kube-minion-fg5i4jwcc2yy.novalocal"},
 	}
 
 	if !reflect.DeepEqual(want, addrs) {


### PR DESCRIPTION
Related to: #67714
Cloud-provider-reported addresses are authoritative in 1.12, this
preserves default behavior that used the internal dns name as
the "Hostname" address on Node status.

**Release note**:

```release-note
The OpenStack cloud provider now reports a `Hostname` address type for nodes
```
