### PR TITLE
[WIP] Remove group discovery handler from delegated servers (legacy/extension)

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -162,14 +162,9 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		discovery: map[schema.GroupVersion]*discovery.APIVersionHandler{},
 		delegate:  delegateHandler,
 	}
-	groupDiscoveryHandler := &groupDiscoveryHandler{
-		discovery: map[string]*discovery.APIGroupHandler{},
-		delegate:  delegateHandler,
-	}
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient.Apiextensions())
 	crdHandler := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,
-		groupDiscoveryHandler,
 		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
 		delegateHandler,
 		c.ExtraConfig.CRDRESTOptionsGetter,
@@ -180,7 +175,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
 
-	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
+	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler)
 	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient.Apiextensions())
 	finalizingController := finalizer.NewCRDFinalizer(
 		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery.go
@@ -71,52 +71,6 @@ func (r *versionDiscoveryHandler) unsetDiscovery(gv schema.GroupVersion) {
 	delete(r.discovery, gv)
 }
 
-type groupDiscoveryHandler struct {
-	// TODO, writing is infrequent, optimize this
-	discoveryLock sync.RWMutex
-	discovery     map[string]*discovery.APIGroupHandler
-
-	delegate http.Handler
-}
-
-func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	pathParts := splitPath(req.URL.Path)
-	// only match /apis/<group>
-	if len(pathParts) != 2 || pathParts[0] != "apis" {
-		r.delegate.ServeHTTP(w, req)
-		return
-	}
-	discovery, ok := r.getDiscovery(pathParts[1])
-	if !ok {
-		r.delegate.ServeHTTP(w, req)
-		return
-	}
-
-	discovery.ServeHTTP(w, req)
-}
-
-func (r *groupDiscoveryHandler) getDiscovery(group string) (*discovery.APIGroupHandler, bool) {
-	r.discoveryLock.RLock()
-	defer r.discoveryLock.RUnlock()
-
-	ret, ok := r.discovery[group]
-	return ret, ok
-}
-
-func (r *groupDiscoveryHandler) setDiscovery(group string, discovery *discovery.APIGroupHandler) {
-	r.discoveryLock.Lock()
-	defer r.discoveryLock.Unlock()
-
-	r.discovery[group] = discovery
-}
-
-func (r *groupDiscoveryHandler) unsetDiscovery(group string) {
-	r.discoveryLock.Lock()
-	defer r.discoveryLock.Unlock()
-
-	delete(r.discovery, group)
-}
-
 // splitPath returns the segments for a URL path.
 func splitPath(path string) []string {
 	path = strings.Trim(path, "/")

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -73,7 +73,6 @@ import (
 // This is registered as a filter so that it never collides with any explicitly registered endpoints
 type crdHandler struct {
 	versionDiscoveryHandler *versionDiscoveryHandler
-	groupDiscoveryHandler   *groupDiscoveryHandler
 
 	customStorageLock sync.Mutex
 	// customStorage contains a crdStorageMap
@@ -123,7 +122,6 @@ type crdStorageMap map[types.UID]*crdInfo
 
 func NewCustomResourceDefinitionHandler(
 	versionDiscoveryHandler *versionDiscoveryHandler,
-	groupDiscoveryHandler *groupDiscoveryHandler,
 	crdInformer informers.CustomResourceDefinitionInformer,
 	delegate http.Handler,
 	restOptionsGetter generic.RESTOptionsGetter,
@@ -132,7 +130,6 @@ func NewCustomResourceDefinitionHandler(
 	masterCount int) *crdHandler {
 	ret := &crdHandler{
 		versionDiscoveryHandler: versionDiscoveryHandler,
-		groupDiscoveryHandler:   groupDiscoveryHandler,
 		customStorage:           atomic.Value{},
 		crdLister:               crdInformer.Lister(),
 		delegate:                delegate,
@@ -166,11 +163,6 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// only registered under /apis
 		if len(pathParts) == 3 {
 			r.versionDiscoveryHandler.ServeHTTP(w, req)
-			return
-		}
-		// only match /apis/<group>
-		if len(pathParts) == 2 {
-			r.groupDiscoveryHandler.ServeHTTP(w, req)
 			return
 		}
 


### PR DESCRIPTION
Fixes #68971

a complete cleanup instead of #68972

/kind cleanup

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
