### PR TITLE
Replace kubernetes-users mailing list links with discuss forum link

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -18,22 +18,12 @@ The Kubernetes Community is active on Stack Overflow, you can post your question
 * [User Documentation](https://kubernetes.io/docs/) 
 * [Troubleshooting Guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
 
-
 ### Real-time Chat
 
 * [Slack](https://kubernetes.slack.com) ([registration](http://slack.k8s.io)):
 The `#kubernetes-users` and `#kubernetes-novice` channels are usual places where 
 people offer support.
 
-* Also check out the 
-[Slack Archive](http://kubernetes.slackarchive.io/) of past conversations.
+### Forum
 
-### Mailing Lists/Groups
-
-* [Kubernetes-users group](https://groups.google.com/forum/#!forum/kubernetes-users)
-
-
-
-<!---
-Derived from https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-user-support.md
---> 
+* [Kubernetes Official Forum](https://discuss.kubernetes.io)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the link in [SUPPORT.md](https://github.com/kubernetes/kubernetes/blob/master/SUPPORT.md)  that currently point to the [Google Groups Kubernetes Mailing List](https://groups.google.com/forum/#!forum/kubernetes-users) to the new [discuss.kubernetes.io](https://discuss.kubernetes.io) forum. 

The mailing list has been archived and set to read only. For more information on this, see issue https://github.com/kubernetes/community/issues/2492

/cc @castrojo 
/sig contributor-experience
/kind documentation

**Release note:**
```release-note
NONE
```