### PR TITLE
WIP: Fix unexpected append mutations

### DIFF
--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -124,7 +124,7 @@ func (i *ImportRestriction) forbiddenImportsFor(pkg Package) []string {
 	forbiddenImportSet := map[string]struct{}{}
 	imports := pkg.Imports
 	if !i.ExcludeTests {
-		imports = append(imports, append(pkg.TestImports, pkg.XTestImports...)...)
+		imports = append(append(append([]string(nil), imports...), pkg.TestImports...), pkg.XTestImports...)
 	}
 	for _, imp := range imports {
 		path := extractVendorPath(imp)

--- a/cmd/kubeadm/app/util/apiclient/dryrunclient.go
+++ b/cmd/kubeadm/app/util/apiclient/dryrunclient.go
@@ -185,7 +185,7 @@ func NewDryRunClientWithOpts(opts DryRunClientOptions) clientset.Interface {
 
 	// The chain of reactors will look like this:
 	// opts.PrependReactors | defaultReactorChain | opts.AppendReactors | client.Fake.ReactionChain (default reactors for the fake clientset)
-	fullReactorChain := append(opts.PrependReactors, defaultReactorChain...)
+	fullReactorChain := append(append([]core.Reactor(nil), opts.PrependReactors...), defaultReactorChain...)
 	fullReactorChain = append(fullReactorChain, opts.AppendReactors...)
 
 	// Prepend the reaction chain with our reactors. Important, these MUST be prepended; not appended due to how the fake clientset works by default

--- a/pkg/cloudprovider/providers/aws/sets_ippermissions.go
+++ b/pkg/cloudprovider/providers/aws/sets_ippermissions.go
@@ -59,7 +59,7 @@ func (s IPPermissionSet) Ungroup() IPPermissionSet {
 			c := &ec2.IpPermission{}
 			*c = *p
 			c.UserIdGroupPairs = []*ec2.UserIdGroupPair{u}
-			l2 = append(l, c)
+			l2 = append(l2, c)
 		}
 	}
 

--- a/pkg/cloudprovider/providers/azure/azure_vmss.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss.go
@@ -825,7 +825,7 @@ func (ss *scaleSet) ensureScaleSetBackendPoolDeleted(poolID, ssName string) erro
 		if strings.EqualFold(poolID, *curPool.ID) {
 			glog.V(10).Infof("ensureScaleSetBackendPoolDeleted gets unwanted backend pool %q for scale set %q", poolID, ssName)
 			foundPool = true
-			newBackendPools = append(existingBackendPools[:i], existingBackendPools[i+1:]...)
+			newBackendPools = append(append([]compute.SubResource(nil), existingBackendPools[:i]...), existingBackendPools[i+1:]...)
 		}
 	}
 	if !foundPool {

--- a/pkg/cloudprovider/providers/gce/cloud/meta/method.go
+++ b/pkg/cloudprovider/providers/gce/cloud/meta/method.go
@@ -167,7 +167,7 @@ func (m *Method) args(skip int, nameArgs bool, prefix []string) []string {
 			a = append(a, args[i].String())
 		}
 	}
-	return append(prefix, a...)
+	return append(append([]string(nil), prefix...), a...)
 }
 
 // init the method. This performs some rudimentary static checking as well as

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -345,7 +345,7 @@ func TestUpdateInternalLoadBalancerNodes(t *testing.T) {
 	newNodesZoneB, err := createAndInsertNodes(gce, []string{node3Name}, vals.SecondaryZoneName)
 	require.NoError(t, err)
 
-	nodes = append(newNodesZoneA, newNodesZoneB...)
+	nodes = append(append([]*v1.Node(nil), newNodesZoneA...), newNodesZoneB...)
 	err = gce.updateInternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nodes)
 	assert.NoError(t, err)
 

--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -55,7 +55,7 @@ func (dc *DeploymentController) rolloutRecreate(d *apps.Deployment, rsList []*ap
 		if err != nil {
 			return err
 		}
-		allRSs = append(oldRSs, newRS)
+		allRSs = append(append([]*apps.ReplicaSet(nil), oldRSs...), newRS)
 	}
 
 	// scale up new replica set.

