### PR TITLE
fix typo: result is of that -> result of that

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -166,7 +166,7 @@ function is_leader() {
 
 # The business logic for whether a given object should be created
 # was already enforced by salt, and /etc/kubernetes/addons is the
-# managed result is of that. Start everything below that directory.
+# managed result of that. Start everything below that directory.
 log INFO "== Kubernetes addon manager started at $(date -Is) with ADDON_CHECK_INTERVAL_SEC=${ADDON_CHECK_INTERVAL_SEC} =="
 
 # Create the namespace that will be used to host the cluster-level add-ons.


### PR DESCRIPTION
**What this PR does / why we need it**:

Simple typo fix in the cluster/addons/addon-manager/kube-addons.sh file.

**Special notes for your reviewer**:

I am studying the code and trying to find something useful that I can contribute with. Found this simple typo and decided to fix it and familiarize myself with the PR process.

**Release note**:

```release-note
none
```
