### PR TITLE
Allow hostname-override arg to be used if specified

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -116,6 +116,9 @@ type Options struct {
 
 	scheme *runtime.Scheme
 	codecs serializer.CodecFactory
+
+	// hostnameOverride, if set from the command line flag, takes precedence over the `HostnameOverride` value from the config file
+	hostnameOverride string
 }
 
 // AddFlags adds flags to fs and binds them to options.
@@ -140,7 +143,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("resource-container", "This feature will be removed in a later release.")
 	fs.StringVar(&o.config.ClientConnection.Kubeconfig, "kubeconfig", o.config.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
 	fs.Var(utilflag.PortRangeVar{Val: &o.config.PortRange}, "proxy-port-range", "Range of host ports (beginPort-endPort, single port or beginPort+offset, inclusive) that may be consumed in order to proxy service traffic. If (unspecified, 0, or 0-0) then ports will be randomly chosen.")
-	fs.StringVar(&o.config.HostnameOverride, "hostname-override", o.config.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
+	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
 	fs.Var(&o.config.Mode, "proxy-mode", "Which proxy mode to use: 'userspace' (older) or 'iptables' (faster) or 'ipvs' (experimental). If blank, use the best-available proxy (currently iptables).  If the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are insufficient, this always falls back to the userspace proxy.")
 	fs.Int32Var(o.config.IPTables.MasqueradeBit, "iptables-masquerade-bit", utilpointer.Int32PtrDerefOr(o.config.IPTables.MasqueradeBit, 14), "If using the pure iptables proxy, the bit of the fwmark space to mark packets requiring SNAT with.  Must be within the range [0, 31].")
 	fs.DurationVar(&o.config.IPTables.SyncPeriod.Duration, "iptables-sync-period", o.config.IPTables.SyncPeriod.Duration, "The maximum interval of how often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
@@ -204,9 +207,26 @@ func (o *Options) Complete() error {
 		}
 	}
 
-	err := utilfeature.DefaultFeatureGate.SetFromMap(o.config.FeatureGates)
-	if err != nil {
+	if err := o.processHostnameOverrideFlag(); err != nil {
 		return err
+	}
+
+	if err := utilfeature.DefaultFeatureGate.SetFromMap(o.config.FeatureGates); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// processHostnameOverrideFlag processes hostname-override flag
+func (o *Options) processHostnameOverrideFlag() error {
+	// Check if hostname-override flag is set and use value since configFile always overrides
+	if len(o.hostnameOverride) > 0 {
+		hostName := strings.TrimSpace(o.hostnameOverride)
+		if len(hostName) == 0 {
+			return fmt.Errorf("empty hostname-override is invalid")
+		}
+		o.config.HostnameOverride = strings.ToLower(hostName)
 	}
 
 	return nil

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -374,3 +374,39 @@ func TestLoadConfigFailures(t *testing.T) {
 		}
 	}
 }
+
+// TestProcessHostnameOverrideFlag tests processing hostname-override arg
+func TestProcessHostnameOverrideFlag(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		hostnameOverrideFlag string
+		expectedHostname     string
+	}{
+		{
+			name:                 "Hostname from config file",
+			hostnameOverrideFlag: "",
+			expectedHostname:     "foo",
+		},
+		{
+			name:                 "Hostname from flag",
+			hostnameOverrideFlag: "  bar ",
+			expectedHostname:     "bar",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := NewOptions()
+			options.config = &kubeproxyconfig.KubeProxyConfiguration{
+				HostnameOverride: "foo",
+			}
+
+			options.hostnameOverride = tc.hostnameOverrideFlag
+
+			err := options.processHostnameOverrideFlag()
+			assert.NoError(t, err, "unexpected error %v", err)
+			if tc.expectedHostname != options.config.HostnameOverride {
+				t.Fatalf("expected hostname: %s, but got: %s", tc.expectedHostname, options.config.HostnameOverride)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently`kube-proxy` loads configuration from a config file. There are cases where the hostname needs to be overridden (See: https://github.com/kubernetes/kubeadm/issues/857). 

There is a flag that allows the hostname to be overridden (`hostname-override`), but when the config file is loaded, if this arg is set, it's overridden by whatever the config file contains making the argument ignored if it was set. 

This PR checks for this argument and uses it if it is passed to `kube-proxy`. 

**Which issue(s) this PR fixes**:
Fixes #57518
Fixes https://github.com/kubernetes/kubeadm/issues/857

**Special notes for your reviewer**:

**Release note**:
```release-note
kube-proxy argument `hostname-override` can be used to override hostname defined in the configuration file
```

// @timothysc 

Signed-off-by: Steve Sloka <steves@heptio.com>
