### PR TITLE
Add coverage profile retrieval to log dumps

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1160,6 +1160,7 @@ function start-kubelet {
   local -r kubelet_env_file="/etc/default/kubelet"
   local kubelet_opts="${KUBELET_ARGS} ${KUBELET_CONFIG_FILE_ARG:-}"
   echo "KUBELET_OPTS=\"${kubelet_opts}\"" > "${kubelet_env_file}"
+  echo "KUBE_COVERAGE_FILE=\"/var/log/kubelet.cov\"" >> "${kubelet_env_file}"
 
   # Write the systemd service file for kubelet.
   cat <<EOF >/etc/systemd/system/kubelet.service

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -41,15 +41,15 @@ readonly master_ssh_supported_providers="gce aws kubernetes-anywhere"
 readonly node_ssh_supported_providers="gce gke aws kubernetes-anywhere"
 readonly gcloud_supported_providers="gce gke kubernetes-anywhere"
 
-readonly master_logfiles="kube-apiserver kube-apiserver-audit kube-scheduler kube-controller-manager etcd etcd-events glbc cluster-autoscaler kube-addon-manager fluentd"
-readonly node_logfiles="kube-proxy fluentd node-problem-detector"
+readonly master_logfiles="kube-apiserver.log kube-apiserver-audit.log kube-scheduler.log kube-controller-manager.log etcd.log etcd-events.log glbc.log cluster-autoscaler.log kube-addon-manager.log fluentd.log kubelet.cov"
+readonly node_logfiles="kube-proxy.log fluentd.log node-problem-detector.log kubelet.cov"
 readonly node_systemd_services="node-problem-detector"
-readonly hollow_node_logfiles="kubelet-hollow-node-* kubeproxy-hollow-node-* npd-hollow-node-*"
-readonly aws_logfiles="cloud-init-output"
-readonly gce_logfiles="startupscript"
-readonly kern_logfile="kern"
-readonly initd_logfiles="docker"
-readonly supervisord_logfiles="kubelet supervisor/supervisord supervisor/kubelet-stdout supervisor/kubelet-stderr supervisor/docker-stdout supervisor/docker-stderr"
+readonly hollow_node_logfiles="kubelet-hollow-node-*.log kubeproxy-hollow-node-*.log npd-hollow-node-*.log"
+readonly aws_logfiles="cloud-init-output.log"
+readonly gce_logfiles="startupscript.log"
+readonly kern_logfile="kern.log"
+readonly initd_logfiles="docker/log"
+readonly supervisord_logfiles="kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log"
 readonly systemd_services="kubelet kubelet-monitor kube-container-runtime-monitor ${LOG_DUMP_SYSTEMD_SERVICES:-docker}"
 
 # Limit the number of concurrent node connections so that we don't run out of
@@ -100,10 +100,10 @@ function copy-logs-from-node() {
     local -r node="${1}"
     local -r dir="${2}"
     local files=( ${3} )
-    # Append ".log*"
+    # Append "*"
     # The * at the end is needed to also copy rotated logs (which happens
     # in large clusters and long runs).
-    files=( "${files[@]/%/.log*}" )
+    files=( "${files[@]/%/*}" )
     # Prepend "/var/log/"
     files=( "${files[@]/#/\/var\/log\/}" )
     # Comma delimit (even the singleton, or scp does the wrong thing), surround by braces.
@@ -166,6 +166,16 @@ function save-logs() {
         done
     else
         files="${kern_logfile} ${files} ${initd_logfiles} ${supervisord_logfiles}"
+    fi
+
+    if log-dump-ssh "${node_name}" "command -v docker" &> /dev/null; then
+      if [[ "${on_master}" == "true" ]]; then
+        log-dump-ssh "${node_name}" 'docker exec "$(docker ps -f label=io.kubernetes.container.name=kube-apiserver --format "{{.ID}}")" cat /tmp/k8s-kube-apiserver.cov' > "${dir}/kube-apiserver.cov" || true
+        log-dump-ssh "${node_name}" 'docker exec "$(docker ps -f label=io.kubernetes.container.name=kube-scheduler --format "{{.ID}}")" cat /tmp/k8s-kube-scheduler.cov' > "${dir}/kube-scheduler.cov" || true
+        log-dump-ssh "${node_name}" 'docker exec "$(docker ps -f label=io.kubernetes.container.name=kube-controller-manager --format "{{.ID}}")" cat /tmp/k8s-kube-controller-manager.cov' > "${dir}/kube-controller-manager.cov" || true
+      else
+        log-dump-ssh "${node_name}" 'docker exec "$(docker ps -f label=io.kubernetes.container.name=kube-proxy --format "{{.ID}}")" cat /tmp/k8s-kube-proxy.cov' > "${dir}/kube-proxy.cov" || true
+      fi
     fi
 
     echo "Changing logfiles to be world-readable for download"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables `kubetest --dump` to retrieve coverage profiles generated by #67971 when using the default `bash` provider (and specifically targeting GCE for the time being).

For kubelet, this is accomplished by simply dumping the coverage file into /var/log and adding it to the retrieval list.

For other components, we use `docker exec` to peek into the containers running the components. It is easier to do this than to mount a volume containing the coverage file due to the way coverage files are written, and executing directly using kubernetes (e.g. via `kubectl exec`) won't work because some components (e.g. apiserver) disable this capability. We know using docker to be viable on our initial targets for this feature.

Finally, it removes the assumption that everything we wish to retrieve will end in .log, because the coverage files don't.

/sig testing
/assign @spiffxp 

```release-note
NONE
```
