### PR TITLE
Tests that use CheckTestingNSDeletedExcept must be [Serial]

### DIFF
--- a/test/e2e/network/dns_scale_records.go
+++ b/test/e2e/network/dns_scale_records.go
@@ -38,7 +38,7 @@ const (
 	checkServicePercent          = 0.05
 )
 
-var _ = SIGDescribe("[Feature:PerformanceDNS]", func() {
+var _ = SIGDescribe("[Feature:PerformanceDNS][Serial]", func() {
 	f := framework.NewDefaultFramework("performancedns")
 
 	BeforeEach(func() {


### PR DESCRIPTION
Otherwise, another e2e test could be running at the same time and cause
a namespace to get created, which fails this test.