### PR TITLE
fix golint errors in package cmd/kubeadm/app

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/conversion.go
@@ -46,6 +46,8 @@ func Convert_kubeadm_InitConfiguration_To_v1alpha3_InitConfiguration(in *kubeadm
 	return Convert_kubeadm_APIEndpoint_To_v1alpha3_APIEndpoint(&in.LocalAPIEndpoint, &out.APIEndpoint, s)
 }
 
+// Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration converts
+// v1alpha3.JoinConfiguration to kubeadm.JoinConfiguration
 func Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in *JoinConfiguration, out *kubeadm.JoinConfiguration, s conversion.Scope) error {
 	if err := autoConvert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in, out, s); err != nil {
 		return err
@@ -96,6 +98,8 @@ func Convert_v1alpha3_JoinConfiguration_To_kubeadm_JoinConfiguration(in *JoinCon
 	return nil
 }
 
+// Convert_kubeadm_JoinConfiguration_To_v1alpha3_JoinConfiguration converts
+// kubeadm.JoinConfiguration to v1alpha3.JoinConfiguration
 func Convert_kubeadm_JoinConfiguration_To_v1alpha3_JoinConfiguration(in *kubeadm.JoinConfiguration, out *JoinConfiguration, s conversion.Scope) error {
 	if err := autoConvert_kubeadm_JoinConfiguration_To_v1alpha3_JoinConfiguration(in, out, s); err != nil {
 		return err

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -65,15 +65,15 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetDefaults_InitConfiguration assigns default values for the InitConfiguration
-func SetDefaults_InitConfiguration(obj *InitConfiguration) {
-	SetDefaults_ClusterConfiguration(&obj.ClusterConfiguration)
-	SetDefaults_BootstrapTokens(obj)
-	SetDefaults_APIEndpoint(&obj.APIEndpoint)
+// SetDefaultsInitConfiguration assigns default values for the InitConfiguration
+func SetDefaultsInitConfiguration(obj *InitConfiguration) {
+	SetDefaultsClusterConfiguration(&obj.ClusterConfiguration)
+	SetDefaultsBootstrapTokens(obj)
+	SetDefaultsAPIEndpoint(&obj.APIEndpoint)
 }
 
-// SetDefaults_ClusterConfiguration assigns default values for the ClusterConfiguration
-func SetDefaults_ClusterConfiguration(obj *ClusterConfiguration) {
+// SetDefaultsClusterConfiguration assigns default values for the ClusterConfiguration
+func SetDefaultsClusterConfiguration(obj *ClusterConfiguration) {
 	if obj.KubernetesVersion == "" {
 		obj.KubernetesVersion = DefaultKubernetesVersion
 	}
@@ -98,12 +98,12 @@ func SetDefaults_ClusterConfiguration(obj *ClusterConfiguration) {
 		obj.ClusterName = DefaultClusterName
 	}
 
-	SetDefaults_Etcd(obj)
-	SetDefaults_AuditPolicyConfiguration(obj)
+	SetDefaultsEtcd(obj)
+	SetDefaultsAuditPolicyConfiguration(obj)
 }
 
-// SetDefaults_Etcd assigns default values for the Proxy
-func SetDefaults_Etcd(obj *ClusterConfiguration) {
+// SetDefaultsEtcd assigns default values for the Proxy
+func SetDefaultsEtcd(obj *ClusterConfiguration) {
 	if obj.Etcd.External == nil && obj.Etcd.Local == nil {
 		obj.Etcd.Local = &LocalEtcd{}
 	}
@@ -114,8 +114,8 @@ func SetDefaults_Etcd(obj *ClusterConfiguration) {
 	}
 }
 
-// SetDefaults_JoinConfiguration assigns default values to a regular node
-func SetDefaults_JoinConfiguration(obj *JoinConfiguration) {
+// SetDefaultsJoinConfiguration assigns default values to a regular node
+func SetDefaultsJoinConfiguration(obj *JoinConfiguration) {
 	if obj.CACertPath == "" {
 		obj.CACertPath = DefaultCACertPath
 	}
@@ -138,11 +138,11 @@ func SetDefaults_JoinConfiguration(obj *JoinConfiguration) {
 		}
 	}
 
-	SetDefaults_APIEndpoint(&obj.APIEndpoint)
+	SetDefaultsAPIEndpoint(&obj.APIEndpoint)
 }
 
-// SetDefaults_AuditPolicyConfiguration sets default values for the AuditPolicyConfiguration
-func SetDefaults_AuditPolicyConfiguration(obj *ClusterConfiguration) {
+// SetDefaultsAuditPolicyConfiguration sets default values for the AuditPolicyConfiguration
+func SetDefaultsAuditPolicyConfiguration(obj *ClusterConfiguration) {
 	if obj.AuditPolicyConfiguration.LogDir == "" {
 		obj.AuditPolicyConfiguration.LogDir = constants.StaticPodAuditPolicyLogDir
 	}
@@ -151,24 +151,24 @@ func SetDefaults_AuditPolicyConfiguration(obj *ClusterConfiguration) {
 	}
 }
 
-// SetDefaults_BootstrapTokens sets the defaults for the .BootstrapTokens field
+// SetDefaultsBootstrapTokens sets the defaults for the .BootstrapTokens field
 // If the slice is empty, it's defaulted with one token. Otherwise it just loops
 // through the slice and sets the defaults for the omitempty fields that are TTL,
 // Usages and Groups. Token is NOT defaulted with a random one in the API defaulting
 // layer, but set to a random value later at runtime if not set before.
-func SetDefaults_BootstrapTokens(obj *InitConfiguration) {
+func SetDefaultsBootstrapTokens(obj *InitConfiguration) {
 
 	if obj.BootstrapTokens == nil || len(obj.BootstrapTokens) == 0 {
 		obj.BootstrapTokens = []BootstrapToken{{}}
 	}
 
 	for i := range obj.BootstrapTokens {
-		SetDefaults_BootstrapToken(&obj.BootstrapTokens[i])
+		SetDefaultsBootstrapToken(&obj.BootstrapTokens[i])
 	}
 }
 
-// SetDefaults_BootstrapToken sets the defaults for an individual Bootstrap Token
-func SetDefaults_BootstrapToken(bt *BootstrapToken) {
+// SetDefaultsBootstrapToken sets the defaults for an individual Bootstrap Token
+func SetDefaultsBootstrapToken(bt *BootstrapToken) {
 	if bt.TTL == nil {
 		bt.TTL = &metav1.Duration{
 			Duration: constants.DefaultTokenDuration,
@@ -183,8 +183,8 @@ func SetDefaults_BootstrapToken(bt *BootstrapToken) {
 	}
 }
 
-// SetDefaults_APIEndpoint sets the defaults for the API server instance deployed on a node.
-func SetDefaults_APIEndpoint(obj *APIEndpoint) {
+// SetDefaultsAPIEndpoint sets the defaults for the API server instance deployed on a node.
+func SetDefaultsAPIEndpoint(obj *APIEndpoint) {
 	if obj.BindPort == 0 {
 		obj.BindPort = DefaultAPIBindPort
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.defaults.go
@@ -28,31 +28,31 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&ClusterConfiguration{}, func(obj interface{}) { SetObjectDefaults_ClusterConfiguration(obj.(*ClusterConfiguration)) })
-	scheme.AddTypeDefaultingFunc(&ClusterStatus{}, func(obj interface{}) { SetObjectDefaults_ClusterStatus(obj.(*ClusterStatus)) })
-	scheme.AddTypeDefaultingFunc(&InitConfiguration{}, func(obj interface{}) { SetObjectDefaults_InitConfiguration(obj.(*InitConfiguration)) })
-	scheme.AddTypeDefaultingFunc(&JoinConfiguration{}, func(obj interface{}) { SetObjectDefaults_JoinConfiguration(obj.(*JoinConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&ClusterConfiguration{}, func(obj interface{}) { SetObjectDefaultsClusterConfiguration(obj.(*ClusterConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&ClusterStatus{}, func(obj interface{}) { SetObjectDefaultsClusterStatus(obj.(*ClusterStatus)) })
+	scheme.AddTypeDefaultingFunc(&InitConfiguration{}, func(obj interface{}) { SetObjectDefaultsInitConfiguration(obj.(*InitConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&JoinConfiguration{}, func(obj interface{}) { SetObjectDefaultsJoinConfiguration(obj.(*JoinConfiguration)) })
 	return nil
 }
 
-func SetObjectDefaults_ClusterConfiguration(in *ClusterConfiguration) {
-	SetDefaults_ClusterConfiguration(in)
+func SetObjectDefaultsClusterConfiguration(in *ClusterConfiguration) {
+	SetDefaultsClusterConfiguration(in)
 }
 
-func SetObjectDefaults_ClusterStatus(in *ClusterStatus) {
+func SetObjectDefaultsClusterStatus(in *ClusterStatus) {
 }
 
-func SetObjectDefaults_InitConfiguration(in *InitConfiguration) {
-	SetDefaults_InitConfiguration(in)
-	SetObjectDefaults_ClusterConfiguration(&in.ClusterConfiguration)
+func SetObjectDefaultsInitConfiguration(in *InitConfiguration) {
+	SetDefaultsInitConfiguration(in)
+	SetObjectDefaultsClusterConfiguration(&in.ClusterConfiguration)
 	for i := range in.BootstrapTokens {
 		a := &in.BootstrapTokens[i]
-		SetDefaults_BootstrapToken(a)
+		SetDefaultsBootstrapToken(a)
 	}
-	SetDefaults_APIEndpoint(&in.APIEndpoint)
+	SetDefaultsAPIEndpoint(&in.APIEndpoint)
 }
 
-func SetObjectDefaults_JoinConfiguration(in *JoinConfiguration) {
-	SetDefaults_JoinConfiguration(in)
-	SetDefaults_APIEndpoint(&in.APIEndpoint)
+func SetObjectDefaultsJoinConfiguration(in *JoinConfiguration) {
+	SetDefaultsJoinConfiguration(in)
+	SetDefaultsAPIEndpoint(&in.APIEndpoint)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
@@ -65,15 +65,15 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetDefaults_InitConfiguration assigns default values for the InitConfiguration
-func SetDefaults_InitConfiguration(obj *InitConfiguration) {
-	SetDefaults_ClusterConfiguration(&obj.ClusterConfiguration)
-	SetDefaults_BootstrapTokens(obj)
-	SetDefaults_APIEndpoint(&obj.LocalAPIEndpoint)
+// SetDefaultsInitConfiguration assigns default values for the InitConfiguration
+func SetDefaultsInitConfiguration(obj *InitConfiguration) {
+	SetDefaultsClusterConfiguration(&obj.ClusterConfiguration)
+	SetDefaultsBootstrapTokens(obj)
+	SetDefaultsAPIEndpoint(&obj.LocalAPIEndpoint)
 }
 
-// SetDefaults_ClusterConfiguration assigns default values for the ClusterConfiguration
-func SetDefaults_ClusterConfiguration(obj *ClusterConfiguration) {
+// SetDefaultsClusterConfiguration assigns default values for the ClusterConfiguration
+func SetDefaultsClusterConfiguration(obj *ClusterConfiguration) {
 	if obj.KubernetesVersion == "" {
 		obj.KubernetesVersion = DefaultKubernetesVersion
 	}
@@ -98,13 +98,13 @@ func SetDefaults_ClusterConfiguration(obj *ClusterConfiguration) {
 		obj.ClusterName = DefaultClusterName
 	}
 
-	SetDefaults_DNS(obj)
-	SetDefaults_Etcd(obj)
-	SetDefaults_APIServer(&obj.APIServer)
+	SetDefaultsDNS(obj)
+	SetDefaultsEtcd(obj)
+	SetDefaultsAPIServer(&obj.APIServer)
 }
 
-// SetDefaults_APIServer assigns default values for the API Server
-func SetDefaults_APIServer(obj *APIServer) {
+// SetDefaultsAPIServer assigns default values for the API Server
+func SetDefaultsAPIServer(obj *APIServer) {
 	if obj.TimeoutForControlPlane == nil {
 		obj.TimeoutForControlPlane = &metav1.Duration{
 			Duration: constants.DefaultControlPlaneTimeout,
@@ -112,15 +112,15 @@ func SetDefaults_APIServer(obj *APIServer) {
 	}
 }
 
-// SetDefaults_DNS assigns default values for the DNS component
-func SetDefaults_DNS(obj *ClusterConfiguration) {
+// SetDefaultsDNS assigns default values for the DNS component
+func SetDefaultsDNS(obj *ClusterConfiguration) {
 	if obj.DNS.Type == "" {
 		obj.DNS.Type = CoreDNS
 	}
 }
 
-// SetDefaults_Etcd assigns default values for the proxy
-func SetDefaults_Etcd(obj *ClusterConfiguration) {
+// SetDefaultsEtcd assigns default values for the proxy
+func SetDefaultsEtcd(obj *ClusterConfiguration) {
 	if obj.Etcd.External == nil && obj.Etcd.Local == nil {
 		obj.Etcd.Local = &LocalEtcd{}
 	}
@@ -131,24 +131,25 @@ func SetDefaults_Etcd(obj *ClusterConfiguration) {
 	}
 }
 
-// SetDefaults_JoinConfiguration assigns default values to a regular node
-func SetDefaults_JoinConfiguration(obj *JoinConfiguration) {
+// SetDefaultsJoinConfiguration assigns default values to a regular node
+func SetDefaultsJoinConfiguration(obj *JoinConfiguration) {
 	if obj.CACertPath == "" {
 		obj.CACertPath = DefaultCACertPath
 	}
 
-	SetDefaults_JoinControlPlane(obj.ControlPlane)
-	SetDefaults_Discovery(&obj.Discovery)
+	SetDefaultsJoinControlPlane(obj.ControlPlane)
+	SetDefaultsDiscovery(&obj.Discovery)
 }
 
-func SetDefaults_JoinControlPlane(obj *JoinControlPlane) {
+// SetDefaultsJoinControlPlane assignes default value for JoinControlPlane
+func SetDefaultsJoinControlPlane(obj *JoinControlPlane) {
 	if obj != nil {
-		SetDefaults_APIEndpoint(&obj.LocalAPIEndpoint)
+		SetDefaultsAPIEndpoint(&obj.LocalAPIEndpoint)
 	}
 }
 
-// SetDefaults_Discovery assigns default values for the discovery process
-func SetDefaults_Discovery(obj *Discovery) {
+// SetDefaultsDiscovery assigns default values for the discovery process
+func SetDefaultsDiscovery(obj *Discovery) {
 	if len(obj.TLSBootstrapToken) == 0 && obj.BootstrapToken != nil {
 		obj.TLSBootstrapToken = obj.BootstrapToken.Token
 	}
@@ -160,12 +161,12 @@ func SetDefaults_Discovery(obj *Discovery) {
 	}
 
 	if obj.File != nil {
-		SetDefaults_FileDiscovery(obj.File)
+		SetDefaultsFileDiscovery(obj.File)
 	}
 }
 
-// SetDefaults_FileDiscovery assigns default values for file based discovery
-func SetDefaults_FileDiscovery(obj *FileDiscovery) {
+// SetDefaultsFileDiscovery assigns default values for file based discovery
+func SetDefaultsFileDiscovery(obj *FileDiscovery) {
 	// Make sure file URL becomes path
 	if len(obj.KubeConfigPath) != 0 {
 		u, err := url.Parse(obj.KubeConfigPath)
@@ -175,24 +176,24 @@ func SetDefaults_FileDiscovery(obj *FileDiscovery) {
 	}
 }
 
-// SetDefaults_BootstrapTokens sets the defaults for the .BootstrapTokens field
+// SetDefaultsBootstrapTokens sets the defaults for the .BootstrapTokens field
 // If the slice is empty, it's defaulted with one token. Otherwise it just loops
 // through the slice and sets the defaults for the omitempty fields that are TTL,
 // Usages and Groups. Token is NOT defaulted with a random one in the API defaulting
 // layer, but set to a random value later at runtime if not set before.
-func SetDefaults_BootstrapTokens(obj *InitConfiguration) {
+func SetDefaultsBootstrapTokens(obj *InitConfiguration) {
 
 	if obj.BootstrapTokens == nil || len(obj.BootstrapTokens) == 0 {
 		obj.BootstrapTokens = []BootstrapToken{{}}
 	}
 
 	for i := range obj.BootstrapTokens {
-		SetDefaults_BootstrapToken(&obj.BootstrapTokens[i])
+		SetDefaultsBootstrapToken(&obj.BootstrapTokens[i])
 	}
 }
 
-// SetDefaults_BootstrapToken sets the defaults for an individual Bootstrap Token
-func SetDefaults_BootstrapToken(bt *BootstrapToken) {
+// SetDefaultsBootstrapToken sets the defaults for an individual Bootstrap Token
+func SetDefaultsBootstrapToken(bt *BootstrapToken) {
 	if bt.TTL == nil {
 		bt.TTL = &metav1.Duration{
 			Duration: constants.DefaultTokenDuration,
@@ -207,8 +208,8 @@ func SetDefaults_BootstrapToken(bt *BootstrapToken) {
 	}
 }
 
-// SetDefaults_APIEndpoint sets the defaults for the API server instance deployed on a node.
-func SetDefaults_APIEndpoint(obj *APIEndpoint) {
+// SetDefaultsAPIEndpoint sets the defaults for the API server instance deployed on a node.
+func SetDefaultsAPIEndpoint(obj *APIEndpoint) {
 	if obj.BindPort == 0 {
 		obj.BindPort = DefaultAPIBindPort
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_unix.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_unix.go
@@ -21,6 +21,6 @@ package v1beta1
 const (
 	// DefaultCACertPath defines default location of CA certificate on Linux
 	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "unix"
+	// DefaultURLScheme defines default socket url scheme
+	DefaultURLScheme = "unix"
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_windows.go
@@ -21,6 +21,6 @@ package v1beta1
 const (
 	// DefaultCACertPath defines default location of CA certificate on Windows
 	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "tcp"
+	// DefaultURLScheme defines default socket url prefix
+	DefaultURLScheme = "tcp"
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.defaults.go
@@ -28,39 +28,39 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&ClusterConfiguration{}, func(obj interface{}) { SetObjectDefaults_ClusterConfiguration(obj.(*ClusterConfiguration)) })
-	scheme.AddTypeDefaultingFunc(&ClusterStatus{}, func(obj interface{}) { SetObjectDefaults_ClusterStatus(obj.(*ClusterStatus)) })
-	scheme.AddTypeDefaultingFunc(&InitConfiguration{}, func(obj interface{}) { SetObjectDefaults_InitConfiguration(obj.(*InitConfiguration)) })
-	scheme.AddTypeDefaultingFunc(&JoinConfiguration{}, func(obj interface{}) { SetObjectDefaults_JoinConfiguration(obj.(*JoinConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&ClusterConfiguration{}, func(obj interface{}) { SetObjectDefaultsClusterConfiguration(obj.(*ClusterConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&ClusterStatus{}, func(obj interface{}) { SetObjectDefaultsClusterStatus(obj.(*ClusterStatus)) })
+	scheme.AddTypeDefaultingFunc(&InitConfiguration{}, func(obj interface{}) { SetObjectDefaultsInitConfiguration(obj.(*InitConfiguration)) })
+	scheme.AddTypeDefaultingFunc(&JoinConfiguration{}, func(obj interface{}) { SetObjectDefaultsJoinConfiguration(obj.(*JoinConfiguration)) })
 	return nil
 }
 
-func SetObjectDefaults_ClusterConfiguration(in *ClusterConfiguration) {
-	SetDefaults_ClusterConfiguration(in)
-	SetDefaults_APIServer(&in.APIServer)
+func SetObjectDefaultsClusterConfiguration(in *ClusterConfiguration) {
+	SetDefaultsClusterConfiguration(in)
+	SetDefaultsAPIServer(&in.APIServer)
 }
 
-func SetObjectDefaults_ClusterStatus(in *ClusterStatus) {
+func SetObjectDefaultsClusterStatus(in *ClusterStatus) {
 }
 
-func SetObjectDefaults_InitConfiguration(in *InitConfiguration) {
-	SetDefaults_InitConfiguration(in)
-	SetObjectDefaults_ClusterConfiguration(&in.ClusterConfiguration)
+func SetObjectDefaultsInitConfiguration(in *InitConfiguration) {
+	SetDefaultsInitConfiguration(in)
+	SetObjectDefaultsClusterConfiguration(&in.ClusterConfiguration)
 	for i := range in.BootstrapTokens {
 		a := &in.BootstrapTokens[i]
-		SetDefaults_BootstrapToken(a)
+		SetDefaultsBootstrapToken(a)
 	}
-	SetDefaults_APIEndpoint(&in.LocalAPIEndpoint)
+	SetDefaultsAPIEndpoint(&in.LocalAPIEndpoint)
 }
 
-func SetObjectDefaults_JoinConfiguration(in *JoinConfiguration) {
-	SetDefaults_JoinConfiguration(in)
-	SetDefaults_Discovery(&in.Discovery)
+func SetObjectDefaultsJoinConfiguration(in *JoinConfiguration) {
+	SetDefaultsJoinConfiguration(in)
+	SetDefaultsDiscovery(&in.Discovery)
 	if in.Discovery.File != nil {
-		SetDefaults_FileDiscovery(in.Discovery.File)
+		SetDefaultsFileDiscovery(in.Discovery.File)
 	}
 	if in.ControlPlane != nil {
-		SetDefaults_JoinControlPlane(in.ControlPlane)
-		SetDefaults_APIEndpoint(&in.ControlPlane.LocalAPIEndpoint)
+		SetDefaultsJoinControlPlane(in.ControlPlane)
+		SetDefaultsAPIEndpoint(&in.ControlPlane.LocalAPIEndpoint)
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -467,7 +467,7 @@ func ValidateSocketPath(socket string, fldPath *field.Path) field.ErrorList {
 		if !filepath.IsAbs(u.Path) {
 			return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("path is not absolute: %s", socket)))
 		}
-	} else if u.Scheme != kubeadmapiv1beta1.DefaultUrlScheme {
+	} else if u.Scheme != kubeadmapiv1beta1.DefaultURLScheme {
 		return append(allErrs, field.Invalid(fldPath, socket, fmt.Sprintf("url scheme %s is not supported", u.Scheme)))
 	}
 

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -113,7 +113,7 @@ func TestValidateNodeRegistrationOptions(t *testing.T) {
 		{"invalid-node?name", "/some/path", true},                                            // Unsupported characters
 		{"valid-nodename", "/some/path", false},                                              // supported
 		{"valid-nodename-with-numbers01234", "/some/path/with/numbers/01234/", false},        // supported, with numbers as well
-		{"valid-nodename", kubeadmapiv1beta1.DefaultUrlScheme + "://" + "/some/path", false}, // supported, with socket url
+		{"valid-nodename", kubeadmapiv1beta1.DefaultURLScheme + "://" + "/some/path", false}, // supported, with socket url
 		{"valid-nodename", "bla:///some/path", true},                                         // unsupported url scheme
 		{"valid-nodename", ":::", true},                                                      // unparseable url
 	}

--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -135,7 +135,7 @@ func addFlags(cmd *cobra.Command, cfg *renewConfig) {
 
 func generateRenewalFunction(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert, cfg *renewConfig) func() {
 	return func() {
-		internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(cfg.cfgPath, &cfg.cfg)
+		internalcfg, err := configutil.FileOrDefaultToInitConfiguration(cfg.cfgPath, &cfg.cfg)
 		kubeadmutil.CheckErr(err)
 
 		if cfg.useCSR {

--- a/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/alpha/kubeconfig.go
@@ -80,7 +80,7 @@ func newCmdUserKubeConfig(out io.Writer) *cobra.Command {
 			}
 
 			// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
-			internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig("", cfg)
+			internalcfg, err := configutil.FileOrDefaultToInitConfiguration("", cfg)
 			kubeadmutil.CheckErr(err)
 
 			// if the kubeconfig file for an additional user has to use a token, use it

--- a/cmd/kubeadm/app/cmd/alpha/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/alpha/selfhosting.go
@@ -124,11 +124,11 @@ func getSelfhostingSubCommand(in io.Reader) *cobra.Command {
 			kubeadmutil.CheckErr(err)
 
 			// KubernetesVersion is not used, but we set it explicitly to avoid the lookup
-			// of the version from the internet when executing ConfigFileAndDefaultsToInternalConfig
+			// of the version from the internet when executing FileOrDefaultToInitConfiguration
 			phases.SetKubernetesVersion(&cfg.ClusterConfiguration)
 
 			// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
-			internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(cfgPath, cfg)
+			internalcfg, err := configutil.FileOrDefaultToInitConfiguration(cfgPath, cfg)
 			kubeadmutil.CheckErr(err)
 
 			// Converts the Static Pod-hosted control plane into a self-hosted one

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -275,7 +275,7 @@ func TestMigrate(t *testing.T) {
 		t.Fatalf("failed to set new-config flag")
 	}
 	command.Run(nil, nil)
-	if _, err := configutil.ConfigFileAndDefaultsToInternalConfig(newConfigPath, &kubeadmapiv1beta1.InitConfiguration{}); err != nil {
+	if _, err := configutil.FileOrDefaultToInitConfiguration(newConfigPath, &kubeadmapiv1beta1.InitConfiguration{}); err != nil {
 		t.Fatalf("Could not read output back into internal type: %v", err)
 	}
 }

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -305,7 +305,7 @@ func newInitData(cmd *cobra.Command, args []string, options *initOptions, out io
 
 	// Either use the config file if specified, or convert public kubeadm API to the internal InitConfiguration
 	// and validates InitConfiguration
-	cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(options.cfgPath, options.externalcfg)
+	cfg, err := configutil.FileOrDefaultToInitConfiguration(options.cfgPath, options.externalcfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/cmd/options/token.go
+++ b/cmd/kubeadm/app/cmd/options/token.go
@@ -30,7 +30,7 @@ import (
 // NewBootstrapTokenOptions creates a new BootstrapTokenOptions object with the default values
 func NewBootstrapTokenOptions() *BootstrapTokenOptions {
 	bto := &BootstrapTokenOptions{&kubeadmapiv1beta1.BootstrapToken{}, ""}
-	kubeadmapiv1beta1.SetDefaults_BootstrapToken(bto.BootstrapToken)
+	kubeadmapiv1beta1.SetDefaultsBootstrapToken(bto.BootstrapToken)
 	return bto
 }
 

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -211,12 +211,12 @@ func NewCmdTokenGenerate(out io.Writer) *cobra.Command {
 // RunCreateToken generates a new bootstrap token and stores it as a secret on the server.
 func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, cfg *kubeadmapiv1beta1.InitConfiguration, printJoinCommand bool, kubeConfigFile string) error {
 	// KubernetesVersion is not used, but we set it explicitly to avoid the lookup
-	// of the version from the internet when executing ConfigFileAndDefaultsToInternalConfig
+	// of the version from the internet when executing FileOrDefaultToInitConfiguration
 	phaseutil.SetKubernetesVersion(&cfg.ClusterConfiguration)
 
 	// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
 	klog.V(1).Infoln("[token] loading configurations")
-	internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(cfgPath, cfg)
+	internalcfg, err := configutil.FileOrDefaultToInitConfiguration(cfgPath, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -92,7 +92,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 			if flags.cfgPath != "" {
 				klog.V(1).Infof("fetching configuration from file %s", flags.cfgPath)
 				// Note that cfg isn't preserved here, it's just an one-off to populate flags.newK8sVersionStr based on --config
-				cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
+				cfg, err := configutil.FileOrDefaultToInitConfiguration(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
 				kubeadmutil.CheckErr(err)
 
 				if cfg.KubernetesVersion != "" {

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -79,7 +79,7 @@ func runDiff(flags *diffFlags, args []string) error {
 
 	// If the version is specified in config file, pick up that value.
 	klog.V(1).Infof("fetching configuration from file %s", flags.cfgPath)
-	cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
+	cfg, err := configutil.FileOrDefaultToInitConfiguration(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -63,7 +63,7 @@ func NewCmdPlan(apf *applyPlanFlags) *cobra.Command {
 			// If the version is specified in config file, pick up that value.
 			if flags.cfgPath != "" {
 				klog.V(1).Infof("fetching configuration from file %s", flags.cfgPath)
-				cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
+				cfg, err := configutil.FileOrDefaultToInitConfiguration(flags.cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
 				kubeadmutil.CheckErr(err)
 
 				if cfg.KubernetesVersion != "" {

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
+	// init klog
 	_ "k8s.io/klog"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -201,7 +201,7 @@ func TestEnsureProxyAddon(t *testing.T) {
 			masterConfig.Networking.PodSubnet = "2001:101::/96"
 		}
 
-		intMaster, err := configutil.ConfigFileAndDefaultsToInternalConfig("", masterConfig)
+		intMaster, err := configutil.FileOrDefaultToInitConfiguration("", masterConfig)
 		if err != nil {
 			t.Errorf("test failed to convert external to internal version")
 			break

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -84,7 +84,7 @@ func TestUploadConfiguration(t *testing.T) {
 					CRISocket: "/var/run/custom-cri.sock",
 				},
 			}
-			cfg, err := configutil.ConfigFileAndDefaultsToInternalConfig("", initialcfg)
+			cfg, err := configutil.FileOrDefaultToInitConfiguration("", initialcfg)
 
 			// cleans up component config to make cfg and decodedcfg comparable (now component config are not stored anymore in kubeadm-config config map)
 			cfg.ComponentConfigs = kubeadmapi.ComponentConfigs{}

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -177,7 +177,7 @@ func MigrateOldConfigFromFile(cfgPath string) ([]byte, error) {
 
 	// Migrate InitConfiguration and ClusterConfiguration if there are any in the config
 	if kubeadmutil.GroupVersionKindsHasInitConfiguration(gvks...) || kubeadmutil.GroupVersionKindsHasClusterConfiguration(gvks...) {
-		o, err := ConfigFileAndDefaultsToInternalConfig(cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
+		o, err := FileOrDefaultToInitConfiguration(cfgPath, &kubeadmapiv1beta1.InitConfiguration{})
 		if err != nil {
 			return []byte{}, err
 		}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
@@ -161,12 +161,12 @@ func SetClusterDynamicDefaults(cfg *kubeadmapi.ClusterConfiguration, advertiseAd
 	return nil
 }
 
-// ConfigFileAndDefaultsToInternalConfig takes a path to a config file and a versioned configuration that can serve as the default config
+// FileOrDefaultToInitConfiguration takes a path to a config file and a versioned configuration that can serve as the default config
 // If cfgPath is specified, defaultversionedcfg will always get overridden. Otherwise, the default config (often populated by flags) will be used.
 // Then the external, versioned configuration is defaulted and converted to the internal type.
 // Right thereafter, the configuration is defaulted again with dynamic values (like IP addresses of a machine, etc)
 // Lastly, the internal config is validated and returned.
-func ConfigFileAndDefaultsToInternalConfig(cfgPath string, defaultversionedcfg *kubeadmapiv1beta1.InitConfiguration) (*kubeadmapi.InitConfiguration, error) {
+func FileOrDefaultToInitConfiguration(cfgPath string, defaultversionedcfg *kubeadmapiv1beta1.InitConfiguration) (*kubeadmapi.InitConfiguration, error) {
 	internalcfg := &kubeadmapi.InitConfiguration{}
 
 	if cfgPath != "" {

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -30,12 +30,12 @@ import (
 )
 
 const (
-	master_v1alpha3YAML   = "testdata/conversion/master/v1alpha3.yaml"
-	master_v1beta1YAML    = "testdata/conversion/master/v1beta1.yaml"
-	master_internalYAML   = "testdata/conversion/master/internal.yaml"
-	master_incompleteYAML = "testdata/defaulting/master/incomplete.yaml"
-	master_defaultedYAML  = "testdata/defaulting/master/defaulted.yaml"
-	master_invalidYAML    = "testdata/validation/invalid_mastercfg.yaml"
+	masterV1alpha3YAML   = "testdata/conversion/master/v1alpha3.yaml"
+	masterV1beta1YAML    = "testdata/conversion/master/v1beta1.yaml"
+	masterInternalYAML   = "testdata/conversion/master/internal.yaml"
+	masterIncompleteYAML = "testdata/defaulting/master/incomplete.yaml"
+	masterDefaultedYAML  = "testdata/defaulting/master/defaulted.yaml"
+	masterInvalidYAML    = "testdata/validation/invalid_mastercfg.yaml"
 )
 
 func diff(expected, actual []byte) string {
@@ -57,43 +57,43 @@ func TestConfigFileAndDefaultsToInternalConfig(t *testing.T) {
 		groupVersion  schema.GroupVersion
 		expectedErr   bool
 	}{
-		// These tests are reading one file, loading it using ConfigFileAndDefaultsToInternalConfig that all of kubeadm is using for unmarshal of our API types,
+		// These tests are reading one file, loading it using FileOrDefaultToInternalConfig that all of kubeadm is using for unmarshal of our API types,
 		// and then marshals the internal object to the expected groupVersion
 		{ // v1alpha3 -> internal
 			name:         "v1alpha3ToInternal",
-			in:           master_v1alpha3YAML,
-			out:          master_internalYAML,
+			in:           masterV1alpha3YAML,
+			out:          masterInternalYAML,
 			groupVersion: kubeadm.SchemeGroupVersion,
 		},
 		{ // v1beta1 -> internal
 			name:         "v1beta1ToInternal",
-			in:           master_v1beta1YAML,
-			out:          master_internalYAML,
+			in:           masterV1beta1YAML,
+			out:          masterInternalYAML,
 			groupVersion: kubeadm.SchemeGroupVersion,
 		},
 		{ // v1alpha3 -> internal -> v1beta1
 			name:         "v1alpha3Tov1beta1",
-			in:           master_v1alpha3YAML,
-			out:          master_v1beta1YAML,
+			in:           masterV1alpha3YAML,
+			out:          masterV1beta1YAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		{ // v1beta1 -> internal -> v1beta1
 			name:         "v1beta1Tov1beta1",
-			in:           master_v1beta1YAML,
-			out:          master_v1beta1YAML,
+			in:           masterV1beta1YAML,
+			out:          masterV1beta1YAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
-		// These tests are reading one file that has only a subset of the fields populated, loading it using ConfigFileAndDefaultsToInternalConfig,
+		// These tests are reading one file that has only a subset of the fields populated, loading it using FileOrDefaultToInternalConfig,
 		// and then marshals the internal object to the expected groupVersion
 		{ // v1beta1 -> default -> validate -> internal -> v1beta1
 			name:         "incompleteYAMLToDefaultedv1beta1",
-			in:           master_incompleteYAML,
-			out:          master_defaultedYAML,
+			in:           masterIncompleteYAML,
+			out:          masterDefaultedYAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		{ // v1alpha3 -> validation should fail
 			name:        "invalidYAMLShouldFail",
-			in:          master_invalidYAML,
+			in:          masterInvalidYAML,
 			expectedErr: true,
 		},
 	}
@@ -101,7 +101,7 @@ func TestConfigFileAndDefaultsToInternalConfig(t *testing.T) {
 	for _, rt := range tests {
 		t.Run(rt.name, func(t2 *testing.T) {
 
-			internalcfg, err := ConfigFileAndDefaultsToInternalConfig(rt.in, &kubeadmapiv1beta1.InitConfiguration{})
+			internalcfg, err := FileOrDefaultToInitConfiguration(rt.in, &kubeadmapiv1beta1.InitConfiguration{})
 			if err != nil {
 				if rt.expectedErr {
 					return

--- a/cmd/kubeadm/app/util/config/joinconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration_test.go
@@ -29,12 +29,12 @@ import (
 )
 
 const (
-	node_v1alpha3YAML   = "testdata/conversion/node/v1alpha3.yaml"
-	node_v1beta1YAML    = "testdata/conversion/node/v1beta1.yaml"
-	node_internalYAML   = "testdata/conversion/node/internal.yaml"
-	node_incompleteYAML = "testdata/defaulting/node/incomplete.yaml"
-	node_defaultedYAML  = "testdata/defaulting/node/defaulted.yaml"
-	node_invalidYAML    = "testdata/validation/invalid_nodecfg.yaml"
+	nodeV1alpha3YAML   = "testdata/conversion/node/v1alpha3.yaml"
+	nodeV1beta1YAML    = "testdata/conversion/node/v1beta1.yaml"
+	nodeInternalYAML   = "testdata/conversion/node/internal.yaml"
+	nodeIncompleteYAML = "testdata/defaulting/node/incomplete.yaml"
+	nodeDefaultedYAML  = "testdata/defaulting/node/defaulted.yaml"
+	nodeInvalidYAML    = "testdata/validation/invalid_nodecfg.yaml"
 )
 
 func TestJoinConfigFileAndDefaultsToInternalConfig(t *testing.T) {
@@ -47,39 +47,39 @@ func TestJoinConfigFileAndDefaultsToInternalConfig(t *testing.T) {
 		// and then marshals the internal object to the expected groupVersion
 		{ // v1alpha3 -> internal
 			name:         "v1alpha3ToInternal",
-			in:           node_v1alpha3YAML,
-			out:          node_internalYAML,
+			in:           nodeV1alpha3YAML,
+			out:          nodeInternalYAML,
 			groupVersion: kubeadm.SchemeGroupVersion,
 		},
 		{ // v1beta1 -> internal
 			name:         "v1beta1ToInternal",
-			in:           node_v1beta1YAML,
-			out:          node_internalYAML,
+			in:           nodeV1beta1YAML,
+			out:          nodeInternalYAML,
 			groupVersion: kubeadm.SchemeGroupVersion,
 		},
 		{ // v1alpha3 -> internal -> v1beta1
 			name:         "v1alpha3Tov1beta1",
-			in:           node_v1alpha3YAML,
-			out:          node_v1beta1YAML,
+			in:           nodeV1alpha3YAML,
+			out:          nodeV1beta1YAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		{ // v1beta1 -> internal -> v1beta1
 			name:         "v1beta1Tov1beta1",
-			in:           node_v1beta1YAML,
-			out:          node_v1beta1YAML,
+			in:           nodeV1beta1YAML,
+			out:          nodeV1beta1YAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		// These tests are reading one file that has only a subset of the fields populated, loading it using JoinConfigFileAndDefaultsToInternalConfig,
 		// and then marshals the internal object to the expected groupVersion
 		{ // v1beta1 -> default -> validate -> internal -> v1beta1
 			name:         "incompleteYAMLToDefaultedv1beta1",
-			in:           node_incompleteYAML,
-			out:          node_defaultedYAML,
+			in:           nodeIncompleteYAML,
+			out:          nodeDefaultedYAML,
 			groupVersion: kubeadmapiv1beta1.SchemeGroupVersion,
 		},
 		{ // v1alpha3 -> validation should fail
 			name:        "invalidYAMLShouldFail",
-			in:          node_invalidYAML,
+			in:          nodeInvalidYAML,
 			expectedErr: true,
 		},
 	}

--- a/cmd/kubeadm/app/util/marshal_test.go
+++ b/cmd/kubeadm/app/util/marshal_test.go
@@ -128,7 +128,7 @@ func TestMarshalUnmarshalToYamlForCodecs(t *testing.T) {
 		// at the kubeadmapiv1beta1.InitConfiguration definition.
 	}
 
-	kubeadmapiv1beta1.SetDefaults_InitConfiguration(cfg)
+	kubeadmapiv1beta1.SetDefaultsInitConfiguration(cfg)
 	scheme := runtime.NewScheme()
 	if err := kubeadmapiv1beta1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/util/system/cgroup_validator.go
+++ b/cmd/kubeadm/app/util/system/cgroup_validator.go
@@ -26,10 +26,12 @@ import (
 
 var _ Validator = &CgroupsValidator{}
 
+// CgroupsValidator validates whether all the required cgroup subsystems are enabled or not
 type CgroupsValidator struct {
 	Reporter Reporter
 }
 
+// Name returns name of CgroupsValidator
 func (c *CgroupsValidator) Name() string {
 	return "cgroups"
 }
@@ -38,6 +40,8 @@ const (
 	cgroupsConfigPrefix = "CGROUPS_"
 )
 
+// Validate validates whether all the required cgroup subsystems are enabled or not,
+// an error will be returned if any subsystem is missing.
 func (c *CgroupsValidator) Validate(spec SysSpec) (error, error) {
 	subsystems, err := c.getCgroupSubsystems()
 	if err != nil {

--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -27,11 +27,12 @@ import (
 
 var _ Validator = &DockerValidator{}
 
-// DockerValidator validates docker configuration.
+// DockerValidator validates docker configuration, currently only docker version and graph driver are checked.
 type DockerValidator struct {
 	Reporter Reporter
 }
 
+// Name returns name of DockerValidator
 func (d *DockerValidator) Name() string {
 	return "docker"
 }
@@ -41,6 +42,8 @@ const (
 	latestValidatedDockerVersion = "18.09"
 )
 
+// Validate validates whether the used docker runtime is supported or not, it does nothing
+// if current runtime is not docker.
 // TODO(random-liu): Add more validating items.
 func (d *DockerValidator) Validate(spec SysSpec) (error, error) {
 	if spec.RuntimeSpec.DockerSpec == nil {

--- a/cmd/kubeadm/app/util/system/kernel_validator_test.go
+++ b/cmd/kubeadm/app/util/system/kernel_validator_test.go
@@ -173,7 +173,7 @@ func TestValidateCachedKernelConfig(t *testing.T) {
 			// Add kernel config prefix.
 			for k, v := range test.config {
 				delete(test.config, k)
-				test.config[kConfigPrefix+k] = v
+				test.config[kernelCfgPrefix+k] = v
 			}
 			err := v.validateCachedKernelConfig(test.config, testKernelSpec)
 			if !test.err {

--- a/cmd/kubeadm/app/util/system/os_validator.go
+++ b/cmd/kubeadm/app/util/system/os_validator.go
@@ -25,14 +25,17 @@ import (
 
 var _ Validator = &OSValidator{}
 
+// OSValidator validates operating system.
 type OSValidator struct {
 	Reporter Reporter
 }
 
+// Name returns name of OSValidator
 func (o *OSValidator) Name() string {
 	return "os"
 }
 
+// Validate validates whether the operating system is supported or not.
 func (o *OSValidator) Validate(spec SysSpec) (error, error) {
 	os, err := exec.Command("uname").CombinedOutput()
 	if err != nil {

--- a/cmd/kubeadm/app/util/system/report.go
+++ b/cmd/kubeadm/app/util/system/report.go
@@ -47,12 +47,14 @@ func colorize(s string, c color) string {
 	return fmt.Sprintf("\033[0;%dm%s\033[0m", c, s)
 }
 
-// The default reporter for the system verification test
+// StreamReporter reports the results of system verification test to a Writer stream.
+// verification results are colorized base on result type.
 type StreamReporter struct {
 	// The stream that this reporter is writing to
 	WriteStream io.Writer
 }
 
+// Report reports the results of system verification test to a Writer stream.
 func (dr *StreamReporter) Report(key, value string, resultType ValidationResultType) error {
 	var c color
 	switch resultType {

--- a/cmd/kubeadm/test/util.go
+++ b/cmd/kubeadm/test/util.go
@@ -157,7 +157,7 @@ func AssertError(t *testing.T, err error, expected string) {
 
 // GetDefaultInternalConfig returns a defaulted kubeadmapi.InitConfiguration
 func GetDefaultInternalConfig(t *testing.T) *kubeadmapi.InitConfiguration {
-	internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig("", &kubeadmapiv1beta1.InitConfiguration{})
+	internalcfg, err := configutil.FileOrDefaultToInitConfiguration("", &kubeadmapiv1beta1.InitConfiguration{})
 	if err != nil {
 		t.Fatalf("unexpected error getting default config: %v", err)
 	}

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -2,11 +2,7 @@ cmd/cloud-controller-manager/app/apis/config/v1alpha1
 cmd/kube-apiserver/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app
-cmd/kubeadm/app
 cmd/kubeadm/app/apis/kubeadm/v1alpha3
-cmd/kubeadm/app/apis/kubeadm/v1beta1
-cmd/kubeadm/app/util/config
-cmd/kubeadm/app/util/system
 cmd/kubelet/app
 cmd/kubelet/app/options
 cmd/kubemark


### PR DESCRIPTION
**What this PR does / why we need it**:
fix golint errors in package cmd/kubeadm/app, since the codes under `cmd/kubeadm/app/apis/kubeadm/v1alpha3` are auto-generated, i keep them untouched.


related to #68026

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```

/kind cleanup
