### PR TITLE
Do not return default limits in non-azure environments

### DIFF
--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -145,7 +145,7 @@ func (plugin *azureDataDiskPlugin) GetVolumeLimits() (map[string]int64, error) {
 		// default values from here will mean, no one can
 		// override them.
 		glog.Errorf("failed to get azure cloud in GetVolumeLimits, plugin.host: %s", plugin.host.GetHostName())
-		return volumeLimits, nil
+		return nil, fmt.Errorf("No cloudprovider present")
 	}
 
 	instances, ok := az.Instances()


### PR DESCRIPTION
Make sure that we do not return default azure limits in non-azure envionments.

/sig storage
/sig azure

```release-note
None
```
