### PR TITLE
remove error brackets.

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -102,7 +102,7 @@ func ComponentProbe(cfg *kubeadmapi.InitConfiguration, componentName string, por
 func EtcdProbe(cfg *kubeadmapi.InitConfiguration, componentName string, port int, certsDir string, CACertName string, CertName string, KeyName string) *v1.Probe {
 	tlsFlags := fmt.Sprintf("--cacert=%[1]s/%[2]s --cert=%[1]s/%[3]s --key=%[1]s/%[4]s", certsDir, CACertName, CertName, KeyName)
 	// etcd pod is alive if a linearizable get succeeds.
-	cmd := fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://[%s]:%d %s get foo", GetProbeAddress(cfg, componentName), port, tlsFlags)
+	cmd := fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://%s:%d %s get foo", GetProbeAddress(cfg, componentName), port, tlsFlags)
 
 	return &v1.Probe{
 		Handler: v1.Handler{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix etcd manifest livenessProbe command. Before this patch the generated livenessProbe command is like this `ETCDCTL_API=3 etcdctl --endpoints=https://[10.0.128.11]:2379`, where the `[10.0.128.11]` is a wrong address format. 

**Release note**:
```release-note
None
```
