### PR TITLE
kubectl rolling-updater test: remove testapi and core testing dependency

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -36,8 +36,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/testapi:go_default_library",
-        "//pkg/api/testing:go_default_library",
         "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/util:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -40,8 +40,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	manualfake "k8s.io/client-go/rest/fake"
 	testcore "k8s.io/client-go/testing"
-	"k8s.io/kubernetes/pkg/api/testapi"
-	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util"
 )
@@ -1444,6 +1442,8 @@ func TestUpdateExistingReplicationController(t *testing.T) {
 func TestUpdateRcWithRetries(t *testing.T) {
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 	one := int32(1)
+	grace := int64(30)
+	enableServiceLinks := corev1.DefaultEnableServiceLinks
 	rc := &corev1.ReplicationController{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -1465,7 +1465,13 @@ func TestUpdateRcWithRetries(t *testing.T) {
 						"foo": "bar",
 					},
 				},
-				Spec: apitesting.V1DeepEqualSafePodSpec(),
+				Spec: corev1.PodSpec{
+					RestartPolicy:                 corev1.RestartPolicyAlways,
+					DNSPolicy:                     corev1.DNSClusterFirst,
+					TerminationGracePeriodSeconds: &grace,
+					SecurityContext:               &corev1.PodSecurityContext{},
+					EnableServiceLinks:            &enableServiceLinks,
+				},
 			},
 		},
 	}
@@ -1490,11 +1496,11 @@ func TestUpdateRcWithRetries(t *testing.T) {
 		{StatusCode: 200, Header: header, Body: objBody(codec, rc)},
 	}
 	fakeClient := &manualfake.RESTClient{
-		GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
+		GroupVersion:         corev1.SchemeGroupVersion,
 		NegotiatedSerializer: scheme.Codecs,
 		Client: manualfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == testapi.Default.ResourcePath("replicationcontrollers", "default", "rc") && m == "PUT":
+			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "PUT":
 				update := updates[0]
 				updates = updates[1:]
 				// We should always get an update with a valid rc even when the get fails. The rc should always
@@ -1508,7 +1514,7 @@ func TestUpdateRcWithRetries(t *testing.T) {
 					delete(c.Spec.Selector, "baz")
 				}
 				return update, nil
-			case p == testapi.Default.ResourcePath("replicationcontrollers", "default", "rc") && m == "GET":
+			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "GET":
 				get := gets[0]
 				gets = gets[1:]
 				return get, nil
@@ -1518,7 +1524,13 @@ func TestUpdateRcWithRetries(t *testing.T) {
 			}
 		}),
 	}
-	clientConfig := &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: scheme.Codecs, GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}}
+	clientConfig := &restclient.Config{
+		APIPath: "/api",
+		ContentConfig: restclient.ContentConfig{
+			NegotiatedSerializer: scheme.Codecs,
+			GroupVersion:         &corev1.SchemeGroupVersion,
+		},
+	}
 	restClient, _ := restclient.RESTClientFor(clientConfig)
 	restClient.Client = fakeClient.Client
 	clientset := kubernetes.New(restClient)
@@ -1586,33 +1598,33 @@ func TestAddDeploymentHash(t *testing.T) {
 	seen := sets.String{}
 	updatedRc := false
 	fakeClient := &manualfake.RESTClient{
-		GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
+		GroupVersion:         corev1.SchemeGroupVersion,
 		NegotiatedSerializer: scheme.Codecs,
 		Client: manualfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Content-Type", runtime.ContentTypeJSON)
 			switch p, m := req.URL.Path, req.Method; {
-			case p == testapi.Default.ResourcePath("pods", "default", "") && m == "GET":
+			case p == "/api/v1/namespaces/default/pods" && m == "GET":
 				if req.URL.RawQuery != "labelSelector=foo%3Dbar" {
 					t.Errorf("Unexpected query string: %s", req.URL.RawQuery)
 				}
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, podList)}, nil
-			case p == testapi.Default.ResourcePath("pods", "default", "foo") && m == "PUT":
+			case p == "/api/v1/namespaces/default/pods/foo" && m == "PUT":
 				seen.Insert("foo")
 				obj := readOrDie(t, req, codec)
 				podList.Items[0] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[0])}, nil
-			case p == testapi.Default.ResourcePath("pods", "default", "bar") && m == "PUT":
+			case p == "/api/v1/namespaces/default/pods/bar" && m == "PUT":
 				seen.Insert("bar")
 				obj := readOrDie(t, req, codec)
 				podList.Items[1] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[1])}, nil
-			case p == testapi.Default.ResourcePath("pods", "default", "baz") && m == "PUT":
+			case p == "/api/v1/namespaces/default/pods/baz" && m == "PUT":
 				seen.Insert("baz")
 				obj := readOrDie(t, req, codec)
 				podList.Items[2] = *(obj.(*corev1.Pod))
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, &podList.Items[2])}, nil
-			case p == testapi.Default.ResourcePath("replicationcontrollers", "default", "rc") && m == "PUT":
+			case p == "/api/v1/namespaces/default/replicationcontrollers/rc" && m == "PUT":
 				updatedRc = true
 				return &http.Response{StatusCode: 200, Header: header, Body: objBody(codec, rc)}, nil
 			default:
@@ -1621,7 +1633,13 @@ func TestAddDeploymentHash(t *testing.T) {
 			}
 		}),
 	}
-	clientConfig := &restclient.Config{APIPath: "/api", ContentConfig: restclient.ContentConfig{NegotiatedSerializer: scheme.Codecs, GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}}
+	clientConfig := &restclient.Config{
+		APIPath: "/api",
+		ContentConfig: restclient.ContentConfig{
+			NegotiatedSerializer: scheme.Codecs,
+			GroupVersion:         &corev1.SchemeGroupVersion,
+		},
+	}
 	restClient, _ := restclient.RESTClientFor(clientConfig)
 	restClient.Client = fakeClient.Client
 	clientset := kubernetes.New(restClient)


### PR DESCRIPTION
* Removes testapi dependency by hard-coding the client path.
* Removes the testing dependency by hard-coding a pod spec.

Helps Address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
