### PR TITLE
Wait for events instead of just checking them in cronjob e2e

### DIFF
--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -180,8 +180,8 @@ var _ = SIGDescribe("CronJob", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring no unexpected event has happened")
-		err = checkNoEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob", "UnexpectedJob"})
-		Expect(err).NotTo(HaveOccurred())
+		err = waitForEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob", "UnexpectedJob"})
+		Expect(err).To(HaveOccurred())
 
 		By("Removing cronjob")
 		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
@@ -219,8 +219,8 @@ var _ = SIGDescribe("CronJob", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring MissingJob event has occurred")
-		err = checkNoEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob"})
-		Expect(err).To(HaveOccurred())
+		err = waitForEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob"})
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Removing cronjob")
 		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
@@ -426,24 +426,26 @@ func waitForAnyFinishedJob(c clientset.Interface, ns string) error {
 	})
 }
 
-// checkNoEventWithReason checks no events with a reason within a list has occurred
-func checkNoEventWithReason(c clientset.Interface, ns, cronJobName string, reasons []string) error {
-	sj, err := c.BatchV1beta1().CronJobs(ns).Get(cronJobName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("Error in getting cronjob %s/%s: %v", ns, cronJobName, err)
-	}
-	events, err := c.CoreV1().Events(ns).Search(legacyscheme.Scheme, sj)
-	if err != nil {
-		return fmt.Errorf("Error in listing events: %s", err)
-	}
-	for _, e := range events.Items {
-		for _, reason := range reasons {
-			if e.Reason == reason {
-				return fmt.Errorf("Found event with reason %s: %#v", reason, e)
+// waitForEventWithReason waits for events with a reason within a list has occurred
+func waitForEventWithReason(c clientset.Interface, ns, cronJobName string, reasons []string) error {
+	return wait.Poll(framework.Poll, 30*time.Second, func() (bool, error) {
+		sj, err := c.BatchV1beta1().CronJobs(ns).Get(cronJobName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		events, err := c.CoreV1().Events(ns).Search(legacyscheme.Scheme, sj)
+		if err != nil {
+			return false, err
+		}
+		for _, e := range events.Items {
+			for _, reason := range reasons {
+				if e.Reason == reason {
+					return true, nil
+				}
 			}
 		}
-	}
-	return nil
+		return false, nil
+	})
 }
 
 // filterNotDeletedJobs returns the job list without any jobs that are pending


### PR DESCRIPTION
**What this PR does / why we need it**:
Before we've only listed the events that the cronjob controller was producing, this PR changes from list to wait, so that we give the controller a bit of time to actually respond to changes. We've noticed this problem in [this test](https://github.com/kubernetes/kubernetes/blob/9228bec334fbda3fa201ea5fb3515f9c0781c82d/test/e2e/apps/cronjob.go#L221-L223) where the controller did produce the event, but ~3 seconds later than the check was performed. This lead to a flaky situation. This fix should prevent such situations. 

**Special notes for your reviewer**:
/assign @juanvallejo 
@janetkuo fyi

**Release note**:
```release-note
NONE
```
