### PR TITLE
Add ssh-login check and test requirement comment

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -48,6 +48,8 @@ var _ = SIGDescribe("Network", func() {
 	fr := framework.NewDefaultFramework("network")
 
 	It("should set TCP CLOSE_WAIT timeout", func() {
+		// This test requires that e2e test runner can ssh-login to
+		// schedulable nodes.
 		nodes := framework.GetReadySchedulableNodesOrDie(fr.ClientSet)
 		ips := framework.CollectAddresses(nodes, v1.NodeInternalIP)
 
@@ -170,11 +172,12 @@ var _ = SIGDescribe("Network", func() {
 		By("Checking /proc/net/nf_conntrack for the timeout")
 		// If test flakes occur here, then this check should be performed
 		// in a loop as there may be a race with the client connecting.
-		framework.IssueSSHCommandWithResult(
+		_, err = framework.IssueSSHCommandWithResult(
 			fmt.Sprintf("sudo cat /proc/net/nf_conntrack | grep 'dport=%v'",
 				testDaemonTcpPort),
 			framework.TestContext.Provider,
 			clientNodeInfo.node)
+		framework.ExpectNoError(err)
 
 		// Timeout in seconds is available as the fifth column from
 		// /proc/net/nf_conntrack.


### PR DESCRIPTION
**What this PR does / why we need it**:

e2e "[sig-network] Network [It] should set TCP CLOSE_WAIT timeout"
requires that e2e test runner can ssh-login to schedulable nodes
in the test to pass it. In addition, the first ssh-login was not
checked. This adds the corresponding check and the requirement
comment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68704

**Release note**:
NONE
