### PR TITLE
Automated cherry pick of #69353: Update provisioner name and don't supply zone in GCE PD CSI

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -19,7 +19,7 @@ spec:
           image: quay.io/k8scsi/csi-provisioner:v0.2.0
           args:
             - "--v=5"
-            - "--provisioner=csi-gce-pd"
+            - "--provisioner=com.google.csi.gcepd"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS


### PR DESCRIPTION
Cherry pick of #69353 on release-1.12.

#69353: Update provisioner name and don't supply zone in GCE PD CSI

```release-note
NONE
```