### PR TITLE
deprecate kube-apiserver flag enable-logs-handler

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -147,8 +147,10 @@ func (s *ServerRunOptions) Flags() (fss apiserverflag.NamedFlagSets) {
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged,
 		"If true, allow privileged containers. [default=false]")
 
+	// Deprecated in release 1.13
 	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
 		"If true, install a /logs handler for the apiserver logs.")
+	fs.MarkDeprecated("enable-logs-handler", "This flag will be removed in a future version.")
 
 	// Deprecated in release 1.9
 	fs.StringVar(&s.SSHUser, "ssh-user", s.SSHUser,


### PR DESCRIPTION
**What this PR does / why we need it**:
deprecate  kube-apiserver flag `--enable-logs-handler`
**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/68366


**Release note**:
```release-note
kube-apiserver's flag `--enable-logs-handler`  is deprecated  because logs handler has potential security problem and its valid user cases are mostly replaced by Audit logging.
```

/sig api-machinery