### PR TITLE
bazel: update debian-iptables and debian-hyperkube-base

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -67,18 +67,18 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:58e53e477d204fe32f761ec2718b792f653063d4192ae89efc79e4b6a8dbba91",
+    digest = "sha256:0987db7ce42949d20ed2647a65d4bee0b616b4d40c7ea54769cc24b7ad003677",
     registry = "k8s.gcr.io",
     repository = "debian-iptables-amd64",
-    tag = "v10.1",  # ignored, but kept here for documentation
+    tag = "v10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:1c83ca9c8ac4a06e4585802edf8a1cd954011152409116e9c801f4736b97b956",
+    digest = "sha256:c50522965140c9f206900bf47d547d601c04943e1e59801ba5f70235773cfbb6",
     registry = "k8s.gcr.io",
     repository = "debian-hyperkube-base-amd64",
-    tag = "0.10.1",  # ignored, but kept here for documentation
+    tag = "0.10.2",  # ignored, but kept here for documentation
 )
 
 docker_pull(


### PR DESCRIPTION
**What this PR does / why we need it**: I embarrassingly forgot to update the bazel workspace dependencies in #68769. This gets us back up-to-sync.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig release
/kind bug
/assign @cblecker @BenTheElder 