### PR TITLE
Fix golint error under pkg/kubelet.

### DIFF
--- a/pkg/kubelet/checkpointmanager/testing/util.go
+++ b/pkg/kubelet/checkpointmanager/testing/util.go
@@ -63,7 +63,7 @@ func (mstore *MemStore) Delete(key string) error {
 func (mstore *MemStore) List() ([]string, error) {
 	mstore.Lock()
 	defer mstore.Unlock()
-	keys := make([]string, 0)
+	var keys []string
 	for key := range mstore.mem {
 		keys = append(keys, key)
 	}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -499,7 +499,7 @@ func (m *ManagerImpl) writeCheckpoint() error {
 // m.allocatedDevices accordingly.
 func (m *ManagerImpl) readCheckpoint() error {
 	registeredDevs := make(map[string][]string)
-	devEntries := make([]checkpoint.PodDevicesEntry, 0)
+	var devEntries []checkpoint.PodDevicesEntry
 	cp := checkpoint.New(devEntries, registeredDevs)
 	err := m.checkpointManager.GetCheckpoint(kubeletDeviceManagerCheckpoint, cp)
 	if err != nil {

--- a/pkg/kubelet/util/store/filestore.go
+++ b/pkg/kubelet/util/store/filestore.go
@@ -81,7 +81,7 @@ func (f *FileStore) Delete(key string) error {
 
 // List returns all keys in the store.
 func (f *FileStore) List() ([]string, error) {
-	keys := make([]string, 0)
+	var keys []string
 	files, err := f.filesystem.ReadDir(f.directoryPath)
 	if err != nil {
 		return keys, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix golint error under pkg/kubelet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
I ran golint 1.10.3, and the error messages are as follows:
pkg/kubelet/checkpointmanager/testing/util.go:66:2: can probably use "var keys []string" instead
pkg/kubelet/cm/devicemanager/manager.go:502:2: can probably use "var devEntries []checkpoint.PodDevicesEntry" instead
pkg/kubelet/util/store/filestore.go:84:2: can probably use "var keys []string" instead

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
