### PR TITLE
Add `ReadOnly` type to feature gate package.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -94,6 +94,18 @@ type FeatureGate interface {
 	DeepCopy() FeatureGate
 }
 
+// ReadOnly provides a read-only view of a `FeatureGate`.
+type ReadOnly interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key Feature) bool
+	// Add adds features to the featureGate.
+	KnownFeatures() []string
+	// DeepCopy returns a deep copy of the FeatureGate object, such that gates can be
+	// set on the copy without mutating the original. This is useful for validating
+	// config against potential feature gate changes before committing those changes.
+	DeepCopy() FeatureGate
+}
+
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
 type featureGate struct {
 	special map[Feature]func(map[Feature]FeatureSpec, map[Feature]bool, bool)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds an interface `feature.ReadOnly` which is a subset of
`feature.FeatureGate`. It removes all mutating functions.

This is useful for a component that wants to snapshot
`feature.DefaultFeatureGate` and also promise not to mutate the copy
during runtime.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
/ref https://github.com/kubernetes/kubernetes/issues/68957

**Special notes for your reviewer**:
This is a proposed part of https://github.com/kubernetes/kubernetes/issues/68957

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/kind cleanup