### PR TITLE
gce: check nil pointer in convertToV1Operation() function

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_op.go
+++ b/pkg/cloudprovider/providers/gce/gce_op.go
@@ -168,6 +168,9 @@ func (gce *GCECloud) waitForZoneOpInProject(op gceObject, projectID, zone string
 }
 
 func convertToV1Operation(object gceObject) *computev1.Operation {
+	if object == nil {
+		return nil
+	}
 	enc, err := object.MarshalJSON()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to encode to json: %v", err))

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -547,6 +547,13 @@ func TestConvertToV1Operation(t *testing.T) {
 	} else {
 		t.Errorf("Expect output to be type v1 operation, but got %v", op)
 	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panicked with nil input")
+		}
+	}()
+	op = convertToV1Operation(nil)
 }
 
 func getTestOperation() *computev1.Operation {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add checking of nil pointer in function `convertToV1Operation()` in gce_op.go

**Which issue(s) this PR fixes**:
Calling this function with nil input will cause panic.  For example, [this function](https://github.com/kubernetes/kubernetes/blob/d0c5edcb8f38d58ae69cb89a391317ef232cc1e6/pkg/cloudprovider/providers/gce/gce_op.go#L137) could return `op` as nil, which is then passed to `convertToV1Operation()` as input.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
