### PR TITLE
isolate logging resources in separate namespace

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/create-logging-namespace.yaml
+++ b/cluster/addons/fluentd-elasticsearch/create-logging-namespace.yaml
@@ -1,0 +1,8 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+ name: logging
+ labels:
+   k8s-app: logging
+   kubernetes.io/cluster-service: "true"
+   addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-elasticsearch/es-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch-logging
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: elasticsearch-logging
     kubernetes.io/cluster-service: "true"

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -28,7 +28,6 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: logging
   name: elasticsearch-logging
   labels:
     k8s-app: elasticsearch-logging

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: elasticsearch-logging
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: elasticsearch-logging
     addonmanager.kubernetes.io/mode: Reconcile
@@ -28,7 +28,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: kube-system
+  namespace: logging
   name: elasticsearch-logging
   labels:
     k8s-app: elasticsearch-logging
@@ -36,7 +36,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: elasticsearch-logging
-    namespace: kube-system
+    namespace: logging
     apiGroup: ""
 roleRef:
   kind: ClusterRole
@@ -48,7 +48,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: elasticsearch-logging
     version: v7.4.3

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: logging
   labels:
     k8s-app: elasticsearch-logging
-    version: v7.4.3
+    version: v7.4.4
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   serviceName: elasticsearch-logging
@@ -59,12 +59,12 @@ spec:
   selector:
     matchLabels:
       k8s-app: elasticsearch-logging
-      version: v7.4.3
+      version: v7.4.4
   template:
     metadata:
       labels:
         k8s-app: elasticsearch-logging
-        version: v7.4.3
+        version: v7.4.4
     spec:
       serviceAccountName: elasticsearch-logging
       containers:

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: fluentd-es-config-v0.2.0
+  name: fluentd-es-config-v0.2.1
   namespace: logging
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: fluentd-es-config-v0.2.0
-  namespace: kube-system
+  namespace: logging
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -45,22 +45,22 @@ roleRef:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: fluentd-es-v3.1.0
+  name: fluentd-es-v3.1.1
   namespace: logging
   labels:
     k8s-app: fluentd-es
-    version: v3.1.0
+    version: v3.1.1
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:
       k8s-app: fluentd-es
-      version: v3.1.0
+      version: v3.1.1
   template:
     metadata:
       labels:
         k8s-app: fluentd-es
-        version: v3.1.0
+        version: v3.1.1
     spec:
       securityContext:
         seccompProfile:
@@ -111,4 +111,4 @@ spec:
           path: /var/lib/docker/containers
       - name: config-volume
         configMap:
-          name: fluentd-es-config-v0.2.0
+          name: fluentd-es-config-v0.2.1

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fluentd-es
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: fluentd-es
     addonmanager.kubernetes.io/mode: Reconcile
@@ -35,7 +35,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: fluentd-es
-  namespace: kube-system
+  namespace: logging
   apiGroup: ""
 roleRef:
   kind: ClusterRole
@@ -46,7 +46,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-es-v3.1.0
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: fluentd-es
     version: v3.1.0

--- a/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana-logging
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: kibana-logging
     addonmanager.kubernetes.io/mode: Reconcile
@@ -34,7 +34,7 @@ spec:
             - name: SERVER_NAME
               value: kibana-logging
             - name: SERVER_BASEPATH
-              value: /api/v1/namespaces/kube-system/services/kibana-logging/proxy
+              value: /api/v1/namespaces/logging/services/kibana-logging/proxy
             - name: SERVER_REWRITEBASEPATH
               value: "false"
           ports:

--- a/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kibana-logging
-  namespace: kube-system
+  namespace: logging
   labels:
     k8s-app: kibana-logging
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Now all the resources(ES, fluentd, kibana) are creating in kube-system namespace which supposed to have only k8s components, so isolated these resources in separate namespace `logging`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fluentd: isolate logging resources in separate namespace
```
