### PR TITLE
Include all used hash types in compare when creating ipsets

### DIFF
--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -286,7 +286,7 @@ func (runner *runner) CreateSet(set *IPSet, ignoreExistErr bool) error {
 // otherwise raised when the same set (setname and create parameters are identical) already exists.
 func (runner *runner) createSet(set *IPSet, ignoreExistErr bool) error {
 	args := []string{"create", set.Name, string(set.SetType)}
-	if set.SetType == HashIPPortIP || set.SetType == HashIPPort {
+	if set.SetType == HashIPPortIP || set.SetType == HashIPPort || set.SetType == HashIPPortNet {
 		args = append(args,
 			"family", set.HashFamily,
 			"hashsize", strconv.Itoa(set.HashSize),


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the `family` argument (and others) when creating the `KUBE-LOAD-BALANCER-SOURCE-CIDR` in proxy-mode=ipvs.

This is needed when the `family` is not the default "family inet", that is for a ipv6-only clusters.

**Which issue(s) this PR fixes**

Fixes #68338

**Special notes for your reviewer**:

**Release note**:

```release-note
```
