### PR TITLE
Add CheckNodeCondition predicate of the scheduler

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -184,7 +184,10 @@ func ApplyFeatureGates() {
 	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
 		// Remove "CheckNodeCondition", "CheckNodeMemoryPressure", "CheckNodePIDPressurePred"
 		// and "CheckNodeDiskPressure" predicates
-		factory.RemoveFitPredicate(predicates.CheckNodeConditionPred)
+
+		// TODO(bsalamat): uncomment the following line to remove "CheckNodeCondition" in 1.13.
+		//                 We had to add it back in 1.12 to get the upgrade tests pass. Issue #68899.
+		// factory.RemoveFitPredicate(predicates.CheckNodeConditionPred)
 		factory.RemoveFitPredicate(predicates.CheckNodeMemoryPressurePred)
 		factory.RemoveFitPredicate(predicates.CheckNodeDiskPressurePred)
 		factory.RemoveFitPredicate(predicates.CheckNodePIDPressurePred)
@@ -192,7 +195,9 @@ func ApplyFeatureGates() {
 		// from ALL algorithm provider
 		// The key will be removed from all providers which in algorithmProviderMap[]
 		// if you just want remove specific provider, call func RemovePredicateKeyFromAlgoProvider()
-		factory.RemovePredicateKeyFromAlgorithmProviderMap(predicates.CheckNodeConditionPred)
+
+		// TODO(bsalamat): same as above TODO. Uncomment the following line in 1.13.
+		// factory.RemovePredicateKeyFromAlgorithmProviderMap(predicates.CheckNodeConditionPred)
 		factory.RemovePredicateKeyFromAlgorithmProviderMap(predicates.CheckNodeMemoryPressurePred)
 		factory.RemovePredicateKeyFromAlgorithmProviderMap(predicates.CheckNodeDiskPressurePred)
 		factory.RemovePredicateKeyFromAlgorithmProviderMap(predicates.CheckNodePIDPressurePred)

--- a/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -105,9 +105,10 @@ func TestApplyFeatureGates(t *testing.T) {
 				t.Fatalf("Failed to find predicate: 'PodToleratesNodeTaints'")
 			}
 
-			if p.FitPredicateKeys.Has("CheckNodeCondition") {
-				t.Fatalf("Unexpected predicate: 'CheckNodeCondition'")
-			}
+			// TODO(bsalamat): Add this again in 1.13. Issue #68899.
+			//if p.FitPredicateKeys.Has("CheckNodeCondition") {
+			//	t.Fatalf("Unexpected predicate: 'CheckNodeCondition'")
+			//}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add CheckNodeCondition predicate of the scheduler back to address the issue in upgrading clusters from previous versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68899

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add CheckNodeCondition predicate of the scheduler back to address the issue in upgrading clusters from previous versions.
```

/sig scheduling
