### PR TITLE
Avoid setting Masked/ReadOnly paths when pod is privileged

### DIFF
--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -137,8 +137,10 @@ func modifyHostConfig(sc *runtimeapi.LinuxContainerSecurityContext, hostConfig *
 		hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, "no-new-privileges")
 	}
 
-	hostConfig.MaskedPaths = sc.MaskedPaths
-	hostConfig.ReadonlyPaths = sc.ReadonlyPaths
+	if !hostConfig.Privileged {
+		hostConfig.MaskedPaths = sc.MaskedPaths
+		hostConfig.ReadonlyPaths = sc.ReadonlyPaths
+	}
 
 	return nil
 }

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -110,11 +110,27 @@ func TestModifyContainerConfig(t *testing.T) {
 
 func TestModifyHostConfig(t *testing.T) {
 	setNetworkHC := &dockercontainer.HostConfig{}
+
+	// When we have Privileged pods, we do not need to use the
+	// Masked / Readonly paths.
 	setPrivSC := &runtimeapi.LinuxContainerSecurityContext{}
 	setPrivSC.Privileged = true
+	setPrivSC.MaskedPaths = []string{"/hello/world/masked"}
+	setPrivSC.ReadonlyPaths = []string{"/hello/world/readonly"}
 	setPrivHC := &dockercontainer.HostConfig{
 		Privileged: true,
 	}
+
+	unsetPrivSC := &runtimeapi.LinuxContainerSecurityContext{}
+	unsetPrivSC.Privileged = false
+	unsetPrivSC.MaskedPaths = []string{"/hello/world/masked"}
+	unsetPrivSC.ReadonlyPaths = []string{"/hello/world/readonly"}
+	unsetPrivHC := &dockercontainer.HostConfig{
+		Privileged:    false,
+		MaskedPaths:   []string{"/hello/world/masked"},
+		ReadonlyPaths: []string{"/hello/world/readonly"},
+	}
+
 	setCapsHC := &dockercontainer.HostConfig{
 		CapAdd:  []string{"addCapA", "addCapB"},
 		CapDrop: []string{"dropCapA", "dropCapB"},
@@ -147,6 +163,11 @@ func TestModifyHostConfig(t *testing.T) {
 			name:     "container.SecurityContext.Privileged",
 			sc:       setPrivSC,
 			expected: setPrivHC,
+		},
+		{
+			name:     "container.SecurityContext.NoPrivileges",
+			sc:       unsetPrivSC,
+			expected: unsetPrivHC,
 		},
 		{
 			name: "container.SecurityContext.Capabilities",


### PR DESCRIPTION
Change-Id: Ic61c4c9c961843a4e064e783fab0b54350762a8d

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In the recent PR on adding [ProcMount](https://github.com/kubernetes/kubernetes/pull/64283/commits), we introduced a regression when
pods are privileged. This shows up in 18.06 docker with kubeadm in the
kube-proxy container.

The kube-proxy container is privilged, but we end up setting the
`/proc/sys` to Read-Only which causes failures when running kube-proxy
as a pod. This shows up as a failure when using sysctl to set various
network things.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68504

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
