### PR TITLE
Fix [sig-storage] naming consistency for upgrade tests

### DIFF
--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -35,7 +35,7 @@ type ConfigMapUpgradeTest struct {
 }
 
 func (ConfigMapUpgradeTest) Name() string {
-	return "configmap-upgrade [sig-storage] [sig-api-machinery]"
+	return "[sig-storage] [sig-api-machinery] configmap-upgrade"
 }
 
 // Setup creates a ConfigMap and then verifies that a pod can consume it.

--- a/test/e2e/upgrades/secrets.go
+++ b/test/e2e/upgrades/secrets.go
@@ -34,7 +34,7 @@ type SecretUpgradeTest struct {
 	secret *v1.Secret
 }
 
-func (SecretUpgradeTest) Name() string { return "secret-upgrade [sig-storage] [sig-api-machinery]" }
+func (SecretUpgradeTest) Name() string { return "[sig-storage] [sig-api-machinery] secret-upgrade" }
 
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *SecretUpgradeTest) Setup(f *framework.Framework) {

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -33,7 +33,7 @@ type PersistentVolumeUpgradeTest struct {
 	pvc      *v1.PersistentVolumeClaim
 }
 
-func (PersistentVolumeUpgradeTest) Name() string { return "persistent-volume-upgrade [sig-storage]" }
+func (PersistentVolumeUpgradeTest) Name() string { return "[sig-storage] persistent-volume-upgrade" }
 
 const (
 	pvTestFile string = "/mnt/volume1/pv_upgrade_test"


### PR DESCRIPTION
see title

/kind cleanup
/sig storage
/assign @msau42 

```release-note
NONE
```