### PR TITLE
Add metrics for apiservice status to aggregator

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/BUILD
@@ -54,6 +54,7 @@ filegroup(
         "//staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1:all-srcs",
         "//staging/src/k8s.io/kube-aggregator/pkg/cmd/server:all-srcs",
         "//staging/src/k8s.io/kube-aggregator/pkg/controllers:all-srcs",
+        "//staging/src/k8s.io/kube-aggregator/pkg/metrics:all-srcs",
         "//staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
@@ -79,6 +79,7 @@ go_library(
         "//staging/src/k8s.io/kube-aggregator/pkg/controllers:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/controllers/status:go_default_library",
+        "//staging/src/k8s.io/kube-aggregator/pkg/metrics:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/rest:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -36,6 +36,7 @@ import (
 	listers "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion"
 	openapicontroller "k8s.io/kube-aggregator/pkg/controllers/openapi"
 	statuscontrollers "k8s.io/kube-aggregator/pkg/controllers/status"
+	"k8s.io/kube-aggregator/pkg/metrics"
 	apiservicerest "k8s.io/kube-aggregator/pkg/registry/apiservice/rest"
 )
 
@@ -186,6 +187,8 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		c.ExtraConfig.ProxyTransport,
 		s.serviceResolver,
 	)
+	// register a collector to report metrics on state of apiservice
+	metrics.RegisterAPIServiceCollector(informerFactory.Apiregistration().InternalVersion().APIServices().Lister())
 
 	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
 		informerFactory.Start(context.StopCh)

--- a/staging/src/k8s.io/kube-aggregator/pkg/metrics/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/metrics/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/metrics",
+    importpath = "k8s.io/kube-aggregator/pkg/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
+        "//staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/kube-aggregator/pkg/metrics/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/metrics/metrics.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/apimachinery/pkg/labels"
+	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	listers "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion"
+)
+
+var (
+	descAPIServiceLabelsDefaultLabels = []string{"apiservice"}
+
+	descAPIServiceStatusCondition = prometheus.NewDesc(
+		"aggregator_apiservice_status_condition",
+		"The condition of an apiservice",
+		append(descAPIServiceLabelsDefaultLabels, "condition", "status"),
+		nil,
+	)
+)
+
+// apiServiceCollector collects metrics about all apiservices in the cluster.
+type apiServiceCollector struct {
+	apiServiceLister listers.APIServiceLister
+}
+
+// Describe implements the prometheus.Collector interface.
+func (ac *apiServiceCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descAPIServiceStatusCondition
+}
+
+// Collect implements the prometheus.Collector interface.
+func (ac *apiServiceCollector) Collect(ch chan<- prometheus.Metric) {
+	apiServices, err := ac.apiServiceLister.List(labels.Everything())
+	if err != nil {
+		glog.Errorf("listing apiservices failed: %s", err)
+		return
+	}
+	for _, apiService := range apiServices {
+		ac.collectAPIService(ch, apiService)
+	}
+	glog.V(4).Infof("collected %d apiservices", len(apiServices))
+}
+
+func (ac *apiServiceCollector) collectAPIService(ch chan<- prometheus.Metric, apiService *apiregistration.APIService) {
+	// Collect apiservice conditions
+	for _, c := range apiService.Status.Conditions {
+		addConditionMetrics(ch, descAPIServiceStatusCondition, c.Status, apiService.Name, string(c.Type))
+	}
+}
+
+// addConditionMetrics generates one metric for each possible apiservice condition
+// status. For this function to work properly, the last label in the metric
+// description must be the condition type.
+func addConditionMetrics(ch chan<- prometheus.Metric, desc *prometheus.Desc, cs apiregistration.ConditionStatus, lv ...string) {
+	ch <- prometheus.MustNewConstMetric(
+		desc, prometheus.GaugeValue, boolFloat64(cs == apiregistration.ConditionTrue),
+		append(lv, "true")...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		desc, prometheus.GaugeValue, boolFloat64(cs == apiregistration.ConditionFalse),
+		append(lv, "false")...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		desc, prometheus.GaugeValue, boolFloat64(cs == apiregistration.ConditionUnknown),
+		append(lv, "unknown")...,
+	)
+}
+
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+var registerAPIServiceCollector sync.Once
+
+// RegisterAPIServiceCollector registers a collector once.
+func RegisterAPIServiceCollector(apiServiceLister listers.APIServiceLister) {
+	registerAPIServiceCollector.Do(func() {
+		prometheus.MustRegister(&apiServiceCollector{apiServiceLister: apiServiceLister})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For each APIService, the aggregator returns a metric like the following:
```
aggregator_apiservice_status_condition{apiservice="apiservicename",condition="Available",status="false"} 0
aggregator_apiservice_status_condition{apiservice="apiservicename",condition="Available",status="true"} 1
aggregator_apiservice_status_condition{apiservice="apiservicename",condition="Available",status="unknown"} 0
```

Including this metric by default is useful for enabling alerting rules as an unavailable APIService can block namespace deletion.

**Special notes for your reviewer**:
- I did not filter out local API services (i.e. spec.service is nil) for consistency, but open to adjusting.
- The syntax aligns with kube-state-metrics usage of conditions, happy to make updates if needed.
- Ideally, we also had a metric to know if a client could get a good response from the apiservice, I am not sure where to best add that capability given how the proxy code path goes into apimachinery.
- Having the metric come from the source rather than an intermediary was preferred.

**Release note**:
```release-note
Aggregator reports metrics for API service status
```
