### PR TITLE
kubectl replace legacyscheme in rollback

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -109,7 +109,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/kubectl",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/v1:go_default_library",

--- a/pkg/kubectl/rollback.go
+++ b/pkg/kubectl/rollback.go
@@ -36,11 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	apiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	kapps "k8s.io/kubernetes/pkg/kubectl/apps"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	sliceutil "k8s.io/kubernetes/pkg/kubectl/util/slice"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	// kubectl should not be taking dependencies on logic in the controllers
@@ -185,7 +185,7 @@ func isRollbackEvent(e *api.Event) (bool, string) {
 
 func simpleDryRun(deployment *extensions.Deployment, c kubernetes.Interface, toRevision int64) (string, error) {
 	externalDeployment := &appsv1.Deployment{}
-	if err := legacyscheme.Scheme.Convert(deployment, externalDeployment, nil); err != nil {
+	if err := scheme.Scheme.Convert(deployment, externalDeployment, nil); err != nil {
 		return "", fmt.Errorf("failed to convert deployment, %v", err)
 	}
 
@@ -382,7 +382,7 @@ func (r *StatefulSetRollbacker) Rollback(obj runtime.Object, updatedAnnotations 
 	return rollbackSuccess, nil
 }
 
-var appsCodec = legacyscheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion)
+var appsCodec = scheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion)
 
 // applyRevision returns a new StatefulSet constructed by restoring the state in revision to set. If the returned error
 // is nil, the returned StatefulSet is valid.


### PR DESCRIPTION
Migrate kubectl `rollback.go` from using `legacyscheme` to using internal version instead as part of the effort in https://github.com/kubernetes/kubectl/issues/83. 

```release-note
NONE
```