### PR TITLE
add /etc/nsswitch.conf to control plane images

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_bundle")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 filegroup(
@@ -21,23 +22,32 @@ filegroup(
     tags = ["automanaged"],
 )
 
+# ensure /etc/nsswitch.conf exists so go's resolver respects /etc/hosts
+container_image(
+    name = "busybox-with-nsswitch",
+    base = "@official_busybox//image",
+    directory = "/etc",
+    files = ["nsswitch.conf"],
+    mode = "0644",
+)
+
 # This list should roughly match kube::build::get_docker_wrapped_binaries()
 # in build/common.sh.
 DOCKERIZED_BINARIES = {
     "cloud-controller-manager": {
-        "base": "@official_busybox//image",
+        "base": ":busybox-with-nsswitch",
         "target": "//cmd/cloud-controller-manager:cloud-controller-manager",
     },
     "kube-apiserver": {
-        "base": "@official_busybox//image",
+        "base": ":busybox-with-nsswitch",
         "target": "//cmd/kube-apiserver:kube-apiserver",
     },
     "kube-controller-manager": {
-        "base": "@official_busybox//image",
+        "base": ":busybox-with-nsswitch",
         "target": "//cmd/kube-controller-manager:kube-controller-manager",
     },
     "kube-scheduler": {
-        "base": "@official_busybox//image",
+        "base": ":busybox-with-nsswitch",
         "target": "//cmd/kube-scheduler:kube-scheduler",
     },
     "kube-proxy": {

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -355,8 +355,16 @@ function kube::release::create_docker_images_for_server() {
         rm -rf "${docker_build_path}"
         mkdir -p "${docker_build_path}"
         ln "${binary_dir}/${binary_name}" "${docker_build_path}/${binary_name}"
-        printf " FROM ${base_image} \n ADD ${binary_name} /usr/local/bin/${binary_name}\n" > "${docker_file_path}"
-
+        ln "${KUBE_ROOT}/build/nsswitch.conf" "${docker_build_path}/nsswitch.conf"
+        chmod 0644 "${docker_build_path}/nsswitch.conf"
+        cat <<EOF > "${docker_file_path}"
+FROM ${base_image}
+COPY ${binary_name} /usr/local/bin/${binary_name}
+EOF
+        # ensure /etc/nsswitch.conf exists so go's resolver respects /etc/hosts
+        if [[ "${base_image}" =~ busybox ]]; then
+          echo "COPY nsswitch.conf /etc/" >> "${docker_file_path}"
+        fi
         "${DOCKER[@]}" build --pull -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
         "${DOCKER[@]}" tag "${docker_image_tag}" "${deprecated_image_tag}" >/dev/null
         "${DOCKER[@]}" save "${docker_image_tag}" "${deprecated_image_tag}" > "${binary_dir}/${binary_name}.tar"

--- a/build/nsswitch.conf
+++ b/build/nsswitch.conf
@@ -1,0 +1,2 @@
+# ensure go's non-cgo resolver respects /etc/hosts
+hosts: files dns


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: adds a minimal [`/etc/nsswitch.conf`](http://man7.org/linux/man-pages/man5/nsswitch.conf.5.html) to control plane images that do not have one, ensuring that they respect /etc/hosts when lookup up hostnames

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69195

**Special notes for your reviewer**: Without this, in some cases we may do unnecessary DNS lookups in EG the API server. This broke my control plane boot due to trying to lookup `localhost`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Images for cloud-controller-manager, kube-apiserver, kube-controller-manager, and kube-scheduler now contain a minimal /etc/nsswitch.conf and should respect /etc/hosts for lookups
```
