### PR TITLE
Bypass versioning conversion short-circuit and force it to call CRD conversion

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/nop_converter.go
@@ -61,6 +61,15 @@ func (c *nopConverter) Convert(in, out, context interface{}) error {
 	if err != nil {
 		return err
 	}
+	// If the context is a groupVersener passed from [this](https://bit.ly/2CCByRM), we should convert to that
+	// version.
+	if context != nil {
+		if groupVersioner, ok := context.(runtime.GroupVersioner); ok {
+			if targetGVK, ok := groupVersioner.KindForGroupVersionKinds([]schema.GroupVersionKind{unstructOut.GroupVersionKind()}); ok {
+				unstructOut.SetGroupVersionKind(targetGVK)
+			}
+		}
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -747,7 +747,12 @@ func (d schemaCoercingDecoder) Decode(data []byte, defaults *schema.GroupVersion
 		}
 	}
 
-	return obj, gvk, nil
+	// TODO(mehdy): This is a non-obvious workaround to makeup for the fact that our machinery does not support __internal
+	// version for Unstructured. It will force versioned converter to call our converter [here](https://bit.ly/2CCByRM).
+	// Because both obj and into are the same but the context parameter of the call is asking for a different version,
+	// our conversion stack should check for the context parameter and do the conversion to the proper version.
+	// This hack should be replaced with a proper support of __internal version.
+	return obj.DeepCopyObject(), gvk, nil
 }
 
 // schemaCoercingConverter calls the delegate converter and applies the Unstructured validator to

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -52,6 +52,18 @@ func NewNoxuSubresourcesCRD(scope apiextensionsv1beta1.ResourceScope) *apiextens
 				ListKind:   "NoxuItemList",
 			},
 			Scope: scope,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1beta1",
+					Served:  true,
+					Storage: false,
+				},
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
 			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
 				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 				Scale: &apiextensionsv1beta1.CustomResourceSubresourceScale{


### PR DESCRIPTION
This is a non-obvious workaround to makeup for the fact that our machinery does not support `__internal` version for `Unstructured`. It will force versioning converter to always call our converter. A comment in the code explains this in more detail.

/cc @sttts @roycaihw @yue9944882

fixes #68035