### PR TITLE
kubectl remove internal version references in polymorphichelpers

### DIFF
--- a/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject.go
+++ b/pkg/kubectl/polymorphichelpers/mapbasedselectorforobject.go
@@ -25,8 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/kubectl"
 )
 
@@ -36,40 +34,21 @@ import (
 func mapBasedSelectorForObject(object runtime.Object) (string, error) {
 	// TODO: replace with a swagger schema based approach (identify pod selector via schema introspection)
 	switch t := object.(type) {
-	case *api.ReplicationController:
-		return kubectl.MakeLabels(t.Spec.Selector), nil
 	case *corev1.ReplicationController:
 		return kubectl.MakeLabels(t.Spec.Selector), nil
 
-	case *api.Pod:
-		if len(t.Labels) == 0 {
-			return "", fmt.Errorf("the pod has no labels and cannot be exposed")
-		}
-		return kubectl.MakeLabels(t.Labels), nil
 	case *corev1.Pod:
 		if len(t.Labels) == 0 {
 			return "", fmt.Errorf("the pod has no labels and cannot be exposed")
 		}
 		return kubectl.MakeLabels(t.Labels), nil
 
-	case *api.Service:
-		if t.Spec.Selector == nil {
-			return "", fmt.Errorf("the service has no pod selector set")
-		}
-		return kubectl.MakeLabels(t.Spec.Selector), nil
 	case *corev1.Service:
 		if t.Spec.Selector == nil {
 			return "", fmt.Errorf("the service has no pod selector set")
 		}
 		return kubectl.MakeLabels(t.Spec.Selector), nil
 
-	case *extensions.Deployment:
-		// TODO(madhusudancs): Make this smarter by admitting MatchExpressions with Equals
-		// operator, DoubleEquals operator and In operator with only one element in the set.
-		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return "", fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
-		}
-		return kubectl.MakeLabels(t.Spec.Selector.MatchLabels), nil
 	case *extensionsv1beta1.Deployment:
 		// TODO(madhusudancs): Make this smarter by admitting MatchExpressions with Equals
 		// operator, DoubleEquals operator and In operator with only one element in the set.
@@ -99,13 +78,6 @@ func mapBasedSelectorForObject(object runtime.Object) (string, error) {
 		}
 		return kubectl.MakeLabels(t.Spec.Selector.MatchLabels), nil
 
-	case *extensions.ReplicaSet:
-		// TODO(madhusudancs): Make this smarter by admitting MatchExpressions with Equals
-		// operator, DoubleEquals operator and In operator with only one element in the set.
-		if len(t.Spec.Selector.MatchExpressions) > 0 {
-			return "", fmt.Errorf("couldn't convert expressions - \"%+v\" to map-based selector format", t.Spec.Selector.MatchExpressions)
-		}
-		return kubectl.MakeLabels(t.Spec.Selector.MatchLabels), nil
 	case *extensionsv1beta1.ReplicaSet:
 		// TODO(madhusudancs): Make this smarter by admitting MatchExpressions with Equals
 		// operator, DoubleEquals operator and In operator with only one element in the set.

--- a/pkg/kubectl/polymorphichelpers/portsforobject.go
+++ b/pkg/kubectl/polymorphichelpers/portsforobject.go
@@ -26,29 +26,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func portsForObject(object runtime.Object) ([]string, error) {
 	switch t := object.(type) {
-	case *api.ReplicationController:
-		return getPortsInternal(t.Spec.Template.Spec), nil
 	case *corev1.ReplicationController:
 		return getPorts(t.Spec.Template.Spec), nil
 
-	case *api.Pod:
-		return getPortsInternal(t.Spec), nil
 	case *corev1.Pod:
 		return getPorts(t.Spec), nil
 
-	case *api.Service:
-		return getServicePortsInternal(t.Spec), nil
 	case *corev1.Service:
 		return getServicePorts(t.Spec), nil
 
-	case *extensions.Deployment:
-		return getPortsInternal(t.Spec.Template.Spec), nil
 	case *extensionsv1beta1.Deployment:
 		return getPorts(t.Spec.Template.Spec), nil
 	case *appsv1.Deployment:
@@ -58,8 +48,6 @@ func portsForObject(object runtime.Object) ([]string, error) {
 	case *appsv1beta1.Deployment:
 		return getPorts(t.Spec.Template.Spec), nil
 
-	case *extensions.ReplicaSet:
-		return getPortsInternal(t.Spec.Template.Spec), nil
 	case *extensionsv1beta1.ReplicaSet:
 		return getPorts(t.Spec.Template.Spec), nil
 	case *appsv1.ReplicaSet:
@@ -69,25 +57,6 @@ func portsForObject(object runtime.Object) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("cannot extract ports from %T", object)
 	}
-}
-
-func getPortsInternal(spec api.PodSpec) []string {
-	result := []string{}
-	for _, container := range spec.Containers {
-		for _, port := range container.Ports {
-			result = append(result, strconv.Itoa(int(port.ContainerPort)))
-		}
-	}
-	return result
-}
-
-// Extracts the ports exposed by a service from the given service spec.
-func getServicePortsInternal(spec api.ServiceSpec) []string {
-	result := []string{}
-	for _, servicePort := range spec.Ports {
-		result = append(result, strconv.Itoa(int(servicePort.Port)))
-	}
-	return result
 }
 
 func getPorts(spec corev1.PodSpec) []string {

--- a/pkg/kubectl/polymorphichelpers/protocolsforobject.go
+++ b/pkg/kubectl/polymorphichelpers/protocolsforobject.go
@@ -26,30 +26,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func protocolsForObject(object runtime.Object) (map[string]string, error) {
 	// TODO: replace with a swagger schema based approach (identify pod selector via schema introspection)
 	switch t := object.(type) {
-	case *api.ReplicationController:
-		return getProtocolsInternal(t.Spec.Template.Spec), nil
 	case *corev1.ReplicationController:
 		return getProtocols(t.Spec.Template.Spec), nil
 
-	case *api.Pod:
-		return getProtocolsInternal(t.Spec), nil
 	case *corev1.Pod:
 		return getProtocols(t.Spec), nil
 
-	case *api.Service:
-		return getServiceProtocolsInternal(t.Spec), nil
 	case *corev1.Service:
 		return getServiceProtocols(t.Spec), nil
 
-	case *extensions.Deployment:
-		return getProtocolsInternal(t.Spec.Template.Spec), nil
 	case *extensionsv1beta1.Deployment:
 		return getProtocols(t.Spec.Template.Spec), nil
 	case *appsv1.Deployment:
@@ -59,8 +49,6 @@ func protocolsForObject(object runtime.Object) (map[string]string, error) {
 	case *appsv1beta1.Deployment:
 		return getProtocols(t.Spec.Template.Spec), nil
 
-	case *extensions.ReplicaSet:
-		return getProtocolsInternal(t.Spec.Template.Spec), nil
 	case *extensionsv1beta1.ReplicaSet:
 		return getProtocols(t.Spec.Template.Spec), nil
 	case *appsv1.ReplicaSet:
@@ -71,25 +59,6 @@ func protocolsForObject(object runtime.Object) (map[string]string, error) {
 	default:
 		return nil, fmt.Errorf("cannot extract protocols from %T", object)
 	}
-}
-
-func getProtocolsInternal(spec api.PodSpec) map[string]string {
-	result := make(map[string]string)
-	for _, container := range spec.Containers {
-		for _, port := range container.Ports {
-			result[strconv.Itoa(int(port.ContainerPort))] = string(port.Protocol)
-		}
-	}
-	return result
-}
-
-// Extracts the protocols exposed by a service from the given service spec.
-func getServiceProtocolsInternal(spec api.ServiceSpec) map[string]string {
-	result := make(map[string]string)
-	for _, servicePort := range spec.Ports {
-		result[strconv.Itoa(int(servicePort.Port))] = string(servicePort.Protocol)
-	}
-	return result
 }
 
 func getProtocols(spec corev1.PodSpec) map[string]string {


### PR DESCRIPTION
* Removes references to internal versions of resources.
* These functions are only called in expose.go, and it is guaranteed that only external versions of resources are available in this file.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
