### PR TITLE
Add node hostname unique check for kubeadm join

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -476,6 +476,13 @@ func (i *Init) Run(out io.Writer) error {
 		return fmt.Errorf("error creating clusterinfo RBAC rules: %v", err)
 	}
 
+	glog.V(1).Infof("[init] creating Nodes RBAC rules")
+	for _, token := range tokens {
+		if err := clusterinfophase.CreateNodesRBACRules(client, token); err != nil {
+			return fmt.Errorf("error creating Nodes RBAC rules: %v", err)
+		}
+	}
+
 	glog.V(1).Infof("[init] ensuring DNS addon")
 	if err := dnsaddonphase.EnsureDNSAddon(i.cfg, client); err != nil {
 		return fmt.Errorf("error ensuring dns addon: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind bug
In my experimental environment，the master and node have the same hostname.
When I initialize the cluster using `kubeadm init` and add the node to the cluster using `kubeadm join`, everything looks well. But I can only get one record when I query the nodes in the cluster through `kubectl get nodes` command.
I think the kubeadm may lack the check of duplicate hostnames.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the bug https://github.com/kubernetes/kubeadm/issues/1130

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
