### PR TITLE
Optimizes calculating stats when only CPU and Memory stats are returned from Kubelet stats/summary http endpoint. 

### DIFF
--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -1011,6 +1011,10 @@ func (f *fakeSummaryProvider) Get(updateStats bool) (*statsapi.Summary, error) {
 	return f.result, nil
 }
 
+func (f *fakeSummaryProvider) GetCPUAndMemoryStats() (*statsapi.Summary, error) {
+	return f.result, nil
+}
+
 // newPodStats returns a pod stat where each container is using the specified working set
 // each pod must have a Name, UID, Namespace
 func newPodStats(pod *v1.Pod, containerWorkingSetBytes int64) statsapi.PodStats {

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -51,6 +51,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+
 	// Do some initialization to decode the query parameters correctly.
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -255,12 +256,16 @@ func (fk *fakeKubelet) ListVolumesForPod(podUID types.UID) (map[string]volume.Vo
 	return map[string]volume.Volume{}, true
 }
 
-func (_ *fakeKubelet) RootFsStats() (*statsapi.FsStats, error)     { return nil, nil }
-func (_ *fakeKubelet) ListPodStats() ([]statsapi.PodStats, error)  { return nil, nil }
-func (_ *fakeKubelet) ImageFsStats() (*statsapi.FsStats, error)    { return nil, nil }
-func (_ *fakeKubelet) RlimitStats() (*statsapi.RlimitStats, error) { return nil, nil }
+func (_ *fakeKubelet) RootFsStats() (*statsapi.FsStats, error)                { return nil, nil }
+func (_ *fakeKubelet) ListPodStats() ([]statsapi.PodStats, error)             { return nil, nil }
+func (_ *fakeKubelet) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error) { return nil, nil }
+func (_ *fakeKubelet) ImageFsStats() (*statsapi.FsStats, error)               { return nil, nil }
+func (_ *fakeKubelet) RlimitStats() (*statsapi.RlimitStats, error)            { return nil, nil }
 func (_ *fakeKubelet) GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error) {
 	return nil, nil, nil
+}
+func (_ *fakeKubelet) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error) {
+	return nil, nil
 }
 
 type fakeAuth struct {

--- a/pkg/kubelet/server/stats/handler.go
+++ b/pkg/kubelet/server/stats/handler.go
@@ -43,6 +43,8 @@ type StatsProvider interface {
 	//
 	// ListPodStats returns the stats of all the containers managed by pods.
 	ListPodStats() ([]statsapi.PodStats, error)
+	// ListPodCPUAndMemoryStats returns the CPU and memory stats of all the containers managed by pods.
+	ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error)
 	// ImageFsStats returns the stats of the image filesystem.
 	ImageFsStats() (*statsapi.FsStats, error)
 
@@ -51,6 +53,9 @@ type StatsProvider interface {
 	// GetCgroupStats returns the stats and the networking usage of the cgroup
 	// with the specified cgroupName.
 	GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error)
+	// GetCgroupCPUAndMemoryStats returns the CPU and memory stats of the cgroup with the specified cgroupName.
+	GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error)
+
 	// RootFsStats returns the stats of the node root filesystem.
 	RootFsStats() (*statsapi.FsStats, error)
 

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -91,30 +91,33 @@ func (sp *summaryProviderImpl) Get(updateStats bool) (*statsapi.Summary, error) 
 }
 
 func (sp *summaryProviderImpl) GetCPUAndMemoryStats() (*statsapi.Summary, error) {
-	summary, err := sp.Get(false)
+	// TODO(timstclair): Consider returning a best-effort response if any of
+	// the following errors occur.
+	node, err := sp.provider.GetNode()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get node info: %v", err)
 	}
