### PR TITLE
Bump ip-masq-agent to v2.1.1

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -29,7 +29,9 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/ip-masq-agent-amd64:v2.0.2
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+        args:
+          - --masq-chain=IP-MASQ
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update debian-iptables image for CVEs.
- Change chain name to IP-MASQ to be compatible with the pre-injected masquerade rules.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Special notes for your reviewer**:
/assign @bowei 
cc @satyasm

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump ip-masq-agent to v2.1.1
- Update debian-iptables image for CVEs.
- Change chain name to IP-MASQ to be compatible with the
pre-injected masquerade rules.
```
