### PR TITLE
Ignore non-avaiable volumes in findMatchingVolume

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -45,7 +45,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim binds to a matching unbound volume.
 			"1-1 - successful bind",
-			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume1-1", "1Gi", "uid1-1", "claim1-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, nil),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "volume1-1", v1.ClaimBound, nil, annBoundByController, annBindCompleted),
@@ -54,8 +54,8 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim does not do anything when there is no matching volume.
 			"1-2 - noop",
-			newVolumeArray("volume1-2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume1-2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim1-2", "uid1-2", "10Gi", "", v1.ClaimPending, nil),
 			newClaimArray("claim1-2", "uid1-2", "10Gi", "", v1.ClaimPending, nil),
 			[]string{"Normal FailedBinding"},
@@ -65,8 +65,8 @@ func TestSync(t *testing.T) {
 			// syncClaim resets claim.Status to Pending when there is no
 			// matching volume.
 			"1-3 - reset to Pending",
-			newVolumeArray("volume1-3", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume1-3", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-3", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-3", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim1-3", "uid1-3", "10Gi", "", v1.ClaimBound, nil),
 			newClaimArray("claim1-3", "uid1-3", "10Gi", "", v1.ClaimPending, nil),
 			[]string{"Normal FailedBinding"},
@@ -76,11 +76,11 @@ func TestSync(t *testing.T) {
 			// syncClaim binds claims to the smallest matching volume
 			"1-4 - smallest volume",
 			[]*v1.PersistentVolume{
-				newVolume("volume1-4_1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-4_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-4_1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-4_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			[]*v1.PersistentVolume{
-				newVolume("volume1-4_1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-4_1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 				newVolume("volume1-4_2", "1Gi", "uid1-4", "claim1-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			},
 			newClaimArray("claim1-4", "uid1-4", "1Gi", "", v1.ClaimPending, nil),
@@ -92,12 +92,12 @@ func TestSync(t *testing.T) {
 			// name), even though a smaller one is available.
 			"1-5 - prebound volume by name - success",
 			[]*v1.PersistentVolume{
-				newVolume("volume1-5_1", "10Gi", "", "claim1-5", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-5_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-5_1", "10Gi", "", "claim1-5", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-5_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			[]*v1.PersistentVolume{
 				newVolume("volume1-5_1", "10Gi", "uid1-5", "claim1-5", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-5_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-5_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			newClaimArray("claim1-5", "uid1-5", "1Gi", "", v1.ClaimPending, nil),
 			withExpectedCapacity("10Gi", newClaimArray("claim1-5", "uid1-5", "1Gi", "volume1-5_1", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -108,12 +108,12 @@ func TestSync(t *testing.T) {
 			// UID), even though a smaller one is available.
 			"1-6 - prebound volume by UID - success",
 			[]*v1.PersistentVolume{
-				newVolume("volume1-6_1", "10Gi", "uid1-6", "claim1-6", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-6_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-6_1", "10Gi", "uid1-6", "claim1-6", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-6_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			[]*v1.PersistentVolume{
 				newVolume("volume1-6_1", "10Gi", "uid1-6", "claim1-6", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-6_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-6_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			newClaimArray("claim1-6", "uid1-6", "1Gi", "", v1.ClaimPending, nil),
 			withExpectedCapacity("10Gi", newClaimArray("claim1-6", "uid1-6", "1Gi", "volume1-6_1", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -123,8 +123,8 @@ func TestSync(t *testing.T) {
 			// syncClaim does not bind claim to a volume prebound to a claim with
 			// same name and different UID
 			"1-7 - prebound volume to different claim",
-			newVolumeArray("volume1-7", "10Gi", "uid1-777", "claim1-7", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume1-7", "10Gi", "uid1-777", "claim1-7", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-7", "10Gi", "uid1-777", "claim1-7", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-7", "10Gi", "uid1-777", "claim1-7", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim1-7", "uid1-7", "1Gi", "", v1.ClaimPending, nil),
 			newClaimArray("claim1-7", "uid1-7", "1Gi", "", v1.ClaimPending, nil),
 			[]string{"Normal FailedBinding"},
@@ -134,7 +134,7 @@ func TestSync(t *testing.T) {
 			// syncClaim completes binding - simulates controller crash after
 			// PV.ClaimRef is saved
 			"1-8 - complete bind after crash - PV bound",
-			newVolumeArray("volume1-8", "1Gi", "uid1-8", "claim1-8", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
+			newVolumeArray("volume1-8", "1Gi", "uid1-8", "claim1-8", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newVolumeArray("volume1-8", "1Gi", "uid1-8", "claim1-8", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim1-8", "uid1-8", "1Gi", "", v1.ClaimPending, nil),
 			newClaimArray("claim1-8", "uid1-8", "1Gi", "volume1-8", v1.ClaimBound, nil, annBoundByController, annBindCompleted),
@@ -163,7 +163,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim binds a claim only when the label selector matches the volume
 			"1-11 - bind when selector matches",
-			withLabels(labels, newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withLabels(labels, newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withLabels(labels, newVolumeArray("volume1-1", "1Gi", "uid1-1", "claim1-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, nil)),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "volume1-1", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -172,8 +172,8 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim does not bind a claim when the label selector doesn't match
 			"1-12 - do not bind when selector does not match",
-			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, nil)),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, nil)),
 			[]string{"Normal FailedBinding"},
@@ -182,8 +182,8 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim does not do anything when binding is delayed
 			"1-13 - delayed binding",
-			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classWait),
-			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classWait),
+			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classWait),
+			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classWait),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait),
 			[]string{"Normal WaitForFirstConsumer"},
@@ -192,7 +192,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncClaim binds when binding is delayed but PV is prebound to PVC
 			"1-14 - successful prebound PV",
-			newVolumeArray("volume1-1", "1Gi", "", "claim1-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classWait),
+			newVolumeArray("volume1-1", "1Gi", "", "claim1-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classWait),
 			newVolumeArray("volume1-1", "1Gi", "uid1-1", "claim1-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classWait),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending, &classWait),
 			newClaimArray("claim1-1", "uid1-1", "1Gi", "volume1-1", v1.ClaimBound, &classWait, annBoundByController, annBindCompleted),
@@ -203,12 +203,12 @@ func TestSync(t *testing.T) {
 			// even if there is smaller volume available
 			"1-15 - successful prebound PVC",
 			[]*v1.PersistentVolume{
-				newVolume("volume1-15_1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume1-15_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-15_1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-15_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			[]*v1.PersistentVolume{
 				newVolume("volume1-15_1", "10Gi", "uid1-15", "claim1-15", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
-				newVolume("volume1-15_2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-15_2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			newClaimArray("claim1-15", "uid1-15", "1Gi", "volume1-15_1", v1.ClaimPending, nil),
 			withExpectedCapacity("10Gi", newClaimArray("claim1-15", "uid1-15", "1Gi", "volume1-15_1", v1.ClaimBound, nil, annBindCompleted)),
@@ -218,10 +218,33 @@ func TestSync(t *testing.T) {
 			// syncClaim does not bind pre-bound PVC to PV with different AccessMode
 			"1-16 - successful prebound PVC",
 			// PV has ReadWriteOnce
-			newVolumeArray("volume1-16", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume1-16", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-16", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume1-16", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			claimWithAccessMode([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}, newClaimArray("claim1-16", "uid1-16", "1Gi", "volume1-16", v1.ClaimPending, nil)),
 			claimWithAccessMode([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany}, newClaimArray("claim1-16", "uid1-16", "1Gi", "volume1-16", v1.ClaimPending, nil)),
+			noevents, noerrors, testSyncClaim,
+		},
+		{
+			// syncClaim does not bind PVC to non-available PV if it's not pre-bind
+			"1-17 - skip non-available PV if it's not pre-bind",
+			[]*v1.PersistentVolume{
+				newVolume("volume1-17-pending", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-failed", "1Gi", "", "", v1.VolumeFailed, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-released", "1Gi", "", "", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-empty", "1Gi", "", "", "", v1.PersistentVolumeReclaimRetain, classEmpty),
+			},
+			[]*v1.PersistentVolume{
+				newVolume("volume1-17-pending", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-failed", "1Gi", "", "", v1.VolumeFailed, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-released", "1Gi", "", "", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume1-17-empty", "1Gi", "", "", "", v1.PersistentVolumeReclaimRetain, classEmpty),
+			},
+			[]*v1.PersistentVolumeClaim{
+				newClaim("claim1-17", "uid1-17", "1Gi", "", v1.ClaimPending, nil),
+			},
+			[]*v1.PersistentVolumeClaim{
+				newClaim("claim1-17", "uid1-17", "1Gi", "", v1.ClaimPending, nil),
+			},
 			noevents, noerrors, testSyncClaim,
 		},
 
@@ -251,7 +274,7 @@ func TestSync(t *testing.T) {
 			// syncClaim with claim pre-bound to a PV that exists and is
 			// unbound. Check it gets bound and no annBoundByController is set.
 			"2-3 - claim prebound to unbound volume",
-			newVolumeArray("volume2-3", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-3", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume2-3", "1Gi", "uid2-3", "claim2-3", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", v1.ClaimPending, nil),
 			newClaimArray("claim2-3", "uid2-3", "1Gi", "volume2-3", v1.ClaimBound, nil, annBindCompleted),
@@ -261,7 +284,7 @@ func TestSync(t *testing.T) {
 			// claim with claim pre-bound to a PV that is pre-bound to the claim
 			// by name. Check it gets bound and no annBoundByController is set.
 			"2-4 - claim prebound to prebound volume by name",
-			newVolumeArray("volume2-4", "1Gi", "", "claim2-4", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-4", "1Gi", "", "claim2-4", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume2-4", "1Gi", "uid2-4", "claim2-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim2-4", "uid2-4", "1Gi", "volume2-4", v1.ClaimPending, nil),
 			newClaimArray("claim2-4", "uid2-4", "1Gi", "volume2-4", v1.ClaimBound, nil, annBindCompleted),
@@ -272,7 +295,7 @@ func TestSync(t *testing.T) {
 			// claim by UID. Check it gets bound and no annBoundByController is
 			// set.
 			"2-5 - claim prebound to prebound volume by UID",
-			newVolumeArray("volume2-5", "1Gi", "uid2-5", "claim2-5", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-5", "1Gi", "uid2-5", "claim2-5", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume2-5", "1Gi", "uid2-5", "claim2-5", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim2-5", "uid2-5", "1Gi", "volume2-5", v1.ClaimPending, nil),
 			newClaimArray("claim2-5", "uid2-5", "1Gi", "volume2-5", v1.ClaimBound, nil, annBindCompleted),
@@ -303,7 +326,7 @@ func TestSync(t *testing.T) {
 			// unbound, but does not match the selector. Check it gets bound
 			// and no annBoundByController is set.
 			"2-8 - claim prebound to unbound volume that does not match the selector",
-			newVolumeArray("volume2-8", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-8", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume2-8", "1Gi", "uid2-8", "claim2-8", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			withLabelSelector(labels, newClaimArray("claim2-8", "uid2-8", "1Gi", "volume2-8", v1.ClaimPending, nil)),
 			withLabelSelector(labels, newClaimArray("claim2-8", "uid2-8", "1Gi", "volume2-8", v1.ClaimBound, nil, annBindCompleted)),
@@ -314,8 +337,8 @@ func TestSync(t *testing.T) {
 			// unbound, but its size is smaller than requested.
 			//Check that the claim status is reset to Pending
 			"2-9 - claim prebound to unbound volume that size is smaller than requested",
-			newVolumeArray("volume2-9", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume2-9", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-9", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume2-9", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim2-9", "uid2-9", "2Gi", "volume2-9", v1.ClaimBound, nil),
 			newClaimArray("claim2-9", "uid2-9", "2Gi", "volume2-9", v1.ClaimPending, nil),
 			[]string{"Warning VolumeMismatch"}, noerrors, testSyncClaim,
@@ -324,8 +347,8 @@ func TestSync(t *testing.T) {
 			// syncClaim with claim pre-bound to a PV that exists and is
 			// unbound, but its class does not match. Check that the claim status is reset to Pending
 			"2-10 - claim prebound to unbound volume that class is different",
-			newVolumeArray("volume2-10", "1Gi", "1", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
-			newVolumeArray("volume2-10", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
+			newVolumeArray("volume2-10", "1Gi", "1", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
+			newVolumeArray("volume2-10", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
 			newClaimArray("claim2-10", "uid2-10", "1Gi", "volume2-10", v1.ClaimBound, nil),
 			newClaimArray("claim2-10", "uid2-10", "1Gi", "volume2-10", v1.ClaimPending, nil),
 			[]string{"Warning VolumeMismatch"}, noerrors, testSyncClaim,
@@ -356,7 +379,7 @@ func TestSync(t *testing.T) {
 			// syncClaim with claim bound to unbound volume. Check it's bound.
 			// Also check that Pending phase is set to Bound
 			"3-3 - bound claim with unbound volume",
-			newVolumeArray("volume3-3", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-3", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume3-3", "10Gi", "uid3-3", "claim3-3", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim3-3", "uid3-3", "10Gi", "volume3-3", v1.ClaimPending, nil, annBoundByController, annBindCompleted),
 			newClaimArray("claim3-3", "uid3-3", "10Gi", "volume3-3", v1.ClaimBound, nil, annBoundByController, annBindCompleted),
@@ -366,8 +389,8 @@ func TestSync(t *testing.T) {
 			// syncClaim with claim bound to volume with missing (or different)
 			// volume.Spec.ClaimRef.UID. Check that the claim is marked as lost.
 			"3-4 - bound claim with prebound volume",
-			newVolumeArray("volume3-4", "10Gi", "claim3-4-x", "claim3-4", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume3-4", "10Gi", "claim3-4-x", "claim3-4", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-4", "10Gi", "claim3-4-x", "claim3-4", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-4", "10Gi", "claim3-4-x", "claim3-4", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim3-4", "uid3-4", "10Gi", "volume3-4", v1.ClaimPending, nil, annBoundByController, annBindCompleted),
 			newClaimArray("claim3-4", "uid3-4", "10Gi", "volume3-4", v1.ClaimLost, nil, annBoundByController, annBindCompleted),
 			[]string{"Warning ClaimMisbound"}, noerrors, testSyncClaim,
@@ -377,7 +400,7 @@ func TestSync(t *testing.T) {
 			// controller does not do anything. Also check that Pending phase is
 			// set to Bound
 			"3-5 - bound claim with bound volume",
-			newVolumeArray("volume3-5", "10Gi", "uid3-5", "claim3-5", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-5", "10Gi", "uid3-5", "claim3-5", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume3-5", "10Gi", "uid3-5", "claim3-5", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim3-5", "uid3-5", "10Gi", "volume3-5", v1.ClaimPending, nil, annBindCompleted),
 			newClaimArray("claim3-5", "uid3-5", "10Gi", "volume3-5", v1.ClaimBound, nil, annBindCompleted),
@@ -388,8 +411,8 @@ func TestSync(t *testing.T) {
 			// claim. Check that the claim is marked as lost.
 			// TODO: test that an event is emitted
 			"3-6 - bound claim with bound volume",
-			newVolumeArray("volume3-6", "10Gi", "uid3-6-x", "claim3-6-x", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-			newVolumeArray("volume3-6", "10Gi", "uid3-6-x", "claim3-6-x", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-6", "10Gi", "uid3-6-x", "claim3-6-x", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-6", "10Gi", "uid3-6-x", "claim3-6-x", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newClaimArray("claim3-6", "uid3-6", "10Gi", "volume3-6", v1.ClaimPending, nil, annBindCompleted),
 			newClaimArray("claim3-6", "uid3-6", "10Gi", "volume3-6", v1.ClaimLost, nil, annBindCompleted),
 			[]string{"Warning ClaimMisbound"}, noerrors, testSyncClaim,
@@ -399,7 +422,7 @@ func TestSync(t *testing.T) {
 			// even if the claim's selector doesn't match the volume. Also
 			// check that Pending phase is set to Bound
 			"3-7 - bound claim with unbound volume where selector doesn't match",
-			newVolumeArray("volume3-3", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume3-3", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume3-3", "10Gi", "uid3-3", "claim3-3", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			withLabelSelector(labels, newClaimArray("claim3-3", "uid3-3", "10Gi", "volume3-3", v1.ClaimPending, nil, annBoundByController, annBindCompleted)),
 			withLabelSelector(labels, newClaimArray("claim3-3", "uid3-3", "10Gi", "volume3-3", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -409,7 +432,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume with pending volume. Check it's marked as Available.
 			"4-1 - pending volume",
-			newVolumeArray("volume4-1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume4-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume4-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			noclaims,
 			noclaims,
@@ -419,7 +442,7 @@ func TestSync(t *testing.T) {
 			// syncVolume with prebound pending volume. Check it's marked as
 			// Available.
 			"4-2 - pending prebound volume",
-			newVolumeArray("volume4-2", "10Gi", "", "claim4-2", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume4-2", "10Gi", "", "claim4-2", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume4-2", "10Gi", "", "claim4-2", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			noclaims,
 			noclaims,
@@ -503,11 +526,11 @@ func TestSync(t *testing.T) {
 			// smaller PV available
 			"13-1 - binding to class",
 			[]*v1.PersistentVolume{
-				newVolume("volume13-1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
-				newVolume("volume13-1-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
+				newVolume("volume13-1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume13-1-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
 			},
 			[]*v1.PersistentVolume{
-				newVolume("volume13-1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume13-1-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 				newVolume("volume13-1-2", "10Gi", "uid13-1", "claim13-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classGold, annBoundByController),
 			},
 			newClaimArray("claim13-1", "uid13-1", "1Gi", "", v1.ClaimPending, &classGold),
@@ -519,11 +542,11 @@ func TestSync(t *testing.T) {
 			// smaller PV with a class available
 			"13-2 - binding without a class",
 			[]*v1.PersistentVolume{
-				newVolume("volume13-2-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
-				newVolume("volume13-2-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+				newVolume("volume13-2-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
+				newVolume("volume13-2-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			},
 			[]*v1.PersistentVolume{
-				newVolume("volume13-2-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
+				newVolume("volume13-2-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
 				newVolume("volume13-2-2", "10Gi", "uid13-2", "claim13-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			},
 			newClaimArray("claim13-2", "uid13-2", "1Gi", "", v1.ClaimPending, nil),
@@ -535,11 +558,11 @@ func TestSync(t *testing.T) {
 			// smaller PV with different class available
 			"13-3 - binding to specific a class",
 			[]*v1.PersistentVolume{
-				newVolume("volume13-3-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classSilver),
-				newVolume("volume13-3-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
+				newVolume("volume13-3-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classSilver),
+				newVolume("volume13-3-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
 			},
 			[]*v1.PersistentVolume{
-				newVolume("volume13-3-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classSilver),
+				newVolume("volume13-3-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classSilver),
 				newVolume("volume13-3-2", "10Gi", "uid13-3", "claim13-3", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classGold, annBoundByController),
 			},
 			newClaimArray("claim13-3", "uid13-3", "1Gi", "", v1.ClaimPending, &classGold),
@@ -550,7 +573,7 @@ func TestSync(t *testing.T) {
 			// syncVolume binds claim requesting class "" to claim to PV with
 			// class=""
 			"13-4 - empty class",
-			newVolumeArray("volume13-4", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume13-4", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume13-4", "1Gi", "uid13-4", "claim13-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim13-4", "uid13-4", "1Gi", "", v1.ClaimPending, &classEmpty),
 			newClaimArray("claim13-4", "uid13-4", "1Gi", "volume13-4", v1.ClaimBound, &classEmpty, annBoundByController, annBindCompleted),
@@ -560,7 +583,7 @@ func TestSync(t *testing.T) {
 			// syncVolume binds claim requesting class nil to claim to PV with
 			// class = ""
 			"13-5 - nil class",
-			newVolumeArray("volume13-5", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty),
+			newVolumeArray("volume13-5", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
 			newVolumeArray("volume13-5", "1Gi", "uid13-5", "claim13-5", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController),
 			newClaimArray("claim13-5", "uid13-5", "1Gi", "", v1.ClaimPending, nil),
 			newClaimArray("claim13-5", "uid13-5", "1Gi", "volume13-5", v1.ClaimBound, nil, annBoundByController, annBindCompleted),
@@ -572,7 +595,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume binds a requested block claim to a block volume
 			"14-1 - binding to volumeMode block",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "uid14-1", "claim14-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-1", "uid14-1", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-1", "uid14-1", "10Gi", "volume14-1", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -581,7 +604,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume binds a requested filesystem claim to a filesystem volume
 			"14-2 - binding to volumeMode filesystem",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "uid14-2", "claim14-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-2", "uid14-2", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-2", "uid14-2", "10Gi", "volume14-2", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -590,7 +613,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume binds an unspecified volumemode for claim to a specified filesystem volume
 			"14-3 - binding to volumeMode filesystem using default for claim",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "uid14-3", "claim14-3", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(nil, newClaimArray("claim14-3", "uid14-3", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(nil, newClaimArray("claim14-3", "uid14-3", "10Gi", "volume14-3", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -599,7 +622,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume binds a requested filesystem claim to an unspecified volumeMode for volume
 			"14-4 - binding to unspecified volumeMode using requested filesystem for claim",
-			withVolumeVolumeMode(nil, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(nil, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(nil, newVolumeArray("volume14-4", "10Gi", "uid14-4", "claim14-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-4", "uid14-4", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-4", "uid14-4", "10Gi", "volume14-4", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -608,7 +631,7 @@ func TestSync(t *testing.T) {
 		{
 			// syncVolume binds a requested filesystem claim to an unspecified volumeMode for volume
 			"14-5 - binding different volumeModes should be ignored",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-5", "10Gi", "uid14-5", "claim14-5", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5", "uid14-5", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5", "uid14-5", "10Gi", "volume14-5", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -637,7 +660,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds a requested block claim to a block volume
 			"14-1 - binding to volumeMode block",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-1", "10Gi", "uid14-1", "claim14-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-1", "uid14-1", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-1", "uid14-1", "10Gi", "volume14-1", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -646,7 +669,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds a requested filesystem claim to a filesystem volume
 			"14-2 - binding to volumeMode filesystem",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-2", "10Gi", "uid14-2", "claim14-2", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-2", "uid14-2", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-2", "uid14-2", "10Gi", "volume14-2", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -655,8 +678,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind to an unspecified volumemode for claim to a specified filesystem volume
 			"14-3 - do not bind pv volumeMode filesystem and pvc volumeMode block",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-3", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-3", "uid14-3", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-3", "uid14-3", "10Gi", "", v1.ClaimPending, nil)),
 			[]string{"Normal FailedBinding"},
@@ -665,8 +688,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind a requested filesystem claim to an unspecified volumeMode for volume
 			"14-4 - do not bind pv volumeMode block and pvc volumeMode filesystem",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-4", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-4", "uid14-4", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-4", "uid14-4", "10Gi", "", v1.ClaimPending, nil)),
 			[]string{"Normal FailedBinding"},
@@ -675,8 +698,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind when matching class but not matching volumeModes
 			"14-5 - do not bind when matching class but not volumeMode",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-5", "uid14-5", "10Gi", "", v1.ClaimPending, &classGold)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-5", "uid14-5", "10Gi", "", v1.ClaimPending, &classGold)),
 			[]string{"Warning ProvisioningFailed"},
@@ -685,8 +708,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind when matching volumeModes but class does not match
 			"14-5-1 - do not bind when matching volumeModes but class does not match",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-1", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-1", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5-1", "uid14-5-1", "10Gi", "", v1.ClaimPending, &classSilver)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5-1", "uid14-5-1", "10Gi", "", v1.ClaimPending, &classSilver)),
 			[]string{"Warning ProvisioningFailed"},
@@ -695,8 +718,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind when pvc is prebound to pv with matching volumeModes but class does not match
 			"14-5-2 - do not bind when pvc is prebound to pv with matching volumeModes but class does not match",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-2", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-5-2", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5-2", "uid14-5-2", "10Gi", "volume14-5-2", v1.ClaimPending, &classSilver)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-5-2", "uid14-5-2", "10Gi", "volume14-5-2", v1.ClaimPending, &classSilver)),
 			[]string{"Warning VolumeMismatch"},
@@ -705,7 +728,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume bind when pv is prebound and volumeModes match
 			"14-7 - bind when pv volume is prebound and volumeModes match",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-7", "10Gi", "", "claim14-7", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-7", "10Gi", "", "claim14-7", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-7", "10Gi", "uid14-7", "claim14-7", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-7", "uid14-7", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-7", "uid14-7", "10Gi", "volume14-7", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -714,8 +737,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind when pvc is prebound to pv with mismatching volumeModes
 			"14-8 - do not bind when pvc is prebound to pv with mismatching volumeModes",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-8", "uid14-8", "10Gi", "volume14-8", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-8", "uid14-8", "10Gi", "volume14-8", v1.ClaimPending, nil)),
 			[]string{"Warning VolumeMismatch"},
@@ -724,8 +747,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// failed syncVolume do not bind when pvc is prebound to pv with mismatching volumeModes
 			"14-8-1 - do not bind when pvc is prebound to pv with mismatching volumeModes",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8-1", "10Gi", "", "claim14-8-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8-1", "10Gi", "", "claim14-8-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8-1", "10Gi", "", "claim14-8-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-8-1", "10Gi", "", "claim14-8-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-8-1", "uid14-8-1", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-8-1", "uid14-8-1", "10Gi", "", v1.ClaimPending, nil)),
 			[]string{"Normal FailedBinding"},
@@ -734,7 +757,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds when pvc is prebound to pv with matching volumeModes block
 			"14-9 - bind when pvc is prebound to pv with matching volumeModes block",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-9", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-9", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-9", "10Gi", "uid14-9", "claim14-9", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-9", "uid14-9", "10Gi", "volume14-9", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-9", "uid14-9", "10Gi", "volume14-9", v1.ClaimBound, nil, annBindCompleted)),
@@ -743,7 +766,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds when pv is prebound to pvc with matching volumeModes block
 			"14-10 - bind when pv is prebound to pvc with matching volumeModes block",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-10", "10Gi", "", "claim14-10", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-10", "10Gi", "", "claim14-10", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-10", "10Gi", "uid14-10", "claim14-10", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-10", "uid14-10", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-10", "uid14-10", "10Gi", "volume14-10", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -752,7 +775,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds when pvc is prebound to pv with matching volumeModes filesystem
 			"14-11 - bind when pvc is prebound to pv with matching volumeModes filesystem",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-11", "10Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-11", "10Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-11", "10Gi", "uid14-11", "claim14-11", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-11", "uid14-11", "10Gi", "volume14-11", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-11", "uid14-11", "10Gi", "volume14-11", v1.ClaimBound, nil, annBindCompleted)),
@@ -761,7 +784,7 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume binds when pv is prebound to pvc with matching volumeModes filesystem
 			"14-12 - bind when pv is prebound to pvc with matching volumeModes filesystem",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-12", "10Gi", "", "claim14-12", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-12", "10Gi", "", "claim14-12", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-12", "10Gi", "uid14-12", "claim14-12", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-12", "uid14-12", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-12", "uid14-12", "10Gi", "volume14-12", v1.ClaimBound, nil, annBoundByController, annBindCompleted)),
@@ -770,8 +793,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume output warning when pv is prebound to pvc with mismatching volumeMode
 			"14-13 - output warning when pv is prebound to pvc with different volumeModes",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-13", "10Gi", "uid14-13", "claim14-13", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-13", "10Gi", "uid14-13", "claim14-13", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-13", "10Gi", "uid14-13", "claim14-13", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-13", "10Gi", "uid14-13", "claim14-13", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-13", "uid14-13", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-13", "uid14-13", "10Gi", "", v1.ClaimPending, nil)),
 			[]string{"Warning VolumeMismatch"},
@@ -780,8 +803,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume output warning when pv is prebound to pvc with mismatching volumeMode
 			"14-13-1 - output warning when pv is prebound to pvc with different volumeModes",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-13-1", "10Gi", "uid14-13-1", "claim14-13-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-13-1", "10Gi", "uid14-13-1", "claim14-13-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-13-1", "10Gi", "uid14-13-1", "claim14-13-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-13-1", "10Gi", "uid14-13-1", "claim14-13-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-13-1", "uid14-13-1", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-13-1", "uid14-13-1", "10Gi", "", v1.ClaimPending, nil)),
 			[]string{"Warning VolumeMismatch"},
@@ -790,8 +813,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume waits for synClaim without warning when pv is prebound to pvc with matching volumeMode block
 			"14-14 - wait for synClaim without warning when pv is prebound to pvc with matching volumeModes block",
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-14", "10Gi", "uid14-14", "claim14-14", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
-			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-14", "10Gi", "uid14-14", "claim14-14", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-14", "10Gi", "uid14-14", "claim14-14", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeBlock, newVolumeArray("volume14-14", "10Gi", "uid14-14", "claim14-14", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-14", "uid14-14", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeBlock, newClaimArray("claim14-14", "uid14-14", "10Gi", "", v1.ClaimPending, nil)),
 			noevents, noerrors, testSyncVolume,
@@ -799,8 +822,8 @@ func TestSyncAlphaBlockVolume(t *testing.T) {
 		{
 			// syncVolume waits for synClaim without warning when pv is prebound to pvc with matching volumeMode file
 			"14-14-1 - wait for synClaim without warning when pv is prebound to pvc with matching volumeModes file",
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-14-1", "10Gi", "uid14-14-1", "claim14-14-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
-			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-14-1", "10Gi", "uid14-14-1", "claim14-14-1", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-14-1", "10Gi", "uid14-14-1", "claim14-14-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
+			withVolumeVolumeMode(&modeFile, newVolumeArray("volume14-14-1", "10Gi", "uid14-14-1", "claim14-14-1", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty, annBoundByController)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-14-1", "uid14-14-1", "10Gi", "", v1.ClaimPending, nil)),
 			withClaimVolumeMode(&modeFile, newClaimArray("claim14-14-1", "uid14-14-1", "10Gi", "", v1.ClaimPending, nil)),
 			noevents, noerrors, testSyncVolume,

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -1222,6 +1222,9 @@ func (plugin *mockVolumePlugin) Provision(selectedNode *v1.Node, allowedTopologi
 					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{},
 				},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		}
 	}
 

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -213,6 +213,9 @@ func TestMatchingWithBoundVolumes(t *testing.T) {
 			// this one we're pretending is already bound
 			ClaimRef: &v1.ObjectReference{UID: "abc123"},
 		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeBound,
+		},
 	}
 
 	pv2 := &v1.PersistentVolume{
@@ -228,6 +231,9 @@ func TestMatchingWithBoundVolumes(t *testing.T) {
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
 		},
 	}
 
@@ -330,6 +336,9 @@ func TestFindingVolumeWithDifferentAccessModes(t *testing.T) {
 				v1.ReadOnlyMany,
 			},
 		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
+		},
 	}
 
 	ebs := &v1.PersistentVolume{
@@ -340,6 +349,9 @@ func TestFindingVolumeWithDifferentAccessModes(t *testing.T) {
 			AccessModes: []v1.PersistentVolumeAccessMode{
 				v1.ReadWriteOnce,
 			},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
 		},
 	}
 
@@ -353,6 +365,9 @@ func TestFindingVolumeWithDifferentAccessModes(t *testing.T) {
 				v1.ReadOnlyMany,
 				v1.ReadWriteMany,
 			},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
 		},
 	}
 
@@ -442,6 +457,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadOnlyMany,
 				},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -462,6 +480,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				// this one we're pretending is already bound
 				ClaimRef: &v1.ObjectReference{UID: "def456"},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeBound,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -480,6 +501,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadOnlyMany,
 					v1.ReadWriteMany,
 				},
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -501,6 +525,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				// this one we're pretending is already bound
 				ClaimRef: &v1.ObjectReference{UID: "abc123"},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeBound,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -520,6 +547,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadWriteMany,
 				},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -537,6 +567,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadWriteOnce,
 					v1.ReadOnlyMany,
 				},
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -557,6 +590,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadWriteMany,
 				},
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -576,6 +612,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				AccessModes: []v1.PersistentVolumeAccessMode{
 					v1.ReadWriteOnce,
 				},
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -598,6 +637,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				},
 				StorageClassName: classSilver,
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -616,6 +658,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				},
 				StorageClassName: classSilver,
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -633,6 +678,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadWriteOnce,
 				},
 				StorageClassName: classGold,
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -654,6 +702,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				},
 				StorageClassName: classLarge,
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -673,6 +724,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 					v1.ReadWriteMany,
 				},
 				StorageClassName: classLarge,
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -694,6 +748,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				StorageClassName: classWait,
 				NodeAffinity:     getVolumeNodeAffinity("key1", "value1"),
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -713,6 +770,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				},
 				StorageClassName: classWait,
 				NodeAffinity:     getVolumeNodeAffinity("key1", "value1"),
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 		{
@@ -735,6 +795,9 @@ func createTestVolumes() []*v1.PersistentVolume {
 				ClaimRef:         &v1.ObjectReference{Name: "claim02", Namespace: "myns"},
 				NodeAffinity:     getVolumeNodeAffinity("key1", "value1"),
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -755,6 +818,98 @@ func createTestVolumes() []*v1.PersistentVolume {
 				StorageClassName: classWait,
 				NodeAffinity:     getVolumeNodeAffinity("key1", "value3"),
 			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "affinity-pv4-pending",
+				Name: "affinity004-pending",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("200G"),
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					Local: &v1.LocalVolumeSource{},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+					v1.ReadOnlyMany,
+				},
+				StorageClassName: classWait,
+				NodeAffinity:     getVolumeNodeAffinity("key1", "value4"),
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumePending,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "affinity-pv4-failed",
+				Name: "affinity004-failed",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("200G"),
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					Local: &v1.LocalVolumeSource{},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+					v1.ReadOnlyMany,
+				},
+				StorageClassName: classWait,
+				NodeAffinity:     getVolumeNodeAffinity("key1", "value4"),
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeFailed,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "affinity-pv4-released",
+				Name: "affinity004-released",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("200G"),
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					Local: &v1.LocalVolumeSource{},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+					v1.ReadOnlyMany,
+				},
+				StorageClassName: classWait,
+				NodeAffinity:     getVolumeNodeAffinity("key1", "value4"),
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeReleased,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "affinity-pv4-empty",
+				Name: "affinity004-empty",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("200G"),
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					Local: &v1.LocalVolumeSource{},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+					v1.ReadOnlyMany,
+				},
+				StorageClassName: classWait,
+				NodeAffinity:     getVolumeNodeAffinity("key1", "value4"),
+			},
 		},
 	}
 }
@@ -769,6 +924,9 @@ func testVolume(name, size string) *v1.PersistentVolume {
 			Capacity:               v1.ResourceList{v1.ResourceName(v1.ResourceStorage): resource.MustParse(size)},
 			PersistentVolumeSource: v1.PersistentVolumeSource{HostPath: &v1.HostPathVolumeSource{}},
 			AccessModes:            []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
 		},
 	}
 }
@@ -811,6 +969,9 @@ func createVolumeModeBlockTestVolume() *v1.PersistentVolume {
 			},
 			VolumeMode: &blockMode,
 		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
+		},
 	}
 }
 
@@ -833,6 +994,9 @@ func createVolumeModeFilesystemTestVolume() *v1.PersistentVolume {
 				v1.ReadWriteOnce,
 			},
 			VolumeMode: &filesystemMode,
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
 		},
 	}
 }
@@ -1054,6 +1218,9 @@ func TestAlphaStorageObjectInUseProtectionFiltering(t *testing.T) {
 			PersistentVolumeSource: v1.PersistentVolumeSource{HostPath: &v1.HostPathVolumeSource{}},
 			AccessModes:            []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
+		},
 	}
 
 	pvToDelete := pv.DeepCopy()
@@ -1274,6 +1441,11 @@ func TestFindMatchVolumeWithNode(t *testing.T) {
 			Labels: map[string]string{"key1": "value3"},
 		},
 	}
+	node4 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"key1": "value4"},
+		},
+	}
 
 	scenarios := map[string]struct {
 		expectedMatch   string
@@ -1340,6 +1512,15 @@ func TestFindMatchVolumeWithNode(t *testing.T) {
 				pvc.Name = "claim02"
 			}),
 			node: node3,
+		},
+		"fail-nonavaiable": {
+			expectedMatch: "",
+			claim: makePVC("100G", func(pvc *v1.PersistentVolumeClaim) {
+				pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+				pvc.Spec.StorageClassName = &classWait
+				pvc.Name = "claim04"
+			}),
+			node: node4,
 		},
 		"success-bad-and-good-node-affinity": {
 			expectedMatch: "affinity-pv3",

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -166,7 +166,7 @@ func TestProvisionSync(t *testing.T) {
 		{
 			// No provisioning if there is a matching volume available
 			"11-6 - provisioning when there is a volume available",
-			newVolumeArray("volume11-6", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain, classGold),
+			newVolumeArray("volume11-6", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classGold),
 			newVolumeArray("volume11-6", "1Gi", "uid11-6", "claim11-6", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classGold, annBoundByController),
 			newClaimArray("claim11-6", "uid11-6", "1Gi", "", v1.ClaimPending, &classGold),
 			newClaimArray("claim11-6", "uid11-6", "1Gi", "volume11-6", v1.ClaimBound, &classGold, annBoundByController, annBindCompleted),

--- a/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
+++ b/pkg/controller/volume/persistentvolume/scheduler_binder_test.go
@@ -494,6 +494,9 @@ func makeTestPV(name, node, capacity, version string, boundToPVC *v1.PersistentV
 			},
 			StorageClassName: className,
 		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: v1.VolumeAvailable,
+		},
 	}
 	if node != "" {
 		pv.Spec.NodeAffinity = getVolumeNodeAffinity(nodeLabelKey, node)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Ignore non-available volumes in findMatchingVolume to reduce chance of unnecessary binding failures.

Especially for scheduler volume binding, newly created volumes will be updated to Available phase by PV controller, which will fail assuming pod volumes and results in partial binding failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68391

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```