### PR TITLE
Add a log in verifyDevicePath

### DIFF
--- a/pkg/volume/gcepd/attacher.go
+++ b/pkg/volume/gcepd/attacher.go
@@ -269,6 +269,8 @@ func (attacher *gcePersistentDiskAttacher) WaitForAttach(spec *volume.Spec, devi
 				// A device path has successfully been created for the PD
 				klog.Infof("Successfully found attached GCE PD %q.", pdName)
 				return path, nil
+			} else {
+				klog.V(4).Infof("could not verify GCE PD (%q) is attached, device path does not exist", pdName)
 			}
 		case <-timer.C:
 			return "", fmt.Errorf("could not find attached GCE PD %q. Timeout waiting for mount paths to be created", pdName)

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -428,8 +428,11 @@ func (b *gcePersistentDiskMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 		return fmt.Errorf("mount of disk %s failed: %v", dir, err)
 	}
 
+	klog.V(4).Infof("mount of disk %s succeeded", dir)
 	if !b.readOnly {
-		volume.SetVolumeOwnership(b, mounterArgs.FsGroup, mounterArgs.FSGroupChangePolicy, util.FSGroupCompleteHook(b.plugin, nil))
+		if err := volume.SetVolumeOwnership(b, mounterArgs.FsGroup, mounterArgs.FSGroupChangePolicy, util.FSGroupCompleteHook(b.plugin, nil)); err != nil {
+			klog.Errorf("SetVolumeOwnership returns error %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Add a log during verifyDevicePath call so that we can differentiate the
operation hanging case with the path not exist case. 

```release-note
NONE
```