### PR TITLE
Build OpenAPI Definitions per group instead of per resource

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -86,11 +86,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/filters:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/openapi:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/registry/rest"
-	openapicommon "k8s.io/kube-openapi/pkg/common"
+	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 )
 
 // APIGroupVersion is a helper for exposing rest.Storage objects as http.Handlers via go-restful
@@ -85,8 +85,8 @@ type APIGroupVersion struct {
 	// if the client requests it via Accept-Encoding
 	EnableAPIResponseCompression bool
 
-	// OpenAPIConfig lets the individual handlers build a subset of the OpenAPI schema before they are installed.
-	OpenAPIConfig *openapicommon.Config
+	// OpenAPIModels exposes the OpenAPI models to each individual handler.
+	OpenAPIModels openapiproto.Models
 }
 
 // InstallREST registers the REST handlers (storage, watch, proxy and redirect) into a restful Container.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -60,7 +60,7 @@ type RequestScope struct {
 	Trace           *utiltrace.Trace
 
 	TableConvertor rest.TableConvertor
-	OpenAPISchema  openapiproto.Schema
+	OpenAPIModels  openapiproto.Models
 
 	Resource    schema.GroupVersionResource
 	Kind        schema.GroupVersionKind

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -103,6 +103,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/logs:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/openapi:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
@@ -113,7 +114,10 @@ go_library(
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	gpath "path"
 	"strings"
 	"sync"
 	"time"
@@ -42,8 +43,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/routes"
+	utilopenapi "k8s.io/apiserver/pkg/util/openapi"
 	restclient "k8s.io/client-go/rest"
+	openapibuilder "k8s.io/kube-openapi/pkg/builder"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
+	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 )
 
 // Info about an API group.
@@ -320,6 +325,10 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 
 // installAPIResources is a private method for installing the REST storage backing each api groupversionresource
 func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *APIGroupInfo) error {
+	openAPIGroupModels, err := s.getOpenAPIModelsForGroup(apiPrefix, apiGroupInfo)
+	if err != nil {
+		return fmt.Errorf("unable to get openapi models for group %v: %v", apiPrefix, err)
+	}
 	for _, groupVersion := range apiGroupInfo.PrioritizedVersions {
 		if len(apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version]) == 0 {
 			klog.Warningf("Skipping API %v because it has no resources.", groupVersion)
@@ -330,6 +339,7 @@ func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *A
 		if apiGroupInfo.OptionsExternalVersion != nil {
 			apiGroupVersion.OptionsExternalVersion = apiGroupInfo.OptionsExternalVersion
 		}
+		apiGroupVersion.OpenAPIModels = openAPIGroupModels
 
 		if err := apiGroupVersion.InstallREST(s.Handler.GoRestfulContainer); err != nil {
 			return fmt.Errorf("unable to setup API %v: %v", apiGroupInfo, err)
@@ -427,7 +437,6 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Admit:                        s.admissionControl,
 		MinRequestTimeout:            s.minRequestTimeout,
 		EnableAPIResponseCompression: s.enableAPIResponseCompression,
-		OpenAPIConfig:                s.openAPIConfig,
 		Authorizer:                   s.Authorizer,
 	}
 }
@@ -444,4 +453,38 @@ func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec
 		ParameterCodec:         parameterCodec,
 		NegotiatedSerializer:   codecs,
 	}
