### PR TITLE
log useful information instead of silent exit without error

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -108,6 +108,8 @@ kube::etcd::install() {
     cd "${KUBE_ROOT}/third_party"
     os=$(uname | tr "[:upper:]" "[:lower:]")
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
+      kube::log::info "etcd v${ETCD_VERSION} already installed at path:"
+      kube::log::info "$(pwd)/$(readlink etcd)"
       return  # already installed
     fi
     if [[ ${os} == "darwin" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
log useful information instead of silent exit without error when etcd has already been installed
in case users forget what next step to do and reinstall etcd and wonder why script exits without error

**Release note**:

```release-note
none
```
