### PR TITLE
Remove json tags for internal types of admission controller's private schema

### DIFF
--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/types.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/types.go
@@ -41,25 +41,25 @@ const (
 // Configuration provides configuration for the EventRateLimit admission
 // controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// limits are the limits to place on event queries received.
 	// Limits can be placed on events received server-wide, per namespace,
 	// per user, and per source+object.
 	// At least one limit is required.
-	Limits []Limit `json:"limits"`
+	Limits []Limit
 }
 
 // Limit is the configuration for a particular limit type
 type Limit struct {
 	// type is the type of limit to which this configuration applies
-	Type LimitType `json:"type"`
+	Type LimitType
 
 	// qps is the number of event queries per second that are allowed for this
 	// type of limit. The qps and burst fields are used together to determine if
 	// a particular event query is accepted. The qps determines how many queries
 	// are accepted once the burst amount of queries has been exhausted.
-	QPS int32 `json:"qps"`
+	QPS int32
 
 	// burst is the burst number of event queries that are allowed for this type
 	// of limit. The qps and burst fields are used together to determine if a
@@ -69,7 +69,7 @@ type Limit struct {
 	// before blocking any queries. Every second, 3 more queries will be allowed.
 	// If some of that allowance is not used, then it will roll over to the next
 	// second, until the maximum allowance of 10 is reached.
-	Burst int32 `json:"burst"`
+	Burst int32
 
 	// cacheSize is the size of the LRU cache for this type of limit. If a bucket
 	// is evicted from the cache, then the allowance for that bucket is reset. If
@@ -81,5 +81,5 @@ type Limit struct {
 	//
 	// If limitType is 'server', then cacheSize is ignored.
 	// +optional
-	CacheSize int32 `json:"cacheSize,omitempty"`
+	CacheSize int32
 }

--- a/plugin/pkg/admission/resourcequota/apis/resourcequota/types.go
+++ b/plugin/pkg/admission/resourcequota/apis/resourcequota/types.go
@@ -39,13 +39,13 @@ type LimitedResource struct {
 
 	// APIGroup is the name of the APIGroup that contains the limited resource.
 	// +optional
-	APIGroup string `json:"apiGroup,omitempty"`
+	APIGroup string
 
 	// Resource is the name of the resource this rule applies to.
 	// For example, if the administrator wants to limit consumption
 	// of a storage resource associated with persistent volume claims,
 	// the value would be "persistentvolumeclaims".
-	Resource string `json:"resource"`
+	Resource string
 
 	// For each intercepted request, the quota system will evaluate
 	// its resource usage.  It will iterate through each resource consumed
@@ -67,6 +67,5 @@ type LimitedResource struct {
 	// the list would include
 	// "PriorityClassNameIn=cluster-services"
 	// +optional
-	//	MatchScopes []string `json:"matchScopes,omitempty"`
 	MatchScopes []corev1.ScopedResourceSelectorRequirement `json:"matchScopes,omitempty"`
 }


### PR DESCRIPTION
inspired by #68722 

it's a trival change but will hold until #67870 to avoid conflict. 

/hold

/kind cleanup
/sig api-machinery

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
