### PR TITLE
Differentiate multizone zonal from Regional Cluster.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -663,6 +663,15 @@ EOF
 multizone = ${MULTIZONE}
 EOF
   fi
+# Multimaster indicates that the cluster is HA.
+# Currently the only HA clusters are regional.
+# If we introduce zonal multimaster this will need to be revisited.
+  if [[ -n "${MULTIMASTER:-}" ]]; then
+    use_cloud_config="true"
+    cat <<EOF >>/etc/gce.conf
+regional = ${MULTIMASTER}
+EOF
+  fi
   if [[ -n "${GCE_ALPHA_FEATURES:-}" ]]; then
     use_cloud_config="true"
     # split GCE_ALPHA_FEATURES into an array by comma.

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -114,6 +114,7 @@ type GCECloud struct {
 	eventRecorder    record.EventRecorder
 	projectID        string
 	region           string
+	regional         bool
 	localZone        string // The zone in which we are running
 	// managedZones will be set to the 1 zone if running a single zone cluster
 	// it will be set to ALL zones in region for any multi-zone cluster
@@ -174,6 +175,7 @@ type ConfigGlobal struct {
 	SecondaryRangeName string   `gcfg:"secondary-range-name"`
 	NodeTags           []string `gcfg:"node-tags"`
 	NodeInstancePrefix string   `gcfg:"node-instance-prefix"`
+	Regional           bool     `gcfg:"regional"`
 	Multizone          bool     `gcfg:"multizone"`
 	// ApiEndpoint is the GCE compute API endpoint to use. If this is blank,
 	// then the default endpoint is used.
@@ -202,6 +204,7 @@ type CloudConfig struct {
 	ProjectID            string
 	NetworkProjectID     string
 	Region               string
+	Regional             bool
 	Zone                 string
 	ManagedZones         []string
 	NetworkName          string
@@ -332,9 +335,14 @@ func generateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 		return nil, err
 	}
 
+	// Determine if its a regional cluster
+	if configFile != nil && configFile.Global.Regional {
+		cloudConfig.Regional = true
+	}
+
 	// generate managedZones
 	cloudConfig.ManagedZones = []string{cloudConfig.Zone}
-	if configFile != nil && configFile.Global.Multizone {
+	if configFile != nil && (configFile.Global.Multizone || configFile.Global.Regional) {
 		cloudConfig.ManagedZones = nil // Use all zones in region
 	}
 
@@ -512,6 +520,7 @@ func CreateGCECloud(config *CloudConfig) (*GCECloud, error) {
 		networkProjectID:         netProjID,
 		onXPN:                    onXPN,
 		region:                   config.Region,
+		regional:                 config.Regional,
 		localZone:                config.Zone,
 		managedZones:             config.ManagedZones,
 		networkURL:               networkURL,

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -39,6 +39,7 @@ secondary-range-name = my-secondary-range
 node-tags = my-node-tag1
 node-instance-prefix = my-prefix
 multizone = true
+regional = true
    `
 	reader := strings.NewReader(s)
 	config, err := readConfig(reader)
@@ -57,6 +58,7 @@ multizone = true
 		NodeTags:           []string{"my-node-tag1"},
 		NodeInstancePrefix: "my-prefix",
 		Multizone:          true,
+		Regional:           true,
 	}}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -328,6 +330,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 		NodeTags:           []string{"node-tag"},
 		NodeInstancePrefix: "node-prefix",
 		Multizone:          false,
+		Regional:           false,
 		ApiEndpoint:        "",
 		LocalZone:          "us-central1-a",
 		AlphaFeatures:      []string{},
@@ -442,6 +445,20 @@ func TestGenerateCloudConfigs(t *testing.T) {
 			},
 			cloud: func() CloudConfig {
 				v := cloudBoilerplate
+				v.ManagedZones = nil
+				return v
+			},
+		},
+		{
+			name: "Regional",
+			config: func() ConfigGlobal {
+				v := configBoilerplate
+				v.Regional = true
+				return v
+			},
+			cloud: func() CloudConfig {
+				v := cloudBoilerplate
+				v.Regional = true
 				v.ManagedZones = nil
 				return v
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Restores multi-zonal support while continuing to provider regional support.
Added a regional flag to the gce cloudprovider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubernetes/pull/69179#pullrequestreview-160103097

**Special notes for your reviewer**: Addresses issue brought up by roberthbailey in cherry pick

**Release note**:
```
NONE
```
