### PR TITLE
Fix AWS NLB security group updates

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func TestElbProtocolsAreEqual(t *testing.T) {
@@ -159,4 +161,64 @@ func TestIsNLB(t *testing.T) {
 			t.Errorf("Incorrect value for isNLB() case %s. Got %t, expected %t.", test.name, got, test.want)
 		}
 	}
+}
+
+func TestSecurityGroupFiltering(t *testing.T) {
+	grid := []struct {
+		in          []*ec2.SecurityGroup
+		name        string
+		expected    int
+		description string
+	}{
+		{
+			in: []*ec2.SecurityGroup{
+				{
+					IpPermissions: []*ec2.IpPermission{
+						{
+							IpRanges: []*ec2.IpRange{
+								{
+									Description: aws.String("an unmanaged"),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "unmanaged",
+			expected:    0,
+			description: "An environment without managed LBs should have %d, but found %d SecurityGroups",
+		},
+		{
+			in: []*ec2.SecurityGroup{
+				{
+					IpPermissions: []*ec2.IpPermission{
+						{
+							IpRanges: []*ec2.IpRange{
+								{
+									Description: aws.String("an unmanaged"),
+								},
+								{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBClientRuleDescription, "managedlb")),
+								},
+								{
+									Description: aws.String(fmt.Sprintf("%s=%s", NLBHealthCheckRuleDescription, "managedlb")),
+								},
+							},
+						},
+					},
+				},
+			},
+			name:        "managedlb",
+			expected:    1,
+			description: "Found %d, but should have %d Security Groups",
+		},
+	}
+
+	for _, g := range grid {
+		actual := len(filterForIPRangeDescription(g.in, g.name))
+		if actual != g.expected {
+			t.Errorf(g.description, actual, g.expected)
+		}
+	}
+
 }


### PR DESCRIPTION
This corrects a problem where valid security group ports were removed
unintentionally when updating a service or when node changes occur.

**What this PR does / why we need it**:

There is a bug in the existing logic that causes valid security group port mappings to be removed incorrectly.

**Which issue(s) this PR fixes**:

Fixes #60825

**Special notes for your reviewer**:

This still needs some unit tests. The existing loadbalancer tests are very minimal. Any pointers to how to mock security group actions?


**Release note**:

```release-note
Fix AWS NLB security group updates where valid security group ports were incorrectly removed
when updating a service or when node changes occur.
```

Root cause was an assumption that the list of security groups was actually a set.

Here's some psuedo code of the cause:

```
existingGroups = [g1:80, g1:80]  // <-- NOT a Set
desiredGroups = [g1:80]

portChanges = { desiredGroups : ports }
// portChanges = [g1:80 = true]

for g in existingGroups:
    desiredSet.Insert(portChanges[g] == true)
    // iter1: desiredSet = [ g1:80 ]
    // iter2: desiredSet = [ ]
    existingSet = portsForGroup() 
    // i1: existingSet = [ g1:80 ]
    // i2: existingSet = [ g1:80 ]

    alreadyExists = desiredSet.Intersection(existingSet)
    removeAlreadyExistsFromPortChanges()
    // i1: portChanges = []
    // i2: portChanges = []

    notDesired = existingSet.Minus(desiredSet)
    // i1: notDesired = []
    // i2: notDesired = [g1:80]
    setPortChangeToFalseForNotDesired
```