### PR TITLE
Update cluster autoscaler to 1.12.0-beta.1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.2-beta.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.0-beta.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler to version 1.12.0-beta.1 which is compatible with k8s 1.12.
Note: this is pre release version. Update to the final version of CA image will be done a week before k8s release deadline.

Version skip from 1.3.x to 1.12.x is to synchronize version numbering between Cluster Autoscaler and k8s core.
```release-note
NONE
```
