### PR TITLE
chore(codegen): respect GOFLAGS when compiling code-generator

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -50,7 +50,7 @@ shift 4
   # To support running this script from anywhere, we have to first cd into this directory
   # so we can install the tools.
   cd $(dirname "${0}")
-  go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+  go install ${GOFLAGS:-} ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 )
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
@@ -72,8 +72,8 @@ if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
-  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/clientset"
-  ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_VERSIONED:-versioned} --input-base "" --input $(codegen::join , "${FQ_APIS[@]}") --output-package ${OUTPUT_PKG}/clientset "$@"
+  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
+  ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_VERSIONED:-versioned} --input-base "" --input $(codegen::join , "${FQ_APIS[@]}") --output-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset} "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
@@ -85,7 +85,7 @@ if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then
   echo "Generating informers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/informers"
   ${GOPATH}/bin/informer-gen \
            --input-dirs $(codegen::join , "${FQ_APIS[@]}") \
-           --versioned-clientset-package ${OUTPUT_PKG}/clientset/${CLIENTSET_NAME_VERSIONED:-versioned} \
+           --versioned-clientset-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}/${CLIENTSET_NAME_VERSIONED:-versioned} \
            --listers-package ${OUTPUT_PKG}/listers \
            --output-package ${OUTPUT_PKG}/informers \
            "$@"

--- a/staging/src/k8s.io/code-generator/generate-internal-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-internal-groups.sh
@@ -47,7 +47,7 @@ EXT_APIS_PKG="$4"
 GROUPS_WITH_VERSIONS="$5"
 shift 5
 
-go install ./$(dirname "${0}")/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
+go install ${GOFLAGS:-} ./$(dirname "${0}")/cmd/{defaulter-gen,conversion-gen,client-gen,lister-gen,informer-gen,deepcopy-gen}
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }
 
 # enumerate group versions
@@ -85,11 +85,11 @@ if [ "${GENS}" = "all" ] || grep -qw "conversion" <<<"${GENS}"; then
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "client" <<<"${GENS}"; then
-  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/clientset"
+  echo "Generating clientset for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}"
   if [ -n "${INT_APIS_PKG}" ]; then
-    ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_INTERNAL:-internalversion} --input-base "" --input $(codegen::join , $(printf '%s/ ' "${INT_FQ_APIS[@]}")) --output-package ${OUTPUT_PKG}/clientset "$@"
+    ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_INTERNAL:-internalversion} --input-base "" --input $(codegen::join , $(printf '%s/ ' "${INT_FQ_APIS[@]}")) --output-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset} "$@"
   fi
-  ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_VERSIONED:-versioned} --input-base "" --input $(codegen::join , "${EXT_FQ_APIS[@]}") --output-package ${OUTPUT_PKG}/clientset "$@"
+  ${GOPATH}/bin/client-gen --clientset-name ${CLIENTSET_NAME_VERSIONED:-versioned} --input-base "" --input $(codegen::join , "${EXT_FQ_APIS[@]}") --output-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset} "$@"
 fi
 
 if [ "${GENS}" = "all" ] || grep -qw "lister" <<<"${GENS}"; then
@@ -101,8 +101,8 @@ if [ "${GENS}" = "all" ] || grep -qw "informer" <<<"${GENS}"; then
   echo "Generating informers for ${GROUPS_WITH_VERSIONS} at ${OUTPUT_PKG}/informers"
   ${GOPATH}/bin/informer-gen \
            --input-dirs $(codegen::join , "${ALL_FQ_APIS[@]}") \
-           --versioned-clientset-package ${OUTPUT_PKG}/clientset/${CLIENTSET_NAME_VERSIONED:-versioned} \
-           --internal-clientset-package ${OUTPUT_PKG}/clientset/${CLIENTSET_NAME_INTERNAL:-internalversion} \
+           --versioned-clientset-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}/${CLIENTSET_NAME_VERSIONED:-versioned} \
+           --internal-clientset-package ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME:-clientset}/${CLIENTSET_NAME_INTERNAL:-internalversion} \
            --listers-package ${OUTPUT_PKG}/listers \
            --output-package ${OUTPUT_PKG}/informers \
            "$@"

