### PR TITLE
Fixes #65869 Do not listen insecurely if secure port is specified

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -51,6 +51,8 @@ import (
 const (
 	// CloudControllerManagerUserAgent is the userAgent name when starting cloud-controller managers.
 	CloudControllerManagerUserAgent = "cloud-controller-manager"
+	// DefaultInsecureCloudControllerManagerPort is the default insecure cloud-controller manager port.
+	DefaultInsecureCloudControllerManagerPort = 0
 )
 
 // CloudControllerManagerOptions is the main context object for the controller manager.
@@ -74,7 +76,7 @@ type CloudControllerManagerOptions struct {
 
 // NewCloudControllerManagerOptions creates a new ExternalCMServer with a default config.
 func NewCloudControllerManagerOptions() (*CloudControllerManagerOptions, error) {
-	componentConfig, err := NewDefaultComponentConfig(ports.InsecureCloudControllerManagerPort)
+	componentConfig, err := NewDefaultComponentConfig(DefaultInsecureCloudControllerManagerPort)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -37,8 +37,8 @@ func TestDefaultFlags(t *testing.T) {
 
 	expected := &CloudControllerManagerOptions{
 		Generic: &cmoptions.GenericControllerManagerConfigurationOptions{
-			Port:            10253,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			Address:         "0.0.0.0", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+			Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+			Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
 			MinResyncPeriod: metav1.Duration{Duration: 12 * time.Hour},
 			ClientConnection: apimachineryconfig.ClientConnectionConfiguration{
 				ContentType: "application/vnd.kubernetes.protobuf",
@@ -85,7 +85,7 @@ func TestDefaultFlags(t *testing.T) {
 		}).WithLoopback(),
 		InsecureServing: (&apiserveroptions.DeprecatedInsecureServingOptions{
 			BindAddress: net.ParseIP("0.0.0.0"),
-			BindPort:    int(10253),
+			BindPort:    int(0),
 			BindNetwork: "tcp",
 		}).WithLoopback(),
 		Authentication: &apiserveroptions.DelegatingAuthenticationOptions{
@@ -155,8 +155,8 @@ func TestAddFlags(t *testing.T) {
 
 	expected := &CloudControllerManagerOptions{
 		Generic: &cmoptions.GenericControllerManagerConfigurationOptions{
-			Port:            10253,     // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
-			Address:         "0.0.0.0", // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+			Port:            DefaultInsecureCloudControllerManagerPort, // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
+			Address:         "0.0.0.0",                                 // Note: InsecureServingOptions.ApplyTo will write the flag value back into the component config
 			MinResyncPeriod: metav1.Duration{Duration: 100 * time.Minute},
 			ClientConnection: apimachineryconfig.ClientConnectionConfiguration{
 				ContentType: "application/vnd.kubernetes.protobuf",

--- a/test/integration/controllermanager/serving_test.go
+++ b/test/integration/controllermanager/serving_test.go
@@ -213,11 +213,13 @@ func testControllerManager(t *testing.T, tester controllerManagerTester, kubecon
 		{"no-flags", nil, "/healthz", false, true, nil, nil},
 		{"insecurely /healthz", []string{
 			"--secure-port=0",
+			"--port=10253",
 			"--kubeconfig", kubeconfig,
 			"--leader-elect=false",
 		}, "/healthz", true, false, nil, intPtr(http.StatusOK)},
 		{"insecurely /metrics", []string{
 			"--secure-port=0",
+			"--port=10253",
 			"--kubeconfig", kubeconfig,
 			"--leader-elect=false",
 		}, "/metrics", true, false, nil, intPtr(http.StatusOK)},
@@ -230,6 +232,7 @@ func testControllerManager(t *testing.T, tester controllerManagerTester, kubecon
 			"--kubeconfig", kubeconfig,
 			"--kubeconfig", kubeconfig,
 			"--leader-elect=false",
+			"--port=10253",
 		}, "/metrics", true, false, intPtr(http.StatusForbidden), intPtr(http.StatusOK)},
 		{"authorization skipped for /healthz with authn/authz", []string{
 			"--port=0",
@@ -254,6 +257,7 @@ func testControllerManager(t *testing.T, tester controllerManagerTester, kubecon
 			"--leader-elect=false",
 		}, "/metrics", false, false, intPtr(http.StatusForbidden), nil},
 		{"not authorized /metrics with BROKEN authn/authz", []string{
+			"--port=10253",
 			"--authentication-kubeconfig", kubeconfig,
 			"--authorization-kubeconfig", brokenKubeconfig,
 			"--kubeconfig", kubeconfig,


### PR DESCRIPTION
**What this PR does / why we need it:**
Make ccm not listen insecurely if secure port is specified 

**Which issue(s) this PR fixes:**
https://github.com/kubernetes/kubernetes/issues/65869

**Special notes for your reviewer:**

I have made it such that the insecure port will be turned off if the secure-port flag is used. Here is the new behavior with this PR.

1. By default, ccm only listens on secure port 10258
2. If secure port is set, only secure port is changed to new port
3. If only `--port` option is used, the ccm will listen on insecure port and default secure port (*current behavior*)
4. If both `--port` and `--secure-port` are provided, then current behavior is retained

```release-note
CCM server will not listen insecurely if secure port is specified
```

@stts @andrewsykim @jhorwit2 @wlan0 Please review
