### PR TITLE
kubeadm: remove unit test TestNewCmdReset

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -68,22 +68,6 @@ func TestNewReset(t *testing.T) {
 	NewReset(in, ignorePreflightErrorsSet, forceReset, certsDir, criSocketPath)
 }
 
-func TestNewCmdReset(t *testing.T) {
-	var out io.Writer
-	var in io.Reader
-	cmd := NewCmdReset(in, out)
-
-	tmpDir, err := ioutil.TempDir("", "kubeadm-reset-test")
-	if err != nil {
-		t.Errorf("Unable to create temporary directory: %v", err)
-	}
-	args := []string{"--ignore-preflight-errors=all", "--cert-dir=" + tmpDir, "--force"}
-	cmd.SetArgs(args)
-	if err := cmd.Execute(); err != nil {
-		t.Errorf("Cannot execute reset command: %v", err)
-	}
-}
-
 func TestConfigDirCleaner(t *testing.T) {
 	tests := map[string]struct {
 		resetDir        string


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the test called TestNewCmdReset in cmd/reset_test.go, since it
can prompt for root password and it then calls an actual reset
and shuts down the kubelet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
i think i've added that last year...oops.
if there are other tests like that in k8s they should be removed!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/kind bug
/priority critical-urgent
/assign @fabriziopandini 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
