### PR TITLE
Replace internal dependency on last-applied-configuration with extern…

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +44,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/dynamic"
 	oapi "k8s.io/kube-openapi/pkg/util/proto"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -399,7 +398,7 @@ func (o *ApplyOptions) Run() error {
 			}
 
 			annotationMap := metadata.GetAnnotations()
-			if _, ok := annotationMap[api.LastAppliedConfigAnnotation]; !ok {
+			if _, ok := annotationMap[corev1.LastAppliedConfigAnnotation]; !ok {
 				fmt.Fprintf(o.ErrOut, warningNoLastAppliedConfigAnnotation, o.cmdBaseName)
 			}
 
@@ -467,7 +466,7 @@ func (o *ApplyOptions) Run() error {
 
 		objToPrint := objs[0]
 		if len(objs) > 1 {
-			list := &v1.List{
+			list := &corev1.List{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "List",
 					APIVersion: "v1",
@@ -619,7 +618,7 @@ func (p *pruner) prune(namespace string, mapping *meta.RESTMapping, includeUnini
 			return err
 		}
 		annots := metadata.GetAnnotations()
-		if _, ok := annots[api.LastAppliedConfigAnnotation]; !ok {
+		if _, ok := annots[corev1.LastAppliedConfigAnnotation]; !ok {
 			// don't prune resources not created with apply
 			continue
 		}


### PR DESCRIPTION
* Small change to reference the staging/external version of "last-applied-config" instead of the internal version.
* Removes a single dependency on the internal version of resources.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
