### PR TITLE
dry-run: Create server-dry-run on kubectl

### DIFF
--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -227,7 +227,7 @@ func (o *ReplaceOptions) Run() error {
 		}
 
 		// Serialize the object with the annotation applied.
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, true, info.Object)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, true, info.Object, nil)
 		if err != nil {
 			return cmdutil.AddSourceToErr("replacing", info.Source, err)
 		}
@@ -317,7 +317,7 @@ func (o *ReplaceOptions) forceReplace() error {
 			glog.V(4).Infof("error recording current command: %v", err)
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -388,7 +388,7 @@ func TestGenerateService(t *testing.T) {
 			addRunFlags(cmd, opts)
 
 			if !test.expectPOST {
-				opts.DryRun = true
+				opts.DryRun.Client = true
 			}
 
 			if len(test.port) > 0 {

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -244,7 +244,7 @@ func (o *ScaleOptions) RunScale() error {
 				return err
 			}
 			helper := resource.NewHelper(client, mapping)
-			if _, err := helper.Patch(info.Namespace, info.Name, types.MergePatchType, mergePatch); err != nil {
+			if _, err := helper.Patch(info.Namespace, info.Name, types.MergePatchType, mergePatch, nil); err != nil {
 				glog.V(4).Infof("error recording reason: %v", err)
 			}
 		}

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -274,9 +274,9 @@ func (o TaintOptions) RunTaint() error {
 
 		var outputObj runtime.Object
 		if createdPatch {
-			outputObj, err = helper.Patch(namespace, name, types.StrategicMergePatchType, patchBytes)
+			outputObj, err = helper.Patch(namespace, name, types.StrategicMergePatchType, patchBytes, nil)
 		} else {
-			outputObj, err = helper.Replace(namespace, name, false, obj)
+			outputObj, err = helper.Replace(namespace, name, false, obj, nil)
 		}
 		if err != nil {
 			return err

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "conversion.go",
+        "dryrun.go",
         "factory.go",
         "factory_client_access.go",
         "generator.go",

--- a/pkg/kubectl/cmd/util/dryrun.go
+++ b/pkg/kubectl/cmd/util/dryrun.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func SetupDryRun(cmd *cobra.Command) {
+	AddDryRunFlag(cmd)
+	AddServerDryRunFlag(cmd)
+}
+
+type DryRun struct {
+	Client bool
+	Server bool
+}
+
+// NewDryRunFromCmd crates a new DryRun structure by reading the values
+// of the flags in the provided cmd.
+func NewDryRunFromCmd(cmd *cobra.Command) *DryRun {
+	return &DryRun{
+		Client: GetDryRunFlag(cmd),
+		Server: GetServerDryRunFlag(cmd),
+	}
+}
+
+// IsDryRun returns true either if it's client-side dry-run or server-side dry-run
+func (d *DryRun) IsDryRun() bool {
+	return d.Server || d.Client
+}
+
+func (d *DryRun) dryRunFlag() []string {
+	if d.Server {
+		return []string{metav1.DryRunAll}
+	}
+	return []string{}
+}
+
+// CreateOptions adds the dry-run information in the CreateOptions
+// passed. If nil is received a new UpdateOptions is created, the new
+// value is returned.
+func (d *DryRun) CreateOptions(opts *metav1.CreateOptions) *metav1.CreateOptions {
+	if opts == nil {
+		opts = &metav1.CreateOptions{}
+	}
+	opts.DryRun = d.dryRunFlag()
+
+	return opts
+}
+
+// UpdateOptions adds the dry-run information in the UpdateOptions
+// arg. If nil is received a new UpdateOptions is created. The value
+// is returned.
+func (d *DryRun) UpdateOptions(opts *metav1.UpdateOptions) *metav1.UpdateOptions {
+	if opts == nil {
+		opts = &metav1.UpdateOptions{}
+	}
+	opts.DryRun = d.dryRunFlag()
+
+	return opts
+}
+
+// DeleteOptions adds the dry-run information in the DeleteOptions
+// passed. If nil is received a new UpdateOptions is created, the new
+// value is returned.
+func (d *DryRun) DeleteOptions(opts *metav1.DeleteOptions) *metav1.DeleteOptions {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+	opts.DryRun = d.dryRunFlag()
+
+	return opts
+}

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -503,7 +503,7 @@ func (o *EditOptions) annotationPatch(update *resource.Info) error {
 		return err
 	}
 	helper := resource.NewHelper(client, mapping)
-	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch)
+	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch, nil)
 	if err != nil {
 		return err
 	}
@@ -632,7 +632,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 			fmt.Fprintf(o.Out, "Patch: %s\n", string(patch))
 		}
 
-		patched, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, patchType, patch)
+		patched, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, patchType, patch, nil)
 		if err != nil {
 			fmt.Fprintln(o.ErrOut, results.addError(err, info))
 			return nil
@@ -650,7 +650,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 
 func (o *EditOptions) visitToCreate(createVisitor resource.Visitor) error {
 	err := createVisitor.Visit(func(info *resource.Info, incomingErr error) error {
-		if err := resource.CreateAndRefresh(info); err != nil {
+		if err := resource.CreateAndRefresh(info, nil); err != nil {
 			return err
 		}
 		printer, err := o.ToPrinter("created")

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -404,6 +404,11 @@ func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
 }
 
+// AddServerDryRunFlag adds server-dry-run flag to a command.
+func AddServerDryRunFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("server-dry-run", false, "If true, requests dry-run from server")
+}
+
 func AddIncludeUninitializedFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool(IncludeUninitializedFlag, false, `If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.`)
 }
@@ -478,6 +483,10 @@ func DumpReaderToFile(reader io.Reader, filename string) error {
 
 func GetDryRunFlag(cmd *cobra.Command) bool {
 	return GetFlagBool(cmd, "dry-run")
+}
+
+func GetServerDryRunFlag(cmd *cobra.Command) bool {
+	return GetFlagBool(cmd, "server-dry-run")
 }
 
 // GetResourcesAndPairs retrieves resources and "KEY=VALUE or KEY-" pair args from given args

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/helper_test.go
@@ -228,7 +228,7 @@ func TestHelperCreate(t *testing.T) {
 				RESTClient:      client,
 				NamespaceScoped: true,
 			}
-			_, err := modifier.Create("bar", tt.Modify, tt.Object)
+			_, err := modifier.Create("bar", tt.Modify, tt.Object, nil)
 			if (err != nil) != tt.Err {
 				t.Errorf("%d: unexpected error: %t %v", i, tt.Err, err)
 			}
@@ -606,7 +606,7 @@ func TestHelperReplace(t *testing.T) {
 				RESTClient:      client,
 				NamespaceScoped: tt.NamespaceScoped,
 			}
-			_, err := modifier.Replace(tt.Namespace, "foo", tt.Overwrite, tt.Object)
+			_, err := modifier.Replace(tt.Namespace, "foo", tt.Overwrite, tt.Object, nil)
 			if (err != nil) != tt.Err {
 				t.Errorf("%d: unexpected error: %t %v", i, tt.Err, err)
 			}

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/resource/visitor.go
@@ -655,8 +655,8 @@ func RetrieveLazy(info *Info, err error) error {
 }
 
 // CreateAndRefresh creates an object from input info and refreshes info with that object
-func CreateAndRefresh(info *Info) error {
-	obj, err := NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
+func CreateAndRefresh(info *Info, options *metav1.CreateOptions) error {
+	obj, err := NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object, options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a new `--server-dry-run` flag for many kubectl commands. This is using the new server-side dry-run.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
To be written
```
