### PR TITLE
Automated cherry pick of #61459: etcd client add dial timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -17,6 +17,8 @@ limitations under the License.
 package factory
 
 import (
+	"time"
+
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
 	"golang.org/x/net/context"
@@ -25,6 +27,11 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	"k8s.io/apiserver/pkg/storage/value"
+)
+
+var (
+	// dialTimeout is the timeout for failing to establish a connection.
+	dialTimeout = 10 * time.Second
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
@@ -43,8 +50,9 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
-		Endpoints: c.ServerList,
-		TLS:       tlsConfig,
+		DialTimeout: dialTimeout,
+		Endpoints:   c.ServerList,
+		TLS:         tlsConfig,
 	}
 	client, err := clientv3.New(cfg)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #61459 on release-1.9.

#61459: etcd client add dial timeout

Fix #62538

```release-note
kube-apiserver now sets a dial timeout when connecting to etcd, to allow it to tolerate/retry connections to a dead etcd server
```