### PR TITLE
Update provisioner name and don't supply zone in GCE PD CSI test

### DIFF
--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -30,7 +30,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	csiv1alpha1 "k8s.io/csi-api/pkg/apis/csi/v1alpha1"
 	csiclient "k8s.io/csi-api/pkg/client/clientset/versioned"
-	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -364,6 +363,7 @@ type gcePDCSIDriver struct {
 func initCSIgcePD(f *framework.Framework, config framework.VolumeTestConfig) csiTestDriver {
 	cs := f.ClientSet
 	framework.SkipUnlessProviderIs("gce", "gke")
+	framework.SkipIfMultizone(cs)
 
 	// TODO(#62561): Use credentials through external pod identity when that goes GA instead of downloading keys.
 	createGCESecrets(cs, config)
@@ -384,13 +384,10 @@ func initCSIgcePD(f *framework.Framework, config framework.VolumeTestConfig) csi
 }
 
 func (g *gcePDCSIDriver) createStorageClassTest(node v1.Node) storageClassTest {
-	nodeZone, ok := node.GetLabels()[kubeletapis.LabelZoneFailureDomain]
-	Expect(ok).To(BeTrue(), "Could not get label %v from node %v", kubeletapis.LabelZoneFailureDomain, node.GetName())
-
 	return storageClassTest{
-		name:         "csi-gce-pd",
-		provisioner:  "csi-gce-pd",
-		parameters:   map[string]string{"type": "pd-standard", "zone": nodeZone},
+		name:         "com.google.csi.gcepd",
+		provisioner:  "com.google.csi.gcepd",
+		parameters:   map[string]string{"type": "pd-standard"},
 		claimSize:    "5Gi",
 		expectedSize: "5Gi",
 		nodeName:     node.Name,

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -19,7 +19,7 @@ spec:
           image: quay.io/k8scsi/csi-provisioner:v0.2.0
           args:
             - "--v=5"
-            - "--provisioner=csi-gce-pd"
+            - "--provisioner=com.google.csi.gcepd"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS


### PR DESCRIPTION
This change updates the manifest/storage class provisioner name to be compatible with the new version of the driver, it also drops supplying "zone" to the driver through parameters.

Sorry about the churn.

Releasing beta soon, getting all the breaking changes in around the same time.

/assign @msau42 
/kind test
/sig storage


```release-note
NONE
```
