### PR TITLE
correct kubelet service file permission

### DIFF
--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -23,7 +23,7 @@ install -m 755 -d %{buildroot}%{_bindir}
 install -m 755 -d %{buildroot}%{_sysconfdir}/systemd/system/
 install -m 755 -d %{buildroot}%{_sysconfdir}/kubernetes/manifests/
 install -p -m 755 -t %{buildroot}%{_bindir} {kubelet}
-install -p -m 755 -t %{buildroot}%{_sysconfdir}/systemd/system/ {kubelet.service}
+install -p -m 644 -t %{buildroot}%{_sysconfdir}/systemd/system/ {kubelet.service}
 
 %files
 %{_bindir}/kubelet


### PR DESCRIPTION
To fix below waring:
systemd[1]: Configuration file /etc/systemd/system/kubelet.service is marked executable. Please remove executable permission bits. Proceeding anyway.

Signed-off-by: Xiang Dai <764524258@qq.com>