### PR TITLE
apiserver: make not-found external-apiserver-authn configmap non-fatal

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",


### PR DESCRIPTION
As client-ca and requestheader-client-ca is optional in the external-apiserver-authentication config file and components like kube-controller-manager and kube-scheduler won't need that anyway, we better make it non-fatal if the configmap is not found in the cluster.

Consumer counter-part PR to https://github.com/kubernetes/kubernetes/pull/67694.

```release-note
Don't let aggregated apiservers fail to launch if the external-apiserver-authentication configmap is not found in the cluster.
```