### PR TITLE
Fixes golint for pkg/probe

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -250,10 +250,6 @@ pkg/master/tunneler
 pkg/printers
 pkg/printers/internalversion
 pkg/printers/storage
-pkg/probe
-pkg/probe/exec
-pkg/probe/http
-pkg/probe/tcp
 pkg/proxy
 pkg/proxy/apis/config
 pkg/proxy/apis/config/v1alpha1

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -46,13 +46,13 @@ const maxProbeRetries = 3
 
 // Prober helps to check the liveness/readiness of a container.
 type prober struct {
-	exec execprobe.ExecProber
+	exec execprobe.Prober
 	// probe types needs different httprobe instances so they don't
 	// share a connection pool which can cause collsions to the
 	// same host:port and transient failures. See #49740.
-	readinessHttp httprobe.HTTPProber
-	livenessHttp  httprobe.HTTPProber
-	tcp           tcprobe.TCPProber
+	readinessHttp httprobe.Prober
+	livenessHttp  httprobe.Prober
+	tcp           tcprobe.Prober
 	runner        kubecontainer.ContainerCommandRunner
 
 	refManager *kubecontainer.RefManager

--- a/pkg/probe/exec/exec.go
+++ b/pkg/probe/exec/exec.go
@@ -23,16 +23,21 @@ import (
 	"github.com/golang/glog"
 )
 
-func New() ExecProber {
+// New creates a Prober.
+func New() Prober {
 	return execProber{}
 }
 
-type ExecProber interface {
+// Prober is an interface defining the Probe object for container readiness/liveness checks.
+type Prober interface {
 	Probe(e exec.Cmd) (probe.Result, string, error)
 }
 
 type execProber struct{}
 
+// Probe executes a command to check the liveness/readiness of container
+// from executing a command. Returns the Result status, command output, and
+// errors if any.
 func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 	data, err := e.CombinedOutput()
 	glog.V(4).Infof("Exec probe response: %q", string(data))
@@ -41,9 +46,8 @@ func (pr execProber) Probe(e exec.Cmd) (probe.Result, string, error) {
 		if ok {
 			if exit.ExitStatus() == 0 {
 				return probe.Success, string(data), nil
-			} else {
-				return probe.Failure, string(data), nil
 			}
+			return probe.Failure, string(data), nil
 		}
 		return probe.Unknown, "", err
 	}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package probe
 
+// Result is a string used to handle the results for probing container readiness/livenss
 type Result string
 
 const (
+	// Success Result
 	Success Result = "success"
+	// Failure Result
 	Failure Result = "failure"
+	// Unknown Result
 	Unknown Result = "unknown"
 )

--- a/pkg/probe/tcp/tcp.go
+++ b/pkg/probe/tcp/tcp.go
@@ -26,16 +26,19 @@ import (
 	"github.com/golang/glog"
 )
 
-func New() TCPProber {
+// New creates Prober.
+func New() Prober {
 	return tcpProber{}
 }
 
-type TCPProber interface {
+// Prober is an interface that defines the Probe function for doing TCP readiness/liveness checks.
+type Prober interface {
 	Probe(host string, port int, timeout time.Duration) (probe.Result, string, error)
 }
 
 type tcpProber struct{}
 
+// Probe returns a ProbeRunner capable of running an TCP check.
 func (pr tcpProber) Probe(host string, port int, timeout time.Duration) (probe.Result, string, error) {
 	return DoTCPProbe(net.JoinHostPort(host, strconv.Itoa(port)), timeout)
 }

--- a/pkg/registry/core/componentstatus/validator.go
+++ b/pkg/registry/core/componentstatus/validator.go
@@ -45,7 +45,7 @@ type Server struct {
 	EnableHTTPS bool
 	TLSConfig   *tls.Config
 	Validate    ValidatorFn
-	Prober      httpprober.HTTPProber
+	Prober      httpprober.Prober
 	Once        sync.Once
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes golint errors in the pkg/probe package. Part of this is that it renamed the Prober interfaces in the following to fix the golint stutter warning:

- http.HTTPProber -> http.Prober
- http.HTTPGetInterface -> http.GetHTTPInterface
- tcp.TCPProber -> tcp.Prober
- exec.ExecProber -> exec.Prober


**Which issue(s) this PR fixes**:
refer #68026

**Special notes for your reviewer**:
This is my first contribution. I did a project wide search for the exported interfaces and functions that I changed and updated all of them. I'm concerned these might break external code and I'm not immediately sure on how to ensure that I do not.

I left the internal variables with the type defined for contextual reference within the package on purpose, as it provided a bit of context. 

**Release note**:
```release-note
NONE
```
