### PR TITLE
Cleaned up lint errors in pkg/kubeapiserver/server.

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -144,7 +144,6 @@ pkg/kubeapiserver/authenticator
 pkg/kubeapiserver/authorizer
 pkg/kubeapiserver/authorizer/modes
 pkg/kubeapiserver/options
-pkg/kubeapiserver/server
 pkg/kubectl
 pkg/kubectl/apps
 pkg/kubectl/cmd

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -28,6 +28,7 @@ import (
 // You shouldn't be using this.  It makes sig-auth sad.
 // DeprecatedInsecureServingInfo *ServingInfo
 
+// BuildInsecureHandlerChain sets up the server to listen to http. Should be removed.
 func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.Handler {
 	handler := apiHandler
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyChecker, c.LongRunningFunc)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes lint errors in pkg/kubeapiserver/server.
Enables lint testing of pkg/kubeapiserver/server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of issues/68026

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
