### PR TITLE
Update usages of http.ResponseWriter.WriteHeader to use http.Error

### DIFF
--- a/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
+++ b/cmd/kubeadm/app/phases/markmaster/markmaster_test.go
@@ -140,7 +140,7 @@ func TestMarkMaster(t *testing.T) {
 
 			if req.URL.Path != "/api/v1/nodes/"+hostname {
 				t.Errorf("MarkMaster(%s): request for unexpected HTTP resource: %v", tc.name, req.URL.Path)
-				w.WriteHeader(http.StatusNotFound)
+				http.Error(w, "", http.StatusNotFound)
 				return
 			}
 
@@ -150,7 +150,7 @@ func TestMarkMaster(t *testing.T) {
 				patchRequest = toString(req.Body)
 			default:
 				t.Errorf("MarkMaster(%s): request for unexpected HTTP verb: %v", tc.name, req.Method)
-				w.WriteHeader(http.StatusNotFound)
+				http.Error(w, "", http.StatusNotFound)
 				return
 			}
 

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -120,7 +120,7 @@ func makeTestServer(t *testing.T, namespace string) (*httptest.Server, *utiltest
 	mux.Handle(testapi.Default.ResourcePath("endpoints/", namespace, ""), &fakeEndpointsHandler)
 	mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
 		t.Errorf("unexpected request: %v", req.RequestURI)
-		res.WriteHeader(http.StatusNotFound)
+		http.Error(res, "", http.StatusNotFound)
 	})
 	return httptest.NewServer(mux), &fakeEndpointsHandler
 }

--- a/pkg/controller/garbagecollector/dump.go
+++ b/pkg/controller/garbagecollector/dump.go
@@ -252,7 +252,7 @@ type debugHTTPHandler struct {
 
 func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.URL.Path != "/graph" {
-		w.WriteHeader(http.StatusNotFound)
+		http.Error(w, "", http.StatusNotFound)
 		return
 	}
 
@@ -270,8 +270,7 @@ func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	data, err := dot.Marshal(graph, "full", "", "  ", false)
 	if err != nil {
-		w.Write([]byte(err.Error()))
-		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Write(data)

--- a/pkg/credentialprovider/gcp/metadata_test.go
+++ b/pkg/credentialprovider/gcp/metadata_test.go
@@ -70,7 +70,7 @@ func TestDockerKeyringFromGoogleDockerConfigMetadata(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprintln(w, sampleDockerConfig)
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -148,7 +148,7 @@ func TestDockerKeyringFromGoogleDockerConfigMetadataUrl(t *testing.T) {
 			w.Header().Set("Content-Type", "application/text")
 			fmt.Fprint(w, "http://foo.bar.com"+valueEndpoint)
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -232,7 +232,7 @@ func TestContainerRegistryBasics(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, "default/\ncustom")
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -291,7 +291,7 @@ func TestContainerRegistryNoServiceAccount(t *testing.T) {
 			}
 			fmt.Fprintln(w, string(bytes))
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -335,7 +335,7 @@ func TestContainerRegistryNoStorageScope(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintln(w, "default/\ncustom")
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -380,7 +380,7 @@ func TestComputePlatformScopeSubstitutesStorageScope(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprintln(w, "default/\ncustom")
 		} else {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, "", http.StatusNotFound)
 		}
 	}))
 	defer server.Close()
@@ -410,7 +410,7 @@ func TestComputePlatformScopeSubstitutesStorageScope(t *testing.T) {
 
 func TestAllProvidersNoMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		http.Error(w, "", http.StatusNotFound)
 	}))
 	defer server.Close()
 

