### PR TITLE
e2e storage: add TERM signal to reduce pod terminating time

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -123,7 +123,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 					{
 						Name:    "liveness",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 10; rm -rf /tmp/health; sleep 600"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; echo ok >/tmp/health; sleep 10; rm -rf /tmp/health; sleep 600"},
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								Exec: &v1.ExecAction{
@@ -155,7 +155,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 					{
 						Name:    "liveness",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 600"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; echo ok >/tmp/health; sleep 600"},
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								Exec: &v1.ExecAction{
@@ -290,7 +290,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 					{
 						Name:    "liveness",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "sleep 600"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; sleep 600"},
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								Exec: &v1.ExecAction{

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -487,7 +487,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 					{
 						Name:    "main",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "echo container is alive; sleep 600"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; echo container is alive; sleep 600"},
 					},
 				},
 			},
@@ -563,7 +563,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 					{
 						Name:    "main",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "echo container is alive; sleep 10000"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; echo container is alive; sleep 10000"},
 					},
 				},
 			},
@@ -618,7 +618,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 					{
 						Name:    containerName,
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "sleep 5", "/crash/missing"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; sleep 5", "/crash/missing"},
 					},
 				},
 			},
@@ -659,7 +659,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 					{
 						Name:    containerName,
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "sleep 5", "/crash/missing"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; sleep 5", "/crash/missing"},
 					},
 				},
 			},
