### PR TITLE
admission: printf cleanups

### DIFF
--- a/plugin/pkg/admission/storage/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/storage/persistentvolume/label/admission.go
@@ -170,7 +170,7 @@ func (l *persistentVolumeLabel) Admit(a admission.Attributes) (err error) {
 				volume.Spec.NodeAffinity.Required.NodeSelectorTerms = make([]api.NodeSelectorTerm, 1)
 			}
 			if nodeSelectorRequirementKeysExistInNodeSelectorTerms(requirements, volume.Spec.NodeAffinity.Required.NodeSelectorTerms) {
-				glog.V(4).Info("NodeSelectorRequirements for cloud labels %v conflict with existing NodeAffinity %v. Skipping addition of NodeSelectorRequirements for cloud labels.",
+				glog.V(4).Infof("NodeSelectorRequirements for cloud labels %v conflict with existing NodeAffinity %v. Skipping addition of NodeSelectorRequirements for cloud labels.",
 					requirements, volume.Spec.NodeAffinity)
 			} else {
 				for _, req := range requirements {


### PR DESCRIPTION
go test in 1.11 now performs some validation of format strings, so this
address the issues highlighted by go test, allowing go test to pass with
1.11.

Fixes pertaining to admission.


```release-note
NONE
```