### PR TITLE
kube-scheduler: output flags in logical sections

### DIFF
--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -39,6 +39,8 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/mux:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/routes:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:go_default_library",
         "//staging/src/k8s.io/client-go/informers/storage/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",

--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -86,7 +86,10 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 	if err != nil {
 		return TestServer{}, err
 	}
-	s.AddFlags(fs)
+	namedFlagSets := s.Flags()
+	for _, f := range namedFlagSets.FlagSets {
+		fs.AddFlagSet(f)
+	}
 
 	fs.Parse(customFlags)
 

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -17,13 +17,13 @@ limitations under the License.
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/spf13/pflag"
+
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
@@ -40,7 +40,6 @@ func main() {
 	// utilflag.InitFlags() (by removing its pflag.Parse() call). For now, we have to set the
 	// normalize func and add the go flag set by hand.
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	// utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/staging/src/BUILD
+++ b/staging/src/BUILD
@@ -102,6 +102,7 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/util/globalflag:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/logs:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/openapi:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/util/proxy:all-srcs",

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["globalflags.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/globalflag",
+    importpath = "k8s.io/apiserver/pkg/util/globalflag",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["globalflags_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalflag
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apiserver/pkg/util/logs"
+)
+
+// AddGlobalFlags explicitly registers flags that libraries (klog, verflag, etc.) register
+// against the global flagsets from "flag" and "github.com/spf13/pflag".
+// We do this in order to prevent unwanted flags from leaking into the component's flagset.
+func AddGlobalFlags(fs *pflag.FlagSet, name string) {
+	addGlogFlags(fs)
+	logs.AddFlags(fs)
+
+	fs.BoolP("help", "h", false, fmt.Sprintf("help for %s", name))
+}
+
+// addGlogFlags explicitly registers flags that klog libraries(k8s.io/klog) register.
+func addGlogFlags(fs *pflag.FlagSet) {
+	// lookup flags in global flag set and re-register the values with our flagset
+	global := flag.CommandLine
+	local := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+	register(global, local, "logtostderr")
+	register(global, local, "alsologtostderr")
+	register(global, local, "v")
+	register(global, local, "skip_headers")
+	register(global, local, "stderrthreshold")
+	register(global, local, "vmodule")
+	register(global, local, "log_backtrace_at")
+	register(global, local, "log_dir")
+	register(global, local, "log_file")
+
+	fs.AddFlagSet(local)
+}
+
+// normalize replaces underscores with hyphens
+// we should always use hyphens instead of underscores when registering component flags
+func normalize(s string) string {
+	return strings.Replace(s, "_", "-", -1)
+}
+
+// register adds a flag to local that targets the Value associated with the Flag named globalName in global
+func register(global *flag.FlagSet, local *pflag.FlagSet, globalName string) {
+	if f := global.Lookup(globalName); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = normalize(pflagFlag.Name)
+		local.AddFlag(pflagFlag)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", globalName))
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/globalflag/globalflags_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalflag
+
+import (
+	"flag"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	apiserverflag "k8s.io/apiserver/pkg/util/flag"
+)
+
+func TestAddGlobalFlags(t *testing.T) {
+	namedFlagSets := &apiserverflag.NamedFlagSets{}
+	nfs := namedFlagSets.FlagSet("global")
+	AddGlobalFlags(nfs, "test-cmd")
+
+	actualFlag := []string{}
+	nfs.VisitAll(func(flag *pflag.Flag) {
+		actualFlag = append(actualFlag, flag.Name)
+	})
+
+	// Get all flags from flags.CommandLine, except flag `test.*`.
+	wantedFlag := []string{"help"}
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		if !strings.Contains(flag.Name, "test.") {
+			wantedFlag = append(wantedFlag, normalize(flag.Name))
+		}
+	})
+	sort.Strings(wantedFlag)
+
+	if !reflect.DeepEqual(wantedFlag, actualFlag) {
+		t.Errorf("[Default]: expected %+v, got %+v", wantedFlag, actualFlag)
+	}
+
+	tests := []struct {
+		expectedFlag  []string
+		matchExpected bool
+	}{
+		{
+			// Happy case
+			expectedFlag:  []string{"alsologtostderr", "help", "log-backtrace-at", "log-dir", "log-file", "log-flush-frequency", "logtostderr", "skip-headers", "stderrthreshold", "v", "vmodule"},
+			matchExpected: false,
+		},
+		{
+			// Missing flag
+			expectedFlag:  []string{"logtostderr", "log-dir"},
+			matchExpected: true,
+		},
+		{
+			// Empty flag
+			expectedFlag:  []string{},
+			matchExpected: true,
+		},
+		{
+			// Invalid flag
+			expectedFlag:  []string{"foo"},
+			matchExpected: true,
+		},
+	}
+
+	for i, test := range tests {
+		if reflect.DeepEqual(test.expectedFlag, actualFlag) == test.matchExpected {
+			t.Errorf("[%d]: expected %+v, got %+v", i, test.expectedFlag, actualFlag)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `kube-scheduler` component contains so many flag, when we run `kube-scheduler --help`, the output are so ugly. This PR make the output more gracefully with servals sections, as below:
```
The Kubernetes scheduler is a policy-rich, topology-aware,
workload-specific function that significantly impacts availability, performance,
and capacity. The scheduler needs to take into account individual and collective
resource requirements, quality of service requirements, hardware/software/policy
constraints, affinity and anti-affinity specifications, data locality, inter-workload
interference, deadlines, and so on. Workload-specific requirements will be exposed
through the API as necessary.

Usage:
  kube-scheduler [flags]

Misc flags:

      --config string                                                                                                   
                The path to the configuration file. Flags override values in this file.
      --master string                                                                                                   
                The address of the Kubernetes API server (overrides any value in kubeconfig)
      --write-config-to string                                                                                          
                If set, write the configuration values to this file and exit.

Insecure serving flags:

      --address string                                                                                                  
                DEPRECATED: the IP address on which to listen for the --port port (set to 0.0.0.0 for all IPv4 interfaces
                and :: for all IPv6 interfaces). See --bind-address instead. (default "0.0.0.0")
      --port int                                                                                                        
                DEPRECATED: the port on which to serve HTTP insecurely without authentication and authorization. If 0,
                don't serve HTTPS at all. See --secure-port instead. (default 10251)

Deprecated flags:

      --algorithm-provider string                                                                                       
                DEPRECATED: the scheduling algorithm provider to use, one of: ClusterAutoscalerProvider | DefaultProvider
      --contention-profiling                                                                                            
                DEPRECATED: enable lock contention profiling, if profiling is enabled
      --kube-api-burst int32                                                                                            
                DEPRECATED: burst to use while talking with kubernetes apiserver (default 100)
      --kube-api-content-type string                                                                                    
                DEPRECATED: content type of requests sent to apiserver. (default "application/vnd.kubernetes.protobuf")
      --kube-api-qps float32                                                                                            
                DEPRECATED: QPS to use while talking with kubernetes apiserver (default 50)
      --kubeconfig string                                                                                               
                DEPRECATED: path to kubeconfig file with authorization and master location information.
      --lock-object-name string                                                                                         
                DEPRECATED: define the name of the lock object. (default "kube-scheduler")
      --lock-object-namespace string                                                                                    
                DEPRECATED: define the namespace of the lock object. (default "kube-system")
      --policy-config-file string                                                                                       
                DEPRECATED: file with scheduler policy configuration. This file is used if policy ConfigMap is not provided
                or --use-legacy-policy-config=true
      --policy-configmap string                                                                                         
                DEPRECATED: name of the ConfigMap object that contains scheduler's policy configuration. It must exist in
                the system namespace before scheduler initialization if --use-legacy-policy-config=false. The config must
                be provided as the value of an element in 'Data' map with the key='policy.cfg'
      --policy-configmap-namespace string                                                                               
                DEPRECATED: the namespace where policy ConfigMap is located. The kube-system namespace will be used if this
                is not provided or is empty. (default "kube-system")
      --profiling                                                                                                       
                DEPRECATED: enable profiling via web interface host:port/debug/pprof/
      --scheduler-name string                                                                                           
                DEPRECATED: name of the scheduler, used to select which pods will be processed by this scheduler, based on
                pod's "spec.schedulerName". (default "default-scheduler")
      --use-legacy-policy-config                                                                                        
                DEPRECATED: when set to true, scheduler will ignore policy ConfigMap and uses policy config file

Leader election flags:

      --leader-elect                                                                                                    
                Start a leader election client and gain leadership before executing the main loop. Enable this when running
                replicated components for high availability. (default true)
      --leader-elect-lease-duration duration                                                                            
                The duration that non-leader candidates will wait after observing a leadership renewal until attempting to
                acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a
                leader can be stopped before it is replaced by another candidate. This is only applicable if leader
                election is enabled. (default 15s)
      --leader-elect-renew-deadline duration                                                                            
                The interval between attempts by the acting master to renew a leadership slot before it stops leading. This
                must be less than or equal to the lease duration. This is only applicable if leader election is enabled.
                (default 10s)
      --leader-elect-resource-lock endpoints                                                                            
                The type of resource object that is used for locking during leader election. Supported options are
                endpoints (default) and `configmaps`. (default "endpoints")
      --leader-elect-retry-period duration                                                                              
                The duration the clients should wait between attempting acquisition and renewal of a leadership. This is
                only applicable if leader election is enabled. (default 2s)

Feature gate flags:

      --feature-gates mapStringBool                                                                                     
                A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                APIListChunking=true|false (BETA - default=true)
                APIResponseCompression=true|false (ALPHA - default=false)
                AdvancedAuditing=true|false (BETA - default=true)
                AllAlpha=true|false (ALPHA - default=false)
                AppArmor=true|false (BETA - default=true)
                AttachVolumeLimit=true|false (ALPHA - default=false)
                BalanceAttachedNodeVolumes=true|false (ALPHA - default=false)
                BlockVolume=true|false (ALPHA - default=false)
                CPUManager=true|false (BETA - default=true)
                CRIContainerLogRotation=true|false (BETA - default=true)
                CSIBlockVolume=true|false (ALPHA - default=false)
                CSIPersistentVolume=true|false (BETA - default=true)
                CustomPodDNS=true|false (BETA - default=true)
                CustomResourceSubresources=true|false (BETA - default=true)
                CustomResourceValidation=true|false (BETA - default=true)
                DebugContainers=true|false (ALPHA - default=false)
                DevicePlugins=true|false (BETA - default=true)
                DryRun=true|false (ALPHA - default=false)
                DynamicKubeletConfig=true|false (BETA - default=true)
                EnableEquivalenceClassCache=true|false (ALPHA - default=false)
                ExpandInUsePersistentVolumes=true|false (ALPHA - default=false)
                ExpandPersistentVolumes=true|false (BETA - default=true)
                ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)
                ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)
                GCERegionalPersistentDisk=true|false (BETA - default=true)
                HugePages=true|false (BETA - default=true)
                HyperVContainer=true|false (ALPHA - default=false)
                Initializers=true|false (ALPHA - default=false)
                KubeletPluginsWatcher=true|false (ALPHA - default=false)
                LocalStorageCapacityIsolation=true|false (BETA - default=true)
                MountContainers=true|false (ALPHA - default=false)
                MountPropagation=true|false (BETA - default=true)
                NodeLease=true|false (ALPHA - default=false)
                PersistentLocalVolumes=true|false (BETA - default=true)
                PodPriority=true|false (BETA - default=true)
                PodReadinessGates=true|false (BETA - default=true)
                PodShareProcessNamespace=true|false (BETA - default=true)
                QOSReserved=true|false (ALPHA - default=false)
                ReadOnlyAPIDataVolumes=true|false (DEPRECATED - default=true)
                ResourceLimitsPriorityFunction=true|false (ALPHA - default=false)
                ResourceQuotaScopeSelectors=true|false (BETA - default=true)
                RotateKubeletClientCertificate=true|false (BETA - default=true)
                RotateKubeletServerCertificate=true|false (BETA - default=true)
                RunAsGroup=true|false (ALPHA - default=false)
                RuntimeClass=true|false (ALPHA - default=false)
                SCTPSupport=true|false (ALPHA - default=false)
                ScheduleDaemonSetPods=true|false (ALPHA - default=false)
                ServiceNodeExclusion=true|false (ALPHA - default=false)
                ServiceProxyAllowExternalIPs=true|false (DEPRECATED - default=false)
                StorageObjectInUseProtection=true|false (default=true)
                StreamingProxyRedirects=true|false (BETA - default=true)
                SupportIPVSProxyMode=true|false (default=true)
                SupportPodPidsLimit=true|false (ALPHA - default=false)
                Sysctls=true|false (BETA - default=true)
                TaintBasedEvictions=true|false (ALPHA - default=false)
                TaintNodesByCondition=true|false (BETA - default=true)
                TokenRequest=true|false (ALPHA - default=false)
                TokenRequestProjection=true|false (ALPHA - default=false)
                VolumeScheduling=true|false (BETA - default=true)
                VolumeSnapshotDataSource=true|false (ALPHA - default=false)
                VolumeSubpath=true|false (default=true)
                VolumeSubpathEnvExpansion=true|false (ALPHA - default=false)

Global flags:

      --alsologtostderr                                                                                                 
                log to standard error as well as files
  -h, --help                                                                                                            
                help for kube-scheduler
      --log-backtrace-at traceLocation                                                                                  
                when logging hits line file:N, emit a stack trace (default :0)
      --log-dir string                                                                                                  
                If non-empty, write log files in this directory
      --log-flush-frequency duration                                                                                    
                Maximum number of seconds between log flushes (default 5s)
      --logtostderr                                                                                                     
                log to standard error instead of files (default true)
      --stderrthreshold severity                                                                                        
                logs at or above this threshold go to stderr (default 2)
  -v, --v Level                                                                                                         
                log level for V logs
      --version version[=true]                                                                                          
                Print version information and quit
      --vmodule moduleSpec                                                                                              
                comma-separated list of pattern=N settings for file-filtered logging
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
