### PR TITLE
Update RBAC rules for CSIDriver

### DIFF
--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -81,6 +81,14 @@ func createCSIRoles(
 			framework.ExpectNoError(err, "Failed to create %s cluster role: %v", role.GetName(), err)
 		}
 	}
+	roleClient := superuserClientset.RbacV1().Roles(config.Namespace)
+	createRole := func(role *rbacv1.Role) {
+		// In contrast to ClusterRoles, Roles are limited to the per-test namespace and thus
+		// should not exist yet.
+		if _, err := roleClient.Create(role); err != nil {
+			framework.ExpectNoError(err, "Failed to create %s cluster role: %v", role.GetName(), err)
+		}
+	}
 	createClusterRole(&rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csiDriverRegistrarClusterRoleName,
@@ -164,6 +172,40 @@ func createCSIRoles(
 				APIGroups: []string{"csi.storage.k8s.io"},
 				Resources: []string{"csinodeinfos"},
 				Verbs:     []string{"get", "watch", "list"},
+			},
+		},
+	})
+
+	// For the leadership election in external-provisioner (to be
+	// introduced in 0.4.x).  Doing this with endpoints is
+	// temporary. See
+	// https://github.com/kubernetes/kubernetes/issues/68819#issuecomment-422827682
+	createRole(&rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csiExternalProvisionerRoleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+
+			{
+				APIGroups: []string{""},
+				Resources: []string{"endpoints"},
+				Verbs:     []string{"get", "create", "update", "patch"},
+			},
+		},
+	})
+
+	// For leadership election in external-attacher. Leadership
+	// election must be turned on explicitly.
+	createRole(&rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: csiExternalAttacherRoleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get", "watch", "list", "delete", "update", "create"},
 			},
 		},
 	})
@@ -252,6 +294,57 @@ func csiClusterRoleBindings(
 		}
 
 		_, err = clusterRoleBindingClient.Create(binding)
