### PR TITLE
Remove dependency on docker daemon for core credential types

### DIFF
--- a/pkg/credentialprovider/BUILD
+++ b/pkg/credentialprovider/BUILD
@@ -18,7 +18,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/credentialprovider",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//vendor/github.com/docker/docker/api/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
@@ -31,7 +30,6 @@ go_test(
         "provider_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/docker/docker/api/types:go_default_library"],
 )
 
 filegroup(

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/golang/glog"
 
-	dockertypes "github.com/docker/docker/api/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -52,17 +51,39 @@ type lazyDockerKeyring struct {
 	Providers []DockerConfigProvider
 }
 
+// AuthConfig contains authorization information for connecting to a Registry
+// This type mirrors "github.com/docker/docker/api/types.AuthConfig"
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
 // LazyAuthConfiguration wraps dockertypes.AuthConfig, potentially deferring its
 // binding. If Provider is non-nil, it will be used to obtain new credentials
 // by calling LazyProvide() on it.
 type LazyAuthConfiguration struct {
-	dockertypes.AuthConfig
+	AuthConfig
 	Provider DockerConfigProvider
 }
 
 func DockerConfigEntryToLazyAuthConfiguration(ident DockerConfigEntry) LazyAuthConfiguration {
 	return LazyAuthConfiguration{
-		AuthConfig: dockertypes.AuthConfig{
+		AuthConfig: AuthConfig{
 			Username: ident.Username,
 			Password: ident.Password,
 			Email:    ident.Email,

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	dockertypes "github.com/docker/docker/api/types"
 )
 
 func TestUrlsMatch(t *testing.T) {
@@ -505,7 +503,7 @@ func TestLazyKeyring(t *testing.T) {
 
 func TestDockerKeyringLookup(t *testing.T) {
 	ada := LazyAuthConfiguration{
-		AuthConfig: dockertypes.AuthConfig{
+		AuthConfig: AuthConfig{
 			Username: "ada",
 			Password: "smash",
 			Email:    "ada@example.com",
@@ -513,7 +511,7 @@ func TestDockerKeyringLookup(t *testing.T) {
 	}
 
 	grace := LazyAuthConfiguration{
-		AuthConfig: dockertypes.AuthConfig{
+		AuthConfig: AuthConfig{
 			Username: "grace",
 			Password: "squash",
 			Email:    "grace@example.com",
@@ -576,7 +574,7 @@ func TestDockerKeyringLookup(t *testing.T) {
 // NOTE: the above covers the case of a more specific match trumping just hostname.
 func TestIssue3797(t *testing.T) {
 	rex := LazyAuthConfiguration{
-		AuthConfig: dockertypes.AuthConfig{
+		AuthConfig: AuthConfig{
 			Username: "rex",
 			Password: "tiny arms",
 			Email:    "rex@example.com",

--- a/pkg/credentialprovider/provider.go
+++ b/pkg/credentialprovider/provider.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	dockertypes "github.com/docker/docker/api/types"
 	"github.com/golang/glog"
 )
 
@@ -40,14 +39,12 @@ type DockerConfigProvider interface {
 	LazyProvide() *DockerConfigEntry
 }
 
-func LazyProvide(creds LazyAuthConfiguration) dockertypes.AuthConfig {
+func LazyProvide(creds LazyAuthConfiguration) AuthConfig {
 	if creds.Provider != nil {
 		entry := *creds.Provider.LazyProvide()
 		return DockerConfigEntryToLazyAuthConfiguration(entry).AuthConfig
-	} else {
-		return creds.AuthConfig
 	}
-
+	return creds.AuthConfig
 }
 
 // A DockerConfigProvider that simply reads the .dockercfg file

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -344,7 +344,7 @@ func ensureSandboxImageExists(client libdocker.Interface, image string) error {
 
 	var pullErrs []error
 	for _, currentCreds := range creds {
-		authConfig := credentialprovider.LazyProvide(currentCreds)
+		authConfig := dockertypes.AuthConfig(credentialprovider.LazyProvide(currentCreds))
 		err := client.PullImage(image, authConfig, dockertypes.ImagePullOptions{})
 		// If there was no error, return success
 		if err == nil {


### PR DESCRIPTION
We are removing dependencies on docker types where possible in the core
libraries. credentialprovider is generic to Docker and uses a public API
(the config file format) that must remain stable. Create an equivalent type
and use a type cast (which would error if we ever change the type) in the
dockershim. We already perform a transformation like this for CRI and so
we aren't changing much.

@derekwaynecarr cutting this dependency is a minor thing but makes our
dependency graph a little cleaner