### PR TITLE
Use dry-run patch to get the merged version of the object

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -60,8 +60,6 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/kubectl:go_default_library",
-        "//pkg/kubectl/apply/parse:go_default_library",
-        "//pkg/kubectl/apply/strategy:go_default_library",
         "//pkg/kubectl/cmd/auth:go_default_library",
         "//pkg/kubectl/cmd/config:go_default_library",
         "//pkg/kubectl/cmd/create:go_default_library",

--- a/pkg/kubectl/cmd/diff_test.go
+++ b/pkg/kubectl/cmd/diff_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/utils/exec"
 )
@@ -41,12 +43,12 @@ func (f *FakeObject) Name() string {
 	return f.name
 }
 
-func (f *FakeObject) Merged() (map[string]interface{}, error) {
-	return f.merged, nil
+func (f *FakeObject) Merged() (runtime.Object, error) {
+	return &unstructured.Unstructured{Object: f.merged}, nil
 }
 
-func (f *FakeObject) Live() (map[string]interface{}, error) {
-	return f.live, nil
+func (f *FakeObject) Live() runtime.Object {
+	return &unstructured.Unstructured{Object: f.live}
 }
 
 func TestDiffProgram(t *testing.T) {
@@ -68,11 +70,11 @@ func TestDiffProgram(t *testing.T) {
 func TestPrinter(t *testing.T) {
 	printer := Printer{}
 
-	obj := map[string]interface{}{
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"string": "string",
 		"list":   []int{1, 2, 3},
 		"int":    12,
-	}
+	}}
 	buf := bytes.Buffer{}
 	printer.Print(obj, &buf)
 	want := `int: 12


### PR DESCRIPTION
Rather than using a custom merge logic on the client, use the same thing that apply would, but with the server dry-run flag, so that we have the exact thing that would be done by the server.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
