### PR TITLE
Add seans3 to sig-cli reviewers list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,6 +44,7 @@ aliases:
     - juanvallejo
     - mengqiy
     - rootfs
+    - seans3
     - shiywang
     - smarterclayton
     - soltysh


### PR DESCRIPTION
* Add seans3 to sig-cli group, which adds seans3 to kubectl reviewers.

```release-note
NONE
```
