### PR TITLE
*: Remove comment tags in GoDoc

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/doc.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kubeadm is the package that contains the libraries that drive the kubeadm binary.
-// kubeadm is responsible for handling a Kubernetes cluster's lifecycle.
-
 // +k8s:deepcopy-gen=package
 // +groupName=kubeadm.k8s.io
 
+// Package kubeadm is the package that contains the libraries that drive the kubeadm binary.
+// kubeadm is responsible for handling a Kubernetes cluster's lifecycle.
 package kubeadm // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/doc.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha2 is the package that contains the libraries that drive the kubeadm binary.
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=kubeadm.k8s.io
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
+
+// Package v1alpha2 is the package that contains the libraries that drive the kubeadm binary.
 package v1alpha2 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha2"

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/doc.go
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:defaulter-gen=TypeMeta
+// +groupName=kubeadm.k8s.io
+// +k8s:deepcopy-gen=package
+// +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
+
 // Package v1alpha3 is the API (config file) for driving the kubeadm binary.
 // Some of these options are also available as command line flags, but
 // the preferred way to configure kubeadm is to pass a YAML file in with the
@@ -90,9 +95,4 @@ limitations under the License.
 //
 // TODO: The BootstrapTokenString object should move out to either k8s.io/client-go or k8s.io/api in the future
 // (probably as part of Bootstrap Tokens going GA). It should not be staged under the kubeadm API as it is now.
-//
-// +k8s:defaulter-gen=TypeMeta
-// +groupName=kubeadm.k8s.io
-// +k8s:deepcopy-gen=package
-// +k8s:conversion-gen=k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm
 package v1alpha3 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3"

--- a/pkg/apis/abac/v0/doc.go
+++ b/pkg/apis/abac/v0/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 
 // +groupName=abac.authorization.kubernetes.io
+
 package v0 // import "k8s.io/kubernetes/pkg/apis/abac/v0"

--- a/pkg/apis/abac/v1beta1/doc.go
+++ b/pkg/apis/abac/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=abac.authorization.kubernetes.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/abac/v1beta1"

--- a/pkg/apis/admission/doc.go
+++ b/pkg/apis/admission/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=admission.k8s.io
+
 package admission // import "k8s.io/kubernetes/pkg/apis/admission"

--- a/pkg/apis/admission/v1beta1/doc.go
+++ b/pkg/apis/admission/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admission/v1beta1
 
 // +groupName=admission.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/admission/v1beta1"

--- a/pkg/apis/admissionregistration/doc.go
+++ b/pkg/apis/admissionregistration/doc.go
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=admissionregistration.k8s.io
 
 // Package admissionregistration is the internal version of the API.
 // AdmissionConfiguration and AdmissionPluginConfiguration are legacy static admission plugin configuration
 // InitializerConfiguration, ValidatingWebhookConfiguration, and MutatingWebhookConfiguration are for the
 // new dynamic admission controller configuration.
-// +groupName=admissionregistration.k8s.io
 package admissionregistration // import "k8s.io/kubernetes/pkg/apis/admissionregistration"

--- a/pkg/apis/admissionregistration/v1alpha1/doc.go
+++ b/pkg/apis/admissionregistration/v1alpha1/doc.go
@@ -18,10 +18,10 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/admissionregistration/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admissionregistration/v1alpha1
+// +groupName=admissionregistration.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 // AdmissionConfiguration and AdmissionPluginConfiguration are legacy static admission plugin configuration
 // InitializerConfiguration, ValidatingWebhookConfiguration, and MutatingWebhookConfiguration are for the
 // new dynamic admission controller configuration.
-// +groupName=admissionregistration.k8s.io
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1"

--- a/pkg/apis/admissionregistration/v1beta1/doc.go
+++ b/pkg/apis/admissionregistration/v1beta1/doc.go
@@ -18,10 +18,10 @@ limitations under the License.
 // +k8s:conversion-gen-external-types=k8s.io/api/admissionregistration/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admissionregistration/v1beta1
+// +groupName=admissionregistration.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.
 // AdmissionConfiguration and AdmissionPluginConfiguration are legacy static admission plugin configuration
 // InitializerConfiguration, ValidatingWebhookConfiguration, and MutatingWebhookConfiguration are for the
 // new dynamic admission controller configuration.
-// +groupName=admissionregistration.k8s.io
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1"

--- a/pkg/apis/authentication/doc.go
+++ b/pkg/apis/authentication/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=authentication.k8s.io
+
 package authentication // import "k8s.io/kubernetes/pkg/apis/authentication"

