### PR TITLE
Cherrypick: Update defaultbackend to v1.5

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
@@ -25,7 +25,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: k8s.gcr.io/defaultbackend:1.4
+        image: k8s.gcr.io/defaultbackend-amd64:1.5
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
```release-note
Update defaultbackend to 1.5: move /metrics to a private endpoint (:10254).
```
