### PR TITLE
Reduce the minwidth of the cli table printer

### DIFF
--- a/pkg/kubectl/cmd/config/get_contexts_test.go
+++ b/pkg/kubectl/cmd/config/get_contexts_test.go
@@ -61,7 +61,7 @@ func TestGetContextsAllNoHeader(t *testing.T) {
 		names:          []string{},
 		noHeader:       true,
 		nameOnly:       false,
-		expectedOut:    "*         shaker-context   big-cluster   blue-user   saw-ns\n",
+		expectedOut:    "*     shaker-context   big-cluster   blue-user   saw-ns\n",
 	}
 	test.run(t)
 }
@@ -171,7 +171,7 @@ func (test getContextsTest) run(t *testing.T) {
 	cmd.Run(cmd, test.names)
 	if len(test.expectedOut) != 0 {
 		if buf.String() != test.expectedOut {
-			t.Errorf("Expected %v, but got %v", test.expectedOut, buf.String())
+			t.Errorf("Expected\n%s\ngot\n%s", test.expectedOut, buf.String())
 		}
 		return
 	}

--- a/pkg/kubectl/cmd/get/get_test.go
+++ b/pkg/kubectl/cmd/get/get_test.go
@@ -260,11 +260,11 @@ func TestGetObjectsWithOpenAPIOutputFormatPresent(t *testing.T) {
 	cmd.Flags().Set(useOpenAPIPrintColumnFlagLabel, "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      RSRC
-foo       10
+	expected := `NAME   RSRC
+foo    10
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -312,11 +312,11 @@ func TestGetObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -338,11 +338,11 @@ func TestGetObjectsShowKind(t *testing.T) {
 	cmd.Flags().Set("show-kind", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-pod/foo   0/0                 0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+pod/foo   0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -394,14 +394,14 @@ func TestGetMultipleResourceTypesShowKinds(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"all"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-pod/foo   0/0                 0          <unknown>
-pod/bar   0/0                 0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+pod/foo   0/0              0          <unknown>
+pod/bar   0/0              0          <unknown>
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -423,11 +423,11 @@ func TestGetObjectsShowLabels(t *testing.T) {
 	cmd.Flags().Set("show-labels", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE         LABELS
-foo       0/0                 0          <unknown>   <none>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE         LABELS
+foo    0/0              0          <unknown>   <none>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -516,13 +516,13 @@ func TestGetSortedObjects(t *testing.T) {
 	cmd.Flags().Set("sort-by", ".metadata.name")
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-a         0/0                 0          <unknown>
-b         0/0                 0          <unknown>
-c         0/0                 0          <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+a      0/0              0          <unknown>
+b      0/0              0          <unknown>
+c      0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -544,11 +544,11 @@ func TestGetObjectsIdentifiedByFile(t *testing.T) {
 	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml")
 	cmd.Run(cmd, []string{})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -569,12 +569,12 @@ func TestGetListObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
-bar       0/0                 0          <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
+bar    0/0              0          <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -601,7 +601,7 @@ serverbad       Unhealthy             bad status: 500
 serverunknown   Unhealthy             fizzbuzz error
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -663,7 +663,7 @@ func TestGetMixedGenericObjects(t *testing.T) {
 }
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -694,14 +694,14 @@ func TestGetMultipleTypeObjects(t *testing.T) {
 	cmd.SetOutput(buf)
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-pod/foo   0/0                 0          <unknown>
-pod/bar   0/0                 0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+pod/foo   0/0              0          <unknown>
+pod/bar   0/0              0          <unknown>
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -836,14 +836,14 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-pod/foo   0/0                 0          <unknown>
-pod/bar   0/0                 0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+pod/foo   0/0              0          <unknown>
+pod/bar   0/0              0          <unknown>
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -879,14 +879,14 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods,services"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-pod/foo   0/0                 0          <unknown>
-pod/bar   0/0                 0          <unknown>
+	expected := `NAME      READY   STATUS   RESTARTS   AGE
+pod/foo   0/0              0          <unknown>
+pod/bar   0/0              0          <unknown>
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -925,11 +925,11 @@ func TestGetMultipleTypeObjectsWithDirectReference(t *testing.T) {
 
 	expected := `NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 service/baz   ClusterIP   <none>       <none>        <none>    <unknown>
-NAME       STATUS    ROLES     AGE         VERSION
-node/foo   Unknown   <none>    <unknown>   
+NAME       STATUS    ROLES    AGE         VERSION
+node/foo   Unknown   <none>   <unknown>   
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1043,14 +1043,14 @@ func TestWatchLabelSelector(t *testing.T) {
 	cmd.Flags().Set("selector", "a=b")
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-bar       0/0                 0          <unknown>
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+bar    0/0              0          <unknown>
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1094,14 +1094,14 @@ func TestWatchFieldSelector(t *testing.T) {
 	cmd.Flags().Set("field-selector", "a=b")
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-bar       0/0                 0          <unknown>
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+bar    0/0              0          <unknown>
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1138,13 +1138,13 @@ func TestWatchResource(t *testing.T) {
 	cmd.Flags().Set("watch", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1182,13 +1182,13 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 	cmd.Flags().Set("filename", "../../../../test/e2e/testing-manifests/statefulset/cassandra/controller.yaml")
 	cmd.Run(cmd, []string{})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1225,12 +1225,12 @@ func TestWatchOnlyResource(t *testing.T) {
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods", "foo"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 
@@ -1270,12 +1270,12 @@ func TestWatchOnlyList(t *testing.T) {
 	cmd.Flags().Set("watch-only", "true")
 	cmd.Run(cmd, []string{"pods"})
 
-	expected := `NAME      READY     STATUS    RESTARTS   AGE
-foo       0/0                 0          <unknown>
-foo       0/0                 0         <unknown>
+	expected := `NAME   READY   STATUS   RESTARTS   AGE
+foo    0/0              0          <unknown>
+foo   0/0         0     <unknown>
 `
 	if e, a := expected, buf.String(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
 }
 

--- a/pkg/printers/customcolumn_test.go
+++ b/pkg/printers/customcolumn_test.go
@@ -286,8 +286,8 @@ bar
 				},
 			},
 			obj: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}},
-			expectedOutput: `NAME      API_VERSION
-foo       baz
+			expectedOutput: `NAME   API_VERSION
+foo    baz
 `,
 		},
 		{
@@ -306,8 +306,8 @@ foo       baz
 				},
 			},
 			obj: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}},
-			expectedOutput: `NAME      API_VERSION   NOT_FOUND
-foo       baz           <none>
+			expectedOutput: `NAME   API_VERSION   NOT_FOUND
+foo    baz           <none>
 `,
 		},
 	}
@@ -349,9 +349,9 @@ func TestIndividualPrintObjOnExistingTabWriter(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"label1": "foo", "label2": "foo"}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "bar", Labels: map[string]string{"label1": "bar", "label2": "bar"}}},
 	}
-	expectedOutput := `NAME      LONG COLUMN NAME   LABEL 2
-foo       foo                foo
-bar       bar                bar
+	expectedOutput := `NAME   LONG COLUMN NAME   LABEL 2
+foo    foo                foo
+bar    bar                bar
 `
 
 	buffer := &bytes.Buffer{}

--- a/pkg/printers/tabwriter.go
+++ b/pkg/printers/tabwriter.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	tabwriterMinWidth = 10
+	tabwriterMinWidth = 6
 	tabwriterWidth    = 4
 	tabwriterPadding  = 3
 	tabwriterPadChar  = ' '


### PR DESCRIPTION
For a few columns we want to have a smaller width and 10 is excessive. The example is CPU and memory for nodes.