### PR TITLE
Rename cadvisor metric labels to match instrumentation guidelines

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -39,7 +39,13 @@ var ProberResults = prometheus.NewGaugeVec(
 		Name:      "probe_result",
 		Help:      "The result of a liveness or readiness probe for a container.",
 	},
-	[]string{"probe_type", "container_name", "pod_name", "namespace", "pod_uid"},
+	[]string{"probe_type",
+		"container_name",
+		"container",
+		"pod_name",
+		"pod",
+		"namespace",
+		"pod_uid"},
 )
 
 // Manager manages pod probing. It creates a probe "worker" for every container that specifies a

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -101,7 +101,9 @@ func newWorker(
 	w.proberResultsMetricLabels = prometheus.Labels{
 		"probe_type":     w.probeType.String(),
 		"container_name": w.container.Name,
+		"container":      w.container.Name,
 		"pod_name":       w.pod.Name,
+		"pod":            w.pod.Name,
 		"namespace":      w.pod.Namespace,
 		"pod_uid":        string(w.pod.UID),
 	}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -865,8 +865,10 @@ func containerPrometheusLabelsFunc(s stats.StatsProvider) metrics.ContainerLabel
 			metrics.LabelName:  name,
 			metrics.LabelImage: image,
 			"pod_name":         podName,
+			"pod":              podName,
 			"namespace":        namespace,
 			"container_name":   containerName,
+			"container":        containerName,
 		}
 		return set
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Changes exported cadvisor metric labels to match the [Kubernetes instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md#normalization).

**Which issue(s) this PR fixes**:

Fixes #66790.

**Special notes for your reviewer**:

See also the [metrics overhaul KEP-0031](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added cadvisor metric labels `pod` and `container` where `pod_name` and `container_name` are present to match instrumentation guidelines.

Action required: any Prometheus queries that match `pod_name` and `container_name` labels (e.g. cadvisor or kubelet probe metrics) should be updated to use `pod` and `container` instead. `pod_name` and `container_name` labels will be present alongside `pod` and `container` labels for one transitional release and removed in the future.
```
