### PR TITLE
Respect Allocation IDs

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -132,9 +132,17 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 			createRequest.Scheme = aws.String("internal")
 		}
 
+		var allocationIDs []string
+		if eipList, present := annotations[ServiceAnnotationLoadBalancerEIPAllocations]; present {
+			allocationIDs = strings.Split(eipList, ",")
+			if len(allocationIDs) != len(subnetIDs) {
+				return nil, fmt.Errorf("Error creating load balancer: Must have same number of EIP AllocationIDs (%d) and SubnetIDs (%d)", len(allocationIDs), len(subnetIDs))
+			}
+		}
+
 		// We are supposed to specify one subnet per AZ.
 		// TODO: What happens if we have more than one subnet per AZ?
-		createRequest.SubnetMappings = createSubnetMappings(subnetIDs)
+		createRequest.SubnetMappings = createSubnetMappings(subnetIDs, allocationIDs)
 
 		for k, v := range tags {
 			createRequest.Tags = append(createRequest.Tags, &elbv2.Tag{
@@ -1347,12 +1355,15 @@ func elbListenersAreEqual(actual, expected *elb.Listener) bool {
 	return true
 }
 
-func createSubnetMappings(subnetIDs []string) []*elbv2.SubnetMapping {
+func createSubnetMappings(subnetIDs []string, allocationIDs []string) []*elbv2.SubnetMapping {
 	response := []*elbv2.SubnetMapping{}
 
-	for _, id := range subnetIDs {
-		// Ignore AllocationId for now
-		response = append(response, &elbv2.SubnetMapping{SubnetId: aws.String(id)})
+	for index, id := range subnetIDs {
+		sm := &elbv2.SubnetMapping{SubnetId: aws.String(id)}
+		if len(allocationIDs) > 0 {
+			sm.AllocationId = aws.String(allocationIDs[index])
+		}
+		response = append(response, sm)
 	}
 
 	return response


### PR DESCRIPTION
**What this PR does / why we need it**:
AWS NLB supports the use of static IP addresses (EIP) with Network Load Balancers. This PR supports a new annotation on services `service.beta.kubernetes.io/aws-load-balancer-eip-allocations` which is a comma separated list of AWS Allocation IDs. The number of Allocation IDs must match the number of subnets used for the load balancer. 

/kind feature
/sig aws

Fixes #63959 

**Special notes for your reviewer**:
None 

**Release note**:
```release-note
Creates an annotation 'service.beta.kubernetes.io/aws-load-balancer-eip-allocations' to assign AWS EIP to the newly created Network Load Balancer. Number of allocations and subnets must match.
```
