### PR TITLE
staing/apimachinery: fix typo "perfer" to "prefer"

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/testrestmapper/test_restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/testrestmapper/test_restmapper.go
@@ -24,7 +24,7 @@ import (
 )
 
 // TestOnlyStaticRESTMapper returns a union RESTMapper of all known types with priorities chosen in the following order:
-//  1. legacy kube group preferred version, extensions preferred version, metrics perferred version, legacy
+//  1. legacy kube group preferred version, extensions preferred version, metrics preferred version, legacy
 //     kube any version, extensions any version, metrics any version, all other groups alphabetical preferred version,
 //     all other groups alphabetical.
 // TODO callers of this method should be updated to build their own specific restmapper based on their scheme for their tests

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -210,7 +210,6 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 	})
 
 	It("Pod should be preferably scheduled to nodes pod can tolerate", func() {
-
 		// make the nodes have balanced cpu,mem usage ratio
 		err := createBalancedPodForNodes(f, cs, ns, nodeList.Items, podRequestedResource, 0.5)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a minor typo.

**Release note**: 

```release-note
"NONE"
```