### PR TITLE
WIP: Remove redundant ObjectMeta validations

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -30,7 +30,7 @@ import (
 )
 
 func ValidateInitializerConfiguration(ic *admissionregistration.InitializerConfiguration) field.ErrorList {
-	allErrors := genericvalidation.ValidateObjectMeta(&ic.ObjectMeta, false, genericvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	var allErrors field.ErrorList
 	for i, initializer := range ic.Initializers {
 		allErrors = append(allErrors, validateInitializer(&initializer, field.NewPath("initializers").Index(i))...)
 	}
@@ -166,7 +166,7 @@ func ValidateInitializerConfigurationUpdate(newIC, oldIC *admissionregistration.
 }
 
 func ValidateValidatingWebhookConfiguration(e *admissionregistration.ValidatingWebhookConfiguration) field.ErrorList {
-	allErrors := genericvalidation.ValidateObjectMeta(&e.ObjectMeta, false, genericvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	var allErrors field.ErrorList
 	for i, hook := range e.Webhooks {
 		allErrors = append(allErrors, validateWebhook(&hook, field.NewPath("webhooks").Index(i))...)
 	}
@@ -174,7 +174,7 @@ func ValidateValidatingWebhookConfiguration(e *admissionregistration.ValidatingW
 }
 
 func ValidateMutatingWebhookConfiguration(e *admissionregistration.MutatingWebhookConfiguration) field.ErrorList {
-	allErrors := genericvalidation.ValidateObjectMeta(&e.ObjectMeta, false, genericvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	var allErrors field.ErrorList
 	for i, hook := range e.Webhooks {
 		allErrors = append(allErrors, validateWebhook(&hook, field.NewPath("webhooks").Index(i))...)
 	}

--- a/pkg/apis/coordination/validation/BUILD
+++ b/pkg/apis/coordination/validation/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/coordination:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/apis/coordination/validation/validation.go
+++ b/pkg/apis/coordination/validation/validation.go
@@ -17,21 +17,20 @@ limitations under the License.
 package validation
 
 import (
-	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/coordination"
 )
 
 // ValidateLease validates a Lease.
 func ValidateLease(lease *coordination.Lease) field.ErrorList {
-	allErrs := validation.ValidateObjectMeta(&lease.ObjectMeta, true, validation.NameIsDNSSubdomain, field.NewPath("metadata"))
+	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateLeaseSpec(&lease.Spec, field.NewPath("spec"))...)
 	return allErrs
 }
 
 // ValidateLeaseUpdate validates an update of Lease object.
 func ValidateLeaseUpdate(lease, oldLease *coordination.Lease) field.ErrorList {
-	allErrs := validation.ValidateObjectMetaUpdate(&lease.ObjectMeta, &oldLease.ObjectMeta, field.NewPath("metadata"))
+	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateLeaseSpec(&lease.Spec, field.NewPath("spec"))...)
 	return allErrs
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -57,7 +57,7 @@ func ValidateCustomResourceDefinition(obj *apiextensions.CustomResourceDefinitio
 
 // ValidateCustomResourceDefinitionUpdate statically validates
 func ValidateCustomResourceDefinitionUpdate(obj, oldObj *apiextensions.CustomResourceDefinition) field.ErrorList {
-	allErrs := genericvalidation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))
+	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionSpecUpdate(&obj.Spec, &oldObj.Spec, apiextensions.IsCRDConditionTrue(oldObj, apiextensions.Established), field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionStatus(&obj.Status, field.NewPath("status"))...)
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionStoredVersions(obj.Status.StoredVersions, obj.Spec.Versions, field.NewPath("status").Child("storedVersions"))...)
@@ -93,7 +93,7 @@ func ValidateCustomResourceDefinitionStoredVersions(storedVersions []string, ver
 
 // ValidateUpdateCustomResourceDefinitionStatus statically validates
 func ValidateUpdateCustomResourceDefinitionStatus(obj, oldObj *apiextensions.CustomResourceDefinition) field.ErrorList {
-	allErrs := genericvalidation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))
+	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateCustomResourceDefinitionStatus(&obj.Status, field.NewPath("status"))...)
 	return allErrs
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/validation/validation.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/validation/validation.go
@@ -89,9 +89,8 @@ func ValidateAPIService(apiService *apiregistration.APIService) field.ErrorList 
 }
 
 func ValidateAPIServiceUpdate(newAPIService *apiregistration.APIService, oldAPIService *apiregistration.APIService) field.ErrorList {
-	allErrs := validation.ValidateObjectMetaUpdate(&newAPIService.ObjectMeta, &oldAPIService.ObjectMeta, field.NewPath("metadata"))
+	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateAPIService(newAPIService)...)
-
 	return allErrs
 }
 
@@ -111,7 +110,7 @@ func ValidateAPIServiceStatus(status *apiregistration.APIServiceStatus, fldPath 
 }
 
 func ValidateAPIServiceStatusUpdate(newAPIService *apiregistration.APIService, oldAPIService *apiregistration.APIService) field.ErrorList {
-	allErrs := validation.ValidateObjectMetaUpdate(&newAPIService.ObjectMeta, &oldAPIService.ObjectMeta, field.NewPath("metadata"))
+	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateAPIServiceStatus(&newAPIService.Status, field.NewPath("status"))...)
 	return allErrs
 }


### PR DESCRIPTION
The generic registry calls the apimachinery ObjectMeta validation already. No need for another call if we don't ha