### PR TITLE
implement HTTPS?_PROXY for upgradeaware

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial_test.go
@@ -127,7 +127,7 @@ func TestDialURL(t *testing.T) {
 			u, _ := url.Parse(ts.URL)
 			_, p, _ := net.SplitHostPort(u.Host)
 			u.Host = net.JoinHostPort("127.0.0.1", p)
-			conn, err := DialURL(context.Background(), u, transport)
+			conn, err := DialURLWithoutProxy(context.Background(), u, transport)
 
 			// Make sure dialing doesn't mutate the transport's TLSConfig
 			if !reflect.DeepEqual(tc.TLSConfig, tlsConfigCopy) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -358,7 +358,7 @@ func (h *UpgradeAwareHandler) DialForUpgrade(req *http.Request) (net.Conn, error
 
 // dial dials the backend at req.URL and writes req to it.
 func dial(req *http.Request, transport http.RoundTripper) (net.Conn, error) {
-	conn, err := DialURL(req.Context(), req.URL, transport)
+	conn, err := DialRequest(req, transport)
 	if err != nil {
 		return nil, fmt.Errorf("error dialing backend: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
kube-apiserver uses upgradaware to do the HTTP upgrade connection for for `kubectl port-forward/exec` calls. This change makes upgradeaware HTTPS_PROXY aware, so that a TCP connection can be retrieved from a support HTTPS_PROXY. This code is very similar to the similar changes made in the spdy implementation to support proxies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
I can demo this working in our environment, but I don't believe there are any unit tests covering this behavior. Unit tests also do not work well since Go's net/http HTTPS_PROXY support will not proxy any calls made to local loopback.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kube-apiserver will use a defined HTTPS_PROXY for port-forward and exec calls
```
