### PR TITLE
Replace internal reference of last-applied-config with external refer…

### DIFF
--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/dynamic"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/apply/parse"
 	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -338,7 +338,7 @@ func (obj InfoObject) Last() (map[string]interface{}, error) {
 		return nil, nil // Not an error, just empty.
 	}
 
-	return obj.toMap([]byte(annots[api.LastAppliedConfigAnnotation]))
+	return obj.toMap([]byte(annots[corev1.LastAppliedConfigAnnotation]))
 }
 
 func (obj InfoObject) Name() string {


### PR DESCRIPTION
* Small change to reference the staging/external version of "last-applied-config" instead of the internal version.
* Removes a single dependency on the internal version of resources.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
