### PR TITLE
kubeadm: fix broken Docker 17.xx validation

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -37,8 +37,8 @@ func (d *DockerValidator) Name() string {
 }
 
 const (
-	dockerConfigPrefix        = "DOCKER_"
-	maxDockerValidatedVersion = "18.06"
+	dockerConfigPrefix           = "DOCKER_"
+	latestValidatedDockerVersion = "18.06"
 )
 
 // TODO(random-liu): Add more validating items.
@@ -78,9 +78,9 @@ func (d *DockerValidator) validateDockerInfo(spec *DockerSpec, info types.Info) 
 		if r.MatchString(info.ServerVersion) {
 			d.Reporter.Report(dockerConfigPrefix+"VERSION", info.ServerVersion, good)
 			w := fmt.Errorf(
-				"docker version is greater than the most recently validated version. Docker version: %s. Max validated version: %s",
+				"this Docker version is not on the list of validated versions: %s. Latest validated version: %s",
 				info.ServerVersion,
-				maxDockerValidatedVersion,
+				latestValidatedDockerVersion,
 			)
 			return w, nil
 		}

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.1[1-3]\..*`, `18\.06\..*`}, // Requires [1.11, 18.06].
+		Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.06\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -68,6 +68,11 @@ func TestValidateDockerInfo(t *testing.T) {
 		},
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "17.06.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.09.0-ce"},
 			err:  false,
 			warn: false,
 		},

--- a/cmd/kubeadm/app/util/system/types_unix.go
+++ b/cmd/kubeadm/app/util/system/types_unix.go
@@ -62,7 +62,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`1\.1[1-3]\..*`, `18\.06\..*`}, // Requires [1.11, 18.06]
+			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.06\..*`},
 			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

A previous commit https://github.com/kubernetes/kubernetes/commit/97c9fa3cb98497460cc8aaed2ae3c1514d6055c6#diff-04e26ffab72c7e12fbb59ad41ba114ad updated 17.xx -> 18.xx, but some systems still use 17.xx.

Add handling for 17.0[3,6,9] as validated versions.
Also re-format the error message because the version is not validated
per maximum basis, but rather based on existing validation for individual versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**release note NONE if we merge now**, otherwise it has to be added.

this is not critical priority for 1.12:
- it throws a warning for users with Docker 17.xx
- the kubeadm unit tests fail

/kind bug
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @timothysc 
