### PR TITLE
Fixes #68026: Revise some errors about golint

### DIFF
--- a/cmd/kube-scheduler/app/options/configfile.go
+++ b/cmd/kube-scheduler/app/options/configfile.go
@@ -66,9 +66,6 @@ func WriteConfigFile(fileName string, cfg *kubeschedulerconfig.KubeSchedulerConf
 		return err
 	}
 	defer configFile.Close()
-	if err := encoder.Encode(cfg, configFile); err != nil {
-		return err
-	}
-
-	return nil
+	err = encoder.Encode(cfg, configFile)
+	return err
 }

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -186,10 +186,10 @@ func removeContainers(execer utilsexec.Interface, criSocketPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := containerRuntime.RemoveContainers(containers); err != nil {
-		return err
-	}
-	return nil
+
+	err = containerRuntime.RemoveContainers(containers)
+	return err
+
 }
 
 // cleanDir removes everything in a directory, but not the directory itself

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -59,11 +59,8 @@ func CreatePKIAssets(cfg *kubeadmapi.InitConfiguration) error {
 	fmt.Printf("[certificates] valid certificates and keys now exist in %q\n", cfg.CertificatesDir)
 
 	// Service accounts are not x509 certs, so handled separately
-	if err := CreateServiceAccountKeyAndPublicKeyFiles(cfg); err != nil {
-		return err
-	}
-
-	return nil
+	err = CreateServiceAccountKeyAndPublicKeyFiles(cfg)
+	return err
 }
 
 // CreateServiceAccountKeyAndPublicKeyFiles create a new public/private key files for signing service account users.

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -4,7 +4,6 @@ cmd/hyperkube
 cmd/kube-apiserver/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app
-cmd/kube-scheduler/app
 cmd/kubeadm/app
 cmd/kubeadm/app/apis/kubeadm/v1alpha2
 cmd/kubeadm/app/apis/kubeadm/v1alpha3

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -43,10 +43,10 @@ var matchEverythingRules = []registrationv1beta1.RuleWithOperations{{
 	},
 }}
 
-var sideEffectsUnknown registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassUnknown
-var sideEffectsNone registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassNone
-var sideEffectsSome registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassSome
-var sideEffectsNoneOnDryRun registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassNoneOnDryRun
+var sideEffectsUnknown = registrationv1beta1.SideEffectClassUnknown
+var sideEffectsNone = registrationv1beta1.SideEffectClassNone
+var sideEffectsSome = registrationv1beta1.SideEffectClassSome
+var sideEffectsNoneOnDryRun = registrationv1beta1.SideEffectClassNoneOnDryRun
 
 // NewFakeDataSource returns a mock client and informer returning the given webhooks.
 func NewFakeDataSource(name string, webhooks []registrationv1beta1.Webhook, mutating bool, stopCh <-chan struct{}) (clientset kubernetes.Interface, factory informers.SharedInformerFactory) {

--- a/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
@@ -88,11 +88,8 @@ func NewCmdNamespace(streams genericclioptions.IOStreams) *cobra.Command {
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := o.Run(); err != nil {
-				return err
-			}
-
-			return nil
+			err := o.Run()
+			return err
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

According to this issue: https://github.com/kubernetes/kubernetes/issues/68026, I revise some errors about golint in kubernetes.

**Which issue(s) this PR fixes**:

Fixes #68026

**Special notes for your reviewer**:

I revised some errors about golint in some package:

-  cmd/kube-scheduler/app
-  cmd/kubeadm/app/cmd
-  staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing
-  staging/src/k8s.io/sample-cli-plugin/pkg/cmd

After I revised above errors, I run `hack/update-bazel.sh` and `hack/update-gofmt.sh` to make sure I fix any problems with gofmt or bazel.

@dims 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

