### PR TITLE
Bump addon-manager to v8.8

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v8.7
+    image: k8s.gcr.io/kube-addon-manager:v8.8
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v8.7
+    image: {{kube_docker_registry}}/kube-addon-manager:v8.8
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
Major change:
- Rebase docker image on debian-base:0.3.2.

Ref https://github.com/kubernetes/kubernetes/pull/69315.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE 

**Special notes for your reviewer**:
/assign @mikedanese 
cc @awly @ixdy

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump addon-manager to v8.8
- Rebase docker image on debian-base:0.3.2.
```
