### PR TITLE
set default value for etcd local image

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -25,6 +25,7 @@ import (
 	kubeproxyconfigv1alpha1 "k8s.io/kube-proxy/config/v1alpha1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeletscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
 	kubeproxyscheme "k8s.io/kubernetes/pkg/proxy/apis/config/scheme"
 	utilpointer "k8s.io/utils/pointer"
@@ -119,6 +120,14 @@ func SetDefaults_Etcd(obj *InitConfiguration) {
 	if obj.Etcd.Local != nil {
 		if obj.Etcd.Local.DataDir == "" {
 			obj.Etcd.Local.DataDir = DefaultEtcdDataDir
+		}
+		if obj.Etcd.Local.Image == "" {
+			etcdImageTag := constants.DefaultEtcdVersion
+			etcdImageVersion, err := constants.EtcdSupportedVersion(obj.KubernetesVersion)
+			if err == nil {
+				etcdImageTag = etcdImageVersion.String()
+			}
+			obj.Etcd.Local.Image = images.GetGenericImage(obj.ImageRepository, constants.Etcd, etcdImageTag)
 		}
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 )
 
 const (
@@ -111,6 +112,14 @@ func SetDefaults_Etcd(obj *ClusterConfiguration) {
 	if obj.Etcd.Local != nil {
 		if obj.Etcd.Local.DataDir == "" {
 			obj.Etcd.Local.DataDir = DefaultEtcdDataDir
+		}
+		if obj.Etcd.Local.Image == "" {
+			etcdImageTag := constants.DefaultEtcdVersion
+			etcdImageVersion, err := constants.EtcdSupportedVersion(obj.KubernetesVersion)
+			if err == nil {
+				etcdImageTag = etcdImageVersion.String()
+			}
+			obj.Etcd.Local.Image = images.GetGenericImage(obj.ImageRepository, constants.Etcd, etcdImageTag)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When I run the command "kubeadm config view",  the value of "etcd.local.image" is an empty string if I have not specified the etcd image name. But I think the default real etcd image name should be displayed.
/kind bug

Here is the kube-config.yaml for "kubeadm init":
```
apiVersion: kubeadm.k8s.io/v1alpha2
kind: MasterConfiguration
apiServerCertSANs:    
- 192.168.192.128
api:
  advertiseAddress: 192.168.192.128
  bindPort: 6440
bootstrapTokens:
- groups:
  - system:bootstrappers:kubeadm:default-node-token
  token: abcdef.0123456789abcdef
  ttl: 48h0m0s
  usages:
  - signing
  - authentication
etcd:
  local:
    extraArgs:
      listen-client-urls: https://127.0.0.1:2379,https://192.168.192.128:2379
      advertise-client-urls: https://192.168.192.128:2379
      listen-peer-urls: https://192.168.192.128:2380
      initial-advertise-peer-urls: https://192.168.192.128:2380
      initial-cluster: kube-dev=https://192.168.192.128:2380
      initial-cluster-state: new
ServerExtraArgs:
  endpoint-reconciler-type: lease

networking:
  podSubnet: 192.168.0.0/16  
kubernetesVersion: v1.11.2 
featureGates:  
   CoreDNS: true
```

Here is the output of the command “kubeadm config view” in my environment:
```
api:
  advertiseAddress: 192.168.192.128
  bindPort: 6440
  controlPlaneEndpoint: ""
apiServerCertSANs:
- 192.168.192.128
apiServerExtraArgs:
  authorization-mode: Node,RBAC
apiVersion: kubeadm.k8s.io/v1alpha2
auditPolicy:
  logDir: /var/log/kubernetes/audit
  logMaxAge: 2
  path: ""
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
etcd:
  local:
    dataDir: /var/lib/etcd
    extraArgs:
      listen-client-urls: https://127.0.0.1:2379,https://192.168.192.128:2379
    image: ""
featureGates:
  CoreDNS: true
imageRepository: k8s.gcr.io
kind: MasterConfiguration
kubeProxy:
  config:
    bindAddress: 0.0.0.0
    clientConnection:
      acceptContentTypes: ""
      burst: 10
      contentType: application/vnd.kubernetes.protobuf
      kubeconfig: /var/lib/kube-proxy/kubeconfig.conf
      qps: 5
    clusterCIDR: 192.200.0.0/16
    configSyncPeriod: 15m0s
    conntrack:
      max: null
      maxPerCore: 32768
      min: 131072
      tcpCloseWaitTimeout: 1h0m0s
      tcpEstablishedTimeout: 24h0m0s
    enableProfiling: false
    healthzBindAddress: 0.0.0.0:10256
    hostnameOverride: ""
    iptables:
      masqueradeAll: false
      masqueradeBit: 14
      minSyncPeriod: 0s
      syncPeriod: 30s
    ipvs:
      excludeCIDRs: null
      minSyncPeriod: 0s
      scheduler: ""
      syncPeriod: 30s
    metricsBindAddress: 127.0.0.1:10249
    mode: ""
    nodePortAddresses: null
    oomScoreAdj: -999
    portRange: ""
    resourceContainer: /kube-proxy
    udpIdleTimeout: 250ms
kubeletConfiguration:
  baseConfig:
    address: 0.0.0.0
    authentication:
      anonymous:
        enabled: false
      webhook:
        cacheTTL: 2m0s
        enabled: true
      x509:
        clientCAFile: /etc/kubernetes/pki/ca.crt
    authorization:
      mode: Webhook
      webhook:
        cacheAuthorizedTTL: 5m0s
        cacheUnauthorizedTTL: 30s
    cgroupDriver: cgroupfs
    cgroupsPerQOS: true
    clusterDNS:
    - 10.96.0.10
    clusterDomain: cluster.local
    containerLogMaxFiles: 5
    containerLogMaxSize: 10Mi
    contentType: application/vnd.kubernetes.protobuf
    cpuCFSQuota: true
    cpuManagerPolicy: none
    cpuManagerReconcilePeriod: 10s
    enableControllerAttachDetach: true
    enableDebuggingHandlers: true
    enforceNodeAllocatable:
    - pods
    eventBurst: 10
    eventRecordQPS: 5
    evictionHard:
      imagefs.available: 15%
      memory.available: 100Mi
      nodefs.available: 10%
      nodefs.inodesFree: 5%
    evictionPressureTransitionPeriod: 5m0s
    failSwapOn: true
    fileCheckFrequency: 20s
    hairpinMode: promiscuous-bridge
    healthzBindAddress: 127.0.0.1
    healthzPort: 10248
    httpCheckFrequency: 20s
    imageGCHighThresholdPercent: 85
    imageGCLowThresholdPercent: 80
    imageMinimumGCAge: 2m0s
    iptablesDropBit: 15
    iptablesMasqueradeBit: 14
    kubeAPIBurst: 10
    kubeAPIQPS: 5
    makeIPTablesUtilChains: true
    maxOpenFiles: 1000000
    maxPods: 110
    nodeStatusUpdateFrequency: 10s
    oomScoreAdj: -999
    podPidsLimit: -1
    port: 10250
    registryBurst: 10
    registryPullQPS: 5
    resolvConf: /etc/resolv.conf
    rotateCertificates: true
    runtimeRequestTimeout: 2m0s
    serializeImagePulls: true
    staticPodPath: /etc/kubernetes/manifests
    streamingConnectionIdleTimeout: 4h0m0s
    syncFrequency: 1m0s
    volumeStatsAggPeriod: 1m0s
kubernetesVersion: v1.11.2
networking:
  dnsDomain: cluster.local
  podSubnet: 192.168.0.0/16
  serviceSubnet: 10.96.0.0/12
nodeRegistration: {}
unifiedControlPlaneImage: ""
```
**Environment**:

Kubernetes version (use kubectl version): v1.11.2
OS (e.g. from /etc/os-release): CentOS Linux release 7.5.1804 (Core)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```