### PR TITLE
apply unschedulable:NoSchedule taint to Daemonset pods

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1333,6 +1333,14 @@ func (dsc *DaemonSetsController) simulate(newPod *v1.Pod, node *v1.Node, ds *app
 		})
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
+		v1helper.AddOrUpdateTolerationInPod(newPod, &v1.Toleration{
+			Key:      algorithm.TaintNodeUnschedulable,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		})
+	}
+
 	objects, err := dsc.podNodeIndex.ByIndex("nodeName", node.Name)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Although unschedulable:NoSchedule taint is applied to daemonset pod (https://github.com/kubernetes/kubernetes/pull/61161/), internally in `simulate()` (say when do calculate  how many ds pods needs to run), the toleration isn't applied. This cause the total pods number of daemonest incorrect when some nodes are cordoned.

This PR is to fix this issue - apply unschedulable:NoSchedule taint also in `simulate()`.

**Which issue(s) this PR fixes**:
Fixes #67845

**Special notes for your reviewer**:

With this patch, daemonset behavior is consistent on following combination:
- TaintNodesByCondition=true,ScheduleDaemonSetPods=true (will be default behavior in 1.12, ScheduleDaemonSetPods isn't enabled in master branch yet)
- TaintNodesByCondition=false,ScheduleDaemonSetPods=false

And we will document the limitation that ScheduleDaemonSetPods must be set the same value with TaintNodesByCondition.

**Release note**:
```release-note
NONE
```
