### PR TITLE
Remove mount propagation feature gate

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -248,13 +248,6 @@ func DropDisabledAlphaFields(podSpec *api.PodSpec) {
 		}
 	}
 
-	for i := range podSpec.Containers {
-		DropDisabledVolumeMountsAlphaFields(podSpec.Containers[i].VolumeMounts)
-	}
-	for i := range podSpec.InitContainers {
-		DropDisabledVolumeMountsAlphaFields(podSpec.InitContainers[i].VolumeMounts)
-	}
-
 	DropDisabledVolumeDevicesAlphaFields(podSpec)
 
 	DropDisabledRunAsGroupField(podSpec)
@@ -300,16 +293,6 @@ func DropDisabledProcMountField(podSpec *api.PodSpec) {
 			if podSpec.InitContainers[i].SecurityContext != nil {
 				podSpec.InitContainers[i].SecurityContext.ProcMount = &defProcMount
 			}
-		}
-	}
-}
-
-// DropDisabledVolumeMountsAlphaFields removes disabled fields from []VolumeMount.
-// This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a VolumeMount
-func DropDisabledVolumeMountsAlphaFields(volumeMounts []api.VolumeMount) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
-		for i := range volumeMounts {
-			volumeMounts[i].MountPropagation = nil
 		}
 	}
 }

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1115,10 +1115,6 @@ func validateMountPropagation(mountPropagation *core.MountPropagationMode, conta
 	if mountPropagation == nil {
 		return allErrs
 	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "mount propagation is disabled by feature-gate"))
-		return allErrs
-	}
 
 	supportedMountPropagations := sets.NewString(string(core.MountPropagationBidirectional), string(core.MountPropagationHostToContainer), string(core.MountPropagationNone))
 	if !supportedMountPropagations.Has(string(*mountPropagation)) {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -5038,26 +5038,6 @@ func TestValidateMountPropagation(t *testing.T) {
 		},
 	}
 
-	// Enable MountPropagation for this test
-	priorityEnabled := utilfeature.DefaultFeatureGate.Enabled("MountPropagation")
-	defer func() {
-		var err error
-		// restoring the old value
-		if priorityEnabled {
-			err = utilfeature.DefaultFeatureGate.Set("MountPropagation=true")
-		} else {
-			err = utilfeature.DefaultFeatureGate.Set("MountPropagation=false")
-		}
-		if err != nil {
-			t.Errorf("Failed to restore feature gate for MountPropagation: %v", err)
-		}
-	}()
-	err := utilfeature.DefaultFeatureGate.Set("MountPropagation=true")
-	if err != nil {
-		t.Errorf("Failed to enable feature gate for MountPropagation: %v", err)
-		return
-	}
-
 	volumes := []core.Volume{
 		{Name: "foo", VolumeSource: core.VolumeSource{HostPath: &core.HostPathVolumeSource{Path: "/foo/baz", Type: newHostPathType(string(core.HostPathUnset))}}},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -140,6 +140,7 @@ const (
 	// owner: @jsafrane
 	// GA: v1.12
 	//
+	// Note: This feature gate is unconditionally enabled in v1.13 and will be removed in v1.14.
 	// Enable mount propagation of volumes.
 	MountPropagation utilfeature.Feature = "MountPropagation"
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
@@ -777,7 +776,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	tokenManager := token.NewManager(kubeDeps.KubeClient)
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
-		glog.Warning("Mount propagation feature gate has been deprecated and will be removed in the next release")
+		return nil, fmt.Errorf("mount propagation feature gate has been deprecated and will be removed in 1.14")
 	}
 
 	klet.volumePluginMgr, err =

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -263,10 +263,6 @@ func translateMountPropagation(mountMode *v1.MountPropagationMode) (runtimeapi.M
 		return runtimeapi.MountPropagation_PROPAGATION_PRIVATE, nil
 	}
 
-	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
-		// mount propagation is disabled, use private as in the old versions
-		return runtimeapi.MountPropagation_PROPAGATION_PRIVATE, nil
-	}
 	switch {
 	case mountMode == nil:
 		// PRIVATE is the default

--- a/pkg/registry/settings/podpreset/BUILD
+++ b/pkg/registry/settings/podpreset/BUILD
@@ -14,7 +14,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/registry/settings/podpreset",
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/api/pod:go_default_library",
         "//pkg/apis/settings:go_default_library",
         "//pkg/apis/settings/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/settings/podpreset/strategy.go
+++ b/pkg/registry/settings/podpreset/strategy.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/settings"
 	"k8s.io/kubernetes/pkg/apis/settings/validation"
 )
@@ -46,17 +45,12 @@ func (podPresetStrategy) NamespaceScoped() bool {
 func (podPresetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	pip := obj.(*settings.PodPreset)
 	pip.Generation = 1
-
-	pod.DropDisabledVolumeMountsAlphaFields(pip.Spec.VolumeMounts)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (podPresetStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newPodPreset := obj.(*settings.PodPreset)
 	oldPodPreset := old.(*settings.PodPreset)
-
-	pod.DropDisabledVolumeMountsAlphaFields(oldPodPreset.Spec.VolumeMounts)
-	pod.DropDisabledVolumeMountsAlphaFields(newPodPreset.Spec.VolumeMounts)
 
 	// Update is not allowed
 	newPodPreset.Spec = oldPodPreset.Spec


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the logic around the mount propagation feature gate deprecated in v1.12. It's a follow-up to #67255.

**Release note**:

```release-note
The `MountPropagation` feature is unconditionally enabled in v1.13, and can no longer be disabled.
```
