### PR TITLE
pkg/proxy: only set sysctl if not already set

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -95,9 +95,12 @@ func (rct realConntracker) SetTCPCloseWaitTimeout(seconds int) error {
 func (realConntracker) setIntSysCtl(name string, value int) error {
 	entry := "net/netfilter/" + name
 
-	glog.Infof("Set sysctl '%v' to %v", entry, value)
-	if err := sysctl.New().SetSysctl(entry, value); err != nil {
-		return err
+	sys := sysctl.New()
+	if val, _ := sys.GetSysctl(entry); val != value {
+		glog.Infof("Set sysctl '%v' to %v", entry, value)
+		if err := sys.SetSysctl(entry, value); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -293,8 +293,10 @@ func NewProxier(ipt utiliptables.Interface,
 	nodePortAddresses []string,
 ) (*Proxier, error) {
 	// Set the route_localnet sysctl we need for
-	if err := sysctl.SetSysctl(sysctlRouteLocalnet, 1); err != nil {
-		return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlRouteLocalnet, err)
+	if val, _ := sysctl.GetSysctl(sysctlRouteLocalnet); val != 1 {
+		if err := sysctl.SetSysctl(sysctlRouteLocalnet, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlRouteLocalnet, err)
+		}
 	}
 
 	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -299,8 +299,10 @@ func NewProxier(ipt utiliptables.Interface,
 	nodePortAddresses []string,
 ) (*Proxier, error) {
 	// Set the route_localnet sysctl we need for
-	if err := sysctl.SetSysctl(sysctlRouteLocalnet, 1); err != nil {
-		return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlRouteLocalnet, err)
+	if val, _ := sysctl.GetSysctl(sysctlRouteLocalnet); val != 1 {
+		if err := sysctl.SetSysctl(sysctlRouteLocalnet, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlRouteLocalnet, err)
+		}
 	}
 
 	// Proxy needs br_netfilter and bridge-nf-call-iptables=1 when containers
@@ -311,13 +313,17 @@ func NewProxier(ipt utiliptables.Interface,
 	}
 
 	// Set the conntrack sysctl we need for
-	if err := sysctl.SetSysctl(sysctlVSConnTrack, 1); err != nil {
-		return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlVSConnTrack, err)
+	if val, _ := sysctl.GetSysctl(sysctlVSConnTrack); val != 1 {
+		if err := sysctl.SetSysctl(sysctlVSConnTrack, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlVSConnTrack, err)
+		}
 	}
 
 	// Set the ip_forward sysctl we need for
-	if err := sysctl.SetSysctl(sysctlForward, 1); err != nil {
-		return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlForward, err)
+	if val, _ := sysctl.GetSysctl(sysctlForward); val != 1 {
+		if err := sysctl.SetSysctl(sysctlForward, 1); err != nil {
+			return nil, fmt.Errorf("can't set sysctl %s: %v", sysctlForward, err)
+		}
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.


### PR DESCRIPTION
cc @thockin 

This will allow for kube-proxy to be run without `privileged` and
with only adding the capability `NET_ADMIN`.

```release-note
NONE
```