### PR TITLE
Fix backward compatibility between critical pod annotation and priority classes to avoid issues during upgrades

### DIFF
--- a/plugin/pkg/admission/priority/admission.go
+++ b/plugin/pkg/admission/priority/admission.go
@@ -183,7 +183,7 @@ func (p *priorityPlugin) admitPod(a admission.Attributes) error {
 		if len(pod.Spec.PriorityClassName) == 0 &&
 			utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalCriticalPodAnnotation) &&
 			kubelettypes.IsCritical(a.GetNamespace(), pod.Annotations) {
-			pod.Spec.PriorityClassName = scheduling.SystemClusterCritical
+			pod.Spec.PriorityClassName = scheduling.SystemNodeCritical
 		}
 		if len(pod.Spec.PriorityClassName) == 0 {
 			var err error


### PR DESCRIPTION
As pods with critical pod annotations are never evicted by kubelet, only system-node-critical being the highest priority class can provide this guarantee, so default assignment should be system-node-critical not system-cluster-critical.

@kubernetes/sig-scheduling-bugs  

-->
```release-note
None
```
