### PR TITLE
Implement semantic comparison of VolumeNodeAffinity for unit tests

### DIFF
--- a/pkg/controller/cloud/BUILD
+++ b/pkg/controller/cloud/BUILD
@@ -66,6 +66,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements a semantic comparison function for VolumeNodeAffinity that is not sensitive to ordering of various members. Previous reflect.DeepEqual was sensitive to ordering causing it to be flaky.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubernetes/issues/67852

**Special notes for your reviewer**:
We want to able to successfully match `VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[{[{a In [1]} {b In [2 3]}] []}],},}` and `VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[{[{b In [3 2]} {a In [1]}] []}],},}` without being sensitive to the ordering of requirements with key `a` and `b` or the order of values with key `b`. This fix enables such semantic comparison of VolumeNodeAffinity

We can move `volumeNodeAffinitiesEqual` to volume/utils post code freeze

**Release note**:

```release-note
NONE
```

/sig storage
cc @msau42 