### PR TITLE
add make targets for building server images

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -90,7 +90,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 kube::build::get_docker_wrapped_binaries() {
   debian_iptables_version=v10.1
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
-  ### in build/BUILD.
+  ### in build/BUILD. And kube::golang::server_image_targets
   case $1 in
     "amd64")
         local targets=(

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -206,7 +206,6 @@ function kube::release::build_server_images() {
     local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
     rm -rf "${release_stage}"
     mkdir -p "${release_stage}/server/bin"
-    mkdir -p "${release_stage}/addons"
 
     # This fancy expression will expand to prepend a path
     # (${LOCAL_OUTPUT_BINPATH}/${platform}/) to every item in the
@@ -225,15 +224,15 @@ function kube::release::build_server_images() {
 
 # Package up all of the server binaries
 function kube::release::package_server_tarballs() {
+  kube::release::build_server_images
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
     local platform_tag=${platform/\//-} # Replace a "/" for a "-"
     local arch=$(basename "${platform}")
     kube::log::status "Building tarball: server $platform_tag"
 
+    # NOTE: this directory was setup in kube::release::build_server_images
     local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
-    rm -rf "${release_stage}"
-    mkdir -p "${release_stage}/server/bin"
     mkdir -p "${release_stage}/addons"
 
     # This fancy expression will expand to prepend a path
@@ -241,8 +240,6 @@ function kube::release::package_server_tarballs() {
     # KUBE_SERVER_BINARIES array.
     cp "${KUBE_SERVER_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
       "${release_stage}/server/bin/"
-
-    kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
 
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins=("${KUBE_CLIENT_BINARIES[@]}")

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -193,6 +193,36 @@ function kube::release::package_node_tarballs() {
   done
 }
 
+# Package up all of the server binaries in docker images
+function kube::release::build_server_images() {
+  # Clean out any old images
+  rm -rf "${RELEASE_IMAGES}"
+  local platform
+  for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
+    local platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    local arch=$(basename "${platform}")
+    kube::log::status "Building images: $platform_tag"
+
+    local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
+    rm -rf "${release_stage}"
+    mkdir -p "${release_stage}/server/bin"
+    mkdir -p "${release_stage}/addons"
+
+    # This fancy expression will expand to prepend a path
+    # (${LOCAL_OUTPUT_BINPATH}/${platform}/) to every item in the
+    # KUBE_SERVER_IMAGE_BINARIES array.
+    cp "${KUBE_SERVER_IMAGE_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
+      "${release_stage}/server/bin/"
+
+    # if we are building hyperkube, we also need to copy that binary
+    if [[ "${KUBE_BUILD_HYPERKUBE}" =~ [yY] ]]; then
+      cp "${LOCAL_OUTPUT_BINPATH}/${platform}/hyperkube" "${release_stage}/server/bin"
+    fi
+
+    kube::release::create_docker_images_for_server "${release_stage}/server/bin" "${arch}"
+  done
+}
+
 # Package up all of the server binaries
 function kube::release::package_server_tarballs() {
   local platform

--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build Kubernetes release images. This will build the server target binaries,
+# and create wrap them in Docker images, see `make release` for full releases
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/build/common.sh"
+source "${KUBE_ROOT}/build/lib/release.sh"
+
+CMD_TARGETS="${KUBE_SERVER_IMAGE_TARGETS[*]}"
+if [[ "${KUBE_BUILD_HYPERKUBE}" =~ [yY] ]]; then
+    CMD_TARGETS="${CMD_TARGETS} cmd/hyperkube"
+fi
+
+kube::build::verify_prereqs
+kube::build::build_image
+kube::build::run_build_command make all WHAT="${CMD_TARGETS}" KUBE_BUILD_PLATFORMS="${KUBE_SERVER_PLATFORMS[*]}"
+
+kube::build::copy_output
+
+kube::release::build_server_images

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -386,6 +386,24 @@ release-in-a-container:
 	build/release-in-a-container.sh
 endif
 
+define RELEASE_IMAGES_HELP_INFO
+# Build release images
+#
+# Args:
+#   KUBE_BUILD_HYPERKUBE: Whether to build hyperkube image as well. Set to 'n' to skip.
+#
+# Example:
+#   make release-images
+endef
+.PHONY: release-images
+ifeq ($(PRINT_HELP),y)
+release-images:
+	@echo "$$RELEASE_IMAGES_HELP_INFO"
+else
+release-images:
+	build/release-images.sh
+endif
+
 define RELEASE_SKIP_TESTS_HELP_INFO
 # Build a release, but skip tests
 #
@@ -406,6 +424,26 @@ release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n
 release-skip-tests quick-release: KUBE_FASTBUILD = true
 release-skip-tests quick-release:
 	build/release.sh
+endif
+
+define QUICK_RELEASE_IMAGES_HELP_INFO
+# Build release images, but only for linux/amd64
+#
+# Args:
+#   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'false' to do so.
+#   KUBE_BUILD_HYPERKUBE: Whether to build hyperkube image as well. Set to 'n' to skip.
+#
+# Example:
+#   make quick-release-images
+endef
+.PHONY: quick-release-images
+ifeq ($(PRINT_HELP),y)
+quick-release-images:
+	@echo "$$QUICK_RELEASE_IMAGES_HELP_INFO"
+else
+quick-release-images: KUBE_FASTBUILD = true
+quick-release-images:
+	build/release-images.sh
 endif
 
 define PACKAGE_HELP_INFO

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -40,6 +40,23 @@ IFS=" " read -ra KUBE_SERVER_TARGETS <<< "$(kube::golang::server_targets)"
 readonly KUBE_SERVER_TARGETS
 readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")
 
+# The set of server targets we build docker images for
+kube::golang::server_image_targets() {
+  # NOTE: this contains cmd targets for kube::build::get_docker_wrapped_binaries
+  local targets=(
+    cmd/cloud-controller-manager
+    cmd/kube-apiserver
+    cmd/kube-controller-manager
+    cmd/kube-scheduler
+    cmd/kube-proxy
+  )
+  echo "${targets[@]}"
+}
+
+IFS=" " read -ra KUBE_SERVER_IMAGE_TARGETS <<< "$(kube::golang::server_image_targets)"
+readonly KUBE_SERVER_IMAGE_TARGETS
+readonly KUBE_SERVER_IMAGE_BINARIES=("${KUBE_SERVER_IMAGE_TARGETS[@]##*/}")
+
 # The set of server targets that we are only building for Kubernetes nodes
 # If you update this list, please also update build/BUILD.
 kube::golang::node_targets() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Adds `make release-images` and `make quick-release-images`, which allow building the docker-wrapped images without building a full release. Without these you can either use `make {quick}-release` and build test tarballs etc, or hack around in the build system yourself. Using this can be considerably faster if you just want to build the binaries and images, and not the release tarballs etc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig release
