### PR TITLE
Add other log backend for audit policy

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -370,7 +370,10 @@ type AuditPolicyConfiguration struct {
 	LogDir string
 	// LogMaxAge is the number of days logs will be stored for. 0 indicates forever.
 	LogMaxAge *int32
-	//TODO(chuckha) add other options for audit policy.
+	// LogMaxBackup is the maximum number of audit log files to retain. 
+	LogMaxBackup *int32
+	// LogMaxSize is the maximum size in megabytes of the audit log file before it gets rotated.
+	LogMaxSize *int32
 }
 
 // CommonConfiguration defines the list of common configuration elements and the getter

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -67,6 +67,10 @@ var (
 	// DefaultAuditPolicyLogMaxAge is defined as a var so its address can be taken
 	// It is the number of days to store audit logs
 	DefaultAuditPolicyLogMaxAge = int32(2)
+	// DefaultAuditPolicyLogMaxBackup is defined the maximum number of audit log files to retain
+	DefaultAuditPolicyLogMaxBackup = int32(2)
+	// DefaultAuditPolicyLogMaxSize is defined the maximum size in megabytes of the audit log file before it gets rotated
+	DefaultAuditPolicyLogMaxSize = int32(100)
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -240,6 +244,12 @@ func SetDefaults_AuditPolicyConfiguration(obj *InitConfiguration) {
 	if obj.AuditPolicyConfiguration.LogMaxAge == nil {
 		obj.AuditPolicyConfiguration.LogMaxAge = &DefaultAuditPolicyLogMaxAge
 	}
+	if obj.AuditPolicyConfiguration.LogMaxBackup == nil {
+		obj.AuditPolicyConfiguration.LogMaxBackup = &DefaultAuditPolicyLogMaxBackup
+	}
+	if obj.AuditPolicyConfiguration.LogMaxSize == nil {
+		obj.AuditPolicyConfiguration.LogMaxSize = &DefaultAuditPolicyLogMaxSize
+        }
 }
 
 // SetDefaults_BootstrapTokens sets the defaults for the .BootstrapTokens field

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/types.go
@@ -327,5 +327,8 @@ type AuditPolicyConfiguration struct {
 	LogDir string `json:"logDir"`
 	// LogMaxAge is the number of days logs will be stored for. 0 indicates forever.
 	LogMaxAge *int32 `json:"logMaxAge,omitempty"`
-	//TODO(chuckha) add other options for audit policy.
+	// LogMaxBackup is the number of audit logs to retain.
+	LogMaxBackup *int32 `json:"logMaxBackup,omitempty"`
+	// LogMaxSize is the max size in MB to retain.
+	LogMaxSize *int32 `json:"logMaxSize,omitempty"`
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -59,6 +59,10 @@ var (
 	// DefaultAuditPolicyLogMaxAge is defined as a var so its address can be taken
 	// It is the number of days to store audit logs
 	DefaultAuditPolicyLogMaxAge = int32(2)
+	// DefaultAuditPolicyLogMaxBackup is defined the maximum number of audit log files to retain
+	DefaultAuditPolicyLogMaxBackup = int32(2)
+	// DefaultAuditPolicyLogMaxSize is defined the maximum size in megabytes of the audit log file before it gets rotated
+	DefaultAuditPolicyLogMaxSize = int32(100)
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -159,6 +163,12 @@ func SetDefaults_AuditPolicyConfiguration(obj *ClusterConfiguration) {
 	}
 	if obj.AuditPolicyConfiguration.LogMaxAge == nil {
 		obj.AuditPolicyConfiguration.LogMaxAge = &DefaultAuditPolicyLogMaxAge
+	}
+	if obj.AuditPolicyConfiguration.LogMaxBackup == nil {
+		obj.AuditPolicyConfiguration.LogMaxBackup = &DefaultAuditPolicyLogMaxBackup
+	}
+	if obj.AuditPolicyConfiguration.LogMaxSize == nil {
+		obj.AuditPolicyConfiguration.LogMaxSize = &DefaultAuditPolicyLogMaxSize
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/types.go
@@ -331,5 +331,8 @@ type AuditPolicyConfiguration struct {
 	LogDir string `json:"logDir"`
 	// LogMaxAge is the number of days logs will be stored for. 0 indicates forever.
 	LogMaxAge *int32 `json:"logMaxAge,omitempty"`
-	//TODO(chuckha) add other options for audit policy.
+	// LogMaxBackup is the number of audit logs to retain.
+	LogMaxBackup *int32 `json:"logMaxBackup,omitempty"`
+	// LogMaxSize is the max size in MB to retain
+	LogMaxSize *int32 `json:"logMaxSize,omitempty"`
 }

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -202,6 +202,16 @@ func getAPIServerCommand(cfg *kubeadmapi.InitConfiguration) []string {
 		} else {
 			defaultArguments["audit-log-maxage"] = fmt.Sprintf("%d", *cfg.AuditPolicyConfiguration.LogMaxAge)
 		}
+		if cfg.AuditPolicyConfiguration.LogMaxBackup == nil {
+			defaultArguments["audit-log-maxbackup"] = fmt.Sprintf("%d", kubeadmapiv1alpha3.DefaultAuditPolicyLogMaxBackup)
+		} else {
+			defaultArguments["audit-log-maxbackup"] = fmt.Sprintf("%d", *cfg.AuditPolicyConfiguration.LogMaxBackup)
+		}
+		if cfg.AuditPolicyConfiguration.LogMaxSize == nil {
+			defaultArguments["audit-log-maxsize"] = fmt.Sprintf("%d", kubeadmapiv1alpha3.DefaultAuditPolicyLogMaxSize)
+		} else {
+			defaultArguments["audit-log-maxsize"] = fmt.Sprintf("%d", *cfg.AuditPolicyConfiguration.LogMaxSize)
+		}
 	}
 	if cfg.APIServerExtraArgs == nil {
 		cfg.APIServerExtraArgs = map[string]string{}

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -405,6 +405,8 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--audit-policy-file=/etc/kubernetes/audit/audit.yaml",
 				"--audit-log-path=/var/log/kubernetes/audit/audit.log",
 				"--audit-log-maxage=0",
+				"--audit-log-maxbackup=0",
+				"--audit-log-maxsize=0",
 			},
 		},
 		{
@@ -496,6 +498,8 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--audit-policy-file=/etc/config/audit.yaml",
 				"--audit-log-path=/var/log/kubernetes",
 				"--audit-log-maxage=2",
+				"--audit-log-maxbackup=1",
+				"--audit-log-maxsize=100",
 			},
 		},
 		{


### PR DESCRIPTION
Support audit-log-maxbackup and audit-log-maxsize

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kubeadm audit featuregates need to add other log backend for audit policy
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes/kubeadm/issues/1080
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
