### PR TITLE
glusterfs: prevent unnecessary creation and deletion of gluster volumes 

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -813,9 +813,6 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 	}
 
 	// The 'endpointname' is created in form of 'glusterfs-dynamic-<claimname>'.
-	// createEndpointService() checks for this 'endpoint' existence in PVC's namespace and
-	// If not found, it create an endpoint and service using the IPs we dynamically picked at time
-	// of volume creation.
 	epServiceName := dynamicEpSvcPrefix + p.options.PVC.Name
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)
@@ -835,6 +832,10 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 	}, sz, volID, nil
 }
 
+// createEndpointService() makes sure an endpoint and service
+// exist for the given namespace, PVC name, endpoint name, and
+// set of IPs. I.e. the endpoint or service is only created
+// if it does not exist yet.
 func (p *glusterfsVolumeProvisioner) createEndpointService(namespace string, epServiceName string, hostips []string, pvcname string) (endpoint *v1.Endpoints, service *v1.Service, err error) {
 
 	addrlist := make([]v1.EndpointAddress, len(hostips))

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -812,7 +812,6 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 		return nil, 0, "", fmt.Errorf("failed to get cluster nodes for volume %s: %v", volume, err)
 	}
 
-	// The 'endpointname' is created in form of 'glusterfs-dynamic-<claimname>'.
 	epServiceName := dynamicEpSvcPrefix + p.options.PVC.Name
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent the glusterfs provisioner from creating and deleting gluster volumes if we already know that the later endpoint creation will fail due to the resulting endpoint name being too long (longer than 63 characters). This unnecessary churn of gluster volumes takes time, and at some point it even amplified the effect of a memory leak in gluster (that is meanwhile fixed). Failing early if we can is good.

**Which issue(s) this PR fixes** 

Fixes #67999 

**Special notes for your reviewer**:

* I wanted to use a central function for the length check against 63 characters, but I did not find one.
* Two preliminary commits in the PR do a slight clean up of the context of the actual fix (last commit). 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
