### PR TITLE
reduce resource quota version conflict in controller

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -205,8 +205,12 @@ func (rq *ResourceQuotaController) addQuota(obj interface{}) {
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 func (rq *ResourceQuotaController) worker(queue workqueue.RateLimitingInterface) func() {
 	workFunc := func() bool {
+		if queue.Len() == 0 {
+			return true
+		}
 		key, quit := queue.Get()
 		if quit {
+			glog.Infof("resource quota controller worker shutting down")
 			return true
 		}
 		defer queue.Done(key)
@@ -223,7 +227,6 @@ func (rq *ResourceQuotaController) worker(queue workqueue.RateLimitingInterface)
 	return func() {
 		for {
 			if quit := workFunc(); quit {
-				glog.Infof("resource quota controller worker shutting down")
 				return
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We can reduce resource quota version conflict.
1. Before this PR: 
There are some workers to  call this function "syncResourceQuotaFromKey" parallel. In this function, resource quota will be update!  Every worker will be blocking if the queue is empty. If some same keys come at the same time (because a quota key will be sent to controller every time delete a pod),  every worker is awakened to deal with the same key. This will lead to update resource quota parallel and many version conflicts occur.

2. After this PR:
Workers are not waiting, they will deal with the key per second. And only unique key will be hold in the queue. We can reduce many conflicts.

3. Result:
Firstly I create a quota. Secondly I create a deployment that there are 30 pod in this deployment. And I delete this deployment.
**Before this optimization**, I observe that there are many log like this `Operation cannot be fulfilled on resourcequotas \"pod-quota\": the object has been modified;`
**After this optimization**, I observe only one log.

4. Other Reason
We can reduce the possibility of pod create  error by reducing resource quota version conflict. Because api-server will also update resource quota when we create a pod. Reducing concurrency of updating the same resource quota will reduce the conflict error by create pod!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#67761
**Special notes for your reviewer**:
Maybe there are similar problems in other controllers.
**Release note**:
None
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
