### PR TITLE
Need a way to fetch bearer token with InClusterConfig

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -156,6 +156,7 @@ go_library(
         "//vendor/github.com/spf13/viper:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
         "//vendor/golang.org/x/net/websocket:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",


### PR DESCRIPTION
Change-Id: Ia8cb2ef0803fd471564f571dc15a2c39ae388021

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In https://github.com/kubernetes/kubernetes/pull/67359/commits/287f6a564fb8c264f281056011f4a66f197b18f4#diff-063e73bab84834a4187b1ad4865050adL337, we stopped initializing `BearerToken`. We need the token for example in the sonobuoy scenario where we serialize the in-cluster config into a file and then use it. 

In this PR, we add another method to fetch the token source as well. which can be used in scenarios where we need it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69234

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a new method to get the token source as well when using the in-cluster-config to fetch the bearer token when required.
```
