### PR TITLE
kubectl run test: remove legacyscheme dependency and cleanups

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -204,6 +204,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",


### PR DESCRIPTION
* Removes legacyscheme (which registers internal types).
* Uses external corev1 type instead of internal api type for hard-coded resources in tests.
* Various small cleanups.

Helps address:
https://github.com/kubernetes/kubectl/issues/83

```release-note
NONE
```
