### PR TITLE
Replace internal version of resource with external version for tests

### DIFF
--- a/pkg/kubectl/polymorphichelpers/BUILD
+++ b/pkg/kubectl/polymorphichelpers/BUILD
@@ -70,10 +70,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/apps:go_default_library",
-        "//pkg/apis/batch:go_default_library",
-        "//pkg/apis/core:go_default_library",
-        "//pkg/apis/extensions:go_default_library",
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/apps/v1beta1:go_default_library",

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
@@ -19,16 +19,35 @@ package polymorphichelpers
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
+	appsv1 "k8s.io/kubernetes/pkg/apis/apps"
+	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func canBeAutoscaled(kind schema.GroupKind) error {
 	switch kind {
-	case api.Kind("ReplicationController"), extensions.Kind("ReplicaSet"),
-		extensions.Kind("Deployment"), apps.Kind("Deployment"), apps.Kind("ReplicaSet"):
+	case
+		schema.GroupKind{
+			Group: corev1.GroupName,
+			Kind:  "ReplicationController",
+		},
+		schema.GroupKind{
+			Group: appsv1.GroupName,
+			Kind:  "Deployment",
+		},
+		schema.GroupKind{
+			Group: appsv1.GroupName,
+			Kind:  "ReplicaSet",
+		},
+		schema.GroupKind{
+			Group: extensionsv1.GroupName,
+			Kind:  "Deployment",
+		},
+		schema.GroupKind{
+			Group: extensionsv1.GroupName,
+			Kind:  "ReplicaSet",
+		}:
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot autoscale a %v", kind)

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled.go
@@ -19,35 +19,20 @@ package polymorphichelpers
 import (
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	appsv1 "k8s.io/kubernetes/pkg/apis/apps"
-	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func canBeAutoscaled(kind schema.GroupKind) error {
 	switch kind {
 	case
-		schema.GroupKind{
-			Group: corev1.GroupName,
-			Kind:  "ReplicationController",
-		},
-		schema.GroupKind{
-			Group: appsv1.GroupName,
-			Kind:  "Deployment",
-		},
-		schema.GroupKind{
-			Group: appsv1.GroupName,
-			Kind:  "ReplicaSet",
-		},
-		schema.GroupKind{
-			Group: extensionsv1.GroupName,
-			Kind:  "Deployment",
-		},
-		schema.GroupKind{
-			Group: extensionsv1.GroupName,
-			Kind:  "ReplicaSet",
-		}:
+		corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot autoscale a %v", kind)

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
@@ -19,6 +19,9 @@ package polymorphichelpers
 import (
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -28,17 +31,27 @@ func TestCanBeAutoscaled(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			kind: schema.GroupKind{
-				Group: "",
-				Kind:  "ReplicationController",
-			},
+			kind:      corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
 			expectErr: false,
 		},
 		{
-			kind: schema.GroupKind{
-				Group: "",
-				Kind:  "Node",
-			},
+			kind:      appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      corev1.SchemeGroupVersion.WithKind("Node").GroupKind(),
+			expectErr: true,
+		},
+		{
+			kind:      corev1.SchemeGroupVersion.WithKind("Service").GroupKind(),
+			expectErr: true,
+		},
+		{
+			kind:      corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(),
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
+++ b/pkg/kubectl/polymorphichelpers/canbeautoscaled_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestCanBeAutoscaled(t *testing.T) {
@@ -29,11 +28,17 @@ func TestCanBeAutoscaled(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			kind:      api.Kind("ReplicationController"),
+			kind: schema.GroupKind{
+				Group: "",
+				Kind:  "ReplicationController",
+			},
 			expectErr: false,
 		},
 		{
-			kind:      api.Kind("Node"),
+			kind: schema.GroupKind{
+				Group: "",
+				Kind:  "Node",
+			},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/canbeexposed.go
+++ b/pkg/kubectl/polymorphichelpers/canbeexposed.go
@@ -19,17 +19,44 @@ package polymorphichelpers
 import (
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // Check whether the kind of resources could be exposed
 func canBeExposed(kind schema.GroupKind) error {
 	switch kind {
-	case api.Kind("ReplicationController"), api.Kind("Service"), api.Kind("Pod"),
-		extensions.Kind("Deployment"), apps.Kind("Deployment"), extensions.Kind("ReplicaSet"), apps.Kind("ReplicaSet"):
+	case
+		schema.GroupKind{
+			Group: corev1.GroupName,
+			Kind:  "ReplicationController",
+		},
+		schema.GroupKind{
+			Group: corev1.GroupName,
+			Kind:  "Service",
+		},
+		schema.GroupKind{
+			Group: corev1.GroupName,
+			Kind:  "Pod",
+		},
+		schema.GroupKind{
+			Group: appsv1.GroupName,
+			Kind:  "Deployment",
+		},
+		schema.GroupKind{
+			Group: appsv1.GroupName,
+			Kind:  "ReplicaSet",
+		},
+		schema.GroupKind{
+			Group: extensionsv1.GroupName,
+			Kind:  "Deployment",
+		},
+		schema.GroupKind{
+			Group: extensionsv1.GroupName,
+			Kind:  "ReplicaSet",
+		}:
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot expose a %s", kind)

--- a/pkg/kubectl/polymorphichelpers/canbeexposed.go
+++ b/pkg/kubectl/polymorphichelpers/canbeexposed.go
@@ -21,7 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -29,34 +29,13 @@ import (
 func canBeExposed(kind schema.GroupKind) error {
 	switch kind {
 	case
-		schema.GroupKind{
-			Group: corev1.GroupName,
-			Kind:  "ReplicationController",
-		},
-		schema.GroupKind{
-			Group: corev1.GroupName,
-			Kind:  "Service",
-		},
-		schema.GroupKind{
-			Group: corev1.GroupName,
-			Kind:  "Pod",
-		},
-		schema.GroupKind{
-			Group: appsv1.GroupName,
-			Kind:  "Deployment",
-		},
-		schema.GroupKind{
-			Group: appsv1.GroupName,
-			Kind:  "ReplicaSet",
-		},
-		schema.GroupKind{
-			Group: extensionsv1.GroupName,
-			Kind:  "Deployment",
-		},
-		schema.GroupKind{
-			Group: extensionsv1.GroupName,
-			Kind:  "ReplicaSet",
-		}:
+		corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
+		corev1.SchemeGroupVersion.WithKind("Service").GroupKind(),
+		corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot expose a %s", kind)

--- a/pkg/kubectl/polymorphichelpers/canbeexposed_test.go
+++ b/pkg/kubectl/polymorphichelpers/canbeexposed_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestCanBeExposed(t *testing.T) {
@@ -29,11 +28,17 @@ func TestCanBeExposed(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			kind:      api.Kind("ReplicationController"),
+			kind: schema.GroupKind{
+				Group: "",
+				Kind:  "ReplicationController",
+			},
 			expectErr: false,
 		},
 		{
-			kind:      api.Kind("Node"),
+			kind: schema.GroupKind{
+				Group: "",
+				Kind:  "Node",
+			},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/canbeexposed_test.go
+++ b/pkg/kubectl/polymorphichelpers/canbeexposed_test.go
@@ -19,6 +19,9 @@ package polymorphichelpers
 import (
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -28,17 +31,27 @@ func TestCanBeExposed(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			kind: schema.GroupKind{
-				Group: "",
-				Kind:  "ReplicationController",
-			},
+			kind:      corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
 			expectErr: false,
 		},
 		{
-			kind: schema.GroupKind{
-				Group: "",
-				Kind:  "Node",
-			},
+			kind:      corev1.SchemeGroupVersion.WithKind("Service").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+			expectErr: false,
+		},
+		{
+			kind:      corev1.SchemeGroupVersion.WithKind("Node").GroupKind(),
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/helpers_test.go
+++ b/pkg/kubectl/polymorphichelpers/helpers_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	fakeexternal "k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -119,18 +118,18 @@ func TestGetFirstPod(t *testing.T) {
 			watching: []watch.Event{
 				{
 					Type: watch.Modified,
-					Object: &api.Pod{
+					Object: &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:              "pod-1",
 							Namespace:         metav1.NamespaceDefault,
 							CreationTimestamp: metav1.Date(2016, time.April, 1, 1, 0, 0, 0, time.UTC),
 							Labels:            map[string]string{"test": "selector"},
 						},
-						Status: api.PodStatus{
-							Conditions: []api.PodCondition{
+						Status: corev1.PodStatus{
+							Conditions: []corev1.PodCondition{
 								{
-									Status: api.ConditionTrue,
-									Type:   api.PodReady,
+									Status: corev1.ConditionTrue,
+									Type:   corev1.PodReady,
 								},
 							},
 						},

--- a/pkg/kubectl/polymorphichelpers/logsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/logsforobject_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -151,9 +151,9 @@ func TestLogsForObject(t *testing.T) {
 		},
 		{
 			name: "replica set logs",
-			obj: &extensions.ReplicaSet{
+			obj: &extensionsv1beta1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
-				Spec: extensions.ReplicaSetSpec{
+				Spec: extensionsv1beta1.ReplicaSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
 			},
@@ -165,9 +165,9 @@ func TestLogsForObject(t *testing.T) {
 		},
 		{
 			name: "deployment logs",
-			obj: &extensions.Deployment{
+			obj: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
-				Spec: extensions.DeploymentSpec{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
 			},
@@ -179,9 +179,9 @@ func TestLogsForObject(t *testing.T) {
 		},
 		{
 			name: "job logs",
-			obj: &batch.Job{
+			obj: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
-				Spec: batch.JobSpec{
+				Spec: batchv1.JobSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
 			},
@@ -193,9 +193,9 @@ func TestLogsForObject(t *testing.T) {
 		},
 		{
 			name: "stateful set logs",
-			obj: &apps.StatefulSet{
+			obj: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
-				Spec: apps.StatefulSetSpec{
+				Spec: appsv1.StatefulSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
 			},

--- a/pkg/kubectl/polymorphichelpers/logsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/logsforobject_test.go
@@ -21,16 +21,16 @@ import (
 	"testing"
 	"time"
 
+	apps "k8s.io/api/apps/v1"
+	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	fakeexternal "k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/testing"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	"k8s.io/kubernetes/pkg/apis/batch"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 var (

--- a/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject_test.go
@@ -19,8 +19,8 @@ package polymorphichelpers
 import (
 	"testing"
 
-	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -32,8 +32,8 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 		expectErr      bool
 	}{
 		{
-			object: &api.ReplicationController{
-				Spec: api.ReplicationControllerSpec{
+			object: &corev1.ReplicationController{
+				Spec: corev1.ReplicationControllerSpec{
 					Selector: map[string]string{
 						"foo": "bar",
 					},
@@ -42,11 +42,11 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectSelector: "foo=bar",
 		},
 		{
-			object:    &api.Pod{},
+			object:    &corev1.Pod{},
 			expectErr: true,
 		},
 		{
-			object: &api.Pod{
+			object: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"foo": "bar",
@@ -56,8 +56,8 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectSelector: "foo=bar",
 		},
 		{
-			object: &api.Service{
-				Spec: api.ServiceSpec{
+			object: &corev1.Service{
+				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
 						"foo": "bar",
 					},
@@ -66,12 +66,12 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectSelector: "foo=bar",
 		},
 		{
-			object:    &api.Service{},
+			object:    &corev1.Service{},
 			expectErr: true,
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"foo": "bar",
@@ -82,8 +82,8 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectSelector: "foo=bar",
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
@@ -96,8 +96,8 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			object: &extensions.ReplicaSet{
-				Spec: extensions.ReplicaSetSpec{
+			object: &extensionsv1beta1.ReplicaSet{
+				Spec: extensionsv1beta1.ReplicaSetSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"foo": "bar",
@@ -108,8 +108,8 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectSelector: "foo=bar",
 		},
 		{
-			object: &extensions.ReplicaSet{
-				Spec: extensions.ReplicaSetSpec{
+			object: &extensionsv1beta1.ReplicaSet{
+				Spec: extensionsv1beta1.ReplicaSetSpec{
 					Selector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
@@ -122,7 +122,7 @@ func TestMapBasedSelectorForObject(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			object:    &api.Node{},
+			object:    &corev1.Node{},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject_test.go
@@ -19,10 +19,10 @@ package polymorphichelpers
 import (
 	"testing"
 
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestMapBasedSelectorForObject(t *testing.T) {

--- a/pkg/kubectl/polymorphichelpers/objectpauser_test.go
+++ b/pkg/kubectl/polymorphichelpers/objectpauser_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -31,8 +31,8 @@ func TestDefaultObjectPauser(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Paused: false,
 				},
 			},
@@ -40,15 +40,15 @@ func TestDefaultObjectPauser(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Paused: true,
 				},
 			},
 			expectErr: true,
 		},
 		{
-			object:    &extensions.ReplicaSet{},
+			object:    &extensionsv1beta1.ReplicaSet{},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/objectpauser_test.go
+++ b/pkg/kubectl/polymorphichelpers/objectpauser_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestDefaultObjectPauser(t *testing.T) {

--- a/pkg/kubectl/polymorphichelpers/objectresumer_test.go
+++ b/pkg/kubectl/polymorphichelpers/objectresumer_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestDefaultObjectResumer(t *testing.T) {

--- a/pkg/kubectl/polymorphichelpers/objectresumer_test.go
+++ b/pkg/kubectl/polymorphichelpers/objectresumer_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"testing"
 
-	extensions "k8s.io/api/extensions/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -31,8 +31,8 @@ func TestDefaultObjectResumer(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Paused: true,
 				},
 			},
@@ -40,15 +40,15 @@ func TestDefaultObjectResumer(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
 					Paused: false,
 				},
 			},
 			expectErr: true,
 		},
 		{
-			object:    &extensions.ReplicaSet{},
+			object:    &extensionsv1beta1.ReplicaSet{},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/portsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/portsforobject_test.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestPortsForObject(t *testing.T) {

--- a/pkg/kubectl/polymorphichelpers/portsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/portsforobject_test.go
@@ -21,8 +21,8 @@ import (
 
 	"reflect"
 
-	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -32,11 +32,11 @@ func TestPortsForObject(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			object: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
+			object: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
-							Ports: []api.ContainerPort{
+							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 101,
 								},
@@ -47,9 +47,9 @@ func TestPortsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &api.Service{
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+			object: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{
 							Port: 101,
 						},
@@ -58,13 +58,13 @@ func TestPortsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &api.ReplicationController{
-				Spec: api.ReplicationControllerSpec{
-					Template: &api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &corev1.ReplicationController{
+				Spec: corev1.ReplicationControllerSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 										},
@@ -77,13 +77,13 @@ func TestPortsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
-					Template: api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 										},
@@ -96,13 +96,13 @@ func TestPortsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &extensions.ReplicaSet{
-				Spec: extensions.ReplicaSetSpec{
-					Template: api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &extensionsv1beta1.ReplicaSet{
+				Spec: extensionsv1beta1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 										},
@@ -115,7 +115,7 @@ func TestPortsForObject(t *testing.T) {
 			},
 		},
 		{
-			object:    &api.Node{},
+			object:    &corev1.Node{},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/protocolsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/protocolsforobject_test.go
@@ -21,8 +21,8 @@ import (
 
 	"reflect"
 
-	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -32,11 +32,11 @@ func TestProtocolsForObject(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			object: &api.Pod{
-				Spec: api.PodSpec{
-					Containers: []api.Container{
+			object: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{
-							Ports: []api.ContainerPort{
+							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 101,
 									Protocol:      "tcp",
@@ -48,9 +48,9 @@ func TestProtocolsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &api.Service{
-				Spec: api.ServiceSpec{
-					Ports: []api.ServicePort{
+			object: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
 						{
 							Port:     101,
 							Protocol: "tcp",
@@ -60,13 +60,13 @@ func TestProtocolsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &api.ReplicationController{
-				Spec: api.ReplicationControllerSpec{
-					Template: &api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &corev1.ReplicationController{
+				Spec: corev1.ReplicationControllerSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 											Protocol:      "tcp",
@@ -80,13 +80,13 @@ func TestProtocolsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &extensions.Deployment{
-				Spec: extensions.DeploymentSpec{
-					Template: api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &extensionsv1beta1.Deployment{
+				Spec: extensionsv1beta1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 											Protocol:      "tcp",
@@ -100,13 +100,13 @@ func TestProtocolsForObject(t *testing.T) {
 			},
 		},
 		{
-			object: &extensions.ReplicaSet{
-				Spec: extensions.ReplicaSetSpec{
-					Template: api.PodTemplateSpec{
-						Spec: api.PodSpec{
-							Containers: []api.Container{
+			object: &extensionsv1beta1.ReplicaSet{
+				Spec: extensionsv1beta1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
-									Ports: []api.ContainerPort{
+									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 101,
 											Protocol:      "tcp",
@@ -120,7 +120,7 @@ func TestProtocolsForObject(t *testing.T) {
 			},
 		},
 		{
-			object:    &api.Node{},
+			object:    &corev1.Node{},
 			expectErr: true,
 		},
 	}

--- a/pkg/kubectl/polymorphichelpers/protocolsforobject_test.go
+++ b/pkg/kubectl/polymorphichelpers/protocolsforobject_test.go
@@ -21,9 +21,9 @@ import (
 
 	"reflect"
 
+	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestProtocolsForObject(t *testing.T) {


### PR DESCRIPTION
* Replaces the internal version of a resource within the test with an external version.

Helps address:
  1) [Umbrella Issue: Remove kubectl dependencies on kubernetes/kubernetes](https://github.com/kubernetes/kubectl/issues/80)
  2) [Remove Kubectl dependencies on kubernetes/pkg/api and kubernetes/pkg/apis](https://github.com/kubernetes/kubectl/issues/83)

```release-note
NONE
```
