### PR TITLE
[kubeadm] - Fix etcd CA usage during upgrade

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -189,10 +189,14 @@ func writeCertificateAuthorithyFilesIfNotExist(pkiDir string, baseName string, c
 	if pkiutil.CertOrKeyExist(pkiDir, baseName) {
 
 		// Try to load .crt and .key from the PKI directory
-		caCert, _, err := pkiutil.TryLoadCertAndKeyFromDisk(pkiDir, baseName)
+		existingCert, existingKey, err := pkiutil.TryLoadCertAndKeyFromDisk(pkiDir, baseName)
 		if err != nil {
 			return fmt.Errorf("failure loading %s certificate: %v", baseName, err)
 		}
+
+		// Update the value of the caCert and caKey pointers rather than the pointers themselves
+		*caCert = *existingCert
+		*caKey = *existingKey
 
 		// Check if the existing cert is a CA
 		if !caCert.IsCA {


### PR DESCRIPTION


**What this PR does / why we need it**:

Ensure usage of existing CA on disk when attempting to create certificates

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubeadm/issues/1104

**Release note**:
```release-note
NONE
```
