### PR TITLE
Add controller roles to CSI e2e tests

### DIFF
--- a/test/e2e/manifest/BUILD
+++ b/test/e2e/manifest/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/rbac/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",

--- a/test/e2e/manifest/manifest.go
+++ b/test/e2e/manifest/manifest.go
@@ -23,6 +23,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -141,4 +142,21 @@ func DaemonSetFromManifest(fileName, ns string) (*apps.DaemonSet, error) {
 	}
 	ds.Namespace = ns
 	return &ds, nil
+}
+
+// RoleFromManifest returns a Role from a manifest stored in fileName in the Namespace indicated by ns.
+func RoleFromManifest(fileName, ns string) (*rbac.Role, error) {
+	var role rbac.Role
+	data := generated.ReadOrDie(fileName)
+
+	json, err := utilyaml.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	err = runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), json, &role)
+	if err != nil {
+		return nil, err
+	}
+	role.Namespace = ns
+	return &role, nil
 }

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -334,6 +334,8 @@ func (h *hostpathCSIDriver) createCSIDriver() {
 	config := h.config
 	h.serviceAccount = csiServiceAccount(cs, config, "hostpath", false)
 	csiClusterRoleBindings(cs, config, false, h.serviceAccount, h.combinedClusterRoleNames)
+	role := csiControllerRole(cs, config, false)
+	csiControllerRoleBinding(cs, config, false, role, h.serviceAccount)
 	csiHostPathPod(cs, config, false, f, h.serviceAccount)
 }
 
@@ -344,6 +346,8 @@ func (h *hostpathCSIDriver) cleanupCSIDriver() {
 	config := h.config
 	csiHostPathPod(cs, config, true, f, h.serviceAccount)
 	csiClusterRoleBindings(cs, config, true, h.serviceAccount, h.combinedClusterRoleNames)
+	role := csiControllerRole(cs, config, true)
+	csiControllerRoleBinding(cs, config, true, role, h.serviceAccount)
 	csiServiceAccount(cs, config, "hostpath", true)
 }
 
@@ -402,8 +406,8 @@ func (g *gcePDCSIDriver) createCSIDriver() {
 	g.nodeServiceAccount = csiServiceAccount(cs, config, "gce-node", false /* teardown */)
 	csiClusterRoleBindings(cs, config, false /* teardown */, g.controllerServiceAccount, g.controllerClusterRoles)
 	csiClusterRoleBindings(cs, config, false /* teardown */, g.nodeServiceAccount, g.nodeClusterRoles)
-	utils.PrivilegedTestPSPClusterRoleBinding(cs, config.Namespace,
-		false /* teardown */, []string{g.controllerServiceAccount.Name, g.nodeServiceAccount.Name})
+	role := csiControllerRole(cs, config, false)
+	csiControllerRoleBinding(cs, config, false, role, g.controllerServiceAccount)
 	deployGCEPDCSIDriver(cs, config, false /* teardown */, f, g.nodeServiceAccount, g.controllerServiceAccount)
 }
 
@@ -415,8 +419,8 @@ func (g *gcePDCSIDriver) cleanupCSIDriver() {
 	deployGCEPDCSIDriver(cs, config, true /* teardown */, f, g.nodeServiceAccount, g.controllerServiceAccount)
 	csiClusterRoleBindings(cs, config, true /* teardown */, g.controllerServiceAccount, g.controllerClusterRoles)
 	csiClusterRoleBindings(cs, config, true /* teardown */, g.nodeServiceAccount, g.nodeClusterRoles)
-	utils.PrivilegedTestPSPClusterRoleBinding(cs, config.Namespace,
-		true /* teardown */, []string{g.controllerServiceAccount.Name, g.nodeServiceAccount.Name})
+	role := csiControllerRole(cs, config, true)
+	csiControllerRoleBinding(cs, config, true, role, g.controllerServiceAccount)
 	csiServiceAccount(cs, config, "gce-controller", true /* teardown */)
 	csiServiceAccount(cs, config, "gce-node", true /* teardown */)
 }

--- a/test/e2e/testing-manifests/storage-csi/controller-role.yaml
+++ b/test/e2e/testing-manifests/storage-csi/controller-role.yaml
@@ -1,0 +1,11 @@
+# Role for external CSI provisioner and attacher.
+# They need to modify Endpoints and ConfigMap for leader election.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "endpoints"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]


### PR DESCRIPTION
External attacher + provisioner need extra role for leader election.
Fixes #68819

**Release note**:
```release-note
NONE
```

/sig storage
@pohly, PTAL
