### PR TITLE
Increase the pod start short timeout

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -114,7 +114,7 @@ const (
 	// Same as `PodStartTimeout` to wait for the pod to be started, but shorter.
 	// Use it case by case when we are sure pod start will not be delayed
 	// minutes by slow docker pulls or something else.
-	PodStartShortTimeout = 1 * time.Minute
+	PodStartShortTimeout = 2 * time.Minute
 
 	// How long to wait for a pod to be deleted
 	PodDeleteTimeout = 5 * time.Minute


### PR DESCRIPTION
We have seen flakes related to this timeout.

cc: @derekwaynecarr @runcom 

Signed-off-by: Mrunal Patel <mpatel@redhat.com>


**What this PR does / why we need it**:
It bumps up the pod short start timeout to 2 minutes as we have seen flakes in this area in CI.


```release-note
Bump up pod short start timeout to 2 minutes.
```
