### PR TITLE
fix golint errors in cluster/images/etcd-version-monitor

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -191,7 +191,7 @@ func (m *monitorGatherer) rewriteExportedMetrics(metrics map[string]*dto.MetricF
 	return results, nil
 }
 
-// Struct for unmarshalling the json response from etcd's /version endpoint.
+// EtcdVersion is for unmarshalling the json response from etcd's /version endpoint.
 type EtcdVersion struct {
 	BinaryVersion  string `json:"etcdserver"`
 	ClusterVersion string `json:"etcdcluster"`

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,4 +1,3 @@
-cluster/images/etcd-version-monitor
 cmd/cloud-controller-manager/app/apis/config/v1alpha1
 cmd/hyperkube
 cmd/kube-apiserver/app


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There's an umbrella bug for golint failures: #68026
This PR fix golint errors in cluster/images/etcd-version-monitor

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/release-note-none
/kind cleanup
