### PR TITLE
release-1.10: Update to use debian-iptables v10.2 and debian-hyperkube-base 0.10.2

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v10.1
+  debian_iptables_version=v10.2
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in

--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -38,6 +38,7 @@ RUN echo CACHEBUST>/dev/null && clean-install \
     jq \
     kmod \
     openssh-client \
+    netbase \
     nfs-common \
     socat \
     udev \

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=staging-k8s.gcr.io
 IMAGE?=debian-hyperkube-base
-TAG=0.10.1
+TAG=0.10.2
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/build/debian-iptables/Dockerfile
+++ b/build/debian-iptables/Dockerfile
@@ -19,4 +19,5 @@ RUN clean-install \
     ebtables \
     ipset \
     iptables \
-    kmod
+    kmod \
+    netbase

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=debian-iptables
-TAG=v10.1
+TAG=v10.2
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -59,18 +59,18 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:58e53e477d204fe32f761ec2718b792f653063d4192ae89efc79e4b6a8dbba91",
+    digest = "sha256:0987db7ce42949d20ed2647a65d4bee0b616b4d40c7ea54769cc24b7ad003677",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10.1",  # ignored, but kept here for documentation
+    tag = "v10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:1c83ca9c8ac4a06e4585802edf8a1cd954011152409116e9c801f4736b97b956",
+    digest = "sha256:c50522965140c9f206900bf47d547d601c04943e1e59801ba5f70235773cfbb6",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.10.1",  # ignored, but kept here for documentation
+    tag = "0.10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -22,7 +22,7 @@ ARCH?=amd64
 OUT_DIR?=_output
 HYPERKUBE_BIN?=$(OUT_DIR)/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10.1
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.10.2
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
Cherry pick of #68764 #68769 #68801 on release-1.10.

#68764: Install netbase in debian-iptables and debian-hyperkube-base as it is needed by ipvs
#68769: Update to use debian-iptables v10.2 and debian-hyperkube-base
#68801: bazel: update debian-iptables and debian-hyperkube-base

Fixes #68703

```release-note
Update to use debian-iptables v10.2 and debian-hyperkube-base 0.10.2 with upstream security fixes, and install netbase in these images, as it is needed by ipvs.
```