### PR TITLE
vsphere: support zone tags at any level in the hierarchy

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -451,7 +451,7 @@ func TestZones(t *testing.T) {
 				t.Fatal(err)
 			}
 		}},
-		{"dc region, cluster zone", true, func() {
+		{"dc region, cluster zone", false, func() {
 			var h mo.HostSystem
 			if err = pc.RetrieveOne(ctx, host.Reference(), []string{"parent"}, &h); err != nil {
 				t.Fatal(err)
@@ -464,8 +464,6 @@ func TestZones(t *testing.T) {
 			if err = m.AttachTag(ctx, zoneID, h.Parent); err != nil {
 				t.Fatal(err)
 			}
-
-			// TODO: this should pass with Datacenter tagged as the region and Cluster tagged as the zone
 		}},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Rather than just looking for zone tags at the VM's Host level, traverse up the hierarchy.
This allows zone tags to be attached at host level, along with cluster, datacenter, root folder
and any inventory folders in between.

Issue #64021

Example log output from the tests, with tags attached at host level:
```console
Found "k8s-region" tag (k8s-region-US) for e85df495-93b9-4b0e-96f1-dc9d56e97263 attached to HostSystem:host-19
Found "k8s-zone" tag (k8s-zone-US-CA1) for e85df495-93b9-4b0e-96f1-dc9d56e97263 attached to HostSystem:host-19
```
And region tag at Datacenter level and zone tag at Cluster level:
```console
Found "k8s-zone" tag (k8s-zone-US-CA1) for e85df495-93b9-4b0e-96f1-dc9d56e97263 attached to ComputeResource:computeresource-21
Found "k8s-region" tag (k8s-region-US) for e85df495-93b9-4b0e-96f1-dc9d56e97263 attached to Datacenter:datacenter-2
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
