### PR TITLE
Update default backend image

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
@@ -25,7 +25,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: k8s.gcr.io/defaultbackend:1.4
+        image: k8s.gcr.io/defaultbackend-amd64:1.5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -891,13 +891,13 @@ def launch_default_ingress_controller():
        context['defaultbackend_image'] == "auto"):
         if context['arch'] == 's390x':
             context['defaultbackend_image'] = \
-                "k8s.gcr.io/defaultbackend-s390x:1.4"
+                "k8s.gcr.io/defaultbackend-s390x:1.5"
         elif context['arch'] == 'arm64':
             context['defaultbackend_image'] = \
-                "k8s.gcr.io/defaultbackend-arm64:1.4"
+                "k8s.gcr.io/defaultbackend-arm64:1.5"
         else:
             context['defaultbackend_image'] = \
-                "k8s.gcr.io/defaultbackend:1.4"
+                "k8s.gcr.io/defaultbackend-amd64:1.5"
 
     # Render the default http backend (404) replicationcontroller manifest
     manifest = addon_path.format('default-http-backend.yaml')


### PR DESCRIPTION
**What this PR does / why we need it**:

Update docker image for default backend service (render 404 page)

**Release note**:

```release-note
Update defaultbackend image to 1.5. Users should concentrate on updating scripts to the new version.
```

@bowei @timstclair 
