### PR TITLE
Update authenticated-image-pulling with fat manifest image

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -288,13 +288,13 @@ while true; do sleep 1; done
 				},
 				{
 					description: "should not be able to pull from private registry without secret",
-					image:       "gcr.io/authenticated-image-pulling/alpine:3.1",
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
 					phase:       v1.PodPending,
 					waiting:     true,
 				},
 				{
 					description: "should be able to pull from private registry with secret",
-					image:       "gcr.io/authenticated-image-pulling/alpine:3.1",
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
 					secret:      true,
 					phase:       v1.PodRunning,
 					waiting:     false,

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -60,7 +60,7 @@ var _ = framework.KubeDescribe("Container Runtime Conformance Test", func() {
 			}{
 				{
 					description: "should be able to pull from private registry with credential provider",
-					image:       "gcr.io/authenticated-image-pulling/alpine:3.1",
+					image:       "gcr.io/authenticated-image-pulling/alpine:3.7",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Update gcr.io/authenticated-image-pulling/alpine:3.1 with proper fat manifest image to support all the different architectures

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

In https://github.com/kubernetes/kubernetes/issues/69104 task we have pushed with latest alpine:3.7 images with all the supported architecture, so this task is to support using that updated image.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
