### PR TITLE
Add guidelines for creating new staging repos

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -46,3 +46,53 @@ import (
 
 Once the change-over to external repositories is complete, these repositories
 will actually be vendored from `k8s.io/<package-name>`.
+
+## Creating a new repository in staging
+
+### Adding the staging repository in `kubernetes/kubernetes`:
+
+1. Send an email to the SIG Architecture
+[mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-architecture)
+and the mailing list of the SIG which would own the repo requesting approval
+for creating the staging repository.
+
+2. Once approval has been granted, create the new staging repository.
+
+3. Add a symlink to the staging repo in `vendor/k8s.io`.
+
+4. Update [`hack/import-restrictions.yaml`](https://github.com/kubernetes/kubernetes/blob/master/hack/import-restrictions.yaml)
+to add the list of other staging repos that this new repo can import.
+
+5. Add all mandatory template files mentioned in
+https://github.com/kubernetes/kubernetes-template-project.
+
+6. Make sure that the `.github/PULL_REQUEST_TEMPLATE.md` and
+`CONTRIBUTING.md` files mention that PRs are not directly accepted to the repo.
+
+### Creating the published repository
+
+1. Create an [issue](https://github.com/kubernetes/org/issues/new?template=repo-create.md)
+in the `kubernetes/org` repo to request creation of the respective published
+repository in the Kubernetes org. The published repository **must** have an
+initial empty commit. It also needs specific access rules and branch settings.
+See [#kubernetes/org#58](https://github.com/kubernetes/org/issues/58)
+for an example.
+
+2. Setup branch protection and enable access to the `stage-bots` team
+by adding the repo in
+[`prow/config.yaml`](https://github.com/kubernetes/test-infra/blob/master/prow/config.yaml).
+
+3. Once the repository has been created in the Kubernetes org,
+update the publishing-bot to publish the staging repository by updating:
+
+    - [`kubernetes-rules-configmap.yaml`](https://github.com/kubernetes/publishing-bot/blob/master/configs/kubernetes-rules-configmap.yaml):
+    Make sure that the list of dependencies reflects the staging repos in the `Godeps.json` file.
+
+    - [`fetch-all-latest-and-push.sh`](https://github.com/kubernetes/publishing-bot/blob/master/hack/fetch-all-latest-and-push.sh):
+    Add the staging repo in the list of repos to be published.
+
+4. Add the staging and published repositories as a subproject for the
+SIG that owns the repos in
+[`sigs.yaml`](https://github.com/kubernetes/community/blob/master/sigs.yaml).
+
+5. Add the repo to the list of staging repos in this `README.md` file.


### PR DESCRIPTION
This PR adds guidelines for creating new staging repos.

Most of the details have been taken from the recent staging repo requests: https://github.com/kubernetes/org/issues/58, https://github.com/kubernetes/org/issues/56.

/sig contributor-experience
/kind documentation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
