### PR TITLE
Fix dry-run output in kubectl apply --prune

### DIFF
--- a/pkg/kubectl/cmd/apply/apply.go
+++ b/pkg/kubectl/cmd/apply/apply.go
@@ -389,12 +389,13 @@ func (o *ApplyOptions) Run() error {
 					return cmdutil.AddSourceToErr("creating", info.Source, err)
 				}
 				info.Refresh(obj, true)
-				metadata, err := meta.Accessor(info.Object)
-				if err != nil {
-					return err
-				}
-				visitedUids.Insert(string(metadata.GetUID()))
 			}
+
+			metadata, err := meta.Accessor(info.Object)
+			if err != nil {
+				return err
+			}
+			visitedUids.Insert(string(metadata.GetUID()))
 
 			count++
 
@@ -410,12 +411,13 @@ func (o *ApplyOptions) Run() error {
 			return printer.PrintObj(info.Object, o.Out)
 		}
 
-		if !o.DryRun {
-			metadata, err := meta.Accessor(info.Object)
-			if err != nil {
-				return err
-			}
+		metadata, err := meta.Accessor(info.Object)
+		if err != nil {
+			return err
+		}
+		visitedUids.Insert(string(metadata.GetUID()))
 
+		if !o.DryRun {
 			annotationMap := metadata.GetAnnotations()
 			if _, ok := annotationMap[corev1.LastAppliedConfigAnnotation]; !ok {
 				fmt.Fprintf(o.ErrOut, warningNoLastAppliedConfigAnnotation, o.cmdBaseName)
@@ -442,8 +444,6 @@ func (o *ApplyOptions) Run() error {
 			}
 
 			info.Refresh(patchedObject, true)
-
-			visitedUids.Insert(string(metadata.GetUID()))
 
 			if string(patchBytes) == "{}" && !printObject {
 				count++

--- a/test/fixtures/pkg/kubectl/cmd/apply/cm.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/cm.yaml
@@ -3,13 +3,13 @@ items:
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-    name: test
+    name: test0
   data:
     key1: apple
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-    name: test2
+    name: test1
   data:
     key2: apple
 kind: ConfigMapList


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Makes dry-run output match what would happen when running in non dry-run mode.

Objects would only get added to visitedUids if running in non dry-run mode.

visitedUids is used by prune() to know if an action should be taked on the item or not.

**Which issue(s) this PR fixes** :

Fixes #67863

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix dry-run output in kubectl apply --prune
```
