### PR TITLE
Update dashboard version to v1.10.0

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -31,7 +31,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: kubernetes-dashboard
-        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.0
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**: New dashboard version is out. This PR updates the addons deployment to use the new version (v1.10.0). 

**Special notes for your reviewer**: Let me know if I missed something. <3

**Release note**:
```release-note
Bump Dashboard version to v1.10.0
```
