### PR TITLE
Collect Metrics Server Logs, Better HPA e2e visibility

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -57,6 +57,8 @@ spec:
         # Remove these lines for non-GKE clusters, and when GKE supports token-based auth.
         - --kubelet-port=10255
         - --deprecated-kubelet-completely-insecure=true
+        - --logtostderr
+        - --v=2
         ports:
         - containerPort: 443
           name: https

--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/slice:go_default_library",
         "//pkg/util/version:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/coordination/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
This makes the test runner collect logs from metrics-server (and should make it easy to collect other addon logs in the future).

It also adds better HPA visibility in the HPA e2e tests, and temporarily increases the log level for parts of metrics-server to 10.  We'll want to roll back or not merge (depending on if we can reproduce the flake here) the "log at 10" change.

This helps debug #68383

**Release note**:
```release-note
None
```
