### PR TITLE
Fix PortForwarder.forward to fill bound port when local port unspecified

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -197,14 +197,14 @@ func (pf *PortForwarder) forward() error {
 	var err error
 
 	listenSuccess := false
-	for _, port := range pf.ports {
-		err = pf.listenOnPort(&port)
+	for i, _ := range pf.ports {
+		err = pf.listenOnPort(&pf.ports[i])
 		switch {
 		case err == nil:
 			listenSuccess = true
 		default:
 			if pf.errOut != nil {
-				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", pf.ports[i].Local, err)
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -187,13 +187,17 @@ func (pf *PortForwarder) ForwardPorts() error {
 	}
 	defer pf.streamConn.Close()
 
+	err = pf.startListeners()
+	if err != nil {
+		return err
+	}
+
 	return pf.forward()
 }
 
-// forward dials the remote host specific in req, upgrades the request, starts
-// listeners for each port specified in ports, and forwards local connections
-// to the remote host via streams.
-func (pf *PortForwarder) forward() error {
+// startListeners binds the local listener ports in preparation to start forwarding
+// local connections to the remote host.
+func (pf *PortForwarder) startListeners() error {
 	var err error
 
 	listenSuccess := false
@@ -213,6 +217,13 @@ func (pf *PortForwarder) forward() error {
 		return fmt.Errorf("Unable to listen on any of the requested ports: %v", pf.ports)
 	}
 
+	return nil
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
 	if pf.Ready != nil {
 		close(pf.Ready)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Bug fix for client-go/tools/portforward

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69052 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
