### PR TITLE
use constant DockerContainerRuntime in kubelet

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/apis/rbac/v1:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
         "//pkg/util/initsystem:go_default_library",
         "//pkg/util/node:go_default_library",
         "//pkg/util/procfs:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilsexec "k8s.io/utils/exec"
@@ -81,7 +82,7 @@ func buildKubeletArgMap(opts kubeletFlagsOpts) map[string]string {
 			kubeletFlags["cgroup-driver"] = driver
 		}
 	} else {
-		kubeletFlags["container-runtime"] = "remote"
+		kubeletFlags["container-runtime"] = kubetypes.RemoteContainerRuntime
 		kubeletFlags["container-runtime-endpoint"] = opts.nodeRegOpts.CRISocket
 	}
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -179,7 +179,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				glog.Fatal(err)
 			}
 
-			if kubeletFlags.ContainerRuntime == "remote" && cleanFlagSet.Changed("pod-infra-container-image") {
+			if kubeletFlags.ContainerRuntime == kubetypes.RemoteContainerRuntime && cleanFlagSet.Changed("pod-infra-container-image") {
 				glog.Warning("Warning: For remote container runtime, --pod-infra-container-image is ignored in kubelet, which should be set in that remote runtime instead")
 			}
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/status"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 	utilfile "k8s.io/kubernetes/pkg/util/file"
@@ -70,7 +71,6 @@ const (
 	// The minimum memory limit allocated to docker container: 150Mi
 	MinDockerMemoryLimit = 150 * 1024 * 1024
 
-	dockerProcessName     = "docker"
 	dockerPidFile         = "/var/run/docker.pid"
 	containerdProcessName = "docker-containerd"
 	containerdPidFile     = "/run/docker/libcontainerd/docker-containerd.pid"
@@ -425,7 +425,7 @@ func (cm *containerManagerImpl) setupNode(activePods ActivePodsFunc) error {
 		// TODO(#27097): Fix this after NodeSpec is clearly defined.
 		cm.periodicTasks = append(cm.periodicTasks, func() {
 			glog.V(4).Infof("[ContainerManager]: Adding periodic tasks for docker CRI integration")
-			cont, err := getContainerNameForProcess(dockerProcessName, dockerPidFile)
+			cont, err := getContainerNameForProcess(kubetypes.DockerContainerRuntime, dockerPidFile)
 			if err != nil {
 				glog.Error(err)
 				return
@@ -709,7 +709,7 @@ func getPidsForProcess(name, pidFile string) ([]int, error) {
 // dockershim as the default.
 func EnsureDockerInContainer(dockerAPIVersion *utilversion.Version, oomScoreAdj int, manager *fs.Manager) error {
 	type process struct{ name, file string }
-	dockerProcs := []process{{dockerProcessName, dockerPidFile}}
+	dockerProcs := []process{{kubetypes.DockerContainerRuntime, dockerPidFile}}
 	if dockerAPIVersion.AtLeast(containerdAPIVersion) {
 		dockerProcs = append(dockerProcs, process{containerdProcessName, containerdPidFile})
 	}

--- a/pkg/kubelet/container/BUILD
+++ b/pkg/kubelet/container/BUILD
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubelet/apis/cri/runtime/v1alpha2:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/util/hash:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/flowcontrol"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -239,7 +240,7 @@ type DockerID string
 
 func (id DockerID) ContainerID() ContainerID {
 	return ContainerID{
-		Type: "docker",
+		Type: kubetypes.DockerContainerRuntime,
 		ID:   string(id),
 	}
 }

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -43,9 +43,6 @@ const (
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2
-
-	// Name of the underlying container runtime
-	runtimeName = "docker"
 )
 
 var (
@@ -164,7 +161,7 @@ func (ds *dockerService) RunPodSandbox(ctx context.Context, r *runtimeapi.RunPod
 	// sandbox networking, but it might insert iptables rules or open ports
 	// on the host as well, to satisfy parts of the pod spec that aren't
 	// recognized by the CNI standard yet.
-	cID := kubecontainer.BuildContainerID(runtimeName, createResp.ID)
+	cID := kubecontainer.BuildContainerID(types.DockerContainerRuntime, createResp.ID)
 	err = ds.network.SetUpPod(config.GetMetadata().Namespace, config.GetMetadata().Name, cID, config.Annotations)
 	if err != nil {
 		errList := []error{fmt.Errorf("failed to set up sandbox container %q network for pod %q: %v", createResp.ID, config.Metadata.Name, err)}
@@ -244,7 +241,7 @@ func (ds *dockerService) StopPodSandbox(ctx context.Context, r *runtimeapi.StopP
 	ready, ok := ds.getNetworkReady(podSandboxID)
 	if !hostNetwork && (ready || !ok) {
 		// Only tear down the pod network if we haven't done so already
-		cID := kubecontainer.BuildContainerID(runtimeName, podSandboxID)
+		cID := kubecontainer.BuildContainerID(types.DockerContainerRuntime, podSandboxID)
 		err := ds.network.TearDownPod(namespace, name, cID)
 		if err == nil {
 			ds.setNetworkReady(podSandboxID, false)
@@ -322,7 +319,7 @@ func (ds *dockerService) getIPFromPlugin(sandbox *dockertypes.ContainerJSON) (st
 		return "", err
 	}
 	msg := fmt.Sprintf("Couldn't find network status for %s/%s through plugin", metadata.Namespace, metadata.Name)
-	cID := kubecontainer.BuildContainerID(runtimeName, sandbox.ID)
+	cID := kubecontainer.BuildContainerID(types.DockerContainerRuntime, sandbox.ID)
 	networkStatus, err := ds.network.GetPodNetworkStatus(metadata.Namespace, metadata.Name, cID)
 	if err != nil {
 		return "", err

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -215,7 +215,7 @@ func TestNetworkPluginInvocation(t *testing.T) {
 		map[string]string{"label": name},
 		map[string]string{"annotation": ns},
 	)
-	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	cID := kubecontainer.ContainerID{Type: types.DockerContainerRuntime, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
 
 	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
 	setup := mockPlugin.EXPECT().SetUpPod(ns, name, cID)
@@ -249,7 +249,7 @@ func TestHostNetworkPluginInvocation(t *testing.T) {
 			},
 		},
 	}
-	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	cID := kubecontainer.ContainerID{Type: types.DockerContainerRuntime, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
 
 	// No calls to network plugin are expected
 	_, err := ds.RunPodSandbox(getTestCTX(), &runtimeapi.RunPodSandboxRequest{Config: c})
@@ -274,7 +274,7 @@ func TestSetUpPodFailure(t *testing.T) {
 		map[string]string{"label": name},
 		map[string]string{"annotation": ns},
 	)
-	cID := kubecontainer.ContainerID{Type: runtimeName, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	cID := kubecontainer.ContainerID{Type: types.DockerContainerRuntime, ID: libdocker.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
 	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
 	mockPlugin.EXPECT().SetUpPod(ns, name, cID).Return(errors.New("setup pod error")).AnyTimes()
 	// If SetUpPod() fails, we expect TearDownPod() to immediately follow

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	kubeAPIVersion    = "0.1.0"
+	kubeAPIVersion = "0.1.0"
 
 	// String used to detect docker host mode for various namespaces (e.g.
 	// networking). Must match the value returned by docker inspect -f

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network/kubenet"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/cache"
 
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
@@ -48,7 +49,6 @@ import (
 )
 
 const (
-	dockerRuntimeName = "docker"
 	kubeAPIVersion    = "0.1.0"
 
 	// String used to detect docker host mode for various namespaces (e.g.
@@ -317,7 +317,7 @@ func (ds *dockerService) Version(_ context.Context, r *runtimeapi.VersionRequest
 	}
 	return &runtimeapi.VersionResponse{
 		Version:           kubeAPIVersion,
-		RuntimeName:       dockerRuntimeName,
+		RuntimeName:       kubetypes.DockerContainerRuntime,
 		RuntimeVersion:    v.Version,
 		RuntimeApiVersion: v.APIVersion,
 	}, nil

--- a/pkg/kubelet/sysctl/BUILD
+++ b/pkg/kubelet/sysctl/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/apis/policy/validation:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/sysctl/runtime.go
+++ b/pkg/kubelet/sysctl/runtime.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -28,8 +29,6 @@ const (
 	// CRI uses semver-compatible API version, while docker does not
 	// (e.g., 1.24). Append the version with a ".0".
 	dockerMinimumAPIVersion = "1.24.0"
-
-	dockerTypeName = "docker"
 )
 
 // TODO: The admission logic in this file is runtime-dependent. It should be
@@ -45,7 +44,7 @@ var _ lifecycle.PodAdmitHandler = &runtimeAdmitHandler{}
 // the given runtime support sysctls.
 func NewRuntimeAdmitHandler(runtime container.Runtime) (*runtimeAdmitHandler, error) {
 	switch runtime.Type() {
-	case dockerTypeName:
+	case kubetypes.DockerContainerRuntime:
 		v, err := runtime.APIVersion()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get runtime version: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
use constant DockerContainerRuntime and RemoteContainerRuntime in kubelet, get rid of using the "docker" and "remote" string directly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
