### PR TITLE
Deprecate cloudstack and ovirt controller projects

### DIFF
--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -42,6 +42,8 @@ var (
 	}{
 		{"openstack", true, "https://github.com/kubernetes/cloud-provider-openstack"},
 		{"photon", false, "The Photon Controller project is no longer maintained."},
+		{"cloudstack", false, "The CloudStack Controller project is no longer maintained."},
+		{"ovirt", false, "The ovirt Controller project is no longer maintained."},
 	}
 )
 


### PR DESCRIPTION
Change-Id: Icca9142940269ad1cd28f1f3491684a1bc626c55

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Do we have folks invested in these providers trying to work on the external controllers for these providers? Is there a future for these providers? If not can we deprecate and eventually remove them?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
cc @ngtuna @sebgoa @svanharmelen (for cloudstack)
cc @simon3z 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecate cloudstack and ovirt controllers
```
