### PR TITLE
Update custom metrics conversion functions

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
@@ -36,12 +37,38 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 }
 
 func Convert_v1beta1_MetricValue_To_custom_metrics_MetricValue(in *MetricValue, out *custom_metrics.MetricValue, s conversion.Scope) error {
+	out.TypeMeta = in.TypeMeta
+	out.DescribedObject = custom_metrics.ObjectReference{
+		Kind:            in.DescribedObject.Kind,
+		Namespace:       in.DescribedObject.Namespace,
+		Name:            in.DescribedObject.Name,
+		UID:             in.DescribedObject.UID,
+		APIVersion:      in.DescribedObject.APIVersion,
+		ResourceVersion: in.DescribedObject.ResourceVersion,
+		FieldPath:       in.DescribedObject.FieldPath,
+	}
+	out.Timestamp = in.Timestamp
+	out.WindowSeconds = in.WindowSeconds
+	out.Value = in.Value
 	out.Metric.Name = in.MetricName
 	out.Metric.Selector = in.Selector
 	return nil
 }
 
 func Convert_custom_metrics_MetricValue_To_v1beta1_MetricValue(in *custom_metrics.MetricValue, out *MetricValue, s conversion.Scope) error {
+	out.TypeMeta = in.TypeMeta
+	out.DescribedObject = v1.ObjectReference{
+		Kind:            in.DescribedObject.Kind,
+		Namespace:       in.DescribedObject.Namespace,
+		Name:            in.DescribedObject.Name,
+		UID:             in.DescribedObject.UID,
+		APIVersion:      in.DescribedObject.APIVersion,
+		ResourceVersion: in.DescribedObject.ResourceVersion,
+		FieldPath:       in.DescribedObject.FieldPath,
+	}
+	out.Timestamp = in.Timestamp
+	out.WindowSeconds = in.WindowSeconds
+	out.Value = in.Value
 	out.MetricName = in.Metric.Name
 	out.Selector = in.Metric.Selector
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Conversions were missed in the ongoing fixes for updates to hpa custom metrics features added in https://github.com/kubernetes/kubernetes/pull/64097

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68011

**Special notes for your reviewer**:
Urgent blocker/regression

**Release note**:
```release-note
NONE
```
