### PR TITLE
Add [Serial] tag on Feature:Empty E2E tests since these tests are not…

### DIFF
--- a/test/e2e/scalability/empty.go
+++ b/test/e2e/scalability/empty.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = SIGDescribe("Empty [Feature:Empty]", func() {
+var _ = SIGDescribe("Empty [Feature:Empty] [Serial]", func() {
 	f := framework.NewDefaultFramework("empty")
 
 	BeforeEach(func() {


### PR DESCRIPTION
… supposed to be executed with other e2e tests in parallel.

Signed-off-by: Jean-Christophe Sirot <jean-christophe.sirot@docker.com>

**What this PR does / why we need it**:
The BeforeEach function in `test/e2e/scalability/empty.go` waits for all e2e namespaces to be in the Terminated space before executing the test. Therefore when run in parallel these test may fail with a timeout and an error message `Namespace e2e-tests-xxxxxx is active `. This limitation should be indicated with a `[Serial]` tag in the test spec.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
