### PR TITLE
The aggregator test can break discovery while removing an apiservice

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		aggrclient = f.AggregatorClient
 	})
 
-	It("Should be able to support the 1.7 Sample API Server using the current Aggregator", func() {
+	It("Should be able to support the 1.7 Sample API Server using the current Aggregator [Disruptive]", func() {
 		// Make sure the relevant provider supports Agggregator
 		framework.SkipUnlessServerVersionGTE(serverAggregatorVersion, f.ClientSet.Discovery())
 		framework.SkipUnlessProviderIs("gce", "gke")


### PR DESCRIPTION
Other tests that depend on discovery not failing can be affected by the removal
of an apiservice mid test:

```
error: Unable to to get list of available resources: unable to retrieve the complete
list of server APIs: wardle.k8s.io/v1alpha1: the server could not find the requested
resource
```

Example of a CLI command test failing because the wardle apiservice was removed mid
test: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18816/pull-ci-origin-e2e-gcp/2909/#conformanceareanetworkingfeaturerouter-the-haproxy-router-should-serve-the-correct-routes-when-running-with-the-haproxy-config-manager-suiteopenshiftconformanceparallel