### PR TITLE
Got allocatable GPUs.

### DIFF
--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -98,7 +98,7 @@ func getGPUsAvailable(f *framework.Framework) int64 {
 	framework.ExpectNoError(err, "getting node list")
 	var gpusAvailable int64
 	for _, node := range nodeList.Items {
-		if val, ok := node.Status.Capacity[gpuResourceName]; ok {
+		if val, ok := node.Status.Allocatable[gpuResourceName]; ok {
 			gpusAvailable += (&val).Value()
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Da K. Ma <klaus1982.cn@gmail.com>

**What this PR does / why we need it**:
It should use `node.Status.Allocatable` instead of `node.Status.Capacity` to calculate available GPUs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #68987 

**Release note**:
```release-note
None
```
