### PR TITLE
Fix chown on distributed flex volumes (like gluster)

### DIFF
--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -223,6 +223,7 @@ type DriverCapabilities struct {
 	Attach          bool `json:"attach"`
 	SELinuxRelabel  bool `json:"selinuxRelabel"`
 	SupportsMetrics bool `json:"supportsMetrics"`
+	FSGroup         bool `json:"fsGroup"`
 }
 
 func defaultCapabilities() *DriverCapabilities {
@@ -230,6 +231,7 @@ func defaultCapabilities() *DriverCapabilities {
 		Attach:          true,
 		SELinuxRelabel:  true,
 		SupportsMetrics: false,
+		FSGroup:         true,
 	}
 }
 

--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -92,7 +92,9 @@ func (f *flexVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if !f.readOnly {
-		volume.SetVolumeOwnership(f, fsGroup)
+		if f.plugin.capabilities.FSGroup {
+			volume.SetVolumeOwnership(f, fsGroup)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
FlexVolume mount operation is performing by default the change of volume ownership when fsGroup is provided.
```
volume.SetVolumeOwnership(f, fsGroup)
```

The problem is that when performing that on distributed volumes like a gluster volume, when mounting the volume into a pod, there is big `chown` operation running on all files on this volume.
For example, as we may always get the same volume for the same user, k8s is trying to perform a lot of  `chown` operations . If there are few files on the volume it’s immediate but with like 5K files, etc it takes a huge time

With the provided patch, the driver capability `fsGroup:false` would skip that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68137

**Release note**:
```release-note
Provides FSGroup capability on FlexVolume driver. It allows to disable the VolumeOwnership operation when volume is mounted
```

/sig-storage