### PR TITLE
Use NodeGetId() as a fallback when NodeGetInfo() is not implemented in the driver

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -391,6 +391,7 @@ pkg/volume/azure_dd
 pkg/volume/azure_file
 pkg/volume/cephfs
 pkg/volume/configmap
+pkg/volume/csi
 pkg/volume/csi/fake
 pkg/volume/empty_dir
 pkg/volume/fc

--- a/pkg/volume/csi/BUILD
+++ b/pkg/volume/csi/BUILD
@@ -33,6 +33,8 @@ go_library(
         "//vendor/github.com/container-storage-interface/spec/lib/go/csi/v0:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
     ],
 )
 
@@ -71,6 +73,8 @@ go_test(
         "//staging/src/k8s.io/csi-api/pkg/client/clientset/versioned/fake:go_default_library",
         "//vendor/github.com/container-storage-interface/spec/lib/go/csi/v0:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
     ],
 )
 

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -19,12 +19,14 @@ package csi
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	csipb "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	api "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/volume/csi/fake"
-	"reflect"
 )
 
 type fakeCsiDriverClient struct {
@@ -46,6 +48,12 @@ func (c *fakeCsiDriverClient) NodeGetInfo(ctx context.Context) (
 	err error) {
 	resp, err := c.nodeClient.NodeGetInfo(ctx, &csipb.NodeGetInfoRequest{})
 	return resp.GetNodeId(), resp.GetMaxVolumesPerNode(), resp.GetAccessibleTopology(), err
+}
+
+// for pre-v1.0
+func (c *fakeCsiDriverClient) NodeGetId(ctx context.Context) (nodeID string, err error) {
+	resp, err := c.nodeClient.NodeGetId(ctx, &csipb.NodeGetIdRequest{})
+	return resp.GetNodeId(), err
 }
 
 func (c *fakeCsiDriverClient) NodePublishVolume(
@@ -205,6 +213,48 @@ func TestClientNodeGetInfo(t *testing.T) {
 	}
 }
 
+func TestClientNodeGetId(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedNodeID string
+		mustFail       bool
+		err            error
+	}{
+		{
+			name:           "test ok",
+			expectedNodeID: "node1",
+		},
+		{
+			name:     "grpc error",
+			mustFail: true,
+			err:      errors.New("grpc error"),
+		},
+	}
+
+	client := setupClient(t, false /* stageUnstageSet */)
+
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		client.(*fakeCsiDriverClient).nodeClient.SetNextError(tc.err)
+		client.(*fakeCsiDriverClient).nodeClient.SetNodeGetIdResp(&csipb.NodeGetIdResponse{
+			NodeId: tc.expectedNodeID,
+		})
+		nodeID, err := client.NodeGetId(context.Background())
+
+		if tc.mustFail && err == nil {
+			t.Error("expected an error but got none")
+		}
+
+		if !tc.mustFail && err != nil {
+			t.Errorf("expected no errors but got: %v", err)
+		}
+
+		if nodeID != tc.expectedNodeID {
+			t.Errorf("expected nodeID: %v; got: %v", tc.expectedNodeID, nodeID)
+		}
+	}
+}
+
 func TestClientNodePublishVolume(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -337,4 +387,101 @@ func TestClientNodeUnstageVolume(t *testing.T) {
 			t.Error("test must fail, but err is nil")
 		}
 	}
+}
+
+func TestGetNodeInfoWithFallback(t *testing.T) {
+	var errRandom = errors.New("some other error")
+	var errUnimplemented = status.Error(codes.Unimplemented, "unknown method someRandomMethod")
+
+	testCases := map[string]struct {
+		nodeGetInfoErr          error
+		nodeGetIdErr            error
+		expectedErr             error
+		expectedGetNodeInfoCall bool
+		expectedGetNodeIdCall   bool
+	}{
+		"no error on neither method": {
+			nodeGetInfoErr:          nil,
+			nodeGetIdErr:            nil,
+			expectedErr:             nil,
+			expectedGetNodeInfoCall: true,
+			expectedGetNodeIdCall:   false,
+		},
+		"unimplemented NodeGetInfo": {
+			nodeGetInfoErr:          errUnimplemented,
+			nodeGetIdErr:            nil,
+			expectedErr:             nil,
+			expectedGetNodeInfoCall: true,
+			expectedGetNodeIdCall:   true,
+		},
+		"other error for NodeGetInfo": {
+			nodeGetInfoErr:          errRandom,
+			nodeGetIdErr:            nil,
+			expectedErr:             errRandom,
+			expectedGetNodeInfoCall: true,
+			expectedGetNodeIdCall:   false,
+		},
+		"unimplemented NodeGetInfo and error on NodeGetId": {
+			nodeGetInfoErr:          errUnimplemented,
+			nodeGetIdErr:            errRandom,
+			expectedErr:             errRandom,
+			expectedGetNodeInfoCall: true,
+			expectedGetNodeIdCall:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.TODO()
+			ig := &nodeInfoGetter{
+				nodeGetInfoErr: tc.nodeGetInfoErr,
+				nodeGetIdErr:   tc.nodeGetIdErr,
+			}
+			_, _, _, err := getNodeInfoWithFallback(ctx, ig)
+			if err != tc.expectedErr {
+				t.Errorf("Expected error %v, got: %v", tc.expectedErr, err)
+			}
+			checkCall(t, ig.nodeGetInfoCallCount, tc.expectedGetNodeInfoCall, "NodeGetInfo")
+			checkCall(t, ig.nodeGetIdCallCount, tc.expectedGetNodeIdCall, "NodeGetId")
+		})
+	}
+}
+
+func checkCall(t *testing.T, callCount int, expectedCall bool, funcName string) {
+	t.Helper()
+
+	if expectedCall {
+		if callCount < 1 {
+			t.Errorf("Expected %s to be called, was not called", funcName)
+		}
+		return
+	}
+
+	if callCount > 0 {
+		t.Errorf("Expected %s not to be calle, was called %d times", funcName, callCount)
+	}
+}
+
+type nodeInfoGetter struct {
+	nodeGetIdErr   error
+	nodeGetInfoErr error
+
+	nodeGetIdCallCount   int
+	nodeGetInfoCallCount int
+}
+
+func (g *nodeInfoGetter) NodeGetId(ctx context.Context) (string, error) {
+	g.nodeGetIdCallCount += 1
+	if err := g.nodeGetIdErr; err != nil {
+		return "", err
+	}
+	return "some node id", nil
+}
+
+func (g *nodeInfoGetter) NodeGetInfo(ctx context.Context) (string, int64, *csipb.Topology, error) {
+	g.nodeGetInfoCallCount += 1
+	if err := g.nodeGetInfoErr; err != nil {
+		return "", 0, nil, err
+	}
+	return "some node id", 0, nil, nil
 }

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -25,10 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"context"
-
 	"github.com/golang/glog"
