### PR TITLE
remove more internal version api which refered by LastAppliedConfigAnnotation

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/dynamic"
 	oapi "k8s.io/kube-openapi/pkg/util/proto"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -399,7 +398,7 @@ func (o *ApplyOptions) Run() error {
 			}
 
 			annotationMap := metadata.GetAnnotations()
-			if _, ok := annotationMap[api.LastAppliedConfigAnnotation]; !ok {
+			if _, ok := annotationMap[v1.LastAppliedConfigAnnotation]; !ok {
 				fmt.Fprintf(o.ErrOut, warningNoLastAppliedConfigAnnotation, o.cmdBaseName)
 			}
 
@@ -619,7 +618,7 @@ func (p *pruner) prune(namespace string, mapping *meta.RESTMapping, includeUnini
 			return err
 		}
 		annots := metadata.GetAnnotations()
-		if _, ok := annots[api.LastAppliedConfigAnnotation]; !ok {
+		if _, ok := annots[v1.LastAppliedConfigAnnotation]; !ok {
 			// don't prune resources not created with apply
 			continue
 		}

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	"k8s.io/client-go/dynamic"
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/apply/parse"
 	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -291,7 +291,7 @@ func (obj InfoObject) Last() (map[string]interface{}, error) {
 		return nil, nil // Not an error, just empty.
 	}
 
-	return obj.toMap([]byte(annots[api.LastAppliedConfigAnnotation]))
+	return obj.toMap([]byte(annots[v1.LastAppliedConfigAnnotation]))
 }
 
 func (obj InfoObject) Name() string {

--- a/pkg/kubectl/cmd/util/editor/BUILD
+++ b/pkg/kubectl/cmd/util/editor/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/kubectl/cmd/util/editor/crlf:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/term:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -524,7 +525,7 @@ func GetApplyPatch(obj runtime.Unstructured) ([]byte, []byte, types.PatchType, e
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[api.LastAppliedConfigAnnotation] = string(beforeJSON)
+	annotations[v1.LastAppliedConfigAnnotation] = string(beforeJSON)
 	accessor.SetAnnotations(objCopy, annotations)
 	afterJSON, err := encodeToJson(objCopy.(runtime.Unstructured))
 	if err != nil {


### PR DESCRIPTION
Patch https://github.com/kubernetes/kubernetes/pull/56984 has removed some internal version api references in apply.go file. And it didn't complete it cleanly. This patch clean all the internal version api reference about "LastAppliedConfigAnnotation" in /pkg/kubectl
Ref:https://github.com/kubernetes/kubectl/issues/83
```release-note
NONE
```
