### PR TITLE
Update Cluster Autoscaler version 1.12.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.0-beta.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.12.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note
Update Cluster Autoscaler version to 1.12.0.
See https://github.com/kubernetes/autoscaler/releases/tag/1.12.0 for CA release notes.
```

This just updates the version to final release. There were no code changes between CA 1.12.0-beta.1 and 1.12.0.