### PR TITLE
Fix CRD storage strategy validator to accept all allowed versions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -426,6 +426,10 @@ func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensions.CustomResource
 	statusScopes := map[string]handlers.RequestScope{}
 	scaleScopes := map[string]handlers.RequestScope{}
 
+	var allowedAPIVersions []string
+	for _, v := range crd.Spec.Versions {
+		allowedAPIVersions = append(allowedAPIVersions, crd.Spec.Group+"/"+v.Name)
+	}
 	for _, v := range crd.Spec.Versions {
 		safeConverter, unsafeConverter := conversion.NewCRDConverter(crd)
 		// In addition to Unstructured objects (Custom Resources), we also may sometimes need to
@@ -481,7 +485,8 @@ func (r *crdHandler) getOrCreateServingInfoFor(crd *apiextensions.CustomResource
 			customresource.NewStrategy(
 				typer,
 				crd.Spec.Scope == apiextensions.NamespaceScoped,
-				kind,
+				kind.GroupKind(),
+				allowedAPIVersions,
 				validator,
 				statusValidator,
 				statusSpec,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -95,7 +95,8 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcdtestin
 		customresource.NewStrategy(
 			typer,
 			true,
-			kind,
+			kind.GroupKind(),
+			[]string{"mygroup.example.com/v1beta1"},
 			nil,
 			nil,
 			status,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -49,7 +49,7 @@ type customResourceStrategy struct {
 	scale           *apiextensions.CustomResourceSubresourceScale
 }
 
-func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, kind schema.GroupVersionKind, schemaValidator, statusSchemaValidator *validate.SchemaValidator, status *apiextensions.CustomResourceSubresourceStatus, scale *apiextensions.CustomResourceSubresourceScale) customResourceStrategy {
+func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, gk schema.GroupKind, allowedAPIVersions []string, schemaValidator, statusSchemaValidator *validate.SchemaValidator, status *apiextensions.CustomResourceSubresourceStatus, scale *apiextensions.CustomResourceSubresourceScale) customResourceStrategy {
 	return customResourceStrategy{
 		ObjectTyper:     typer,
 		NameGenerator:   names.SimpleNameGenerator,
@@ -58,7 +58,8 @@ func NewStrategy(typer runtime.ObjectTyper, namespaceScoped bool, kind schema.Gr
 		scale:           scale,
 		validator: customResourceValidator{
 			namespaceScoped:       namespaceScoped,
-			kind:                  kind,
+			groupKind:             gk,
+			allowedAPIVersions:    allowedAPIVersions,
 			schemaValidator:       schemaValidator,
 			statusSchemaValidator: statusSchemaValidator,
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -52,6 +52,18 @@ func NewNoxuSubresourcesCRD(scope apiextensionsv1beta1.ResourceScope) *apiextens
 				ListKind:   "NoxuItemList",
 			},
 			Scope: scope,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: false,
+				},
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{


### PR DESCRIPTION
The customResource validator was expecting an specific version of CRD (the request one) while the storage may have any version. This change will allow any apiVersion that is listed in CR definition.

Fixes #68035

@sttts @roycaihw 