### PR TITLE
Add "only_cpu_and_memory" GET parameter to /stats/summary http handler in kubele

### DIFF
--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -1011,6 +1011,10 @@ func (f *fakeSummaryProvider) Get(updateStats bool) (*statsapi.Summary, error) {
 	return f.result, nil
 }
 
+func (f *fakeSummaryProvider) GetCPUAndMemoryStats() (*statsapi.Summary, error) {
+	return f.result, nil
+}
+
 // newPodStats returns a pod stat where each container is using the specified working set
 // each pod must have a Name, UID, Namespace
 func newPodStats(pod *v1.Pod, containerWorkingSetBytes int64) statsapi.PodStats {

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -32,39 +32,39 @@ import (
 	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
 )
 
-func TestSummaryProvider(t *testing.T) {
-	var (
-		podStats = []statsapi.PodStats{
-			{
-				PodRef:      statsapi.PodReference{Name: "test-pod", Namespace: "test-namespace", UID: "UID_test-pod"},
-				StartTime:   metav1.NewTime(time.Now()),
-				Containers:  []statsapi.ContainerStats{*getContainerStats()},
-				Network:     getNetworkStats(),
-				VolumeStats: []statsapi.VolumeStats{*getVolumeStats()},
-			},
-		}
-		imageFsStats = getFsStats()
-		rootFsStats  = getFsStats()
-		node         = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
-		nodeConfig   = cm.NodeConfig{
-			RuntimeCgroupsName: "/runtime",
-			SystemCgroupsName:  "/misc",
-			KubeletCgroupsName: "/kubelet",
-		}
-		cgroupRoot     = "/kubepods"
-		cgroupStatsMap = map[string]struct {
-			cs *statsapi.ContainerStats
-			ns *statsapi.NetworkStats
-		}{
-			"/":        {cs: getContainerStats(), ns: getNetworkStats()},
-			"/runtime": {cs: getContainerStats(), ns: getNetworkStats()},
-			"/misc":    {cs: getContainerStats(), ns: getNetworkStats()},
-			"/kubelet": {cs: getContainerStats(), ns: getNetworkStats()},
-			"/pods":    {cs: getContainerStats(), ns: getNetworkStats()},
-		}
-		rlimitStats = getRlimitStats()
-	)
+var (
+	podStats = []statsapi.PodStats{
+		{
+			PodRef:      statsapi.PodReference{Name: "test-pod", Namespace: "test-namespace", UID: "UID_test-pod"},
+			StartTime:   metav1.NewTime(time.Now()),
+			Containers:  []statsapi.ContainerStats{*getContainerStats()},
+			Network:     getNetworkStats(),
+			VolumeStats: []statsapi.VolumeStats{*getVolumeStats()},
+		},
+	}
+	imageFsStats = getFsStats()
+	rootFsStats  = getFsStats()
+	node         = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	nodeConfig   = cm.NodeConfig{
+		RuntimeCgroupsName: "/runtime",
+		SystemCgroupsName:  "/misc",
+		KubeletCgroupsName: "/kubelet",
+	}
+	cgroupRoot     = "/kubepods"
+	cgroupStatsMap = map[string]struct {
+		cs *statsapi.ContainerStats
+		ns *statsapi.NetworkStats
+	}{
+		"/":        {cs: getContainerStats(), ns: getNetworkStats()},
+		"/runtime": {cs: getContainerStats(), ns: getNetworkStats()},
+		"/misc":    {cs: getContainerStats(), ns: getNetworkStats()},
+		"/kubelet": {cs: getContainerStats(), ns: getNetworkStats()},
+		"/pods":    {cs: getContainerStats(), ns: getNetworkStats()},
+	}
+	rlimitStats = getRlimitStats()
+)
 
+func TestSummaryProviderGetStats(t *testing.T) {
 	assert := assert.New(t)
 
 	mockStatsProvider := new(statstest.StatsProvider)
@@ -126,6 +126,64 @@ func TestSummaryProvider(t *testing.T) {
 		Memory:             cgroupStatsMap["/pods"].cs.Memory,
 		Accelerators:       cgroupStatsMap["/pods"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/pods"].cs.UserDefinedMetrics,
+	})
+	assert.Equal(summary.Pods, podStats)
+}
+
+func TestSummaryProviderGetCPUAndMemoryStats(t *testing.T) {
+	assert := assert.New(t)
+
+	mockStatsProvider := new(statstest.StatsProvider)
+	mockStatsProvider.
+		On("GetNode").Return(node, nil).
+		On("GetNodeConfig").Return(nodeConfig).
+		On("GetPodCgroupRoot").Return(cgroupRoot).
+		On("ListPodStats").Return(podStats, nil).
+		On("ImageFsStats").Return(imageFsStats, nil).
+		On("RootFsStats").Return(rootFsStats, nil).
+		On("RlimitStats").Return(rlimitStats, nil).
+		On("GetCgroupStats", "/", false).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).
+		On("GetCgroupStats", "/runtime", false).Return(cgroupStatsMap["/runtime"].cs, cgroupStatsMap["/runtime"].ns, nil).
+		On("GetCgroupStats", "/misc", false).Return(cgroupStatsMap["/misc"].cs, cgroupStatsMap["/misc"].ns, nil).
+		On("GetCgroupStats", "/kubelet", false).Return(cgroupStatsMap["/kubelet"].cs, cgroupStatsMap["/kubelet"].ns, nil).
+		On("GetCgroupStats", "/kubepods", false).Return(cgroupStatsMap["/pods"].cs, cgroupStatsMap["/pods"].ns, nil)
+
+	provider := NewSummaryProvider(mockStatsProvider)
+	summary, err := provider.GetCPUAndMemoryStats()
+	assert.NoError(err)
+
+	assert.Equal(summary.Node.NodeName, "test-node")
+	assert.Equal(summary.Node.StartTime, cgroupStatsMap["/"].cs.StartTime)
+	assert.Equal(summary.Node.CPU, cgroupStatsMap["/"].cs.CPU)
+	assert.Equal(summary.Node.Memory, cgroupStatsMap["/"].cs.Memory)
+	assert.Nil(summary.Node.Network)
+	assert.Nil(summary.Node.Fs)
+	assert.Nil(summary.Node.Runtime)
+
+	assert.Equal(len(summary.Node.SystemContainers), 4)
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "kubelet",
+		StartTime: cgroupStatsMap["/kubelet"].cs.StartTime,
+		CPU:       cgroupStatsMap["/kubelet"].cs.CPU,
+		Memory:    cgroupStatsMap["/kubelet"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "misc",
+		StartTime: cgroupStatsMap["/misc"].cs.StartTime,
+		CPU:       cgroupStatsMap["/misc"].cs.CPU,
+		Memory:    cgroupStatsMap["/misc"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "runtime",
+		StartTime: cgroupStatsMap["/runtime"].cs.StartTime,
+		CPU:       cgroupStatsMap["/runtime"].cs.CPU,
+		Memory:    cgroupStatsMap["/runtime"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "pods",
+		StartTime: cgroupStatsMap["/pods"].cs.StartTime,
+		CPU:       cgroupStatsMap["/pods"].cs.CPU,
+		Memory:    cgroupStatsMap["/pods"].cs.Memory,
 	})
 	assert.Equal(summary.Pods, podStats)
 }

--- a/pkg/kubelet/stats/stats_provider_test.go
+++ b/pkg/kubelet/stats/stats_provider_test.go
@@ -634,8 +634,9 @@ type fakeResourceAnalyzer struct {
 	podVolumeStats serverstats.PodVolumeStats
 }
 
-func (o *fakeResourceAnalyzer) Start()                              {}
-func (o *fakeResourceAnalyzer) Get(bool) (*statsapi.Summary, error) { return nil, nil }
+func (o *fakeResourceAnalyzer) Start()                                           {}
+func (o *fakeResourceAnalyzer) Get(bool) (*statsapi.Summary, error)              { return nil, nil }
+func (o *fakeResourceAnalyzer) GetCPUAndMemoryStats() (*statsapi.Summary, error) { return nil, nil }
 func (o *fakeResourceAnalyzer) GetPodVolumeStats(uid types.UID) (serverstats.PodVolumeStats, bool) {
 	return o.podVolumeStats, true
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
PR adds "only_cpu_and_memory" GET parameter to /stats/summary http handler in kubelet. If parameter is true then only cpu and memory will be present in response. The parameter will be used by Metric Server to avoid sending/decoding unneeded data. Metric server needs only cpu and memory.

**Release note:**
```release-note
Add "only_cpu_and_memory" GET parameter to /stats/summary http handler in kubelet. If parameter is true then only cpu and memory will be present in response.
```


