### PR TITLE
kubeadm: fix kubeadm join using existing certs

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -99,9 +99,13 @@ func ValidateDiscovery(c *kubeadm.JoinConfiguration) field.ErrorList {
 	}
 	if len(c.DiscoveryFile) != 0 {
 		allErrs = append(allErrs, ValidateDiscoveryFile(c.DiscoveryFile, field.NewPath("discoveryFile"))...)
+		if len(c.TLSBootstrapToken) != 0 {
+			allErrs = append(allErrs, ValidateToken(c.TLSBootstrapToken, field.NewPath("tlsBootstrapToken"))...)
+		}
+	} else {
+		allErrs = append(allErrs, ValidateToken(c.TLSBootstrapToken, field.NewPath("tlsBootstrapToken"))...)
 	}
 	allErrs = append(allErrs, ValidateArgSelection(c, field.NewPath("discovery"))...)
-	allErrs = append(allErrs, ValidateToken(c.TLSBootstrapToken, field.NewPath("tlsBootstrapToken"))...)
 	allErrs = append(allErrs, ValidateJoinDiscoveryTokenAPIServer(c.DiscoveryTokenAPIServers, field.NewPath("discoveryTokenAPIServers"))...)
 
 	return allErrs


### PR DESCRIPTION
**What this PR does / why we need it**:

If 'kubeadm join' is run with --discovery-file option it still
prompts for bootstrap token. This makes it impossible to use
existing client certificates mentioned in the discovery file.

Fixed by checking for empty bootstrap token only if discovery file
is not specified.

**Which issue(s) this PR fixes**

Fixes: kubernetes/kubeadm#1142

**Release note**:
```release-note
kubeadm: Fixed support of node certificates when joining a cluster
```
