### PR TITLE
volume/rbd: fix the default value of fstype

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -667,6 +667,9 @@ func (r *rbdVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	if r.Id == "" {
 		r.Id = r.adminId
 	}
+	if fstype == "" {
+		fstype = "ext4"
+	}
 
 	// create random image name
 	image := fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

According to the [document](https://kubernetes.io/docs/concepts/storage/storage-classes/#ceph-rbd), `fsType` should have a default value: `ext4`, but I didn't see where we set this default value (or I miss something?)


**Which issue(s) this PR fixes**:

none

**Special notes for your reviewer**:

none

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
