### PR TITLE
Fix Golint errors in pkg/proxy/apis

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -254,7 +254,6 @@ pkg/probe/exec
 pkg/probe/http
 pkg/probe/tcp
 pkg/proxy
-pkg/proxy/apis/config
 pkg/proxy/apis/config/v1alpha1
 pkg/proxy/iptables
 pkg/proxy/userspace

--- a/pkg/proxy/apis/config/register.go
+++ b/pkg/proxy/apis/config/register.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme adds the component types to the scheme
+	AddToScheme = schemeBuilder.AddToScheme
 )
 
 // GroupName is the group name use in this package

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -142,6 +142,7 @@ type KubeProxyConfiguration struct {
 	NodePortAddresses []string
 }
 
+// ProxyMode is the type of proxy to use
 // Currently, three modes of proxy are available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
 // (newer, faster), 'ipvs'(newest, better in performance and scalability).
 //
@@ -151,22 +152,26 @@ type KubeProxyConfiguration struct {
 // future). If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
 // insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
 // and the fall back path is firstly iptables and then userspace.
-
+//
 // In Windows platform, if proxy mode is blank, use the best-available proxy (currently userspace, but may change in the
 // future). If winkernel proxy is selected, regardless of how, but the Windows kernel can't support this mode of proxy,
 // this always falls back to the userspace proxy.
 type ProxyMode string
 
 const (
-	ProxyModeUserspace   ProxyMode = "userspace"
-	ProxyModeIPTables    ProxyMode = "iptables"
-	ProxyModeIPVS        ProxyMode = "ipvs"
+	// ProxyModeUserspace is the ProxyMode for userspace
+	ProxyModeUserspace ProxyMode = "userspace"
+	// ProxyModeIPTables is the ProxyMode for iptables
+	ProxyModeIPTables ProxyMode = "iptables"
+	// ProxyModeIPVS is the ProxyMode for ipvs
+	ProxyModeIPVS ProxyMode = "ipvs"
+	// ProxyModeKernelspace is the ProxyMode for kernelspace
 	ProxyModeKernelspace ProxyMode = "kernelspace"
 )
 
 // IPVSSchedulerMethod is the algorithm for allocating TCP connections and
 // UDP datagrams to real servers.  Scheduling algorithms are imple-
-//wanted as kernel modules. Ten are shipped with the Linux Virtual Server.
+// wanted as kernel modules. Ten are shipped with the Linux Virtual Server.
 type IPVSSchedulerMethod string
 
 const (
@@ -206,6 +211,7 @@ const (
 	NeverQueue IPVSSchedulerMethod = "nq"
 )
 
+// Set sets the ProxyMode from a given string
 func (m *ProxyMode) Set(s string) error {
 	*m = ProxyMode(s)
 	return nil
@@ -218,10 +224,12 @@ func (m *ProxyMode) String() string {
 	return ""
 }
 
+// Type returns
 func (m *ProxyMode) Type() string {
 	return "ProxyMode"
 }
 
+// ConfigurationMap is a map of configurations to their values
 type ConfigurationMap map[string]string
 
 func (m *ConfigurationMap) String() string {
@@ -233,6 +241,7 @@ func (m *ConfigurationMap) String() string {
 	return strings.Join(pairs, ",")
 }
 
+// Set sets the ConfigurationMap from a comma delimited string
 func (m *ConfigurationMap) Set(value string) error {
 	for _, s := range strings.Split(value, ",") {
 		if len(s) == 0 {
@@ -248,6 +257,7 @@ func (m *ConfigurationMap) Set(value string) error {
 	return nil
 }
 
+// Type returns the base type of the ConfigurationMap
 func (*ConfigurationMap) Type() string {
 	return "mapStringString"
 }

--- a/pkg/proxy/apis/config/v1alpha1/BUILD
+++ b/pkg/proxy/apis/config/v1alpha1/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//pkg/kubelet/qos:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/proxy/apis/config:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -33,7 +33,9 @@ func addDefaultingFuncs(scheme *kruntime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
+// SetDefaults_KubeProxyConfiguration assigns default values to the ProxyConfiguration
 func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyConfiguration) {
+
 	if len(obj.BindAddress) == 0 {
 		obj.BindAddress = "0.0.0.0"
 	}

--- a/pkg/proxy/apis/config/v1alpha1/doc.go
+++ b/pkg/proxy/apis/config/v1alpha1/doc.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha1 provides the v1alpha1 default configs for the proxy api
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/proxy/apis/config
 // +k8s:conversion-gen-external-types=k8s.io/kube-proxy/config/v1alpha1

--- a/pkg/proxy/apis/config/v1alpha1/register.go
+++ b/pkg/proxy/apis/config/v1alpha1/register.go
@@ -30,7 +30,8 @@ var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha
 var (
 	// localSchemeBuilder and AddToScheme will stay in k8s.io/kubernetes.
 	localSchemeBuilder = &kubeproxyconfigv1alpha1.SchemeBuilder
-	AddToScheme        = localSchemeBuilder.AddToScheme
+	// AddToScheme applies all the stored functions to the scheme.
+	AddToScheme = localSchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -23,7 +23,6 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
-	configv1alpha1 "k8s.io/apimachinery/pkg/apis/config/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -89,7 +88,8 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	out.EnableProfiling = in.EnableProfiling
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
-	if err := configv1alpha1.Convert_v1alpha1_ClientConnectionConfiguration_To_config_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ClientConnection, &out.ClientConnection, 0); err != nil {
 		return err
 	}
 	if err := Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {
@@ -124,7 +124,8 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	out.EnableProfiling = in.EnableProfiling
 	out.ClusterCIDR = in.ClusterCIDR
 	out.HostnameOverride = in.HostnameOverride
-	if err := configv1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
+	// TODO: Inefficient conversion - can we improve it?
+	if err := s.Convert(&in.ClientConnection, &out.ClientConnection, 0); err != nil {
 		return err
 	}
 	if err := Convert_config_KubeProxyIPTablesConfiguration_To_v1alpha1_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes linting errors in pkg/proxy/apis/

**Which issue(s) this PR fixes**
Fixes part of #68026 

**Special notes for your reviewer**:
- A lot of it was adding comments, so any feedback about parts that could be better described would be great.
- pkg/proxy/apis/config/types.go seemed to be the place that probably needs to be changed. I didn't really know how to state the ProxyMode consts without restating what was already there.
-  cmd/kubeadm/app/apis/kubeadm/v1alpha2 had some changes after defaulter-gen ran. Did I do something wrong for it to delete lines and an import like that?
- There was talk in the issue about combining packages into a single pull request. I only pulled a couple of lines so that the PR doesn't get too large. My plan is to pull 2 or 3 more on the next PR, similar to this one.

**Release note**:
```
NONE
```
