### PR TITLE
Automated cherry pick of #58646: Change the portworx volume attribute SupportsSELinux to false

### DIFF
--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -269,10 +269,9 @@ var _ volume.Mounter = &portworxVolumeMounter{}
 
 func (b *portworxVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
-		ReadOnly: b.readOnly,
-		Managed:  !b.readOnly,
-		// true ?
-		SupportsSELinux: true,
+		ReadOnly:        b.readOnly,
+		Managed:         !b.readOnly,
+		SupportsSELinux: false,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #58646 on release-1.12.

#58646: Change the portworx volume attribute SupportsSELinux to false

Issue: #69183 