### PR TITLE
Add fallbacks for getting node IP from Azure IMDS

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -87,6 +87,15 @@ func (az *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.N
 		if err != nil {
 			return nil, err
 		}
+
+		// Fall back to ARM API if the address is empty string.
+		// TODO: this is a workaround because IMDS is not stable enough.
+		// It should be removed after IMDS fixing the issue.
+		if strings.TrimSpace(ipAddress.PrivateIP) == "" {
+			return addressGetter(name)
+		}
+
+		// Use ip address got from instance metadata.
 		addresses := []v1.NodeAddress{
 			{Type: v1.NodeInternalIP, Address: ipAddress.PrivateIP},
 			{Type: v1.NodeHostName, Address: string(name)},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The internal IP address is got from instance metadata, but it is empty sometimes. This PR adds fallbacks to ARM API, so that the IP could be ensured non empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69075

**Special notes for your reviewer**:

Should cherry pick to all old releases.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add fallbacks to ARM API when getting empty node IP from Azure IMDS
```