-
 	api "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,10 +134,10 @@ func (h *RegistrationHandler) RegisterPlugin(pluginName string, endpoint string)
 	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
 	defer cancel()
 
-	driverNodeID, maxVolumePerNode, accessibleTopology, err := csi.NodeGetInfo(ctx)
+	driverNodeID, maxVolumePerNode, accessibleTopology, err := getNodeInfoWithFallback(ctx, csi)
 	if err != nil {
 		unregisterDriver(pluginName)
-		return fmt.Errorf("error during CSI NodeGetInfo() call: %v", err)
+		return fmt.Errorf("error during CSI NodeGetInfo()/NodeGetId() call: %v", err)
 	}
 
 	err = nim.AddNodeInfo(pluginName, driverNodeID, maxVolumePerNode, accessibleTopology)

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -21,14 +21,16 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
-	"time"
 )
 
 const (
@@ -139,4 +141,17 @@ func hasReadWriteOnce(modes []api.PersistentVolumeAccessMode) bool {
 		}
 	}
 	return false
+}
+
+func isUnimplementedMethodErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	status, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	return status.Code() == codes.Unimplemented
 }

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -67,6 +67,7 @@ type NodeClient struct {
 	nodeStagedVolumes    map[string]CSIVolume
 	stageUnstageSet      bool
 	nodeGetInfoResp      *csipb.NodeGetInfoResponse
+	nodeGetIdResp        *csipb.NodeGetIdResponse
 	nextErr              error
 }
 
@@ -86,6 +87,11 @@ func (f *NodeClient) SetNextError(err error) {
 
 func (f *NodeClient) SetNodeGetInfoResp(resp *csipb.NodeGetInfoResponse) {
 	f.nodeGetInfoResp = resp
+}
+
+// for pre-v1.0
+func (f *NodeClient) SetNodeGetIdResp(resp *csipb.NodeGetIdResponse) {
+	f.nodeGetIdResp = resp
 }
 
 // GetNodePublishedVolumes returns node published volumes
@@ -146,7 +152,7 @@ func (f *NodeClient) NodeUnpublishVolume(ctx context.Context, req *csipb.NodeUnp
 	return &csipb.NodeUnpublishVolumeResponse{}, nil
 }
 
-// NodeStagevolume implements csi method
+// NodeStageVolume implements csi method
 func (f *NodeClient) NodeStageVolume(ctx context.Context, req *csipb.NodeStageVolumeRequest, opts ...grpc.CallOption) (*csipb.NodeStageVolumeResponse, error) {
 	if f.nextErr != nil {
 		return nil, f.nextErr
@@ -193,12 +199,15 @@ func (f *NodeClient) NodeUnstageVolume(ctx context.Context, req *csipb.NodeUnsta
 	return &csipb.NodeUnstageVolumeResponse{}, nil
 }
 
-// NodeGetId implements method
+// NodeGetId implements csi method for pre-v1.0
 func (f *NodeClient) NodeGetId(ctx context.Context, in *csipb.NodeGetIdRequest, opts ...grpc.CallOption) (*csipb.NodeGetIdResponse, error) {
-	return nil, nil
+	if e := f.nextErr; e != nil {
+		return nil, e
+	}
+	return f.nodeGetIdResp, nil
 }
 
-// NodeGetId implements csi method
+// NodeGetInfo implements csi method
 func (f *NodeClient) NodeGetInfo(ctx context.Context, in *csipb.NodeGetInfoRequest, opts ...grpc.CallOption) (*csipb.NodeGetInfoResponse, error) {
 	if f.nextErr != nil {
 		return nil, f.nextErr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Some CSI drivers (e.g. OpenSDS) might not implement the `NodeGetInfo()` call yet but only `NodeGetId()`. With this PR we fall back to `NodeGetId()` when `NodeGetInfo()` returns an `Unimplemented` error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

#68688 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CSI: Use NodeGetId() as a fallback when NodeGetInfo() is not implemented in the driver
```
