### PR TITLE
Fix PortForwarder.forward to fill bound port when local port unspecified

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -151,14 +151,14 @@ func (pf *PortForwarder) forward() error {
 	var err error
 
 	listenSuccess := false
-	for _, port := range pf.ports {
-		err = pf.listenOnPort(&port)
+	for i, _ := range pf.ports {
+		err = pf.listenOnPort(&pf.ports[i])
 		switch {
 		case err == nil:
 			listenSuccess = true
 		default:
 			if pf.errOut != nil {
-				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", pf.ports[i].Local, err)
 			}
 		}
 	}


### PR DESCRIPTION
  - Fixes https://github.com/kubernetes/kubernetes/issues/69052

**What this PR does / why we need it**: Fixes issue in portforward code in client-go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69052

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
