### PR TITLE
Support multiple arguments for cordon and drain

### DIFF
--- a/pkg/kubectl/cmd/drain/drain.go
+++ b/pkg/kubectl/cmd/drain/drain.go
@@ -235,9 +235,6 @@ func (o *DrainOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	if len(args) > 0 && len(o.Selector) > 0 {
 		return cmdutil.UsageErrorf(cmd, "error: cannot specify both a node name and a --selector option")
 	}
-	if len(args) > 0 && len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("USAGE: %s [flags]", cmd.Use))
-	}
 
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Support multiple arguments for cordon/uncordon and drain

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68630 

**Special notes for your reviewer**:

**Release note**:
```release-note
kubectl: support multiple arguments for cordon/uncordon and drain
```
