### PR TITLE
Add fall-back to get node IP on host_path tests

### DIFF
--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -136,9 +136,12 @@ var _ = Describe("[sig-storage] HostPath", func() {
 
 		// Create the subPath directory on the host
 		existing := path.Join(source.Path, subPath)
-		externalIP, err := framework.GetNodeExternalIP(&nodeList.Items[0])
+		nodeIP, err := framework.GetNodeExternalIP(&nodeList.Items[0])
+		if err != nil {
+			nodeIP, err = framework.GetNodeInternalIP(&nodeList.Items[0])
+		}
 		framework.ExpectNoError(err)
-		result, err := framework.SSH(fmt.Sprintf("mkdir -p %s", existing), externalIP, framework.TestContext.Provider)
+		result, err := framework.SSH(fmt.Sprintf("mkdir -p %s", existing), nodeIP, framework.TestContext.Provider)
 		framework.LogSSHResult(result)
 		framework.ExpectNoError(err)
 		if result.Code != 0 {
@@ -182,9 +185,12 @@ var _ = Describe("[sig-storage] HostPath", func() {
 
 		// Create the subPath file on the host
 		existing := path.Join(source.Path, subPath)
-		externalIP, err := framework.GetNodeExternalIP(&nodeList.Items[0])
+		nodeIP, err := framework.GetNodeExternalIP(&nodeList.Items[0])
+		if err != nil {
+			nodeIP, err = framework.GetNodeInternalIP(&nodeList.Items[0])
+		}
 		framework.ExpectNoError(err)
-		result, err := framework.SSH(fmt.Sprintf("echo \"mount-tester new file\" > %s", existing), externalIP, framework.TestContext.Provider)
+		result, err := framework.SSH(fmt.Sprintf("echo \"mount-tester new file\" > %s", existing), nodeIP, framework.TestContext.Provider)
 		framework.LogSSHResult(result)
 		framework.ExpectNoError(err)
 		if result.Code != 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

As the same as the commit[1], this adds fall-back way to get a
node IP address on host_path e2e tests for environments which
don't support external IPs.

[1]: https://github.com/kubernetes/kubernetes/commit/4e7c2f638d311a6a939ef7aa146f195bc33d06dc#diff-5ee86aefbb33223865bc542107ea8560L81

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68914

**Release note**:
```None```
