### PR TITLE
Let the service controller retry when presistUpdate returns a conflict error

### DIFF
--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -46,10 +46,13 @@ go_test(
         "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -17,15 +17,20 @@ limitations under the License.
 package service
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	fakecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/fake"
@@ -323,7 +328,6 @@ func TestGetNodeConditionPredicate(t *testing.T) {
 // TODO(a-robinson): Add tests for update/sync/delete.
 
 func TestProcessServiceUpdate(t *testing.T) {
-
 	var controller *ServiceController
 
 	//A pair of old and new loadbalancer IP address
@@ -409,6 +413,38 @@ func TestProcessServiceUpdate(t *testing.T) {
 		}
 	}
 
+}
+
+// TestConflictWhenProcessServiceUpdate tests if processServiceUpdate will
+// retry creating the load balancer if the update operation returns a conflict
+// error.
+func TestConflictWhenProcessServiceUpdate(t *testing.T) {
+	svcName := "conflict-lb"
+	svc := newService(svcName, types.UID("123"), v1.ServiceTypeLoadBalancer)
+	controller, _, client := newController()
+	client.PrependReactor("update", "services", func(action core.Action) (bool, runtime.Object, error) {
+		update := action.(core.UpdateAction)
+		return true, update.GetObject(), apierrors.NewConflict(action.GetResource().GroupResource(), svcName, errors.New("Object changed"))
+	})
+
+	svcCache := controller.cache.getOrCreate(svcName)
+	if err := controller.processServiceUpdate(svcCache, svc, svcName); err == nil {
+		t.Fatalf("controller.processServiceUpdate() = nil, want error")
+	}
+
+	retryMsg := "Error creating load balancer (will retry)"
+	if gotEvent := func() bool {
+		events := controller.eventRecorder.(*record.FakeRecorder).Events
+		for len(events) > 0 {
+			e := <-events
+			if strings.Contains(e, retryMsg) {
+				return true
+			}
+		}
+		return false
+	}(); !gotEvent {
+		t.Errorf("controller.processServiceUpdate() = can't find retry creating lb event, want event contains %q", retryMsg)
+	}
 }
 
 func TestSyncService(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If a load balancer is changed while provisioning, it will fall into an error state and will not self-recover.
This PR picks up the conflict error and let serviceController retry in order to get the load balancer out of error state.

**Special notes for your reviewer**:
/assign @MrHohn @rramkumar1 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Let service controller retry creating load balancer when persistUpdate failed due to conflict.
```
