### PR TITLE
Add doc.go imports for staging/src/k8s.io/client-go/util/workqueue

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/doc.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/doc.go
@@ -23,4 +23,4 @@ limitations under the License.
 //  * Multiple consumers and producers. In particular, it is allowed for an
 //      item to be reenqueued while it is being processed.
 //  * Shutdown notifications.
-package workqueue
+package workqueue // import "k8s.io/client-go/util/workqueue"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds canonical import paths to existing doc.go files for all packages under staging/src/k8s.io/client-go/util/workqueue. This is so that we can use vanity URLs when importing staging packages.

**Which issue(s) this PR fixes** :
Only a partial fix for #68231.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
