### PR TITLE
Ensure reproducible builds - support for SOURCE_DATE_EPOCH with docke…

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -600,6 +600,7 @@ function kube::build::run_build_command_ex() {
     --env "GOFLAGS=${GOFLAGS:-}"
     --env "GOLDFLAGS=${GOLDFLAGS:-}"
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
+    --env "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-}"
   )
 
   if [[ -n "${DOCKER_CGROUP_PARENT:-}" ]]; then

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -557,6 +557,7 @@ kube::golang::build_some_binaries() {
      fi
    else
     V=2 kube::log::info "Coverage is disabled."
+    kube::log::status "go install" "${build_args[@]}" "$@"
     go install "${build_args[@]}" "$@"
    fi
 }
@@ -586,6 +587,7 @@ kube::golang::build_binaries_for_platform() {
       -installsuffix static
       ${goflags:+"${goflags[@]}"}
       -gcflags "${gogcflags:-}"
+      -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
     )
     CGO_ENABLED=0 kube::golang::build_some_binaries "${statics[@]}"
@@ -595,6 +597,7 @@ kube::golang::build_binaries_for_platform() {
     build_args=(
       ${goflags:+"${goflags[@]}"}
       -gcflags "${gogcflags:-}"
+      -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
     )
     kube::golang::build_some_binaries "${nonstatics[@]}"
@@ -608,6 +611,7 @@ kube::golang::build_binaries_for_platform() {
     go test -c \
       ${goflags:+"${goflags[@]}"} \
       -gcflags "${gogcflags:-}" \
+      -asmflags "${goasmflags:-}" \
       -ldflags "${goldflags:-}" \
       -o "${outfile}" \
       "${testpkg}"
@@ -661,10 +665,11 @@ kube::golang::build_binaries() {
     host_platform=$(kube::golang::host_platform)
 
     # Use eval to preserve embedded quoted strings.
-    local goflags goldflags gogcflags
+    local goflags goldflags goasmflags gogcflags
     eval "goflags=(${GOFLAGS:-})"
-    goldflags="${GOLDFLAGS:-} $(kube::version::ldflags)"
-    gogcflags="${GOGCFLAGS:-}"
+    goldflags="${GOLDFLAGS:-} -s -w $(kube::version::ldflags)"
+    goasmflags="-trimpath=${KUBE_ROOT}"
+    gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"
 
     local -a targets=()
     local arg


### PR DESCRIPTION
…rized builds

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

- Pass in SOURCE_DATE_EPOCH when we run the docker container
- Looks like cleaning up symbol table also helps
- Also trimming the path

Tips from
- https://blog.filippo.io/reproducing-go-binaries-byte-by-byte/
- https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/

Change-Id: Iedba85d9c1a36790fb8814795f7c27c1371cff1b

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #48710

**Special notes for your reviewer**:
Also see https://github.com/kubernetes/release/issues/637

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
