### PR TITLE
add test to verify vsphere cloud provider report node hostname

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -762,9 +762,6 @@ func (vs *VSphere) InstanceID(ctx context.Context, nodeName k8stypes.NodeName) (
 		}
 		vm, err := vs.getVMFromNodeName(ctx, nodeName)
 		if err != nil {
-			if err == vclib.ErrNoVMFound {
-				return "", cloudprovider.InstanceNotFound
-			}
 			glog.Errorf("Failed to get VM object for node: %q. err: +%v", convertToString(nodeName), err)
 			return "", err
 		}
@@ -782,9 +779,8 @@ func (vs *VSphere) InstanceID(ctx context.Context, nodeName k8stypes.NodeName) (
 
 	instanceID, err := instanceIDInternal()
 	if err != nil {
-		var isManagedObjectNotFoundError bool
-		isManagedObjectNotFoundError, err = vs.retry(nodeName, err)
-		if isManagedObjectNotFoundError {
+		if vclib.IsManagedObjectNotFoundError(err) {
+			err = vs.nodeManager.RediscoverNode(nodeName)
 			if err == nil {
 				glog.V(4).Infof("InstanceID: Found node %q", convertToString(nodeName))
 				instanceID, err = instanceIDInternal()
@@ -871,9 +867,8 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyName string, nodeN
 	requestTime := time.Now()
 	diskUUID, err = attachDiskInternal(vmDiskPath, storagePolicyName, nodeName)
 	if err != nil {
-		var isManagedObjectNotFoundError bool
-		isManagedObjectNotFoundError, err = vs.retry(nodeName, err)
-		if isManagedObjectNotFoundError {
+		if vclib.IsManagedObjectNotFoundError(err) {
+			err = vs.nodeManager.RediscoverNode(nodeName)
 			if err == nil {
 				glog.V(4).Infof("AttachDisk: Found node %q", convertToString(nodeName))
 				diskUUID, err = attachDiskInternal(vmDiskPath, storagePolicyName, nodeName)
@@ -884,18 +879,6 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyName string, nodeN
 	glog.V(4).Infof("AttachDisk executed for node %s and volume %s with diskUUID %s. Err: %s", convertToString(nodeName), vmDiskPath, diskUUID, err)
 	vclib.RecordvSphereMetric(vclib.OperationAttachVolume, requestTime, err)
 	return diskUUID, err
-}
-
-func (vs *VSphere) retry(nodeName k8stypes.NodeName, err error) (bool, error) {
-	isManagedObjectNotFoundError := false
-	if err != nil {
-		if vclib.IsManagedObjectNotFoundError(err) {
-			isManagedObjectNotFoundError = true
-			glog.V(4).Infof("error %q ManagedObjectNotFound for node %q", err, convertToString(nodeName))
-			err = vs.nodeManager.RediscoverNode(nodeName)
-		}
-	}
-	return isManagedObjectNotFoundError, err
 }
 
 // DetachDisk detaches given virtual disk volume from the compute running kubelet.
@@ -942,9 +925,8 @@ func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error 
 	requestTime := time.Now()
 	err := detachDiskInternal(volPath, nodeName)
 	if err != nil {
-		var isManagedObjectNotFoundError bool
-		isManagedObjectNotFoundError, err = vs.retry(nodeName, err)
-		if isManagedObjectNotFoundError {
+		if vclib.IsManagedObjectNotFoundError(err) {
+			err = vs.nodeManager.RediscoverNode(nodeName)
 			if err == nil {
 				err = detachDiskInternal(volPath, nodeName)
 			}
@@ -1000,9 +982,8 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 	requestTime := time.Now()
 	isAttached, err := diskIsAttachedInternal(volPath, nodeName)
 	if err != nil {
-		var isManagedObjectNotFoundError bool
-		isManagedObjectNotFoundError, err = vs.retry(nodeName, err)
-		if isManagedObjectNotFoundError {
+		if vclib.IsManagedObjectNotFoundError(err) {
+			err = vs.nodeManager.RediscoverNode(nodeName)
 			if err == vclib.ErrNoVMFound {
 				isAttached, err = false, nil
 			} else if err == nil {

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -36,6 +36,7 @@ import (
 	vapi "github.com/vmware/govmomi/vapi/simulator"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25/mo"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -526,6 +527,15 @@ func TestInstances(t *testing.T) {
 	addrs, err := i.NodeAddresses(context.TODO(), nodeName)
 	if err != nil {
 		t.Fatalf("Instances.NodeAddresses(%s) failed: %s", nodeName, err)
+	}
+	found := false
+	for _, addr := range addrs {
+		if addr.Type == v1.NodeHostName {
+			found = true
+		}
+	}
+	if found == false {
+		t.Fatalf("NodeAddresses does not report hostname, %s %s", nodeName, addrs)
 	}
 	t.Logf("Found NodeAddresses(%s) = %s\n", nodeName, addrs)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
as in pull #67922 has modify vsphere cloud provider to report
node hostname, this patch is to add the test for it.

also fix an issue at InstanceID(), it suppose to return
cloudprovider.InstanceNotFound when vm not found,  
but it did double error type translation with a retry() logic,  
after removing the retry() (which is not necessary), the logic is simpler, and easier to understand how double translation happened, after the fix,
test TestInstance() can pass


**Which issue(s) this PR fixes** :
Fixes #67714


**Special notes for your reviewer**:
as in the process of create pull to fix https://github.com/crosscloudci/crosscloudci/issues/65#,
i saw #67922 already merged, so this pull is just to submit the test part.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```


/cc @abrarshivani @BaluDontu @divyenpatel @imkin @kerneltime @luomiao @frapposelli @dougm @liggitt
/sig cloudprovider