### PR TITLE
refactor envelope to use cryptobytes

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -627,6 +627,14 @@
 			"Rev": "de0752318171da717af4ce24d0a2e8626afaeb11"
 		},
 		{
+			"ImportPath": "golang.org/x/crypto/cryptobyte",
+			"Rev": "de0752318171da717af4ce24d0a2e8626afaeb11"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/cryptobyte/asn1",
+			"Rev": "de0752318171da717af4ce24d0a2e8626afaeb11"
+		},
+		{
 			"ImportPath": "golang.org/x/crypto/ed25519",
 			"Rev": "de0752318171da717af4ce24d0a2e8626afaeb11"
 		},

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/hashicorp/golang-lru:go_default_library",
+        "//vendor/golang.org/x/crypto/cryptobyte:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
@@ -200,4 +201,71 @@ func benchmarkRead(b *testing.B, transformer value.Transformer, valueLength int)
 		}
 	}
 	b.StopTimer()
+}
+
+// remove after 1.13
+func TestBackwardsCompatibility(t *testing.T) {
+	envelopeService := newTestEnvelopeService()
+	envelopeTransformerInst, err := NewEnvelopeTransformer(envelopeService, testEnvelopeCacheSize, aestransformer.NewCBCTransformer)
+	if err != nil {
+		t.Fatalf("failed to initialize envelope transformer: %v", err)
+	}
+	context := value.DefaultContext([]byte(testContextText))
+	originalText := []byte(testText)
+
+	transformedData, err := oldTransformToStorage(envelopeTransformerInst.(*envelopeTransformer), originalText, context)
+	if err != nil {
+		t.Fatalf("envelopeTransformer: error while transforming data to storage: %s", err)
+	}
+	untransformedData, _, err := envelopeTransformerInst.TransformFromStorage(transformedData, context)
+	if err != nil {
+		t.Fatalf("could not decrypt Envelope transformer's encrypted data even once: %v", err)
+	}
+	if bytes.Compare(untransformedData, originalText) != 0 {
+		t.Fatalf("envelopeTransformer transformed data incorrectly. Expected: %v, got %v", originalText, untransformedData)
+	}
+
+	envelopeService.SetDisabledStatus(true)
+	// Subsequent read for the same data should work fine due to caching.
+	untransformedData, _, err = envelopeTransformerInst.TransformFromStorage(transformedData, context)
+	if err != nil {
+		t.Fatalf("could not decrypt Envelope transformer's encrypted data using just cache: %v", err)
+	}
+	if bytes.Compare(untransformedData, originalText) != 0 {
+		t.Fatalf("envelopeTransformer transformed data incorrectly using cache. Expected: %v, got %v", originalText, untransformedData)
+	}
+}
+
+// remove after 1.13
+func oldTransformToStorage(t *envelopeTransformer, data []byte, context value.Context) ([]byte, error) {
+	newKey, err := generateKey(32)
+	if err != nil {
+		return nil, err
+	}
+
+	encKey, err := t.envelopeService.Encrypt(newKey)
+	if err != nil {
+		return nil, err
+	}
+
+	transformer, err := t.addTransformer(encKey, newKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Append the length of the encrypted DEK as the first 2 bytes.
+	encKeyLen := make([]byte, 2)
+	encKeyBytes := []byte(encKey)
+	binary.BigEndian.PutUint16(encKeyLen, uint16(len(encKeyBytes)))
+
+	prefix := append(encKeyLen, encKeyBytes...)
+
+	prefixedData := make([]byte, len(prefix), len(data)+len(prefix))
+	copy(prefixedData, prefix)
+	result, err := transformer.TransformToStorage(data, context)
+	if err != nil {
+		return nil, err
+	}
+	prefixedData = append(prefixedData, result...)
+	return prefixedData, nil
 }


### PR DESCRIPTION
A little less hairy.

```release-note
NONE
```
