### PR TITLE
"gcloud beta compute networks subnets" does not work with the latest gcloud release

### DIFF
--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -83,9 +83,6 @@ function create-master-instance-internal() {
     retries=30
     sleep_sec=60
   fi
-  if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    gcloud="gcloud beta"
-  fi
 
   local -r master_name="${1}"
   local -r address="${2:-}"

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -68,7 +68,7 @@ function detect-k8s-subnetwork() {
 #   REGION
 function set-allow-subnet-cidr-routes-overlap() {
   local allow_subnet_cidr_routes_overlap
-  allow_subnet_cidr_routes_overlap=$(gcloud beta compute networks subnets \
+  allow_subnet_cidr_routes_overlap=$(gcloud compute networks subnets \
     describe ${IP_ALIAS_SUBNETWORK} --project=${PROJECT} --region=${REGION} \
     --format='value(allowSubnetCidrRoutesOverlap)')
   local allow_overlap=$1
@@ -78,7 +78,7 @@ function set-allow-subnet-cidr-routes-overlap() {
   fi
 
   echo "Setting subnet \"${IP_ALIAS_SUBNETWORK}\" allowSubnetCidrRoutesOverlap to $1"
-  local fingerprint=$(gcloud beta compute networks subnets describe \
+  local fingerprint=$(gcloud compute networks subnets describe \
     ${IP_ALIAS_SUBNETWORK} --project=${PROJECT} --region=${REGION} \
     --format='value(fingerprint)')
   local access_token=$(gcloud auth print-access-token)
@@ -100,7 +100,7 @@ function set-allow-subnet-cidr-routes-overlap() {
 #   CLUSTER_IP_RANGE
 #   SERVICE_CLUSTER_IP_RANGE
 function add-k8s-subnet-secondary-ranges() {
-  local secondary_ranges=$(gcloud beta compute networks subnets describe "${IP_ALIAS_SUBNETWORK}" \
+  local secondary_ranges=$(gcloud compute networks subnets describe "${IP_ALIAS_SUBNETWORK}" \
     --project="${PROJECT}" --region="${REGION}" \
     --format='value(secondaryIpRanges)')
   if [[ "${secondary_ranges}" =~ "pods-default" && "${secondary_ranges}" =~ "services-default" ]]; then
@@ -109,7 +109,7 @@ function add-k8s-subnet-secondary-ranges() {
   fi
 
   echo "Adding secondary ranges: pods-default (${CLUSTER_IP_RANGE}), services-default (${SERVICE_CLUSTER_IP_RANGE})"
-  until gcloud beta compute networks subnets update ${IP_ALIAS_SUBNETWORK} \
+  until gcloud compute networks subnets update ${IP_ALIAS_SUBNETWORK} \
     --project=${PROJECT} --region=${REGION} \
     --add-secondary-ranges="pods-default=${CLUSTER_IP_RANGE},services-default=${SERVICE_CLUSTER_IP_RANGE}"; do
     printf "."

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1665,10 +1665,6 @@ function create-node-template() {
     gcloud="gcloud beta"
   fi
 
-  if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    gcloud="gcloud beta"
-  fi
-
   local preemptible_minions=""
   if [[ "${PREEMPTIBLE_NODE}" == "true" ]]; then
     preemptible_minions="--preemptible --maintenance-policy TERMINATE"
@@ -1903,13 +1899,13 @@ function create-subnetworks() {
 
   # Look for the alias subnet, it must exist and have a secondary
   # range configured.
-  local subnet=$(gcloud beta compute networks subnets describe \
+  local subnet=$(gcloud compute networks subnets describe \
     --project "${NETWORK_PROJECT}" \
     --region ${REGION} \
     ${IP_ALIAS_SUBNETWORK} 2>/dev/null)
   if [[ -z ${subnet} ]]; then
     echo "Creating subnet ${NETWORK}:${IP_ALIAS_SUBNETWORK}"
-    gcloud beta compute networks subnets create \
+    gcloud compute networks subnets create \
       ${IP_ALIAS_SUBNETWORK} \
       --description "Automatically generated subnet for ${INSTANCE_PREFIX} cluster. This will be removed on cluster teardown." \
       --project "${NETWORK_PROJECT}" \
@@ -1948,7 +1944,7 @@ function detect-subnetworks() {
     return 0
   fi
 
-  SUBNETWORK=$(gcloud beta compute networks subnets list \
+  SUBNETWORK=$(gcloud compute networks subnets list \
     --network=${NETWORK} \
     --regions=${REGION} \
     --project=${NETWORK_PROJECT} \
@@ -2017,11 +2013,11 @@ function delete-subnetworks() {
     # Only delete the subnet if we created it (i.e it's not pre-existing).
     if [[ -z "${KUBE_GCE_IP_ALIAS_SUBNETWORK:-}" ]]; then
       echo "Removing auto-created subnet ${NETWORK}:${IP_ALIAS_SUBNETWORK}"
-      if [[ -n $(gcloud beta compute networks subnets describe \
+      if [[ -n $(gcloud compute networks subnets describe \
             --project "${NETWORK_PROJECT}" \
             --region ${REGION} \
             ${IP_ALIAS_SUBNETWORK} 2>/dev/null) ]]; then
-        gcloud beta --quiet compute networks subnets delete \
+        gcloud --quiet compute networks subnets delete \
           --project "${NETWORK_PROJECT}" \
           --region ${REGION} \
           ${IP_ALIAS_SUBNETWORK}
@@ -2392,10 +2388,6 @@ function create-nodes() {
 # - IP_ALIAS_SIZE
 function create-heapster-node() {
   local gcloud="gcloud"
-
-  if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    gcloud="gcloud beta"
-  fi
 
   local network=$(make-gcloud-network-argument \
       "${NETWORK_PROJECT}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
"gcloud beta compute networks subnets" stopped working, fails with the erros:  - The request did not match the specified API.

"gcloud compute networks subnets" works with the latest gcloud release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
