### PR TITLE
Use HTTPHeaders in httpGet pod-lifecycle handler

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -43,8 +43,8 @@ type fakeHTTP struct {
 	err error
 }
 
-func (f *fakeHTTP) Get(url string) (*http.Response, error) {
-	f.url = url
+func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
+	f.url = req.URL.String()
 	return nil, f.err
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -148,7 +148,7 @@ func NewKubeGenericRuntimeManager(
 	podStateProvider podStateProvider,
 	osInterface kubecontainer.OSInterface,
 	runtimeHelper kubecontainer.RuntimeHelper,
-	httpClient types.HttpGetter,
+	httpClient types.HttpDoer,
 	imageBackOff *flowcontrol.Backoff,
 	serializeImagePulls bool,
 	imagePullQPS float32,

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -122,13 +122,15 @@ func TestRunHandlerExec(t *testing.T) {
 }
 
 type fakeHTTP struct {
-	url  string
-	err  error
-	resp *http.Response
+	url     string
+	headers *http.Header
+	err     error
+	resp    *http.Response
 }
 
-func (f *fakeHTTP) Get(url string) (*http.Response, error) {
-	f.url = url
+func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
+	f.url = req.URL.String()
+	f.headers = req.Header
 	return f.resp, f.err
 }
 

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -26,8 +26,8 @@ import (
 
 // TODO: Reconcile custom types in kubelet/types and this subpackage
 
-type HttpGetter interface {
-	Get(url string) (*http.Response, error)
+type HttpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // Timestamp wraps around time.Time and offers utilities to format and parse


### PR DESCRIPTION
**What this PR does / why we need it**:
`v1.HTTPGetAction` defines a `HTTPHeaders` field. These headers are used in liveness/readiness probes requests, but not in the `HTTPGet` lifecycle handler.

**Which issue(s) this PR fixes**:
Fixes #68846

**Special notes for your reviewer**:
* Before this can be approved, I should fix the case where users want to set 'Host' - You can't set the 'Host' header using `req.Headers.Set()` (see http docs)
* I may submit another PR to refactor / remove the `kubetypes.HttpDoer` type, as it's not used anywhere else, and gets passed down through the runtime_manager solely for this purpose

**Release note**:
```release-note
Allow http headers to be used by the httpGet lifecycle handler
```