--- a/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
+++ b/staging/src/k8s.io/kube-aggregator/hack/update-codegen.sh
@@ -18,65 +18,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
-SCRIPT_BASE=${SCRIPT_ROOT}/../..
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo k8s.io/code-generator)}
+SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-if LANG=C sed --help 2>&1 | grep -q GNU; then
-  SED="sed"
-elif which gsed &>/dev/null; then
-  SED="gsed"
-else
-  echo "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed." >&2
-  exit 1
-fi
-
-# Register function to be called on EXIT to remove generated binary.
-function cleanup {
-  rm -f "${CLIENTGEN:-}"
-  rm -f "${listergen:-}"
-  rm -f "${informergen:-}"
-}
-trap cleanup EXIT
-
-echo "Building client-gen"
-CLIENTGEN="${PWD}/client-gen"
-
-go build -o "${CLIENTGEN}" ${CODEGEN_PKG}/cmd/client-gen
-
-PREFIX=k8s.io/kube-aggregator/pkg/apis
-INPUT_BASE="--input-base ${PREFIX}"
-INPUT_APIS=(
-apiregistration/
-apiregistration/v1beta1
-apiregistration/v1
-)
-INPUT="--input ${INPUT_APIS[@]}"
-CLIENTSET_PATH="--output-package k8s.io/kube-aggregator/pkg/client/clientset_generated"
-
-${CLIENTGEN} ${INPUT_BASE} ${INPUT} ${CLIENTSET_PATH} --output-base ${SCRIPT_BASE}
-${CLIENTGEN} --clientset-name="clientset" ${INPUT_BASE} --input apiregistration/v1beta1,apiregistration/v1 ${CLIENTSET_PATH}  --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
-
-
-echo "Building lister-gen"
-listergen="${PWD}/lister-gen"
-go build -o "${listergen}" ${CODEGEN_PKG}/cmd/lister-gen
-
-LISTER_INPUT="--input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration --input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1,k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-LISTER_PATH="--output-package k8s.io/kube-aggregator/pkg/client/listers"
-${listergen} ${LISTER_INPUT} ${LISTER_PATH} --output-base ${SCRIPT_BASE} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
-
-
-echo "Building informer-gen"
-informergen="${PWD}/informer-gen"
-go build -o "${informergen}" ${CODEGEN_PKG}/cmd/informer-gen
-
-${informergen} \
-  --output-base ${SCRIPT_BASE} \
-  --input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration --input-dirs k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1,k8s.io/kube-aggregator/pkg/apis/apiregistration/v1 \
-  --versioned-clientset-package k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset \
-  --internal-clientset-package k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset \
-  --listers-package k8s.io/kube-aggregator/pkg/client/listers \
-  --output-package k8s.io/kube-aggregator/pkg/client/informers \
+CLIENTSET_NAME_VERSIONED=clientset \
+CLIENTSET_PKG_NAME=clientset_generated \
+${CODEGEN_PKG}/generate-groups.sh deepcopy,client,lister,informer \
+  k8s.io/kube-aggregator/pkg/client k8s.io/kube-aggregator/pkg/apis \
+  "apiregistration:v1beta1,v1" \
+  --output-base "$(dirname ${BASH_SOURCE})/../../.." \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
-  "$@"
+
+CLIENTSET_NAME_VERSIONED=clientset \
+CLIENTSET_PKG_NAME=clientset_generated \
+CLIENTSET_NAME_INTERNAL=internalclientset \
+${CODEGEN_PKG}/generate-internal-groups.sh deepcopy,client,lister,informer,conversion \
+  k8s.io/kube-aggregator/pkg/client k8s.io/kube-aggregator/pkg/apis k8s.io/kube-aggregator/pkg/apis \
+  "apiregistration:v1beta1,v1" \
+  --output-base "$(dirname ${BASH_SOURCE})/../../.." \
+  --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt


### PR DESCRIPTION
Respect `GOFLAGS` env var which is inherited from Makefile.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
