### PR TITLE
[JobController]: Fix update ActiveDeadlineSeconds does not work

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -320,7 +320,7 @@ func (jm *JobController) deletePod(obj interface{}) {
 }
 
 func (jm *JobController) updateJob(old, cur interface{}) {
-	oldJob := cur.(*batch.Job)
+	oldJob := old.(*batch.Job)
 	curJob := cur.(*batch.Job)
 
 	// never return error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
From current JobController code, it is intended to support job's ActiveDeadlineSeconds can be updated on the fly.
However, the update does not work due to a small **mistake** in the code.
The mistake causes the controller cannot detect changes of ActiveDeadlineSeconds.

> func (jm *JobController) updateJob(old, cur interface{}) {
> 	**oldJob := cur**.(*batch.Job)
> 	curJob := cur.(*batch.Job)
> 	...
> }



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
controller: fix a bug related to ActiveDeadlineSeconds not being respected on Job objects
```
