### PR TITLE
Add RuntimeClass read permission for nodes

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -165,6 +165,11 @@ func NodeRules() []rbacv1.PolicyRule {
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeLease) {
 		nodePolicyRules = append(nodePolicyRules, rbacv1helpers.NewRule("get", "create", "update", "patch", "delete").Groups("coordination.k8s.io").Resources("leases").RuleOrDie())
 	}
+
+	// RuntimeClass
+	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
+		nodePolicyRules = append(nodePolicyRules, rbacv1helpers.NewRule("get", "list", "watch").Groups("node.k8s.io").Resources("runtimeclasses").RuleOrDie())
+	}
 	return nodePolicyRules
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the necessary permissions for nodes to read RuntimeClasses when the feature gate is enabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For kubernetes/features#585

**Release note**:
Covered by #67737
```release-note
NONE
```

/sig node
/sig auth
/kind feature
/priority important-soon
/milestone v1.12