### PR TITLE
kubeadm: handle stable-1 as the default version

### DIFF
--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -380,3 +380,75 @@ func TestKubeadmVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateStableVersion(t *testing.T) {
+	type T struct {
+		name          string
+		remoteVersion string
+		clientVersion string
+		output        string
+		expectedError bool
+	}
+	cases := []T{
+		{
+			name:          "valid: remote version is newer; return stable label [1]",
+			remoteVersion: "v1.12.0",
+			clientVersion: "v1.11.0",
+			output:        "stable-1.11",
+		},
+		{
+			name:          "valid: remote version is newer; return stable label [2]",
+			remoteVersion: "v2.0.0",
+			clientVersion: "v1.11.0",
+			output:        "stable-1.11",
+		},
+		{
+			name:          "valid: remote version is newer; return stable label [3]",
+			remoteVersion: "v2.1.5",
+			clientVersion: "v1.11.5",
+			output:        "stable-1.11",
+		},
+		{
+			name:          "valid: return the remote version as it is part of the same release",
+			remoteVersion: "v1.11.5",
+			clientVersion: "v1.11.0",
+			output:        "v1.11.5",
+		},
+		{
+			name:          "valid: return the same version",
+			remoteVersion: "v1.11.0",
+			clientVersion: "v1.11.0",
+			output:        "v1.11.0",
+		},
+		{
+			name:          "valid: client version is empty; use remote version",
+			remoteVersion: "v1.12.1",
+			clientVersion: "",
+			output:        "v1.12.1",
+		},
+		{
+			name:          "invalid: error parsing the remote version",
+			remoteVersion: "invalid-version",
+			clientVersion: "v1.12.0",
+			expectedError: true,
+		},
+		{
+			name:          "invalid: error parsing the client version",
+			remoteVersion: "v1.12.0",
+			clientVersion: "invalid-version",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := validateStableVersion(tc.remoteVersion, tc.clientVersion)
+			if (err != nil) != tc.expectedError {
+				t.Fatalf("expected error: %v, got: %v", tc.expectedError, err != nil)
+			}
+			if output != tc.output {
+				t.Fatalf("expected output: %s, got: %s", tc.output, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The default version in kubeadm is now `stable-1`. This will
pull a version from the `stable-1.txt` endpoint which might
end up being newer than the version of the client by a magnitude
of MINOR or even a MAJOR release.

To be able to prevent this scenario add the new helper function:
validateStableVersion()

This function determines if the remote version is newer than the
local client version and if that's the case it returns `stable-X.xx`
that conforms with the version of the client. If not it returns
the remote version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#1141

**Special notes for your reviewer**:
- the unit tests can illustrate what the function does.
- **NOTE: we need to backport this to 1.12 !!!**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: fix a possible scenario where kubeadm can pull much newer control-plane images
```

/kind bug
/assign @kad @timothysc 
@kubernetes/sig-cluster-lifecycle-pr-reviews 
