### PR TITLE
kubectl get test: remove testapi dependencies and cleanups

### DIFF
--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -67,7 +67,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/testing:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",


### PR DESCRIPTION
* Removes testapi dependency by hard-coding Pod spec.
* Various import alias fixes to make it more consistent with other files.
* Removed some unused code.

Helps address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
