### PR TITLE
kubeadm: Detect CRIs automatically

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults.go
@@ -68,7 +68,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_InitConfiguration assigns default values for the InitConfiguration
 func SetDefaults_InitConfiguration(obj *InitConfiguration) {
 	SetDefaults_ClusterConfiguration(&obj.ClusterConfiguration)
-	SetDefaults_NodeRegistrationOptions(&obj.NodeRegistration)
 	SetDefaults_BootstrapTokens(obj)
 	SetDefaults_APIEndpoint(&obj.APIEndpoint)
 }
@@ -139,14 +138,7 @@ func SetDefaults_JoinConfiguration(obj *JoinConfiguration) {
 		}
 	}
 
-	SetDefaults_NodeRegistrationOptions(&obj.NodeRegistration)
 	SetDefaults_APIEndpoint(&obj.APIEndpoint)
-}
-
-func SetDefaults_NodeRegistrationOptions(obj *NodeRegistrationOptions) {
-	if obj.CRISocket == "" {
-		obj.CRISocket = DefaultCRISocket
-	}
 }
 
 // SetDefaults_AuditPolicyConfiguration sets default values for the AuditPolicyConfiguration

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_unix.go
@@ -21,8 +21,4 @@ package v1alpha3
 const (
 	// DefaultCACertPath defines default location of CA certificate on Linux
 	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "unix"
-	// DefaultCRISocket defines the default cri socket
-	DefaultCRISocket = "/var/run/dockershim.sock"
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/defaults_windows.go
@@ -21,8 +21,4 @@ package v1alpha3
 const (
 	// DefaultCACertPath defines default location of CA certificate on Windows
 	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "tcp"
-	// DefaultCRISocket defines the default cri socket
-	DefaultCRISocket = "tcp://localhost:2375"
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha3/zz_generated.defaults.go
@@ -49,12 +49,10 @@ func SetObjectDefaults_InitConfiguration(in *InitConfiguration) {
 		a := &in.BootstrapTokens[i]
 		SetDefaults_BootstrapToken(a)
 	}
-	SetDefaults_NodeRegistrationOptions(&in.NodeRegistration)
 	SetDefaults_APIEndpoint(&in.APIEndpoint)
 }
 
 func SetObjectDefaults_JoinConfiguration(in *JoinConfiguration) {
 	SetDefaults_JoinConfiguration(in)
-	SetDefaults_NodeRegistrationOptions(&in.NodeRegistration)
 	SetDefaults_APIEndpoint(&in.APIEndpoint)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults.go
@@ -68,7 +68,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_InitConfiguration assigns default values for the InitConfiguration
 func SetDefaults_InitConfiguration(obj *InitConfiguration) {
 	SetDefaults_ClusterConfiguration(&obj.ClusterConfiguration)
-	SetDefaults_NodeRegistrationOptions(&obj.NodeRegistration)
 	SetDefaults_BootstrapTokens(obj)
 	SetDefaults_APIEndpoint(&obj.LocalAPIEndpoint)
 }
@@ -138,15 +137,8 @@ func SetDefaults_JoinConfiguration(obj *JoinConfiguration) {
 		obj.CACertPath = DefaultCACertPath
 	}
 
-	SetDefaults_NodeRegistrationOptions(&obj.NodeRegistration)
 	SetDefaults_JoinControlPlane(obj.ControlPlane)
 	SetDefaults_Discovery(&obj.Discovery)
-}
-
-func SetDefaults_NodeRegistrationOptions(obj *NodeRegistrationOptions) {
-	if obj.CRISocket == "" {
-		obj.CRISocket = DefaultCRISocket
-	}
 }
 
 func SetDefaults_JoinControlPlane(obj *JoinControlPlane) {

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_windows.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/defaults_windows.go
@@ -23,6 +23,4 @@ const (
 	DefaultCACertPath = "C:/etc/kubernetes/pki/ca.crt"
 	// DefaultUrlScheme defines default socket url prefix
 	DefaultUrlScheme = "tcp"
-	// DefaultCRISocket defines the default cri socket
-	DefaultCRISocket = "tcp://localhost:2375"
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta1/zz_generated.defaults.go
@@ -50,13 +50,11 @@ func SetObjectDefaults_InitConfiguration(in *InitConfiguration) {
 		a := &in.BootstrapTokens[i]
 		SetDefaults_BootstrapToken(a)
 	}
-	SetDefaults_NodeRegistrationOptions(&in.NodeRegistration)
 	SetDefaults_APIEndpoint(&in.LocalAPIEndpoint)
 }
 
 func SetObjectDefaults_JoinConfiguration(in *JoinConfiguration) {
 	SetDefaults_JoinConfiguration(in)
-	SetDefaults_NodeRegistrationOptions(&in.NodeRegistration)
 	SetDefaults_Discovery(&in.Discovery)
 	if in.Discovery.File != nil {
 		SetDefaults_FileDiscovery(in.Discovery.File)

--- a/cmd/kubeadm/app/cmd/config_test.go
+++ b/cmd/kubeadm/app/cmd/config_test.go
@@ -145,6 +145,9 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 				ClusterConfiguration: kubeadmapiv1beta1.ClusterConfiguration{
 					KubernetesVersion: dummyKubernetesVersion,
 				},
+				NodeRegistration: kubeadmapiv1beta1.NodeRegistrationOptions{
+					CRISocket: constants.DefaultDockerCRISocket,
+				},
 			},
 		},
 		{
@@ -158,6 +161,9 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 					},
 					KubernetesVersion: dummyKubernetesVersion,
 				},
+				NodeRegistration: kubeadmapiv1beta1.NodeRegistrationOptions{
+					CRISocket: constants.DefaultDockerCRISocket,
+				},
 			},
 			expectedImages: defaultNumberOfImages - 1,
 		},
