### PR TITLE
add deprecation warnings for all cloud providers

### DIFF
--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -40,10 +40,14 @@ var (
 		external bool
 		detail   string
 	}{
-		{"openstack", true, "https://github.com/kubernetes/cloud-provider-openstack"},
-		{"photon", false, "The Photon Controller project is no longer maintained."},
+		{"aws", false, "The AWS provider is deprecated and will be removed in a future release"},
+		{"azure", false, "The Azure provider is deprecated and will be removed in a future release"},
 		{"cloudstack", false, "The CloudStack Controller project is no longer maintained."},
+		{"gce", false, "The GCE provider is deprecated and will be removed in a future release"},
+		{"openstack", true, "https://github.com/kubernetes/cloud-provider-openstack"},
 		{"ovirt", false, "The ovirt Controller project is no longer maintained."},
+		{"photon", false, "The Photon Controller project is no longer maintained."},
+		{"vsphere", false, "The vSphere provider is deprecated and will be removed in a future release"},
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a deprecation warning for all cloud providers. Please note that this is only a deprecation warning, there are no expected code changes from doing this. Once all providers have external cloud controllers that are stable and widely used we will fully disable provider functionality, but we don't anticipate that for maybe another year. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add deprecation warning for all cloud providers
```
