### PR TITLE
change default storage class annotation for all storage-class addons

### DIFF
--- a/cluster/addons/storage-class/aws/default.yaml
+++ b/cluster/addons/storage-class/aws/default.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: gp2
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/storage-class/azure/default.yaml
+++ b/cluster/addons/storage-class/azure/default.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: standard
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/storage-class/gce/default.yaml
+++ b/cluster/addons/storage-class/gce/default.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: standard
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/storage-class/local/default.yaml
+++ b/cluster/addons/storage-class/local/default.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: kube-system
   name: standard
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 provisioner: kubernetes.io/host-path

--- a/cluster/addons/storage-class/openstack/default.yaml
+++ b/cluster/addons/storage-class/openstack/default.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: standard
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/storage-class/vsphere/default.yaml
+++ b/cluster/addons/storage-class/vsphere/default.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: thin
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
 provisioner: kubernetes.io/vsphere-volume


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently all addons are annotated with the beta default storage class annotation. As the GA annotation is available this is quite confusing, as the docs only reference the GA annotation.
```release-note
The default storage class annotation for the storage addons has been changed to use the GA variant
```