### PR TITLE
Make sure we pass mount options while creating bind mounts

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -83,11 +83,8 @@ func (f *FakeMounter) Mount(source string, target string, fstype string, options
 				}
 			}
 		}
-		// find 'ro' option
-		if option == "ro" {
-			// reuse MountPoint.Opts field to mark mount as readonly
-			opts = append(opts, "ro")
-		}
+		// reuse MountPoint.Opts field to mark mount as readonly
+		opts = append(opts, option)
 	}
 
 	// If target is a symlink, get its absolute path
@@ -95,7 +92,6 @@ func (f *FakeMounter) Mount(source string, target string, fstype string, options
 	if err != nil {
 		absTarget = target
 	}
-
 	f.MountPoints = append(f.MountPoints, MountPoint{Device: source, Path: absTarget, Type: fstype, Opts: opts})
 	glog.V(5).Infof("Fake mounter: mounted %s to %s", source, absTarget)
 	f.Log = append(f.Log, FakeAction{Action: FakeActionMount, Target: absTarget, Source: source, FSType: fstype})

--- a/pkg/volume/awsebs/aws_ebs_test.go
+++ b/pkg/volume/awsebs/aws_ebs_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -323,5 +324,55 @@ func TestMounterAndUnmounterTypeAssert(t *testing.T) {
 	}
 	if _, ok := unmounter.(volume.Mounter); ok {
 		t.Errorf("Volume Unmounter can be type-assert to Mounter")
+	}
+}
+
+func TestMountOptions(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("aws-ebs")
+	if err != nil {
+		t.Fatalf("can't make a temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(tmpDir, nil, nil))
+
+	plug, err := plugMgr.FindPluginByName("kubernetes.io/aws-ebs")
+	if err != nil {
+		t.Errorf("Can't find the plugin by name")
+	}
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pvA",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{},
+			},
+			ClaimRef: &v1.ObjectReference{
+				Name: "claimA",
+			},
+			MountOptions: []string{"_netdev"},
+		},
+	}
+
+	fakeManager := &fakePDManager{}
+	fakeMounter := &mount.FakeMounter{}
+
+	mounter, err := plug.(*awsElasticBlockStorePlugin).newMounterInternal(volume.NewSpecFromPersistentVolume(pv, false), types.UID("poduid"), fakeManager, fakeMounter)
+	if err != nil {
+		t.Errorf("Failed to make a new Mounter: %v", err)
+	}
+	if mounter == nil {
+		t.Errorf("Got a nil Mounter")
+	}
+
+	if err := mounter.SetUp(nil); err != nil {
+		t.Errorf("Expected success, got: %v", err)
+	}
+	mountOptions := fakeMounter.MountPoints[0].Opts
+	expectedMountOptions := []string{"bind", "_netdev"}
+	if !reflect.DeepEqual(mountOptions, expectedMountOptions) {
+		t.Errorf("Expected mount options to be %v got %v", expectedMountOptions, mountOptions)
 	}
 }

--- a/pkg/volume/fc/disk_manager.go
+++ b/pkg/volume/fc/disk_manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util"
 )
 
 // Abstract interface to disk operations.
@@ -57,7 +58,8 @@ func diskSetUp(manager diskManager, b fcDiskMounter, volPath string, mounter mou
 	if b.readOnly {
 		options = append(options, "ro")
 	}
-	err = mounter.Mount(globalPDPath, volPath, "", options)
+	mountOptions := util.JoinMountOptions(options, b.mountOptions)
+	err = mounter.Mount(globalPDPath, volPath, "", mountOptions)
 	if err != nil {
 		glog.Errorf("Failed to bind mount: source:%s, target:%s, err:%v", globalPDPath, volPath, err)
 		noMnt, mntErr := b.mounter.IsLikelyNotMountPoint(volPath)

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -139,20 +139,22 @@ func (plugin *fcPlugin) newMounterInternal(spec *volume.Spec, podUID types.UID, 
 		}
 		glog.V(5).Infof("fc: newMounterInternal volumeMode %s", volumeMode)
 		return &fcDiskMounter{
-			fcDisk:     fcDisk,
-			fsType:     fc.FSType,
-			volumeMode: volumeMode,
-			readOnly:   readOnly,
-			mounter:    &mount.SafeFormatAndMount{Interface: mounter, Exec: exec},
-			deviceUtil: util.NewDeviceHandler(util.NewIOHandler()),
+			fcDisk:       fcDisk,
+			fsType:       fc.FSType,
+			volumeMode:   volumeMode,
+			readOnly:     readOnly,
+			mounter:      &mount.SafeFormatAndMount{Interface: mounter, Exec: exec},
+			deviceUtil:   util.NewDeviceHandler(util.NewIOHandler()),
+			mountOptions: []string{},
 		}, nil
 	}
 	return &fcDiskMounter{
-		fcDisk:     fcDisk,
-		fsType:     fc.FSType,
-		readOnly:   readOnly,
-		mounter:    &mount.SafeFormatAndMount{Interface: mounter, Exec: exec},
-		deviceUtil: util.NewDeviceHandler(util.NewIOHandler()),
+		fcDisk:       fcDisk,
+		fsType:       fc.FSType,
+		readOnly:     readOnly,
+		mounter:      &mount.SafeFormatAndMount{Interface: mounter, Exec: exec},
+		deviceUtil:   util.NewDeviceHandler(util.NewIOHandler()),
+		mountOptions: util.MountOptionFromSpec(spec),
 	}, nil
 
 }
@@ -374,11 +376,12 @@ func (fc *fcDisk) fcPodDeviceMapPath() (string, string) {
 
 type fcDiskMounter struct {
 	*fcDisk
-	readOnly   bool
-	fsType     string
-	volumeMode v1.PersistentVolumeMode
-	mounter    *mount.SafeFormatAndMount
-	deviceUtil util.DeviceUtil
+	readOnly     bool
+	fsType       string
+	volumeMode   v1.PersistentVolumeMode
+	mounter      *mount.SafeFormatAndMount
+	deviceUtil   util.DeviceUtil
+	mountOptions []string
 }
 
 var _ volume.Mounter = &fcDiskMounter{}


### PR DESCRIPTION
This fixes an inconsitency that exists in mounter

Fixes https://github.com/kubernetes/kubernetes/issues/68692

/sig storage

```release-note
None
```