### PR TITLE
fluentd doesn't receive the signal TERM 

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -55,4 +55,4 @@ EXPOSE 80
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
 # Start Fluentd to pick up our config that watches Docker container logs.
-CMD /run.sh $FLUENTD_ARGS
+CMD ["/run.sh"]

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
@@ -20,4 +20,4 @@
 # For systems without journald
 mkdir -p /var/log/journal
 
-exec /usr/local/bin/fluentd $@
+exec /usr/local/bin/fluentd $FLUENTD_ARGS


### PR DESCRIPTION
Sometimes when my fluentd daemonset restarts, it sends all the logs again, even logs already sent.

My first assumption was the [pos file](https://docs.fluentd.org/v0.12/articles/in_tail#pos_file-(highly-recommended)) were misconfigured but after a long time working on this I found the issue. When fluentd is stopped by kubernetes it does not receive the TERM signal, "broking" the position file. The cause of this issue is the [CMD spec](https://docs.docker.com/engine/reference/builder/#cmd) without "["  uses a shell form and doesn't use exec to start a process. 

To reproduce the error you could delete the fluentd pod and you will never see a message saying fluentd has been killed `(ex: ...fluentd main process get SIGTERM). `

After I applied the patch, fluentd started receiving the SIGTERM 

## Fluentd logs after the patch

```
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: fluentd main process get SIGTERM
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: getting start to shutdown main process
2018-08-30 11:42:43 +0000 [info]: fluent/log.rb:322:info: fluentd worker is now stopping worker=0
2018-08-30 11:42:43 +0000 [info]: fluent/log.rb:322:info: shutting down fluentd worker worker=0
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="fluentd-containers.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:forward plugin_id="object:3fb7a18ccf88"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:prometheus plugin_id="object:3fb79eb05834"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:monitor_agent plugin_id="object:3fb79ec9ea4c"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:prometheus_monitor plugin_id="object:3fb79ef47e9c"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:prometheus_output_monitor plugin_id="object:3fb79ec5412c"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:prometheus_tail_monitor plugin_id="object:3fb79ec2c258"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="minion"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="startupscript.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="docker.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="kubelet.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="kube-proxy.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="kube-apiserver.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="kube-controller-manager.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="kube-scheduler.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="rescheduler.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="glbc.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:tail plugin_id="cluster-autoscaler.log"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:systemd plugin_id="journald-docker"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:systemd plugin_id="journald-kubelet"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on input plugin type=:systemd plugin_id="journald-node-problem-detector"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on output plugin type=:detect_exceptions plugin_id="raw.kubernetes"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on output plugin type=:elasticsearch plugin_id="apps"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on output plugin type=:elasticsearch plugin_id="infrastructure"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on filter plugin type=:kubernetes_metadata plugin_id="object:3fb7a35c0ce8"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on filter plugin type=:record_transformer plugin_id="object:3fb7a0208d4c"
2018-08-30 11:42:43 +0000 [debug]: fluent/log.rb:302:debug: calling stop on output plugin type=:null plugin_id="object:3fb7a19121c8"

```

### Release note:

```release-note
Pass signals to fluentd process
```
