### PR TITLE
Revert "#67504: Decrease CPU requests of master components in two times."

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1311,7 +1311,7 @@ function prepare-kube-proxy-manifest-variables {
   sed -i -e "s@{{container_env}}@${container_env}@g" ${src_file}
   sed -i -e "s@{{kube_cache_mutation_detector_env_name}}@${kube_cache_mutation_detector_env_name}@g" ${src_file}
   sed -i -e "s@{{kube_cache_mutation_detector_env_value}}@${kube_cache_mutation_detector_env_value}@g" ${src_file}
-  sed -i -e "s@{{ cpurequest }}@50m@g" ${src_file}
+  sed -i -e "s@{{ cpurequest }}@100m@g" ${src_file}
   sed -i -e "s@{{api_servers_with_port}}@${api_servers}@g" ${src_file}
   sed -i -e "s@{{kubernetes_service_host_env_value}}@${KUBERNETES_MASTER_NAME}@g" ${src_file}
   if [[ -n "${CLUSTER_IP_RANGE:-}" ]]; then
@@ -1432,10 +1432,10 @@ function start-etcd-servers {
     rm -f /etc/init.d/etcd
   fi
   prepare-log-file /var/log/etcd.log
-  prepare-etcd-manifest "" "2379" "2380" "100m" "etcd.manifest"
+  prepare-etcd-manifest "" "2379" "2380" "200m" "etcd.manifest"
 
   prepare-log-file /var/log/etcd-events.log
-  prepare-etcd-manifest "-events" "4002" "2381" "50m" "etcd-events.manifest"
+  prepare-etcd-manifest "-events" "4002" "2381" "100m" "etcd-events.manifest"
 }
 
 # Calculates the following variables based on env variables, which will be used

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -44,7 +44,7 @@
                 ],
                 "resources": {
                     "requests": {
-                        "cpu": "5m",
+                        "cpu": "10m",
                         "memory": "300Mi"
                     }
                 },

--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -39,7 +39,7 @@ spec:
       # master components on a single core master.
       # TODO: Make resource requirements depend on the size of the cluster
       requests:
-        cpu: 5m
+        cpu: 10m
         memory: 50Mi
     command:
     # TODO: split this out into args when we no longer need to pipe stdout to a file #6428

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -21,7 +21,7 @@ spec:
     - exec /opt/kube-addons.sh 1>>/var/log/kube-addon-manager.log 2>&1
     resources:
       requests:
-        cpu: 3m
+        cpu: 5m
         memory: 50Mi
     volumeMounts:
     - mountPath: /etc/kubernetes/

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -22,7 +22,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "125m"
+        "cpu": "250m"
       }
     },
     "command": [

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -21,7 +21,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "100m"
+        "cpu": "200m"
       }
     },
     "command": [

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -21,7 +21,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "40m"
+        "cpu": "75m"
       }
     },
     "command": [


### PR DESCRIPTION
This may break users that run workload on master node, because control plane is going to get two times less resources.

Cherrypick was already reverted in 1.11 branch. We need to apply it on master too.

```release-note
none
```