### PR TITLE
Configure resource-only container with memory limit

### DIFF
--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -101,8 +101,15 @@ func (m *containerManager) doWork() {
 
 func createCgroupManager(name string) (*fs.Manager, error) {
 	var memoryLimit uint64
+
 	memoryCapacity, err := getMemoryCapacity()
-	if err != nil || memoryCapacity*dockerMemoryLimitThresholdPercent/100 < minDockerMemoryLimit {
+	if err != nil {
+		glog.Errorf("Failed to get the memory capacity on machine: %v", err)
+	} else {
+		memoryLimit = memoryCapacity * dockerMemoryLimitThresholdPercent / 100
+	}
+
+	if err != nil || memoryLimit < minDockerMemoryLimit {
 		memoryLimit = minDockerMemoryLimit
 	}
 	glog.V(2).Infof("Configure resource-only container %q with memory limit: %d", name, memoryLimit)


### PR DESCRIPTION
The docker memory limit should base on the memory capacity of
machine. Currently CgroupManager specify wrong memory limit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68928

**Release note**:
```release-note
NONE
```
