### PR TITLE
Add support for mount options to CSI drivers

### DIFF
--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -276,6 +276,7 @@ func (m *csiBlockMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, vol
 		csiSource.VolumeAttributes,
 		nodePublishSecrets,
 		fsTypeBlockName,
+		[]string{},
 	)
 
 	if err != nil {

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -48,6 +48,7 @@ type csiClient interface {
 		volumeAttribs map[string]string,
 		nodePublishSecrets map[string]string,
 		fsType string,
+		mountOptions []string,
 	) error
 	NodeUnpublishVolume(
 		ctx context.Context,
@@ -113,6 +114,7 @@ func (c *csiDriverClient) NodePublishVolume(
 	volumeAttribs map[string]string,
 	nodePublishSecrets map[string]string,
 	fsType string,
+	mountOptions []string,
 ) error {
 	glog.V(4).Info(log("calling NodePublishVolume rpc [volid=%s,target_path=%s]", volID, targetPath))
 	if volID == "" {
@@ -153,7 +155,8 @@ func (c *csiDriverClient) NodePublishVolume(
 	} else {
 		req.VolumeCapability.AccessType = &csipb.VolumeCapability_Mount{
 			Mount: &csipb.VolumeCapability_MountVolume{
-				FsType: fsType,
+				FsType:     fsType,
+				MountFlags: mountOptions,
 			},
 		}
 	}

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -59,6 +59,7 @@ func (c *fakeCsiDriverClient) NodePublishVolume(
 	volumeAttribs map[string]string,
 	nodePublishSecrets map[string]string,
 	fsType string,
+	mountOptions []string,
 ) error {
 	c.t.Log("calling fake.NodePublishVolume...")
 	req := &csipb.NodePublishVolumeRequest{
@@ -74,7 +75,8 @@ func (c *fakeCsiDriverClient) NodePublishVolume(
 			},
 			AccessType: &csipb.VolumeCapability_Mount{
 				Mount: &csipb.VolumeCapability_MountVolume{
-					FsType: fsType,
+					FsType:     fsType,
+					MountFlags: mountOptions,
 				},
 			},
 		},
@@ -237,6 +239,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 			map[string]string{"attr0": "val0"},
 			map[string]string{},
 			tc.fsType,
+			[]string{},
 		)
 
 		if tc.mustFail && err == nil {

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -195,6 +195,7 @@ func (c *csiMountMgr) SetUpAt(dir string, fsGroup *int64) error {
 		attribs,
 		nodePublishSecrets,
 		fsType,
+		c.spec.PersistentVolume.Spec.MountOptions,
 	)
 
 	if err != nil {

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -164,6 +164,7 @@ func MounterSetUpTests(t *testing.T, podInfoEnabled bool) {
 
 			pv := makeTestPV("test-pv", 10, test.driver, testVol)
 			pv.Spec.CSI.VolumeAttributes = test.attributes
+			pv.Spec.MountOptions = []string{"foo=bar", "baz=qux"}
 			pvName := pv.GetName()
 
 			mounter, err := plug.NewMounter(
@@ -239,6 +240,9 @@ func MounterSetUpTests(t *testing.T, podInfoEnabled bool) {
 			}
 			if vol.Path != csiMounter.GetPath() {
 				t.Errorf("csi server expected path %s, got %s", csiMounter.GetPath(), vol.Path)
+			}
+			if !reflect.DeepEqual(vol.MountFlags, pv.Spec.MountOptions) {
+				t.Errorf("csi server expected mount options %v, got %v", pv.Spec.MountOptions, vol.MountFlags)
 			}
 			if podInfoEnabled {
 				if !reflect.DeepEqual(vol.Attributes, test.expectedAttributes) {

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -333,7 +333,10 @@ func (p *csiPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.S
 func (p *csiPlugin) SupportsMountOption() bool {
 	// TODO (vladimirvivien) use CSI VolumeCapability.MountVolume.mount_flags
 	// to probe for the result for this method
-	return false
+	// (bswartz) Until the CSI spec supports probing, our only option is to
+	// make plugins register their support for mount options or lack thereof
+	// directly with kubernetes.
+	return true
 }
 
 func (p *csiPlugin) SupportsBulkVolumeVerification() bool {

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -59,6 +59,7 @@ func (f *IdentityClient) Probe(ctx context.Context, in *csipb.ProbeRequest, opts
 type CSIVolume struct {
 	Attributes map[string]string
 	Path       string
+	MountFlags []string
 }
 
 // NodeClient returns CSI node client
@@ -126,6 +127,7 @@ func (f *NodeClient) NodePublishVolume(ctx context.Context, req *csipb.NodePubli
 	f.nodePublishedVolumes[req.GetVolumeId()] = CSIVolume{
 		Path:       req.GetTargetPath(),
 		Attributes: req.GetVolumeAttributes(),
+		MountFlags: req.GetVolumeCapability().GetMount().MountFlags,
 	}
 	return &csipb.NodePublishVolumeResponse{}, nil
 }


### PR DESCRIPTION
Declare support for mount option in CSI drivers, and implement usage for the mountOptions field of the storage class when invoking CSI RPCs that accept mount options.

Fixes #67897 

```release-note
CSI drivers now have access to mountOptions defined on the storage class when attaching volumes.
```
