### PR TITLE
Fix a golint error on head (type doesn't need to declared as it will be inferred)

### DIFF
--- a/pkg/api/testing/deep_copy_test.go
+++ b/pkg/api/testing/deep_copy_test.go
@@ -37,7 +37,7 @@ func parseTimeOrDie(ts string) metav1.Time {
 	return metav1.Time{Time: t}
 }
 
-var benchmarkPod api.Pod = api.Pod{
+var benchmarkPod = api.Pod{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Pod",
 		APIVersion: "v1",


### PR DESCRIPTION
fix golint error on head. the type should not be declared with the var, as it will be inferred

**What this PR does / why we need it**:

This fixes a linting issue on head.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
