### PR TITLE
Remove legacyscheme by adding ParameterCodec to kubectl scheme

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
@@ -137,7 +136,7 @@ func defaultAttachFunc(o *AttachOptions, containerToAttach *corev1.Container, ra
 			Stdout:    o.Out != nil,
 			Stderr:    !o.DisableStderr,
 			TTY:       raw,
-		}, legacyscheme.ParameterCodec)
+		}, scheme.ParameterCodec)
 
 		return o.Attach.Attach("POST", req.URL(), o.Config, o.In, o.Out, o.ErrOut, raw, sizeQueue)
 	}

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -30,10 +30,10 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 	"k8s.io/kubernetes/pkg/util/interrupt"
@@ -321,7 +321,7 @@ func (p *ExecOptions) Run() error {
 			Stdout:    p.Out != nil,
 			Stderr:    p.ErrOut != nil,
 			TTY:       t.Raw,
-		}, legacyscheme.ParameterCodec)
+		}, scheme.ParameterCodec)
 
 		return p.Executor.Execute("POST", req.URL(), p.Config, p.In, p.Out, p.ErrOut, t.Raw, sizeQueue)
 	}

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -30,7 +30,6 @@ import (
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -314,7 +313,7 @@ func (p *ExecOptions) Run() error {
 			Namespace(pod.Namespace).
 			SubResource("exec").
 			Param("container", containerName)
-		req.VersionedParams(&api.PodExecOptions{
+		req.VersionedParams(&corev1.PodExecOptions{
 			Container: containerName,
 			Command:   p.Command,
 			Stdin:     p.Stdin,

--- a/pkg/kubectl/scheme/scheme.go
+++ b/pkg/kubectl/scheme/scheme.go
@@ -30,6 +30,9 @@ var Scheme = runtime.NewScheme()
 // Codecs provides access to encoding and decoding for the scheme
 var Codecs = serializer.NewCodecFactory(Scheme)
 
+// ParameterCodec handles versioning of objects that are converted to query parameters.
+var ParameterCodec = runtime.NewParameterCodec(Scheme)
+
 // DefaultJSONEncoder returns a default encoder for our scheme
 func DefaultJSONEncoder() runtime.Encoder {
 	return unstructured.JSONFallbackEncoder{Encoder: Codecs.LegacyCodec(Scheme.PrioritizedVersionsAllGroups()...)}


### PR DESCRIPTION
* Add ParameterCodec to kubectl scheme
* Move use of legacyscheme.ParameterCode to scheme.ParameterCodec
* Removes a couple dependencies on legacyscheme

Helps address:
  1) [Umbrella Issue: Remove kubectl dependencies on kubernetes/kubernetes](https://github.com/kubernetes/kubectl/issues/80)
  2) [Remove Kubectl dependencies on kubernetes/pkg/api and kubernetes/pkg/apis](https://github.com/kubernetes/kubectl/issues/83)

```release-note
NONE
```
