### PR TITLE
Start synchronizing pods after network is ready.

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "active_deadline.go",
         "doc.go",
+        "errors.go",
         "kubelet.go",
         "kubelet_getters.go",
         "kubelet_network.go",

--- a/pkg/kubelet/errors.go
+++ b/pkg/kubelet/errors.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+const (
+	NetworkNotReadyErrorMsg = "network is not ready"
+)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1561,8 +1561,8 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 
 	// If the network plugin is not ready, only start the pod if it uses the host network
 	if rs := kl.runtimeState.networkErrors(); len(rs) != 0 && !kubecontainer.IsHostNetworkPod(pod) {
-		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "network is not ready: %v", rs)
-		return fmt.Errorf("network is not ready: %v", rs)
+		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "%s: %v", NetworkNotReadyErrorMsg, rs)
+		return fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, rs)
 	}
 
 	// Create Cgroups for the pod and apply resource parameters


### PR DESCRIPTION
**What this PR does / why we need it**:
Start synchronizing pods after network is ready. If pod is synchronized before network is ready then it fails and kubelet tries to synchronize pod after 10 seconds.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68751

**Release note**:
```release-note
Start synchronizing pods after network is ready. 
```
