### PR TITLE
Use the v1.12 branch by default

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha2/defaults.go
@@ -38,7 +38,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.11"
+	DefaultKubernetesVersion = "stable-1"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultCertificatesDir defines default certificate directory

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -33,7 +33,7 @@ const (
 	// DefaultClusterDNSIP defines default DNS IP
 	DefaultClusterDNSIP = "10.96.0.10"
 	// DefaultKubernetesVersion defines default kubernetes version
-	DefaultKubernetesVersion = "stable-1.11"
+	DefaultKubernetesVersion = "stable-1"
 	// DefaultAPIBindPort defines default API port
 	DefaultAPIBindPort = 6443
 	// DefaultCertificatesDir defines default certificate directory


### PR DESCRIPTION
Final update for kubeadm 1.12 default switching. 

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/sig-release-members 
/assign @tpepper 
/lgtm 
/approve 

@tpepper unhold when ready to cut RC!  