### PR TITLE
Update generated code for private schema of admission controllers

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -138,3 +138,20 @@ CODEGEN_PKG=./vendor/k8s.io/code-generator vendor/k8s.io/sample-controller/hack/
 CODEGEN_PKG=./vendor/k8s.io/code-generator vendor/k8s.io/apiextensions-apiserver/hack/update-codegen.sh
 CODEGEN_PKG=./vendor/k8s.io/code-generator vendor/k8s.io/metrics/hack/update-codegen.sh
 CODEGEN_PKG=./vendor/k8s.io/code-generator vendor/k8s.io/apiextensions-apiserver/examples/client-go/hack/update-codegen.sh
+
+# call generation on admission controllers for now
+
+# resourcequota admission controller
+vendor/k8s.io/code-generator/generate-internal-groups.sh deepcopy,conversion,defaults \
+  k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis \
+  k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis \
+  k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis \
+  "resourcequota:v1alpha1,v1beta1"
+
+# eventratelimit admission controller
+vendor/k8s.io/code-generator/generate-internal-groups.sh deepcopy,conversion,defaults \
+  k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis \
+  k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis \
+  k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis \
+  "eventratelimit:v1alpha1"
+


### PR DESCRIPTION
running `make update` cannot flush generated code for private schema of admission controllers for now (for `eventratelimit`, `resourcequota` currently). when i have a api-change for these, i'll have to  generate stuffs manually myself 😢

this pull will ensure it's continously updated


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
