### PR TITLE
kubectl set tests: remove testapi core dependency

### DIFF
--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -63,7 +63,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/testapi:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +38,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -121,20 +119,20 @@ func TestSetMultiResourcesEnvLocal(t *testing.T) {
 
 func TestSetEnvRemote(t *testing.T) {
 	inputs := []struct {
-		name                            string
-		object                          runtime.Object
-		apiPrefix, apiGroup, apiVersion string
-		testAPIGroup                    string
-		args                            []string
+		name         string
+		object       runtime.Object
+		groupVersion schema.GroupVersion
+		path         string
+		args         []string
 	}{
 		{
 			name: "test extensions.v1beta1 replicaset",
 			object: &extensionsv1beta1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -144,18 +142,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"replicaset", "nginx", "env=prod"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "env=prod"},
 		},
 		{
 			name: "test apps.v1beta2 replicaset",
 			object: &appsv1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -165,18 +163,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"replicaset", "nginx", "env=prod"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1 replicaset",
 			object: &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -186,18 +184,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"replicaset", "nginx", "env=prod"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "env=prod"},
 		},
 		{
 			name: "test extensions.v1beta1 daemonset",
 			object: &extensionsv1beta1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -207,18 +205,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"daemonset", "nginx", "env=prod"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1beta2 daemonset",
 			object: &appsv1beta2.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -228,18 +226,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"daemonset", "nginx", "env=prod"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1 daemonset",
 			object: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -249,18 +247,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"daemonset", "nginx", "env=prod"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "env=prod"},
 		},
 		{
 			name: "test extensions.v1beta1 deployment",
 			object: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -270,18 +268,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", "env=prod"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "env=prod"},
 		},
 		{
-			name: "test appsv1bta1 deployment",
+			name: "test appsv1beta1 deployment",
 			object: &appsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -291,18 +289,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", "env=prod"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "env=prod"},
 		},
 		{
-			name: "test appsv1beta2n deployment",
+			name: "test appsv1beta2 deployment",
 			object: &appsv1beta2.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -312,18 +310,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"deployment", "nginx", "env=prod"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1 deployment",
 			object: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -333,18 +331,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"deployment", "nginx", "env=prod"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1beta1 statefulset",
 			object: &appsv1beta1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -354,18 +352,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"statefulset", "nginx", "env=prod"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1beta2 statefulset",
 			object: &appsv1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -375,18 +373,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"statefulset", "nginx", "env=prod"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "env=prod"},
 		},
 		{
 			name: "test appsv1 statefulset",
 			object: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -396,17 +394,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"statefulset", "nginx", "env=prod"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "env=prod"},
 		},
 		{
+			name: "test batchv1 Job",
 			object: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: batchv1.JobSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -416,17 +415,18 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "batch",
-			apiPrefix:    "/apis", apiGroup: "batch", apiVersion: "v1",
-			args: []string{"job", "nginx", "env=prod"},
+			groupVersion: batchv1.SchemeGroupVersion,
+			path:         "/namespaces/test/jobs/nginx",
+			args:         []string{"job", "nginx", "env=prod"},
 		},
 		{
-			object: &v1.ReplicationController{
+			name: "test corev1 replication controller",
+			object: &corev1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
-				Spec: v1.ReplicationControllerSpec{
-					Template: &v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+				Spec: corev1.ReplicationControllerSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -436,28 +436,24 @@ func TestSetEnvRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "",
-			apiPrefix:    "/api", apiGroup: "", apiVersion: "v1",
-			args: []string{"replicationcontroller", "nginx", "env=prod"},
+			groupVersion: corev1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicationcontrollers/nginx",
+			args:         []string{"replicationcontroller", "nginx", "env=prod"},
 		},
 	}
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {
-			groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
-			testapi.Default = testapi.Groups[input.testAPIGroup]
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
-			tf.ClientConfigVal = &restclient.Config{ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Version: ""}}}
 			defer tf.Cleanup()
 
 			tf.Client = &fake.RESTClient{
-				GroupVersion:         groupVersion,
+				GroupVersion:         input.groupVersion,
 				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					resourcePath := testapi.Default.ResourcePath(input.args[0]+"s", "test", input.args[1])
 					switch p, m := req.URL.Path, req.Method; {
-					case p == resourcePath && m == http.MethodGet:
+					case p == input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(input.object)}, nil
-					case p == resourcePath && m == http.MethodPatch:
+					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
 						if err != nil {
 							return nil, err
@@ -473,7 +469,6 @@ func TestSetEnvRemote(t *testing.T) {
 						return nil, fmt.Errorf("unexpected request")
 					}
 				}),
