### PR TITLE
Correctly handle TTLs on update

### DIFF
--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -49,6 +49,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 		NewListFunc:   func() runtime.Object { return &api.EventList{} },
 		PredicateFunc: event.MatchEvent,
 		TTLFunc: func(runtime.Object, uint64, bool) (uint64, error) {
+			// this means that on every update, bump the TTL
+			// so an event expires at last modified time + ttl
+			// the last modified timestamp is not stored
 			return ttl, nil
 		},
 		DefaultQualifiedResource: resource,

--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -49,9 +49,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 		NewListFunc:   func() runtime.Object { return &api.EventList{} },
 		PredicateFunc: event.MatchEvent,
 		TTLFunc: func(runtime.Object, uint64, bool) (uint64, error) {
-			// this means that on every update, bump the TTL
-			// so an event expires at last modified time + ttl
-			// the last modified timestamp is not stored
+			// bump the TTL on every update so events expire at lastTimestamp + TTL
 			return ttl, nil
 		},
 		DefaultQualifiedResource: resource,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -48,6 +48,8 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/storage/testing:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
+        "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
+        "//vendor/github.com/coreos/etcd/mvcc/mvccpb:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -33,7 +33,7 @@ func (s *DryRunnableStorage) Versioner() storage.Versioner {
 	return s.Storage.Versioner()
 }
 
