### PR TITLE
allow condition value to specified for kubectl wait

### DIFF
--- a/pkg/kubectl/cmd/wait/wait.go
+++ b/pkg/kubectl/cmd/wait/wait.go
@@ -174,10 +174,15 @@ func conditionFuncFor(condition string) (ConditionFunc, error) {
 	}
 	if strings.HasPrefix(condition, "condition=") {
 		conditionName := condition[len("condition="):]
+		conditionValue := "true"
+		if equalsIndex := strings.Index(conditionName, "="); equalsIndex != -1 {
+			conditionValue = conditionName[equalsIndex+1:]
+			conditionName = conditionName[0:equalsIndex]
+		}
+
 		return ConditionalWait{
-			conditionName: conditionName,
-			// TODO allow specifying a false
-			conditionStatus: "true",
+			conditionName:   conditionName,
+			conditionStatus: conditionValue,
 		}.IsConditionMet, nil
 	}
 


### PR DESCRIPTION
Allows kubectl wait to check for a `false` condition. The unit tests in this area already checked against a non-standard value.

```release-note
`kubectl wait` now supports condition value checks other than true using `--for condition=available=false`
```

@kubernetes/sig-cli-maintainers 