### PR TITLE
[wip] ipvs support localhost:nodePort

### DIFF
--- a/pkg/proxy/ipvs/netlink.go
+++ b/pkg/proxy/ipvs/netlink.go
@@ -35,4 +35,6 @@ type NetLinkHandle interface {
 	// GetLocalAddresses returns all unique local type IP addresses based on specified device and filter device
 	// If device is not specified, it will list all unique local type addresses except filter device addresses
 	GetLocalAddresses(dev, filterDev string) (sets.String, error)
+	// ChangeLORouteSrc change the src of lo link in table local
+	ChangeLORouteSrc(typ string) error
 }

--- a/pkg/proxy/ipvs/netlink_unsupported.go
+++ b/pkg/proxy/ipvs/netlink_unsupported.go
@@ -20,7 +20,6 @@ package ipvs
 
 import (
 	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -60,4 +59,9 @@ func (h *emptyHandle) ListBindAddress(devName string) ([]string, error) {
 // GetLocalAddresses is part of interface.
 func (h *emptyHandle) GetLocalAddresses(dev, filterDev string) (sets.String, error) {
 	return nil, fmt.Errorf("netlink is not supported in this platform")
+}
+
+// ChangeLORouteSrc is part of interface.
+func (h *netlinkHandle) ChangeLORouteSrc(typ ChangeLoRouteSrcType) error {
+	return fmt.Errorf("netlink is not supported in this platform")
 }

--- a/pkg/proxy/ipvs/testing/fake.go
+++ b/pkg/proxy/ipvs/testing/fake.go
@@ -146,3 +146,8 @@ func (h *FakeNetlinkHandle) SetLocalAddresses(dev string, ips ...string) error {
 	h.localAddresses[dev] = append(h.localAddresses[dev], ips...)
 	return nil
 }
+
+// ChangeLORouteSrc is a mock implementation
+func (h *FakeNetlinkHandle) ChangeLORouteSrc(typ string) error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To make ipvs proxier mode support localhost:nodePort, lots people may need this function in local test cases, or other scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67730

**Special notes for your reviewer**:

**Release note**:
```release-note
IPVS proxier mode now support localhost:nodePort.
```
