### PR TITLE
Disable DNS federation test

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -41,7 +41,7 @@ var (
 	moreForeverTestTimeout = 2 * 60 * time.Second
 )
 
-var _ = SIGDescribe("DNS configMap federations", func() {
+var _ = SIGDescribe("DNS configMap federations [Feature:Federation]", func() {
 
 	t := &dnsFederationsConfigMapTest{dnsTestCommon: newDnsTestCommon()}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Per discussion on #67600, we are disabling DNS federation test for v1.12 and will be removing this test in the next release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67600 

**Special notes for your reviewer**:
/assign @bowei 
cc @tpepper @csbell @shashidharatd @fturib @rajansandeep 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
