### PR TITLE
Check possible proxy.NewServer error

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -145,6 +145,9 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	keepalive := cmdutil.GetFlagDuration(cmd, "keepalive")
 
 	server, err := proxy.NewServer(staticDir, apiProxyPrefix, staticPrefix, filter, clientConfig, keepalive)
+	if err != nil {
+		glog.Fatal(err)
+	}
 
 	// Separate listening from serving so we can report the bound port
 	// when it is chosen by os (eg: port == 0)

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -146,7 +146,7 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 
 	server, err := proxy.NewServer(staticDir, apiProxyPrefix, staticPrefix, filter, clientConfig, keepalive)
 	if err != nil {
-		glog.Fatal(err)
+		return err
 	}
 
 	// Separate listening from serving so we can report the bound port
@@ -161,6 +161,5 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		glog.Fatal(err)
 	}
 	fmt.Fprintf(out, "Starting to serve on %s\n", l.Addr().String())
-	glog.Fatal(server.ServeOnListener(l))
-	return nil
+	return server.ServeOnListener(l)
 }

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -158,7 +158,7 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		l, err = server.ListenUnix(path)
 	}
 	if err != nil {
-		glog.Fatal(err)
+		return err
 	}
 	fmt.Fprintf(out, "Starting to serve on %s\n", l.Addr().String())
 	return server.ServeOnListener(l)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I was receiving a crash because of a null server instance being used. This is the backtrace:

```
$ kubectl proxy
Starting to serve on 127.0.0.1:8001
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12ced00]

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubectl/proxy.(*Server).ServeOnListener(0x0, 0x18ad820, 0xc4200ec060, 0x18, 0xc4208c9ba8)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/proxy/proxy_server.go:246 +0x70
k8s.io/kubernetes/pkg/kubectl/cmd.RunProxy(0x18c7680, 0xc4204ea000, 0x18940a0, 0xc42000c018, 0xc42069cf00, 0x0, 0x0)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/proxy.go:158 +0x75a
k8s.io/kubernetes/pkg/kubectl/cmd.NewCmdProxy.func1(0xc42069cf00, 0x241d990, 0x0, 0x0)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/proxy.go:81 +0x4f
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc42069cf00, 0x241d990, 0x0, 0x0, 0xc42069cf00, 0x241d990)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760 +0x2c1
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4200e0f00, 0xc4205d5b00, 0x12a05f200, 0xc4208c9ee8)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846 +0x30a
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200e0f00, 0x17eb070, 0x23ff060)
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
	/workspace/anago-v1.11.2-beta.0.50+bb9ffb1654d4a7/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:50 +0x196
```

Other commands returned a different error:

```
$ kubectl version
error: cannot construct google default token source: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

After fixing google default token, both errors went away.

```release-note
Fix: check error condition on kubectl proxy
```