@@ -166,6 +172,9 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 			cfg: kubeadmapiv1beta1.InitConfiguration{
 				ClusterConfiguration: kubeadmapiv1beta1.ClusterConfiguration{
 					KubernetesVersion: dummyKubernetesVersion,
+				},
+				NodeRegistration: kubeadmapiv1beta1.NodeRegistrationOptions{
+					CRISocket: constants.DefaultDockerCRISocket,
 				},
 			},
 			expectedImages: defaultNumberOfImages,
@@ -178,6 +187,9 @@ func TestConfigImagesListRunWithoutPath(t *testing.T) {
 					DNS: kubeadmapiv1beta1.DNS{
 						Type: kubeadmapiv1beta1.KubeDNS,
 					},
+				},
+				NodeRegistration: kubeadmapiv1beta1.NodeRegistrationOptions{
+					CRISocket: constants.DefaultDockerCRISocket,
 				},
 			},
 			expectedImages: defaultNumberOfImages + 2,
@@ -226,7 +238,7 @@ func TestImagesPull(t *testing.T) {
 		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/docker", nil },
 	}
 
-	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, kubeadmapiv1beta1.DefaultCRISocket)
+	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultDockerCRISocket)
 	if err != nil {
 		t.Errorf("unexpected NewContainerRuntime error: %v", err)
 	}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -230,10 +230,7 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.InitConfig
 		&cfg.NodeRegistration.Name, options.NodeName, cfg.NodeRegistration.Name,
 		`Specify the node name.`,
 	)
-	flagSet.StringVar(
-		&cfg.NodeRegistration.CRISocket, options.NodeCRISocket, cfg.NodeRegistration.CRISocket,
-		`Specify the CRI socket to connect to.`,
-	)
+	cmdutil.AddCRISocketFlag(flagSet, &cfg.NodeRegistration.CRISocket)
 	flagSet.StringVar(featureGatesString, options.FeatureGatesString, *featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 }
