### PR TITLE
Update addon-manager to use debian-base:0.3.2.

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 8.8  (Mon October 1 2018 Zihong Zheng <zihongz@google.com>)
+ - Update to use debian-base:0.3.2.
+
 ### Version 8.7  (Tue September 4 2018 Zihong Zheng <zihongz@google.com>)
  - Support extra `--prune-whitelist` resources in kube-addon-manager.
  - Update kubectl to v1.10.7.

--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM BASEIMAGE
 
+RUN clean-install bash
+
 ADD kube-addons.sh /opt/
 ADD namespace.yaml /opt/
 ADD kubectl /usr/local/bin/

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,24 +15,10 @@
 IMAGE=staging-k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v8.7
+VERSION=v8.8
 KUBECTL_VERSION?=v1.10.7
 
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=bashell/alpine-bash
-endif
-ifeq ($(ARCH),arm)
-	BASEIMAGE?=arm32v7/debian
-endif
-ifeq ($(ARCH),arm64)
-	BASEIMAGE?=arm64v8/debian
-endif
-ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/debian
-endif
-ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/debian
-endif
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.3.2
 
 .PHONY: build push
 


### PR DESCRIPTION
**What this PR does / why we need it**:
/assign @awly @ixdy

This is similar to https://github.com/kubernetes/kubernetes/pull/67283.

The actual image bump will happen separately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68858 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
