### PR TITLE
Cleaned Up Sig-Azure

### DIFF
--- a/CHANGELOG-1.12.md
+++ b/CHANGELOG-1.12.md
@@ -9,8 +9,6 @@
     - [SIG API Machinery](#sig-api-machinery)
     - [SIG-autoscaling](#sig-autoscaling)
     - [SIG-Azure](#sig-azure)
-- [Adding Azure Availability Zones support to cloud provider.](#adding-azure-availability-zones-support-to-cloud-provider)
-- [Supporting Cross RG resources (disks, Azure File and node [Experimental]](#supporting-cross-rg-resources-disks-azure-file-and-node-experimental)
     - [SIG-cli](#sig-cli)
     - [SIG-cloud-provider](#sig-cloud-provider)
     - [SIG-cluster-lifecycle](#sig-cluster-lifecycle)
@@ -167,16 +165,13 @@ SIG Autoscaling focused on improving the Horizontal Pod Autoscaling API and algo
 ### SIG-Azure
 
 Sig Azure was focused on two primary new alpha features:
-# Adding Azure Availability Zones support to cloud provider.
-# Supporting Cross RG resources (disks, Azure File and node [Experimental]
+- Adding Azure Availability Zones support to cloud provider.
+- Supporting Cross RG resources (disks, Azure File and node [Experimental]
 
 Besides the above new features, support for Azure Virtual Machine Scale Sets (VMSS) and Cluster-Autoscaler is now stable and considered GA:
 
-- Azure virtual machine scale sets (VMSS) allow you to create and manage identical load balanced
-VMs that automatically increase or decrease based on demand or a set schedule.
-- With this new stable feature, Kubernetes supports the scaling of containerized applications
-with Azure VMSS, including the ability to integrate it with cluster-autoscaler to automatically
-adjust the size of the Kubernetes clusters based on the same conditions. 
+- Azure virtual machine scale sets (VMSS) allow you to create and manage identical load balanced VMs that automatically increase or decrease based on demand or a set schedule.
+- With this new stable feature, Kubernetes supports the scaling of containerized applications with Azure VMSS, including the ability to integrate it with cluster-autoscaler to automatically adjust the size of the Kubernetes clusters based on the same conditions. 
 
 ### SIG-cli
 


### PR DESCRIPTION
Sig-Azure headings were off and did not conform with the rest of the document format.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The PR cleans up the misformated headings for Sig-Azure
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I was part of the release team (Release Notes) and this must of been misformated during doc cleanup
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
