### PR TITLE
update import restrictions for pkg printers and subpkg internalversion

### DIFF
--- a/pkg/printers/.import-restrictions
+++ b/pkg/printers/.import-restrictions
@@ -1,8 +1,52 @@
 {
   "Rules": [
     {
-      "SelectorRegexp": "k8s[.]io/kubernetes/pkg/(api$|apis/)",
-      "ForbiddenPrefixes": [
+      "SelectorRegexp": "k8s[.]io/(api|client-go|cli-runtime)/",
+      "AllowedPrefixes": [
+        "k8s.io/api/admission",
+        "k8s.io/api/apps",
+        "k8s.io/api/authentication",
+        "k8s.io/api/authorization",
+        "k8s.io/api/autoscaling",
+        "k8s.io/api/batch",
+        "k8s.io/api/certificates",
+        "k8s.io/api/core",
+        "k8s.io/api/extensions",
+        "k8s.io/api/imagepolicy",
+        "k8s.io/api/networking",
+        "k8s.io/api/policy",
+        "k8s.io/api/rbac",
+        "k8s.io/api/scheduling",
+        "k8s.io/api/settings",
+        "k8s.io/api/storage",
+        "k8s.io/client-go/kubernetes/scheme",
+        "k8s.io/client-go/util/jsonpath",
+        "k8s.io/cli-runtime/pkg/genericclioptions"
+      ]
+    },
+    {
+      "SelectorRegexp": "github[.]com/",
+      "AllowedPrefixes": [
+        "github.com/spf13/cobra"
+      ]
+    },
+    {
+      "SelectorRegexp": "k8s[.]io/apimachinery/pkg/",
+      "AllowedPrefixes": [
+        "k8s.io/apimachinery/pkg/api/meta",
+        "k8s.io/apimachinery/pkg/apis/meta",
+        "k8s.io/apimachinery/pkg/labels",
+        "k8s.io/apimachinery/pkg/runtime",
+        "k8s.io/apimachinery/pkg/runtime/schema",
+        "k8s.io/apimachinery/pkg/util/runtime"
+      ]
+    },
+    {
+      "SelectorRegexp": "k8s[.]io/kubernetes/pkg/",
+      "AllowedPrefixes": [
+        "k8s.io/kubernetes/pkg/api/legacyscheme",
+        "k8s.io/kubernetes/pkg/apis/core",
+        "k8s.io/kubernetes/pkg/kubectl/scheme",
         "k8s.io/kubernetes/pkg/printers"
       ]
     }

--- a/pkg/printers/internalversion/.import-restrictions
+++ b/pkg/printers/internalversion/.import-restrictions
@@ -1,4 +1,118 @@
 {
   "Rules": [
+    {
+      "SelectorRegexp": "k8s[.]io/apimachinery/pkg/",
+      "AllowedPrefixes": [
+        "k8s.io/apimachinery/pkg/api/equality",
+        "k8s.io/apimachinery/pkg/api/errors",
+        "k8s.io/apimachinery/pkg/api/meta",
+        "k8s.io/apimachinery/pkg/api/resource",
+        "k8s.io/apimachinery/pkg/api/validation",
+        "k8s.io/apimachinery/pkg/apis/meta",
+        "k8s.io/apimachinery/pkg/conversion",
+        "k8s.io/apimachinery/pkg/fields",
+        "k8s.io/apimachinery/pkg/labels",
+        "k8s.io/apimachinery/pkg/runtime",
+        "k8s.io/apimachinery/pkg/runtime/schema",
+        "k8s.io/apimachinery/pkg/runtime/serializer/yaml",
+        "k8s.io/apimachinery/pkg/selection",
+        "k8s.io/apimachinery/pkg/types",
+        "k8s.io/apimachinery/pkg/util",
+        "k8s.io/apimachinery/pkg/watch"
+      ]
+    },
+    {
+      "SelectorRegexp": "k8s[.]io/kubernetes/pkg/",
+      "AllowedPrefixes": [
+        "k8s.io/kubernetes/pkg/api/events",
+        "k8s.io/kubernetes/pkg/api/legacyscheme",
+        "k8s.io/kubernetes/pkg/api/ref",
+        "k8s.io/kubernetes/pkg/api/resource",
+        "k8s.io/kubernetes/pkg/api/service",
+        "k8s.io/kubernetes/pkg/api/testapi",
+        "k8s.io/kubernetes/pkg/api/v1/pod",
+        "k8s.io/kubernetes/pkg/apis/admissionregistration",
+        "k8s.io/kubernetes/pkg/apis/apps",
+        "k8s.io/kubernetes/pkg/apis/authentication",
+        "k8s.io/kubernetes/pkg/apis/authorization",
+        "k8s.io/kubernetes/pkg/apis/autoscaling",
+        "k8s.io/kubernetes/pkg/apis/batch",
+        "k8s.io/kubernetes/pkg/apis/certificates",
+        "k8s.io/kubernetes/pkg/apis/coordination",
+        "k8s.io/kubernetes/pkg/apis/core",
+        "k8s.io/kubernetes/pkg/apis/events",
+        "k8s.io/kubernetes/pkg/apis/extensions",
+        "k8s.io/kubernetes/pkg/apis/networking",
+        "k8s.io/kubernetes/pkg/apis/policy",
+        "k8s.io/kubernetes/pkg/apis/rbac",
+        "k8s.io/kubernetes/pkg/apis/scheduling",
+        "k8s.io/kubernetes/pkg/apis/settings",
+        "k8s.io/kubernetes/pkg/apis/storage",
+        "k8s.io/kubernetes/pkg/capabilities",
+        "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+        "k8s.io/kubernetes/pkg/controller",
+        "k8s.io/kubernetes/pkg/kubectl",
+        "k8s.io/kubernetes/pkg/kubelet",
+        "k8s.io/kubernetes/pkg/master/ports",
+        "k8s.io/kubernetes/pkg/features",
+        "k8s.io/kubernetes/pkg/fieldpath",
+        "k8s.io/kubernetes/pkg/printers",
+        "k8s.io/kubernetes/pkg/registry/rbac/validation",
+        "k8s.io/kubernetes/pkg/scheduler",
+        "k8s.io/kubernetes/pkg/security/apparmor",
+        "k8s.io/kubernetes/pkg/serviceaccount",
+        "k8s.io/kubernetes/pkg/util"
+      ]
+    },
+    {
+      "SelectorRegexp": "k8s[.]io/api/",
+      "AllowedPrefixes": [
+        "k8s.io/api/admission",
+        "k8s.io/api/admissionregistration",
+        "k8s.io/api/apps",
+        "k8s.io/api/authentication",
+        "k8s.io/api/authorization",
+        "k8s.io/api/autoscaling",
+        "k8s.io/api/batch",
+        "k8s.io/api/certificates",
+        "k8s.io/api/coordination",
+        "k8s.io/api/core",
+        "k8s.io/api/events",
+        "k8s.io/api/extensions",
+        "k8s.io/api/imagepolicy",
+        "k8s.io/api/networking",
+        "k8s.io/api/policy",
+        "k8s.io/api/rbac",
+        "k8s.io/api/scheduling",
+        "k8s.io/api/settings",
+        "k8s.io/api/storage"
+      ]
+    },
+    {
+      "SelectorRegexp": "github[.]com/",
+      "AllowedPrefixes": [
+        "github.com/davecgh/go-spew/spew",
+        "github.com/docker/distribution/reference",
+        "github.com/fatih/camelcase",
+        "github.com/ghodss/yaml",
+        "github.com/golang/glog",
+        "github.com/golang/groupcache/lru",
+        "github.com/spf13/cobra"
+      ]
+    },
+    {
+      "SelectorRegexp": "k8s[.]io/(utils|client-go|cli-runtime)/",
+      "AllowedPrefixes": [
+        "k8s.io/utils/pointer",
+        "k8s.io/client-go/discovery",
+        "k8s.io/client-go/dynamic",
+        "k8s.io/client-go/kubernetes",
+        "k8s.io/client-go/rest",
+        "k8s.io/client-go/tools",
+        "k8s.io/client-go/util",
+        "k8s.io/cli-runtime/pkg/genericclioptions",
+        "k8s.io/cli-runtime/pkg/genericclioptions/printers"
+      ]
+    }
   ]
 }

--- a/pkg/printers/internalversion/sorted_resource_name_list_test.go
+++ b/pkg/printers/internalversion/sorted_resource_name_list_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package internalversion
 
 import (
-	api "k8s.io/kubernetes/pkg/apis/core"
 	"reflect"
 	"sort"
 	"testing"
+
+	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func TestSortableResourceNamesSorting(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
update import restrictions for pkg printers and subpkg internalversion
**Which issue(s) this PR fixes** :
Refers to #68201

**Special notes for your reviewer**:
If both pkg `a/b/c/v1` and  `a/b/c/v2` are imported, i write an allowed prefix `a/b/c`
If both pkg `a/b/c/d` and  `a/b/c/e` are imported, i sometimes write an allowed prefix `a/b/c`
**Release note**:

```release-note
none
```
