### PR TITLE
Revert "Add DNS pod resource monitoring option" (CoreDNS, scale testing)

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -112,7 +112,7 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 1000Mi
+            memory: 170Mi
           requests:
             cpu: 100m
             memory: 70Mi

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -112,7 +112,7 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 1000Mi
+            memory: 170Mi
           requests:
             cpu: 100m
             memory: 70Mi

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -112,7 +112,7 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 1000Mi
+            memory: 170Mi
           requests:
             cpu: 100m
             memory: 70Mi

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -259,7 +259,7 @@ fi
 
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'true' to install CoreDNS instead of kube-dns.
-CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"
+CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-false}"
 ENABLE_CLUSTER_DNS="${KUBE_ENABLE_CLUSTER_DNS:-true}"
 DNS_SERVER_IP="${KUBE_DNS_SERVER_IP:-10.0.0.10}"
 DNS_DOMAIN="${KUBE_DNS_DOMAIN:-cluster.local}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -266,7 +266,7 @@ fi
 
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'true' to install CoreDNS instead of kube-dns.
-CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"
+CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-false}"
 ENABLE_CLUSTER_DNS="${KUBE_ENABLE_CLUSTER_DNS:-true}"
 DNS_SERVER_IP="10.0.0.10"
 DNS_DOMAIN="cluster.local"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -251,18 +251,9 @@ func (f *Framework) BeforeEach() {
 
 	if TestContext.GatherKubeSystemResourceUsageData != "false" && TestContext.GatherKubeSystemResourceUsageData != "none" {
 		var err error
-		var nodeMode NodesSet
-		switch TestContext.GatherKubeSystemResourceUsageData {
-		case "master":
-			nodeMode = MasterAndDNSNodes
-		case "masteranddns":
-			nodeMode = MasterAndDNSNodes
-		default:
-			nodeMode = AllNodes
-		}
 		f.gatherer, err = NewResourceUsageGatherer(f.ClientSet, ResourceGathererOptions{
-			InKubemark: ProviderIs("kubemark"),
-			Nodes:      nodeMode,
+			InKubemark:                  ProviderIs("kubemark"),
+			MasterOnly:                  TestContext.GatherKubeSystemResourceUsageData == "master",
 			ResourceDataGatheringPeriod: 60 * time.Second,
 			ProbeDuration:               15 * time.Second,
 			PrintVerboseLogs:            false,

--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -137,7 +137,7 @@ func SetupNVIDIAGPUNode(f *framework.Framework, setupResourceGatherer bool) *fra
 	var rsgather *framework.ContainerResourceGatherer
 	if setupResourceGatherer {
 		framework.Logf("Starting ResourceUsageGather for the created DaemonSet pods.")
-		rsgather, err = framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{InKubemark: false, Nodes: framework.AllNodes, ResourceDataGatheringPeriod: 2 * time.Second, ProbeDuration: 2 * time.Second, PrintVerboseLogs: true}, pods)
+		rsgather, err = framework.NewResourceUsageGatherer(f.ClientSet, framework.ResourceGathererOptions{InKubemark: false, MasterOnly: false, ResourceDataGatheringPeriod: 2 * time.Second, ProbeDuration: 2 * time.Second, PrintVerboseLogs: true}, pods)
 		framework.ExpectNoError(err, "creating ResourceUsageGather for the daemonset pods")
 		go rsgather.StartGatheringData()
 	}


### PR DESCRIPTION
It was not expected to have the PR #68683 merged.

Reverts kubernetes/kubernetes#68683.

initial PR was:
- bumping max mem limit of CoreDNS to 1Gi
- set CoreDNS as default DNS option
- add monitoring tools for DNS Pods in the e2e framework.
