### PR TITLE
Change pod-GC from polling nodes periodically to informer

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -255,6 +255,7 @@ func startPodGCController(ctx ControllerContext) (http.Handler, bool, error) {
 	go podgc.NewPodGC(
 		ctx.ClientBuilder.ClientOrDie("pod-garbage-collector"),
 		ctx.InformerFactory.Core().V1().Pods(),
+		ctx.InformerFactory.Core().V1().Nodes(),
 		int(ctx.ComponentConfig.PodGCController.TerminatedPodGCThreshold),
 	).Run(ctx.Stop)
 	return nil, true, nil

--- a/pkg/controller/podgc/BUILD
+++ b/pkg/controller/podgc/BUILD
@@ -15,12 +15,12 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/controller/podgc",
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/controller/util/node:go_default_library",
         "//pkg/util/metrics:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",


### PR DESCRIPTION
This is changing the behaviour of pod GC as follows:

Instead of periodically polling for nodes and deleting pods whose nodes are non-existent, it will now delete pods on a given node on receiving a delete node event from informer. Note that it means we wouldn't anymore be deleting pods whose nodes weren't existing at any point (i.e imaginary nodes).

However, if there's still a good reason to delete even such pods, I can add a periodic clean-up, but by listing nodes from cache instead of etcd. This approach has one problem that if a newly added node hasn't appeared in the cache yet, we may wrongly delete it. But I think we can neglect this case as it should usually take more time for a node to become schedulable than it should take for the controller's cache to get the new node. And until the former happens, pods shouldn't be assigned to that node anyway (unless someone evil bypasses the scheduler and assigns that node manually).

/cc @wojtek-t @liggitt 
Let me know your thoughts on this.

```release-note
NONE
```
