### PR TITLE
kubectl remove references to internal version of resources

### DIFF
--- a/pkg/kubectl/polymorphichelpers/BUILD
+++ b/pkg/kubectl/polymorphichelpers/BUILD
@@ -22,10 +22,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/polymorphichelpers",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/apps:go_default_library",
-        "//pkg/apis/batch:go_default_library",
-        "//pkg/apis/core:go_default_library",
-        "//pkg/apis/extensions:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",

--- a/pkg/kubectl/polymorphichelpers/helpers.go
+++ b/pkg/kubectl/polymorphichelpers/helpers.go
@@ -26,7 +26,6 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,22 +34,18 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	"k8s.io/kubernetes/pkg/apis/batch"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // GetFirstPod returns a pod matching the namespace and label selector
 // and the number of all pods that match the label selector.
-func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string, timeout time.Duration, sortBy func([]*v1.Pod) sort.Interface) (*v1.Pod, int, error) {
+func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string, timeout time.Duration, sortBy func([]*corev1.Pod) sort.Interface) (*corev1.Pod, int, error) {
 	options := metav1.ListOptions{LabelSelector: selector}
 
 	podList, err := client.Pods(namespace).List(options)
 	if err != nil {
 		return nil, 0, err
 	}
-	pods := []*v1.Pod{}
+	pods := []*corev1.Pod{}
 	for i := range podList.Items {
 		pod := podList.Items[i]
 		pods = append(pods, &pod)
@@ -78,7 +73,7 @@ func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string
 	if err != nil {
 		return nil, 0, err
 	}
-	pod, ok := event.Object.(*v1.Pod)
+	pod, ok := event.Object.(*corev1.Pod)
 	if !ok {
 		return nil, 0, fmt.Errorf("%#v is not a pod event", event)
 	}
@@ -88,12 +83,6 @@ func GetFirstPod(client coreclient.PodsGetter, namespace string, selector string
 // SelectorsForObject returns the pod label selector for a given object
 func SelectorsForObject(object runtime.Object) (namespace string, selector labels.Selector, err error) {
 	switch t := object.(type) {
-	case *extensions.ReplicaSet:
-		namespace = t.Namespace
-		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid label selector: %v", err)
-		}
 	case *extensionsv1beta1.ReplicaSet:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -113,19 +102,10 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 			return "", nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
-	case *api.ReplicationController:
-		namespace = t.Namespace
-		selector = labels.SelectorFromSet(t.Spec.Selector)
 	case *corev1.ReplicationController:
 		namespace = t.Namespace
 		selector = labels.SelectorFromSet(t.Spec.Selector)
 
-	case *apps.StatefulSet:
-		namespace = t.Namespace
-		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid label selector: %v", err)
-		}
 	case *appsv1.StatefulSet:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -145,12 +125,6 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 			return "", nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
-	case *extensions.DaemonSet:
-		namespace = t.Namespace
-		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid label selector: %v", err)
-		}
 	case *extensionsv1beta1.DaemonSet:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -170,12 +144,6 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 			return "", nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
-	case *extensions.Deployment:
-		namespace = t.Namespace
-		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid label selector: %v", err)
-		}
 	case *extensionsv1beta1.Deployment:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -201,12 +169,6 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 			return "", nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
-	case *batch.Job:
-		namespace = t.Namespace
-		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
-		if err != nil {
-			return "", nil, fmt.Errorf("invalid label selector: %v", err)
-		}
 	case *batchv1.Job:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -214,12 +176,6 @@ func SelectorsForObject(object runtime.Object) (namespace string, selector label
 			return "", nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
-	case *api.Service:
-		namespace = t.Namespace
-		if t.Spec.Selector == nil || len(t.Spec.Selector) == 0 {
-			return "", nil, fmt.Errorf("invalid service '%s': Service is defined without a selector", t.Name)
-		}
-		selector = labels.SelectorFromSet(t.Spec.Selector)
 	case *corev1.Service:
 		namespace = t.Namespace
 		if t.Spec.Selector == nil || len(t.Spec.Selector) == 0 {


### PR DESCRIPTION
* Removes references to internal versions of resources (e.g. extensions.Deployment) within polymorphichelpers/helpers.go
* This file exports two functions: GetFirstPod and SelectorsForObject
* Both of these functions are guaranteed to only receive external versions of resources.
* Updates import aliases for consistency.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