--- a/pkg/kubectl/proxy/proxy_server.go
+++ b/pkg/kubectl/proxy/proxy_server.go
@@ -140,8 +140,7 @@ func (f *FilterServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	glog.V(3).Infof("Filter rejecting %v %v %v", req.Method, req.URL.Path, host)
-	rw.WriteHeader(http.StatusForbidden)
-	rw.Write([]byte("<h3>Unauthorized</h3>"))
+	http.Error(rw, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 }
 
 // Server is a http.Handler which proxies Kubernetes APIs to remote API server.

--- a/pkg/kubelet/server/remotecommand/httpstream.go
+++ b/pkg/kubelet/server/remotecommand/httpstream.go
@@ -125,8 +125,7 @@ func createStreams(req *http.Request, w http.ResponseWriter, opts *Options, supp
 func createHttpStreamStreams(req *http.Request, w http.ResponseWriter, opts *Options, supportedStreamProtocols []string, idleTimeout, streamCreationTimeout time.Duration) (*context, bool) {
 	protocol, err := httpstream.Handshake(req, w, supportedStreamProtocols)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return nil, false
 	}
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -57,7 +57,7 @@ func TestHTTPProbeChecker(t *testing.T) {
 			if r.URL.Path == "/" {
 				http.Redirect(w, r, "/new", s)
 			} else if bad && r.URL.Path == "/new" {
-				w.WriteHeader(http.StatusInternalServerError)
+				http.Error(w, "", http.StatusInternalServerError)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -136,12 +136,12 @@ func Handshake(req *http.Request, w http.ResponseWriter, serverProtocols []strin
 
 	negotiatedProtocol := negotiateProtocol(clientProtocols, serverProtocols)
 	if len(negotiatedProtocol) == 0 {
-		w.WriteHeader(http.StatusForbidden)
 		for i := range serverProtocols {
 			w.Header().Add(HeaderAcceptedProtocolVersions, serverProtocols[i])
 		}
-		fmt.Fprintf(w, "unable to upgrade: unable to negotiate protocol: client supports %v, server accepts %v", clientProtocols, serverProtocols)
-		return "", fmt.Errorf("unable to upgrade: unable to negotiate protocol: client supports %v, server supports %v", clientProtocols, serverProtocols)
+		err := fmt.Errorf("unable to upgrade: unable to negotiate protocol: client supports %v, server accepts %v", clientProtocols, serverProtocols)
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return "", err
 	}
 
 	w.Header().Add(HeaderProtocolVersion, negotiatedProtocol)

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/upgrade.go
@@ -74,15 +74,15 @@ func (u responseUpgrader) UpgradeResponse(w http.ResponseWriter, req *http.Reque
 	connectionHeader := strings.ToLower(req.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(req.Header.Get(httpstream.HeaderUpgrade))
 	if !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "unable to upgrade: missing upgrade headers in request: %#v", req.Header)
+		errorMsg := fmt.Sprintf("unable to upgrade: missing upgrade headers in request: %#v", req.Header)
+		http.Error(w, errorMsg, http.StatusBadRequest)
 		return nil
 	}
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "unable to upgrade: unable to hijack response")
+		errorMsg := fmt.Sprintf("unable to upgrade: unable to hijack response")
+		http.Error(w, errorMsg, http.StatusInternalServerError)
 		return nil
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authn_audit_test.go
@@ -33,7 +33,7 @@ func TestFailedAuthnAudit(t *testing.T) {
 	policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
+			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, policyChecker)
 	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
@@ -65,7 +65,7 @@ func TestFailedMultipleAuthnAudit(t *testing.T) {
 	policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
+			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, policyChecker)
 	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
@@ -98,7 +98,7 @@ func TestFailedAuthnAuditWithoutAuthorization(t *testing.T) {
 	policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse, nil)
 	handler := WithFailedAuthenticationAudit(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
+			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, policyChecker)
 	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
@@ -129,7 +129,7 @@ func TestFailedAuthnAuditOmitted(t *testing.T) {
 	policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse, []auditinternal.Stage{auditinternal.StageResponseStarted})
 	handler := WithFailedAuthenticationAudit(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
+			http.Error(w, "", http.StatusUnauthorized)
 		}),
 		sink, policyChecker)
 	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -45,8 +45,8 @@ const (
 var nonMutatingRequestVerbs = sets.NewString("get", "list", "watch")
 
 func handleError(w http.ResponseWriter, r *http.Request, err error) {
-	w.WriteHeader(http.StatusInternalServerError)
-	fmt.Fprintf(w, "Internal Server Error: %#v", r.RequestURI)
+	errorMsg := fmt.Sprintf("Internal Server Error: %#v", r.RequestURI)
+	http.Error(w, errorMsg, http.StatusInternalServerError)
 	glog.Errorf(err.Error())
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/util/etcd_util_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/util/etcd_util_test.go
@@ -60,7 +60,7 @@ func TestGetEtcdVersion_ValidVersion(t *testing.T) {
 
 func TestGetEtcdVersion_ErrorStatus(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusServiceUnavailable)
+		http.Error(w, "", http.StatusServiceUnavailable)
 	}))
 	defer testServer.Close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces most usages of `http.ResponseWrite.WriteHeader` with `http.Error` to ensure `Content-Type` and `X-Content-Type-Options` headers are set.

**Which issue(s) this PR fixes**
fixes #69011

**Special notes for your reviewer**:
* Should we add a message in the empty responses?
* Any other places that should be updated?

**Release note**:
```release-note
NONE
```
