### PR TITLE
Fix ipam controller to not drop nodes forever in case of failures

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -157,7 +157,6 @@ func (ca *cloudCIDRAllocator) worker(stopChan <-chan struct{}) {
 			}
 			if err := ca.updateCIDRAllocation(workItem); err == nil {
 				glog.V(3).Infof("Updated CIDR for %q", workItem)
-				ca.removeNodeFromProcessing(workItem)
 			} else {
 				glog.Errorf("Error updating CIDR for %q: %v", workItem, err)
 				if canRetry, timeout := ca.retryParams(workItem); canRetry {
@@ -170,6 +169,7 @@ func (ca *cloudCIDRAllocator) worker(stopChan <-chan struct{}) {
 				}
 				glog.Errorf("Exceeded retry count for %q, dropping from queue", workItem)
 			}
+			ca.removeNodeFromProcessing(workItem)
 		case <-stopChan:
 			return
 		}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/68084 introduced a problem that when 10 attempts to assign a cidr would fail, we stop retrying but the node is still marked as "in-processing" so it would never be reconciled again.

This PR is fixing this problem.