@@ -316,7 +313,7 @@ func newInitData(cmd *cobra.Command, options *initOptions, out io.Writer) (initD
 	if options.externalcfg.NodeRegistration.Name != "" {
 		cfg.NodeRegistration.Name = options.externalcfg.NodeRegistration.Name
 	}
-	if options.externalcfg.NodeRegistration.CRISocket != kubeadmapiv1beta1.DefaultCRISocket {
+	if options.externalcfg.NodeRegistration.CRISocket != "" {
 		cfg.NodeRegistration.CRISocket = options.externalcfg.NodeRegistration.CRISocket
 	}
 

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery"
 	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
@@ -233,16 +234,13 @@ func AddJoinConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiv1beta1.JoinConfig
 		`Specify the node name.`,
 	)
 	flagSet.StringVar(
-		&cfg.NodeRegistration.CRISocket, options.NodeCRISocket, cfg.NodeRegistration.CRISocket,
-		`Specify the CRI socket to connect to.`,
-	)
-	flagSet.StringVar(
 		&cfg.Discovery.TLSBootstrapToken, options.TLSBootstrapToken, cfg.Discovery.TLSBootstrapToken,
 		`Specify the token used to temporarily authenticate with the Kubernetes Master while joining the node.`,
 	)
 	AddControlPlaneFlags(flagSet, cfg.ControlPlane)
 	AddJoinBootstrapTokenDiscoveryFlags(flagSet, cfg.Discovery.BootstrapToken)
 	AddJoinFileDiscoveryFlags(flagSet, cfg.Discovery.File)
+	cmdutil.AddCRISocketFlag(flagSet, &cfg.NodeRegistration.CRISocket)
 }
 
 // AddJoinBootstrapTokenDiscoveryFlags adds bootstrap token specific discovery flags to the specified flagset
