### PR TITLE
apiextensions: allow labelSelectorPath to not be under .status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -87578,7 +87578,7 @@
     ],
     "properties": {
      "labelSelectorPath": {
-      "description": "LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector. Only JSON paths without the array notation are allowed. Must be a JSON Path under .status. Must be set to work with HPA. If there is no value under the given path in the CustomResource, the status label selector value in the /scale subresource will default to the empty string.",
+      "description": "LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector. Only JSON paths without the array notation are allowed. Must be set to work with HPA. If there is no value under the given path in the CustomResource, the status label selector value in the /scale subresource will default to the empty string.",
       "type": "string"
      },
      "specReplicasPath": {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
@@ -241,7 +241,6 @@ type CustomResourceSubresourceScale struct {
 	StatusReplicasPath string
 	// LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector.
 	// Only JSON paths without the array notation are allowed.
-	// Must be a JSON Path under .status.
 	// Must be set to work with HPA.
 	// If there is no value under the given path in the CustomResource, the status label selector value in the /scale
 	// subresource will default to the empty string.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -218,7 +218,6 @@ message CustomResourceSubresourceScale {
 
   // LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector.
   // Only JSON paths without the array notation are allowed.
-  // Must be a JSON Path under .status.
   // Must be set to work with HPA.
   // If there is no value under the given path in the CustomResource, the status label selector value in the /scale
   // subresource will default to the empty string.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -256,7 +256,6 @@ type CustomResourceSubresourceScale struct {
 	StatusReplicasPath string `json:"statusReplicasPath" protobuf:"bytes,2,opt,name=statusReplicasPath"`
 	// LabelSelectorPath defines the JSON path inside of a CustomResource that corresponds to Scale.Status.Selector.
 	// Only JSON paths without the array notation are allowed.
-	// Must be a JSON Path under .status.
 	// Must be set to work with HPA.
 	// If there is no value under the given path in the CustomResource, the status label selector value in the /scale
 	// subresource will default to the empty string.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -504,12 +504,10 @@ func ValidateCustomResourceDefinitionSubresources(subresources *apiextensions.Cu
 			}
 		}
 
-		// if labelSelectorPath is present, it should be a constrained json path under .status
+		// if labelSelectorPath is present, it should be a constrained json path
 		if subresources.Scale.LabelSelectorPath != nil && len(*subresources.Scale.LabelSelectorPath) > 0 {
 			if errs := validateSimpleJSONPath(*subresources.Scale.LabelSelectorPath, fldPath.Child("scale.labelSelectorPath")); len(errs) > 0 {
 				allErrs = append(allErrs, errs...)
-			} else if !strings.HasPrefix(*subresources.Scale.LabelSelectorPath, ".status.") {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("scale.labelSelectorPath"), subresources.Scale.LabelSelectorPath, "should be a json path under .status"))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/66688

Currently, `labelSelectorPath` is restricted to be a JSONPath under `.status`. However, for native resources this value is present in the spec. To make sure custom resources behave like native resources, we should remove this restriction.

Also, it does not make sense to restrict it under spec because being in the status does not harm and should be allowed. And restricting it to spec would be a breaking change...

Since this removes a restriction, it "lessens" validation and is thus a backward compatible change.

/sig api-machinery
/kind bug
/area custom-resources
/assign sttts DirectXMan12 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Custom resources using scale subresources no longer need to have the `.spec.subresources.scale.labelSelectorPath` value as a JSONPath under `.status`.
```
