### PR TITLE
allow audit policy to be loaded from any byte source

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
@@ -55,17 +55,26 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 		return nil, fmt.Errorf("failed to read file path %q: %+v", filePath, err)
 	}
 
+	ret, err := LoadPolicyFromBytes(policyDef)
+	if err != nil {
+		return nil, fmt.Errorf("%v: from file %v", err.Error(), filePath)
+	}
+
+	return ret, nil
+}
+
+func LoadPolicyFromBytes(policyDef []byte) (*auditinternal.Policy, error) {
 	policy := &auditinternal.Policy{}
 	decoder := audit.Codecs.UniversalDecoder(apiGroupVersions...)
 
 	_, gvk, err := decoder.Decode(policyDef, nil, policy)
 	if err != nil {
-		return nil, fmt.Errorf("failed decoding file %q: %v", filePath, err)
+		return nil, fmt.Errorf("failed decoding: %v", err)
 	}
 
 	// Ensure the policy file contained an apiVersion and kind.
 	if !apiGroupVersionSet[schema.GroupVersion{Group: gvk.Group, Version: gvk.Version}] {
-		return nil, fmt.Errorf("unknown group version field %v in policy file %s", gvk, filePath)
+		return nil, fmt.Errorf("unknown group version field %v in policy", gvk)
 	}
 
 	if err := validation.ValidatePolicy(policy); err != nil {
@@ -74,8 +83,8 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 
 	policyCnt := len(policy.Rules)
 	if policyCnt == 0 {
-		return nil, fmt.Errorf("loaded illegal policy with 0 rules from file %s", filePath)
+		return nil, fmt.Errorf("loaded illegal policy with 0 rules")
 	}
-	glog.V(4).Infof("Loaded %d audit policy rules from file %s", policyCnt, filePath)
+	glog.V(4).Infof("Loaded %d audit policy rules", policyCnt)
 	return policy, nil
 }


### PR DESCRIPTION
Refactor the config loading mechanism for audit policy to allow any byte source to be used.  The location is still kept as a hint in the error message, but can be set to anything.  A URL or resource path for instance.

@kubernetes/sig-api-machinery-pr-reviews 

```release-note
NONE
```