### PR TITLE
implement InstanceShutdownByProviderID to openstack

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -36,6 +36,10 @@ type Instances struct {
 	opts    MetadataOpts
 }
 
+const (
+	instanceShutoff = "SHUTOFF"
+)
+
 // Instances returns an implementation of Instances for OpenStack.
 func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 	glog.V(4).Info("openstack.Instances() called")
@@ -132,7 +136,21 @@ func (i *Instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 
 // InstanceShutdownByProviderID returns true if the instances is in safe state to detach volumes
 func (i *Instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
-	return false, cloudprovider.NotImplemented
+	instanceID, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return false, err
+	}
+
+	server, err := servers.Get(i.compute, instanceID).Extract()
+	if err != nil {
+		return false, err
+	}
+
+	// SHUTOFF is the only state where we can detach volumes immediately
+	if server.Status == instanceShutoff {
+		return true, nil
+	}
+	return false, nil
 }
 
 // InstanceID returns the kubelet's cloud provider ID.


### PR DESCRIPTION
**What this PR does / why we need it**: without this openstack cannot get shutdown taint when instance is shutdown (original pr where this feature was added https://github.com/kubernetes/kubernetes/pull/60009)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Openstack supports now node shutdown taint. Taint is added when instance is shutdown in openstack.
```
