### PR TITLE
Fix Redis StatefulSet e2e test

### DIFF
--- a/test/e2e/testing-manifests/statefulset/redis/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/service.yaml
@@ -13,3 +13,4 @@ spec:
   clusterIP: None
   selector:
     app: redis
+  publishNotReadyAddresses: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This fixes the Redis StatefulSet e2e test by adding the missing `publishNotReadyAddresses: true` field, which was accidentially left out in #63742.

Without this fix, the redis e2e test will fail because the pod is unable
to lookup the service:

```
2018/09/14 13:57:10 lookup redis on 172.31.9.247:53: no such host
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
