### PR TITLE
Add `log-level` mount option support for glusterfs plugin

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -290,6 +290,7 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 	var errs error
 	options := []string{}
 	hasLogFile := false
+	hasLogLevel := false
 	log := ""
 
 	if b.readOnly {
@@ -297,13 +298,19 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 
 	}
 
-	// Check logfile has been provided by user, if provided, use that as the log file.
+	// Check for log-file,log-level options existence in user supplied mount options, if provided, use those.
 	for _, userOpt := range b.mountOptions {
-		if dstrings.HasPrefix(userOpt, "log-file") {
+
+		switch {
+		case dstrings.HasPrefix(userOpt, "log-file"):
 			glog.V(4).Infof("log-file mount option has provided")
 			hasLogFile = true
-			break
+
+		case dstrings.HasPrefix(userOpt, "log-level"):
+			glog.V(4).Infof("log-level mount option has provided")
+			hasLogLevel = true
 		}
+
 	}
 
 	// If logfile has not been provided, create driver specific log file.
@@ -324,7 +331,9 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 
 	}
 
-	options = append(options, "log-level=ERROR")
+	if !hasLogLevel {
+		options = append(options, "log-level=ERROR")
+	}
 
 	var addrlist []string
 	if b.hosts == nil {


### PR DESCRIPTION
The glusterfs plugin/driver set log-level to ERROR by default while
mounting glusterfs shares. However at times, its required to supply other
log-level options like INFO, TRACE..etc. This patch enables the support
to provide other log-level values from storageclass.

Additional Ref#
https://docs.gluster.org/en/v3/Administrator%20Guide/Setting%20Up%20Clients/

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
