### PR TITLE
Start deprecating all generators in run except for run-pod/v1

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -323,6 +323,13 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		}
 	}
 
+	// start deprecating all generators except for 'run-pod/v1' which will be
+	// the only supported on a route to simple kubectl run which should mimic
+	// docker run
+	if generatorName != cmdutil.RunPodV1GeneratorName {
+		fmt.Fprintf(o.ErrOut, "kubectl run --generator=%s is DEPRECATED and will be removed in a future version. Use kubectl create instead.\n", generatorName)
+	}
+
 	generators := cmdutil.GeneratorFn("run")
 	generator, found := generators[generatorName]
 	if !found {


### PR DESCRIPTION
**What this PR does / why we need it**:
This was discussed during SIG-CLI meetings over several past months. The direction is that we want to move away from `kubectl run` because it's over bloated and complicated for both users and developers. We want to mimic `docker run` with `kubectl run` so that it *only* creates a pod, and if you're interested in other resources `kubectl create` is the intended replacement. 

This PR starts with deprecating all of the generator except for the pod one.

/assign @juanvallejo 
/sig cli
/milestone v1.12

**Release note**:
```release-note
Deprecate kubectl run generators, except for run-pod/v1
```