-func (s *DryRunnableStorage) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64, dryRun bool) error {
+func (s *DryRunnableStorage) Create(ctx context.Context, key string, obj, out runtime.Object, ttl *uint64, dryRun bool) error {
 	if dryRun {
 		if err := s.Storage.Get(ctx, key, "", out, false); err == nil {
 			return storage.NewKeyExistsError(key, 0)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun_test.go
@@ -63,7 +63,7 @@ func TestDryRunCreateDoesntCreate(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, true)
+	err := s.Create(context.Background(), "key", obj, out, nil, true)
 	if err != nil {
 		t.Fatalf("Failed to create new dry-run object: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestDryRunCreateReturnsObject(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, true)
+	err := s.Create(context.Background(), "key", obj, out, nil, true)
 	if err != nil {
 		t.Fatalf("Failed to create new dry-run object: %v", err)
 	}
@@ -98,12 +98,12 @@ func TestDryRunCreateExistingObjectFails(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
 
-	err = s.Create(context.Background(), "key", obj, out, 0, true)
+	err = s.Create(context.Background(), "key", obj, out, nil, true)
 	if e, ok := err.(*storage.StorageError); !ok || e.Code != storage.ErrCodeKeyExists {
 		t.Errorf("Expected KeyExists error: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestDryRunUpdatePreconditions(t *testing.T) {
 
 	obj := UnstructuredOrDie(`{"kind": "Pod", "metadata": {"uid": "my-uid"}}`)
 	out := UnstructuredOrDie(`{}`)
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestDryRunUpdateDoesntUpdate(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	created := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, created, 0, false)
+	err := s.Create(context.Background(), "key", obj, created, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestDryRunUpdateReturnsObject(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestDryRunDeleteDoesntDelete(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestDryRunDeleteReturnsObject(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod"}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestDryRunDeletePreconditions(t *testing.T) {
 	obj := UnstructuredOrDie(`{"kind": "Pod", "metadata": {"uid": "my-uid"}}`)
 	out := UnstructuredOrDie(`{}`)
 
-	err := s.Create(context.Background(), "key", obj, out, 0, false)
+	err := s.Create(context.Background(), "key", obj, out, nil, false)
 	if err != nil {
 		t.Fatalf("Failed to create new object: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -346,13 +346,9 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 		return nil, err
 	}
 	qualifiedResource := e.qualifiedResourceFromContext(ctx)
-	var ttl uint64
-	ttlPtr, err := e.calculateTTL(obj, 0, false)
+	ttl, err := e.calculateTTL(obj, 0, false)
 	if err != nil {
 		return nil, err
-	}
-	if ttlPtr != nil {
-		ttl = *ttlPtr
 	}
 	out := e.NewFunc()
 	if err := e.Storage.Create(ctx, key, obj, out, ttl, dryrun.IsDryRun(options.DryRun)); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -850,12 +850,12 @@ func TestReuseLeaseOnUpdate(t *testing.T) {
 	// store updated pod
 	updated := getPod()
 
-	// make sure ETCD considers this to be the same key
+	// make sure etcd considers this to be the same key
 	if created.CreateRevision != updated.CreateRevision {
 		t.Errorf("expected same create revision: create=%#v updated=%#v", created, updated)
 	}
 
-	// make sure ETCD saw this as a write
+	// make sure etcd saw this as a write
 	if created.ModRevision == updated.ModRevision {
 		t.Errorf("expected different resource version on mutating update: create=%#v updated=%#v", created, updated)
 	}
@@ -883,7 +883,7 @@ func TestReuseLeaseOnUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// ETCD3 lease manager adds 5% to the requested TTL
+	// etcd3 lease manager adds 5% to the requested TTL
 	// see newDefaultLeaseManager if this breaks
 	if ttlResp.GrantedTTL != defaultLeaseTTL+defaultLeaseTTL/20 {
 		t.Errorf("expected lease to match initial TTL request: %#v", ttlResp)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -279,7 +279,7 @@ func (c *Cacher) Versioner() storage.Versioner {
 }
 
 // Create implements storage.Interface.
-func (c *Cacher) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+func (c *Cacher) Create(ctx context.Context, key string, obj, out runtime.Object, ttl *uint64) error {
 	return c.storage.Create(ctx, key, obj, out, ttl)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -107,7 +107,7 @@ func (h *etcdHelper) Versioner() storage.Versioner {
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+func (h *etcdHelper) Create(ctx context.Context, key string, obj, out runtime.Object, ttl *uint64) error {
 	trace := utiltrace.New("etcdHelper::Create " + getTypeName(obj))
 	defer trace.LogIfLong(250 * time.Millisecond)
 	if ctx == nil {
@@ -127,9 +127,14 @@ func (h *etcdHelper) Create(ctx context.Context, key string, obj, out runtime.Ob
 	}
 	trace.Step("Version checked")
 
+	var ttlDuration time.Duration
+	if ttl != nil {
+		ttlDuration = time.Duration(*ttl) * time.Second
+	}
+
 	startTime := time.Now()
 	opts := etcd.SetOptions{
-		TTL:       time.Duration(ttl) * time.Second,
+		TTL:       ttlDuration,
 		PrevExist: etcd.PrevNoExist,
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -107,7 +107,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("expecting empty result on key: %s", key)
 	}
 
-	err = store.Create(ctx, key, obj, out, 0)
+	err = store.Create(ctx, key, obj, out, nil)
 	if err != nil {
 		t.Fatalf("Set failed: %v", err)
 	}
@@ -154,7 +154,8 @@ func TestCreateWithTTL(t *testing.T) {
 	key := "/somekey"
 
 	out := &example.Pod{}
-	if err := store.Create(ctx, key, input, out, 1); err != nil {
+	ttl := uint64(1)
+	if err := store.Create(ctx, key, input, out, &ttl); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
@@ -171,7 +172,7 @@ func TestCreateWithKeyExist(t *testing.T) {
 	obj := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 	key, _ := testPropogateStore(ctx, t, store, obj)
 	out := &example.Pod{}
-	err := store.Create(ctx, key, obj, out, 0)
+	err := store.Create(ctx, key, obj, out, nil)
 	if err == nil || !storage.IsNodeExist(err) {
 		t.Errorf("expecting key exists error, but get: %s", err)
 	}
@@ -968,7 +969,7 @@ func TestTransformationFailure(t *testing.T) {
 	}}
 	for i, ps := range preset[:1] {
 		preset[i].storedObj = &example.Pod{}
-		err := store.Create(ctx, ps.key, ps.obj, preset[:1][i].storedObj, 0)
+		err := store.Create(ctx, ps.key, ps.obj, preset[:1][i].storedObj, nil)
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)
 		}
@@ -979,7 +980,7 @@ func TestTransformationFailure(t *testing.T) {
 	store.transformer = prefixTransformer{prefix: []byte("otherprefix!")}
 	for i, ps := range preset[1:] {
 		preset[1:][i].storedObj = &example.Pod{}
-		err := store.Create(ctx, ps.key, ps.obj, preset[1:][i].storedObj, 0)
+		err := store.Create(ctx, ps.key, ps.obj, preset[1:][i].storedObj, nil)
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)
 		}
@@ -1077,7 +1078,7 @@ func TestList(t *testing.T) {
 
 	for i, ps := range preset {
 		preset[i].storedObj = &example.Pod{}
-		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, 0)
+		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, nil)
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)
 		}
@@ -1382,7 +1383,7 @@ func TestListContinuation(t *testing.T) {
 
 	for i, ps := range preset {
 		preset[i].storedObj = &example.Pod{}
-		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, 0)
+		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, nil)
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)
 		}
@@ -1493,7 +1494,7 @@ func TestListInconsistentContinuation(t *testing.T) {
 
 	for i, ps := range preset {
 		preset[i].storedObj = &example.Pod{}
-		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, 0)
+		err := store.Create(ctx, ps.key, ps.obj, preset[i].storedObj, nil)
 		if err != nil {
 			t.Fatalf("Set failed: %v", err)
 		}
@@ -1621,7 +1622,7 @@ func testPropogateStore(ctx context.Context, t *testing.T, store *store, obj *ex
 		t.Fatalf("Cleanup failed: %v", err)
 	}
 	setOutput := &example.Pod{}
-	if err := store.Create(ctx, key, obj, setOutput, 0); err != nil {
+	if err := store.Create(ctx, key, obj, setOutput, nil); err != nil {
 		t.Fatalf("Set failed: %v", err)
 	}
 	return key, setOutput

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -210,7 +210,12 @@ type Interface interface {
 	//       curr.Counter++
 	//
 	//       // Return the modified object - return an error to stop iterating. Return
-	//       // a uint64 to alter the TTL on the object, or nil to keep it the same value.
+	//       // a uint64 to alter the TTL on the object, or res.TTL to keep it the same value.
+	//       // Returning a zero TTL when the object previously had a TTL means "remove the TTL."
+	//       // Returning a nonzero TTL when the object previously had no TTL means "add this TTL."
+	//       // Returning a nil TTL when the object previously had no TTL means "no TTL."
+	//       // Returning a nil TTL when the object previously had a TTL is an error
+	//       // and will lead to undefined behavior.
 	//       return cur, nil, nil
 	//    }
 	// })

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -140,7 +140,7 @@ type Interface interface {
 	// Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
 	// in seconds (0 means forever). If no error is returned and out is not nil, out will be
 	// set to the read value from database.
-	Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error
+	Create(ctx context.Context, key string, obj, out runtime.Object, ttl *uint64) error
 
 	// Delete removes the specified key and returns the value that existed at that spot.
 	// If key didn't exist, it will return NotFound storage error.

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -26,8 +26,8 @@ import (
 )
 
 // CreateObj will create a single object using the storage interface
-func CreateObj(helper storage.Interface, name string, obj, out runtime.Object, ttl uint64) error {
-	return helper.Create(context.TODO(), name, obj, out, ttl)
+func CreateObj(helper storage.Interface, name string, obj, out runtime.Object) error {
+	return helper.Create(context.TODO(), name, obj, out, nil)
 }
 
 //CreateObjList will create a list from the array of objects
@@ -38,7 +38,7 @@ func CreateObjList(prefix string, helper storage.Interface, items []runtime.Obje
 		if err != nil {
 			return err
 		}
-		err = CreateObj(helper, path.Join(prefix, meta.GetName()), obj, obj, 0)
+		err = CreateObj(helper, path.Join(prefix, meta.GetName()), obj, obj)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change updates the ETCD3 objState to store the associated lease ID.  If the objState has an associated lease, the value is used to look up the remaining TTL.  This value is used to populate the ResponseMeta.TTL field which is passed to TTLFuncs as the existing TTL value.

This guarantees that an object with a TTLFunc can reliably use the existing TTL value on update.  Furthermore, as an optimization, objects that use the existing TTL on update will reuse the same lease.

If an object with a TTL is updated, it will ignore the suggestion from the watch cache and instead directly pull from ETCD.  This could have some performance implications for TTL'd resources that rely on the watch cache as an optimization.  No such resource exists in core Kubernetes today.

To understand the underlying issue, one must look at how TTLFunc is defined today:

```go
// TTLFunc returns the TTL (time to live) that objects should be persisted
// with. The existing parameter is the current TTL or the default for this
// operation. The update parameter indicates whether this is an operation
// against an existing object.
//
// Objects that are persisted with a TTL are evicted once the TTL expires.
TTLFunc func(obj runtime.Object, existing uint64, update bool) (uint64, error)
```

In the ETCD2 code, when `update` was `true`, you could simply `return existing` if you wanted to leave the TTL value unchanged. Getting this same behavior with ETCD3 is more difficult since you have to deal with an extra API (leases) and the watch cache (data from the cache does not have lease/TTL information).

The code as it stands today, with ETCD3, always sets `existing` to `0` because it does not fetch the lease to retrieve the current TTL value. This change corrects that deficit as best as it can while preserving the watch cache optimization for all non-TTL'd objects.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/kind bug
@kubernetes/sig-api-machinery-pr-reviews

```release-note
NONE
```