### PR TITLE
Automated part cherry pick of #68691: Fix load balancer issues when running zero nodes in vmss

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_vmss.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss.go
@@ -631,6 +631,12 @@ func (ss *scaleSet) EnsureHostsInPool(serviceName string, nodes []*v1.Node, back
 		instanceIDs = append(instanceIDs, instanceID)
 	}
 
+	if len(instanceIDs) == 0 {
+		glog.V(3).Infof("scale set %q has 0 nodes, adding it to load balancer anyway", vmSetName)
+		// InstanceIDs is required to update vmss, use * instead here since there are no nodes actually.
+		instanceIDs = []string{"*"}
+	}
+
 	// Update instances to latest VMSS model.
 	vmInstanceIDs := computepreview.VirtualMachineScaleSetVMInstanceRequiredIDs{
 		InstanceIds: &instanceIDs,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Scaling one of the agent pools to 0 breaks all services of type `LoadBalancer`. For example, creating a new service with type `LoadBalancer` will fail, with following events:

```
  Type     Reason                      Age               From                Message                                                                                                                                     
  ----     ------                      ----              ----                -------                                                                                                                                     
  Normal   EnsuringLoadBalancer        3m (x5 over 10m)  service-controller  Ensuring load balancer                                                                                                                      
  Warning  CreatingLoadBalancerFailed  1m (x5 over 9m)   service-controller  Error creating load balancer (will retry): failed to ensure load balancer for service polyaxon/polyaxon-polyaxon-ingress-backup: timed out waiting for the condition   
```

Looking at the `kube-controller-manager` logs (`k8s-k80-28106673-vmss` is the name of the VMSS that was scaled to 0):

```
I0917 20:07:15.187694       1 azure_vmss.go:643] VirtualMachineScaleSetsClient.UpdateInstances for service (default/will-svc-test): scale set (k8s-k80-28106673-vmss) - updating, err=compute.VirtualMachineScaleSetsClie
nt#UpdateInstances: Failure sending request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidParameter" Message="Required parameter 'upgradePolicies.instanceIds' is
 missing (null)."  
```

Azure cloud provider has fixed this issue since v1.11.0 in PR #62707 but the fix hasn't cherry-picked to v1.10 branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68773

**Special notes for your reviewer**:

#62707 is a feature PR for standard LB, which includes the fix commit. This PR only cherry picks the essential commit for the bug fix instead of the whole PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix load balancer issues when running zero nodes in Azure vmss.
```
