### PR TITLE
Add spiffxp to OWNERS files in bash-heavy dirs

### DIFF
--- a/build/OWNERS
+++ b/build/OWNERS
@@ -3,6 +3,7 @@ reviewers:
   - ixdy
   - jbeda
   - lavalamp
+  - spiffxp
   - zmerlynn
 approvers:
   - cblecker

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -3,6 +3,7 @@ reviewers:
   - jbeda
   - mikedanese
   - roberthbailey
+  - spiffxp
   - zmerlynn
 approvers:
   - eparis

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -10,6 +10,7 @@ reviewers:
   - sttts
   - gmarek
   - vishh
+  - spiffxp
 approvers:
   - cblecker
   - deads2k
@@ -28,3 +29,4 @@ approvers:
   - liggitt
   - soltysh # for sig-cli related stuff
   - dims # for local-up-cluster related files
+  - spiffxp


### PR DESCRIPTION
I'm comfortable approving changes in hack/, I think I still need
to build up a corpus of reviews in build/ and cluster/ before I'm
comfortable asking for those rights. I'm willing to be voluntold
otherwise if existing approvers feel differently.

Approvers, WDYT?

```release-note
NONE
```