### PR TITLE
Bump addon-manager to v8.7

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 8.7  (Tue September 4 2018 Zihong Zheng <zihongz@google.com>)
+ - Support extra `--prune-whitelist` resources in kube-addon-manager.
+ - Update kubectl to v1.10.7.
+
 ### Version 8.6  (Tue February 20 2018 Zihong Zheng <zihongz@google.com>)
  - Allow reconcile/ensure loop to work with resource under non-kube-system namespace.
  - Update kubectl to v1.9.3.

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v8.6
-KUBECTL_VERSION?=v1.9.3
+VERSION=v8.7
+KUBECTL_VERSION?=v1.10.7
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.6
+    image: k8s.gcr.io/kube-addon-manager:v8.7
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.6
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.7
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
Major changes:
- Support extra `--prune-whitelist` resources in kube-addon-manager.
- Update kubectl to v1.10.7.

Basically picking up https://github.com/kubernetes/kubernetes/pull/67743.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Special notes for your reviewer**:
/assign @Random-Liu @mikedanese 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump addon-manager to v8.7
- Support extra `--prune-whitelist` resources in kube-addon-manager.
- Update kubectl to v1.10.7.
```
