### PR TITLE
apiextensions: remove area/custom-resources label from OWNERS

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -9,4 +9,3 @@ approvers:
 - sttts
 labels:
 - sig/api-machinery
-- area/custom-resources


### PR DESCRIPTION
Sometimes changes in apiextensions-apiserver are not really related to custom resources but just general api-machinery (or worse godep updates). Adding the label `area/custom-resources` to such PRs makes triaging using the label hard.

Adding the label manually is much cleaner.

See https://github.com/kubernetes/kubernetes/pull/67753 for an example.

/assign sttts 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
