### PR TITLE
Set api version and action name in fake evictions

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_eviction_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_eviction_expansion.go
@@ -26,8 +26,9 @@ func (c *FakeEvictions) Evict(eviction *policy.Eviction) error {
 	action := core.GetActionImpl{}
 	action.Verb = "post"
 	action.Namespace = c.ns
-	action.Resource = schema.GroupVersionResource{Group: "", Version: "", Resource: "pods"}
+	action.Resource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	action.Subresource = "eviction"
+	action.Name = eviction.Name
 	_, err := c.Fake.Invokes(action, eviction)
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The mock for evicting a Pod doesn't set the API version, preventing us from finding the pod to evict later on.

We try finding every pods matching the `GroupVersionResource` [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/testing/fixture.go#L247). So not setting any API version gives us 404s all the time.

This change also sets the pod name to evict as the action name, so we can properly fetch the right Pod.

**Special notes for your reviewer**:

The fake package has absolutely no tests. So I haven't written any here. It feels like setting up tests here would be quite useful.
Provided with a bit of guidance, I wouldn't mind working on that.

**Release note**:
```release-note
NONE
```
