### PR TITLE
fix UnmountDevice failure on Windows

### DIFF
--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -458,17 +458,14 @@ func getAllParentLinks(path string) ([]string, error) {
 	return links, nil
 }
 
+// GetMountRefs : empty implementation here since there is no place to query all mount points on Windows
 func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
 	if _, err := os.Stat(normalizeWindowsPath(pathname)); os.IsNotExist(err) {
 		return []string{}, nil
 	} else if err != nil {
 		return nil, err
 	}
-	refs, err := getAllParentLinks(normalizeWindowsPath(pathname))
-	if err != nil {
-		return nil, err
-	}
-	return refs, nil
+	return []string{pathname}, nil
 }
 
 // Note that on windows, it always returns 0. We actually don't set FSGroup on

--- a/pkg/util/mount/mount_windows_test.go
+++ b/pkg/util/mount/mount_windows_test.go
@@ -111,30 +111,25 @@ func setEquivalent(set1, set2 []string) bool {
 
 // this func must run in admin mode, otherwise it will fail
 func TestGetMountRefs(t *testing.T) {
-	fm := &FakeMounter{MountPoints: []MountPoint{}}
-	mountPath := `c:\secondmountpath`
-	expectedRefs := []string{`c:\`, `c:\firstmountpath`, mountPath}
-
-	// remove symbolic links first
-	for i := 1; i < len(expectedRefs); i++ {
-		removeLink(expectedRefs[i])
+	tests := []struct {
+		mountPath    string
+		expectedRefs []string
+	}{
+		{
+			mountPath:    `c:\windows`,
+			expectedRefs: []string{`c:\windows`},
+		},
+		{
+			mountPath:    `c:\doesnotexist`,
+			expectedRefs: []string{},
+		},
 	}
 
-	// create symbolic links
-	for i := 1; i < len(expectedRefs); i++ {
-		if err := makeLink(expectedRefs[i], expectedRefs[i-1]); err != nil {
-			t.Errorf("makeLink failed: %v", err)
-		}
-	}
+	mounter := Mounter{"fake/path"}
 
-	if refs, err := fm.GetMountRefs(mountPath); err != nil || !setEquivalent(expectedRefs, refs) {
-		t.Errorf("getMountRefs(%q) = %v, error: %v; expected %v", mountPath, refs, err, expectedRefs)
-	}
-
-	// remove symbolic links
-	for i := 1; i < len(expectedRefs); i++ {
-		if err := removeLink(expectedRefs[i]); err != nil {
-			t.Errorf("removeLink failed: %v", err)
+	for _, test := range tests {
+		if refs, err := mounter.GetMountRefs(test.mountPath); err != nil || !setEquivalent(test.expectedRefs, refs) {
+			t.Errorf("getMountRefs(%q) = %v, error: %v; expected %v", test.mountPath, refs, err, test.expectedRefs)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
fix UnmountDevice failure on Windows, root cause is `GetMountRefs` on windows is not correctly implemented.
Error code is like following:
```
E0912 04:11:58.069277    4308 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/azure-disk//subscriptions/xxx/resourceGroups/andy-k8swin1120beta1/providers/Microsoft.Compute/disks/andy-k8swin1120beta1-dynamic-pvc-ec35a4b1-b637-11e8-bb79-000d3af7dab4\"" failed. No retries permitted until 2018-09-12 04:14:00.0692771 +0000 GMT m=+572.648837101 (durationBeforeRetry 2m2s). Error: "GetDeviceMountRefs check failed for volume \"pvc-ec35a4b1-b637-11e8-bb79-000d3af7dab4\" (UniqueName: \"kubernetes.io/azure-disk//subscriptions/xxx/resourceGroups/andy-k8swin1120beta1/providers/Microsoft.Compute/disks/andy-k8swin1120beta1-dynamic-pvc-ec35a4b1-b637-11e8-bb79-000d3af7dab4\") on node \"18986k8s9001\" : The device mount path \"\\\\var\\\\lib\\\\kubelet\\\\plugins\\\\kubernetes.io\\\\azure-disk\\\\mounts\\\\m1433781257\" is still mounted by other references [c:\\var\\lib\\kubelet\\plugins\\kubernetes.io\\azure-disk\\mounts\\m1433781257 F:\\]"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68512

**Special notes for your reviewer**:
On Windows, there is no place to query all mount points like `/proc/mounts` on Linux, so I actually did an empty implementation for `GetMountRefs` on Windows, which could skip the below error check:
https://github.com/kubernetes/kubernetes/blob/426ef9d349bb3a277c3e8826fb772b6bdb008382/pkg/volume/util/operationexecutor/operation_generator.go#L756-L758

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix UnmountDevice failure on Windows
```

/kind bug
/sig windows
@PatrickLang 