### PR TITLE
Automated cherry pick of #68565: Bug fix - revert metrics-server base CPU resources back to 40

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2461,7 +2461,7 @@ EOF
     metrics_server_memory_per_node="4"
     metrics_server_min_cluster_size="16"
     if [[ "${ENABLE_SYSTEM_ADDON_RESOURCE_OPTIMIZATIONS:-}" == "true" ]]; then
-      base_metrics_server_cpu="5m"
+      base_metrics_server_cpu="40m"
       base_metrics_server_memory="35Mi"
       metrics_server_memory_per_node="4"
       metrics_server_min_cluster_size="5"


### PR DESCRIPTION
Cherry pick of #68565 on release-1.12.

#68565: Bug fix - revert metrics-server base CPU resources back to 40

**Release note**:
```release-note
Revert metrics-server base CPU resources back to 40 mCPU from 5 mCPU for GKE.
```