### PR TITLE
Add tests for `csiDriverClient`

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
@@ -69,14 +70,39 @@ type csiClient interface {
 
 // csiClient encapsulates all csi-plugin methods
 type csiDriverClient struct {
-	driverName string
-	nodeClient csipb.NodeClient
+	driverName        string
+	nodeClientCreator nodeClientCreator
 }
 
 var _ csiClient = &csiDriverClient{}
 
+type nodeClientCreator func(driverName string) (
+	nodeClient csipb.NodeClient,
+	closer io.Closer,
+	err error,
+)
+
+// newNodeClient creates a new NodeClient with the internally used gRPC
+// connection set up. It also returns a closer which must to be called to close
+// the gRPC connection when the NodeClient is not used anymore.
+// This is the default implementation for the nodeClientCreator, used in
+// newCsiDriverClient.
+func newNodeClient(driverName string) (nodeClient csipb.NodeClient, closer io.Closer, err error) {
+	var conn *grpc.ClientConn
+	conn, err = newGrpcConn(driverName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nodeClient = csipb.NewNodeClient(conn)
+	return nodeClient, conn, nil
+}
+
 func newCsiDriverClient(driverName string) *csiDriverClient {
-	c := &csiDriverClient{driverName: driverName}
+	c := &csiDriverClient{
+		driverName:        driverName,
+		nodeClientCreator: newNodeClient,
+	}
 	return c
 }
 
@@ -87,12 +113,11 @@ func (c *csiDriverClient) NodeGetInfo(ctx context.Context) (
 	err error) {
 	glog.V(4).Info(log("calling NodeGetInfo rpc"))
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return "", 0, nil, err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	res, err := nodeClient.NodeGetInfo(ctx, &csipb.NodeGetInfoRequest{})
 	if err != nil {
@@ -122,12 +147,11 @@ func (c *csiDriverClient) NodePublishVolume(
 		return errors.New("missing target path")
 	}
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	req := &csipb.NodePublishVolumeRequest{
 		VolumeId:           volID,
@@ -171,12 +195,11 @@ func (c *csiDriverClient) NodeUnpublishVolume(ctx context.Context, volID string,
 		return errors.New("missing target path")
 	}
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	req := &csipb.NodeUnpublishVolumeRequest{
 		VolumeId:   volID,
@@ -204,12 +227,11 @@ func (c *csiDriverClient) NodeStageVolume(ctx context.Context,
 		return errors.New("missing staging target path")
 	}
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	req := &csipb.NodeStageVolumeRequest{
 		VolumeId:          volID,
@@ -249,12 +271,11 @@ func (c *csiDriverClient) NodeUnstageVolume(ctx context.Context, volID, stagingT
 		return errors.New("missing staging target path")
 	}
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	req := &csipb.NodeUnstageVolumeRequest{
 		VolumeId:          volID,
@@ -267,12 +288,11 @@ func (c *csiDriverClient) NodeUnstageVolume(ctx context.Context, volID, stagingT
 func (c *csiDriverClient) NodeGetCapabilities(ctx context.Context) ([]*csipb.NodeServiceCapability, error) {
 	glog.V(4).Info(log("calling NodeGetCapabilities rpc"))
 
-	conn, err := newGrpcConn(c.driverName)
+	nodeClient, closer, err := c.nodeClientCreator(c.driverName)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
-	nodeClient := csipb.NewNodeClient(conn)
+	defer closer.Close()
 
 	req := &csipb.NodeGetCapabilitiesRequest{}
 	resp, err := nodeClient.NodeGetCapabilities(ctx, req)

--- a/pkg/volume/csi/fake/BUILD
+++ b/pkg/volume/csi/fake/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["fake_client.go"],
+    srcs = [
+        "fake_client.go",
+        "fake_closer.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/volume/csi/fake",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/volume/csi/fake/fake_closer.go
+++ b/pkg/volume/csi/fake/fake_closer.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"testing"
+)
+
+func NewCloser(t *testing.T) *Closer {
+	return &Closer{
+		t: t,
+	}
+}
+
+type Closer struct {
+	wasCalled bool
+	t         *testing.T
+}
+
+func (c *Closer) Close() error {
+	c.wasCalled = true
+	return nil
+}
+
+func (c *Closer) Check() *Closer {
+	c.t.Helper()
+
+	if !c.wasCalled {
+		c.t.Error("expected closer to have been called")
+	}
+
+	return c
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

As #69219 outlines the unit tests in `csi_client_test.go` where not
testing the actual implementation of the `csiDriverClient` but was
testing the fake.

To fix this, we changed the `csiDriverClient` to use a
`nodeClientCreator` which is responsible for creating a new
`NodeClient`, a real one in prod and a fake one in the tests.

The setup of the gRPC connection has been pushed into that creator. The
node client uses that connection; that's transparent to the driver
client.  It's the responsibility of the driver client to close the
connection when it is done with the node client. To achieve this, we
have the node client creator return a closer function which handles the
connection teardown.

In the tests we now also check if the driver client actually calls
this closer, thus closing the gRPC connection.

/cc @mariantalla 
/cc @flangewad
/cc @davidz627 
/cc @vladimirvivien 
/sig storage

**Which issue(s) this PR fixes** :
Fixes #69219

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
