### PR TITLE
kubectl-diff: Simplify interface

### DIFF
--- a/hack/testdata/pod-changed.yaml
+++ b/hack/testdata/pod-changed.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:3.0

--- a/pkg/kubectl/cmd/diff_test.go
+++ b/pkg/kubectl/cmd/diff_test.go
@@ -31,10 +31,8 @@ import (
 
 type FakeObject struct {
 	name   string
-	local  map[string]interface{}
 	merged map[string]interface{}
 	live   map[string]interface{}
-	last   map[string]interface{}
 }
 
 var _ Object = &FakeObject{}
@@ -43,97 +41,12 @@ func (f *FakeObject) Name() string {
 	return f.name
 }
 
-func (f *FakeObject) Local() (map[string]interface{}, error) {
-	return f.local, nil
-}
-
 func (f *FakeObject) Merged() (map[string]interface{}, error) {
 	return f.merged, nil
 }
 
 func (f *FakeObject) Live() (map[string]interface{}, error) {
 	return f.live, nil
-}
-
-func (f *FakeObject) Last() (map[string]interface{}, error) {
-	return f.last, nil
-}
-
-func TestArguments(t *testing.T) {
-	tests := []struct {
-		// Input
-		args []string
-
-		// Outputs
-		from string
-		to   string
-		err  string
-	}{
-		// Defaults
-		{
-			args: []string{},
-			from: "LOCAL",
-			to:   "LIVE",
-			err:  "",
-		},
-		// One valid argument
-		{
-			args: []string{"MERGED"},
-			from: "MERGED",
-			to:   "LIVE",
-			err:  "",
-		},
-		// One invalid argument
-		{
-			args: []string{"WRONG"},
-			from: "",
-			to:   "",
-			err:  `Invalid parameter "WRONG", must be either "LOCAL", "LIVE", "LAST" or "MERGED"`,
-		},
-		// Two valid arguments
-		{
-			args: []string{"MERGED", "LAST"},
-			from: "MERGED",
-			to:   "LAST",
-			err:  "",
-		},
-		// Two same arguments is fine
-		{
-			args: []string{"MERGED", "MERGED"},
-			from: "MERGED",
-			to:   "MERGED",
-			err:  "",
-		},
-		// Second argument is invalid
-		{
-			args: []string{"MERGED", "WRONG"},
-			from: "",
-			to:   "",
-			err:  `Invalid parameter "WRONG", must be either "LOCAL", "LIVE", "LAST" or "MERGED"`,
-		},
-		// Three arguments
-		{
-			args: []string{"MERGED", "LIVE", "LAST"},
-			from: "",
-			to:   "",
-			err:  `Invalid number of arguments: expected at most 2.`,
-		},
-	}
-
-	for _, test := range tests {
-		from, to, e := parseDiffArguments(test.args)
-		err := ""
-		if e != nil {
-			err = e.Error()
-		}
-		if from != test.from || to != test.to || err != test.err {
-			t.Errorf("parseDiffArguments(%v) = (%v, %v, %v), expected (%v, %v, %v)",
-				test.args,
-				from, to, err,
-				test.from, test.to, test.err,
-			)
-		}
-	}
 }
 
 func TestDiffProgram(t *testing.T) {
@@ -175,7 +88,7 @@ string: string
 }
 
 func TestDiffVersion(t *testing.T) {
-	diff, err := NewDiffVersion("LOCAL")
+	diff, err := NewDiffVersion("MERGED")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,8 +96,6 @@ func TestDiffVersion(t *testing.T) {
 
 	obj := FakeObject{
 		name:   "bla",
-		local:  map[string]interface{}{"local": true},
-		last:   map[string]interface{}{"last": true},
 		live:   map[string]interface{}{"live": true},
 		merged: map[string]interface{}{"merged": true},
 	}
@@ -196,7 +107,7 @@ func TestDiffVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	econtent := "local: true\n"
+	econtent := "merged: true\n"
 	if string(fcontent) != econtent {
 		t.Fatalf("File has %q, expected %q", string(fcontent), econtent)
 	}
@@ -248,7 +159,7 @@ func TestDirectory(t *testing.T) {
 }
 
 func TestDiffer(t *testing.T) {
-	diff, err := NewDiffer("LOCAL", "LIVE")
+	diff, err := NewDiffer("LIVE", "MERGED")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,8 +167,6 @@ func TestDiffer(t *testing.T) {
 
 	obj := FakeObject{
 		name:   "bla",
-		local:  map[string]interface{}{"local": true},
-		last:   map[string]interface{}{"last": true},
 		live:   map[string]interface{}{"live": true},
 		merged: map[string]interface{}{"merged": true},
 	}
@@ -269,7 +178,7 @@ func TestDiffer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	econtent := "local: true\n"
+	econtent := "live: true\n"
 	if string(fcontent) != econtent {
 		t.Fatalf("File has %q, expected %q", string(fcontent), econtent)
 	}
@@ -278,7 +187,7 @@ func TestDiffer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	econtent = "live: true\n"
+	econtent = "merged: true\n"
 	if string(fcontent) != econtent {
 		t.Fatalf("File has %q, expected %q", string(fcontent), econtent)
 	}

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -27,27 +27,13 @@ run_kubectl_diff_tests() {
     kube::log::status "Testing kubectl alpha diff"
 
     # Test that it works when the live object doesn't exist
-    output_message=$(kubectl alpha diff LOCAL LIVE -f hack/testdata/pod.yaml)
+    output_message=$(kubectl alpha diff -f hack/testdata/pod.yaml)
     kube::test::if_has_string "${output_message}" 'test-pod'
 
     kubectl apply -f hack/testdata/pod.yaml
 
-    # Ensure that selfLink has been added, and shown in the diff
-    output_message=$(kubectl alpha diff -f hack/testdata/pod.yaml)
-    kube::test::if_has_string "${output_message}" 'selfLink'
-    output_message=$(kubectl alpha diff LOCAL LIVE -f hack/testdata/pod.yaml)
-    kube::test::if_has_string "${output_message}" 'selfLink'
-    output_message=$(kubectl alpha diff LOCAL MERGED -f hack/testdata/pod.yaml)
-    kube::test::if_has_string "${output_message}" 'selfLink'
-
-    output_message=$(kubectl alpha diff MERGED MERGED -f hack/testdata/pod.yaml)
-    kube::test::if_empty_string "${output_message}"
-    output_message=$(kubectl alpha diff LIVE LIVE -f hack/testdata/pod.yaml)
-    kube::test::if_empty_string "${output_message}"
-    output_message=$(kubectl alpha diff LAST LAST -f hack/testdata/pod.yaml)
-    kube::test::if_empty_string "${output_message}"
-    output_message=$(kubectl alpha diff LOCAL LOCAL -f hack/testdata/pod.yaml)
-    kube::test::if_empty_string "${output_message}"
+    output_message=$(kubectl alpha diff -f hack/testdata/pod-changed.yaml)
+    kube::test::if_has_string "${output_message}" 'k8s.gcr.io/pause:3.0'
 
     kubectl delete -f  hack/testdata/pod.yaml
 


### PR DESCRIPTION
The current interface is kind of clunky and not super easy to use, since
you have to specify parameters to specify which versions to diff. Also
the default isn't the most useful setting.

Change the interface by removing all the parameters and force only one
useful use-case, that is: diffing what's currently live against
what would be live if applied.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
