### PR TITLE
kubectl small replacement of legacyscheme with kubectl scheme

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/scale:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/pkg/kubectl/cmd/util/kubectl_match_version.go
+++ b/pkg/kubectl/cmd/util/kubectl_match_version.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -120,7 +120,7 @@ func setKubernetesDefaults(config *rest.Config) error {
 		config.APIPath = "/api"
 	}
 	if config.NegotiatedSerializer == nil {
-		config.NegotiatedSerializer = legacyscheme.Codecs
+		config.NegotiatedSerializer = scheme.Codecs
 	}
 	return rest.SetKubernetesDefaults(config)
 }


### PR DESCRIPTION
* Replaces legacyscheme with kubectl scheme to ensure no reference of internal version of resource.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
None
```
