### PR TITLE
Replace extension server's discovery manager with the delegation's

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -180,7 +180,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
 
-	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
+	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler, s.GenericAPIServer.DiscoveryGroupManager)
 	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient.Apiextensions())
 	finalizingController := finalizer.NewCRDFinalizer(
 		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -442,6 +442,11 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 	}
 	apiServerHandler := NewAPIServerHandler(name, c.Serializer, handlerChainBuilder, delegationTarget.UnprotectedHandler())
 
+	discoveryManager := delegationTarget.GroupManager()
+	if discoveryManager == nil {
+		discoveryManager = discovery.NewRootAPIsHandler(c.DiscoveryAddresses, c.Serializer)
+	}
+
 	s := &GenericAPIServer{
 		discoveryAddresses:     c.DiscoveryAddresses,
 		LoopbackClientConfig:   c.LoopbackClientConfig,
@@ -472,7 +477,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 		healthzChecks: c.HealthzChecks,
 
-		DiscoveryGroupManager: discovery.NewRootAPIsHandler(c.DiscoveryAddresses, c.Serializer),
+		DiscoveryGroupManager: discoveryManager,
 
 		enableAPIResponseCompression: c.EnableAPIResponseCompression,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -175,6 +175,9 @@ type DelegationTarget interface {
 
 	// NextDelegate returns the next delegationTarget in the chain of delegations
 	NextDelegate() DelegationTarget
+
+	// GroupManager returns instance managing api group discovery
+	GroupManager() discovery.GroupManager
 }
 
 func (s *GenericAPIServer) UnprotectedHandler() http.Handler {
@@ -196,6 +199,10 @@ func (s *GenericAPIServer) ListedPaths() []string {
 
 func (s *GenericAPIServer) NextDelegate() DelegationTarget {
 	return s.delegationTarget
+}
+
+func (s *GenericAPIServer) GroupManager() discovery.GroupManager {
+	return s.DiscoveryGroupManager
 }
 
 type emptyDelegate struct {
@@ -221,6 +228,10 @@ func (s emptyDelegate) ListedPaths() []string {
 	return []string{}
 }
 func (s emptyDelegate) NextDelegate() DelegationTarget {
+	return nil
+}
+
+func (s emptyDelegate) GroupManager() discovery.GroupManager {
 	return nil
 }
 


### PR DESCRIPTION

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

the pull allows apiextension server to add/remove group discovery info to the legay server, so that the discovery `/apis` interface from will work without aggregator.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68971

/sig api-machinery
/kind bug

@deads2k will this impact the server plumbing on the complexity? in this pull, we're overwriting sth along the delegation chain.