### PR TITLE
Add CoreDNS configmap to federation test

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -57,39 +57,97 @@ func (t *dnsFederationsConfigMapTest) run() {
 	defer t.c.CoreV1().ConfigMaps(t.ns).Delete(t.name, nil)
 	t.createUtilPodLabel("e2e-dns-configmap")
 	defer t.deleteUtilPod()
+	originalConfigMapData := t.fetchDNSConfigMapData()
+	defer t.restoreDNSConfigMap(originalConfigMapData)
 
 	t.validate()
 
-	t.labels = []string{"abc", "ghi"}
-	valid1 := map[string]string{"federations": t.labels[0] + "=def"}
-	valid1m := map[string]string{t.labels[0]: "def"}
-	valid2 := map[string]string{"federations": t.labels[1] + "=xyz"}
-	valid2m := map[string]string{t.labels[1]: "xyz"}
-	invalid := map[string]string{"federations": "invalid.map=xyz"}
+	if t.name == "coredns" {
+		t.labels = []string{"abc", "ghi"}
+		defaultConfig := map[string]string{
+			"Corefile": `.:53 {
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           upstream
+           fallthrough in-addr.arpa ip6.arpa
+        }
+    }`}
 
-	By("empty -> valid1")
-	t.setConfigMap(&v1.ConfigMap{Data: valid1}, valid1m, true)
-	t.validate()
+		valid1 := map[string]string{
+			"Corefile": `.:53 {
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        federation cluster.local {
+           abc def.com
+        }
+        proxy . /etc/resolv.conf
+    }`}
+		valid1m := map[string]string{t.labels[0]: "def.com"}
 
-	By("valid1 -> valid2")
-	t.setConfigMap(&v1.ConfigMap{Data: valid2}, valid2m, true)
-	t.validate()
+		valid2 := map[string]string{
+			"Corefile": `:53 {
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        federation cluster.local {
+           ghi xyz.com
+        }
+        proxy . /etc/resolv.conf
+    }`}
+		valid2m := map[string]string{t.labels[1]: "xyz.com"}
 
-	By("valid2 -> invalid")
-	t.setConfigMap(&v1.ConfigMap{Data: invalid}, nil, false)
-	t.validate()
+		By("default -> valid1")
+		t.setConfigMap(&v1.ConfigMap{Data: valid1}, valid1m, true)
+		t.deleteCoreDNSPods()
+		t.validate()
 
-	By("invalid -> valid1")
-	t.setConfigMap(&v1.ConfigMap{Data: valid1}, valid1m, true)
-	t.validate()
+		By("valid1 -> valid2")
+		t.setConfigMap(&v1.ConfigMap{Data: valid2}, valid2m, true)
+		t.deleteCoreDNSPods()
+		t.validate()
 
-	By("valid1 -> deleted")
-	t.deleteConfigMap()
-	t.validate()
+		By("valid2 -> default")
+		t.setConfigMap(&v1.ConfigMap{Data: defaultConfig}, nil, false)
+		t.deleteCoreDNSPods()
+		t.validate()
 
-	By("deleted -> invalid")
-	t.setConfigMap(&v1.ConfigMap{Data: invalid}, nil, false)
-	t.validate()
+	} else {
+		t.labels = []string{"abc", "ghi"}
+		valid1 := map[string]string{"federations": t.labels[0] + "=def"}
+		valid1m := map[string]string{t.labels[0]: "def"}
+		valid2 := map[string]string{"federations": t.labels[1] + "=xyz"}
+		valid2m := map[string]string{t.labels[1]: "xyz"}
+		invalid := map[string]string{"federations": "invalid.map=xyz"}
+
+		By("empty -> valid1")
+		t.setConfigMap(&v1.ConfigMap{Data: valid1}, valid1m, true)
+		t.validate()
+
+		By("valid1 -> valid2")
+		t.setConfigMap(&v1.ConfigMap{Data: valid2}, valid2m, true)
+		t.validate()
+
+		By("valid2 -> invalid")
+		t.setConfigMap(&v1.ConfigMap{Data: invalid}, nil, false)
+		t.validate()
+
+		By("invalid -> valid1")
+		t.setConfigMap(&v1.ConfigMap{Data: valid1}, valid1m, true)
+		t.validate()
+
+		By("valid1 -> deleted")
+		t.deleteConfigMap()
+		t.validate()
+
+		By("deleted -> invalid")
+		t.setConfigMap(&v1.ConfigMap{Data: invalid}, nil, false)
+		t.validate()
+	}
 }
 
 func (t *dnsFederationsConfigMapTest) validate() {
@@ -104,7 +162,7 @@ func (t *dnsFederationsConfigMapTest) validate() {
 			predicate := func(actual []string) bool {
 				return len(actual) == 0
 			}
-			t.checkDNSRecord(federationDNS, predicate, wait.ForeverTestTimeout)
+			t.checkDNSRecordFrom(federationDNS, predicate, "cluster-dns", wait.ForeverTestTimeout)
 		}
 	} else {
 		for label := range federations {
@@ -112,6 +170,9 @@ func (t *dnsFederationsConfigMapTest) validate() {
 				t.utilService.ObjectMeta.Name, t.f.Namespace.Name, label)
 			var localDNS = fmt.Sprintf("%s.%s.svc.cluster.local.",
 				t.utilService.ObjectMeta.Name, t.f.Namespace.Name)
+			if t.name == "coredns" {
+				localDNS = t.utilService.Spec.ClusterIP
+			}
 			// Check local mapping. Checking a remote mapping requires
 			// creating an arbitrary DNS record which is not possible at the
 			// moment.
@@ -124,12 +185,14 @@ func (t *dnsFederationsConfigMapTest) validate() {
 				}
 				return false
 			}
-			t.checkDNSRecord(federationDNS, predicate, wait.ForeverTestTimeout)
+			t.checkDNSRecordFrom(federationDNS, predicate, "cluster-dns", wait.ForeverTestTimeout)
 		}
 	}
 }
 
 func (t *dnsFederationsConfigMapTest) setConfigMap(cm *v1.ConfigMap, fedMap map[string]string, isValid bool) {
+	t.fedMap = nil
+
 	if isValid {
 		t.fedMap = fedMap
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the federation test by adding the correct CoreDNS configmap.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67600 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
