### PR TITLE
Orphan DaemonSet when deleting with --cascade option set

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -321,8 +321,9 @@ func (o *DeleteOptions) deleteResource(info *resource.Info, deleteOptions *metav
 	// TODO: Remove this in or after 1.12 release.
 	//       Server version >= 1.11 no longer needs this hack.
 	mapping := info.ResourceMapping()
-	if mapping.Resource.GroupResource() == (schema.GroupResource{Group: "extensions", Resource: "daemonsets"}) ||
-		mapping.Resource.GroupResource() == (schema.GroupResource{Group: "apps", Resource: "daemonsets"}) {
+	if (mapping.Resource.GroupResource() == (schema.GroupResource{Group: "extensions", Resource: "daemonsets"}) ||
+		mapping.Resource.GroupResource() == (schema.GroupResource{Group: "apps", Resource: "daemonsets"})) &&
+		(deleteOptions.PropagationPolicy != nil && *deleteOptions.PropagationPolicy != metav1.DeletePropagationOrphan) {
 		if err := updateDaemonSet(info.Namespace, info.Name, o.DynamicClient); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a followup to https://github.com/kubernetes/kubernetes/pull/64847 to ensure that `--cascade` options is properly handled for DaemonSet

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This was originally described in https://bugzilla.redhat.com/show_bug.cgi?id=1623352

For review:
/assign @mfojtik 
For 1.11 approval:
/assign @foxish 

cc @janetkuo 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Orphan DaemonSet when deleting with --cascade option set
```
