### PR TITLE
shutdown schedulingQueue gracefully

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -332,6 +332,7 @@ func NewConfigFactory(args *ConfigFactoryArgs) scheduler.Configurator {
 		for {
 			select {
 			case <-c.StopEverything:
+				c.podQueue.Close()
 				return
 			case <-ch:
 				comparer.Compare()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -396,6 +396,10 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 // scheduleOne does the entire scheduling workflow for a single pod.  It is serialized on the scheduling algorithm's host fitting.
 func (sched *Scheduler) scheduleOne() {
 	pod := sched.config.NextPod()
+	// pod could be nil when schedulerQueue is closed
+	if pod == nil {
+		return
+	}
 	if pod.DeletionTimestamp != nil {
 		sched.config.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", "skip schedule deleting pod: %v/%v", pod.Namespace, pod.Name)
 		glog.V(3).Infof("Skip schedule deleting pod: %v/%v", pod.Namespace, pod.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

When schedulingQueue is empty, scheduler is blocked to wait for new items (through `cond.Wait()`). At this time if stopCh() is closed(), actually the main scheduling goroutine has no chance to gracefully exit - it's still hanging there at step `cond.Wait()`.

It's not actually a bug, but it's good to add a fix to let scheduling goroutine exit gracefully in this case.

**Which issue(s) this PR fixes**:
Fixes #68453

**Special notes for your reviewer**:

- I'm only aware of FIFO and PriorityQueue implements schedulingQueue. If there are others, please let me know
- External scheduler implementation might be impacted  as a new `Close()` method is introduced in interface `SchedulingQueue`.

**Release note**:
```release-note
NONE
```

/kind cleanup
/sig scheduling
/assign @k82cn 
