### PR TITLE
add flags `default-pod-annotations` for e2e tests.

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -238,7 +238,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
-	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotation", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
+	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotations", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -125,6 +125,10 @@ type TestContextType struct {
 	// Indicates what path the kubernetes-anywhere is installed on
 	KubernetesAnywherePath string
 
+	// Annotations used for to test existing annotation based features, e.g. seccomp profile, sandbox container etc.
+	// Usage: --default-pod-annotation=k1=v1,k2=v2.
+	DefaultPodAnnotations map[string]string
+
 	// Viper-only parameters.  These will in time replace all flags.
 
 	// Example: Create a file 'e2e.json' with the following:
@@ -234,6 +238,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
+	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotation", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -420,6 +420,18 @@ func RunIfContainerRuntimeIs(runtimes ...string) {
 	Skipf("Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
 }
 
+func InjectDefaultPodAnnotations(pod *v1.Pod) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
+		return
+	}
+	annotations := pod.GetObjectMeta().GetAnnotations()
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
+	pod.SetAnnotations(annotations)
+}
+
 func RunIfSystemSpecNameIs(names ...string) {
 	for _, name := range names {
 		if name == TestContext.SystemSpecName {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

- New flag `default-pod-annotation ` in `TestContext` for e2e tests
- This flag represents a set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.
- For example, This flag will be useful for testing sandbox containers like kata and gvisor.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
test/e2e/framework: add support for setting pod annotations via `default-pod-annotations`
```