### PR TITLE
Add validation for percentage-of-nodes-to-score of the scheduler config

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -44,6 +44,10 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) f
 	if cc.BindTimeoutSeconds == nil {
 		allErrs = append(allErrs, field.Required(field.NewPath("bindTimeoutSeconds"), ""))
 	}
+	if cc.PercentageOfNodesToScore < 0 || cc.PercentageOfNodesToScore > 100 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("percentageOfNodesToScore"),
+			cc.PercentageOfNodesToScore, "not in valid range 0-100"))
+	}
 	return allErrs
 }
 

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -58,7 +58,8 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 				RetryPeriod:   metav1.Duration{Duration: 5 * time.Second},
 			},
 		},
-		BindTimeoutSeconds: &testTimeout,
+		BindTimeoutSeconds:       &testTimeout,
+		PercentageOfNodesToScore: 35,
 	}
 
 	HardPodAffinitySymmetricWeightGt100 := validConfig.DeepCopy()
@@ -91,6 +92,9 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 
 	bindTimeoutUnset := validConfig.DeepCopy()
 	bindTimeoutUnset.BindTimeoutSeconds = nil
+
+	percentageOfNodesToScore101 := validConfig.DeepCopy()
+	percentageOfNodesToScore101.PercentageOfNodesToScore = int32(101)
 
 	scenarios := map[string]struct {
 		expectedToFail bool
@@ -135,6 +139,10 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 		"bind-timeout-unset": {
 			expectedToFail: true,
 			config:         bindTimeoutUnset,
+		},
+		"bad-percentage-of-nodes-to-score": {
+			expectedToFail: true,
+			config:         percentageOfNodesToScore101,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The config validation for the scheduler was added almost at the same time we added "percentage-of-nodes-to-score". So, it was missing in the validation logic. This PR adds the validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig scheduling