--- a/pkg/controller/deployment/rolling.go
+++ b/pkg/controller/deployment/rolling.go
@@ -140,7 +140,7 @@ func (dc *DeploymentController) reconcileOldReplicaSets(allRSs []*apps.ReplicaSe
 	glog.V(4).Infof("Cleaned up unhealthy replicas from old RSes by %d", cleanupCount)
 
 	// Scale down old replica sets, need check maxUnavailable to ensure we can scale down
-	allRSs = append(oldRSs, newRS)
+	allRSs = append(append([]*apps.ReplicaSet(nil), oldRSs...), newRS)
 	scaledDownCount, err := dc.scaleDownOldReplicaSetsForRollingUpdate(allRSs, oldRSs, deployment)
 	if err != nil {
 		return false, nil

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -312,7 +312,7 @@ func (dc *DeploymentController) scale(deployment *apps.Deployment, newRS *apps.R
 	// We need to proportionally scale all replica sets (new and old) in case of a
 	// rolling deployment.
 	if deploymentutil.IsRollingUpdate(deployment) {
-		allRSs := controller.FilterActiveReplicaSets(append(oldRSs, newRS))
+		allRSs := controller.FilterActiveReplicaSets(append(append([]*apps.ReplicaSet(nil), oldRSs...), newRS))
 		allRSsReplicas := deploymentutil.GetReplicaCountForReplicaSets(allRSs)
 
 		allowedSize := int32(0)

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -131,8 +131,8 @@ func SetDeploymentCondition(status *apps.DeploymentStatus, condition apps.Deploy
 	if currentCond != nil && currentCond.Status == condition.Status {
 		condition.LastTransitionTime = currentCond.LastTransitionTime
 	}
-	newConditions := filterOutCondition(status.Conditions, condition.Type)
-	status.Conditions = append(newConditions, condition)
+	status.Conditions = filterOutCondition(status.Conditions, condition.Type)
+	status.Conditions = append(status.Conditions, condition)
 }
 
 // RemoveDeploymentCondition removes the deployment condition with the provided type.

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -344,7 +344,7 @@ func FindActiveOrLatest(newRS *apps.ReplicaSet, oldRSs []*apps.ReplicaSet) *apps
 	}
 
 	sort.Sort(sort.Reverse(controller.ReplicaSetsByCreationTimestamp(oldRSs)))
-	allRSs := controller.FilterActiveReplicaSets(append(oldRSs, newRS))
+	allRSs := controller.FilterActiveReplicaSets(append(append([]*apps.ReplicaSet(nil), oldRSs...), newRS))
 
 	switch len(allRSs) {
 	case 0:

--- a/pkg/controller/replicaset/replica_set_utils.go
+++ b/pkg/controller/replicaset/replica_set_utils.go
@@ -154,8 +154,8 @@ func SetCondition(status *apps.ReplicaSetStatus, condition apps.ReplicaSetCondit
 	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
 		return
 	}
-	newConditions := filterOutCondition(status.Conditions, condition.Type)
-	status.Conditions = append(newConditions, condition)
+	status.Conditions = filterOutCondition(status.Conditions, condition.Type)
+	status.Conditions = append(status.Conditions, condition)
 }
 
 // RemoveCondition removes the condition with the provided type from the replicaset status.

--- a/pkg/controller/replication/replication_controller_utils.go
+++ b/pkg/controller/replication/replication_controller_utils.go
@@ -51,8 +51,8 @@ func SetCondition(status *v1.ReplicationControllerStatus, condition v1.Replicati
 	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
 		return
 	}
-	newConditions := filterOutCondition(status.Conditions, condition.Type)
-	status.Conditions = append(newConditions, condition)
+	status.Conditions = filterOutCondition(status.Conditions, condition.Type)
+	status.Conditions = append(status.Conditions, condition)
 }
 
 // RemoveCondition removes the condition with the provided type from the replication controller status.

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -257,7 +257,7 @@ func (o *EnvOptions) Validate() error {
 
 // RunEnv contains all the necessary functionality for the OpenShift cli env command
 func (o *EnvOptions) RunEnv() error {
-	env, remove, err := envutil.ParseEnv(append(o.EnvParams, o.envArgs...), o.In)
+	env, remove, err := envutil.ParseEnv(append(append([]string(nil), o.EnvParams...), o.envArgs...), o.In)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/templates/command_groups.go
+++ b/pkg/kubectl/cmd/templates/command_groups.go
@@ -55,5 +55,5 @@ func AddAdditionalCommands(g CommandGroups, message string, cmds []*cobra.Comman
 	if len(group.Commands) == 0 {
 		return g
 	}
-	return append(g, group)
+	return append(append(CommandGroups(nil), g...), group)
 }

--- a/pkg/kubectl/cmd/util/editor/editor.go
+++ b/pkg/kubectl/cmd/util/editor/editor.go
@@ -94,7 +94,7 @@ func defaultEnvEditor(envs []string) ([]string, bool) {
 	}
 	// rather than parse the shell arguments ourselves, punt to the shell
 	shell := defaultEnvShell()
-	return append(shell, editor), true
+	return append(append([]string(nil), shell...), editor), true
 }
 
 func (e Editor) args(path string) []string {

--- a/pkg/kubectl/explain/formatter.go
+++ b/pkg/kubectl/explain/formatter.go
@@ -94,7 +94,7 @@ func (l *line) Len() int {
 func (l *line) Add(word string) bool {
 	newLine := line{
 		wrap:  l.wrap,
-		words: append(l.words, word),
+		words: append(l.words, word), // this mutates the array behind l.words, but not the length of l.words
 	}
 	if newLine.Len() <= l.wrap || len(l.words) == 0 {
 		l.words = newLine.words

--- a/pkg/kubectl/explain/model_printer.go
+++ b/pkg/kubectl/explain/model_printer.go
@@ -56,7 +56,7 @@ func (m *modelPrinter) PrintDescription(schema proto.Schema) error {
 	if err := m.Writer.Write("DESCRIPTION:"); err != nil {
 		return err
 	}
-	for i, desc := range append(m.Descriptions, schema.GetDescription()) {
+	for i, desc := range append(append([]string(nil), m.Descriptions...), schema.GetDescription()) {
 		if desc == "" {
 			continue
 		}

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -67,7 +67,7 @@ func NewCgroupName(base CgroupName, components ...string) CgroupName {
 			panic(fmt.Errorf("invalid character in component [%q] of CgroupName", component))
 		}
 	}
-	return CgroupName(append(base, components...))
+	return CgroupName(append(append([]string(nil), base...), components...))
 }
 
 func escapeSystemdCgroupName(part string) string {

--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -73,7 +73,7 @@ func (m *unsupportedCgroupManager) ReduceCPULimits(cgroupName CgroupName) error 
 var RootCgroupName = CgroupName([]string{})
 
 func NewCgroupName(base CgroupName, components ...string) CgroupName {
-	return CgroupName(append(base, components...))
+	return CgroupName(append(append([]string(nil), base...), components...))
 }
 
 func (cgroupName CgroupName) ToSystemd() string {

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -279,7 +279,7 @@ func GetContainerSpec(pod *v1.Pod, containerName string) *v1.Container {
 
 // HasPrivilegedContainer returns true if any of the containers in the pod are privileged.
 func HasPrivilegedContainer(pod *v1.Pod) bool {
-	for _, c := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
+	for _, c := range append(append([]v1.Container(nil), pod.Spec.Containers...), pod.Spec.InitContainers...) {
 		if c.SecurityContext != nil &&
 			c.SecurityContext.Privileged != nil &&
 			*c.SecurityContext.Privileged {

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -151,7 +151,7 @@ func addAllocatableThresholds(thresholds []evictionapi.Threshold) []evictionapi.
 			})
 		}
 	}
-	return append(thresholds, additionalThresholds...)
+	return append(append([]evictionapi.Threshold(nil), thresholds...), additionalThresholds...)
 }
 
 // parseThresholdStatements parses the input statements into a list of Threshold objects.

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -129,7 +129,7 @@ func (p *cadvisorStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
 		if vstats, found := p.resourceAnalyzer.GetPodVolumeStats(podUID); found {
 			ephemeralStats = make([]statsapi.VolumeStats, len(vstats.EphemeralVolumes))
 			copy(ephemeralStats, vstats.EphemeralVolumes)
-			podStats.VolumeStats = append(vstats.EphemeralVolumes, vstats.PersistentVolumes...)
+			podStats.VolumeStats = append(append([]statsapi.VolumeStats(nil), vstats.EphemeralVolumes...), vstats.PersistentVolumes...)
 		}
 		podStats.EphemeralStorage = calcEphemeralStorage(podStats.Containers, ephemeralStats, &rootFsInfo)
 		// Lookup the pod-level cgroup's CPU and memory stats

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -259,7 +259,7 @@ func (p *criStatsProvider) makePodStorageStats(s *statsapi.PodStats, rootFsInfo 
 	if vstats, found := p.resourceAnalyzer.GetPodVolumeStats(podUID); found {
 		ephemeralStats := make([]statsapi.VolumeStats, len(vstats.EphemeralVolumes))
 		copy(ephemeralStats, vstats.EphemeralVolumes)
-		s.VolumeStats = append(vstats.EphemeralVolumes, vstats.PersistentVolumes...)
+		s.VolumeStats = append(append([]statsapi.VolumeStats(nil), vstats.EphemeralVolumes...), vstats.PersistentVolumes...)
 		s.EphemeralStorage = calcEphemeralStorage(s.Containers, ephemeralStats, rootFsInfo)
 	}
 	return s

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -566,7 +566,7 @@ func printRowsForHandlerEntry(output io.Writer, handler *handlerEntry, obj runti
 		// LABELS is always the last column.
 		headers = append(headers, formatShowLabelsHeader(options.ShowLabels)...)
 		if options.WithNamespace {
-			headers = append(withNamespacePrefixColumns, headers...)
+			headers = append(append([]string(nil), withNamespacePrefixColumns...), headers...)
 		}
 		printHeader(headers, output)
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -381,7 +381,7 @@ var iptablesCleanupOnlyChains = []iptablesJumpChain{
 // It returns true if an error was encountered. Errors are logged.
 func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 	// Unlink our chains
-	for _, chain := range append(iptablesJumpChains, iptablesCleanupOnlyChains...) {
+	for _, chain := range append(append([]iptablesJumpChain(nil), iptablesJumpChains...), iptablesCleanupOnlyChains...) {
 		args := append(chain.extraArgs,
 			"-m", "comment", "--comment", chain.comment,
 			"-j", string(chain.chain),

--- a/pkg/registry/rbac/reconciliation/BUILD
+++ b/pkg/registry/rbac/reconciliation/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/apis/audit/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1:go_default_library",
     ],

--- a/pkg/registry/rbac/reconciliation/reconcile_role.go
+++ b/pkg/registry/rbac/reconciliation/reconcile_role.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/apis/audit/v1"
 	"k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
@@ -200,7 +201,7 @@ func computeReconciledRole(existing, expected RuleOwner, removeExtraPermissions 
 	switch {
 	case !removeExtraPermissions && len(result.MissingRules) > 0:
 		// add missing rules in the union case
-		result.Role.SetRules(append(result.Role.GetRules(), result.MissingRules...))
+		result.Role.SetRules(append(append([]rbacv1.PolicyRule(nil), result.Role.GetRules()...), result.MissingRules...))
 		result.Operation = ReconcileUpdate
 
 	case removeExtraPermissions && (len(result.MissingRules) > 0 || len(result.ExtraRules) > 0):

--- a/pkg/registry/rbac/reconciliation/reconcile_rolebindings.go
+++ b/pkg/registry/rbac/reconciliation/reconcile_rolebindings.go
@@ -204,7 +204,7 @@ func computeReconciledRoleBinding(existing, expected RoleBinding, removeExtraSub
 	switch {
 	case !removeExtraSubjects && len(result.MissingSubjects) > 0:
 		// add missing subjects in the union case
-		result.RoleBinding.SetSubjects(append(result.RoleBinding.GetSubjects(), result.MissingSubjects...))
+		result.RoleBinding.SetSubjects(append(append([]rbacv1.Subject(nil), result.RoleBinding.GetSubjects()...), result.MissingSubjects...))
 		result.Operation = ReconcileUpdate
 
 	case removeExtraSubjects && (len(result.MissingSubjects) > 0 || len(result.ExtraSubjects) > 0):

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -114,8 +114,8 @@ func (p RESTStorageProvider) storage(version schema.GroupVersion, apiResourceCon
 
 func (p RESTStorageProvider) PostStartHook() (string, genericapiserver.PostStartHookFunc, error) {
 	policy := &PolicyData{
-		ClusterRoles:            append(bootstrappolicy.ClusterRoles(), bootstrappolicy.ControllerRoles()...),
-		ClusterRoleBindings:     append(bootstrappolicy.ClusterRoleBindings(), bootstrappolicy.ControllerRoleBindings()...),
+		ClusterRoles:            append(append([]rbacapiv1.ClusterRole(nil), bootstrappolicy.ClusterRoles()...), bootstrappolicy.ControllerRoles()...),
+		ClusterRoleBindings:     append(append([]rbacapiv1.ClusterRoleBinding(nil), bootstrappolicy.ClusterRoleBindings()...), bootstrappolicy.ControllerRoleBindings()...),
 		Roles:                   bootstrappolicy.NamespaceRoles(),
 		RoleBindings:            bootstrappolicy.NamespaceRoleBindings(),
 		ClusterRolesToAggregate: bootstrappolicy.ClusterRolesToAggregate(),

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -154,7 +154,7 @@ func (f *FakeExtender) ProcessPreemption(
 			delete(nodeToVictimsCopy, node)
 		} else {
 			// Append new victims to original victims
-			nodeToVictimsCopy[node].Pods = append(victims.Pods, extenderVictimPods...)
+			nodeToVictimsCopy[node].Pods = append(append([]*v1.Pod(nil), victims.Pods...), extenderVictimPods...)
 			nodeToVictimsCopy[node].NumPDBViolations = victims.NumPDBViolations + extendernPDBViolations
 		}
 	}

--- a/pkg/util/interrupt/interrupt.go
+++ b/pkg/util/interrupt/interrupt.go
@@ -44,7 +44,7 @@ func Chain(handler *Handler, notify ...func()) *Handler {
 	if handler == nil {
 		return New(nil, notify...)
 	}
-	return New(handler.Signal, append(notify, handler.Close)...)
+	return New(handler.Signal, append(append([](func())(nil), notify...), handler.Close)...)
 }
 
 // New creates a new handler that guarantees all notify functions are run after the critical

--- a/plugin/pkg/auth/authorizer/node/graph.go
+++ b/plugin/pkg/auth/authorizer/node/graph.go
@@ -189,7 +189,7 @@ func (g *Graph) deleteVertex_locked(vertexType vertexType, namespace, name strin
 			neighborsToRemove = append(neighborsToRemove, neighbor)
 		} else {
 			// recompute the destination edge index on this neighbor
-			neighborsToRecompute = append(neighborsToRemove, neighbor)
+			neighborsToRecompute = append(append([]graph.Node(nil), neighborsToRemove...), neighbor)
 		}
 		return true
 	})

--- a/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack.go
@@ -39,7 +39,7 @@ func GetNameFromCallsite(ignoredPackages ...string) string {
 			}
 			i += maxStack
 		}
-		if hasPackage(file, append(ignoredPackages, "/runtime/asm_")) {
+		if hasPackage(file, ignoredPackages) || hasPackage(file, []string{"/runtime/asm_"}) {
 			continue
 		}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1018,7 +1018,6 @@ func validatePatchWithSetOrderList(patchList, setOrderList interface{}, mergeKey
 	if patchIndex < len(nonDeleteList) && setOrderIndex >= len(typedSetOrderList) {
 		return fmt.Errorf("The order in patch list:\n%v\n doesn't match %s list:\n%v\n", typedPatchList, setElementOrderDirectivePrefix, setOrderList)
 	}
-	typedPatchList = append(nonDeleteList, toDeleteList...)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -140,19 +140,19 @@ func (m *AdmissionMetrics) reset() {
 // ObserveAdmissionStep records admission related metrics for a admission step, identified by step type.
 func (m *AdmissionMetrics) ObserveAdmissionStep(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
 	gvr := attr.GetResource()
-	m.step.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.step.observe(elapsed, append(append([]string(nil), extraLabels...), stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
 }
 
 // ObserveAdmissionController records admission related metrics for a built-in admission controller, identified by it's plugin handler name.
 func (m *AdmissionMetrics) ObserveAdmissionController(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
 	gvr := attr.GetResource()
-	m.controller.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.controller.observe(elapsed, append(append([]string(nil), extraLabels...), stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
 }
 
 // ObserveWebhook records admission related metrics for a admission webhook.
 func (m *AdmissionMetrics) ObserveWebhook(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
 	gvr := attr.GetResource()
-	m.webhook.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+	m.webhook.observe(elapsed, append(append([]string(nil), extraLabels...), stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
@@ -128,7 +128,7 @@ func TestValidatePolicy(t *testing.T) {
 	}
 
 	// Multiple rules.
-	errorCases = append(errorCases, audit.Policy{Rules: append(validRules, audit.PolicyRule{})})
+	errorCases = append(errorCases, audit.Policy{Rules: append(append([]audit.PolicyRule(nil), validRules...), audit.PolicyRule{})})
 
 	// invalid omitStages in policy
 	policy := audit.Policy{OmitStages: []audit.Stage{

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
@@ -54,7 +54,7 @@ func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (user.I
 	return &user.DefaultInfo{
 		Name:   u.GetName(),
 		UID:    u.GetUID(),
-		Groups: append(u.GetGroups(), user.AllAuthenticated),
+		Groups: append(append([]string(nil), u.GetGroups()...), user.AllAuthenticated),
 		Extra:  u.GetExtra(),
 	}, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -44,7 +44,7 @@ func (g *GroupAdder) AuthenticateRequest(req *http.Request) (user.Info, bool, er
 	return &user.DefaultInfo{
 		Name:   u.GetName(),
 		UID:    u.GetUID(),
-		Groups: append(u.GetGroups(), g.Groups...),
+		Groups: append(append([]string(nil), u.GetGroups()...), g.Groups...),
 		Extra:  u.GetExtra(),
 	}, true, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -129,7 +129,7 @@ func (a *APIInstaller) newWebService() *restful.WebService {
 	// endpoint by endpoint basis
 	ws.Consumes("*/*")
 	mediaTypes, streamMediaTypes := negotiation.MediaTypesForSerializer(a.group.Serializer)
-	ws.Produces(append(mediaTypes, streamMediaTypes...)...)
+	ws.Produces(append(append([]string(nil), mediaTypes...), streamMediaTypes...)...)
 	ws.ApiVersion(a.group.GroupVersion.String())
 
 	return ws
@@ -584,7 +584,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("read"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Returns(http.StatusOK, "OK", producedObject).
 				Writes(producedObject)
 			if isGetterWithOptions {
@@ -612,7 +612,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("list"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), allMediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), allMediaTypes...)...).
 				Returns(http.StatusOK, "OK", versionedList).
 				Writes(versionedList)
 			if err := addObjectParams(ws, route, versionedListOptions); err != nil {
@@ -644,7 +644,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("replace"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Returns(http.StatusOK, "OK", producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
@@ -669,7 +669,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Consumes(string(types.JSONPatchType), string(types.MergePatchType), string(types.StrategicMergePatchType)).
 				Operation("patch"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Returns(http.StatusOK, "OK", producedObject).
 				Reads(metav1.Patch{}).
 				Writes(producedObject)
@@ -692,7 +692,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("create"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Returns(http.StatusOK, "OK", producedObject).
 				// TODO: in some cases, the API may return a v1.Status instead of the versioned object
 				// but currently go-restful can't handle multiple different objects being returned.
@@ -713,7 +713,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("delete"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Writes(versionedStatus).
 				Returns(http.StatusOK, "OK", versionedStatus).
 				Returns(http.StatusAccepted, "Accepted", versionedStatus)
@@ -735,7 +735,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).
 				Operation("deletecollection"+namespaced+kind+strings.Title(subresource)+operationSuffix).
-				Produces(append(storageMeta.ProducesMIMETypes(action.Verb), mediaTypes...)...).
+				Produces(append(append([]string(nil), storageMeta.ProducesMIMETypes(action.Verb)...), mediaTypes...)...).
 				Writes(versionedStatus).
 				Returns(http.StatusOK, "OK", versionedStatus)
 			if err := addObjectParams(ws, route, versionedListOptions); err != nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/builder.go
@@ -39,7 +39,7 @@ import (
 )
 
 var FileExtensions = []string{".json", ".yaml", ".yml"}
-var InputExtensions = append(FileExtensions, "stdin")
+var InputExtensions = append(append([]string{}, FileExtensions...), "stdin")
 
 const defaultHttpGetAttempts int = 3
 

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -304,6 +304,7 @@ func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []by
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
+// makeURLSegments returns a new slice with the URL segments of the given name.
 func (c *dynamicResourceClient) makeURLSegments(name string) []string {
 	url := []string{}
 	if len(c.resource.Group) == 0 {

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -189,7 +189,7 @@ func packageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, cli
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)).GenerateClient
+			return util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)).GenerateClient
 		},
 	}
 }
@@ -359,7 +359,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			} else {
 				// User has not specified any override for this group version.
 				// filter out types which dont have genclient.
-				if tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)); !tags.GenerateClient {
+				if tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)); !tags.GenerateClient {
 					continue
 				}
 			}
@@ -409,7 +409,7 @@ type tagOverrideNamer struct {
 }
 
 func (n *tagOverrideNamer) Name(t *types.Type) string {
-	if nameOverride := extractTag(n.tagName, append(t.SecondClosestCommentLines, t.CommentLines...)); nameOverride != "" {
+	if nameOverride := extractTag(n.tagName, append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)); nameOverride != "" {
 		return nameOverride
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
@@ -79,7 +79,7 @@ func PackageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, cli
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)).GenerateClient
+			return util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)).GenerateClient
 		},
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
@@ -82,7 +82,7 @@ func (g *genFakeForGroup) GenerateType(c *generator.Context, t *types.Type, w io
 
 	sw.Do(groupClientTemplate, m)
 	for _, t := range g.types {
-		tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+		tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -69,7 +69,7 @@ func genStatus(t *types.Type) bool {
 		}
 	}
 
-	tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+	tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	return hasStatus && !tags.NoStatus
 }
 
@@ -87,7 +87,7 @@ func hasObjectMeta(t *types.Type) bool {
 func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	pkg := filepath.Base(t.Name.Package)
-	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+	tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -108,7 +108,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)
 	for _, t := range g.types {
-		tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+		tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -67,14 +67,14 @@ func genStatus(t *types.Type) bool {
 			break
 		}
 	}
-	return hasStatus && !util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)).NoStatus
+	return hasStatus && !util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)).NoStatus
 }
 
 // GenerateType makes the body of a file implementing the individual typed client for type t.
 func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	pkg := filepath.Base(t.Name.Package)
-	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+	tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
@@ -260,7 +260,7 @@ func Run(g *Generator) {
 		}
 
 		// generate the gogoprotobuf protoc
-		cmd := exec.Command("protoc", append(args, path)...)
+		cmd := exec.Command("protoc", append(append([]string(nil), args...), path)...)
 		out, err := cmd.CombinedOutput()
 		if len(out) > 0 {
 			log.Printf(string(out))

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -72,7 +72,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 	clientSetInterface := c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"})
 	informerFor := "InformerFor"
 
-	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+	tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -66,7 +66,7 @@ func DefaultNameSystem() string {
 func objectMetaForPackage(p *types.Package) (*types.Type, bool, error) {
 	generatingForPackage := false
 	for _, t := range p.Types {
-		if !util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)).GenerateClient {
+		if !util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)).GenerateClient {
 			continue
 		}
 		generatingForPackage = true
@@ -170,7 +170,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
-			tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+			tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 			if !tags.GenerateClient || tags.NoVerbs || !tags.HasVerb("list") || !tags.HasVerb("watch") {
 				continue
 			}
@@ -302,7 +302,7 @@ func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+			tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}
@@ -345,7 +345,7 @@ func versionPackage(basePackage string, groupPkgName string, gv clientgentypes.G
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+			tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/expansion.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/expansion.go
@@ -43,7 +43,7 @@ func (g *expansionGenerator) Filter(c *generator.Context, t *types.Type) bool {
 func (g *expansionGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	for _, t := range g.types {
-		tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+		tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 		if _, err := os.Stat(filepath.Join(g.packagePath, strings.ToLower(t.Name.Name+"_expansion.go"))); os.IsNotExist(err) {
 			sw.Do(expansionInterfaceTemplate, t)
 			if !tags.NonNamespaced {

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -110,7 +110,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
-			tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+			tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 			if !tags.GenerateClient || !tags.HasVerb("list") || !tags.HasVerb("get") {
 				continue
 			}
@@ -152,7 +152,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				return generators
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
-				tags := util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+				tags := util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 				return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("get")
 			},
 		})
@@ -166,7 +166,7 @@ func objectMetaForPackage(p *types.Package) (*types.Type, bool, error) {
 	generatingForPackage := false
 	for _, t := range p.Types {
 		// filter out types which dont have genclient.
-		if !util.MustParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...)).GenerateClient {
+		if !util.MustParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...)).GenerateClient {
 			continue
 		}
 		generatingForPackage = true
@@ -230,7 +230,7 @@ func (g *listerGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 		"objectMeta": g.objectMeta,
 	}
 
-	tags, err := util.ParseClientGenTags(append(t.SecondClosestCommentLines, t.CommentLines...))
+	tags, err := util.ParseClientGenTags(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -165,7 +165,7 @@ func WatchRecreateDeployment(c clientset.Interface, d *apps.Deployment) error {
 			if err == nil && nerr == nil {
 				Logf("%+v", d)
 				logReplicaSetsOfDeployment(d, allOldRSs, newRS)
-				logPodsOfDeployment(c, d, append(allOldRSs, newRS))
+				logPodsOfDeployment(c, d, append(append([]*apps.ReplicaSet(nil), allOldRSs...), newRS))
 			}
 			return false, fmt.Errorf("deployment %q is running new pods alongside old pods: %#v", d.Name, status)
 		}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4679,7 +4679,8 @@ func CoreDump(dir string) {
 		Logf("Dumping logs locally to: %s", dir)
 		cmd = exec.Command(path.Join(TestContext.RepoRoot, "cluster", "log-dump", "log-dump.sh"), dir)
 	}
-	cmd.Env = append(os.Environ(), fmt.Sprintf("LOG_DUMP_SYSTEMD_SERVICES=%s", parseSystemdServices(TestContext.SystemdServices)))
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("LOG_DUMP_SYSTEMD_SERVICES=%s", parseSystemdServices(TestContext.SystemdServices)))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -490,8 +490,7 @@ func setWriteCommand(file string, container *v1.Container) {
 }
 
 func addSubpathVolumeContainer(container *v1.Container, volumeMount v1.VolumeMount) {
-	existingMounts := container.VolumeMounts
-	container.VolumeMounts = append(existingMounts, volumeMount)
+	container.VolumeMounts = append(container.VolumeMounts, volumeMount)
 }
 
 func addMultipleWrites(container *v1.Container, file1 string, file2 string) {

--- a/test/e2e/storage/vsphere/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_placement.go
@@ -297,7 +297,7 @@ var _ = utils.SIGDescribe("Volume Placement", func() {
 		volumePath, err := vsp.CreateVolume(&VolumeOptions{}, nodeInfo.DataCenterRef)
 		Expect(err).NotTo(HaveOccurred())
 		volumePaths = append(volumePaths, volumePath)
-		testvolumePathsPodB = append(testvolumePathsPodA, volumePath)
+		testvolumePathsPodB = append(append([]string(nil), testvolumePathsPodA...), volumePath)
 
 		for index := 0; index < 5; index++ {
 			By(fmt.Sprintf("Creating pod-A on the node: %v with volume: %v", node1Name, testvolumePathsPodA[0]))

--- a/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
+++ b/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
@@ -518,7 +518,7 @@ func (g *genDeepCopy) deepCopyableInterfacesInner(c *generator.Context, t *types
 		return nil, nil
 	}
 
-	intfs := extractInterfacesTag(append(t.SecondClosestCommentLines, t.CommentLines...))
+	intfs := extractInterfacesTag(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 
 	var ts []*types.Type
 	for _, intf := range intfs {
@@ -557,7 +557,7 @@ func (g *genDeepCopy) deepCopyableInterfaces(c *generator.Context, t *types.Type
 
 	TypeSlice(result).Sort() // we need a stable sorting because it determines the order in generation
 
-	nonPointerReceiver, err := extractNonPointerInterfaces(append(t.SecondClosestCommentLines, t.CommentLines...))
+	nonPointerReceiver, err := extractNonPointerInterfaces(append(append([]string(nil), t.SecondClosestCommentLines...), t.CommentLines...))
 	if err != nil {
 		return nil, false, err
 	}

--- a/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go
+++ b/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go
@@ -762,14 +762,14 @@ func (n *callNode) WriteMethod(varName string, depth int, ancestors []*callNode,
 
 		n.writeCalls(local, true, sw)
 		for i := range n.children {
-			n.children[i].WriteMethod(local, depth+1, append(ancestors, n), sw)
+			n.children[i].WriteMethod(local, depth+1, append(append([]*callNode(nil), ancestors...), n), sw)
 		}
 		sw.Do("}\n", nil)
 	case n.key:
 	default:
 		n.writeCalls(varName, isPointer, sw)
 		for i := range n.children {
-			n.children[i].WriteMethod(varName, depth, append(ancestors, n), sw)
+			n.children[i].WriteMethod(varName, depth, append(append([]*callNode(nil), ancestors...), n), sw)
 		}
 	}
 

--- a/vendor/k8s.io/gengo/examples/set-gen/generators/sets.go
+++ b/vendor/k8s.io/gengo/examples/set-gen/generators/sets.go
@@ -129,7 +129,7 @@ func (g *genSet) Namers(c *generator.Context) namer.NameSystems {
 }
 
 func (g *genSet) Imports(c *generator.Context) (imports []string) {
-	return append(g.imports.ImportLines(), "reflect", "sort")
+	return append(append([]string(nil), g.imports.ImportLines()...), "reflect", "sort")
 }
 
 // args constructs arguments for templates. Usage:

--- a/vendor/k8s.io/gengo/generator/default_package.go
+++ b/vendor/k8s.io/gengo/generator/default_package.go
@@ -62,7 +62,7 @@ func (d *DefaultPackage) Generators(c *Context) []Generator {
 
 func (d *DefaultPackage) Header(filename string) []byte {
 	if filename == "doc.go" {
-		return append(d.HeaderText, d.PackageDocumentation...)
+		return append(append([]byte(nil), d.HeaderText...), d.PackageDocumentation...)
 	}
 	return d.HeaderText
 }


### PR DESCRIPTION
Golang's append mutates the array behind a slice:

```golang
l := make([]string, 0, 10)
x := append(l, "foo")
y := append(l, "bar")
fmt.Println(x, y)
```

This prints `bar bar`.

It looks like we have many places where we append to a slice that we do not own, or at best it is not obvious and not documented that we own it.

If ownership is unclear, we have to do:

```golang
l := make([]string, 0, 10)
x := append(append([]string(nil), l...), "foo")
y := append(append([]string(nil), l...), "bar")
fmt.Println(x, y)
```

This prints `foo bar` as expected.

One special case are global supposedly constant slices:

```golang
var commonFoo = []string{"a", "b", "c"}

for DoSomething(x string) {
    for _, y := range append(commonFoo, x) {
      ...
    }
}
```

If `DoSomething` is called in parallel from different Go routines, the behaviour is totally undefined, possibly leading to panic in tests due to concurrent access.