### PR TITLE
Fix panic when processing http response

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -361,7 +361,12 @@ func processHTTPRetryResponse(resp *http.Response, err error) (bool, error) {
 	}
 
 	if shouldRetryHTTPRequest(resp, err) {
-		glog.Errorf("processHTTPRetryResponse: backoff failure, will retry, HTTP response=%d, err=%v", resp.StatusCode, err)
+		if err != nil {
+			glog.Errorf("processHTTPRetryResponse: backoff failure, will retry, err=%v", err)
+		} else {
+			glog.Errorf("processHTTPRetryResponse: backoff failure, will retry, HTTP response=%d", resp.StatusCode)
+		}
+
 		// suppress the error object so that backoff process continues
 		return false, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When Azure ARM API gets something wrong, kube-controller-manager may panic because of azure cloud provider:

```
/usr/local/go/src/runtime/asm_amd64.s:2361
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d4cad9]

goroutine 1386 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x107
panic(0x44468c0, 0x8b76a30)
	/usr/local/go/src/runtime/panic.go:502 +0x229
k8s.io/kubernetes/pkg/cloudprovider/providers/azure.processHTTPRetryResponse(0x0, 0x64ffec0, 0xc4229fd1f0, 0xc422ed05b0, 0x2, 0x2)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_backoff.go:364 +0x69
k8s.io/kubernetes/pkg/cloudprovider/providers/azure.(*Cloud).CreateOrUpdatePIPWithRetry.func1(0xc422ed0600, 0x0, 0x0)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_backoff.go:205 +0x298
```

This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68209

**Special notes for your reviewer**:

Should cherry pick to old releases.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix panic when processing Azure HTTP response.
```
