### PR TITLE
kubeadm: add mandatory configuration to "phase preflight"

### DIFF
--- a/cmd/kubeadm/app/cmd/options/generic.go
+++ b/cmd/kubeadm/app/cmd/options/generic.go
@@ -27,3 +27,11 @@ func AddKubeConfigFlag(fs *pflag.FlagSet, kubeConfigFile *string) {
 func AddConfigFlag(fs *pflag.FlagSet, cfgPath *string) {
 	fs.StringVar(cfgPath, "config", *cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
 }
+
+// AddIgnorePreflightErrorsFlag adds the --ignore-preflight-errors flag to the given flagset
+func AddIgnorePreflightErrorsFlag(fs *pflag.FlagSet, ignorePreflightErrors *[]string) {
+	fs.StringSliceVar(
+		ignorePreflightErrors, "ignore-preflight-errors", *ignorePreflightErrors,
+		"A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.",
+	)
+}

--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -49,7 +49,6 @@ go_library(
         "//pkg/util/normalizer:go_default_library",
         "//pkg/util/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/bootstrap/token/api:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/preflight.go
@@ -17,13 +17,19 @@ limitations under the License.
 package phases
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	kubeadmapiv1alpha3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	"k8s.io/kubernetes/pkg/util/normalizer"
 	utilsexec "k8s.io/utils/exec"
 )
@@ -46,32 +52,59 @@ var (
 		# Run node pre-flight checks.
 		kubeadm alpha phase preflight node
 	`)
+
+	errorMissingConfigFlag = errors.New("the --config flag is mandatory")
 )
 
 // NewCmdPreFlight calls cobra.Command for preflight checks
 func NewCmdPreFlight() *cobra.Command {
+	var cfgPath string
+	var ignorePreflightErrors []string
+
 	cmd := &cobra.Command{
 		Use:   "preflight",
 		Short: "Run pre-flight checks",
 		Long:  cmdutil.MacroCommandLongDescription,
 	}
 
-	cmd.AddCommand(NewCmdPreFlightMaster())
-	cmd.AddCommand(NewCmdPreFlightNode())
+	options.AddConfigFlag(cmd.PersistentFlags(), &cfgPath)
+	options.AddIgnorePreflightErrorsFlag(cmd.PersistentFlags(), &ignorePreflightErrors)
+
+	cmd.AddCommand(NewCmdPreFlightMaster(&cfgPath, &ignorePreflightErrors))
+	cmd.AddCommand(NewCmdPreFlightNode(&cfgPath, &ignorePreflightErrors))
+
 	return cmd
 }
 
 // NewCmdPreFlightMaster calls cobra.Command for master preflight checks
-func NewCmdPreFlightMaster() *cobra.Command {
+func NewCmdPreFlightMaster(cfgPath *string, ignorePreflightErrors *[]string) *cobra.Command {
+
 	cmd := &cobra.Command{
 		Use:     "master",
 		Short:   "Run master pre-flight checks",
 		Long:    masterPreflightLongDesc,
 		Example: masterPreflightExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg := &kubeadmapi.InitConfiguration{}
-			err := preflight.RunInitMasterChecks(utilsexec.New(), cfg, sets.NewString())
+			if len(*cfgPath) == 0 {
+				kubeadmutil.CheckErr(errorMissingConfigFlag)
+			}
+			ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(*ignorePreflightErrors)
 			kubeadmutil.CheckErr(err)
+
+			cfg := &kubeadmapiv1alpha3.InitConfiguration{}
+			kubeadmscheme.Scheme.Default(cfg)
+
+			internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(*cfgPath, cfg)
+			kubeadmutil.CheckErr(err)
+			err = configutil.VerifyAPIServerBindAddress(internalcfg.APIEndpoint.AdvertiseAddress)
+			kubeadmutil.CheckErr(err)
+
+			fmt.Println("[preflight] running pre-flight checks")
+
+			err = preflight.RunInitMasterChecks(utilsexec.New(), internalcfg, ignorePreflightErrorsSet)
+			kubeadmutil.CheckErr(err)
+
+			fmt.Println("[preflight] pre-flight checks passed")
 		},
 	}
 
@@ -79,16 +112,33 @@ func NewCmdPreFlightMaster() *cobra.Command {
 }
 
 // NewCmdPreFlightNode calls cobra.Command for node preflight checks
-func NewCmdPreFlightNode() *cobra.Command {
+func NewCmdPreFlightNode(cfgPath *string, ignorePreflightErrors *[]string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "node",
 		Short:   "Run node pre-flight checks",
 		Long:    nodePreflightLongDesc,
 		Example: nodePreflightExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg := &kubeadmapi.JoinConfiguration{}
-			err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, sets.NewString())
+			if len(*cfgPath) == 0 {
+				kubeadmutil.CheckErr(errorMissingConfigFlag)
+			}
+			ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(*ignorePreflightErrors)
 			kubeadmutil.CheckErr(err)
+
+			cfg := &kubeadmapiv1alpha3.JoinConfiguration{}
+			kubeadmscheme.Scheme.Default(cfg)
+
+			internalcfg, err := configutil.NodeConfigFileAndDefaultsToInternalConfig(*cfgPath, cfg)
+			kubeadmutil.CheckErr(err)
+			err = configutil.VerifyAPIServerBindAddress(internalcfg.APIEndpoint.AdvertiseAddress)
+			kubeadmutil.CheckErr(err)
+
+			fmt.Println("[preflight] running pre-flight checks")
+
+			err = preflight.RunJoinNodeChecks(utilsexec.New(), internalcfg, ignorePreflightErrorsSet)
+			kubeadmutil.CheckErr(err)
+
+			fmt.Println("[preflight] pre-flight checks passed")
 		},
 	}
 

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapiv1alpha3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -60,10 +61,7 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringSliceVar(
-		&ignorePreflightErrors, "ignore-preflight-errors", ignorePreflightErrors,
-		"A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.",
-	)
+	options.AddIgnorePreflightErrorsFlag(cmd.PersistentFlags(), &ignorePreflightErrors)
 
 	cmd.PersistentFlags().StringVar(
 		&certsDir, "cert-dir", kubeadmapiv1alpha3.DefaultCertificatesDir,

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -77,8 +77,8 @@ func addApplyPlanFlags(fs *pflag.FlagSet, flags *applyPlanFlags) {
 	fs.BoolVar(&flags.allowExperimentalUpgrades, "allow-experimental-upgrades", flags.allowExperimentalUpgrades, "Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.")
 	fs.BoolVar(&flags.allowRCUpgrades, "allow-release-candidate-upgrades", flags.allowRCUpgrades, "Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.")
 	fs.BoolVar(&flags.printConfig, "print-config", flags.printConfig, "Specifies whether the configuration file that will be used in the upgrade should be printed or not.")
-	fs.StringSliceVar(&flags.ignorePreflightErrors, "ignore-preflight-errors", flags.ignorePreflightErrors, "A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.")
 	fs.MarkDeprecated("skip-preflight-checks", "it is now equivalent to --ignore-preflight-errors=all")
 	fs.StringVar(&flags.featureGatesString, "feature-gates", flags.featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
+	options.AddIgnorePreflightErrorsFlag(fs, &flags.ignorePreflightErrors)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add the:
- mandatory flag "--config" to the preflight phase
and parse the specified config file for either "master" or "node".
- flag "--ignore-preflight-errors" to the preflight phase to
allow skipping errors.
- the function AddIgnorePreflightErrorsFlag()
to "options/generic.go", because the flag is used in multiple commands.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#924

**Special notes for your reviewer**:
this is following:
https://github.com/kubernetes/kubeadm/issues/924#issuecomment-397874380

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: add mandatory "--config" flag to "kubeadm alpha phase preflight"
```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @fabriziopandini 
/milestone 1.12
/kind bug