@@ -716,7 +716,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 					{
 						Name:    "pod-readiness-gate",
 						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-						Command: []string{"/bin/sh", "-c", "echo container is alive; sleep 10000"},
+						Command: []string{"/bin/sh", "-c", "trap exit TERM; echo container is alive; sleep 10000"},
 					},
 				},
 				ReadinessGates: []v1.PodReadinessGate{

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -85,7 +85,7 @@ while true; do sleep 1; done
 `
 					tmpCmd := fmt.Sprintf(cmdScripts, path.Join(restartCountVolumePath, "restartCount"))
 					testContainer.Name = testCase.Name
-					testContainer.Command = []string{"sh", "-c", tmpCmd}
+					testContainer.Command = []string{"sh", "-c", fmt.Sprintf("trap exit TERM; %s", tmpCmd)}
 					terminateContainer := ConformanceContainer{
 						PodClient:     f.PodClient(),
 						Container:     testContainer,
@@ -298,7 +298,7 @@ while true; do sleep 1; done
 				testCase := testCase
 				It(testCase.description+" [NodeConformance]", func() {
 					name := "image-pull-test"
-					command := []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
+					command := []string{"/bin/sh", "-c", "trap exit TERM; while true; do sleep 1; done"}
 					container := ConformanceContainer{
 						PodClient: f.PodClient(),
 						Container: v1.Container{

--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -262,7 +262,7 @@ func MakeDeployment(replicas int32, podLabels map[string]string, nodeSelector ma
 							Name:    "write-pod",
 							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 							Command: []string{"/bin/sh"},
-							Args:    []string{"-c", command},
+							Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 							SecurityContext: &v1.SecurityContext{
 								Privileged: &isPrivileged,
 							},

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -837,7 +837,7 @@ func MakePod(ns string, nodeSelector map[string]string, pvclaims []*v1.Persisten
 					Name:    "write-pod",
 					Image:   BusyBoxImage,
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
+					Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &isPrivileged,
 					},
@@ -935,7 +935,7 @@ func MakeSecPod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bo
 					Name:    "write-pod",
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
+					Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &isPrivileged,
 					},

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -5141,7 +5141,7 @@ func (f *Framework) NewTestPod(name string, requests v1.ResourceList, limits v1.
 
 // create empty file at given path on the pod.
 func CreateEmptyFileOnPod(namespace string, podName string, filePath string) error {
-	_, err := RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName, "--", "/bin/sh", "-c", fmt.Sprintf("touch %s", filePath))
+	_, err := RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName, "--", "/bin/sh", "-c", fmt.Sprintf("trap exit TERM; touch %s", filePath))
 	return err
 }
 

--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -440,7 +440,7 @@ func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGro
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"while true ; do cat /opt/0/index.html ; sleep 2 ; ls -altrh /opt/  ; sleep 2 ; done ",
+						"trap exit TERM; while true ; do cat /opt/0/index.html ; sleep 2 ; ls -altrh /opt/  ; sleep 2 ; done ",
 					},
 					VolumeMounts: []v1.VolumeMount{},
 				},

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -106,7 +106,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 					Args: []string{
 						"/bin/sh",
 						"-c",
-						fmt.Sprintf("while true ; do echo %v ; sleep %v; done", kilobyte, sleep.Seconds()),
+						fmt.Sprintf("trap exit TERM; while true ; do echo %v ; sleep %v; done", kilobyte, sleep.Seconds()),
 					},
 				}},
 				NodeName:      n.Name,

--- a/test/e2e/instrumentation/logging/stackdriver/basic.go
+++ b/test/e2e/instrumentation/logging/stackdriver/basic.go
@@ -112,7 +112,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 				cmd := []string{
 					"/bin/sh",
 					"-c",
-					fmt.Sprintf("while :; do printf '%%*s' %d | tr ' ' 'A'; echo; sleep 60; done", maxLength+1),
+					fmt.Sprintf("trap exit TERM; while :; do printf '%%*s' %d | tr ' ' 'A'; echo; sleep 60; done", maxLength+1),
 				}
 
 				pod, err := utils.StartAndReturnSelf(utils.NewExecLoggingPod("synthlogger-4", cmd), f)

--- a/test/e2e/instrumentation/logging/utils/logging_pod.go
+++ b/test/e2e/instrumentation/logging/utils/logging_pod.go
@@ -142,7 +142,7 @@ func NewRepeatingLoggingPod(podName string, line string) LoggingPod {
 	cmd := []string{
 		"/bin/sh",
 		"-c",
-		fmt.Sprintf("while :; do echo '%s'; sleep 1; done", line),
+		fmt.Sprintf("trap exit TERM; while :; do echo '%s'; sleep 1; done", line),
 	}
 	return NewExecLoggingPod(podName, cmd)
 }

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -34,7 +34,7 @@ func preparePod(name string, node *v1.Node, propagation *v1.MountPropagationMode
 	bTrue := true
 	var oneSecond int64 = 1
 	// The pod prepares /mnt/test/<podname> and sleeps.
-	cmd := fmt.Sprintf("mkdir /mnt/test/%[1]s; sleep 3600", name)
+	cmd := fmt.Sprintf("trap exit TERM; mkdir /mnt/test/%[1]s; sleep 3600", name)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -320,7 +320,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 				ssTester := framework.NewStatefulSetTester(c)
 
 				By("Creating a StatefulSet pod to initialize data")
-				writeCmd := "true"
+				writeCmd := "trap exit TERM; true"
 				for i := 0; i < numVols; i++ {
 					writeCmd += fmt.Sprintf("&& touch %v", getVolumeFile(i))
 				}
@@ -360,7 +360,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Creating a new Statefulset and validating the data")
-				validateCmd := "true"
+				validateCmd := "trap exit TERM; true"
 				for i := 0; i < numVols; i++ {
 					validateCmd += fmt.Sprintf("&& test -f %v", getVolumeFile(i))
 				}

--- a/test/e2e/storage/regional_pd.go
+++ b/test/e2e/storage/regional_pd.go
@@ -450,7 +450,7 @@ func newPodTemplate(labels map[string]string) *v1.PodTemplateSpec {
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"sh", "-c"},
 					Args: []string{
-						"echo ${POD_NAME} >> /mnt/data/regional-pd/pods.txt;" +
+						"trap exit TERM; echo ${POD_NAME} >> /mnt/data/regional-pd/pods.txt;" +
 							"cat /mnt/data/regional-pd/pods.txt;" +
 							"sleep 3600;",
 					},

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -498,7 +498,7 @@ func volumeFormatPod(f *framework.Framework, volumeSource *v1.VolumeSource) *v1.
 				{
 					Name:    fmt.Sprintf("init-volume-%s", f.Namespace.Name),
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
-					Command: []string{"/bin/sh", "-ec", "echo nothing"},
+					Command: []string{"/bin/sh", "-ec", "trap exit TERM; echo nothing"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -525,7 +525,7 @@ func clearSubpathPodCommands(pod *v1.Pod) {
 }
 
 func setInitCommand(pod *v1.Pod, command string) {
-	pod.Spec.InitContainers[0].Command = []string{"/bin/sh", "-ec", command}
+	pod.Spec.InitContainers[0].Command = []string{"/bin/sh", "-ec", fmt.Sprintf("trap exit TERM; %s", command)}
 }
 
 func setWriteCommand(file string, container *v1.Container) {
@@ -608,9 +608,9 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 	pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
 
 	pod.Spec.Containers[0].Image = imageutils.GetE2EImage(imageutils.BusyBox)
-	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
+	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-ec", "trap exit TERM; sleep 100000"}
 	pod.Spec.Containers[1].Image = imageutils.GetE2EImage(imageutils.BusyBox)
-	pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
+	pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "trap exit TERM; sleep 100000"}
 
 	// Add liveness probe to subpath container
 	pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
@@ -703,9 +703,9 @@ func testSubpathReconstruction(f *framework.Framework, pod *v1.Pod, forceDelete 
 
 	// Change to busybox
 	pod.Spec.Containers[0].Image = imageutils.GetE2EImage(imageutils.BusyBox)
-	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
+	pod.Spec.Containers[0].Command = []string{"/bin/sh", "-ec", "trap exit TERM; sleep 100000"}
 	pod.Spec.Containers[1].Image = imageutils.GetE2EImage(imageutils.BusyBox)
-	pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
+	pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "trap exit TERM; sleep 100000"}
 
 	// If grace period is too short, then there is not enough time for the volume
 	// manager to cleanup the volumes

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -216,7 +216,7 @@ func makePodSpec(config framework.VolumeTestConfig, dir, initCmd string, volsrc 
 					Command: []string{
 						"/bin/sh",
 						"-c",
-						"sleep 3600", // keep pod alive until explicitly deleted
+						"trap exit TERM; sleep 3600", // keep pod alive until explicitly deleted
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{

--- a/test/e2e/storage/utils/utils.go
+++ b/test/e2e/storage/utils/utils.go
@@ -283,7 +283,7 @@ func RunInPodWithVolume(c clientset.Interface, ns, claimName, command string) {
 					Name:    "volume-tester",
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
+					Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "my-volume",

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -1221,7 +1221,7 @@ func runInPodWithVolume(c clientset.Interface, ns, claimName, nodeName, command 
 					Name:    "volume-tester",
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
+					Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "my-volume",

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -290,7 +290,7 @@ func getVSpherePodSpecWithClaim(claimName string, nodeSelectorKV map[string]stri
 					Name:    "volume-tester",
 					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", command},
+					Args:    []string{"-c", fmt.Sprintf("trap exit TERM; %s", command)},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      "my-volume",
@@ -338,7 +338,7 @@ func getVSpherePodSpecWithVolumePaths(volumePaths []string, keyValuelabel map[st
 		commands = []string{
 			"/bin/sh",
 			"-c",
-			"while true; do sleep 2; done",
+			"trap exit TERM; while true; do sleep 2; done",
 		}
 	}
 	pod := &v1.Pod{

--- a/test/e2e/upgrades/nvidia-gpu.go
+++ b/test/e2e/upgrades/nvidia-gpu.go
@@ -74,7 +74,7 @@ func (t *NvidiaGPUUpgradeTest) startJob(f *framework.Framework) {
 			{
 				Name:    "vector-addition",
 				Image:   imageutils.GetE2EImage(imageutils.CudaVectorAdd),
-				Command: []string{"/bin/sh", "-c", "./vectorAdd && sleep 60"},
+				Command: []string{"/bin/sh", "-c", "trap exit TERM; ./vectorAdd && sleep 60"},
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
 						framework.NVIDIAGPUResourceName: *resource.NewQuantity(1, resource.DecimalSI),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
xref #64015

Shorten the termination time for e2e storage tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68809

**Special notes for your reviewer**:
/sig storage
@kubernetes/sig-storage-pr-reviews 
/cc @msau42 @cofyc 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
e2e storage: add TERM signal to reduce pod terminating time
```
