### PR TITLE
Bump kube-dns to 1.14.13

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -96,7 +96,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.12
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -147,7 +147,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.12
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -187,7 +187,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.12
+        image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -96,7 +96,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.12
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -147,7 +147,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.12
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -187,7 +187,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.12
+        image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -96,7 +96,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.12
+        image: k8s.gcr.io/k8s-dns-kube-dns:1.14.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -147,7 +147,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.12
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -187,7 +187,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar:1.14.12
+        image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -147,7 +147,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
 						DNSType:        "kube-dns",
-						DNSVersion:     "1.14.12",
+						DNSVersion:     "1.14.13",
 						EtcdVersion:    "3.1.12",
 					},
 				},
@@ -163,7 +163,7 @@ API Server           v1.8.3    v1.9.0
 Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
-Kube DNS             1.14.5    1.14.12
+Kube DNS             1.14.5    1.14.13
 Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:
@@ -213,7 +213,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
 						DNSType:        "kube-dns",
-						DNSVersion:     "1.14.12",
+						DNSVersion:     "1.14.13",
 						EtcdVersion:    "3.1.12",
 					},
 				},
@@ -249,7 +249,7 @@ API Server           v1.8.3    v1.9.0
 Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
-Kube DNS             1.14.5    1.14.12
+Kube DNS             1.14.5    1.14.13
 Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:
@@ -281,7 +281,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0-beta.1",
 						KubeadmVersion: "v1.9.0-beta.1",
 						DNSType:        "kube-dns",
-						DNSVersion:     "1.14.12",
+						DNSVersion:     "1.14.13",
 						EtcdVersion:    "3.1.12",
 					},
 				},
@@ -297,7 +297,7 @@ API Server           v1.8.5    v1.9.0-beta.1
 Controller Manager   v1.8.5    v1.9.0-beta.1
 Scheduler            v1.8.5    v1.9.0-beta.1
 Kube Proxy           v1.8.5    v1.9.0-beta.1
-Kube DNS             1.14.5    1.14.12
+Kube DNS             1.14.5    1.14.13
 Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:
@@ -329,7 +329,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0-rc.1",
 						KubeadmVersion: "v1.9.0-rc.1",
 						DNSType:        "kube-dns",
-						DNSVersion:     "1.14.12",
+						DNSVersion:     "1.14.13",
 						EtcdVersion:    "3.1.12",
 					},
 				},
@@ -345,7 +345,7 @@ API Server           v1.8.5    v1.9.0-rc.1
 Controller Manager   v1.8.5    v1.9.0-rc.1
 Scheduler            v1.8.5    v1.9.0-rc.1
 Kube Proxy           v1.8.5    v1.9.0-rc.1
-Kube DNS             1.14.5    1.14.12
+Kube DNS             1.14.5    1.14.13
 Etcd                 3.0.17    3.1.12
 
 You can now apply the upgrade by executing the following command:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -299,7 +299,7 @@ const (
 	LeaseEndpointReconcilerType = "lease"
 
 	// KubeDNSVersion is the version of kube-dns to be deployed if it is used
-	KubeDNSVersion = "1.14.12"
+	KubeDNSVersion = "1.14.13"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
 	CoreDNSVersion = "1.2.2"

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -715,7 +715,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						KubeVersion:    "v1.12.0",
 						KubeadmVersion: "v1.12.0",
 						DNSType:        "kube-dns",
-						DNSVersion:     "1.14.12",
+						DNSVersion:     "1.14.13",
 						EtcdVersion:    "3.2.24",
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubernetes/pull/68430#issuecomment-423292582.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @bowei @timothysc
cc @neolit123 @tpepper @dims @Random-Liu 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump kube-dns to 1.14.13
- Update Alpine base image to 3.8.1.
- Build multi-arch images correctly.
```
