### PR TITLE
kubeadm: Add initial SELinux support

### DIFF
--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -30,6 +30,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	kubeadmsystem "k8s.io/kubernetes/cmd/kubeadm/app/util/system"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
@@ -92,6 +93,10 @@ func WriteCert(pkiPath, name string, cert *x509.Certificate) error {
 	if err := certutil.WriteCert(certificatePath, certutil.EncodeCertPEM(cert)); err != nil {
 		return fmt.Errorf("unable to write certificate to file %q: [%v]", certificatePath, err)
 	}
+	selinuxContext := kubeadmsystem.NewSELinuxContext()
+	if err := kubeadmsystem.SetSELinuxFilecon(certificatePath, selinuxContext); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -105,6 +110,10 @@ func WriteKey(pkiPath, name string, key *rsa.PrivateKey) error {
 	privateKeyPath := pathForKey(pkiPath, name)
 	if err := certutil.WriteKey(privateKeyPath, certutil.EncodePrivateKeyPEM(key)); err != nil {
 		return fmt.Errorf("unable to write private key to file %q: [%v]", privateKeyPath, err)
+	}
+	selinuxContext := kubeadmsystem.NewSELinuxContext()
+	if err := kubeadmsystem.SetSELinuxFilecon(privateKeyPath, selinuxContext); err != nil {
+		return err
 	}
 
 	return nil
@@ -123,6 +132,10 @@ func WritePublicKey(pkiPath, name string, key *rsa.PublicKey) error {
 	publicKeyPath := pathForPublicKey(pkiPath, name)
 	if err := certutil.WriteKey(publicKeyPath, publicKeyBytes); err != nil {
 		return fmt.Errorf("unable to write public key to file %q: [%v]", publicKeyPath, err)
+	}
+	selinuxContext := kubeadmsystem.NewSELinuxContext()
+	if err := kubeadmsystem.SetSELinuxFilecon(publicKeyPath, selinuxContext); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/kubeadm/app/util/system/selinux.go
+++ b/cmd/kubeadm/app/util/system/selinux.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	selinux "k8s.io/kubernetes/pkg/util/selinux"
+)
+
+type SELinuxContext struct {
+	User  string
+	Role  string
+	Type  string
+	Level string
+}
+
+// Create a new SELinux context by default allowing files to be shared
+// with containers
+func NewSELinuxContext() *SELinuxContext {
+	return &SELinuxContext{
+		"unconfined_u", "object_r", "container_file_t", "s0"}
+}
+
+// Converts the context into an SELinux label
+func (c SELinuxContext) ToString() string {
+	arr := []string{c.User, c.Role, c.Type, c.Level}
+	return strings.Join(arr, ":")
+}
+
+// Sets the SELinux file context using the provided SELinux context
+func SetSELinuxFilecon(path string, context *SELinuxContext) error {
+	if !selinux.SELinuxEnabled() {
+		return nil
+	}
+	selinuxRunner := selinux.NewSELinuxRunner()
+	err := selinuxRunner.Setfilecon(path, context.ToString())
+	if err != nil {
+		return fmt.Errorf("unable to set SELinux file context for file %q: [%v]", path, err)
+	}
+	glog.V(1).Infof("[selinux] Set SELinux file context on %q to %q.\n", path, context.ToString())
+	return nil
+}

--- a/cmd/kubeadm/app/util/system/selinux_test.go
+++ b/cmd/kubeadm/app/util/system/selinux_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"testing"
+)
+
+func TestNewSELinuxContext(t *testing.T) {
+	v := NewSELinuxContext()
+	expected := "unconfined_u:object_r:container_file_t:s0"
+	got := v.ToString()
+
+	if got != expected {
+		t.Errorf("ToString() = %q, want %q", got, expected)
+	}
+
+}

--- a/pkg/util/selinux/selinux.go
+++ b/pkg/util/selinux/selinux.go
@@ -29,6 +29,7 @@ type SELinuxRunner interface {
 	// Getfilecon returns the SELinux context for the given path or returns an
 	// error.
 	Getfilecon(path string) (string, error)
+	Setfilecon(path string, context string) error
 }
 
 // NewSELinuxRunner returns a new SELinuxRunner appropriate for the platform.

--- a/pkg/util/selinux/selinux_linux.go
+++ b/pkg/util/selinux/selinux_linux.go
@@ -50,3 +50,11 @@ func (_ *realSELinuxRunner) Getfilecon(path string) (string, error) {
 	}
 	return selinux.FileLabel(path)
 }
+
+func (_ *realSELinuxRunner) Setfilecon(path string, label string) error {
+	err := selinux.SetFileLabel(path, label)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/util/selinux/selinux_unsupported.go
+++ b/pkg/util/selinux/selinux_unsupported.go
@@ -31,3 +31,7 @@ var _ SELinuxRunner = &realSELinuxRunner{}
 func (_ *realSELinuxRunner) Getfilecon(path string) (string, error) {
 	return "", nil
 }
+
+func (_ *realSELinuxRunner) Setfilecon(path string, label string) error {
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Addresses parts of https://github.com/kubernetes/kubeadm/issues/279 (to discuss)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
-->
```release-note
initial support for kubeadm on systems with SELinux enabled.
```

For files mounted into containers, this sets `container_file_t` as the `security.selinux`
extended attribute.

This isn't on its own sufficient to get fully up and running. Users will need to set
appropriate labels for common CNI manifests like Calico to work as they rely on
modifying files in `/opt/cni`. High security environments may not want to do this
anyway.

We may want to now, or later tighten further by making each particular file/directory 
private to its own specific container. This will require setting different levels for
each static pod using PodSecurityPolicies.

E2E for Fedora 28+ is also required here.