### PR TITLE
Simplify kube-scheduler's run() method

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -81,35 +81,7 @@ constraints, affinity and anti-affinity specifications, data locality, inter-wor
 interference, deadlines, and so on. Workload-specific requirements will be exposed
 through the API as necessary.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			verflag.PrintAndExitIfRequested()
-			utilflag.PrintFlags(cmd.Flags())
-
-			if len(args) != 0 {
-				fmt.Fprint(os.Stderr, "arguments are not supported\n")
-			}
-
-			if errs := opts.Validate(); len(errs) > 0 {
-				fmt.Fprintf(os.Stderr, "%v\n", utilerrors.NewAggregate(errs))
-				os.Exit(1)
-			}
-
-			if len(opts.WriteConfigTo) > 0 {
-				if err := options.WriteConfigFile(opts.WriteConfigTo, &opts.ComponentConfig); err != nil {
-					fmt.Fprintf(os.Stderr, "%v\n", err)
-					os.Exit(1)
-				}
-				glog.Infof("Wrote configuration to: %s\n", opts.WriteConfigTo)
-				return
-			}
-
-			c, err := opts.Config()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "%v\n", err)
-				os.Exit(1)
-			}
-
-			stopCh := make(chan struct{})
-			if err := Run(c.Complete(), stopCh); err != nil {
+			if err := run(cmd, args, opts); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}
@@ -122,8 +94,39 @@ through the API as necessary.`,
 	return cmd
 }
 
-// Run runs the Scheduler.
-func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error {
+// run runs the scheduler.
+func run(cmd *cobra.Command, args []string, opts *options.Options) error {
+	verflag.PrintAndExitIfRequested()
+	utilflag.PrintFlags(cmd.Flags())
+
+	if len(args) != 0 {
+		fmt.Fprint(os.Stderr, "arguments are not supported\n")
+	}
+
+	if errs := opts.Validate(); len(errs) > 0 {
+		fmt.Fprintf(os.Stderr, "%v\n", utilerrors.NewAggregate(errs))
+		os.Exit(1)
+	}
+
+	if len(opts.WriteConfigTo) > 0 {
+		if err := options.WriteConfigFile(opts.WriteConfigTo, &opts.ComponentConfig); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		glog.Infof("Wrote configuration to: %s\n", opts.WriteConfigTo)
+	}
+
+	c, err := opts.Config()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	stopCh := make(chan struct{})
+
+	// Get the completed config
+	cc := c.Complete()
+
 	// To help debugging, immediately log version
 	glog.Infof("Version: %+v", version.Get())
 
@@ -139,7 +142,7 @@ func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error 
 	}
 
 	// Build a scheduler config from the provided algorithm source.
-	schedulerConfig, err := NewSchedulerConfig(c)
+	schedulerConfig, err := NewSchedulerConfig(cc)
 	if err != nil {
 		return err
 	}
@@ -148,39 +151,39 @@ func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error 
 	sched := scheduler.NewFromConfig(schedulerConfig)
 
 	// Prepare the event broadcaster.
-	if c.Broadcaster != nil && c.EventClient != nil {
-		c.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: c.EventClient.Events("")})
+	if cc.Broadcaster != nil && cc.EventClient != nil {
+		cc.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: cc.EventClient.Events("")})
 	}
 
 	// Start up the healthz server.
-	if c.InsecureServing != nil {
-		separateMetrics := c.InsecureMetricsServing != nil
-		handler := buildHandlerChain(newHealthzHandler(&c.ComponentConfig, separateMetrics), nil, nil)
-		if err := c.InsecureServing.Serve(handler, 0, stopCh); err != nil {
+	if cc.InsecureServing != nil {
+		separateMetrics := cc.InsecureMetricsServing != nil
+		handler := buildHandlerChain(newHealthzHandler(&cc.ComponentConfig, separateMetrics), nil, nil)
+		if err := cc.InsecureServing.Serve(handler, 0, stopCh); err != nil {
 			return fmt.Errorf("failed to start healthz server: %v", err)
 		}
 	}
-	if c.InsecureMetricsServing != nil {
-		handler := buildHandlerChain(newMetricsHandler(&c.ComponentConfig), nil, nil)
-		if err := c.InsecureMetricsServing.Serve(handler, 0, stopCh); err != nil {
+	if cc.InsecureMetricsServing != nil {
+		handler := buildHandlerChain(newMetricsHandler(&cc.ComponentConfig), nil, nil)
+		if err := cc.InsecureMetricsServing.Serve(handler, 0, stopCh); err != nil {
 			return fmt.Errorf("failed to start metrics server: %v", err)
 		}
 	}
-	if c.SecureServing != nil {
-		handler := buildHandlerChain(newHealthzHandler(&c.ComponentConfig, false), c.Authentication.Authenticator, c.Authorization.Authorizer)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+	if cc.SecureServing != nil {
+		handler := buildHandlerChain(newHealthzHandler(&cc.ComponentConfig, false), cc.Authentication.Authenticator, cc.Authorization.Authorizer)
+		if err := cc.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			// fail early for secure handlers, removing the old error loop from above
 			return fmt.Errorf("failed to start healthz server: %v", err)
 		}
 	}
 
 	// Start all informers.
-	go c.PodInformer.Informer().Run(stopCh)
-	c.InformerFactory.Start(stopCh)
+	go cc.PodInformer.Informer().Run(stopCh)
+	cc.InformerFactory.Start(stopCh)
 
 	// Wait for all caches to sync before scheduling.
-	c.InformerFactory.WaitForCacheSync(stopCh)
-	controller.WaitForCacheSync("scheduler", stopCh, c.PodInformer.Informer().HasSynced)
+	cc.InformerFactory.WaitForCacheSync(stopCh)
+	controller.WaitForCacheSync("scheduler", stopCh, cc.PodInformer.Informer().HasSynced)
 
 	// Prepare a reusable run function.
 	run := func(ctx context.Context) {
@@ -200,14 +203,14 @@ func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error 
 	}()
 
 	// If leader election is enabled, run via LeaderElector until done and exit.
-	if c.LeaderElection != nil {
-		c.LeaderElection.Callbacks = leaderelection.LeaderCallbacks{
+	if cc.LeaderElection != nil {
+		cc.LeaderElection.Callbacks = leaderelection.LeaderCallbacks{
 			OnStartedLeading: run,
 			OnStoppedLeading: func() {
 				utilruntime.HandleError(fmt.Errorf("lost master"))
 			},
 		}
-		leaderElector, err := leaderelection.NewLeaderElector(*c.LeaderElection)
+		leaderElector, err := leaderelection.NewLeaderElector(*cc.LeaderElection)
 		if err != nil {
 			return fmt.Errorf("couldn't create leader elector: %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR simplifies kube-scheduler's `run()` method by consolidating the logic into the already existing `run()` method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68964 
Addresses #68951

**Special notes for your reviewer**: N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/sig scheduling
/kind cleanup
/cc @misterikkit 
