### PR TITLE
Fix for man pages do not build reproducibly

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -19,6 +19,7 @@ package genericclioptions
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -49,6 +50,7 @@ func (f *JSONPathPrintFlags) AllowedFormats() []string {
 	for format := range jsonFormats {
 		formats = append(formats, format)
 	}
+	sort.Strings(formats)
 	return formats
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -101,6 +102,9 @@ func TestPrinterSupportsExpectedJSONPathFormats(t *testing.T) {
 			printFlags := JSONPathPrintFlags{
 				TemplateArgument: templateArg,
 			}
+			if !sort.StringsAreSorted(printFlags.AllowedFormats()) {
+				t.Fatalf("allowed formats are not sorted")
+			}
 
 			p, err := printFlags.ToPrinter(tc.outputFormat)
 			if tc.expectNoMatch {
@@ -179,6 +183,9 @@ func TestJSONPathPrinterDefaultsAllowMissingKeysToTrue(t *testing.T) {
 			printFlags := JSONPathPrintFlags{
 				TemplateArgument: &tc.templateArg,
 				AllowMissingKeys: tc.allowMissingKeys,
+			}
+			if !sort.StringsAreSorted(printFlags.AllowedFormats()) {
+				t.Fatalf("allowed formats are not sorted")
 			}
 
 			outputFormat := "jsonpath"

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -19,6 +19,7 @@ package genericclioptions
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,6 +52,7 @@ func (f *GoTemplatePrintFlags) AllowedFormats() []string {
 	for format := range templateFormats {
 		formats = append(formats, format)
 	}
+	sort.Strings(formats)
 	return formats
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/template_flags_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -101,6 +102,9 @@ func TestPrinterSupportsExpectedTemplateFormats(t *testing.T) {
 			printFlags := GoTemplatePrintFlags{
 				TemplateArgument: templateArg,
 			}
+			if !sort.StringsAreSorted(printFlags.AllowedFormats()) {
+				t.Fatalf("allowed formats are not sorted")
+			}
 
 			p, err := printFlags.ToPrinter(tc.outputFormat)
 			if tc.expectNoMatch {
@@ -173,6 +177,9 @@ func TestTemplatePrinterDefaultsAllowMissingKeysToTrue(t *testing.T) {
 			printFlags := GoTemplatePrintFlags{
 				TemplateArgument: &tc.templateArg,
 				AllowMissingKeys: tc.allowMissingKeys,
+			}
+			if !sort.StringsAreSorted(printFlags.AllowedFormats()) {
+				t.Fatalf("allowed formats are not sorted")
 			}
 
 			outputFormat := "template"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In different distros or environments, we may end up with a different
order of the strings printed during help and man page generation,
So we should sort so the strings in the man pages is the same everytime.

Change-Id: Id8fcbd89336aad8d709ba3adac4b29c808d97ebe

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52269

**Special notes for your reviewer**:
Please see https://github.com/kubernetes/kubernetes/issues/48710#issuecomment-422326597

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
