### PR TITLE
conversion-gen issues with import that are exactly the same

### DIFF
--- a/cmd/cloud-controller-manager/app/apis/config/v1alpha1/doc.go
+++ b/cmd/cloud-controller-manager/app/apis/config/v1alpha1/doc.go
@@ -21,6 +21,8 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/kubernetes/cmd/cloud-controller-manager/app/apis/config
+// +k8s:conversion-gen=k8s.io/apimachinery/pkg/apis/config/v1alpha1
+// +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/config/v1alpha1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta


### PR DESCRIPTION
Technically we don't need this. the instruction below:
```
// +k8s:conversion-gen=k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1
```
registers the apiserver/apimachinery packages in the "package universe"
of the conversion-gen program per comment from lucas in PR 68233

However it looks like some files that use both packages run into trouble
and causes failures in CI harness. Attempting here to see if we fix the
order by specifying them explicitly helps.

Change-Id: I20e9c9256f0b7ffdf4e2101d0ca1fe5090e51344

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
