### PR TITLE
add metrics port to kube-dns service

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -99,6 +99,8 @@ spec:
         k8s-app: kube-dns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9153"
     spec:
       serviceAccountName: coredns
       tolerations:
@@ -162,9 +164,6 @@ kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
-  annotations:
-    prometheus.io/port: "9153"
-    prometheus.io/scrape: "true"
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -99,6 +99,8 @@ spec:
         k8s-app: kube-dns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9153"
     spec:
       serviceAccountName: coredns
       tolerations:
@@ -162,9 +164,6 @@ kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
-  annotations:
-    prometheus.io/port: "9153"
-    prometheus.io/scrape: "true"
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -99,6 +99,8 @@ spec:
         k8s-app: kube-dns
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9153"
     spec:
       serviceAccountName: coredns
       tolerations:
@@ -162,9 +164,6 @@ kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
-  annotations:
-    prometheus.io/port: "9153"
-    prometheus.io/scrape: "true"
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Metrics port must be defined for prometheus to be able to scrape these metrics
via service.

**What this PR does / why we need it**:

Prometheus scraping is enable for `kube-dns` service on port  `9153` but this port isn't included in ports under this service. It make scraping impossible.

**Special notes for your reviewer**:


**Release note**:

```release-note
NONE
```
