### PR TITLE
kubeadm 883 Updated logging to be consistent.

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -331,7 +331,7 @@ func (j *Join) Run(out io.Writer) error {
 		}
 
 		// run kubeadm init preflight checks for checking all the prequisites
-		glog.Infoln("[join] running pre-flight checks before initializing the new control plane instance")
+		fmt.Printf("[join] running pre-flight checks before initializing the new control plane instance\n")
 		preflight.RunInitMasterChecks(utilsexec.New(), initConfiguration, j.ignorePreflightErrors)
 
 		// Prepares the node for hosting a new control plane instance by writing necessary

--- a/cmd/kubeadm/app/util/system/kernel_validator.go
+++ b/cmd/kubeadm/app/util/system/kernel_validator.go
@@ -78,7 +78,6 @@ func (k *KernelValidator) Validate(spec SysSpec) (error, error) {
 
 // validateKernelVersion validates the kernel version.
 func (k *KernelValidator) validateKernelVersion(kSpec KernelSpec) error {
-	glog.V(1).Info("Validating kernel version")
 	versionRegexps := kSpec.Versions
 	for _, versionRegexp := range versionRegexps {
 		r := regexp.MustCompile(versionRegexp)
@@ -93,7 +92,6 @@ func (k *KernelValidator) validateKernelVersion(kSpec KernelSpec) error {
 
 // validateKernelConfig validates the kernel configurations.
 func (k *KernelValidator) validateKernelConfig(kSpec KernelSpec) error {
-	glog.V(1).Info("Validating kernel config")
 	allConfig, err := k.getKernelConfig()
 	if err != nil {
 		return fmt.Errorf("failed to parse kernel config: %v", err)

--- a/cmd/kubeadm/app/util/system/validators.go
+++ b/cmd/kubeadm/app/util/system/validators.go
@@ -17,7 +17,7 @@ limitations under the License.
 package system
 
 import (
-	"github.com/golang/glog"
+	"fmt"
 	"k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -41,7 +41,7 @@ func Validate(spec SysSpec, validators []Validator) (error, error) {
 	var warns []error
 
 	for _, v := range validators {
-		glog.Infof("Validating %s...", v.Name())
+		fmt.Printf("Validating %s...\n", v.Name())
 		warn, err := v.Validate(spec)
 		errs = append(errs, err)
 		warns = append(warns, warn)


### PR DESCRIPTION
**What this PR does / why we need it**:
There was inconsistent logging methods used in `kubeadm init` using glog, these have been updated to output like the rest of kubeadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubeadm/issues/883

**Special notes for your reviewer**:
SIG Cluster Lifecycle/kubeadm 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE
