### PR TITLE
remove --show-all

### DIFF
--- a/pkg/kubectl/cmd/get/get_flags.go
+++ b/pkg/kubectl/cmd/get/get_flags.go
@@ -164,10 +164,6 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	if f.NoHeaders != nil {
 		cmd.Flags().BoolVar(f.NoHeaders, "no-headers", *f.NoHeaders, "When using the default or custom-column output format, don't print headers (default print headers).")
 	}
-
-	// TODO(juanvallejo): This is deprecated - remove
-	cmd.Flags().BoolP("show-all", "a", true, "When printing, show all resources (default show all pods including terminated one.)")
-	cmd.Flags().MarkDeprecated("show-all", "will be removed in an upcoming release")
 }
 
 // NewGetPrintFlags returns flags associated with humanreadable,


### PR DESCRIPTION
**What this PR does / why we need it**:
remove `show-all`, it is deprecated in 1.10
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated args '--show-all'
```