--- a/pkg/apis/authentication/v1/doc.go
+++ b/pkg/apis/authentication/v1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1
+
 package v1 // import "k8s.io/kubernetes/pkg/apis/authentication/v1"

--- a/pkg/apis/authentication/v1beta1/doc.go
+++ b/pkg/apis/authentication/v1beta1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1beta1
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"

--- a/pkg/apis/authorization/doc.go
+++ b/pkg/apis/authorization/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=authorization.k8s.io
+
 package authorization // import "k8s.io/kubernetes/pkg/apis/authorization"

--- a/pkg/apis/authorization/v1/doc.go
+++ b/pkg/apis/authorization/v1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1
 
 // +groupName=authorization.k8s.io
+
 package v1 // import "k8s.io/kubernetes/pkg/apis/authorization/v1"

--- a/pkg/apis/authorization/v1beta1/doc.go
+++ b/pkg/apis/authorization/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1beta1
 
 // +groupName=authorization.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"

--- a/pkg/apis/certificates/doc.go
+++ b/pkg/apis/certificates/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=certificates.k8s.io
+
 package certificates // import "k8s.io/kubernetes/pkg/apis/certificates"

--- a/pkg/apis/certificates/v1beta1/doc.go
+++ b/pkg/apis/certificates/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/certificates/v1beta1
 
 // +groupName=certificates.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"

--- a/pkg/apis/coordination/doc.go
+++ b/pkg/apis/coordination/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 
 // +groupName=coordination.k8s.io
+
 package coordination // import "k8s.io/kubernetes/pkg/apis/coordination"

--- a/pkg/apis/coordination/v1beta1/doc.go
+++ b/pkg/apis/coordination/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/coordination/v1beta1
 
 // +groupName=coordination.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/coordination/v1beta1"

--- a/pkg/apis/events/doc.go
+++ b/pkg/apis/events/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +groupName=events.k8s.io
+
 package events // import "k8s.io/kubernetes/pkg/apis/events"

--- a/pkg/apis/events/v1beta1/doc.go
+++ b/pkg/apis/events/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/events/v1beta1
 
 // +groupName=events.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/events/v1beta1"

--- a/pkg/apis/imagepolicy/doc.go
+++ b/pkg/apis/imagepolicy/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=imagepolicy.k8s.io
+
 package imagepolicy // import "k8s.io/kubernetes/pkg/apis/imagepolicy"

--- a/pkg/apis/imagepolicy/v1alpha1/doc.go
+++ b/pkg/apis/imagepolicy/v1alpha1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/imagepolicy/v1alpha1
 
 // +groupName=imagepolicy.k8s.io
+
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1"

--- a/pkg/apis/networking/doc.go
+++ b/pkg/apis/networking/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=networking.k8s.io
+
 package networking // import "k8s.io/kubernetes/pkg/apis/networking"

--- a/pkg/apis/networking/v1/doc.go
+++ b/pkg/apis/networking/v1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/networking/v1
 // +groupName=networking.k8s.io
+
 package v1 // import "k8s.io/kubernetes/pkg/apis/networking/v1"

--- a/pkg/apis/rbac/doc.go
+++ b/pkg/apis/rbac/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=rbac.authorization.k8s.io
+
 package rbac // import "k8s.io/kubernetes/pkg/apis/rbac"

--- a/pkg/apis/rbac/v1/doc.go
+++ b/pkg/apis/rbac/v1/doc.go
@@ -21,4 +21,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1 // import "k8s.io/kubernetes/pkg/apis/rbac/v1"

--- a/pkg/apis/rbac/v1alpha1/doc.go
+++ b/pkg/apis/rbac/v1alpha1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1alpha1
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"

--- a/pkg/apis/rbac/v1beta1/doc.go
+++ b/pkg/apis/rbac/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1beta1
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"

--- a/pkg/apis/scheduling/doc.go
+++ b/pkg/apis/scheduling/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=scheduling.k8s.io
+
 package scheduling // import "k8s.io/kubernetes/pkg/apis/scheduling"

--- a/pkg/apis/scheduling/v1alpha1/doc.go
+++ b/pkg/apis/scheduling/v1alpha1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1alpha1
+
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1"

--- a/pkg/apis/scheduling/v1beta1/doc.go
+++ b/pkg/apis/scheduling/v1beta1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1beta1
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/scheduling/v1beta1"

--- a/pkg/apis/settings/doc.go
+++ b/pkg/apis/settings/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=settings.k8s.io
+
 package settings // import "k8s.io/kubernetes/pkg/apis/settings"

