### PR TITLE
kubectl apply test: remove core testapi dependency

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -189,7 +189,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/api/testapi:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/kubectl/cmd/create:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",


### PR DESCRIPTION
* Updates kubectl apply_test to use a locally created codec instead of the testapi codec.
* Removes a dependency on testapi.

Helps address:

https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
