### PR TITLE
Increase metrics-server scrape frequency to 30s

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -52,6 +52,7 @@ spec:
         image: k8s.gcr.io/metrics-server-amd64:v0.3.0
         command:
         - /metrics-server
+        - --metric-resolution=30s
         # These are needed for GKE, which doesn't support secure communication yet.
         # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
         - --kubelet-port=10255


### PR DESCRIPTION
With new release of metrics-server and it's performance improvement, we will reduce metrics pipeline latency from 60s to 30s. 
This is part of sig-autoscaling effort to improve HPA https://github.com/kubernetes/kubernetes/pull/68021
```release-note
Increase scrape frequency of metrics-server to 30s
```
/cc @kawych @mwielgus @DirectXMan12 @dashpole 