### PR TITLE
Put fluentd back to host network

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -26,6 +26,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: fluentd-gcp
       dnsPolicy: Default
+      hostNetwork: true
       containers:
       - name: fluentd-gcp
         image: gcr.io/stackdriver-agents/stackdriver-logging-agent:{{ fluentd_gcp_version }}


### PR DESCRIPTION
In the future we will want to monitor each system component that is deployed as a DaemonSet using only one instance of prometheus-to-sd (which will be deployed as a DaemonSet too), but for this we need all the system components to be part of host network. There is no port colision created with this change.
```release-note
Port 31337 will be used by fluentd
```