### PR TITLE
add interactive session for kubectl delete --all

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"os"
+	"bufio"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -209,6 +211,19 @@ func (o *DeleteOptions) Validate(cmd *cobra.Command) error {
 	if o.GracePeriod == 0 && !o.ForceDeletion && !o.WaitForDeletion {
 		// With the explicit --wait flag we need extra validation for backward compatibility
 		return fmt.Errorf("--grace-period=0 must have either --force specified, or --wait to be set to true")
+	}
+
+	//  interactive session when --all is specified without --force.
+	if  o.DeleteAll && !o.ForceDeletion {
+		fmt.Fprintf(o.Out, "are you sure you want to delete all[Y/N]:")
+		reader := bufio.NewReader(os.Stdin)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSuffix(input, "\n")
+		if strings.EqualFold(input, "y") || strings.EqualFold(input, "ye")  || strings.EqualFold(input, "yes") {
+			fmt.Fprintf(o.Out, "deleting all\n")
+		} else {
+			return fmt.Errorf("none deleted")
+		}
 	}
 
 	switch {


### PR DESCRIPTION
**What this PR does / why we need it**:
adds interactive session for kubectl delete <resource type> --all unless --force is specified.

kubectl delete --all is really dangerous without interactive session, i have faced the brunt of this in our development environment.

i was trying to get options of kubectl delete  by adding --help, and instead of copying --help, i copied --all and pressed entered(kubectl delete configmaps -all). I know i was stupid, as i should have typed not copied (and gave much more observation to what i was copying)and 
this resulted in deleting configmaps of other developers and caused them inconvenience.

I think this pull request will create stupid proof for delete --all (for people like me)

kubectl delete <> --all --force will delete without any interaction

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
<pre>
$output/local/bin/linux/amd64/kubectl delete pods --all 
are you sure you want to delete all[Y/N]:Y
deleting all
pod "hello-world-5b446dd74b-4j5sf" deleted
pod "hello-world-5b446dd74b-frxb7" deleted
pod "hello-world-5b446dd74b-qbx4x" deleted
pod "hello-world-5b446dd74b-zgh6h" deleted
</pre>
```
