### PR TITLE
Fix syncReplicaSet by re-enqueuing on a wider criterion

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -635,7 +635,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 	// Resync the ReplicaSet after MinReadySeconds as a last line of defense to guard against clock-skew.
 	if manageReplicasErr == nil && updatedRS.Spec.MinReadySeconds > 0 &&
 		(updatedRS.Status.ReadyReplicas != *(updatedRS.Spec.Replicas) ||
-		updatedRS.Status.AvailableReplicas != *(updatedRS.Spec.Replicas)) {
+			updatedRS.Status.AvailableReplicas != *(updatedRS.Spec.Replicas)) {
 		rsc.enqueueReplicaSetAfter(updatedRS, time.Duration(updatedRS.Spec.MinReadySeconds)*time.Second)
 	}
 	return manageReplicasErr

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -634,8 +634,8 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 	}
 	// Resync the ReplicaSet after MinReadySeconds as a last line of defense to guard against clock-skew.
 	if manageReplicasErr == nil && updatedRS.Spec.MinReadySeconds > 0 &&
-		updatedRS.Status.ReadyReplicas == *(updatedRS.Spec.Replicas) &&
-		updatedRS.Status.AvailableReplicas != *(updatedRS.Spec.Replicas) {
+		(updatedRS.Status.ReadyReplicas != *(updatedRS.Spec.Replicas) ||
+		updatedRS.Status.AvailableReplicas != *(updatedRS.Spec.Replicas)) {
 		rsc.enqueueReplicaSetAfter(updatedRS, time.Duration(updatedRS.Spec.MinReadySeconds)*time.Second)
 	}
 	return manageReplicasErr


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix syncReplicaSet in replica_set.go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67662

**Special notes for your reviewer**:
NONE

**Release note**:
```release-note
NONE
```
