### PR TITLE
Upgraded e2e/apimachinery/aggregator to 1.10 Sample API server

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -26,6 +26,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/apimachinery",
     deps = [
         "//pkg/api/v1/pod:go_default_library",
+        "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/printers:go_default_library",
         "//staging/src/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -83,7 +83,7 @@ var (
 	sampleRegistry        = registry.SampleRegistry
 
 	AdmissionWebhook         = ImageConfig{e2eRegistry, "webhook", "1.13v1"}
-	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.0"}
+	APIServer                = ImageConfig{e2eRegistry, "sample-apiserver", "1.10"}
 	AppArmorLoader           = ImageConfig{e2eRegistry, "apparmor-loader", "1.0"}
 	BusyBox                  = ImageConfig{dockerLibraryRegistry, "busybox", "1.29"}
 	CheckMetadataConcealment = ImageConfig{e2eRegistry, "metadata-concealment", "1.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Upgraded the e2e test "Should be able to support the 1.10 Sample API Server using the current Aggregator" from 1.7

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #63622

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
