### PR TITLE
Cluster Autoscaler 1.2.3

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.2.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note
Cluster Autoscaler 1.2.3 (release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.2.3)
```
