### PR TITLE
Bump cluster-proportional-autoscaler to 1.3.0

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -82,7 +82,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.2.0
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.3.0
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
**What this PR does / why we need it**:
Major change:
- Rebase docker image on scratch.

Ref https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/pull/52.

/kind bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #NONE

**Special notes for your reviewer**:
/assign @awly @tallclair 
cc @bowei 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump cluster-proportional-autoscaler to 1.3.0
- Rebase docker image on scratch.
```