-				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
 
 			outputFormat := "yaml"
@@ -491,7 +486,7 @@ func TestSetEnvRemote(t *testing.T) {
 }
 
 func TestSetEnvFromResource(t *testing.T) {
-	mockConfigMap := &v1.ConfigMap{
+	mockConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "testconfigmap"},
 		Data: map[string]string{
 			"env":          "prod",
@@ -500,7 +495,7 @@ func TestSetEnvFromResource(t *testing.T) {
 		},
 	}
 
-	mockSecret := &v1.Secret{
+	mockSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "testsecret"},
 		Data: map[string][]byte{
 			"env":          []byte("prod"),
@@ -569,9 +564,9 @@ func TestSetEnvFromResource(t *testing.T) {
 		mockDeployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			Spec: appsv1.DeploymentSpec{
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
 							{
 								Name:  "nginx",
 								Image: "nginx",

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"strings"
 	"testing"
 
@@ -30,7 +29,7 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +39,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -204,20 +202,20 @@ func TestSetMultiResourcesImageLocal(t *testing.T) {
 
 func TestSetImageRemote(t *testing.T) {
 	inputs := []struct {
-		name                            string
-		object                          runtime.Object
-		apiPrefix, apiGroup, apiVersion string
-		testAPIGroup                    string
-		args                            []string
+		name         string
+		object       runtime.Object
+		groupVersion schema.GroupVersion
+		path         string
+		args         []string
 	}{
 		{
 			name: "set image extensionsv1beta1 ReplicaSet",
 			object: &extensionsv1beta1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -227,18 +225,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"replicaset", "nginx", "*=thingy"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta2 ReplicaSet",
 			object: &appsv1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -248,18 +246,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"replicaset", "nginx", "*=thingy"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1 ReplicaSet",
 			object: &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -269,18 +267,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"replicaset", "nginx", "*=thingy"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image extensionsv1beta1 DaemonSet",
 			object: &extensionsv1beta1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -290,18 +288,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"daemonset", "nginx", "*=thingy"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta2 DaemonSet",
 			object: &appsv1beta2.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -311,18 +309,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"daemonset", "nginx", "*=thingy"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1 DaemonSet",
 			object: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -332,18 +330,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"daemonset", "nginx", "*=thingy"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image extensionsv1beta1 Deployment",
 			object: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -353,18 +351,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", "*=thingy"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta1 Deployment",
 			object: &appsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -374,18 +372,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", "*=thingy"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta2 Deployment",
 			object: &appsv1beta2.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -395,18 +393,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"deployment", "nginx", "*=thingy"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1 Deployment",
 			object: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -416,18 +414,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"deployment", "nginx", "*=thingy"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta1 StatefulSet",
 			object: &appsv1beta1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -437,18 +435,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"statefulset", "nginx", "*=thingy"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1beta2 StatefulSet",
 			object: &appsv1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -458,18 +456,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"statefulset", "nginx", "*=thingy"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image appsv1 StatefulSet",
 			object: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -479,18 +477,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"statefulset", "nginx", "*=thingy"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", "*=thingy"},
 		},
 		{
 			name: "set image batchv1 Job",
 			object: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: batchv1.JobSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -500,18 +498,18 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "batch",
-			apiPrefix:    "/apis", apiGroup: "batch", apiVersion: "v1",
-			args: []string{"job", "nginx", "*=thingy"},
+			groupVersion: batchv1.SchemeGroupVersion,
+			path:         "/namespaces/test/jobs/nginx",
+			args:         []string{"job", "nginx", "*=thingy"},
 		},
 		{
-			name: "set image v1.ReplicationController",
-			object: &v1.ReplicationController{
+			name: "set image corev1.ReplicationController",
+			object: &corev1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
-				Spec: v1.ReplicationControllerSpec{
-					Template: &v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+				Spec: corev1.ReplicationControllerSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -521,27 +519,24 @@ func TestSetImageRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "",
-			apiPrefix:    "/api", apiGroup: "", apiVersion: "v1",
-			args: []string{"replicationcontroller", "nginx", "*=thingy"},
+			groupVersion: corev1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicationcontrollers/nginx",
+			args:         []string{"replicationcontroller", "nginx", "*=thingy"},
 		},
 	}
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {
-			groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
-			testapi.Default = testapi.Groups[input.testAPIGroup]
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
 			tf.Client = &fake.RESTClient{
-				GroupVersion:         groupVersion,
+				GroupVersion:         input.groupVersion,
 				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					resourcePath := testapi.Default.ResourcePath(input.args[0]+"s", "test", input.args[1])
 					switch p, m := req.URL.Path, req.Method; {
-					case p == resourcePath && m == http.MethodGet:
+					case p == input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(input.object)}, nil
-					case p == resourcePath && m == http.MethodPatch:
+					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
 						if err != nil {
 							return nil, err
@@ -557,7 +552,6 @@ func TestSetImageRemote(t *testing.T) {
 						return nil, fmt.Errorf("unexpected request")
 					}
 				}),
-				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
 
 			outputFormat := "yaml"

--- a/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/pkg/kubectl/cmd/set/set_resources_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +38,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -143,18 +141,20 @@ func TestSetMultiResourcesLimitsLocal(t *testing.T) {
 
 func TestSetResourcesRemote(t *testing.T) {
 	inputs := []struct {
-		object                          runtime.Object
-		apiPrefix, apiGroup, apiVersion string
-		testAPIGroup                    string
-		args                            []string
+		name         string
+		object       runtime.Object
+		groupVersion schema.GroupVersion
+		path         string
+		args         []string
 	}{
 		{
+			name: "set image extensionsv1beta1 ReplicaSet",
 			object: &extensionsv1beta1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -164,17 +164,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"replicaset", "nginx"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx"},
 		},
 		{
+			name: "set image appsv1beta2 ReplicaSet",
 			object: &appsv1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -184,17 +185,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"replicaset", "nginx"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx"},
 		},
 		{
+			name: "set image appsv1 ReplicaSet",
 			object: &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -204,17 +206,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"replicaset", "nginx"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx"},
 		},
 		{
+			name: "set image extensionsv1beta1 DaemonSet",
 			object: &extensionsv1beta1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -224,17 +227,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"daemonset", "nginx"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx"},
 		},
 		{
+			name: "set image appsv1beta2 DaemonSet",
 			object: &appsv1beta2.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -244,17 +248,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"daemonset", "nginx"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx"},
 		},
 		{
+			name: "set image appsv1 DaemonSet",
 			object: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -264,17 +269,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"daemonset", "nginx"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx"},
 		},
 		{
+			name: "set image extensionsv1beta1 Deployment",
 			object: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: extensionsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -284,17 +290,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx"},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx"},
 		},
 		{
+			name: "set image appsv1beta1 Deployment",
 			object: &appsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -304,17 +311,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx"},
 		},
 		{
+			name: "set image appsv1beta2 Deployment",
 			object: &appsv1beta2.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -324,17 +332,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"deployment", "nginx"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx"},
 		},
 		{
+			name: "set image appsv1 Deployment",
 			object: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -344,17 +353,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"deployment", "nginx"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx"},
 		},
 		{
+			name: "set image appsv1beta1 StatefulSet",
 			object: &appsv1beta1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -364,17 +374,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"statefulset", "nginx"},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx"},
 		},
 		{
+			name: "set image appsv1beta2 StatefulSet",
 			object: &appsv1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -384,17 +395,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"statefulset", "nginx"},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx"},
 		},
 		{
+			name: "set image appsv1 StatefulSet",
 			object: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -404,17 +416,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"statefulset", "nginx"},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx"},
 		},
 		{
+			name: "set image batchv1 Job",
 			object: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: batchv1.JobSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -424,17 +437,18 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "batch",
-			apiPrefix:    "/apis", apiGroup: "batch", apiVersion: "v1",
-			args: []string{"job", "nginx"},
+			groupVersion: batchv1.SchemeGroupVersion,
+			path:         "/namespaces/test/jobs/nginx",
+			args:         []string{"job", "nginx"},
 		},
 		{
-			object: &v1.ReplicationController{
+			name: "set image corev1.ReplicationController",
+			object: &corev1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
-				Spec: v1.ReplicationControllerSpec{
-					Template: &v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+				Spec: corev1.ReplicationControllerSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -444,27 +458,25 @@ func TestSetResourcesRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "",
-			apiPrefix:    "/api", apiGroup: "", apiVersion: "v1",
-			args: []string{"replicationcontroller", "nginx"},
+			groupVersion: corev1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicationcontrollers/nginx",
+			args:         []string{"replicationcontroller", "nginx"},
 		},
 	}
+
 	for i, input := range inputs {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
-			testapi.Default = testapi.Groups[input.testAPIGroup]
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
 			tf.Client = &fake.RESTClient{
-				GroupVersion:         groupVersion,
+				GroupVersion:         input.groupVersion,
 				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					resourcePath := testapi.Default.ResourcePath(input.args[0]+"s", "test", input.args[1])
 					switch p, m := req.URL.Path, req.Method; {
-					case p == resourcePath && m == http.MethodGet:
+					case p == input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(input.object)}, nil
-					case p == resourcePath && m == http.MethodPatch:
+					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
 						if err != nil {
 							return nil, err
@@ -480,7 +492,6 @@ func TestSetResourcesRemote(t *testing.T) {
 						return nil, fmt.Errorf("unexpected request")
 					}
 				}),
-				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
 
 			outputFormat := "yaml"

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +39,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
-	"k8s.io/kubernetes/pkg/api/testapi"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
@@ -85,7 +83,6 @@ func TestSetServiceAccountLocal(t *testing.T) {
 			cmd := NewCmdServiceAccount(tf, streams)
 			cmd.Flags().Set("output", outputFormat)
 			cmd.Flags().Set("local", "true")
-			testapi.Default = testapi.Groups[input.apiGroup]
 			saConfig := SetServiceAccountOptions{
 				PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput(outputFormat).WithTypeSetter(scheme.Scheme),
 				fileNameOptions: resource.FilenameOptions{
@@ -103,7 +100,6 @@ func TestSetServiceAccountLocal(t *testing.T) {
 }
 
 func TestSetServiceAccountMultiLocal(t *testing.T) {
-	testapi.Default = testapi.Groups[""]
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
@@ -146,26 +142,26 @@ func TestSetServiceAccountMultiLocal(t *testing.T) {
 
 func TestSetServiceAccountRemote(t *testing.T) {
 	inputs := []struct {
-		object                          runtime.Object
-		apiPrefix, apiGroup, apiVersion string
-		testAPIGroup                    string
-		args                            []string
+		object       runtime.Object
+		groupVersion schema.GroupVersion
+		path         string
+		args         []string
 	}{
 		{
 			object: &extensionsv1beta1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"replicaset", "nginx", serviceAccount},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta2.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -175,17 +171,17 @@ func TestSetServiceAccountRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"replicaset", "nginx", serviceAccount},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -195,65 +191,65 @@ func TestSetServiceAccountRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"replicaset", "nginx", serviceAccount},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicasets/nginx",
+			args:         []string{"replicaset", "nginx", serviceAccount},
 		},
 		{
 			object: &extensionsv1beta1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"daemonset", "nginx", serviceAccount},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta2.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"daemonset", "nginx", serviceAccount},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"daemonset", "nginx", serviceAccount},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/daemonsets/nginx",
+			args:         []string{"daemonset", "nginx", serviceAccount},
 		},
 		{
 			object: &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "extensions", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", serviceAccount},
+			groupVersion: extensionsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"deployment", "nginx", serviceAccount},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta2.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"deployment", "nginx", serviceAccount},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -263,33 +259,33 @@ func TestSetServiceAccountRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "extensions",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"deployment", "nginx", serviceAccount},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/deployments/nginx",
+			args:         []string{"deployment", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta1",
-			args: []string{"statefulset", "nginx", serviceAccount},
+			groupVersion: appsv1beta1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1beta2.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1beta2",
-			args: []string{"statefulset", "nginx", serviceAccount},
+			groupVersion: appsv1beta2.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", serviceAccount},
 		},
 		{
 			object: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 				Spec: appsv1.StatefulSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx",
@@ -299,43 +295,40 @@ func TestSetServiceAccountRemote(t *testing.T) {
 					},
 				},
 			},
-			testAPIGroup: "apps",
-			apiPrefix:    "/apis", apiGroup: "apps", apiVersion: "v1",
-			args: []string{"statefulset", "nginx", serviceAccount},
+			groupVersion: appsv1.SchemeGroupVersion,
+			path:         "/namespaces/test/statefulsets/nginx",
+			args:         []string{"statefulset", "nginx", serviceAccount},
 		},
 		{
 			object: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "batch",
-			apiPrefix:    "/apis", apiGroup: "batch", apiVersion: "v1",
-			args: []string{"job", "nginx", serviceAccount},
+			groupVersion: batchv1.SchemeGroupVersion,
+			path:         "/namespaces/test/jobs/nginx",
+			args:         []string{"job", "nginx", serviceAccount},
 		},
 		{
-			object: &v1.ReplicationController{
+			object: &corev1.ReplicationController{
 				ObjectMeta: metav1.ObjectMeta{Name: "nginx"},
 			},
-			testAPIGroup: "",
-			apiPrefix:    "/api", apiGroup: "", apiVersion: "v1",
-			args: []string{"replicationcontroller", "nginx", serviceAccount},
+			groupVersion: corev1.SchemeGroupVersion,
+			path:         "/namespaces/test/replicationcontrollers/nginx",
+			args:         []string{"replicationcontroller", "nginx", serviceAccount},
 		},
 	}
-	for _, input := range inputs {
-		t.Run(input.apiPrefix, func(t *testing.T) {
-			groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
-			testapi.Default = testapi.Groups[input.testAPIGroup]
+	for i, input := range inputs {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
 			tf.Client = &fake.RESTClient{
-				GroupVersion:         groupVersion,
+				GroupVersion:         input.groupVersion,
 				NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					resourcePath := testapi.Default.ResourcePath(input.args[0]+"s", "test", input.args[1])
 					switch p, m := req.URL.Path, req.Method; {
-					case p == resourcePath && m == http.MethodGet:
+					case p == input.path && m == http.MethodGet:
 						return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: objBody(input.object)}, nil
-					case p == resourcePath && m == http.MethodPatch:
+					case p == input.path && m == http.MethodPatch:
 						stream, err := req.GetBody()
 						if err != nil {
 							return nil, err
@@ -351,7 +344,6 @@ func TestSetServiceAccountRemote(t *testing.T) {
 						return nil, fmt.Errorf("unexpected request")
 					}
 				}),
-				VersionedAPIPath: path.Join(input.apiPrefix, testapi.Default.GroupVersion().String()),
 			}
 
 			outputFormat := "yaml"


### PR DESCRIPTION
* For kubectl "set" tests, removes dependency on testapi.
* Fixes erroneous tests, which weren't calculating the correct api path.
* Updates import alias from v1 to corev1 to be more consistent with other files.
* Adds helper function "versionedAPIPath" to calculate the versioned api string from the full api path.

Helps Address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
