### PR TITLE
Fold error type check for reflector list-watch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -71,6 +71,8 @@ func IsProbableEOF(err error) bool {
 	switch {
 	case err == io.EOF:
 		return true
+	case err == io.ErrUnexpectedEOF:
+		return true
 	case err.Error() == "http: can't write HTTP request on broken connection":
 		return true
 	case strings.Contains(err.Error(), "connection reset by peer"):

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"io"
 	"math/rand"
 	"net"
 	"net/url"
@@ -242,14 +241,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		r.metrics.numberOfWatches.Inc()
 		w, err := r.listerWatcher.Watch(options)
 		if err != nil {
-			switch err {
-			case io.EOF:
-				// watch closed normally
-			case io.ErrUnexpectedEOF:
-				glog.V(1).Infof("%s: Watch for %v closed with unexpected EOF: %v", r.name, r.expectedType, err)
-			default:
-				utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.expectedType, err))
-			}
+			utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.expectedType, err))
 			// If this is "connection refused" error, it means that most likely apiserver is not responsive.
 			// It doesn't make sense to re-list all objects because most likely we will be able to restart
 			// watch where we ended.


### PR DESCRIPTION
`Watch` call will hijack some errors return a dummy watch by `IsProbableEOF `. so we dont need to make the reflector dependency-wise with error types.

[https://github.com/kubernetes/kubernetes/blob/36877dafe40495cb43994464e2427355f99042c7/staging/src/k8s.io/client-go/rest/request.go#L541](https://github.com/kubernetes/kubernetes/blob/36877dafe40495cb43994464e2427355f99042c7/staging/src/k8s.io/client-go/rest/request.go#L541)


/sig api-machinery
/kind cleanup
/cc @kubernetes/client-go-maintainers @sttts 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
