### PR TITLE
Add statefulset.kubernetes.io/pod-ordinal label

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -113,7 +113,8 @@ func identityMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 		set.Name == parent &&
 		pod.Name == getPodName(set, ordinal) &&
 		pod.Namespace == set.Namespace &&
-		pod.Labels[apps.StatefulSetPodNameLabel] == pod.Name
+		pod.Labels[apps.StatefulSetPodNameLabel] == pod.Name &&
+		pod.Labels[apps.StatefulSetPodOrdinalLabel] == fmt.Sprint(ordinal)
 }
 
 // storageMatches returns true if pod's Volumes cover the set of PersistentVolumeClaims
@@ -194,15 +195,17 @@ func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Spec.Subdomain = set.Spec.ServiceName
 }
 
-// updateIdentity updates pod's name, hostname, and subdomain, and StatefulSetPodNameLabel to conform to set's name
-// and headless service.
+// updateIdentity updates pod's name, hostname, and subdomain, StatefulSetPodNameLabel
+// and StatefulSetPodOrdinalLabel to conform to set's name and headless service.
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
-	pod.Name = getPodName(set, getOrdinal(pod))
+	ordinal := getOrdinal(pod)
+	pod.Name = getPodName(set, ordinal)
 	pod.Namespace = set.Namespace
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
 	pod.Labels[apps.StatefulSetPodNameLabel] = pod.Name
+	pod.Labels[apps.StatefulSetPodOrdinalLabel] = fmt.Sprint(ordinal)
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -84,6 +84,11 @@ func TestIdentityMatches(t *testing.T) {
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with the wrong statefulSetPodNameLabel")
 	}
+	pod = newStatefulSetPod(set, 1)
+	delete(pod.Labels, apps.StatefulSetPodOrdinalLabel)
+	if identityMatches(set, pod) {
+		t.Error("identity matches for a Pod with the wrong StatefulSetPodOrdinalLabel")
+	}
 }
 
 func TestStorageMatches(t *testing.T) {
@@ -137,6 +142,11 @@ func TestUpdateIdentity(t *testing.T) {
 	updateIdentity(set, pod)
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to restore the statefulSetPodName label")
+	}
+	delete(pod.Labels, apps.StatefulSetPodOrdinalLabel)
+	updateIdentity(set, pod)
+	if !identityMatches(set, pod) {
+		t.Error("updateIdentity failed to restore the statefulSetPodOrdinal label")
 	}
 }
 

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -533,12 +533,22 @@ message RollingUpdateStatefulSetStrategy {
   optional int32 partition = 1;
 }
 
-// StatefulSet represents a set of pods with consistent identities.
+// StatefulSet represents a set of Pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
 //  - Storage: As many VolumeClaims as requested.
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+//
+// For a StatefulSet with N replicas, each Pod in the StatefulSet will be
+// assigned an integer ordinal, from 0 up through N-1, that is unique
+// over the Set.
+//
+// Each Pod is assigned two labels based on its identity:
+//  - statefulset.kubernetes.io/pod-name: The unique name of the Pod.
+//  - statefulset.kubernetes.io/pod-ordinal: The ordinal number of the Pod in the StatefulSet.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 message StatefulSet {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -28,7 +28,13 @@ const (
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
-	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
+	// StatefulSetPodNameLabel corresponds to the unique name of each Pod.
+	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-name-label
+	StatefulSetPodNameLabel = "statefulset.kubernetes.io/pod-name"
+	// StatefulSetPodOrdinalLabel corresponds to the ordinal number of
+	// each Pod in a StatefulSet.
+	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#ordinal-index
+	StatefulSetPodOrdinalLabel = "statefulset.kubernetes.io/pod-ordinal"
 )
 
 // +genclient
@@ -36,12 +42,22 @@ const (
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// StatefulSet represents a set of pods with consistent identities.
+// StatefulSet represents a set of Pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
 //  - Storage: As many VolumeClaims as requested.
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+//
+// For a StatefulSet with N replicas, each Pod in the StatefulSet will be
+// assigned an integer ordinal, from 0 up through N-1, that is unique
+// over the Set.
+//
+// Each Pod is assigned two labels based on its identity:
+//  - statefulset.kubernetes.io/pod-name: The unique name of the Pod.
+//  - statefulset.kubernetes.io/pod-ordinal: The ordinal number of the Pod in the StatefulSet.
+//
+// More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1/types_swagger_doc_generated.go
@@ -289,7 +289,7 @@ func (RollingUpdateStatefulSetStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"":       "StatefulSet represents a set of Pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.\n\nFor a StatefulSet with N replicas, each Pod in the StatefulSet will be assigned an integer ordinal, from 0 up through N-1, that is unique over the Set.\n\nEach Pod is assigned two labels based on its identity:\n - statefulset.kubernetes.io/pod-name: The unique name of the Pod.\n - statefulset.kubernetes.io/pod-ordinal: The ordinal number of the Pod in the StatefulSet.\n\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/",
 	"spec":   "Spec defines the desired identities of pods in this set.",
 	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -27,6 +27,7 @@ const (
 	ControllerRevisionHashLabelKey = "controller-revision-hash"
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
+	StatefulSetPodOrdinalLabel     = "statefulset.kubernetes.io/pod-ordinal"
 )
 
 // ScaleSpec describes the attributes of a scale subresource

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -29,6 +29,7 @@ const (
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
+	StatefulSetPodOrdinalLabel     = "statefulset.kubernetes.io/pod-ordinal"
 )
 
 // ScaleSpec describes the attributes of a scale subresource

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -112,6 +112,9 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Verifying statefulset provides a stable hostname for each pod")
 			framework.ExpectNoError(e2esset.CheckHostname(c, ss))
+
+			ginkgo.By("Verifying statefulset provides identity labels for each pod")
+			framework.ExpectNoError(e2esset.CheckIdentityLabels(c, ss))
 
 			ginkgo.By("Verifying statefulset set proper service name")
 			framework.ExpectNoError(e2esset.CheckServiceName(ss, headlessSvcName))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes the ordinal number of each pod in a statefulset available with the label `statefulset.kubernetes.io/pod-ordinal`.

This enables direct access to each pod’s ordinal number as an environment variable via the downward API:

```yaml
env:
- name: POD_ORDINAL
  valueFrom:
    fieldRef:
      fieldPath: metadata.labels['statefulset.kubernetes.io/pod-ordinal']
```

**Which issue(s) this PR fixes**:
Fixes #30427 and fixes #40651 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string “action required”.
2. If no release note is required, just write “NONE”.
-->
```release-note
StatefulSet controller will create a label, `statefulset.kubernetes.io/pod-ordinal`, for the ordinal number of each Pod in a StatefulSet. This enables access to the ordinal number of each Pod controlled by a StatefulSet via the downward API.
```