### PR TITLE
api: change owners from apimachinery to architecture

### DIFF
--- a/staging/src/k8s.io/api/OWNERS
+++ b/staging/src/k8s.io/api/OWNERS
@@ -49,4 +49,4 @@ reviewers:
 - yujuhong
 - zmerlynn
 labels:
-- sig/api-machinery
+- sig/architecture


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/67672#issuecomment-415566887
Change in the sigs files in k/community: https://github.com/kubernetes/community/pull/2584

/sig api-machinery
/sig architecture

/cc dims
/assign lavalamp 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
