### PR TITLE
Better error handling in DeferredRESTMapper and memcached discovery client

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -612,7 +612,7 @@ func BuildAdmissionPluginInitializers(
 
 	admissionPostStartHook := func(context genericapiserver.PostStartHookContext) error {
 		discoveryRESTMapper.Reset()
-		go utilwait.Until(discoveryRESTMapper.Reset, 30*time.Second, context.StopCh)
+		go utilwait.Until(func() { discoveryRESTMapper.Reset() }, 30*time.Second, context.StopCh)
 		return nil
 	}
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -612,6 +612,7 @@ func BuildAdmissionPluginInitializers(
 
 	admissionPostStartHook := func(context genericapiserver.PostStartHookContext) error {
 		discoveryRESTMapper.Reset()
+		// TOOD: remove the anonymous function wrapper after #68865 is solved.
 		go utilwait.Until(func() { discoveryRESTMapper.Reset() }, 30*time.Second, context.StopCh)
 		return nil
 	}

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -154,7 +154,7 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 // from discovery.
 type resettableRESTMapper interface {
 	meta.RESTMapper
-	Reset()
+	Reset() error
 }
 
 // Sync periodically resyncs the garbage collector when new resources are

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -53,7 +53,7 @@ type testRESTMapper struct {
 	meta.RESTMapper
 }
 
-func (_ *testRESTMapper) Reset() {}
+func (_ *testRESTMapper) Reset() error { return nil }
 
 func TestGarbageCollectorConstruction(t *testing.T) {
 	config := &restclient.Config{}

--- a/staging/src/k8s.io/client-go/discovery/cached/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memcache.go
@@ -122,7 +122,10 @@ func (d *memCacheClient) Invalidate() error {
 	// APIResourceList to have the same GroupVersion, the lists would need merged.
 	gl, err := d.delegate.ServerGroups()
 	if err != nil || len(gl.Groups) == 0 {
-		return fmt.Errorf("couldn't get current server API group list; will keep using cached value. (%v)", err)
+		// TODO: remove the redundant error logging #68865 is solved.
+		err2 := fmt.Errorf("couldn't get current server API group list; will keep using cached value. (%v)", err)
+		utilruntime.HandleError(err2)
+		return err2
 	}
 
 	rl := map[string]*metav1.APIResourceList{}

--- a/staging/src/k8s.io/client-go/discovery/cached/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memcache.go
@@ -73,7 +73,7 @@ func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
 func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
-	if d.groupList == nil {
+	if !d.cacheValid {
 		return nil, ErrCacheEmpty
 	}
 	return d.groupList, nil
@@ -103,7 +103,7 @@ func (d *memCacheClient) Fresh() bool {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 	// Fresh is supposed to tell the caller whether or not to retry if the cache
-	// fails to find something. The idea here is that Invalidate will be called
+	// fails to find something. The idea here is that Invalidate() will be called
 	// periodically and therefore we'll always be returning the latest data. (And
 	// in the future we can watch and stay even more up-to-date.) So we only
 	// return false if the cache has never been filled.
@@ -113,7 +113,7 @@ func (d *memCacheClient) Fresh() bool {
 // Invalidate refreshes the cache, blocking calls until the cache has been
 // refreshed. It would be trivial to make a version that does this in the
 // background while continuing to respond to requests if needed.
-func (d *memCacheClient) Invalidate() {
+func (d *memCacheClient) Invalidate() error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
@@ -122,8 +122,7 @@ func (d *memCacheClient) Invalidate() {
 	// APIResourceList to have the same GroupVersion, the lists would need merged.
 	gl, err := d.delegate.ServerGroups()
 	if err != nil || len(gl.Groups) == 0 {
-		utilruntime.HandleError(fmt.Errorf("couldn't get current server API group list; will keep using cached value. (%v)", err))
-		return
+		return fmt.Errorf("couldn't get current server API group list; will keep using cached value. (%v)", err)
 	}
 
 	rl := map[string]*metav1.APIResourceList{}
@@ -145,6 +144,7 @@ func (d *memCacheClient) Invalidate() {
 
 	d.groupToServerResources, d.groupList = rl, gl
 	d.cacheValid = true
+	return nil
 }
 
 // NewMemCacheClient creates a new CachedDiscoveryInterface which caches

--- a/staging/src/k8s.io/client-go/discovery/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached_discovery.go
@@ -229,13 +229,14 @@ func (d *CachedDiscoveryClient) Fresh() bool {
 	return d.fresh
 }
 
-func (d *CachedDiscoveryClient) Invalidate() {
+func (d *CachedDiscoveryClient) Invalidate() error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
 	d.ourFiles = map[string]struct{}{}
 	d.fresh = true
 	d.invalidated = true
+	return nil
 }
 
 // NewCachedDiscoveryClientForConfig creates a new DiscoveryClient for the given config, and wraps

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -71,6 +71,7 @@ type CachedDiscoveryInterface interface {
 	// Invalidate enforces that no cached data is used in the future that is older
 	// than the current time. If an error is returned, caller should retry the
 	// Invalidate.
+	// TODO: do not return error when #68865 is solved.
 	Invalidate() error
 }
 

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -68,8 +68,10 @@ type CachedDiscoveryInterface interface {
 	// TODO: this needs to be revisited, this interface can't be locked properly
 	// and doesn't make a lot of sense.
 	Fresh() bool
-	// Invalidate enforces that no cached data is used in the future that is older than the current time.
-	Invalidate()
+	// Invalidate enforces that no cached data is used in the future that is older
+	// than the current time. If an error is returned, caller should retry the
+	// Invalidate.
+	Invalidate() error
 }
 
 // ServerGroupsInterface has methods for obtaining supported groups on the API server

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -407,7 +407,12 @@ func createClients(numberOfClients int) ([]clientset.Interface, []internalclient
 		}
 		cachedDiscoClient := cacheddiscovery.NewMemCacheClient(discoClient)
 		restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoClient)
-		restMapper.Reset()
+
+		reset := func() (bool, error) {
+			err := restMapper.Reset()
+			return err == nil, nil
+		}
+		err = retryWithExponentialBackOff(1*time.Second, reset)
 		resolver := scaleclient.NewDiscoveryScaleKindResolver(cachedDiscoClient)
 		scalesClients[i] = scaleclient.New(restClient, restMapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 	}


### PR DESCRIPTION
1. `DeferredRESTMapper.Reset()` return error if it fails. This allows the user of the `DeferredRESTMapper` to retry `Reset()`.

Currently, `Reset()` hides the errors, user needs to compare the error returned by `DeferredRESTMapper` with the memcached client's [error](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/discovery/cached/memcache.go#L48) to determine if the RESTMapper needs to be `Reset`. This breaks package boundary.

2. Upon mapping request failure, the `DeferredRESTMapper` checks if the underlying discovery client is fresh, if not, the mapper refreshes the discovery client. The current code is already doing this, but missed the `getDelegate()` call path.

Fixes #68735
/sig api-machinery

/assign @wojtek-t @dims @deads2k @liggitt 

