### PR TITLE
Removes dependency on internal version of resource

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -115,7 +115,6 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/pod:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
-        "//pkg/apis/apps:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/v1:go_default_library",
         "//pkg/apis/extensions:go_default_library",

--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
-	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -38,11 +37,13 @@ type StatusViewer interface {
 // StatusViewerFor returns a StatusViewer for the resource specified by kind.
 func StatusViewerFor(kind schema.GroupKind, c kubernetes.Interface) (StatusViewer, error) {
 	switch kind {
-	case extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(), apps.Kind("Deployment"):
+	case extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind():
 		return &DeploymentStatusViewer{c.AppsV1()}, nil
-	case extensionsv1beta1.SchemeGroupVersion.WithKind("DaemonSet").GroupKind(), apps.Kind("DaemonSet"):
+	case extensionsv1beta1.SchemeGroupVersion.WithKind("DaemonSet").GroupKind(),
+		appsv1.SchemeGroupVersion.WithKind("DaemonSet").GroupKind():
 		return &DaemonSetStatusViewer{c.AppsV1()}, nil
-	case apps.Kind("StatefulSet"):
+	case appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind():
 		return &StatefulSetStatusViewer{c.AppsV1()}, nil
 	}
 	return nil, fmt.Errorf("no status viewer has been implemented for %v", kind)
@@ -141,7 +142,7 @@ func (s *StatefulSetStatusViewer) Status(obj runtime.Unstructured, revision int6
 	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
 		return fmt.Sprintf("Waiting for %d pods to be ready...\n", *sts.Spec.Replicas-sts.Status.ReadyReplicas), false, nil
 	}
-	if sts.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
+	if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
 		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
 			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
 				return fmt.Sprintf("Waiting for partitioned roll out to finish: %d out of %d new pods have been updated...\n",


### PR DESCRIPTION
* Removes dependency on internal version of resource in rollout_status.go

Helps address:
  1) [Umbrella Issue: Remove kubectl dependencies on kubernetes/kubernetes](https://github.com/kubernetes/kubectl/issues/80)
  2) [Remove Kubectl dependencies on kubernetes/pkg/api and kubernetes/pkg/apis](https://github.com/kubernetes/kubectl/issues/83)

```release-note
NONE
```
