### PR TITLE
kubectl remove internal version of resource for rollout pause/resume

### DIFF
--- a/pkg/kubectl/cmd/rollout/BUILD
+++ b/pkg/kubectl/cmd/rollout/BUILD
@@ -68,9 +68,9 @@ go_test(
     srcs = ["rollout_pause_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/apis/extensions:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
+        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/kubectl/cmd/rollout/rollout_pause_test.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause_test.go
@@ -23,23 +23,23 @@ import (
 	"net/url"
 	"testing"
 
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 var rolloutPauseGroupVersionEncoder = schema.GroupVersion{Group: "extensions", Version: "v1beta1"}
-var rolloutPauseGroupVersionDecoder = schema.GroupVersion{Group: "extensions", Version: runtime.APIVersionInternal}
+var rolloutPauseGroupVersionDecoder = schema.GroupVersion{Group: "extensions", Version: "v1beta1"}
 
 func TestRolloutPause(t *testing.T) {
 	deploymentName := "deployment/nginx-deployment"
-	ns := legacyscheme.Codecs
+	ns := scheme.Codecs
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 
 	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
@@ -50,7 +50,7 @@ func TestRolloutPause(t *testing.T) {
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
 				case p == "/namespaces/test/deployments/nginx-deployment" && (m == "GET" || m == "PATCH"):
-					responseDeployment := &extensions.Deployment{}
+					responseDeployment := &extensionsv1beta1.Deployment{}
 					responseDeployment.Name = deploymentName
 					body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))
 					return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: body}, nil

--- a/pkg/kubectl/polymorphichelpers/BUILD
+++ b/pkg/kubectl/polymorphichelpers/BUILD
@@ -22,7 +22,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/polymorphichelpers",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/core:go_default_library",
@@ -40,7 +39,6 @@ go_library(
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/kubectl/polymorphichelpers/objectpauser.go
+++ b/pkg/kubectl/polymorphichelpers/objectpauser.go
@@ -24,23 +24,13 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 // Currently only supports Deployments.
 func defaultObjectPauser(obj runtime.Object) ([]byte, error) {
 	switch obj := obj.(type) {
-	case *extensions.Deployment:
-		if obj.Spec.Paused {
-			return nil, errors.New("is already paused")
-		}
-		obj.Spec.Paused = true
-		return runtime.Encode(internalVersionJSONEncoder(), obj)
-
 	case *extensionsv1beta1.Deployment:
 		if obj.Spec.Paused {
 			return nil, errors.New("is already paused")
@@ -72,9 +62,4 @@ func defaultObjectPauser(obj runtime.Object) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("pausing is not supported")
 	}
-}
-
-func internalVersionJSONEncoder() runtime.Encoder {
-	encoder := legacyscheme.Codecs.LegacyCodec(legacyscheme.Scheme.PrioritizedVersionsAllGroups()...)
-	return unstructured.JSONFallbackEncoder{Encoder: encoder}
 }

--- a/pkg/kubectl/polymorphichelpers/objectresumer.go
+++ b/pkg/kubectl/polymorphichelpers/objectresumer.go
@@ -25,19 +25,11 @@ import (
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 func defaultObjectResumer(obj runtime.Object) ([]byte, error) {
 	switch obj := obj.(type) {
-	case *extensions.Deployment:
-		if !obj.Spec.Paused {
-			return nil, errors.New("is not paused")
-		}
-		obj.Spec.Paused = false
-		return runtime.Encode(internalVersionJSONEncoder(), obj)
-
 	case *extensionsv1beta1.Deployment:
 		if !obj.Spec.Paused {
 			return nil, errors.New("is not paused")


### PR DESCRIPTION
* Updates rollout pause/resume to not check for internal version of Deployment or ReplicaSet.
* The only places that call these functions are guaranteed to be external versions of the resource.
* Updates tests to use the external version of Deployment and ReplicaSet

Helps Address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
