### PR TITLE
Add validation rule for --enforce-node-allocatable

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/validation_test.go
+++ b/cmd/kubeadm/app/componentconfigs/validation_test.go
@@ -286,7 +286,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 				ComponentConfigs: kubeadm.ComponentConfigs{
 					Kubelet: &kubeletconfig.KubeletConfiguration{
 						CgroupsPerQOS:               true,
-						EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved"},
+						EnforceNodeAllocatable:      []string{"pods"},
 						SystemCgroups:               "",
 						CgroupRoot:                  "",
 						EventBurst:                  10,

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation.go
@@ -109,7 +109,13 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 		switch val {
 		case kubetypes.NodeAllocatableEnforcementKey:
 		case kubetypes.SystemReservedEnforcementKey:
+			if kc.SystemReserved == nil {
+				allErrors = append(allErrors, fmt.Errorf("invalid configuration: EnforceNodeAllocatable (--enforce-node-allocatable) must not contain '%s' when '%s' is not specified", kubetypes.SystemReservedEnforcementKey, "--system-reserved"))
+			}
 		case kubetypes.KubeReservedEnforcementKey:
+			if kc.KubeReserved == nil {
+				allErrors = append(allErrors, fmt.Errorf("invalid configuration: EnforceNodeAllocatable (--enforce-node-allocatable) must not contain '%s' when '%s' is not specified", kubetypes.KubeReservedEnforcementKey, "--kube-reserved"))
+			}
 		case kubetypes.NodeAllocatableNoneKey:
 			if len(kc.EnforceNodeAllocatable) > 1 {
 				allErrors = append(allErrors, fmt.Errorf("invalid configuration: EnforceNodeAllocatable (--enforce-node-allocatable) may not contain additional enforcements when '%s' is specified", kubetypes.NodeAllocatableNoneKey))

--- a/pkg/kubelet/apis/kubeletconfig/validation/validation_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/validation/validation_test.go
@@ -26,7 +26,7 @@ import (
 func TestValidateKubeletConfiguration(t *testing.T) {
 	successCase := &kubeletconfig.KubeletConfiguration{
 		CgroupsPerQOS:               true,
-		EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved"},
+		EnforceNodeAllocatable:      []string{"pods"},
 		SystemCgroups:               "",
 		CgroupRoot:                  "",
 		EventBurst:                  10,
@@ -78,7 +78,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		HairpinMode:                 "foo",
 		NodeLeaseDurationSeconds:    -1,
 	}
-	const numErrs = 23
+	const numErrs = 25
 	if allErrors := ValidateKubeletConfiguration(errorCase); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrs {
 		t.Errorf("expect %d errors, got %v", numErrs, len(allErrors.(utilerrors.Aggregate).Errors()))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add validation rule for --enforce-node-allocatable
1. Flag --enforce-node-allocatable must not contain 'kube-reserved' when '--kube-reserved' is not specified
2. Flag --enforce-node-allocatable must not contain 'system-reserved' when '--system-reserved' is not specified

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66189

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
kubelet: Flag --enforce-node-allocatable must not contain 'system-reserved'(or kube-reserved)  when '--system-reserved'(or '--kube-reserved') is not specified
```

/sig node