### PR TITLE
Mark optional CSIDriver fields as really optional.

### DIFF
--- a/staging/src/k8s.io/csi-api/pkg/apis/csi/v1alpha1/types.go
+++ b/staging/src/k8s.io/csi-api/pkg/apis/csi/v1alpha1/types.go
@@ -63,7 +63,7 @@ type CSIDriverSpec struct {
 	// If value is not specified, default is false -- meaning attach will not be
 	// called.
 	// +optional
-	AttachRequired *bool `json:"attachRequired"`
+	AttachRequired *bool `json:"attachRequired,omitempty"`
 
 	// If specified, podInfoRequiredOnMount indicates this CSI volume driver
 	// requires additional pod information (like podName, podUID, etc.) during
@@ -77,7 +77,7 @@ type CSIDriverSpec struct {
 	// "csi.storage.k8s.io/pod.namespace": pod.Namespace
 	// "csi.storage.k8s.io/pod.uid": string(pod.UID)
 	// +optional
-	PodInfoOnMountVersion *string `json:"podInfoOnMountVersion"`
+	PodInfoOnMountVersion *string `json:"podInfoOnMountVersion,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
**What this PR does / why we need it**:
CSIDriver has couple of optional fields which don't have `omitempty`. See the issue below for error message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-csi/driver-registrar/issues/57

**Release note**:
```release-note
Fixed CSIDriver API object to allow missing fields.
```

cc @pohly @davidz627 @verult 