### PR TITLE
Fixup openstack cloud provider loadbalancer deletion error

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -474,10 +474,13 @@ func (lbaas *LbaasV2) GetLoadBalancer(ctx context.Context, clusterName string, s
 	portID := loadbalancer.VipPortID
 	if portID != "" {
 		floatIP, err := getFloatingIPByPortID(lbaas.network, portID)
-		if err != nil {
+		if err != nil && err != ErrNotFound {
 			return nil, false, fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
 		}
-		status.Ingress = []v1.LoadBalancerIngress{{IP: floatIP.FloatingIP}}
+
+		if floatIP != nil {
+			status.Ingress = []v1.LoadBalancerIngress{{IP: floatIP.FloatingIP}}
+		}
 	} else {
 		status.Ingress = []v1.LoadBalancerIngress{{IP: loadbalancer.VipAddress}}
 	}


### PR DESCRIPTION
This change enables ```getLoadBalancer``` to return the loadbalancer even if no floating ip is associated to the VIP port of the loadbalancer.

Signed-off-by: Eunsoo Park <esevan.park@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes the bug like below.
```
Warning  CreatingLoadBalancerFailed  17m (x3445 over 12d)  service-controller  Error creating load balancer (will retry): error getting LB for service default/influxdb: error getting floating ip for port 81253cae-acd6-4bed-8006-814c8729be8c: failed to find object
```
**Special notes for your reviewer**:
Refer to following bug description for better understanding of this PR.
When k8s service type is changed from LoadBalancer to others, there's a deleting loadbalancer process in kubernetes cloud provider as below.

https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/service/service_controller.go#L284 
```
if !wantsLoadBalancer(service) {
	_, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service)
	if err != nil {
		return fmt.Errorf("error getting LB for service %s: %v", key, err)
	}
	if exists {
		glog.Infof("Deleting existing load balancer for service %s that no longer needs a loadbalancer.", key)
		s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletingLoadBalancer", "Deleting loadbalancer")
		if err := s.balancer.EnsureLoadBalancerDeleted(context.TODO(), s.clusterName, service); err != nil {
			return err
		}
		s.eventRecorder.Event(service, v1.EventTypeNormal, "DeletedLoadBalancer", "Deleted loadbalancer")
	}
```

Openstack cloud provider returns error even though LB exists since there's no associated floating IP with VIP port. 
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L476

```
floatIP, err := getFloatingIPByPortID(lbaas.network, portID)
if err != nil {
	return nil, false, fmt.Errorf("error getting floating ip for port %s: %v", portID, err)
}
```

This caused ```GetLoadBalancer()``` failed and retrying over and over in ```processServiceUpdate``` of ```k8sServiceController```.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
