### PR TITLE
Extract cpu requests to separate env variables.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -30,6 +30,10 @@ readonly UUID_BLOCK_PREFIX="/dev/disk/by-uuid/google-local-ssds"
 readonly COREDNS_AUTOSCALER="Deployment/coredns"
 readonly KUBEDNS_AUTOSCALER="Deployment/kube-dns"
 
+# Resource requests of master components.
+KUBE_CONTROLLER_MANAGER_CPU_REQUEST="${KUBE_CONTROLLER_MANAGER_CPU_REQUEST:-200m}"
+KUBE_SCHEDULER_CPU_REQUEST="${KUBE_SCHEDULER_CPU_REQUEST:-75m}"
+
 # Use --retry-connrefused opt only if it's supported by curl.
 CURL_RETRY_CONNREFUSED=""
 if curl --help | grep -q -- '--retry-connrefused'; then
@@ -1979,6 +1983,7 @@ function start-kube-controller-manager {
   sed -i -e "s@{{pv_recycler_volume}}@${PV_RECYCLER_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath_mount}}@${FLEXVOLUME_HOSTPATH_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath}}@${FLEXVOLUME_HOSTPATH_VOLUME}@g" "${src_file}"
+  sed -i -e "s@{{cpurequest}}@${KUBE_CONTROLLER_MANAGER_CPU_REQUEST}@g" "${src_file}"
 
   cp "${src_file}" /etc/kubernetes/manifests
 }
@@ -2016,6 +2021,7 @@ function start-kube-scheduler {
   sed -i -e "s@{{params}}@${params}@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${DOCKER_REGISTRY}@g" "${src_file}"
   sed -i -e "s@{{pillar\['kube-scheduler_docker_tag'\]}}@${kube_scheduler_docker_tag}@g" "${src_file}"
+  sed -i -e "s@{{cpurequest}}@${KUBE_SCHEDULER_CPU_REQUEST}@g" "${src_file}"
   cp "${src_file}" /etc/kubernetes/manifests
 }
 

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -21,7 +21,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "200m"
+        "cpu": "{{cpurequest}}"
       }
     },
     "command": [

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -21,7 +21,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "75m"
+        "cpu": "{{cpurequest}}"
       }
     },
     "command": [


### PR DESCRIPTION
This PR doesn't change current behavior of cluster, but introduces functionality that allow to control cpu requests of kube-controller-manager and kube-scheduler via environment variables.

```release-note
[GCP] Added env variables to control CPU requests of kube-controller-manager and kube-scheduler.
```