### PR TITLE
node lifecycle manager not started in taint_test.go

### DIFF
--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -125,6 +125,8 @@ func TestTaintNodeByCondition(t *testing.T) {
 	// Waiting for all controller sync.
 	internalInformers.Start(controllerCh)
 	internalInformers.WaitForCacheSync(controllerCh)
+	informers.Start(controllerCh)
+	informers.WaitForCacheSync(controllerCh)
 
 	// -------------------------------------------
 	// Test TaintNodeByCondition feature.
@@ -616,11 +618,11 @@ func TestTaintNodeByCondition(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			node := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "node-1",
+					Name: fmt.Sprintf("node-%d", i),
 				},
 				Spec: v1.NodeSpec{
 					Unschedulable: test.unschedulable,
@@ -641,9 +643,9 @@ func TestTaintNodeByCondition(t *testing.T) {
 			}
 
 			var pods []*v1.Pod
-			for i, p := range test.pods {
+			for j, p := range test.pods {
 				pod := p.pod.DeepCopy()
-				pod.Name = fmt.Sprintf("%s-%d", pod.Name, i)
+				pod.Name = fmt.Sprintf("%s-%d-%d", pod.Name, i, j)
 				pod.Spec.Tolerations = p.tolerations
 
 				createdPod, err := cs.CoreV1().Pods(pod.Namespace).Create(pod)


### PR DESCRIPTION
**What this PR does / why we need it**:

Actually node lifecycle manager isn't started in taint_test.go - it's hanging in the cache sync step.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/pull/67864#pullrequestreview-151186597

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
