### PR TITLE
Fix bug with InClusterConfig requiring bearer token.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -323,8 +323,8 @@ func InClusterConfig() (*Config, error) {
 	}
 
 	ts := newCachedPathTokenSource(tokenFile)
-
-	if _, err := ts.Token(); err != nil {
+	tok, err := ts.Token()
+	if err != nil {
 		return nil, err
 	}
 
@@ -338,7 +338,10 @@ func InClusterConfig() (*Config, error) {
 
 	return &Config{
 		// TODO: switch to using cluster DNS.
-		Host:            "https://" + net.JoinHostPort(host, port),
+		Host: "https://" + net.JoinHostPort(host, port),
+		// TODO: This is a fix for #69234, caused by #67359
+		// It looks like we will need to be careful on rotation.
+		BearerToken:     tok.AccessToken,
 		TLSClientConfig: tlsClientConfig,
 		WrapTransport:   TokenSourceWrapTransport(ts),
 	}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
In cluster configs were failing b/c of changes made by https://github.com/kubernetes/kubernetes/pull/67359

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #69234

**Special notes for your reviewer**:
I've verified this PR fixes the issue, and is critical priority.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Fix bug caused by #67359 that caused some client-go generated InCluster KubeConfigs to fail.  
```

/sig testing 
/sig auth
/sig apimachinery 

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @dims 
/assign @liggitt @mikedanese @smarterclayton 
