### PR TITLE
Update Cluster Autoscaler version to 1.3.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.3.2. This version is meant to be used with Kubernetes 1.11 and was never on master branch, so automated cherry-pick isn't possible.

```release-note:
Updated Cluster Autoscaler version to 1.3.2. Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.3.2
```

/sig autoscaling
/cc @maciekpytel