### PR TITLE
Increase Horizontal Pod Autoscaler update frequency to every 15s

### DIFF
--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -84,7 +84,7 @@ func SetDefaults_KubeControllerManagerConfiguration(obj *KubeControllerManagerCo
 		obj.PersistentVolumeBinderController.PVClaimBinderSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
 	if obj.HPAController.HorizontalPodAutoscalerSyncPeriod == zero {
-		obj.HPAController.HorizontalPodAutoscalerSyncPeriod = metav1.Duration{Duration: 30 * time.Second}
+		obj.HPAController.HorizontalPodAutoscalerSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
 	if obj.HPAController.HorizontalPodAutoscalerUpscaleForbiddenWindow == zero {
 		obj.HPAController.HorizontalPodAutoscalerUpscaleForbiddenWindow = metav1.Duration{Duration: 3 * time.Minute}


### PR DESCRIPTION
**What this PR does / why we need it**:
PR increases Horizontal Pod Autoscaler default update interval (30s -> 15s). It will improve HPA reaction time for metric changes.

**Release note**:
```release-note
Increase Horizontal Pod Autoscaler default update interval (30s -> 15s). It will improve HPA reaction time for metric changes.
```
