### PR TITLE
Remove pointer receivers from schema structs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
@@ -66,7 +66,7 @@ func (gr GroupResource) Empty() bool {
 	return len(gr.Group) == 0 && len(gr.Resource) == 0
 }
 
-func (gr *GroupResource) String() string {
+func (gr GroupResource) String() string {
 	if len(gr.Group) == 0 {
 		return gr.Resource
 	}
@@ -111,7 +111,7 @@ func (gvr GroupVersionResource) GroupVersion() GroupVersion {
 	return GroupVersion{Group: gvr.Group, Version: gvr.Version}
 }
 
-func (gvr *GroupVersionResource) String() string {
+func (gvr GroupVersionResource) String() string {
 	return strings.Join([]string{gvr.Group, "/", gvr.Version, ", Resource=", gvr.Resource}, "")
 }
 
@@ -130,7 +130,7 @@ func (gk GroupKind) WithVersion(version string) GroupVersionKind {
 	return GroupVersionKind{Group: gk.Group, Version: version, Kind: gk.Kind}
 }
 
-func (gk *GroupKind) String() string {
+func (gk GroupKind) String() string {
 	if len(gk.Group) == 0 {
 		return gk.Kind
 	}
@@ -281,8 +281,8 @@ func bestMatch(kinds []GroupVersionKind, targets []GroupVersionKind) GroupVersio
 
 // ToAPIVersionAndKind is a convenience method for satisfying runtime.Object on types that
 // do not use TypeMeta.
-func (gvk *GroupVersionKind) ToAPIVersionAndKind() (string, string) {
-	if gvk == nil {
+func (gvk GroupVersionKind) ToAPIVersionAndKind() (string, string) {
+	if gvk.Empty() {
 		return "", ""
 	}
 	return gvk.GroupVersion().String(), gvk.Kind

--- a/test/cmd/generic-resources.sh
+++ b/test/cmd/generic-resources.sh
@@ -430,7 +430,7 @@ run_recursive_resources_tests() {
   ## Attempt to rollback the replication controllers to revision 1 recursively
   output_message=$(! kubectl rollout undo -f hack/testdata/recursive/rc --recursive --to-revision=1 2>&1 "${kube_flags[@]}")
   # Post-condition: busybox0 & busybox1 should error as they are RC's, and since busybox2 is malformed, it should error
-  kube::test::if_has_string "${output_message}" 'no rollbacker has been implemented for {"" "ReplicationController"}'
+  kube::test::if_has_string "${output_message}" 'no rollbacker has been implemented for "ReplicationController"'
   kube::test::if_has_string "${output_message}" "Object 'Kind' is missing"
   ## Attempt to pause the replication controllers recursively
   output_message=$(! kubectl rollout pause -f hack/testdata/recursive/rc --recursive 2>&1 "${kube_flags[@]}")


### PR DESCRIPTION
This change makes the schema structs consistently use non-pointer receivers.  This makes it easier to call these methods since these structs are used as values instead of pointers.

Signed-off-by: Monis Khan <mkhan@redhat.com>

```release-note
NONE
```

@kubernetes/sig-api-machinery-pr-reviews