### PR TITLE
make test zone an option in test-e2e-node.sh script

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -96,7 +96,7 @@ if [ $remote = true ] ; then
   test_suite=${TEST_SUITE:-"default"}
 
   # Get the compute zone
-  zone=$(gcloud info --format='value(config.properties.compute.zone)')
+  zone=${ZONE:-"$(gcloud info --format='value(config.properties.compute.zone)')"}
   if [[ $zone == "" ]]; then
     echo "Could not find gcloud compute/zone when running: \`gcloud info --format='value(config.properties.compute.zone)'\`"
     exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:
make test zone an option in test-e2e-node.sh script, so it's easier to run e2e-node test in different zone by setting environment variable ZONE rather than changing the default setting of gcloud.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
