### PR TITLE
Automated cherry pick of #67916: Bump ip-masq-agent to v2.1.1

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -29,7 +29,9 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: k8s.gcr.io/ip-masq-agent-amd64:v2.0.2
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.1.1
+        args:
+          - --masq-chain=IP-MASQ
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Cherry pick of #67916 on release-1.10.

#67916: Bump ip-masq-agent to v2.1.1 - Update debian-iptables image

```release-note
Bump ip-masq-agent to v2.1.1
- Update debian-iptables image for CVEs.
- Change chain name to IP-MASQ to be compatible with the
pre-injected masquerade rules.
```