### PR TITLE
[scheduler cleanup phase 1]: Move CacheComparer to pkg/scheduler/inte…

### DIFF
--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "cache_comparer.go",
         "factory.go",
         "plugins.go",
         "signal.go",
@@ -22,10 +21,10 @@ go_library(
         "//pkg/scheduler/algorithm/priorities:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/api/validation:go_default_library",
-        "//pkg/scheduler/cache:go_default_library",
         "//pkg/scheduler/core:go_default_library",
         "//pkg/scheduler/core/equivalence:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
+        "//pkg/scheduler/internal/cache/comparer:go_default_library",
         "//pkg/scheduler/internal/queue:go_default_library",
         "//pkg/scheduler/util:go_default_library",
         "//pkg/scheduler/volumebinder:go_default_library",
@@ -57,7 +56,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "cache_comparer_test.go",
         "factory_test.go",
         "plugins_test.go",
     ],
@@ -78,7 +76,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	"k8s.io/kubernetes/pkg/scheduler/core/equivalence"
 	schedulerinternalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	cachecomparer "k8s.io/kubernetes/pkg/scheduler/internal/cache/comparer"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
@@ -305,12 +306,12 @@ func NewConfigFactory(args *ConfigFactoryArgs) scheduler.Configurator {
 	}
 
 	// Setup cache comparer
-	comparer := &cacheComparer{
-		podLister:  args.PodInformer.Lister(),
-		nodeLister: args.NodeInformer.Lister(),
-		cache:      c.schedulerCache,
-		podQueue:   c.podQueue,
-	}
+	comparer := cachecomparer.New(
+		args.NodeInformer.Lister(),
+		args.PodInformer.Lister(),
+		c.schedulerCache,
+		c.podQueue,
+	)
 
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, compareSignal)

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -55,6 +55,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/scheduler/internal/cache/comparer:all-srcs",
         "//pkg/scheduler/internal/cache/fake:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/scheduler/internal/cache/comparer/BUILD
+++ b/pkg/scheduler/internal/cache/comparer/BUILD
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["comparer.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/internal/cache/comparer",
+    visibility = ["//pkg/scheduler:__subpackages__"],
+    deps = [
+        "//pkg/scheduler/cache:go_default_library",
+        "//pkg/scheduler/internal/cache:go_default_library",
+        "//pkg/scheduler/internal/queue:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["comparer_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/scheduler/cache:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/internal/cache/comparer/comparer_test.go
+++ b/pkg/scheduler/internal/cache/comparer/comparer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factory
+package comparer
 
 import (
 	"reflect"
@@ -64,7 +64,7 @@ func TestCompareNodes(t *testing.T) {
 }
 
 func testCompareNodes(actual, cached, missing, redundant []string, t *testing.T) {
-	compare := compareStrategy{}
+	compare := CacheComparer{}
 	nodes := []*v1.Node{}
 	for _, nodeName := range actual {
 		node := &v1.Node{}
@@ -155,7 +155,7 @@ func TestComparePods(t *testing.T) {
 }
 
 func testComparePods(actual, cached, queued, missing, redundant []string, t *testing.T) {
-	compare := compareStrategy{}
+	compare := CacheComparer{}
 	pods := []*v1.Pod{}
 	for _, uid := range actual {
 		pod := &v1.Pod{}


### PR DESCRIPTION
…rnal/cache/comparer

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #68960

**Special notes for your reviewer**:
@misterikkit 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move CacheComparer to pkg/scheduler/internal/cache/comparer.
```
