### PR TITLE
Update metrics-server to v0.3.0

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,24 +23,24 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.2.1
+  name: metrics-server-v0.3.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.2.1
+    version: v0.3.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.2.1
+      version: v0.3.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.2.1
+        version: v0.3.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
@@ -49,10 +49,13 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.2.1
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.0
         command:
         - /metrics-server
-        - --source=kubernetes.summary_api:''
+        # These are needed for GKE, which doesn't support secure communication yet.
+        # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
+        - --kubelet-port=10255
+        - --deprecated-kubelet-completely-insecure=true
         ports:
         - containerPort: 443
           name: https
@@ -86,7 +89,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.2.1
+          - --deployment=metrics-server-v0.3.0
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential


### PR DESCRIPTION
v0.3.0 is the latest version of metrics-server, and brings a number of
internal stability improvements as well as some bugfixes and features.

NB: this currently disables Kubelet auth entirely, since this setup
needs to work on GKE for the tests, and GKE doesn't support delegated
Kubelet auth yet.  When that's rectified, we can switch this over to
use secure options.

```release-note
Update metrics-server to v0.3.0.
```