--- a/pkg/apis/settings/v1alpha1/doc.go
+++ b/pkg/apis/settings/v1alpha1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/settings/v1alpha1
 
 // +groupName=settings.k8s.io
+
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/settings/v1alpha1"

--- a/pkg/apis/storage/doc.go
+++ b/pkg/apis/storage/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=storage.k8s.io
+
 package storage // import "k8s.io/kubernetes/pkg/apis/storage"

--- a/pkg/apis/storage/v1/doc.go
+++ b/pkg/apis/storage/v1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1
+
 package v1

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1alpha1
+
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/storage/v1alpha1"

--- a/pkg/apis/storage/v1beta1/doc.go
+++ b/pkg/apis/storage/v1beta1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1beta1
+
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/storage/v1beta1"

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:openapi-gen=true
+
 // Package version supplies version information collected at build time to
 // kubernetes components.
-// +k8s:openapi-gen=true
 package version // import "k8s.io/kubernetes/pkg/version"

--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/doc.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=eventratelimit.admission.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=eventratelimit.admission.k8s.io
 package v1alpha1 // import "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1"

--- a/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1/doc.go
+++ b/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=podtolerationrestriction.admission.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=podtolerationrestriction.admission.k8s.io
 package v1alpha1 // import "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1"

--- a/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/doc.go
+++ b/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=resourcequota.admission.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=resourcequota.admission.k8s.io
 package v1alpha1 // import "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1"

--- a/plugin/pkg/admission/resourcequota/apis/resourcequota/v1beta1/doc.go
+++ b/plugin/pkg/admission/resourcequota/apis/resourcequota/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=resourcequota.admission.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.
-// +groupName=resourcequota.admission.k8s.io
 package v1beta1 // import "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/v1beta1"

--- a/staging/src/k8s.io/api/admission/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/admission/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=false
 
 // +groupName=admission.k8s.io
+
 package v1beta1 // import "k8s.io/api/admission/v1beta1"

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/doc.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
+// +groupName=admissionregistration.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 // AdmissionConfiguration and AdmissionPluginConfiguration are legacy static admission plugin configuration
 // InitializerConfiguration and validatingWebhookConfiguration is for the
 // new dynamic admission controller configuration.
-// +groupName=admissionregistration.k8s.io
 package v1alpha1 // import "k8s.io/api/admissionregistration/v1alpha1"

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/doc.go
@@ -16,10 +16,10 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
+// +groupName=admissionregistration.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.
 // AdmissionConfiguration and AdmissionPluginConfiguration are legacy static admission plugin configuration
 // InitializerConfiguration and validatingWebhookConfiguration is for the
 // new dynamic admission controller configuration.
-// +groupName=admissionregistration.k8s.io
 package v1beta1 // import "k8s.io/api/admissionregistration/v1beta1"

--- a/staging/src/k8s.io/api/authentication/v1/doc.go
+++ b/staging/src/k8s.io/api/authentication/v1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=authentication.k8s.io
 // +k8s:openapi-gen=true
+
 package v1 // import "k8s.io/api/authentication/v1"

--- a/staging/src/k8s.io/api/authentication/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=authentication.k8s.io
 // +k8s:openapi-gen=true
+
 package v1beta1 // import "k8s.io/api/authentication/v1beta1"

--- a/staging/src/k8s.io/api/authorization/v1/doc.go
+++ b/staging/src/k8s.io/api/authorization/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=authorization.k8s.io
+
 package v1 // import "k8s.io/api/authorization/v1"

--- a/staging/src/k8s.io/api/authorization/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=authorization.k8s.io
+
 package v1beta1 // import "k8s.io/api/authorization/v1beta1"

--- a/staging/src/k8s.io/api/certificates/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=certificates.k8s.io
+
 package v1beta1 // import "k8s.io/api/certificates/v1beta1"

--- a/staging/src/k8s.io/api/coordination/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=coordination.k8s.io
+
 package v1beta1 // import "k8s.io/api/coordination/v1beta1"

--- a/staging/src/k8s.io/api/events/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/events/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=events.k8s.io
+
 package v1beta1 // import "k8s.io/api/events/v1beta1"

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=imagepolicy.k8s.io
+
 package v1alpha1 // import "k8s.io/api/imagepolicy/v1alpha1"

--- a/staging/src/k8s.io/api/networking/v1/doc.go
+++ b/staging/src/k8s.io/api/networking/v1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 // +groupName=networking.k8s.io
+
 package v1 // import "k8s.io/api/networking/v1"

