### PR TITLE
kube-apiserver should wait/block for kms-plugin to start.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	yaml "github.com/ghodss/yaml"
 
@@ -40,6 +41,7 @@ const (
 	aesGCMTransformerPrefixV1    = "k8s:enc:aesgcm:v1:"
 	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1:"
 	kmsTransformerPrefixV1       = "k8s:enc:kms:v1:"
+	kmsPluginConnectionTimeout   = 3 * time.Second
 )
 
 // GetTransformerOverrides returns the transformer overrides by reading and parsing the encryption provider configuration file
@@ -160,7 +162,7 @@ func GetPrefixTransformers(config *ResourceConfig) ([]value.PrefixTransformer, e
 			}
 
 			// Get gRPC client service with endpoint.
-			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint)
+			envelopeService, err := envelopeServiceFactory(provider.KMS.Endpoint, kmsPluginConnectionTimeout)
 			if err != nil {
 				return nil, fmt.Errorf("could not configure KMS plugin %q, error: %v", provider.KMS.Name, err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage/value"
@@ -239,7 +240,7 @@ func (t *testEnvelopeService) Encrypt(data []byte) ([]byte, error) {
 }
 
 // The factory method to create mock envelope service.
-func newMockEnvelopeService(endpoint string) (envelope.Service, error) {
+func newMockEnvelopeService(endpoint string, timeout time.Duration) (envelope.Service, error) {
 	return &testEnvelopeService{}, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -39,19 +40,20 @@ const (
 	// Current version for the protocol interface definition.
 	kmsapiVersion = "v1beta1"
 
-	// The timeout that communicate with KMS server.
-	timeout = 30 * time.Second
+	versionErrorf = "KMS provider api version %s is not supported, only %s is supported now"
 )
 
 // The gRPC implementation for envelope.Service.
 type gRPCService struct {
-	// gRPC client instance
-	kmsClient  kmsapi.KeyManagementServiceClient
-	connection *grpc.ClientConn
+	kmsClient      kmsapi.KeyManagementServiceClient
+	connection     *grpc.ClientConn
+	callTimeout    time.Duration
+	mux            sync.RWMutex
+	versionChecked bool
 }
 
 // NewGRPCService returns an envelope.Service which use gRPC to communicate the remote KMS provider.
-func NewGRPCService(endpoint string) (Service, error) {
+func NewGRPCService(endpoint string, callTimeout time.Duration) (Service, error) {
 	glog.V(4).Infof("Configure KMS provider with endpoint: %s", endpoint)
 
 	addr, err := parseEndpoint(endpoint)
@@ -59,28 +61,28 @@ func NewGRPCService(endpoint string) (Service, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	connection, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.FailFast(false)), grpc.WithDialer(
+		func(string, time.Duration) (net.Conn, error) {
+			// Ignoring addr and timeout arguments:
+			// addr - comes from the closure
+			// timeout - is ignored since we are connecting in a non-blocking configuration
+			c, err := net.DialTimeout(unixProtocol, addr, 0)
+			if err != nil {
+				glog.Errorf("failed to create connection to unix socket: %s, error: %v", addr, err)
+			}
+			return c, err
+		}))
 
-	connection, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithDialer(unixDial))
 	if err != nil {
-		return nil, fmt.Errorf("connect remote KMS provider %q failed, error: %v", addr, err)
+		return nil, fmt.Errorf("failed to create connection to %s, error: %v", endpoint, err)
 	}
 
 	kmsClient := kmsapi.NewKeyManagementServiceClient(connection)
-
-	err = checkAPIVersion(kmsClient)
-	if err != nil {
-		connection.Close()
-		return nil, fmt.Errorf("failed check version for %q, error: %v", addr, err)
-	}
-
-	return &gRPCService{kmsClient: kmsClient, connection: connection}, nil
-}
-
-// This dialer explicitly ask gRPC to use unix socket as network.
-func unixDial(addr string, timeout time.Duration) (net.Conn, error) {
-	return net.DialTimeout(unixProtocol, addr, timeout)
+	return &gRPCService{
+		kmsClient:   kmsClient,
+		connection:  connection,
+		callTimeout: callTimeout,
+	}, nil
 }
 
 // Parse the endpoint to extract schema, host or path.
@@ -109,30 +111,36 @@ func parseEndpoint(endpoint string) (string, error) {
 	return u.Path, nil
 }
 
-// Check the KMS provider API version.
-// Only matching kmsapiVersion is supported now.
-func checkAPIVersion(kmsClient kmsapi.KeyManagementServiceClient) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+func (g *gRPCService) checkAPIVersion(ctx context.Context) error {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+
+	if g.versionChecked {
+		return nil
+	}
 
 	request := &kmsapi.VersionRequest{Version: kmsapiVersion}
-	response, err := kmsClient.Version(ctx, request)
+	response, err := g.kmsClient.Version(ctx, request)
 	if err != nil {
 		return fmt.Errorf("failed get version from remote KMS provider: %v", err)
 	}
 	if response.Version != kmsapiVersion {
-		return fmt.Errorf("KMS provider api version %s is not supported, only %s is supported now",
-			response.Version, kmsapiVersion)
+		return fmt.Errorf(versionErrorf, response.Version, kmsapiVersion)
 	}
+	g.versionChecked = true
 
-	glog.V(4).Infof("KMS provider %s initialized, version: %s", response.RuntimeName, response.RuntimeVersion)
+	glog.V(4).Infof("Version of KMS provider is %s", response.Version)
 	return nil
 }
 
 // Decrypt a given data string to obtain the original byte data.
 func (g *gRPCService) Decrypt(cipher []byte) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), g.callTimeout)
 	defer cancel()
+
+	if err := g.checkAPIVersion(ctx); err != nil {
+		return nil, err
+	}
 
 	request := &kmsapi.DecryptRequest{Cipher: cipher, Version: kmsapiVersion}
 	response, err := g.kmsClient.Decrypt(ctx, request)
@@ -144,8 +152,11 @@ func (g *gRPCService) Decrypt(cipher []byte) ([]byte, error) {
 
 // Encrypt bytes to a string ciphertext.
 func (g *gRPCService) Encrypt(plain []byte) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), g.callTimeout)
 	defer cancel()
+	if err := g.checkAPIVersion(ctx); err != nil {
+		return nil, err
+	}
 
 	request := &kmsapi.EncryptRequest{Plain: plain, Version: kmsapiVersion}
 	response, err := g.kmsClient.Encrypt(ctx, request)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When using KMS Provider, a situation could occur where kube-apiserver starts before kms-plugin pod. Currently, kube-apiserver, on startup, attempts to establish a gRPC connection to the kms-plugin domain socket. However, such connection attempt is non-blocking which leads to the failure of kube-apiserver. 
Making this initial connection attempt blocking with a time-out of 45 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
