### PR TITLE
use http.Redirect instead of writing responses directly

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -208,8 +208,8 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		if len(req.URL.RawQuery) > 0 {
 			queryPart = "?" + req.URL.RawQuery
 		}
-		w.Header().Set("Location", req.URL.Path+"/"+queryPart)
-		w.WriteHeader(http.StatusMovedPermanently)
+		req.URL.Path += "/"
+		http.Redirect(w, req, queryPart, http.StatusMovedPermanently)
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
use http.Redirect instead of writing responses directly for better conformance with RFC 2616
related to https://github.com/kubernetes/kubernetes/issues/69011


**Release note**:
```release-note
None
```