--- a/staging/src/k8s.io/api/policy/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/doc.go
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +k8s:openapi-gen=true
 
 // Package policy is for any kind of policy object.  Suitable examples, even if
 // they aren't all here, are PodDisruptionBudget, PodSecurityPolicy,
 // NetworkPolicy, etc.
-// +k8s:openapi-gen=true
 package v1beta1 // import "k8s.io/api/policy/v1beta1"

--- a/staging/src/k8s.io/api/rbac/v1/doc.go
+++ b/staging/src/k8s.io/api/rbac/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1 // import "k8s.io/api/rbac/v1"

--- a/staging/src/k8s.io/api/rbac/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1alpha1 // import "k8s.io/api/rbac/v1alpha1"

--- a/staging/src/k8s.io/api/rbac/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=rbac.authorization.k8s.io
+
 package v1beta1 // import "k8s.io/api/rbac/v1beta1"

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=scheduling.k8s.io
+
 package v1alpha1 // import "k8s.io/api/scheduling/v1alpha1"

--- a/staging/src/k8s.io/api/scheduling/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=scheduling.k8s.io
+
 package v1beta1 // import "k8s.io/api/scheduling/v1beta1"

--- a/staging/src/k8s.io/api/settings/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/settings/v1alpha1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:openapi-gen=true
 
 // +groupName=settings.k8s.io
+
 package v1alpha1 // import "k8s.io/api/settings/v1alpha1"

--- a/staging/src/k8s.io/api/storage/v1/doc.go
+++ b/staging/src/k8s.io/api/storage/v1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=storage.k8s.io
 // +k8s:openapi-gen=true
+
 package v1

--- a/staging/src/k8s.io/api/storage/v1alpha1/doc.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +groupName=storage.k8s.io
 // +k8s:openapi-gen=true
+
 package v1alpha1 // import "k8s.io/api/storage/v1alpha1"

--- a/staging/src/k8s.io/api/storage/v1beta1/doc.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=storage.k8s.io
 // +k8s:openapi-gen=true
+
 package v1beta1 // import "k8s.io/api/storage/v1beta1"

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=cr.example.apiextensions.k8s.io
 
 // Package v1 is the v1 version of the API.
-// +groupName=cr.example.apiextensions.k8s.io
 package v1

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=apiextensions.k8s.io
 
 // Package apiextensions is the internal version of the API.
-// +groupName=apiextensions.k8s.io
 package apiextensions // import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
@@ -17,8 +17,8 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 // +k8s:defaulter-gen=TypeMeta
+// +k8s:openapi-gen=true
+// +groupName=apiextensions.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.
-// +groupName=apiextensions.k8s.io
-// +k8s:openapi-gen=true
 package v1beta1 // import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=meta.k8s.io
+
 package v1 // import "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=meta.k8s.io
+
 package v1beta1

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=testapigroup.apimachinery.k8s.io
+
 package v1 // import "k8s.io/apimachinery/pkg/apis/testapigroup/v1"

--- a/staging/src/k8s.io/apimachinery/pkg/version/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/doc.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package version supplies the type for version information collected at build time.
 // +k8s:openapi-gen=true
+
+// Package version supplies the type for version information collected at build time.
 package version // import "k8s.io/apimachinery/pkg/version"

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=apiserver.config.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=apiserver.config.k8s.io
 package v1alpha1

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=apiserver.k8s.io
 
 // Package apiserver is the internal version of the API.
-// +groupName=apiserver.k8s.io
 package apiserver // import "k8s.io/apiserver/pkg/apis/apiserver"

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/apiserver
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=apiserver.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=apiserver.k8s.io
 package v1alpha1 // import "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=audit.k8s.io
+
 package audit // import "k8s.io/apiserver/pkg/apis/audit"

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=audit.k8s.io
+
 package v1 // import "k8s.io/apiserver/pkg/apis/audit/v1"

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=audit.k8s.io
+
 package v1alpha1 // import "k8s.io/apiserver/pkg/apis/audit/v1alpha1"

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=audit.k8s.io
+
 package v1beta1 // import "k8s.io/apiserver/pkg/apis/audit/v1beta1"

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=example.k8s.io
-//
+
 // package example contains an example API used to demonstrate how to create api groups. Moreover, this is
 // used within tests.
 package example // import "k8s.io/apiserver/pkg/apis/example"

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=example.apiserver.k8s.io
+
 package v1 // import "k8s.io/apiserver/pkg/apis/example/v1"

