### PR TITLE
Register RuntimeClass CRD as an addon

### DIFF
--- a/cluster/addons/runtimeclass/OWNERS
+++ b/cluster/addons/runtimeclass/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- tallclair
+- dchen1107
+reviewers:
+- sig-node-reviewers

--- a/cluster/addons/runtimeclass/README.md
+++ b/cluster/addons/runtimeclass/README.md
@@ -1,0 +1,12 @@
+# RuntimeClass
+
+RuntimeClass is an alpha feature for supporting multiple container runtimes within a cluster. When
+enabled, pods can select a RuntimeClass to run with using the `PodSpec.RuntimeClassName` field.
+
+To enable RuntimeClass, set the feature gate `RuntimeClass=true`, and ensure the CRD defined in this
+directory is installed.
+
+For more information, see:
+https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/runtimeclass/README.md?pixel)]()

--- a/cluster/addons/runtimeclass/runtimeclass_crd.yaml
+++ b/cluster/addons/runtimeclass/runtimeclass_crd.yaml
@@ -1,0 +1,26 @@
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: runtimeclasses.node.k8s.io
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  group: node.k8s.io
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  names:
+    plural:   runtimeclasses
+    singular: runtimeclass
+    kind:     RuntimeClass
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            runtimeHandler:
+              type: string
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2498,10 +2498,14 @@ EOF
       setup-addon-manifests "addons" "istio/noauth"
     fi
   fi
+  if [[ "${FEATURE_GATES:-}" =~ "RuntimeClass=true" ]]; then
+    setup-addon-manifests "addons" "runtimeclass"
+  fi
   if [[ -n "${EXTRA_ADDONS_URL:-}" ]]; then
     download-extra-addons
     setup-addon-manifests "addons" "gce-extras"
   fi
+
 
   # Place addon manager pod manifest.
   cp "${src_dir}/kube-addon-manager.yaml" /etc/kubernetes/manifests


### PR DESCRIPTION
**What this PR does / why we need it**:

Register the RuntimeClass CRD when the RuntimeClass feature gate is enabled. This is done in through the addon manager.

This is an alternative approach to https://github.com/kubernetes/kubernetes/pull/67924

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For https://github.com/kubernetes/features/issues/585

**Release note**:
Covered by #67737
```release-note
NONE
```

/sig node
/kind feature
/priority important-soon
/milestone v1.12