### PR TITLE
fix kubectl wait with no resource name provided

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -242,6 +242,9 @@ func (o *WaitOptions) RunWait() error {
 func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
 	endTime := time.Now().Add(o.Timeout)
 	for {
+		if len(info.Name) == 0 {
+			return info.Object, false, fmt.Errorf("resource name must be provided")
+		}
 		gottenObj, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Get(info.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return info.Object, true, nil
@@ -308,6 +311,9 @@ type ConditionalWait struct {
 func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error) {
 	endTime := time.Now().Add(o.Timeout)
 	for {
+		if len(info.Name) == 0 {
+			return info.Object, false, fmt.Errorf("resource name must be provided")
+		}
 		resourceVersion := ""
 		gottenObj, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Get(info.Name, metav1.GetOptions{})
 		switch {

--- a/pkg/kubectl/cmd/wait/wait_test.go
+++ b/pkg/kubectl/cmd/wait/wait_test.go
@@ -379,6 +379,28 @@ func TestWaitForCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "handles empty object name",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Namespace: "ns-foo",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				return dynamicfakeclient.NewSimpleDynamicClient(scheme)
+			},
+			timeout:     10 * time.Second,
+			expectedErr: "resource name must be provided",
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
 			name: "times out",
 			infos: []*resource.Info{
 				{


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/69039

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
