### PR TITLE
kubectl small fix for config view to replace legacyscheme with kubect…

### DIFF
--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -28,9 +28,9 @@ go_library(
         "//build/visible_to:pkg_kubectl_cmd_config_CONSUMERS",
     ],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util/i18n:go_default_library",
         "//pkg/printers:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/printers"
 )
@@ -70,7 +70,7 @@ var (
 
 func NewCmdConfigView(f cmdutil.Factory, streams genericclioptions.IOStreams, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	o := &ViewOptions{
-		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(legacyscheme.Scheme).WithDefaultOutput("yaml"),
+		PrintFlags:   genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
 		ConfigAccess: ConfigAccess,
 
 		IOStreams: streams,


### PR DESCRIPTION
* Replaces legacyscheme with kubectl scheme for print typesetter in config view command.
* Removes a dependency on internal versions of resources.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
