### PR TITLE
[kubeadm] warn if the CIDR is missing

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -465,8 +465,9 @@ func (HTTPProxyCIDRCheck) Name() string {
 // If it is not directly connected and goes via proxy it will produce warning.
 func (subnet HTTPProxyCIDRCheck) Check() (warnings, errors []error) {
 	glog.V(1).Infoln("validating http connectivity to first IP address in the CIDR")
+	// Check if the CIDR is missing
 	if len(subnet.CIDR) == 0 {
-		return nil, nil
+		return []error{fmt.Errorf("the CIDR is missing")}, nil
 	}
 
 	_, cidr, err := net.ParseCIDR(subnet.CIDR)

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -502,6 +502,13 @@ func TestHTTPProxyCIDRCheck(t *testing.T) {
 			}, // Expected to go via proxy, range is not in 2001:db8::/48
 			expectWarnings: true,
 		},
+		{
+			check: HTTPProxyCIDRCheck{
+				Proto: "https",
+				CIDR:  "",
+			}, // Expected to warn, when the CIDR is missing
+			expectWarnings: true,
+		},
 	}
 
 	// Save current content of *_proxy and *_PROXY variables.


### PR DESCRIPTION
**What this PR does / why we need it**:
warn if the CIDR is missing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [kubernetes/kubeadm/#1011](https://github.com/kubernetes/kubeadm/issues/1011)

**Special notes for your reviewer**:
/assign @stealthybox 
/assign @neolit123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
