### PR TITLE
fix kubeconfig path

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -59,7 +59,7 @@ const (
 	// DefaultProxyBindAddressv6 is the default bind address when the advertise address is v6
 	DefaultProxyBindAddressv6 = "::"
 	// KubeproxyKubeConfigFileName defines the file name for the kube-proxy's KubeConfig file
-	KubeproxyKubeConfigFileName = "/var/lib/kube-proxy/kubeconfig.conf"
+	KubeproxyKubeConfigFileName = "/var/lib/kubelet/pods/"
 
 	// DefaultDiscoveryTimeout specifies the default discovery timeout for kubeadm (used unless one is specified in the JoinConfiguration)
 	DefaultDiscoveryTimeout = 5 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**:
When I run the command "kubeadm config view", the value of "kubeconfig" path is not valid.

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)**:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```