### PR TITLE
RESTMapper in NewRESTMetricsClient

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -63,6 +63,7 @@ func startHPAControllerWithRESTClient(ctx ControllerContext) (http.Handler, bool
 		resourceclient.NewForConfigOrDie(clientConfig),
 		custom_metrics.NewForConfig(clientConfig, ctx.RESTMapper, apiVersionsGetter),
 		external_metrics.NewForConfigOrDie(clientConfig),
+		ctx.RESTMapper,
 	)
 	return startHPAControllerWithMetricsClient(ctx, metricsClient)
 }

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -617,6 +617,7 @@ func (tc *testCase) verifyResults(t *testing.T) {
 
 func (tc *testCase) setupController(t *testing.T) (*HorizontalController, informers.SharedInformerFactory) {
 	testClient, testMetricsClient, testCMClient, testEMClient, testScaleClient := tc.prepareTestClient(t)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
 	if tc.testClient != nil {
 		testClient = tc.testClient
 	}
@@ -636,6 +637,7 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 		testMetricsClient.MetricsV1beta1(),
 		testCMClient,
 		testEMClient,
+		mapper,
 	)
 
 	eventClient := &fake.Clientset{}

--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client.go
@@ -24,6 +24,7 @@ import (
 
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,10 +38,10 @@ const (
 	metricServerDefaultMetricWindow = time.Minute
 )
 
-func NewRESTMetricsClient(resourceClient resourceclient.PodMetricsesGetter, customClient customclient.CustomMetricsClient, externalClient externalclient.ExternalMetricsClient) MetricsClient {
+func NewRESTMetricsClient(resourceClient resourceclient.PodMetricsesGetter, customClient customclient.CustomMetricsClient, externalClient externalclient.ExternalMetricsClient, mapper apimeta.RESTMapper) MetricsClient {
 	return &restMetricsClient{
 		&resourceMetricsClient{resourceClient},
-		&customMetricsClient{customClient},
+		&customMetricsClient{customClient, mapper},
 		&externalMetricsClient{externalClient},
 	}
 }
@@ -105,6 +106,7 @@ func (c *resourceMetricsClient) GetResourceMetric(resource v1.ResourceName, name
 // using data from the custom metrics API.
 type customMetricsClient struct {
 	client customclient.CustomMetricsClient
+	mapper apimeta.RESTMapper
 }
 
 // GetRawMetric gets the given metric (and an associated oldest timestamp)
@@ -145,8 +147,8 @@ func (c *customMetricsClient) GetObjectMetric(metricName string, namespace strin
 	gvk := schema.FromAPIVersionAndKind(objectRef.APIVersion, objectRef.Kind)
 	var metricValue *customapi.MetricValue
 	var err error
-	if gvk.Kind == "Namespace" && gvk.Group == "" {
-		// handle namespace separately
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if mapping.Scope.Name() == apimeta.RESTScopeNameRoot {
 		// NB: we ignore namespace name here, since CrossVersionObjectReference isn't
 		// supposed to allow you to escape your namespace
 		metricValue, err = c.client.RootScopedMetrics().GetForObject(gvk.GroupKind(), namespace, metricName, metricSelector)

--- a/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/rest_metrics_client_test.go
@@ -226,7 +226,8 @@ func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo
 func (tc *restClientTestCase) runTest(t *testing.T) {
 	var err error
 	testMetricsClient, testCMClient, testEMClient := tc.prepareTestClient(t)
-	metricsClient := NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
+	metricsClient := NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient, mapper)
 	isResource := len(tc.resourceName) > 0
 	isExternal := tc.metricSelector != nil
 	if isResource {

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -338,7 +338,8 @@ func (tc *replicaCalcTestCase) prepareTestClient(t *testing.T) (*fake.Clientset,
 
 func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	testClient, testMetricsClient, testCMClient, testEMClient := tc.prepareTestClient(t)
-	metricsClient := metricsclient.NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient)
+	mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
+	metricsClient := metricsclient.NewRESTMetricsClient(testMetricsClient.MetricsV1beta1(), testCMClient, testEMClient, mapper)
 
 	informerFactory := informers.NewSharedInformerFactory(testClient, controller.NoResyncPeriodFunc())
 	informer := informerFactory.Core().V1().Pods()


### PR DESCRIPTION
**What this PR does / why we need it**:
Use RESTMapper in NewRESTMetricsClient to determine that scope is namespaced or root. 

**Which issue(s) this PR fixes**:
Fixes #67777

**Special notes for your reviewer**:

**Release note**:
