### PR TITLE
feat: refresh ecr token earlier

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -124,8 +124,8 @@ func (p *lazyEcrProvider) LazyProvide() *credentialprovider.DockerConfigEntry {
 		glog.V(2).Infof("Creating ecrProvider for %s", p.region)
 		p.actualProvider = &credentialprovider.CachingDockerConfigProvider{
 			Provider: newEcrProvider(p.region, nil),
-			// Refresh credentials a little earlier than expiration time
-			Lifetime: 11*time.Hour + 55*time.Minute,
+			// Refresh credentials earlier than expiration time
+			Lifetime: 11 * time.Hour,
 		}
 		if !p.actualProvider.Enabled() {
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We pull images from AWS ECR in our k8s cluster, but we occasionally encounter a problem that the auth token got expired earlier than 12 hours as the following log shows.

kubelet log:
```
Aug 22 15:31:12 ip-172-31-72-199 kubelet[1018]: I0822 15:31:12.600432    1018 provider.go:119] Refreshing cache for provider: *credentials.ecrProvider

Aug 22 15:31:12 ip-172-31-72-199 kubelet[1018]: I0822 15:31:12.895399    1018 kube_docker_client.go:348] Stop pulling image "<id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service:master-a6cd66e4": "Status: Image is up to date for <id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service:master-a6cd66e4"

Aug 23 03:09:05 ip-172-31-72-199 kubelet[1018]: E0823 03:09:05.926097    1018 remote_image.go:108] PullImage "<id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service:master-a6cd66e4" from image service failed: rpc error: code = Unknown desc = Error response from daemon: repository <id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service not found: does not exist or no pull access
```

dockerd log:
```
Aug 23 03:09:05 ip-172-31-72-199 dockerd[1251]: time="2018-08-23T03:09:05.925621539Z" level=error msg="Not continuing with pull after error: denied: The security token included in the request is invalid"

Aug 23 03:09:05 ip-172-31-72-199 dockerd[1251]: time="2018-08-23T03:09:05.925694770Z" level=error msg="Handler for POST /v1.27/images/create returned error: repository <id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service not found: does not exist or no pull access"
```

As reflected in kubelet logs, the very image `<id>.dkr.ecr.cn-north-1.amazonaws.com.cn/topic-service:master-a6cd66e4` does exist and can be pulled successfully after the ecr token got refreshed at `Aug 22 15:31:12`. 

Ideally, that token would only be expired after `Aug 23 03:31:12`, but it seems that the token became invalid at `Aug 23 03:09:05`, about 20 minutes earlier than expected.

Therefore, I think we could refresh the ECR token much more earlier to workaround this problem. In addition, the AWS official [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper/blob/master/ecr-login/cache/credentials.go#L32) also refreshes the credentials every 6 hours.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Refresh ECR token every 11 hours.
```
