### PR TITLE
Fix pastBackoffLimitOnFailure in job controller

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -643,6 +643,9 @@ func pastBackoffLimitOnFailure(job *batch.Job, pods []*v1.Pod) bool {
 			result += stat.RestartCount
 		}
 	}
+	if *job.Spec.BackoffLimit == 0 {
+		return result > 0
+	}
 	return result >= *job.Spec.BackoffLimit
 }
 

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -1422,6 +1422,21 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 		expectedCondition       *batch.JobConditionType
 		expectedConditionReason string
 	}{
+		"backoffLimit 0 should have 1 pod active": {
+			1, 1, 0,
+			true, []int32{0},
+			1, 0, 0, nil, "",
+		},
+		"backoffLimit 1 with restartCount 0 should have 1 pod active": {
+			1, 1, 1,
+			true, []int32{0},
+			1, 0, 0, nil, "",
+		},
+		"backoffLimit 1 with restartCount 1 should have 0 pod active": {
+			1, 1, 1,
+			true, []int32{1},
+			0, 0, 1, &jobConditionFailed, "BackoffLimitExceeded",
+		},
 		"too many job failures - single pod": {
 			1, 5, 2,
 			true, []int32{2},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix pastBackoffLimitOnFailure in job controller.
The judging criteria should be restartCount > *job.Spec.BackoffLimit instead of >= when *job.Spec.BackoffLimit is 0.

1) if *job.Spec.BackoffLimit is 0, having ">= *job.Spec.BackoffLimit" will make the job not run any pod and get "Job has reached the specified backoff limit" directly.

2) if *job.Spec.BackoffLimit is other number greater than 0, say 3, having ">= *job.Spec.BackoffLimit" is correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67848 

**Special notes for your reviewer**:
NONE
**Release note**:

```release-note
NONE
```
