### PR TITLE
kubectl validation test: remove unused testapi dependency

### DIFF
--- a/pkg/kubectl/cmd/util/openapi/validation/BUILD
+++ b/pkg/kubectl/cmd/util/openapi/validation/BUILD
@@ -29,7 +29,6 @@ go_test(
     data = ["//api/openapi-spec:swagger-spec"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/testapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kube-openapi/pkg/util/proto/validation"
 	// This dependency is needed to register API types.
 	"k8s.io/kube-openapi/pkg/util/proto/testing"
-	_ "k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 )
 


### PR DESCRIPTION
* Small change to remove unused, unneeded import of testapi dependency.

Helps address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
