### PR TITLE
make sure that log includes user information

### DIFF
--- a/pkg/kubelet/server/auth.go
+++ b/pkg/kubelet/server/auth.go
@@ -108,7 +108,7 @@ func (n nodeAuthorizerAttributesGetter) GetRequestAttributes(u user.Info, r *htt
 		attrs.Subresource = "spec"
 	}
 
-	glog.V(5).Infof("Node request attributes: attrs=%#v", attrs)
+	glog.V(5).Infof("Node request attributes: user=%#v attrs=%#v", attrs.GetUser(), attrs)
 
 	return attrs
 }


### PR DESCRIPTION
Right now we see 

> Node request attributes: attrs=authorizer.AttributesRecord{User:(*user.DefaultInfo)(0xc422b6fe80), Verb:"get", Namespace:"", APIGroup:"", APIVersion:"v1", Resource:"nodes", Subresource:"metrics", Name:"qe-jialiu2-node-new-1", ResourceRequest:true, Path:"/metrics"}

This ensures we'll see the user info too.

```release-note
NONE
```

@kubernetes/sig-auth-pr-reviews 