### PR TITLE
Add logic to set hostname even if hostNetwork: true

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -82,7 +82,7 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxConfig(pod *v1.Pod, attemp
 	}
 	podSandboxConfig.DnsConfig = dnsConfig
 
-	if !kubecontainer.IsHostNetworkPod(pod) {
+	if !kubecontainer.IsHostNetworkPod(pod) || pod.Spec.Hostname != "" {
 		// TODO: Add domain support in new runtime interface
 		hostname, _, err := m.runtimeHelper.GeneratePodHostNameAndDomain(pod)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

NOTE: This is my first PR, and I decided to start really simple :-)
Please correct me if something should not be according to the rules / guidelines.

**What this PR does / why we need it**:
The issue describes a problem that the kubelet ignores the Pods `Spec.Hostname` if `hostNetwork` is set to `true`. (see below)
This PR adds a check to set the hostname even if `hostNetwork` is true. 

**Which issue(s) this PR fixes**:
Fixes #67019


**Special notes for your reviewer**:
- none

**Release note**:

```release-note
- be able to set the container's hostname even when using `hostNetwork: true`
```
