### PR TITLE
Replace git volume with configmap in emptydir wrapper conflict test

### DIFF
--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -76,10 +76,22 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
 		}
 
-		gitVolumeName := "git-volume"
-		gitVolumeMountPath := "/etc/git-volume"
-		gitURL, gitRepo, gitCleanup := createGitServer(f)
-		defer gitCleanup()
+		configMapVolumeName := "configmap-volume"
+		configMapVolumeMountPath := "/etc/configmap-volume"
+
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: f.Namespace.Name,
+				Name:      name,
+			},
+			BinaryData: map[string][]byte{
+				"data-1": []byte("value-1\n"),
+			},
+		}
+
+		if configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(configMap); err != nil {
+			framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
+		}
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -96,11 +108,12 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 						},
 					},
 					{
-						Name: gitVolumeName,
+						Name: configMapVolumeName,
 						VolumeSource: v1.VolumeSource{
-							GitRepo: &v1.GitRepoVolumeSource{
-								Repository: gitURL,
-								Directory:  gitRepo,
+							ConfigMap: &v1.ConfigMapVolumeSource{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: name,
+								},
 							},
 						},
 					},
@@ -116,8 +129,8 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 								ReadOnly:  true,
 							},
 							{
-								Name:      gitVolumeName,
-								MountPath: gitVolumeMountPath,
+								Name:      configMapVolumeName,
+								MountPath: configMapVolumeMountPath,
 							},
 						},
 					},
@@ -131,9 +144,13 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 			if err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(secret.Name, nil); err != nil {
 				framework.Failf("unable to delete secret %v: %v", secret.Name, err)
 			}
-			By("Cleaning up the git vol pod")
+			By("Cleaning up the configmap")
+			if err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(configMap.Name, nil); err != nil {
+				framework.Failf("unable to delete configmap %v: %v", configMap.Name, err)
+			}
+			By("Cleaning up the pod")
 			if err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(pod.Name, metav1.NewDeleteOptions(0)); err != nil {
-				framework.Failf("unable to delete git vol pod %v: %v", pod.Name, err)
+				framework.Failf("unable to delete pod %v: %v", pod.Name, err)
 			}
 		}()
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: GitRepoVolumeSource is deprecated, use a ConfigMap instead. (This test is part of the conformance suite, so it would be good to allow downstreams to disable/not support gitRepo)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
