### PR TITLE
Automated cherry pick of #68380: Remove feature tag from ScheudulerPreemption tests

### DIFF
--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -34,7 +34,7 @@ import (
 	_ "github.com/stretchr/testify/assert"
 )
 
-var _ = SIGDescribe("SchedulerPreemption [Serial] [Feature:PodPreemption]", func() {
+var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 	var cs clientset.Interface
 	var nodeList *v1.NodeList
 	var ns string


### PR DESCRIPTION
Cherry pick of #68380 on release-1.11.

#68380: Remove feature tag from ScheudulerPreemption tests

```release-note
NONE
```