### PR TITLE
add flag `--no-headers` to `kubectl top ...`

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -40,6 +40,7 @@ import (
 type TopNodeOptions struct {
 	ResourceName    string
 	Selector        string
+	NoHeaders       bool
 	NodeClient      corev1client.CoreV1Interface
 	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
@@ -118,6 +119,8 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 		Aliases: []string{"nodes", "no"},
 	}
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
+
 	o.HeapsterOptions.Bind(cmd.Flags())
 	return cmd
 }
@@ -216,7 +219,7 @@ func (o TopNodeOptions) RunTopNode() error {
 		allocatable[n.Name] = n.Status.Allocatable
 	}
 
-	return o.Printer.PrintNodeMetrics(metrics.Items, allocatable)
+	return o.Printer.PrintNodeMetrics(metrics.Items, allocatable, o.NoHeaders)
 }
 
 func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector) (*metricsapi.NodeMetricsList, error) {

--- a/pkg/kubectl/cmd/top_node_test.go
+++ b/pkg/kubectl/cmd/top_node_test.go
@@ -81,6 +81,7 @@ func TestTopNodeAllMetrics(t *testing.T) {
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
 
 	cmd := NewCmdTopNode(tf, nil, streams)
+	cmd.Flags().Set("no-headers", "true")
 	cmd.Run(cmd, []string{})
 
 	// Check the presence of node names in the output.
@@ -89,6 +90,9 @@ func TestTopNodeAllMetrics(t *testing.T) {
 		if !strings.Contains(result, m.Name) {
 			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
 		}
+	}
+	if strings.Contains(result, "MEMORY") {
+		t.Errorf("should not print headers with --no-headers option set:\n%s\n", result)
 	}
 }
 

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -45,6 +45,7 @@ type TopPodOptions struct {
 	Selector        string
 	AllNamespaces   bool
 	PrintContainers bool
+	NoHeaders       bool
 	PodClient       corev1client.PodsGetter
 	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
@@ -109,6 +110,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.PrintContainers, "containers", o.PrintContainers, "If present, print usage of containers within a pod.")
 	cmd.Flags().BoolVar(&o.AllNamespaces, "all-namespaces", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers.")
 	o.HeapsterOptions.Bind(cmd.Flags())
 	return cmd
 }
@@ -198,7 +200,7 @@ func (o TopPodOptions) RunTopPod() error {
 		return err
 	}
 
-	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces)
+	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders)
 }
 
 func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, selector labels.Selector) (*metricsapi.PodMetricsList, error) {

--- a/pkg/kubectl/cmd/top_pod_test.go
+++ b/pkg/kubectl/cmd/top_pod_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -132,6 +133,14 @@ func TestTopPod(t *testing.T) {
 			namespaces:   []string{testNS},
 			containers:   true,
 		},
+		{
+			name:         "no-headers set",
+			flags:        map[string]string{"containers": "true", "no-headers": "true"},
+			args:         []string{"pod1"},
+			expectedPath: topPathPrefix + "/namespaces/" + testNS + "/pods/pod1",
+			namespaces:   []string{testNS},
+			containers:   true,
+		},
 	}
 	initTestErrorHandler(t)
 	for _, testCase := range testCases {
@@ -220,6 +229,9 @@ func TestTopPod(t *testing.T) {
 				if strings.Contains(result, name) {
 					t.Errorf("%s: unexpected metrics for %s: \n%s", testCase.name, name, result)
 				}
+			}
+			if cmdutil.GetFlagBool(cmd, "no-headers") && strings.Contains(result, "MEMORY") {
+				t.Errorf("%s: unexpected headers with no-headers option set: \n%s", testCase.name, result)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
add flag `--no-headers` to `kubectl top ...`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67886 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubectl: add the --no-headers flag to `kubectl top ...`
```
