### PR TITLE
return error when occurs in the LoadPods

### DIFF
--- a/pkg/kubelet/checkpoint/checkpoint.go
+++ b/pkg/kubelet/checkpoint/checkpoint.go
@@ -31,7 +31,6 @@ import (
 const (
 	// Delimiter used on checkpoints written to disk
 	delimiter = "_"
-	podPrefix = "Pod"
 )
 
 type PodCheckpoint interface {
@@ -94,6 +93,7 @@ func LoadPods(cpm checkpointmanager.CheckpointManager) ([]*v1.Pod, error) {
 	checkpointKeys, err = cpm.ListCheckpoints()
 	if err != nil {
 		glog.Errorf("Failed to list checkpoints: %v", err)
+		return nil, err
 	}
 
 	for _, key := range checkpointKeys {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
1. remove useless attributes.
2. return error when occurs in the LoadPods(), should let the caller know what happened.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
