### PR TITLE
Automated cherry pick of #68388: locking fix in vSphere cleanup function

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -19,24 +19,23 @@ package vsphere
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/vmware/govmomi/vim25"
-
-	"fmt"
-
 	"github.com/vmware/govmomi/vim25/mo"
-	"io/ioutil"
+
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers"
 	"k8s.io/kubernetes/pkg/util/version"
-	"path/filepath"
 )
 
 const (
@@ -298,11 +297,15 @@ func (vs *VSphere) cleanUpDummyVMs(dummyVMPrefix string) {
 			continue
 		}
 		// A write lock is acquired to make sure the cleanUp routine doesn't delete any VM's created by ongoing PVC requests.
-		defer cleanUpDummyVMLock.Lock()
-		err = diskmanagers.CleanUpDummyVMs(ctx, vmFolder, dc)
-		if err != nil {
-			glog.V(4).Infof("Unable to clean up dummy VM's in the kubernetes cluster: %q. err: %+v", vs.cfg.Workspace.Folder, err)
+		cleanUpDummyVMs := func() {
+			cleanUpDummyVMLock.Lock()
+			defer cleanUpDummyVMLock.Unlock()
+			err = diskmanagers.CleanUpDummyVMs(ctx, vmFolder, dc)
+			if err != nil {
+				glog.V(4).Infof("Unable to clean up dummy VM's in the kubernetes cluster: %q. err: %+v", vs.cfg.Workspace.Folder, err)
+			}
 		}
+		cleanUpDummyVMs()
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
locking fix in vSphere cleanup function

The vSphere cloud provider has a cleanup function with a loop,
inside of which a write lock was intended to prevent races against
VM creation, but the usage of the sync.RWMutex type is incorrect,
plus is placed in a defer call so the locking is effectively
nonexistent.  This patch adds an anonymous function call inside
the loop to correctly handle acquiring the write lock with deferred
unlock to run at that function's completion, following the normal
golang lock/deferred-unlock pattern.
```
