### PR TITLE
Fixes #68026: revise some errors about golint in some packages

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -99,9 +99,6 @@ pkg/apis/storage/v1beta1
 pkg/apis/storage/v1beta1/util
 pkg/auth/authorizer/abac
 pkg/capabilities
-pkg/client/chaosclient
-pkg/client/leaderelectionconfig
-pkg/client/tests
 pkg/cloudprovider
 pkg/cloudprovider/providers/aws
 pkg/cloudprovider/providers/fake

--- a/pkg/client/chaosclient/chaosclient.go
+++ b/pkg/client/chaosclient/chaosclient.go
@@ -62,9 +62,11 @@ type ChaosNotifier interface {
 // error.
 type ChaosFunc func(req *http.Request) (bool, *http.Response, error)
 
+// Intercept calls the nested method `Intercept`
 func (fn ChaosFunc) Intercept(req *http.Request) (bool, *http.Response, error) {
 	return fn.Intercept(req)
 }
+
 func (fn ChaosFunc) String() string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 }
@@ -141,7 +143,7 @@ type Error struct {
 	error
 }
 
-// C returns the nested error
+// Intercept returns the nested error
 func (e Error) Intercept(_ *http.Request) (bool, *http.Response, error) {
 	return true, nil, e.error
 }

--- a/pkg/client/leaderelectionconfig/config.go
+++ b/pkg/client/leaderelectionconfig/config.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	// DefaultLeaseDuration defines a default duration of lease.
 	DefaultLeaseDuration = 15 * time.Second
 )
 

--- a/pkg/client/tests/doc.go
+++ b/pkg/client/tests/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This package runs tests against the client which require an internal client
+// Package tests runs tests against the client which require an internal client
 package tests

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -43,10 +43,10 @@ var matchEverythingRules = []registrationv1beta1.RuleWithOperations{{
 	},
 }}
 
-var sideEffectsUnknown registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassUnknown
-var sideEffectsNone registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassNone
-var sideEffectsSome registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassSome
-var sideEffectsNoneOnDryRun registrationv1beta1.SideEffectClass = registrationv1beta1.SideEffectClassNoneOnDryRun
+var sideEffectsUnknown = registrationv1beta1.SideEffectClassUnknown
+var sideEffectsNone = registrationv1beta1.SideEffectClassNone
+var sideEffectsSome = registrationv1beta1.SideEffectClassSome
+var sideEffectsNoneOnDryRun = registrationv1beta1.SideEffectClassNoneOnDryRun
 
 // NewFakeDataSource returns a mock client and informer returning the given webhooks.
 func NewFakeDataSource(name string, webhooks []registrationv1beta1.Webhook, mutating bool, stopCh <-chan struct{}) (clientset kubernetes.Interface, factory informers.SharedInformerFactory) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

According to this issue: https://github.com/kubernetes/kubernetes/issues/68026, I revise some errors about golint in some packages as below

1. pkg/client
2. staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing

**Which issue(s) this PR fixes** :

Ref #68026 

**Special notes for your reviewer**:

After I revised above errors, I run `hack/update-bazel.sh` and `hack/update-gofmt.sh` to make sure I fix any problems with gofmt or bazel.
@dims 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