+		if err != nil {
+			framework.ExpectNoError(err, "Failed to create %s role binding: %v", binding.GetName(), err)
+		}
+	}
+}
+
+func csiRoleBindings(
+	client clientset.Interface,
+	config framework.VolumeTestConfig,
+	teardown bool,
+	sa *v1.ServiceAccount,
+	rolesNames []string,
+) {
+	bindingString := "Binding"
+	if teardown {
+		bindingString = "Unbinding"
+	}
+	By(fmt.Sprintf("%v roles %v to the CSI service account %v in namespace %s", bindingString, rolesNames, sa.GetName(), config.Namespace))
+	roleBindingClient := client.RbacV1().RoleBindings(config.Namespace)
+	for _, roleName := range rolesNames {
+
+		binding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: config.Prefix + "-" + roleName + "-role-binding",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      sa.GetName(),
+					Namespace: sa.GetNamespace(),
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "Role",
+				Name:     roleName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		}
+
+		roleBindingClient.Delete(binding.GetName(), &metav1.DeleteOptions{})
+		err := wait.Poll(2*time.Second, 10*time.Minute, func() (bool, error) {
+			_, err := roleBindingClient.Get(binding.GetName(), metav1.GetOptions{})
+			return apierrs.IsNotFound(err), nil
+		})
+		framework.ExpectNoError(err, "Timed out waiting for deletion: %v", err)
+
+		if teardown {
+			return
+		}
+
+		_, err = roleBindingClient.Create(binding)
 		if err != nil {
 			framework.ExpectNoError(err, "Failed to create %s role binding: %v", binding.GetName(), err)
 		}

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -428,6 +428,9 @@ func csiHostPathPod(
 					ImagePullPolicy: v1.PullAlways,
 					Args: []string{
 						"--v=5",
+						"--leader-election",
+						"--leader-election-namespace=" + config.Namespace,
+						"--leader-election-identity=external-attacher",
 						"--csi-address=$(ADDRESS)",
 					},
 					Env: []v1.EnvVar{

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -43,8 +43,8 @@ import (
 
 var csiImageVersions = map[string]string{
 	"hostpathplugin":   "canary", // TODO (verult) update tag once new hostpathplugin release is cut
-	"csi-attacher":     "v0.2.0",
-	"csi-provisioner":  "v0.2.1",
+	"csi-attacher":     "v0.3.0",
+	"csi-provisioner":  "v0.3.1",
 	"driver-registrar": "v0.3.0",
 }
 

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -50,6 +50,8 @@ const (
 	csiExternalProvisionerClusterRoleName string = "csi-external-provisioner"
 	csiExternalAttacherClusterRoleName    string = "csi-external-attacher"
 	csiDriverRegistrarClusterRoleName     string = "csi-driver-registrar"
+	csiExternalAttacherRoleName           string = "csi-external-attacher-role"
+	csiExternalProvisionerRoleName        string = "csi-external-provisioner-role"
 )
 
 type csiTestDriver interface {
@@ -304,6 +306,7 @@ func startPausePod(cs clientset.Interface, t storageClassTest, ns string) (*stor
 
 type hostpathCSIDriver struct {
 	combinedClusterRoleNames []string
+	combinedRoleNames        []string
 	serviceAccount           *v1.ServiceAccount
 
 	f      *framework.Framework
@@ -316,6 +319,10 @@ func initCSIHostpath(f *framework.Framework, config framework.VolumeTestConfig) 
 			csiExternalAttacherClusterRoleName,
 			csiExternalProvisionerClusterRoleName,
 			csiDriverRegistrarClusterRoleName,
+		},
+		combinedRoleNames: []string{
+			csiExternalAttacherRoleName,
+			csiExternalProvisionerRoleName,
 		},
 		f:      f,
 		config: config,
@@ -340,6 +347,7 @@ func (h *hostpathCSIDriver) createCSIDriver() {
 	config := h.config
 	h.serviceAccount = csiServiceAccount(cs, config, "hostpath", false)
 	csiClusterRoleBindings(cs, config, false, h.serviceAccount, h.combinedClusterRoleNames)
+	csiRoleBindings(cs, config, false, h.serviceAccount, h.combinedRoleNames)
 	csiHostPathPod(cs, config, false, f, h.serviceAccount)
 }
 
@@ -350,6 +358,7 @@ func (h *hostpathCSIDriver) cleanupCSIDriver() {
 	config := h.config
 	csiHostPathPod(cs, config, true, f, h.serviceAccount)
 	csiClusterRoleBindings(cs, config, true, h.serviceAccount, h.combinedClusterRoleNames)
+	csiRoleBindings(cs, config, true, h.serviceAccount, h.combinedRoleNames)
 	csiServiceAccount(cs, config, "hostpath", true)
 }
 

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -41,9 +41,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// All of these roles are getting created by createCSIRoles. They
+// mimick the permissions that real-world deployments of CSI drivers
+// must create themselves.
+//
+// The builtin system:csi* roles are deprecated.
 const (
-	csiExternalProvisionerClusterRoleName string = "system:csi-external-provisioner"
-	csiExternalAttacherClusterRoleName    string = "system:csi-external-attacher"
+	csiExternalProvisionerClusterRoleName string = "csi-external-provisioner"
+	csiExternalAttacherClusterRoleName    string = "csi-external-attacher"
 	csiDriverRegistrarClusterRoleName     string = "csi-driver-registrar"
 )
 
@@ -85,7 +90,7 @@ var _ = utils.SIGDescribe("[Serial] CSI Volumes", func() {
 			ServerNodeName:    node.Name,
 			WaitForCompletion: true,
 		}
-		csiDriverRegistrarClusterRole(config)
+		createCSIRoles(config)
 		createCSICRDs(crdclient)
 	})
 


### PR DESCRIPTION
The leadership election in external-provisioner versions > v0.3.0 needs
additional permissions, otherwise the provisioner fails in the CSI E2E
test completely with:

E0919 08:34:56.218106       1 leaderelection.go:224] error retrieving
resource lock e2e-tests-csi-mock-plugin-l84wg/csi-hostpath: endpoints
"csi-hostpath" is forbidden: User
"system:serviceaccount:e2e-tests-csi-mock-plugin-l84wg:csi-hostpath-service-account"
cannot get resource "endpoints" in API group "" in the namespace
"e2e-tests-csi-mock-plugin-l84wg"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This makes it possible to run the CSI E2E tests with a more recent release of the external-provisioner, something that is planned for the 1.12 release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68819

**Special notes for your reviewer**:

This turned into a more complete set of changes. For example, leadership election gets enabled and turned on also for the external-attacher.

It's probably best to review each commit separately.

/sig storage

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
