### PR TITLE
Add flag to change image for GCE PD CSI Driver in tests

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -170,6 +170,8 @@ type StorageTestContextType struct {
 	CSIImageVersion string
 	// CSIImageRegistry defines the image registry hosting the CSI container images.
 	CSIImageRegistry string
+	// GCEPDCSIImage overrides the image location of the GCE PD CSI Driver
+	GCEPDCSIImage string
 }
 
 type CloudConfig struct {
@@ -309,6 +311,7 @@ func RegisterNodeFlags() {
 func RegisterStorageFlags() {
 	flag.StringVar(&TestContext.CSIImageVersion, "csiImageVersion", "", "overrides the default tag used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
 	flag.StringVar(&TestContext.CSIImageRegistry, "csiImageRegistry", "quay.io/k8scsi", "overrides the default repository used for hostpathplugin/csi-attacher/csi-provisioner/driver-registrar images")
+	flag.StringVar(&TestContext.GCEPDCSIImage, "gcePDCSIImage", "", "overrides the default image used for GCE PD CSI images")
 }
 
 // ViperizeFlags sets up all flag and config processing. Future configuration info should be added to viper, not to flags.

--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -392,6 +392,20 @@ func deployGCEPDCSIDriver(
 	controllerservice, err := manifest.SvcFromManifest("test/e2e/testing-manifests/storage-csi/gce-pd/controller_service.yaml")
 	framework.ExpectNoError(err, "Failed to create Service from manifest")
 
+	if len(framework.TestContext.GCEPDCSIImage) != 0 {
+		// Override Controller and Node GCE PD CSI Image with provided flag
+		for i, c := range nodeds.Spec.Template.Spec.Containers {
+			if c.Name == "gce-driver" {
+				nodeds.Spec.Template.Spec.Containers[i].Image = framework.TestContext.GCEPDCSIImage
+			}
+		}
+		for i, c := range controllerss.Spec.Template.Spec.Containers {
+			if c.Name == "gce-driver" {
+				controllerss.Spec.Template.Spec.Containers[i].Image = framework.TestContext.GCEPDCSIImage
+			}
+		}
+	}
+
 	// Got all objects from manifests now try to delete objects
 	err = client.CoreV1().Services(config.Namespace).Delete(controllerservice.GetName(), nil)
 	if err != nil {

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -42,7 +42,7 @@ spec:
               mountPath: /csi
         - name: gce-driver
           imagePullPolicy: Always
-          image: gcr.io/google-containers/volume-csi/compute-persistent-disk-csi-driver:v0.2.0.alpha
+          image: gcr.io/google-containers/volume-csi/gcp-compute-persistent-disk-csi-driver:v0.1.0.alpha
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: Always
-          image: gcr.io/google-containers/volume-csi/compute-persistent-disk-csi-driver:v0.2.0.alpha
+          image: gcr.io/google-containers/volume-csi/gcp-compute-persistent-disk-csi-driver:v0.1.0.alpha
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
Added a flag to change the image for the GCE PD CSI Driver in the CSI tests. This is one step in enabling automated testing of new CSI Driver versions.

/kind feature
/sig storage
/assign @msau42 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
