### PR TITLE
Replace legacyscheme (internal version) with kubectl scheme

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -36,7 +36,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/api/testing:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",

--- a/pkg/kubectl/cmd/auth/BUILD
+++ b/pkg/kubectl/cmd/auth/BUILD
@@ -57,8 +57,8 @@ go_test(
     srcs = ["cani_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/pkg/kubectl/cmd/auth/cani_test.go
+++ b/pkg/kubectl/cmd/auth/cani_test.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 func TestRunAccessCheck(t *testing.T) {
@@ -124,7 +124,7 @@ func TestRunAccessCheck(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
-			ns := legacyscheme.Codecs
+			ns := scheme.Codecs
 
 			tf.Client = &fake.RESTClient{
 				GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},

--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//build/visible_to:pkg_kubectl_cmd_config_CONSUMERS",
     ],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
@@ -37,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api/latest:go_default_library",

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -23,10 +23,10 @@ import (
 
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
@@ -70,7 +70,7 @@ var (
 
 func NewCmdConfigView(f cmdutil.Factory, streams genericclioptions.IOStreams, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := &ViewOptions{
-		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(legacyscheme.Scheme).WithDefaultOutput("yaml"),
+		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
 		ConfigAccess: ConfigAccess,
 
 		IOStreams: streams,

--- a/pkg/kubectl/cmd/rollout/BUILD
+++ b/pkg/kubectl/cmd/rollout/BUILD
@@ -68,9 +68,9 @@ go_test(
     srcs = ["rollout_pause_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/apis/extensions:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
+        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/kubectl/cmd/rollout/rollout_pause_test.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause_test.go
@@ -23,23 +23,23 @@ import (
 	"net/url"
 	"testing"
 
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 var rolloutPauseGroupVersionEncoder = schema.GroupVersion{Group: "extensions", Version: "v1beta1"}
-var rolloutPauseGroupVersionDecoder = schema.GroupVersion{Group: "extensions", Version: runtime.APIVersionInternal}
+var rolloutPauseGroupVersionDecoder = schema.GroupVersion{Group: "extensions", Version: "v1beta1"}
 
 func TestRolloutPause(t *testing.T) {
 	deploymentName := "deployment/nginx-deployment"
-	ns := legacyscheme.Codecs
+	ns := scheme.Codecs
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 
 	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
@@ -50,7 +50,7 @@ func TestRolloutPause(t *testing.T) {
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
 				case p == "/namespaces/test/deployments/nginx-deployment" && (m == "GET" || m == "PATCH"):
-					responseDeployment := &extensions.Deployment{}
+					responseDeployment := &extensionsv1beta1.Deployment{}
 					responseDeployment.Name = deploymentName
 					body := ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(encoder, responseDeployment))))
 					return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: body}, nil

--- a/pkg/kubectl/cmd/testing/BUILD
+++ b/pkg/kubectl/cmd/testing/BUILD
@@ -9,11 +9,11 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/testing",
     visibility = ["//build/visible_to:pkg_kubectl_cmd_testing_CONSUMERS"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/testing:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta/testrestmapper:go_default_library",

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -43,11 +43,11 @@ import (
 	scaleclient "k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 	openapitesting "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/testing"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/validation"
 )
 
@@ -274,7 +274,7 @@ func NewTestFactory() *TestFactory {
 	return &TestFactory{
 		Factory:           cmdutil.NewFactory(configFlags),
 		kubeConfigFlags:   configFlags,
-		FakeDynamicClient: fakedynamic.NewSimpleDynamicClient(legacyscheme.Scheme),
+		FakeDynamicClient: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 		tempConfigFile:    tmpFile,
 
 		ClientConfigVal: restConfig,
@@ -404,7 +404,7 @@ func testRESTMapper() meta.RESTMapper {
 	mapper = meta.FirstHitRESTMapper{
 		MultiRESTMapper: meta.MultiRESTMapper{
 			mapper,
-			testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme),
+			testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 		},
 	}
 

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/validation:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",

--- a/pkg/kubectl/cmd/util/kubectl_match_version.go
+++ b/pkg/kubectl/cmd/util/kubectl_match_version.go
@@ -23,12 +23,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -120,7 +119,7 @@ func setKubernetesDefaults(config *rest.Config) error {
 		config.APIPath = "/api"
 	}
 	if config.NegotiatedSerializer == nil {
-		config.NegotiatedSerializer = legacyscheme.Codecs
+		config.NegotiatedSerializer = scheme.Codecs
 	}
 	return rest.SetKubernetesDefaults(config)
 }

--- a/pkg/kubectl/sorter_test.go
+++ b/pkg/kubectl/sorter_test.go
@@ -21,16 +21,16 @@ import (
 	"strings"
 	"testing"
 
-	api "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 func encodeOrDie(obj runtime.Object) []byte {
-	data, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(api.SchemeGroupVersion), obj)
+	data, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), obj)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -40,19 +40,19 @@ func encodeOrDie(obj runtime.Object) []byte {
 func TestSortingPrinter(t *testing.T) {
 	intPtr := func(val int32) *int32 { return &val }
 
-	a := &api.Pod{
+	a := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "a",
 		},
 	}
 
-	b := &api.Pod{
+	b := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "b",
 		},
 	}
 
-	c := &api.Pod{
+	c := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "c",
 		},
@@ -67,8 +67,8 @@ func TestSortingPrinter(t *testing.T) {
 	}{
 		{
 			name: "in-order-already",
-			obj: &api.PodList{
-				Items: []api.Pod{
+			obj: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "a",
@@ -86,8 +86,8 @@ func TestSortingPrinter(t *testing.T) {
 					},
 				},
 			},
-			sort: &api.PodList{
-				Items: []api.Pod{
+			sort: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "a",
@@ -109,8 +109,8 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "reverse-order",
-			obj: &api.PodList{
-				Items: []api.Pod{
+			obj: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "b",
@@ -128,8 +128,8 @@ func TestSortingPrinter(t *testing.T) {
 					},
 				},
 			},
-			sort: &api.PodList{
-				Items: []api.Pod{
+			sort: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "a",
@@ -151,8 +151,8 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "random-order-timestamp",
-			obj: &api.PodList{
-				Items: []api.Pod{
+			obj: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: metav1.Unix(300, 0),
@@ -170,8 +170,8 @@ func TestSortingPrinter(t *testing.T) {
 					},
 				},
 			},
-			sort: &api.PodList{
-				Items: []api.Pod{
+			sort: &corev1.PodList{
+				Items: []corev1.Pod{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							CreationTimestamp: metav1.Unix(100, 0),
@@ -193,39 +193,39 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "random-order-numbers",
-			obj: &api.ReplicationControllerList{
-				Items: []api.ReplicationController{
+			obj: &corev1.ReplicationControllerList{
+				Items: []corev1.ReplicationController{
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(5),
 						},
 					},
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(1),
 						},
 					},
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(9),
 						},
 					},
 				},
 			},
-			sort: &api.ReplicationControllerList{
-				Items: []api.ReplicationController{
+			sort: &corev1.ReplicationControllerList{
+				Items: []corev1.ReplicationController{
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(1),
 						},
 					},
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(5),
 						},
 					},
 					{
-						Spec: api.ReplicationControllerSpec{
+						Spec: corev1.ReplicationControllerSpec{
 							Replicas: intPtr(9),
 						},
 					},
@@ -235,14 +235,14 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "v1.List in order",
-			obj: &api.List{
+			obj: &corev1.List{
 				Items: []runtime.RawExtension{
 					{Raw: encodeOrDie(a)},
 					{Raw: encodeOrDie(b)},
 					{Raw: encodeOrDie(c)},
 				},
 			},
-			sort: &api.List{
+			sort: &corev1.List{
 				Items: []runtime.RawExtension{
 					{Raw: encodeOrDie(a)},
 					{Raw: encodeOrDie(b)},
@@ -253,14 +253,14 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "v1.List in reverse",
-			obj: &api.List{
+			obj: &corev1.List{
 				Items: []runtime.RawExtension{
 					{Raw: encodeOrDie(c)},
 					{Raw: encodeOrDie(b)},
 					{Raw: encodeOrDie(a)},
 				},
 			},
-			sort: &api.List{
+			sort: &corev1.List{
 				Items: []runtime.RawExtension{
 					{Raw: encodeOrDie(a)},
 					{Raw: encodeOrDie(b)},
@@ -372,16 +372,16 @@ func TestSortingPrinter(t *testing.T) {
 		},
 		{
 			name: "model-invalid-fields",
-			obj: &api.ReplicationControllerList{
-				Items: []api.ReplicationController{
+			obj: &corev1.ReplicationControllerList{
+				Items: []corev1.ReplicationController{
 					{
-						Status: api.ReplicationControllerStatus{},
+						Status: corev1.ReplicationControllerStatus{},
 					},
 					{
-						Status: api.ReplicationControllerStatus{},
+						Status: corev1.ReplicationControllerStatus{},
 					},
 					{
-						Status: api.ReplicationControllerStatus{},
+						Status: corev1.ReplicationControllerStatus{},
 					},
 				},
 			},
@@ -391,7 +391,7 @@ func TestSortingPrinter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sort := &SortingPrinter{SortField: tt.field, Decoder: legacyscheme.Codecs.UniversalDecoder()}
+			sort := &SortingPrinter{SortField: tt.field, Decoder: scheme.Codecs.UniversalDecoder()}
 			err := sort.sortObj(tt.obj)
 			if err != nil {
 				if len(tt.expectedErr) > 0 {
@@ -415,8 +415,8 @@ func TestSortingPrinter(t *testing.T) {
 func TestRuntimeSortLess(t *testing.T) {
 	var testobj runtime.Object
 
-	testobj = &api.PodList{
-		Items: []api.Pod{
+	testobj = &corev1.PodList{
+		Items: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b",


### PR DESCRIPTION
* Replaces legacyscheme with kubectl scheme
* Ensures resources returned by client are external versions, not internal

Helps Address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