+}
+
+// getOpenAPIModelsForGroup is a private method for getting the OpenAPI Schemas for each  api group
+func (s *GenericAPIServer) getOpenAPIModelsForGroup(apiPrefix string, apiGroupInfo *APIGroupInfo) (openapiproto.Models, error) {
+	if s.openAPIConfig == nil {
+		return nil, nil
+	}
+	pathsToIgnore := openapiutil.NewTrie(s.openAPIConfig.IgnorePrefixes)
+	// Get the canonical names of every resource we need to build in this api group
+	resourceNames := make([]string, 0)
+	for _, groupVersion := range apiGroupInfo.PrioritizedVersions {
+		for resource, storage := range apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version] {
+			path := gpath.Join(apiPrefix, groupVersion.Group, groupVersion.Version, resource)
+			if !pathsToIgnore.HasPrefix(path) {
+				kind, err := genericapi.GetResourceKind(groupVersion, storage, apiGroupInfo.Scheme)
+				if err != nil {
+					return nil, err
+				}
+				sampleObject, err := apiGroupInfo.Scheme.New(kind)
+				if err != nil {
+					return nil, err
+				}
+				name := openapiutil.GetCanonicalTypeName(sampleObject)
+				resourceNames = append(resourceNames, name)
+			}
+		}
+	}
+
+	// Build the openapi definitions for those resources and convert it to proto models
+	openAPISpec, err := openapibuilder.BuildOpenAPIDefinitionsForResources(s.openAPIConfig, resourceNames...)
+	if err != nil {
+		return nil, err
+	}
+	return utilopenapi.ToProtoModels(openAPISpec)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/BUILD
@@ -7,7 +7,6 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/util/openapi",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
@@ -35,7 +34,6 @@ go_test(
     srcs = ["proto_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/proto.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/proto.go
@@ -18,29 +18,17 @@ package openapi
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/go-openapi/spec"
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 	"github.com/googleapis/gnostic/compiler"
 	yaml "gopkg.in/yaml.v2"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/util/proto"
 )
 
-const (
-	// groupVersionKindExtensionKey is the key used to lookup the
-	// GroupVersionKind value for an object definition from the
-	// definition's "extensions" map.
-	groupVersionKindExtensionKey = "x-kubernetes-group-version-kind"
-)
-
-// ToProtoSchema builds the proto formatted schema from an OpenAPI spec
-func ToProtoSchema(openAPIDefinitions *spec.Definitions, gvk schema.GroupVersionKind) (proto.Schema, error) {
-	openAPISpec := newMinimalValidOpenAPISpec()
-	openAPISpec.Definitions = *openAPIDefinitions
-
+// ToProtoModels builds the proto formatted models from OpenAPI spec
+func ToProtoModels(openAPISpec *spec.Swagger) (proto.Models, error) {
 	specBytes, err := json.MarshalIndent(openAPISpec, " ", " ")
 	if err != nil {
 		return nil, err
@@ -62,81 +50,5 @@ func ToProtoSchema(openAPIDefinitions *spec.Definitions, gvk schema.GroupVersion
 		return nil, err
 	}
 
-	for _, modelName := range models.ListModels() {
-		model := models.LookupModel(modelName)
-		if model == nil {
-			return nil, fmt.Errorf("the ListModels function returned a model that can't be looked-up")
-		}
-		gvkList := parseGroupVersionKind(model)
-		for _, modelGVK := range gvkList {
-			if modelGVK == gvk {
-				return model, nil
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("no model found with a %v tag matching %v", groupVersionKindExtensionKey, gvk)
-}
-
-// newMinimalValidOpenAPISpec creates a minimal openapi spec with only the required fields filled in
-func newMinimalValidOpenAPISpec() *spec.Swagger {
-	return &spec.Swagger{
-		SwaggerProps: spec.SwaggerProps{
-			Swagger: "2.0",
-			Info: &spec.Info{
-				InfoProps: spec.InfoProps{
-					Title:   "Kubernetes",
-					Version: "0.0.0",
-				},
-			},
-		},
-	}
-}
-
-// parseGroupVersionKind gets and parses GroupVersionKind from the extension. Returns empty if it doesn't have one.
-func parseGroupVersionKind(s proto.Schema) []schema.GroupVersionKind {
-	extensions := s.GetExtensions()
-
-	gvkListResult := []schema.GroupVersionKind{}
-
-	// Get the extensions
-	gvkExtension, ok := extensions[groupVersionKindExtensionKey]
-	if !ok {
-		return []schema.GroupVersionKind{}
-	}
-
-	// gvk extension must be a list of at least 1 element.
-	gvkList, ok := gvkExtension.([]interface{})
-	if !ok {
-		return []schema.GroupVersionKind{}
-	}
-
-	for _, gvk := range gvkList {
-		// gvk extension list must be a map with group, version, and
-		// kind fields
-		gvkMap, ok := gvk.(map[interface{}]interface{})
-		if !ok {
-			continue
-		}
-		group, ok := gvkMap["group"].(string)
-		if !ok {
-			continue
-		}
-		version, ok := gvkMap["version"].(string)
-		if !ok {
-			continue
-		}
-		kind, ok := gvkMap["kind"].(string)
-		if !ok {
-			continue
-		}
-
-		gvkListResult = append(gvkListResult, schema.GroupVersionKind{
-			Group:   group,
-			Version: version,
-			Kind:    kind,
-		})
-	}
-
-	return gvkListResult
+	return models, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/proto_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/proto_test.go
@@ -22,35 +22,40 @@ import (
 
 	"github.com/go-openapi/spec"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/util/proto"
 )
 
 // TestOpenAPIDefinitionsToProtoSchema tests the openapi parser
-func TestOpenAPIDefinitionsToProtoSchema(t *testing.T) {
-	openAPIDefinitions := &spec.Definitions{
-		"io.k8s.api.testgroup.v1.Foo": spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Description: "Description of Foos",
-				Properties:  map[string]spec.Schema{},
+func TestOpenAPIDefinitionsToProtoModels(t *testing.T) {
+	openAPISpec := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Swagger: "2.0",
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title:   "Kubernetes",
+					Version: "0.0.0",
+				},
 			},
-			VendorExtensible: spec.VendorExtensible{
-				Extensions: spec.Extensions{
-					"x-kubernetes-group-version-kind": []map[string]string{
-						{
-							"group":   "testgroup.k8s.io",
-							"version": "v1",
-							"kind":    "Foo",
+			Definitions: spec.Definitions{
+				"io.k8s.api.testgroup.v1.Foo": spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Description: "Description of Foos",
+						Properties:  map[string]spec.Schema{},
+					},
+					VendorExtensible: spec.VendorExtensible{
+						Extensions: spec.Extensions{
+							"x-kubernetes-group-version-kind": []map[string]string{
+								{
+									"group":   "testgroup.k8s.io",
+									"version": "v1",
+									"kind":    "Foo",
+								},
+							},
 						},
 					},
 				},
 			},
 		},
-	}
-	gvk := schema.GroupVersionKind{
-		Group:   "testgroup.k8s.io",
-		Version: "v1",
-		Kind:    "Foo",
 	}
 	expectedSchema := &proto.Arbitrary{
 		BaseSchema: proto.BaseSchema{
@@ -67,10 +72,11 @@ func TestOpenAPIDefinitionsToProtoSchema(t *testing.T) {
 			Path: proto.NewPath("io.k8s.api.testgroup.v1.Foo"),
 		},
 	}
-	actualSchema, err := ToProtoSchema(openAPIDefinitions, gvk)
+	protoModels, err := ToProtoModels(openAPISpec)
 	if err != nil {
-		t.Fatalf("expected ToProtoSchema not to return an error")
+		t.Fatalf("expected ToProtoModels not to return an error")
 	}
+	actualSchema := protoModels.LookupModel("io.k8s.api.testgroup.v1.Foo")
 	if !reflect.DeepEqual(expectedSchema, actualSchema) {
 		t.Fatalf("expected schema:\n%v\nbut got:\n%v", expectedSchema, actualSchema)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses inefficiencies in the implementation of #63893

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of fixing #66368
Not sure where the 40 seconds comes from in the referenced bug, but this PR reduced startup time of kube apiserver by ~20% on my computer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
