### PR TITLE
Deprecation notice of the storage-versions flag

### DIFF
--- a/pkg/kubeapiserver/options/storage_versions.go
+++ b/pkg/kubeapiserver/options/storage_versions.go
@@ -103,6 +103,11 @@ func (s *StorageSerializationOptions) AddFlags(fs *pflag.FlagSet) {
 		"You only need to pass the groups you wish to change from the defaults. "+
 		"It defaults to a list of preferred versions of all known groups.")
 
+	fs.MarkDeprecated("storage-versions", ""+
+		"Please omit this flag to ensure the default storage versions are used ."+
+		"Otherwise the cluster is not safe to upgrade to a version newer than 1.12. "+
+		"This flag will be removed in 1.13.")
+
 }
 
 // ToPreferredVersionString returns the preferred versions of all registered


### PR DESCRIPTION
This PR deprecates the `--storage-versions` flag of kube-apiserver. The flag allows user to change the API version the content in etcd will be serialized to.

The flag provides unnecessary flexibility, with the side-effect of making kube-apiserver upgrades/downgrades hard to reason about. Specifically, Kubernetes follows the 4-step API version deprecation [policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/), which makes upgrades/downgrades across minor versions safe as long as all the data in etcd is encoded to the default storage versions. However, if users can specify their own storage versions, then the safety of each upgrade/downgrade needs to be analyzed case-by-case.

```release-note
Action required: The --storage-versions flag of kube-apiserver is deprecated. Please omit this flag to ensure the default storage versions are used. Otherwise the cluster is not safe to upgrade to a version newer than 1.12. This flag will be removed in 1.13.
```

/assign @deads2k @liggitt @lavalamp @enj 
/sig api-machinery
