### PR TITLE
Fix typo in aggregator test cleanup

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -87,7 +87,7 @@ func cleanTest(client clientset.Interface, aggrclient *aggregatorclient.Clientse
 	// delete the APIService first to avoid causing discovery errors
 	_ = aggrclient.ApiregistrationV1beta1().APIServices().Delete("v1alpha1.wardle.k8s.io", nil)
 
-	_ = client.AppsV1().Deployments(namespace).Delete("sample-apiserver", nil)
+	_ = client.AppsV1().Deployments(namespace).Delete("sample-apiserver-deployment", nil)
 	_ = client.CoreV1().Secrets(namespace).Delete("sample-apiserver-secret", nil)
 	_ = client.CoreV1().Services(namespace).Delete("sample-api", nil)
 	_ = client.CoreV1().ServiceAccounts(namespace).Delete("sample-apiserver", nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor typo fix

The name of the deployment created by the test is "[sample-apiserver-deployment](https://github.com/kubernetes/kubernetes/blob/ad2ed0e7dfe1ac914e6d1ecd369d57111fd365c6/test/e2e/apimachinery/aggregator.go#L135)" but the name of the deployment it attempts to delete in the cleanup is "[sample-apiserver](https://github.com/kubernetes/kubernetes/blob/ad2ed0e7dfe1ac914e6d1ecd369d57111fd365c6/test/e2e/apimachinery/aggregator.go#L90)"

**Release note**:
```release-note
NONE
```

/sig api-machinery
/kind bug
