### PR TITLE
oidc: respect the legacy goog issuer

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -342,6 +342,12 @@ func untrustedIssuer(token string) (string, error) {
 	if err := json.Unmarshal(payload, &claims); err != nil {
 		return "", fmt.Errorf("while unmarshaling token: %v", err)
 	}
+	// Coalesce the legacy GoogleIss with the new one.
+	//
+	// http://openid.net/specs/openid-connect-core-1_0.html#GoogleIss
+	if claims.Issuer == "accounts.google.com" {
+		return "https://accounts.google.com", nil
+	}
 	return claims.Issuer, nil
 }
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -1365,6 +1365,28 @@ func TestToken(t *testing.T) {
 			},
 			wantInitErr: true,
 		},
+		{
+			name: "accounts.google.com issuer",
+			options: Options{
+				IssuerURL:     "https://accounts.google.com",
+				ClientID:      "my-client",
+				UsernameClaim: "email",
+				now:           func() time.Time { return now },
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "accounts.google.com",
+				"email": "thomas.jefferson@gmail.com",
+				"aud": "my-client",
+				"exp": %d
+			}`, valid.Unix()),
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			want: &user.DefaultInfo{
+				Name: "thomas.jefferson@gmail.com",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, test.run)


### PR DESCRIPTION
We used to do this, we stopped, and it broke people.

Respect http://openid.net/specs/openid-connect-core-1_0.html#GoogleIss

Fixes: https://github.com/kubernetes/kubernetes/issues/65317

```release-note
NONE
```