-	summary.Node.Network = nil
-	summary.Node.Fs = nil
-	summary.Node.Runtime = nil
-	summary.Node.Rlimit = nil
-	for i := 0; i < len(summary.Node.SystemContainers); i++ {
-		summary.Node.SystemContainers[i].Accelerators = nil
-		summary.Node.SystemContainers[i].Rootfs = nil
-		summary.Node.SystemContainers[i].Logs = nil
-		summary.Node.SystemContainers[i].UserDefinedMetrics = nil
+	nodeConfig := sp.provider.GetNodeConfig()
+	rootStats, err := sp.provider.GetCgroupCPUAndMemoryStats("/", false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get root cgroup stats: %v", err)
 	}
-	for i := 0; i < len(summary.Pods); i++ {
-		summary.Pods[i].Network = nil
-		summary.Pods[i].VolumeStats = nil
-		summary.Pods[i].EphemeralStorage = nil
-		for j := 0; j < len(summary.Pods[i].Containers); j++ {
-			summary.Pods[i].Containers[j].Accelerators = nil
-			summary.Pods[i].Containers[j].Rootfs = nil
-			summary.Pods[i].Containers[j].Logs = nil
-			summary.Pods[i].Containers[j].UserDefinedMetrics = nil
-		}
+
+	podStats, err := sp.provider.ListPodCPUAndMemoryStats()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pod stats: %v", err)
 	}
-	return summary, nil
+
+	nodeStats := statsapi.NodeStats{
+		NodeName:         node.Name,
+		CPU:              rootStats.CPU,
+		Memory:           rootStats.Memory,
+		StartTime:        rootStats.StartTime,
+		SystemContainers: sp.GetSystemContainersCPUAndMemoryStats(nodeConfig, podStats, false),
+	}
+	summary := statsapi.Summary{
+		Node: nodeStats,
+		Pods: podStats,
+	}
+	return &summary, nil
 }

--- a/pkg/kubelet/server/stats/summary_sys_containers_windows.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers_windows.go
@@ -27,11 +27,16 @@ import (
 )
 
 func (sp *summaryProviderImpl) GetSystemContainersStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
-	stats = append(stats, sp.getSystemPodsStats(nodeConfig, podStats, updateStats))
+	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
 	return stats
 }
 