--- a/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example2/v1/doc.go
@@ -21,4 +21,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=example2.apiserver.k8s.io
+
 package v1 // import "k8s.io/apiserver/pkg/apis/example2/v1"

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/doc.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=client.authentication.k8s.io
+
 package clientauthentication // import "k8s.io/client-go/pkg/apis/clientauthentication"

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/doc.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=client.authentication.k8s.io
+
 package v1alpha1 // import "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"

--- a/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/doc.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1/doc.go
@@ -20,4 +20,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=client.authentication.k8s.io
+
 package v1beta1 // import "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"

--- a/staging/src/k8s.io/client-go/pkg/version/doc.go
+++ b/staging/src/k8s.io/client-go/pkg/version/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:openapi-gen=true
+
 // Package version supplies version information collected at build time to
 // kubernetes components.
-// +k8s:openapi-gen=true
 package version // import "k8s.io/client-go/pkg/version"

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/doc.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+
 package api

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/doc.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/doc.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+
 package v1

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=example.apiserver.code-generator.k8s.io
+
 package example // import "k8s.io/code-generator/_examples/apiserver/apis/example"

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/v1/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:conversion-gen=k8s.io/code-generator/_examples/apiserver/apis/example
 // +groupName=example.apiserver.code-generator.k8s.io
+
 package v1

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +groupName=example.test.apiserver.code-generator.k8s.io
 // +groupGoName=SecondExample
+
 package example2 // import "k8s.io/code-generator/_examples/apiserver/apis/example2"

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/v1/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example2/v1/doc.go
@@ -19,4 +19,5 @@ limitations under the License.
 // +groupName=example.test.apiserver.code-generator.k8s.io
 // +k8s:conversion-gen=k8s.io/code-generator/_examples/apiserver/apis/example2
 // +groupGoName=SecondExample
+
 package v1

--- a/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/doc.go
@@ -17,4 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=example.crd.code-generator.k8s.io
+
 package v1

--- a/staging/src/k8s.io/code-generator/_examples/crd/apis/example2/v1/doc.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/apis/example2/v1/doc.go
@@ -18,4 +18,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=example.test.crd.code-generator.k8s.io
 // +groupGoName=SecondExample
+
 package v1

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=apiregistration.k8s.io
 
 // Package api is the internal version of the API.
-// +groupName=apiregistration.k8s.io
 package apiregistration // import "k8s.io/kube-aggregator/pkg/apis/apiregistration"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kube-aggregator/pkg/apis/apiregistration
 // +k8s:openapi-gen=true
+// +groupName=apiregistration.k8s.io
 
 // Package v1beta1 contains the API Registration API, which is responsible for
 // registering an API `Group`/`Version` with another kubernetes like API server.
@@ -31,6 +32,4 @@ limitations under the License.
 // The return status is a set of conditions for this aggregation. Currently
 // there is only one condition named "Available", if true, it means the
 // api/server requests will be redirected to specified API server.
-//
-// +groupName=apiregistration.k8s.io
 package v1 // import "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kube-aggregator/pkg/apis/apiregistration
 // +k8s:openapi-gen=true
+// +groupName=apiregistration.k8s.io
 
 // Package v1beta1 contains the API Registration API, which is responsible for
 // registering an API `Group`/`Version` with another kubernetes like API server.
@@ -31,6 +32,4 @@ limitations under the License.
 // The return status is a set of conditions for this aggregation. Currently
 // there is only one condition named "Available", if true, it means the
 // api/server requests will be redirected to specified API server.
-//
-// +groupName=apiregistration.k8s.io
 package v1beta1 // import "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=custom.metrics.k8s.io
+
 package custom_metrics

--- a/staging/src/k8s.io/metrics/pkg/apis/external_metrics/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/external_metrics/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=external.metrics.k8s.io
+
 package external_metrics

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=metrics.k8s.io
+
 package metrics

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=wardle.k8s.io
 
 // Package api is the internal version of the API.
-// +groupName=wardle.k8s.io
 package wardle

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/sample-apiserver/pkg/apis/wardle
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=wardle.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=wardle.k8s.io
 package v1alpha1

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/sample-apiserver/pkg/apis/wardle
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=wardle.k8s.io
 
 // Package v1beta1 is the v1beta1 version of the API.
-// +groupName=wardle.k8s.io
 package v1beta1

--- a/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/doc.go
+++ b/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+// +groupName=samplecontroller.k8s.io
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=samplecontroller.k8s.io
 package v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove comment tags in GoDoc. Adding blank line between comment tag and package name in doc.go. So that the comment tags such as '+k8s:deepcopy-gen=package' do not show up in GoDoc.

