### PR TITLE
Use KUBE_BUILD_WITH_COVERAGE directly

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -523,14 +523,14 @@ kube::golang::delete_coverage_dummy_test() {
 # Arguments: a list of kubernetes packages to build.
 # Expected variables: ${build_args} should be set to an array of Go build arguments.
 # In addition, ${package} and ${platform} should have been set earlier, and if
-# ${build_with_coverage} is set, coverage instrumentation will be enabled.
+# ${KUBE_BUILD_WITH_COVERAGE} is set, coverage instrumentation will be enabled.
 #
 # Invokes Go to actually build some packages. If coverage is disabled, simply invokes
 # go install. If coverage is enabled, builds covered binaries using go test, temporarily
 # producing the required unit test files and then cleaning up after itself.
 # Non-covered binaries are then built using go install as usual.
 kube::golang::build_some_binaries() {
-  if [[ -n "${build_with_coverage:-}" ]]; then
+  if [[ -n "${KUBE_BUILD_WITH_COVERAGE:-}" ]]; then
     local -a uncovered=()
     for package in "$@"; do
       if kube::golang::is_instrumented_package "${package}"; then
@@ -661,11 +661,10 @@ kube::golang::build_binaries() {
     host_platform=$(kube::golang::host_platform)
 
     # Use eval to preserve embedded quoted strings.
-    local goflags goldflags gogcflags build_with_coverage
+    local goflags goldflags gogcflags
     eval "goflags=(${GOFLAGS:-})"
     goldflags="${GOLDFLAGS:-} $(kube::version::ldflags)"
     gogcflags="${GOGCFLAGS:-}"
-    build_with_coverage="${KUBE_BUILD_WITH_COVERAGE:-}"
 
     local -a targets=()
     local arg


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor cleanup from #67971 to use `KUBE_BUILD_WITH_COVERAGE` directly instead of capturing it in a 'local'.

**Which issue(s) this PR fixes**:
Fixes #68163

/sig testing
/cc @spiffxp 
/kind cleanup

```release-note
NONE
```
