### PR TITLE
Update Cluster Autoscaler version to 1.3.3

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.3.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
CA 1.3.3 release notes:
https://github.com/kubernetes/autoscaler/releases/tag/1.3.3

```release-note
Update Cluster Autoscaler to version 1.3.3.
```