@@ -388,7 +386,7 @@ func newJoinData(cmd *cobra.Command, options *joinOptions, out io.Writer) (joinD
 	if options.externalcfg.NodeRegistration.Name != "" {
 		cfg.NodeRegistration.Name = options.externalcfg.NodeRegistration.Name
 	}
-	if options.externalcfg.NodeRegistration.CRISocket != kubeadmapiv1beta1.DefaultCRISocket {
+	if options.externalcfg.NodeRegistration.CRISocket != "" {
 		cfg.NodeRegistration.CRISocket = options.externalcfg.NodeRegistration.CRISocket
 	}
 

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -67,6 +67,12 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 				kubeadmutil.CheckErr(err)
 			}
 
+			if criSocketPath != "" {
+				criSocketPath, err = resetDetectCRISocket(client)
+				kubeadmutil.CheckErr(err)
+				klog.V(1).Infof("[reset] detected and using CRI socket: %s", criSocketPath)
+			}
+
 			r, err := NewReset(in, ignorePreflightErrorsSet, forceReset, certsDir, criSocketPath)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(r.Run(out, client))
@@ -81,10 +87,7 @@ func NewCmdReset(in io.Reader, out io.Writer) *cobra.Command {
 		"The path to the directory where the certificates are stored. If specified, clean this directory.",
 	)
 
-	cmd.PersistentFlags().StringVar(
-		&criSocketPath, "cri-socket", kubeadmapiv1beta1.DefaultCRISocket,
-		"The path to the CRI socket to use with crictl when cleaning up containers.",
-	)
+	cmdutil.AddCRISocketFlag(cmd.PersistentFlags(), &criSocketPath)
 
 	cmd.PersistentFlags().BoolVarP(
 		&forceReset, "force", "f", false,
@@ -294,4 +297,15 @@ func resetConfigDir(configPathDir, pkiPathDir string) {
 			klog.Errorf("[reset] failed to remove file: %q [%v]\n", path, err)
 		}
 	}
+}
+
+func resetDetectCRISocket(client clientset.Interface) (string, error) {
+	// first try to connect to the cluster for the CRI socket
+	cfg, err := configutil.FetchConfigFromFileOrCluster(client, os.Stdout, "reset", "", false)
+	if err == nil {
+		return cfg.NodeRegistration.CRISocket, nil
+	}
+
+	// if this fails, try to detect it
+	return utilruntime.DetectCRISocket()
 }

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -88,7 +88,7 @@ func assertDirEmpty(t *testing.T, path string) {
 func TestNewReset(t *testing.T) {
 	var in io.Reader
 	certsDir := kubeadmapiv1beta1.DefaultCertificatesDir
-	criSocketPath := kubeadmapiv1beta1.DefaultCRISocket
+	criSocketPath := kubeadmconstants.DefaultDockerCRISocket
 	forceReset := true
 
 	ignorePreflightErrors := []string{"all"}

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -29,6 +29,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/features"
@@ -70,7 +71,7 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 		applyPlanFlags:   apf,
 		imagePullTimeout: defaultImagePullTimeout,
 		etcdUpgrade:      true,
-		criSocket:        kubeadmapiv1beta1.DefaultCRISocket,
+		// Don't set criSocket to a default value here, as this will override the setting in the stored config in RunApply below.
 	}
 
 	cmd := &cobra.Command{
@@ -127,8 +128,11 @@ func NewCmdApply(apf *applyPlanFlags) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", flags.dryRun, "Do not change any state, just output what actions would be performed.")
 	cmd.Flags().BoolVar(&flags.etcdUpgrade, "etcd-upgrade", flags.etcdUpgrade, "Perform the upgrade of etcd.")
 	cmd.Flags().DurationVar(&flags.imagePullTimeout, "image-pull-timeout", flags.imagePullTimeout, "The maximum amount of time to wait for the control plane pods to be downloaded.")
-	// TODO: Register this flag in a generic place
-	cmd.Flags().StringVar(&flags.criSocket, "cri-socket", flags.criSocket, "Specify the CRI socket to connect to.")
+
+	// The CRI socket flag is deprecated here, since it should be taken from the NodeRegistrationOptions for the current
+	// node instead of the command line. This prevents errors by the users (such as attempts to use wrong CRI during upgrade).
+	cmdutil.AddCRISocketFlag(cmd.Flags(), &flags.criSocket)
+	cmd.Flags().MarkDeprecated(options.NodeCRISocket, "This flag is deprecated. Please, avoid using it.")
 	return cmd
 }
 

--- a/cmd/kubeadm/app/cmd/util/BUILD
+++ b/cmd/kubeadm/app/cmd/util/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//cmd/kubeadm/app/util/pubkeypin:go_default_library",
@@ -18,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -19,8 +19,10 @@ package util
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -72,4 +74,12 @@ func FindExistingKubeConfig(file string) string {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.Precedence = append(rules.Precedence, kubeadmconstants.GetAdminKubeConfigPath())
 	return rules.GetDefaultFilename()
+}
+
+// AddCRISocketFlag adds the cri-socket flag to the supplied flagSet
+func AddCRISocketFlag(flagSet *pflag.FlagSet, criSocket *string) {
+	flagSet.StringVar(
+		criSocket, options.NodeCRISocket, *criSocket,
+		"Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.",
+	)
 }

--- a/cmd/kubeadm/app/constants/BUILD
+++ b/cmd/kubeadm/app/constants/BUILD
@@ -8,7 +8,11 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["constants.go"],
+    srcs = [
+        "constants.go",
+        "constants_unix.go",
+        "constants_windows.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/constants",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",

--- a/cmd/kubeadm/app/constants/constants_unix.go
+++ b/cmd/kubeadm/app/constants/constants_unix.go
@@ -1,7 +1,7 @@
 // +build !windows
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package constants
 
 const (
-	// DefaultCACertPath defines default location of CA certificate on Linux
-	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "unix"
+	// DefaultDockerCRISocket defines the default Docker CRI socket
+	DefaultDockerCRISocket = "/var/run/dockershim.sock"
 )

--- a/cmd/kubeadm/app/constants/constants_windows.go
+++ b/cmd/kubeadm/app/constants/constants_windows.go
@@ -1,7 +1,7 @@
-// +build !windows
+// +build windows
 
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package constants
 
 const (
-	// DefaultCACertPath defines default location of CA certificate on Linux
-	DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
-	// DefaultUrlScheme defines default socket url prefix
-	DefaultUrlScheme = "unix"
+	// DefaultDockerCRISocket defines the default Docker CRI socket
+	DefaultDockerCRISocket = "tcp://localhost:2375"
 )

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
@@ -74,7 +73,7 @@ func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.InitConfiguration, registerTaint
 func buildKubeletArgMap(opts kubeletFlagsOpts) map[string]string {
 	kubeletFlags := map[string]string{}
 
-	if opts.nodeRegOpts.CRISocket == kubeadmapiv1beta1.DefaultCRISocket {
+	if opts.nodeRegOpts.CRISocket == constants.DefaultDockerCRISocket {
 		// These flags should only be set when running docker
 		kubeletFlags["network-plugin"] = "cni"
 		driver, err := kubeadmutil.GetCgroupDriverDocker(opts.execer)

--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -45,7 +45,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -31,7 +31,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 	"k8s.io/utils/exec"
@@ -756,7 +755,7 @@ func TestImagePullCheck(t *testing.T) {
 		LookPathFunc: func(cmd string) (string, error) { return "/usr/bin/docker", nil },
 	}
 
-	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, kubeadmapiv1beta1.DefaultCRISocket)
+	containerRuntime, err := utilruntime.NewContainerRuntime(&fexec, constants.DefaultDockerCRISocket)
 	if err != nil {
 		t.Errorf("unexpected NewContainerRuntime error: %v", err)
 	}

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/config/strict:go_default_library",
+        "//cmd/kubeadm/app/util/runtime:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -40,6 +40,7 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/config/strict"
+	kubeadmruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -94,6 +95,14 @@ func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions,
 	// Only if the slice is nil, we should append the master taint. This allows the user to specify an empty slice for no default master taint
 	if masterTaint && cfg.Taints == nil {
 		cfg.Taints = []v1.Taint{kubeadmconstants.MasterTaint}
+	}
+
+	if cfg.CRISocket == "" {
+		cfg.CRISocket, err = kubeadmruntime.DetectCRISocket()
+		if err != nil {
+			return err
+		}
+		klog.V(1).Infof("detected and using CRI socket: %s", cfg.CRISocket)
 	}
 
 	return nil

--- a/cmd/kubeadm/app/util/runtime/BUILD
+++ b/cmd/kubeadm/app/util/runtime/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime",
     visibility = ["//visibility:public"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
@@ -18,7 +18,7 @@ go_test(
     srcs = ["runtime_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm/v1beta1:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package util
 
 import (
+	"io/ioutil"
+	"net"
+	"os"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/pkg/errors"
 
-	kubeadmapiv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
 )
@@ -41,7 +45,7 @@ func TestNewContainerRuntime(t *testing.T) {
 		isDocker  bool
 		isError   bool
 	}{
-		{"valid: default cri socket", execLookPathOK, kubeadmapiv1beta1.DefaultCRISocket, true, false},
+		{"valid: default cri socket", execLookPathOK, constants.DefaultDockerCRISocket, true, false},
 		{"valid: cri-o socket url", execLookPathOK, "unix:///var/run/crio/crio.sock", false, false},
 		{"valid: cri-o socket path", execLookPathOK, "/var/run/crio/crio.sock", false, false},
 		{"invalid: no crictl", execLookPathErr, "unix:///var/run/crio/crio.sock", false, true},
@@ -105,8 +109,8 @@ func TestIsRunning(t *testing.T) {
 	}{
 		{"valid: CRI-O is running", "unix:///var/run/crio/crio.sock", criExecer, false},
 		{"invalid: CRI-O is not running", "unix:///var/run/crio/crio.sock", criExecer, true},
-		{"valid: docker is running", kubeadmapiv1beta1.DefaultCRISocket, dockerExecer, false},
-		{"invalid: docker is not running", kubeadmapiv1beta1.DefaultCRISocket, dockerExecer, true},
+		{"valid: docker is running", constants.DefaultDockerCRISocket, dockerExecer, false},
+		{"invalid: docker is not running", constants.DefaultDockerCRISocket, dockerExecer, true},
 	}
 
 	for _, tc := range cases {
@@ -146,7 +150,7 @@ func TestListKubeContainers(t *testing.T) {
 	}{
 		{"valid: list containers using CRI socket url", "unix:///var/run/crio/crio.sock", false},
 		{"invalid: list containers using CRI socket url", "unix:///var/run/crio/crio.sock", true},
-		{"valid: list containers using docker", kubeadmapiv1beta1.DefaultCRISocket, false},
+		{"valid: list containers using docker", constants.DefaultDockerCRISocket, false},
 	}
 
 	for _, tc := range cases {
@@ -199,8 +203,8 @@ func TestRemoveContainers(t *testing.T) {
 		{"valid: remove containers using CRI", "unix:///var/run/crio/crio.sock", []string{"k8s_p1", "k8s_p2", "k8s_p3"}, false}, // Test case 1
 		{"invalid: CRI rmp failure", "unix:///var/run/crio/crio.sock", []string{"k8s_p1", "k8s_p2", "k8s_p3"}, true},
 		{"invalid: CRI stopp failure", "unix:///var/run/crio/crio.sock", []string{"k8s_p1", "k8s_p2", "k8s_p3"}, true},
-		{"valid: remove containers using docker", kubeadmapiv1beta1.DefaultCRISocket, []string{"k8s_c1", "k8s_c2", "k8s_c3"}, false},
-		{"invalid: remove containers using docker", kubeadmapiv1beta1.DefaultCRISocket, []string{"k8s_c1", "k8s_c2", "k8s_c3"}, true},
+		{"valid: remove containers using docker", constants.DefaultDockerCRISocket, []string{"k8s_c1", "k8s_c2", "k8s_c3"}, false},
+		{"invalid: remove containers using docker", constants.DefaultDockerCRISocket, []string{"k8s_c1", "k8s_c2", "k8s_c3"}, true},
 	}
 
 	for _, tc := range cases {
@@ -243,8 +247,8 @@ func TestPullImage(t *testing.T) {
 	}{
 		{"valid: pull image using CRI", "unix:///var/run/crio/crio.sock", "image1", false},
 		{"invalid: CRI pull error", "unix:///var/run/crio/crio.sock", "image2", true},
-		{"valid: pull image using docker", kubeadmapiv1beta1.DefaultCRISocket, "image1", false},
-		{"invalide: docer pull error", kubeadmapiv1beta1.DefaultCRISocket, "image2", true},
+		{"valid: pull image using docker", constants.DefaultDockerCRISocket, "image1", false},
+		{"invalide: docer pull error", constants.DefaultDockerCRISocket, "image2", true},
 	}
 
 	for _, tc := range cases {
@@ -287,8 +291,8 @@ func TestImageExists(t *testing.T) {
 	}{
 		{"valid: test if image exists using CRI", "unix:///var/run/crio/crio.sock", "image1", false},
 		{"invalid: CRI inspecti failure", "unix:///var/run/crio/crio.sock", "image2", true},
-		{"valid: test if image exists using docker", kubeadmapiv1beta1.DefaultCRISocket, "image1", false},
-		{"invalid: docker inspect failure", kubeadmapiv1beta1.DefaultCRISocket, "image2", true},
+		{"valid: test if image exists using docker", constants.DefaultDockerCRISocket, "image1", false},
+		{"invalid: docker inspect failure", constants.DefaultDockerCRISocket, "image2", true},
 	}
 
 	for _, tc := range cases {
@@ -301,6 +305,145 @@ func TestImageExists(t *testing.T) {
 			result, err := runtime.ImageExists(tc.image)
 			if !tc.result != result {
 				t.Errorf("unexpected ImageExists result: %t, criSocket: %s, image: %s, expected result: %t", err, tc.criSocket, tc.image, tc.result)
+			}
+		})
+	}
+}
+
+func TestIsExistingSocket(t *testing.T) {
+	// this test is not expected to work on Windows
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	const tempPrefix = "test.kubeadm.runtime.isExistingSocket."
+	tests := []struct {
+		name string
+		proc func(*testing.T)
+	}{
+		{
+			name: "Valid domain socket is detected as such",
+			proc: func(t *testing.T) {
+				tmpFile, err := ioutil.TempFile("", tempPrefix)
+				if err != nil {
+					t.Fatalf("unexpected error by TempFile: %v", err)
+				}
+				theSocket := tmpFile.Name()
+				os.Remove(theSocket)
+				tmpFile.Close()
+
+				con, err := net.Listen("unix", theSocket)
+				if err != nil {
+					t.Fatalf("unexpected error while dialing a socket: %v", err)
+				}
+				defer con.Close()
+
+				if !isExistingSocket(theSocket) {
+					t.Fatalf("isExistingSocket(%q) gave unexpected result. Should have been true, instead of false", theSocket)
+				}
+			},
+		},
+		{
+			name: "Regular file is not a domain socket",
+			proc: func(t *testing.T) {
+				tmpFile, err := ioutil.TempFile("", tempPrefix)
+				if err != nil {
+					t.Fatalf("unexpected error by TempFile: %v", err)
+				}
+				theSocket := tmpFile.Name()
+				defer os.Remove(theSocket)
+				tmpFile.Close()
+
+				if isExistingSocket(theSocket) {
+					t.Fatalf("isExistingSocket(%q) gave unexpected result. Should have been false, instead of true", theSocket)
+				}
+			},
+		},
+		{
+			name: "Non existent socket is not a domain socket",
+			proc: func(t *testing.T) {
+				const theSocket = "/non/existent/socket"
+				if isExistingSocket(theSocket) {
+					t.Fatalf("isExistingSocket(%q) gave unexpected result. Should have been false, instead of true", theSocket)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, test.proc)
+	}
+}
+
+func TestDetectCRISocketImpl(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingSockets []string
+		expectedError   bool
+		expectedSocket  string
+	}{
+		{
+			name:            "No existing sockets, use Docker",
+			existingSockets: []string{},
+			expectedError:   false,
+			expectedSocket:  constants.DefaultDockerCRISocket,
+		},
+		{
+			name:            "One valid CRI socket leads to success",
+			existingSockets: []string{"/var/run/crio/crio.sock"},
+			expectedError:   false,
+			expectedSocket:  "/var/run/crio/crio.sock",
+		},
+		{
+			name:            "Correct Docker CRI socket is returned",
+			existingSockets: []string{"/var/run/docker.sock"},
+			expectedError:   false,
+			expectedSocket:  constants.DefaultDockerCRISocket,
+		},
+		{
+			name: "CRI and Docker sockets lead to an error",
+			existingSockets: []string{
+				"/var/run/docker.sock",
+				"/var/run/crio/crio.sock",
+			},
+			expectedError: true,
+		},
+		{
+			name: "Docker and containerd lead to Docker being used",
+			existingSockets: []string{
+				"/var/run/docker.sock",
+				"/run/containerd/containerd.sock",
+			},
+			expectedError:  false,
+			expectedSocket: constants.DefaultDockerCRISocket,
+		},
+		{
+			name: "A couple of CRI sockets lead to an error",
+			existingSockets: []string{
+				"/var/run/crio/crio.sock",
+				"/run/containerd/containerd.sock",
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socket, err := detectCRISocketImpl(func(path string) bool {
+				for _, existing := range test.existingSockets {
+					if path == existing {
+						return true
+					}
+				}
+
+				return false
+			})
+			if (err != nil) != test.expectedError {
+				t.Fatalf("detectCRISocketImpl returned unexpected result\n\tExpected error: %t\n\tGot error: %t", test.expectedError, err != nil)
+			}
+			if !test.expectedError && socket != test.expectedSocket {
+				t.Fatalf("detectCRISocketImpl returned unexpected CRI socket\n\tExpected socket: %s\n\tReturned socket: %s",
+					test.expectedSocket, socket)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In order to allow for a smoother UX with CRIs different than Docker, we have to make the --cri-socket command line flag optional when just one CRI is installed.
    
This change does that by doing the following:
    
- Introduce a new runtime function (DetectCRISocket) that will attempt to detect a CRI socket, or return an appropriate error.
- Default to using the above function if `--cri-socket` is not specified and CRISocket in NodeRegistrationOptions is empty.
- Stop static defaulting to DefaultCRISocket. And rename it to DefaultDockerCRISocket. Its use is now narrowed to "Docker or not" distinguishment and tests.
- Introduce AddCRISocketFlag function that adds `--cri-socket` flag to a flagSet. Use that in all commands, that support `--cri-socket`.
- Remove the deprecated `--cri-socket-path` flag from kubeadm config images pull and deprecate `--cri-socket` in kubeadm upgrade apply.

In short, if multiple CRIs are detected, we bail out with an error. If no CRI is detected, we attempt to use Docker by default and this will fail if it's not installed and we actually need the CRI for the operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs kubernetes/kubeadm#1117 (probably needs docs update too)

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/kind feature
/assign @fabriziopandini
/assign @timothysc
/cc @neolit123 @bart0sh @kad 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm now attempts to detect an installed CRI by its usual domain socket, so that --cri-socket can be omitted from the command line if Docker is not used and there is a single CRI installed.
```
