### PR TITLE
CSI sidecar containers 0.4.0

### DIFF
--- a/test/e2e/storage/csi_objects.go
+++ b/test/e2e/storage/csi_objects.go
@@ -47,10 +47,10 @@ import (
 )
 
 var csiImageVersions = map[string]string{
-	"hostpathplugin":   "canary", // TODO (verult) update tag once new hostpathplugin release is cut
-	"csi-attacher":     "v0.2.0",
-	"csi-provisioner":  "v0.2.1",
-	"driver-registrar": "v0.3.0",
+	"hostpathplugin":   "v0.4.0",
+	"csi-attacher":     "v0.4.0",
+	"csi-provisioner":  "v0.4.0",
+	"driver-registrar": "v0.4.0",
 }
 
 func csiContainerImage(image string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This updates the versions of the sidecar containers so that the latest stable releases are used, the ones that get released together with Kubernetes 1.12.

**Special notes for your reviewer**:

This includes the rebased commit from PR #68887, which is needed because the new external-attacher requires additional permissions for leader election.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig storage