-func (sp *summaryProviderImpl) getSystemPodsStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) statsapi.ContainerStats {
+func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) (stats []statsapi.ContainerStats) {
+	stats = append(stats, sp.getSystemPodsCPUAndMemoryStats(nodeConfig, podStats, updateStats))
+	return stats
+}
+
+func (sp *summaryProviderImpl) getSystemPodsCPUAndMemoryStats(nodeConfig cm.NodeConfig, podStats []statsapi.PodStats, updateStats bool) statsapi.ContainerStats {
 	now := metav1.NewTime(time.Now())
 	podsSummary := statsapi.ContainerStats{
 		StartTime: now,

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -32,39 +32,39 @@ import (
 	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
 )
 
-func TestSummaryProvider(t *testing.T) {
-	var (
-		podStats = []statsapi.PodStats{
-			{
-				PodRef:      statsapi.PodReference{Name: "test-pod", Namespace: "test-namespace", UID: "UID_test-pod"},
-				StartTime:   metav1.NewTime(time.Now()),
-				Containers:  []statsapi.ContainerStats{*getContainerStats()},
-				Network:     getNetworkStats(),
-				VolumeStats: []statsapi.VolumeStats{*getVolumeStats()},
-			},
-		}
-		imageFsStats = getFsStats()
-		rootFsStats  = getFsStats()
-		node         = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
-		nodeConfig   = cm.NodeConfig{
-			RuntimeCgroupsName: "/runtime",
-			SystemCgroupsName:  "/misc",
-			KubeletCgroupsName: "/kubelet",
-		}
-		cgroupRoot     = "/kubepods"
-		cgroupStatsMap = map[string]struct {
-			cs *statsapi.ContainerStats
-			ns *statsapi.NetworkStats
-		}{
-			"/":        {cs: getContainerStats(), ns: getNetworkStats()},
-			"/runtime": {cs: getContainerStats(), ns: getNetworkStats()},
-			"/misc":    {cs: getContainerStats(), ns: getNetworkStats()},
-			"/kubelet": {cs: getContainerStats(), ns: getNetworkStats()},
-			"/pods":    {cs: getContainerStats(), ns: getNetworkStats()},
-		}
-		rlimitStats = getRlimitStats()
-	)
+var (
+	podStats = []statsapi.PodStats{
+		{
+			PodRef:      statsapi.PodReference{Name: "test-pod", Namespace: "test-namespace", UID: "UID_test-pod"},
+			StartTime:   metav1.NewTime(time.Now()),
+			Containers:  []statsapi.ContainerStats{*getContainerStats()},
+			Network:     getNetworkStats(),
+			VolumeStats: []statsapi.VolumeStats{*getVolumeStats()},
+		},
+	}
+	imageFsStats = getFsStats()
+	rootFsStats  = getFsStats()
+	node         = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	nodeConfig   = cm.NodeConfig{
+		RuntimeCgroupsName: "/runtime",
+		SystemCgroupsName:  "/misc",
+		KubeletCgroupsName: "/kubelet",
+	}
+	cgroupRoot     = "/kubepods"
+	cgroupStatsMap = map[string]struct {
+		cs *statsapi.ContainerStats
+		ns *statsapi.NetworkStats
+	}{
+		"/":        {cs: getContainerStats(), ns: getNetworkStats()},
+		"/runtime": {cs: getContainerStats(), ns: getNetworkStats()},
+		"/misc":    {cs: getContainerStats(), ns: getNetworkStats()},
+		"/kubelet": {cs: getContainerStats(), ns: getNetworkStats()},
+		"/pods":    {cs: getContainerStats(), ns: getNetworkStats()},
+	}
+	rlimitStats = getRlimitStats()
+)
 
+func TestSummaryProviderGetStats(t *testing.T) {
 	assert := assert.New(t)
 
 	mockStatsProvider := new(statstest.StatsProvider)
@@ -126,6 +126,64 @@ func TestSummaryProvider(t *testing.T) {
 		Memory:             cgroupStatsMap["/pods"].cs.Memory,
 		Accelerators:       cgroupStatsMap["/pods"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/pods"].cs.UserDefinedMetrics,
+	})
+	assert.Equal(summary.Pods, podStats)
+}
+
+func TestSummaryProviderGetCPUAndMemoryStats(t *testing.T) {
+	assert := assert.New(t)
+
+	mockStatsProvider := new(statstest.StatsProvider)
+	mockStatsProvider.
+		On("GetNode").Return(node, nil).
+		On("GetNodeConfig").Return(nodeConfig).
+		On("GetPodCgroupRoot").Return(cgroupRoot).
+		On("ListPodStats").Return(podStats, nil).
+		On("ImageFsStats").Return(imageFsStats, nil).
+		On("RootFsStats").Return(rootFsStats, nil).
+		On("RlimitStats").Return(rlimitStats, nil).
+		On("GetCgroupStats", "/", false).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).
+		On("GetCgroupStats", "/runtime", false).Return(cgroupStatsMap["/runtime"].cs, cgroupStatsMap["/runtime"].ns, nil).
+		On("GetCgroupStats", "/misc", false).Return(cgroupStatsMap["/misc"].cs, cgroupStatsMap["/misc"].ns, nil).
+		On("GetCgroupStats", "/kubelet", false).Return(cgroupStatsMap["/kubelet"].cs, cgroupStatsMap["/kubelet"].ns, nil).
+		On("GetCgroupStats", "/kubepods", false).Return(cgroupStatsMap["/pods"].cs, cgroupStatsMap["/pods"].ns, nil)
+
+	provider := NewSummaryProvider(mockStatsProvider)
+	summary, err := provider.GetCPUAndMemoryStats()
+	assert.NoError(err)
+
+	assert.Equal(summary.Node.NodeName, "test-node")
+	assert.Equal(summary.Node.StartTime, cgroupStatsMap["/"].cs.StartTime)
+	assert.Equal(summary.Node.CPU, cgroupStatsMap["/"].cs.CPU)
+	assert.Equal(summary.Node.Memory, cgroupStatsMap["/"].cs.Memory)
+	assert.Nil(summary.Node.Network)
+	assert.Nil(summary.Node.Fs)
+	assert.Nil(summary.Node.Runtime)
+
+	assert.Equal(len(summary.Node.SystemContainers), 4)
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "kubelet",
+		StartTime: cgroupStatsMap["/kubelet"].cs.StartTime,
+		CPU:       cgroupStatsMap["/kubelet"].cs.CPU,
+		Memory:    cgroupStatsMap["/kubelet"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "misc",
+		StartTime: cgroupStatsMap["/misc"].cs.StartTime,
+		CPU:       cgroupStatsMap["/misc"].cs.CPU,
+		Memory:    cgroupStatsMap["/misc"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "runtime",
+		StartTime: cgroupStatsMap["/runtime"].cs.StartTime,
+		CPU:       cgroupStatsMap["/runtime"].cs.CPU,
+		Memory:    cgroupStatsMap["/runtime"].cs.Memory,
+	})
+	assert.Contains(summary.Node.SystemContainers, statsapi.ContainerStats{
+		Name:      "pods",
+		StartTime: cgroupStatsMap["/pods"].cs.StartTime,
+		CPU:       cgroupStatsMap["/pods"].cs.CPU,
+		Memory:    cgroupStatsMap["/pods"].cs.Memory,
 	})
 	assert.Equal(summary.Pods, podStats)
 }

--- a/pkg/kubelet/server/stats/testing/mock_stats_provider.go
+++ b/pkg/kubelet/server/stats/testing/mock_stats_provider.go
@@ -64,6 +64,29 @@ func (_m *StatsProvider) GetCgroupStats(cgroupName string, updateStats bool) (*v
 	return r0, r1, r2
 }
 
+// GetCgroupCPUAndMemoryStats provides a mock function with given fields: cgroupName, updateStats
+func (_m *StatsProvider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*v1alpha1.ContainerStats, error) {
+	ret := _m.Called(cgroupName, updateStats)
+
+	var r0 *v1alpha1.ContainerStats
+	if rf, ok := ret.Get(0).(func(string, bool) *v1alpha1.ContainerStats); ok {
+		r0 = rf(cgroupName, updateStats)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1alpha1.ContainerStats)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, bool) error); ok {
+		r1 = rf(cgroupName, updateStats)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetPodByCgroupfs provides the pod that maps to the specified cgroup, as well
 // as whether the pod was found.
 func (_m *StatsProvider) GetPodByCgroupfs(cgroupfs string) (*corev1.Pod, bool) {
@@ -231,6 +254,29 @@ func (_m *StatsProvider) ImageFsStats() (*v1alpha1.FsStats, error) {
 
 // ListPodStats provides a mock function with given fields:
 func (_m *StatsProvider) ListPodStats() ([]v1alpha1.PodStats, error) {
+	ret := _m.Called()
+
+	var r0 []v1alpha1.PodStats
+	if rf, ok := ret.Get(0).(func() []v1alpha1.PodStats); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v1alpha1.PodStats)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListPodCPUAndMemoryStats provides a mock function with given fields:
+func (_m *StatsProvider) ListPodCPUAndMemoryStats() ([]v1alpha1.PodStats, error) {
 	ret := _m.Called()
 
 	var r0 []v1alpha1.PodStats

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -258,6 +258,169 @@ func TestCadvisorListPodStats(t *testing.T) {
 	checkNetworkStats(t, "Pod2", seedPod2Infra, ps.Network)
 }
 
+func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
+	const (
+		namespace0 = "test0"
+		namespace2 = "test2"
+	)
+	const (
+		seedRoot              = 0
+		seedRuntime           = 100
+		seedKubelet           = 200
+		seedMisc              = 300
+		seedPod0Infra         = 1000
+		seedPod0Container0    = 2000
+		seedPod0Container1    = 2001
+		seedPod1Infra         = 3000
+		seedPod1Container     = 4000
+		seedPod2Infra         = 5000
+		seedPod2Container     = 6000
+		seedEphemeralVolume1  = 10000
+		seedEphemeralVolume2  = 10001
+		seedPersistentVolume1 = 20000
+		seedPersistentVolume2 = 20001
+	)
+	const (
+		pName0 = "pod0"
+		pName1 = "pod1"
+		pName2 = "pod0" // ensure pName2 conflicts with pName0, but is in a different namespace
+	)
+	const (
+		cName00 = "c0"
+		cName01 = "c1"
+		cName10 = "c0" // ensure cName10 conflicts with cName02, but is in a different pod
+		cName20 = "c1" // ensure cName20 conflicts with cName01, but is in a different pod + namespace
+	)
+
+	prf0 := statsapi.PodReference{Name: pName0, Namespace: namespace0, UID: "UID" + pName0}
+	prf1 := statsapi.PodReference{Name: pName1, Namespace: namespace0, UID: "UID" + pName1}
+	prf2 := statsapi.PodReference{Name: pName2, Namespace: namespace2, UID: "UID" + pName2}
+	infos := map[string]cadvisorapiv2.ContainerInfo{
+		"/":              getTestContainerInfo(seedRoot, "", "", ""),
+		"/docker-daemon": getTestContainerInfo(seedRuntime, "", "", ""),
+		"/kubelet":       getTestContainerInfo(seedKubelet, "", "", ""),
+		"/system":        getTestContainerInfo(seedMisc, "", "", ""),
+		// Pod0 - Namespace0
+		"/pod0-i":  getTestContainerInfo(seedPod0Infra, pName0, namespace0, leaky.PodInfraContainerName),
+		"/pod0-c0": getTestContainerInfo(seedPod0Container0, pName0, namespace0, cName00),
+		"/pod0-c1": getTestContainerInfo(seedPod0Container1, pName0, namespace0, cName01),
+		// Pod1 - Namespace0
+		"/pod1-i":  getTestContainerInfo(seedPod1Infra, pName1, namespace0, leaky.PodInfraContainerName),
+		"/pod1-c0": getTestContainerInfo(seedPod1Container, pName1, namespace0, cName10),
+		// Pod2 - Namespace2
+		"/pod2-i":                        getTestContainerInfo(seedPod2Infra, pName2, namespace2, leaky.PodInfraContainerName),
+		"/pod2-c0":                       getTestContainerInfo(seedPod2Container, pName2, namespace2, cName20),
+		"/kubepods/burstable/podUIDpod0": getTestContainerInfo(seedPod0Infra, pName0, namespace0, leaky.PodInfraContainerName),
+		"/kubepods/podUIDpod1":           getTestContainerInfo(seedPod1Infra, pName1, namespace0, leaky.PodInfraContainerName),
+	}
+
+	// memory limit overrides for each container (used to test available bytes if a memory limit is known)
+	memoryLimitOverrides := map[string]uint64{
+		"/":        uint64(1 << 30),
+		"/pod2-c0": uint64(1 << 15),
+	}
+	for name, memoryLimitOverride := range memoryLimitOverrides {
+		info, found := infos[name]
+		if !found {
+			t.Errorf("No container defined with name %v", name)
+		}
+		info.Spec.Memory.Limit = memoryLimitOverride
+		infos[name] = info
+	}
+
+	options := cadvisorapiv2.RequestOptions{
+		IdType:    cadvisorapiv2.TypeName,
+		Count:     2,
+		Recursive: true,
+	}
+
+	mockCadvisor := new(cadvisortest.Mock)
+	mockCadvisor.
+		On("ContainerInfoV2", "/", options).Return(infos, nil)
+
+	ephemeralVolumes := []statsapi.VolumeStats{getPodVolumeStats(seedEphemeralVolume1, "ephemeralVolume1"),
+		getPodVolumeStats(seedEphemeralVolume2, "ephemeralVolume2")}
+	persistentVolumes := []statsapi.VolumeStats{getPodVolumeStats(seedPersistentVolume1, "persistentVolume1"),
+		getPodVolumeStats(seedPersistentVolume2, "persistentVolume2")}
+	volumeStats := serverstats.PodVolumeStats{
+		EphemeralVolumes:  ephemeralVolumes,
+		PersistentVolumes: persistentVolumes,
+	}
+
+	resourceAnalyzer := &fakeResourceAnalyzer{podVolumeStats: volumeStats}
+
+	p := NewCadvisorStatsProvider(mockCadvisor, resourceAnalyzer, nil, nil, nil)
+	pods, err := p.ListPodCPUAndMemoryStats()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, len(pods))
+	indexPods := make(map[statsapi.PodReference]statsapi.PodStats, len(pods))
+	for _, pod := range pods {
+		indexPods[pod.PodRef] = pod
+	}
+
+	// Validate Pod0 Results
+	ps, found := indexPods[prf0]
+	assert.True(t, found)
+	assert.Len(t, ps.Containers, 2)
+	indexCon := make(map[string]statsapi.ContainerStats, len(ps.Containers))
+	for _, con := range ps.Containers {
+		indexCon[con.Name] = con
+	}
+	con := indexCon[cName00]
+	assert.EqualValues(t, testTime(creationTime, seedPod0Container0).Unix(), con.StartTime.Time.Unix())
+	checkCPUStats(t, "Pod0Container0", seedPod0Container0, con.CPU)
+	checkMemoryStats(t, "Pod0Conainer0", seedPod0Container0, infos["/pod0-c0"], con.Memory)
+	assert.Nil(t, con.Rootfs)
+	assert.Nil(t, con.Logs)
+	assert.Nil(t, con.Accelerators)
+	assert.Nil(t, con.UserDefinedMetrics)
+
+	con = indexCon[cName01]
+	assert.EqualValues(t, testTime(creationTime, seedPod0Container1).Unix(), con.StartTime.Time.Unix())
+	checkCPUStats(t, "Pod0Container1", seedPod0Container1, con.CPU)
+	checkMemoryStats(t, "Pod0Container1", seedPod0Container1, infos["/pod0-c1"], con.Memory)
+	assert.Nil(t, con.Rootfs)
+	assert.Nil(t, con.Logs)
+	assert.Nil(t, con.Accelerators)
+	assert.Nil(t, con.UserDefinedMetrics)
+
+	assert.EqualValues(t, testTime(creationTime, seedPod0Infra).Unix(), ps.StartTime.Time.Unix())
+	assert.Nil(t, ps.EphemeralStorage)
+	assert.Nil(t, ps.VolumeStats)
+	assert.Nil(t, ps.Network)
+	if ps.CPU != nil {
+		checkCPUStats(t, "Pod0", seedPod0Infra, ps.CPU)
+	}
+	if ps.Memory != nil {
+		checkMemoryStats(t, "Pod0", seedPod0Infra, infos["/pod0-i"], ps.Memory)
+	}
+
+	// Validate Pod1 Results
+	ps, found = indexPods[prf1]
+	assert.True(t, found)
+	assert.Len(t, ps.Containers, 1)
+	con = ps.Containers[0]
+	assert.Equal(t, cName10, con.Name)
+	checkCPUStats(t, "Pod1Container0", seedPod1Container, con.CPU)
+	checkMemoryStats(t, "Pod1Container0", seedPod1Container, infos["/pod1-c0"], con.Memory)
+	assert.Nil(t, ps.EphemeralStorage)
+	assert.Nil(t, ps.VolumeStats)
+	assert.Nil(t, ps.Network)
+
+	// Validate Pod2 Results
+	ps, found = indexPods[prf2]
+	assert.True(t, found)
+	assert.Len(t, ps.Containers, 1)
+	con = ps.Containers[0]
+	assert.Equal(t, cName20, con.Name)
+	checkCPUStats(t, "Pod2Container0", seedPod2Container, con.CPU)
+	checkMemoryStats(t, "Pod2Container0", seedPod2Container, infos["/pod2-c0"], con.Memory)
+	assert.Nil(t, ps.EphemeralStorage)
+	assert.Nil(t, ps.VolumeStats)
+	assert.Nil(t, ps.Network)
+}
+
 func TestCadvisorImagesFsStats(t *testing.T) {
 	var (
 		assert       = assert.New(t)

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -132,6 +132,21 @@ func cadvisorInfoToContainerStats(name string, info *cadvisorapiv2.ContainerInfo
 	return result
 }
 
+// cadvisorInfoToContainerCPUAndMemoryStats returns the statsapi.ContainerStats converted
+// from the container and filesystem info.
+func cadvisorInfoToContainerCPUAndMemoryStats(name string, info *cadvisorapiv2.ContainerInfo) *statsapi.ContainerStats {
+	result := &statsapi.ContainerStats{
+		StartTime: metav1.NewTime(info.Spec.CreationTime),
+		Name:      name,
+	}
+
+	cpu, memory := cadvisorInfoToCPUandMemoryStats(info)
+	result.CPU = cpu
+	result.Memory = memory
+
+	return result
+}
+
 // cadvisorInfoToNetworkStats returns the statsapi.NetworkStats converted from
 // the container info from cadvisor.
 func cadvisorInfoToNetworkStats(name string, info *cadvisorapiv2.ContainerInfo) *statsapi.NetworkStats {

--- a/pkg/kubelet/stats/stats_provider_test.go
+++ b/pkg/kubelet/stats/stats_provider_test.go
@@ -634,8 +634,9 @@ type fakeResourceAnalyzer struct {
 	podVolumeStats serverstats.PodVolumeStats
 }
 
-func (o *fakeResourceAnalyzer) Start()                              {}
-func (o *fakeResourceAnalyzer) Get(bool) (*statsapi.Summary, error) { return nil, nil }
+func (o *fakeResourceAnalyzer) Start()                                           {}
+func (o *fakeResourceAnalyzer) Get(bool) (*statsapi.Summary, error)              { return nil, nil }
+func (o *fakeResourceAnalyzer) GetCPUAndMemoryStats() (*statsapi.Summary, error) { return nil, nil }
 func (o *fakeResourceAnalyzer) GetPodVolumeStats(uid types.UID) (serverstats.PodVolumeStats, bool) {
 	return o.podVolumeStats, true
 }

--- a/pkg/kubelet/stats/stats_provider_test.go
+++ b/pkg/kubelet/stats/stats_provider_test.go
@@ -100,6 +100,39 @@ func TestGetCgroupStats(t *testing.T) {
 	mockCadvisor.AssertExpectations(t)
 }
 
+func TestGetCgroupCPUAndMemoryStats(t *testing.T) {
+	const (
+		cgroupName        = "test-cgroup-name"
+		containerInfoSeed = 1000
+		updateStats       = false
+	)
+	var (
+		mockCadvisor     = new(cadvisortest.Mock)
+		mockPodManager   = new(kubepodtest.MockManager)
+		mockRuntimeCache = new(kubecontainertest.MockRuntimeCache)
+
+		assert  = assert.New(t)
+		options = cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false}
+
+		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container")
+		containerInfoMap = map[string]cadvisorapiv2.ContainerInfo{cgroupName: containerInfo}
+	)
+
+	mockCadvisor.On("ContainerInfoV2", cgroupName, options).Return(containerInfoMap, nil)
+
+	provider := newStatsProvider(mockCadvisor, mockPodManager, mockRuntimeCache, fakeContainerStatsProvider{})
+	cs, err := provider.GetCgroupCPUAndMemoryStats(cgroupName, updateStats)
+	assert.NoError(err)
+
+	checkCPUStats(t, "", containerInfoSeed, cs.CPU)
+	checkMemoryStats(t, "", containerInfoSeed, containerInfo, cs.Memory)
+
+	assert.Equal(cgroupName, cs.Name)
+	assert.Equal(metav1.NewTime(containerInfo.Spec.CreationTime), cs.StartTime)
+
+	mockCadvisor.AssertExpectations(t)
+}
+
 func TestRootFsStats(t *testing.T) {
 	const (
 		rootFsInfoSeed    = 1000
@@ -648,6 +681,11 @@ type fakeContainerStatsProvider struct {
 func (p fakeContainerStatsProvider) ListPodStats() ([]statsapi.PodStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+func (p fakeContainerStatsProvider) ListPodCPUAndMemoryStats() ([]statsapi.PodStats, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (p fakeContainerStatsProvider) ImageFsStats() (*statsapi.FsStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
PR optimizes calculating stats when only CPU and Memory stats are returned from Kubelet stats/summary http endpoint. After this PR is submitted only CPU and memory stats will be calculated instead of calculating all stats and removing them from response.

**Release note**:
```release-note
Optimizes calculating stats when only CPU and Memory stats are returned from Kubelet stats/summary http endpoint. 
```
